### PR TITLE
refactor: unify symbolic/concrete FSL evaluators behind a Domain abstraction

### DIFF
--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -20,6 +20,74 @@ from .model import (
     resolve_action_name,
     z3_sort,
 )
+from .values import (
+    _display_state_keys,
+    _enum_name,
+    _is_enum_member,
+    _lvalue_key,
+    _seq_val_parts,
+    _struct_field_ty,
+    _struct_info,
+    eval_count,
+    eval_field,
+    eval_index,
+    eval_is,
+    eval_quant,
+    eval_sum,
+    logical_map_access,
+    option_logical_eq,
+    option_none_cmp,
+    reject_option_binop,
+    seq_compare,
+    struct_compare,
+)
+
+
+class _SymDomain:
+    def int_lit(self, n):
+        return z3.IntVal(n)
+
+    def select_int(self, cond, body_thunk):
+        return z3.If(cond, body_thunk(), z3.IntVal(0))
+
+    def quantify(self, qop, terms):
+        insts = []
+        for w, body_thunk in terms:
+            bi = body_thunk()
+            if w is not None:
+                insts.append(z3.Implies(w, bi) if qop == "forall" else z3.And(w, bi))
+            else:
+                insts.append(bi)
+        if not insts:
+            return z3.BoolVal(qop == "forall")
+        return z3.And(*insts) if qop == "forall" else z3.Or(*insts)
+
+    def not_(self, x):
+        return z3.Not(x)
+
+    def and_(self, x, y):
+        return z3.And(x, y)
+
+    def implies(self, x, y):
+        return z3.Implies(x, y)
+
+    def true_(self):
+        return z3.BoolVal(True)
+
+    def seq_eq(self, data1, len1, data2, len2, cap):
+        parts = [len1 == len2]
+        for i in range(cap):
+            parts.append(z3.Implies(i < len1, z3.Select(data1, i) == z3.Select(data2, i)))
+        return z3.And(*parts)
+
+    def and_all(self, parts):
+        return z3.And(*parts) if parts else z3.BoolVal(True)
+
+    def select(self, container, idx):
+        return z3.Select(container, idx)
+
+
+_SYM = _SymDomain()
 
 
 def _err(msg, kind="semantics", loc=None, expected=None, hint=None):
@@ -290,12 +358,6 @@ def _enum_phys_constraints(spec, state):
         cons.append(state[phys] <= hi)
     return cons
 
-
-def _is_enum_member(name, spec):
-    for info in spec["types"].values():
-        if info["kind"] == "enum" and name in info["members"]:
-            return info["members"].index(name)
-    return None
 
 
 def _type_of_expr(e, spec, ctx_ty=None):
@@ -573,107 +635,25 @@ def _ite_value(c, a, b, spec):
     _err("if arms must have the same type", kind="type")
 
 
-def _struct_info(val, spec):
-    if not isinstance(val, tuple):
-        return None, None
-    if val[0] == "struct_val":
-        return val[1], val[2]
-    if val[0] == "struct_map_val":
-        logical = val[1]
-        ty = spec["state"].get(logical)
-        if ty and ty[0] == "map" and ty[2][0] == "struct":
-            return ty[2][1], val[3]
-    return None, None
-
 
 def _seq_compare(a, b, op, spec):
-    if not (isinstance(a, tuple) and a[0] == "seq_val"
-            and isinstance(b, tuple) and b[0] == "seq_val"):
-        if isinstance(a, tuple) and a[0] == "seq_val":
-            _err("Seq comparison requires two Seq values", kind="type")
-        if isinstance(b, tuple) and b[0] == "seq_val":
-            _err("Seq comparison requires two Seq values", kind="type")
-        return None
-    data1, len1, _, cap1 = a[1], a[2], a[3], a[4]
-    data2, len2, _, cap2 = b[1], b[2], b[3], b[4]
-    if cap1 != cap2:
-        _err("Seq comparison between different capacities", kind="type")
-    parts = [len1 == len2]
-    for i in range(cap1):
-        parts.append(z3.Implies(i < len1, z3.Select(data1, i) == z3.Select(data2, i)))
-    res = z3.And(*parts)
-    return z3.Not(res) if op == "!=" else res
+    return seq_compare(a, b, op, spec, _SYM)
 
 
 def _struct_compare(a, b, op, spec):
-    sa, fa = _struct_info(a, spec)
-    sb, fb = _struct_info(b, spec)
-    if sa is None and sb is None:
-        return None
-    if sa is None or sb is None:
-        _err("struct comparison requires two struct values", kind="type")
-    if sa != sb:
-        _err(f"struct comparison between '{sa}' and '{sb}'", kind="type")
-    if set(fa) != set(fb):
-        _err(f"struct field mismatch in comparison of '{sa}'", kind="type")
-    fields = spec["types"][sa]["fields"]
-    parts = []
-    for k in fa:
-        fty = fields[k]
-        if fty[0] == "option":
-            parts.append(_option_logical_eq(fa[k], fb[k]))
-        else:
-            parts.append(fa[k] == fb[k])
-    res = z3.And(*parts) if parts else z3.BoolVal(True)
-    return z3.Not(res) if op == "!=" else res
+    return struct_compare(a, b, op, spec, _SYM)
 
 
 def _option_logical_eq(a, b):
-    if isinstance(a, tuple) and a[0] == "option_val":
-        if isinstance(b, tuple) and b[0] == "option_val":
-            return z3.And(a[1] == b[1], z3.Implies(a[1], a[2] == b[2]))
-        if isinstance(b, tuple) and b[0] == "none":
-            return z3.Not(a[1])
-    if isinstance(b, tuple) and b[0] == "option_val":
-        if isinstance(a, tuple) and a[0] == "none":
-            return z3.Not(b[1])
-    if isinstance(a, tuple) and a[0] == "none" and isinstance(b, tuple) and b[0] == "none":
-        return z3.BoolVal(True)
-    _err("struct Option field comparison requires Option values", kind="type")
+    return option_logical_eq(a, b, _SYM)
 
 
 def _option_none_cmp(a, b, op):
-    if isinstance(a, tuple) and a[0] == "option_val" and isinstance(b, tuple) and b[0] == "none":
-        present = a[1]
-        return z3.Not(present) if op == "==" else present
-    if isinstance(b, tuple) and b[0] == "option_val" and isinstance(a, tuple) and a[0] == "none":
-        present = b[1]
-        return z3.Not(present) if op == "==" else present
-    return None
-
-
-_OPTION_EQ_HINT = "use `x is some(v)` to compare the contained value"
-
-
-def _option_tag(v):
-    if isinstance(v, tuple) and v[0] in ("option_val", "none"):
-        return v[0]
-    return None
+    return option_none_cmp(a, b, op, _SYM)
 
 
 def _reject_option_binop(a, b, op):
-    ta, tb = _option_tag(a), _option_tag(b)
-    if ta is None and tb is None:
-        return
-    if op in ("==", "!="):
-        if ta == "none" and tb == "none":
-            return
-        _err(
-            "Option == and != are only defined against none",
-            kind="type",
-            hint=_OPTION_EQ_HINT,
-        )
-    _err(f"Option values cannot be used with '{op}'", kind="type")
+    return reject_option_binop(a, b, op)
 
 
 def _z3_div(a, b):
@@ -695,63 +675,16 @@ def _unify_option_cmp(a, b):
 
 
 def _logical_map_access(logical, idx, state, spec):
-    ty = spec["state"][logical]
-    if ty[0] != "map":
-        _err(f"'{logical}' is not a map")
-    kty, vty = ty[1], ty[2]
-    if vty[0] == "struct":
-        sname = vty[1]
-        fields = spec["types"][sname]["fields"]
-        return ("struct_map_val", logical, idx, {
-            fn: (
-                ("option_val",
-                 z3.Select(state[f"{logical}__{fn}__present"], idx),
-                 z3.Select(state[f"{logical}__{fn}__value"], idx))
-                if fty[0] == "option"
-                else z3.Select(state[f"{logical}__{fn}"], idx)
-            )
-            for fn, fty in fields.items()
-        })
-    if vty[0] == "option":
-        return ("option_val",
-                z3.Select(state[f"{logical}__present"], idx),
-                z3.Select(state[f"{logical}__value"], idx))
-    return z3.Select(state[logical], idx)
+    return logical_map_access(logical, idx, state, spec, _SYM)
 
 
 def _eval_index(base_e, idx, state, binds, spec, old_state, in_ensures):
-    if isinstance(base_e, str):
-        name = base_e
-    elif base_e[0] == "var":
-        name = base_e[1]
-    else:
-        _err("complex index base not supported")
-    if name in spec["state"]:
-        return _logical_map_access(name, idx, state, spec)
-    if name in state:
-        return z3.Select(state[name], idx)
-    _err(f"unknown map '{name}'")
+    return eval_index(base_e, idx, state, spec, _SYM)
 
 
 def _eval_field(base, field, state, binds, spec):
-    if isinstance(base, tuple) and base[0] == "struct_map_val":
-        logical, idx, fields = base[1], base[2], base[3]
-        if field not in fields:
-            _err(f"unknown field '{field}'")
-        return fields[field]
-    if isinstance(base, tuple) and base[0] == "struct_val":
-        _, sname, vals = base
-        if field not in vals:
-            _err(f"unknown field '{field}' in struct {sname}")
-        return vals[field]
-    _err(f"cannot access field '{field}' on this value")
+    return eval_field(base, field)
 
-
-def _struct_field_ty(spec, sname, field):
-    try:
-        return spec["types"][sname]["fields"][field]
-    except KeyError:
-        _err(f"unknown field '{field}' in struct {sname}")
 
 
 def _assign_option_to_phys(pend, state, present_phys, value_phys, val, none_ok=True):
@@ -804,11 +737,6 @@ def _set_elem_ty(base, state, spec):
                 return base, ty[1]
     return None
 
-
-def _seq_val_parts(base):
-    if isinstance(base, tuple) and base[0] == "seq_val":
-        return base[1], base[2], base[3], base[4]
-    return None
 
 
 def _eval_set_method(m, elem_ty, method, args, state, binds, spec, old_state, in_ensures):
@@ -906,92 +834,20 @@ def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures):
 
 
 def _eval_is(inner, pat, state, binds, spec, old_state, in_ensures):
-    val = eval_expr(inner, state, binds, spec, old_state, in_ensures)
-    if pat[0] == "pat_none":
-        if isinstance(val, tuple) and val[0] == "option_val":
-            return z3.Not(val[1])
-        _err("is none applied to non-Option value", kind="type")
-    if pat[0] == "pat_some":
-        vname = pat[1]
-        if isinstance(val, tuple) and val[0] == "option_val":
-            present, value = val[1], val[2]
-            binds[vname] = value
-            return present
-        _err("is some applied to non-Option value", kind="type")
-    _err("invalid pattern")
+    return eval_is(inner, pat, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
 
 def _eval_quant(e, state, binds, spec, old_state, in_ensures):
-    qop, binder, body = e[0], e[1], e[2]
-    v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
-    insts = []
-    for i in range(lo, hi + 1):
-        b2 = dict(binds)
-        b2[v] = i
-        if where is not None:
-            w = eval_expr(where, state, b2, spec, old_state, in_ensures)
-            if qop == "forall":
-                body_inst = eval_expr(body, state, b2, spec, old_state, in_ensures)
-                insts.append(z3.Implies(w, body_inst))
-            else:
-                body_inst = eval_expr(body, state, b2, spec, old_state, in_ensures)
-                insts.append(z3.And(w, body_inst))
-        else:
-            insts.append(eval_expr(body, state, b2, spec, old_state, in_ensures))
-    if not insts:
-        return z3.BoolVal(qop == "forall")
-    return z3.And(*insts) if qop == "forall" else z3.Or(*insts)
+    return eval_quant(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
 
 def _eval_count(e, state, binds, spec, old_state, in_ensures):
-    _, v, ty_name, cond = e
-    if ty_name not in spec["types"]:
-        _err(f"unknown type '{ty_name}' in count")
-    ty = spec["types"][ty_name]["ty"]
-    lo, hi = domain_range(ty, spec["types"])
-    terms = []
-    for i in range(lo, hi + 1):
-        b2 = {**binds, v: i}
-        c = eval_expr(cond, state, b2, spec, old_state, in_ensures)
-        terms.append(z3.If(c, z3.IntVal(1), z3.IntVal(0)))
-    acc = z3.IntVal(0)
-    for t in terms:
-        acc = acc + t
-    return acc
+    return eval_count(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
 
 def _eval_sum(e, state, binds, spec, old_state, in_ensures):
-    _, v, ty_name, body, cond = e
-    if ty_name not in spec["types"]:
-        _err(f"unknown type '{ty_name}' in sum")
-    ty = spec["types"][ty_name]["ty"]
-    lo, hi = domain_range(ty, spec["types"])
-    terms = []
-    for i in range(lo, hi + 1):
-        b2 = {**binds, v: i}
-        if cond is not None:
-            c = eval_expr(cond, state, b2, spec, old_state, in_ensures)
-            val = eval_expr(body, state, b2, spec, old_state, in_ensures)
-            terms.append(z3.If(c, val, z3.IntVal(0)))
-        else:
-            terms.append(eval_expr(body, state, b2, spec, old_state, in_ensures))
-    acc = z3.IntVal(0)
-    for t in terms:
-        acc = acc + t
-    return acc
+    return eval_sum(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
-
-def _lvalue_key(lv):
-    if lv[0] == "var":
-        return ("scalar", lv[1])
-    if lv[0] == "index":
-        return ("map", lv[1], lv[2])
-    if lv[0] == "field_lv":
-        base, field = lv[1], lv[2]
-        if base[0] == "index":
-            return ("map_field", base[1], base[2], field)
-        return ("field", base[1], field)
-    _err(f"invalid lvalue {lv}")
 
 
 def _apply_assign(lv, rhs, pend, state, binds, spec):
@@ -1375,13 +1231,6 @@ def transition(spec, instances, cur, nxt, choice, expr_cache=None):
     return z3.And(*clauses)
 
 
-def _enum_name(spec, ename, val):
-    members = spec["types"][ename]["members"]
-    i = int(val)
-    if 0 <= i < len(members):
-        return members[i]
-    return str(val)
-
 
 def _display_value(ty, val, spec):
     if ty[0] == "bool":
@@ -1442,12 +1291,6 @@ def _display_map_key(kty, value, spec):
         return str(_display_value(kty, value, spec))
     return str(value)
 
-
-def _display_state_keys(logical, spec):
-    dn = spec.get("display_names") or {}
-    if not dn:
-        return logical
-    return {dn.get(k, k): v for k, v in logical.items()}
 
 
 def logical_state_values(model, state, spec):

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -541,7 +541,7 @@ def exit_code(result):
     return 3
 
 
-def main(argv=None):
+def _build_arg_parser():
     from . import __version__
     ap = argparse.ArgumentParser(prog="fslc")
     ap.add_argument("-V", "--version", action="version",
@@ -606,8 +606,11 @@ def main(argv=None):
     ts.add_argument("--ts", action="store_true",
                     help="emit only the derivable entities' TypeScript to stdout instead of JSON")
 
-    args = ap.parse_args(argv)
+    return ap
 
+
+def _dispatch(args):
+    from . import __version__
     if args.cmd == "version":
         print(f"fslc {__version__}")
         return 0
@@ -661,6 +664,12 @@ def main(argv=None):
         print(json.dumps(result, indent=2, ensure_ascii=False))
 
     sys.exit(exit_code(result))
+
+
+def main(argv=None):
+    ap = _build_arg_parser()
+    args = ap.parse_args(argv)
+    return _dispatch(args)
 
 
 if __name__ == "__main__":

--- a/src/fslc/compose.py
+++ b/src/fslc/compose.py
@@ -431,18 +431,7 @@ def _expand_sync_action(sync, action_by_name, aliases, loc):
     return ("action", name, _rewrite_params(params, aliases), merged, loc, fair, sync_meta, True)
 
 
-def expand_compose(ast, base_dir):
-    """Expand compose AST to a single spec AST. Returns (spec_ast, display_names)."""
-    _, compose_name, items = ast
-    uses, internals, compose_rest = [], [], []
-    for it in items:
-        if it[0] == "use":
-            uses.append(it)
-        elif it[0] == "internal":
-            internals.append(it)
-        else:
-            compose_rest.append(it)
-
+def _resolve_components(uses, base_dir, display_names):
     aliases = {}
     for use in uses:
         _, spec_name, alias, path, loc = use
@@ -451,7 +440,6 @@ def expand_compose(ast, base_dir):
         aliases[alias] = (spec_name, path, loc)
 
     merged = []
-    display_names = {}
     all_actions = []
 
     for use in uses:
@@ -468,6 +456,10 @@ def expand_compose(ast, base_dir):
         merged.extend(prefixed)
         all_actions.extend([a for a in prefixed if a[0] == "action"])
 
+    return aliases, merged, all_actions
+
+
+def _merge_internal_actions(internals, aliases, all_actions):
     action_by_name = _action_lookup(all_actions)
     internal_phys = set()
     for internal in internals:
@@ -478,8 +470,10 @@ def expand_compose(ast, base_dir):
         if key not in action_by_name:
             _compose_err(f"unknown action '{alias}.{act_name}'", loc=loc)
         internal_phys.add(key)
+    return action_by_name, internal_phys
 
-    compose_aliases = set(aliases.keys())
+
+def _rewrite_compose_items(compose_rest, action_by_name, compose_aliases, merged, all_actions):
     empty_comp = set()
 
     for it in compose_rest:
@@ -522,6 +516,8 @@ def expand_compose(ast, base_dir):
                            _rewrite_expr(it[4], compose_aliases, empty_comp, set(), set()),
                            it[5], it[6] if len(it) > 6 else None))
 
+
+def _finalize_compose_merged(merged, internal_phys):
     final_actions = [a for a in merged if a[0] == "action" and a[1] not in internal_phys]
     non_actions = [a for a in merged if a[0] not in ("action", "init")]
     init_stmts = []
@@ -532,5 +528,26 @@ def expand_compose(ast, base_dir):
     if init_stmts:
         merged.append(("init", init_stmts))
     merged.extend(final_actions)
+    return merged
+
+
+def expand_compose(ast, base_dir):
+    """Expand compose AST to a single spec AST. Returns (spec_ast, display_names)."""
+    _, compose_name, items = ast
+    uses, internals, compose_rest = [], [], []
+    for it in items:
+        if it[0] == "use":
+            uses.append(it)
+        elif it[0] == "internal":
+            internals.append(it)
+        else:
+            compose_rest.append(it)
+
+    display_names = {}
+    aliases, merged, all_actions = _resolve_components(uses, base_dir, display_names)
+    action_by_name, internal_phys = _merge_internal_actions(internals, aliases, all_actions)
+    compose_aliases = set(aliases.keys())
+    _rewrite_compose_items(compose_rest, action_by_name, compose_aliases, merged, all_actions)
+    merged = _finalize_compose_merged(merged, internal_phys)
 
     return ("spec", compose_name, merged), display_names

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -721,9 +721,7 @@ def _collect_process(item, actors, cases):
     }
 
 
-def expand_business(ast):
-    """Expand business AST to a kernel spec AST."""
-    _, name, items = ast
+def _collect_business_entities(items):
     actors = set()
     cases = {}
     process_items = []
@@ -765,6 +763,10 @@ def expand_business(ast):
     for proc in processes:
         process_by_case.setdefault(proc["name"], []).append(proc)
 
+    return actors, cases, processes, kpis, policies, goals, process_by_case, process_by_name
+
+
+def _build_kpi_metadata(kpis, process_by_name):
     kpi_infos = []
     kpi_names = set()
     for item in kpis:
@@ -791,7 +793,10 @@ def expand_business(ast):
             "process": proc,
             "loc": loc,
         })
+    return kpi_infos
 
+
+def _generate_business_items(cases, processes, kpi_infos, policies, goals, process_by_case):
     out = []
     generated_names = []
     for case_name, data in cases.items():
@@ -880,4 +885,17 @@ def expand_business(ast):
 
     if generated_names:
         out.append(("__generated", generated_names))
+    return out
+
+
+def expand_business(ast):
+    """Expand business AST to a kernel spec AST."""
+    _, name, items = ast
+    _, cases, processes, kpis, policies, goals, process_by_case, process_by_name = (
+        _collect_business_entities(items)
+    )
+    kpi_infos = _build_kpi_metadata(kpis, process_by_name)
+    out = _generate_business_items(
+        cases, processes, kpi_infos, policies, goals, process_by_case,
+    )
     return ("spec", name, out)

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -13,6 +13,27 @@ from .model import FslError, binder_range, display_label, domain_range, eval_con
 from .parser import parse_src
 from .model import build_spec
 from .bmc import build_instances, compute_changes, _collect_partial_op_sites
+from .values import (
+    _display_state_keys,
+    _enum_name,
+    _is_enum_member,
+    _lvalue_key,
+    _seq_val_parts,
+    _struct_field_ty,
+    _struct_info,
+    eval_count,
+    eval_field,
+    eval_index,
+    eval_is,
+    eval_quant,
+    eval_sum,
+    logical_map_access,
+    option_logical_eq,
+    option_none_cmp,
+    reject_option_binop,
+    seq_compare,
+    struct_compare,
+)
 
 _INIT_HINT = "runtime monitor requires a deterministic init"
 _PARTIAL_OP_HINT = "guard the action with requires q.size() > 0 (or bound the index)"
@@ -65,20 +86,6 @@ class _EvalError(Exception):
 def _err(message, kind="semantics", loc=None, hint=None):
     raise FslError(message, kind=kind, loc=loc, hint=hint)
 
-
-def _is_enum_member(name, spec):
-    for info in spec["types"].values():
-        if info["kind"] == "enum" and name in info["members"]:
-            return info["members"].index(name)
-    return None
-
-
-def _enum_name(spec, ename, val):
-    members = spec["types"][ename]["members"]
-    i = int(val)
-    if 0 <= i < len(members):
-        return members[i]
-    return str(val)
 
 
 def _display_value(ty, val, spec):
@@ -550,68 +557,16 @@ def _read_logical(name, ty, state, spec):
 
 
 def _logical_map_access(logical, idx, state, spec):
-    ty = spec["state"][logical]
-    if ty[0] != "map":
-        _err(f"'{logical}' is not a map")
-    vty = ty[2]
-    if vty[0] == "struct":
-        sname = vty[1]
-        return ("struct_map_val", logical, idx, {
-            fn: (
-                ("option_val",
-                 state[f"{logical}__{fn}__present"][idx],
-                 state[f"{logical}__{fn}__value"][idx])
-                if fty[0] == "option"
-                else state[f"{logical}__{fn}"][idx]
-            )
-            for fn, fty in spec["types"][sname]["fields"].items()
-        })
-    if vty[0] == "option":
-        return (
-            "option_val",
-            state[f"{logical}__present"][idx],
-            state[f"{logical}__value"][idx],
-        )
-    return state[logical][idx]
+    return logical_map_access(logical, idx, state, spec, _CONC)
 
 
 def _eval_index(base_e, idx, state, spec):
-    if isinstance(base_e, str):
-        name = base_e
-    elif base_e[0] == "var":
-        name = base_e[1]
-    else:
-        _err("complex index base not supported")
-    if name in spec["state"]:
-        return _logical_map_access(name, idx, state, spec)
-    if name in state:
-        val = state[name]
-        if isinstance(val, dict):
-            return val[idx]
-        if isinstance(val, list):
-            return val[idx]
-        _err(f"cannot index '{name}'")
-    _err(f"unknown map '{name}'")
+    return eval_index(base_e, idx, state, spec, _CONC)
 
 
 def _eval_field(base, field, spec):
-    if isinstance(base, tuple) and base[0] == "struct_map_val":
-        fields = base[3]
-        if field not in fields:
-            _err(f"unknown field '{field}'")
-        return fields[field]
-    if isinstance(base, tuple) and base[0] == "struct_val":
-        _, sname, vals = base
-        if field not in vals:
-            _err(f"unknown field '{field}' in struct {sname}")
-        return vals[field]
-    _err(f"cannot access field '{field}' on this value")
+    return eval_field(base, field)
 
-
-def _seq_val_parts(base):
-    if isinstance(base, tuple) and base[0] == "seq_val":
-        return base[1], base[2], base[3], base[4]
-    return None
 
 
 def _set_elem_ty(base):
@@ -698,175 +653,88 @@ def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures, 
 
 
 def _eval_is(inner, pat, state, binds, spec, old_state, in_ensures):
-    val = eval_concrete(inner, state, binds, spec, old_state, in_ensures)
-    if pat[0] == "pat_none":
-        if isinstance(val, tuple) and val[0] == "option_val":
-            return not val[1]
-        if isinstance(val, tuple) and val[0] == "none":
+    return eval_is(inner, pat, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
+
+
+class _ConcDomain:
+    def int_lit(self, n):
+        return n
+
+    def select_int(self, cond, body_thunk):
+        return body_thunk() if _as_bool(cond) else 0
+
+    def quantify(self, qop, terms):
+        if qop == "forall":
+            for w, body_thunk in terms:
+                if w is not None and not _as_bool(w):
+                    continue
+                if not _as_bool(body_thunk()):
+                    return False
             return True
-        _err("is none applied to non-Option value", kind="type")
-    if pat[0] == "pat_some":
-        vname = pat[1]
-        if isinstance(val, tuple) and val[0] == "option_val":
-            present, value = val[1], val[2]
-            binds[vname] = value
-            return present
-        _err("is some applied to non-Option value", kind="type")
-    _err("invalid pattern")
+        for w, body_thunk in terms:
+            if w is not None and not _as_bool(w):
+                continue
+            if _as_bool(body_thunk()):
+                return True
+        return False
+
+    def not_(self, x):
+        return not x
+
+    def and_(self, x, y):
+        return x and y
+
+    def implies(self, x, y):
+        return (not x) or y
+
+    def true_(self):
+        return True
+
+    def seq_eq(self, data1, len1, data2, len2, cap):
+        return len1 == len2 and all(data1[i] == data2[i] for i in range(len1))
+
+    def and_all(self, parts):
+        return all(parts)
+
+    def select(self, container, idx):
+        return container[idx]
+
+
+_CONC = _ConcDomain()
 
 
 def _eval_quant(e, state, binds, spec, old_state, in_ensures):
-    qop, binder, body = e[0], e[1], e[2]
-    v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
-    if qop == "forall":
-        for i in range(lo, hi + 1):
-            b2 = dict(binds)
-            b2[v] = i
-            if where is not None:
-                w = eval_concrete(where, state, b2, spec, old_state, in_ensures)
-                if not _as_bool(w):
-                    continue
-            if not _as_bool(eval_concrete(body, state, b2, spec, old_state, in_ensures)):
-                return False
-        return True
-    for i in range(lo, hi + 1):
-        b2 = dict(binds)
-        b2[v] = i
-        if where is not None:
-            w = eval_concrete(where, state, b2, spec, old_state, in_ensures)
-            if not _as_bool(w):
-                continue
-        if _as_bool(eval_concrete(body, state, b2, spec, old_state, in_ensures)):
-            return True
-    return False
+    return eval_quant(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
 
 
 def _eval_count(e, state, binds, spec, old_state, in_ensures):
-    _, v, ty_name, cond = e
-    ty = spec["types"][ty_name]["ty"]
-    lo, hi = domain_range(ty, spec["types"])
-    total = 0
-    for i in range(lo, hi + 1):
-        b2 = {**binds, v: i}
-        if _as_bool(eval_concrete(cond, state, b2, spec, old_state, in_ensures)):
-            total += 1
-    return total
+    return eval_count(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
 
 
 def _eval_sum(e, state, binds, spec, old_state, in_ensures):
-    _, v, ty_name, body, cond = e
-    ty = spec["types"][ty_name]["ty"]
-    lo, hi = domain_range(ty, spec["types"])
-    total = 0
-    for i in range(lo, hi + 1):
-        b2 = {**binds, v: i}
-        if cond is not None:
-            if not _as_bool(eval_concrete(cond, state, b2, spec, old_state, in_ensures)):
-                continue
-        total += eval_concrete(body, state, b2, spec, old_state, in_ensures)
-    return total
+    return eval_sum(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
 
-
-def _struct_info(val, spec):
-    if not isinstance(val, tuple):
-        return None, None
-    if val[0] == "struct_val":
-        return val[1], val[2]
-    if val[0] == "struct_map_val":
-        logical = val[1]
-        ty = spec["state"].get(logical)
-        if ty and ty[0] == "map" and ty[2][0] == "struct":
-            return ty[2][1], val[3]
-    return None, None
 
 
 def _seq_compare(a, b, op, spec):
-    if not (isinstance(a, tuple) and a[0] == "seq_val" and isinstance(b, tuple) and b[0] == "seq_val"):
-        return None
-    _, data1, len1, _, cap1 = a
-    _, data2, len2, _, cap2 = b
-    if cap1 != cap2:
-        _err("Seq comparison between different capacities", kind="type")
-    eq = len1 == len2 and all(data1[i] == data2[i] for i in range(len1))
-    return (not eq) if op == "!=" else eq
+    return seq_compare(a, b, op, spec, _CONC)
 
 
 def _struct_compare(a, b, op, spec):
-    sa, fa = _struct_info(a, spec)
-    sb, fb = _struct_info(b, spec)
-    if sa is None and sb is None:
-        return None
-    if sa is None or sb is None:
-        _err("struct comparison requires two struct values", kind="type")
-    if sa != sb:
-        _err(f"struct comparison between '{sa}' and '{sb}'", kind="type")
-    fields = spec["types"][sa]["fields"]
-    eq = True
-    for k in set(fa) | set(fb):
-        if fields[k][0] == "option":
-            eq = eq and _option_logical_eq(fa.get(k), fb.get(k))
-        else:
-            eq = eq and fa.get(k) == fb.get(k)
-    return (not eq) if op == "!=" else eq
+    return struct_compare(a, b, op, spec, _CONC)
 
 
 def _option_logical_eq(a, b):
-    if isinstance(a, tuple) and a[0] == "option_val":
-        if isinstance(b, tuple) and b[0] == "option_val":
-            return a[1] == b[1] and (not a[1] or a[2] == b[2])
-        if isinstance(b, tuple) and b[0] == "none":
-            return not a[1]
-    if isinstance(b, tuple) and b[0] == "option_val":
-        if isinstance(a, tuple) and a[0] == "none":
-            return not b[1]
-    if isinstance(a, tuple) and a[0] == "none" and isinstance(b, tuple) and b[0] == "none":
-        return True
-    _err("struct Option field comparison requires Option values", kind="type")
+    return option_logical_eq(a, b, _CONC)
 
 
 def _option_none_cmp(a, b, op):
-    if isinstance(a, tuple) and a[0] == "option_val" and isinstance(b, tuple) and b[0] == "none":
-        present = a[1]
-        return (not present) if op == "==" else present
-    if isinstance(b, tuple) and b[0] == "option_val" and isinstance(a, tuple) and a[0] == "none":
-        present = b[1]
-        return (not present) if op == "==" else present
-    return None
+    return option_none_cmp(a, b, op, _CONC)
 
 
 def _reject_option_binop(a, b, op):
-    def tag(v):
-        if isinstance(v, tuple) and v[0] in ("option_val", "none"):
-            return v[0]
-        return None
-    ta, tb = tag(a), tag(b)
-    if ta is None and tb is None:
-        return
-    if op in ("==", "!=") and ta == "none" and tb == "none":
-        return
-    if op in ("==", "!="):
-        _err("Option == and != are only defined against none", kind="type")
-    _err(f"Option values cannot be used with '{op}'", kind="type")
+    return reject_option_binop(a, b, op)
 
-
-def _lvalue_key(lv):
-    if lv[0] == "var":
-        return ("scalar", lv[1])
-    if lv[0] == "index":
-        return ("map", lv[1], lv[2])
-    if lv[0] == "field_lv":
-        base, field = lv[1], lv[2]
-        if base[0] == "index":
-            return ("map_field", base[1], base[2], field)
-        return ("field", base[1], field)
-    _err(f"invalid lvalue {lv}")
-
-
-def _struct_field_ty(spec, sname, field):
-    try:
-        return spec["types"][sname]["fields"][field]
-    except KeyError:
-        _err(f"unknown field '{field}' in struct {sname}")
 
 
 def _assign_option_to_phys(pend, state, present_phys, value_phys, val):
@@ -1114,12 +982,6 @@ def _exec_init(spec):
         run(st, binds)
     return state
 
-
-def _display_state_keys(logical, spec):
-    dn = spec.get("display_names") or {}
-    if not dn:
-        return logical
-    return {dn.get(k, k): v for k, v in logical.items()}
 
 
 def phys_to_logical(state, spec):

--- a/src/fslc/values.py
+++ b/src/fslc/values.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Shared pure helpers for symbolic and concrete value handling."""
+from __future__ import annotations
+
+from .model import _err, binder_range, domain_range
+
+_OPTION_EQ_HINT = "use `x is some(v)` to compare the contained value"
+
+
+def _is_enum_member(name, spec):
+    for info in spec["types"].values():
+        if info["kind"] == "enum" and name in info["members"]:
+            return info["members"].index(name)
+    return None
+
+
+def _struct_info(val, spec):
+    if not isinstance(val, tuple):
+        return None, None
+    if val[0] == "struct_val":
+        return val[1], val[2]
+    if val[0] == "struct_map_val":
+        logical = val[1]
+        ty = spec["state"].get(logical)
+        if ty and ty[0] == "map" and ty[2][0] == "struct":
+            return ty[2][1], val[3]
+    return None, None
+
+
+def _struct_field_ty(spec, sname, field):
+    try:
+        return spec["types"][sname]["fields"][field]
+    except KeyError:
+        _err(f"unknown field '{field}' in struct {sname}")
+
+
+def _seq_val_parts(base):
+    if isinstance(base, tuple) and base[0] == "seq_val":
+        return base[1], base[2], base[3], base[4]
+    return None
+
+
+def _lvalue_key(lv):
+    if lv[0] == "var":
+        return ("scalar", lv[1])
+    if lv[0] == "index":
+        return ("map", lv[1], lv[2])
+    if lv[0] == "field_lv":
+        base, field = lv[1], lv[2]
+        if base[0] == "index":
+            return ("map_field", base[1], base[2], field)
+        return ("field", base[1], field)
+    _err(f"invalid lvalue {lv}")
+
+
+def _enum_name(spec, ename, val):
+    members = spec["types"][ename]["members"]
+    i = int(val)
+    if 0 <= i < len(members):
+        return members[i]
+    return str(val)
+
+
+def _display_state_keys(logical, spec):
+    dn = spec.get("display_names") or {}
+    if not dn:
+        return logical
+    return {dn.get(k, k): v for k, v in logical.items()}
+
+
+def eval_count(e, state, binds, spec, old_state, in_ensures, dom, ev):
+    _, v, ty_name, cond = e
+    if ty_name not in spec["types"]:
+        _err(f"unknown type '{ty_name}' in count")
+    ty = spec["types"][ty_name]["ty"]
+    lo, hi = domain_range(ty, spec["types"])
+    acc = dom.int_lit(0)
+    for i in range(lo, hi + 1):
+        b2 = {**binds, v: i}
+        c = ev(cond, state, b2, spec, old_state, in_ensures)
+        acc = acc + dom.select_int(c, lambda: dom.int_lit(1))
+    return acc
+
+
+def eval_sum(e, state, binds, spec, old_state, in_ensures, dom, ev):
+    _, v, ty_name, body, cond = e
+    if ty_name not in spec["types"]:
+        _err(f"unknown type '{ty_name}' in sum")
+    ty = spec["types"][ty_name]["ty"]
+    lo, hi = domain_range(ty, spec["types"])
+    acc = dom.int_lit(0)
+    for i in range(lo, hi + 1):
+        b2 = {**binds, v: i}
+        if cond is None:
+            acc = acc + ev(body, state, b2, spec, old_state, in_ensures)
+        else:
+            c = ev(cond, state, b2, spec, old_state, in_ensures)
+            acc = acc + dom.select_int(
+                c, lambda b2=b2: ev(body, state, b2, spec, old_state, in_ensures)
+            )
+    return acc
+
+
+def eval_quant(e, state, binds, spec, old_state, in_ensures, dom, ev):
+    qop, binder, body = e[0], e[1], e[2]
+    v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
+
+    def terms():
+        for i in range(lo, hi + 1):
+            b2 = dict(binds)
+            b2[v] = i
+            w = ev(where, state, b2, spec, old_state, in_ensures) if where is not None else None
+            yield w, (lambda b2=b2: ev(body, state, b2, spec, old_state, in_ensures))
+
+    return dom.quantify(qop, terms())
+
+
+def option_logical_eq(a, b, dom):
+    if isinstance(a, tuple) and a[0] == "option_val":
+        if isinstance(b, tuple) and b[0] == "option_val":
+            return dom.and_(a[1] == b[1], dom.implies(a[1], a[2] == b[2]))
+        if isinstance(b, tuple) and b[0] == "none":
+            return dom.not_(a[1])
+    if isinstance(b, tuple) and b[0] == "option_val":
+        if isinstance(a, tuple) and a[0] == "none":
+            return dom.not_(b[1])
+    if isinstance(a, tuple) and a[0] == "none" and isinstance(b, tuple) and b[0] == "none":
+        return dom.true_()
+    _err("struct Option field comparison requires Option values", kind="type")
+
+
+def option_none_cmp(a, b, op, dom):
+    if isinstance(a, tuple) and a[0] == "option_val" and isinstance(b, tuple) and b[0] == "none":
+        present = a[1]
+        return dom.not_(present) if op == "==" else present
+    if isinstance(b, tuple) and b[0] == "option_val" and isinstance(a, tuple) and a[0] == "none":
+        present = b[1]
+        return dom.not_(present) if op == "==" else present
+    return None
+
+
+def reject_option_binop(a, b, op):
+    def tag(v):
+        if isinstance(v, tuple) and v[0] in ("option_val", "none"):
+            return v[0]
+        return None
+    ta, tb = tag(a), tag(b)
+    if ta is None and tb is None:
+        return
+    if op in ("==", "!=") and ta == "none" and tb == "none":
+        return
+    if op in ("==", "!="):
+        _err("Option == and != are only defined against none", kind="type", hint=_OPTION_EQ_HINT)
+    _err(f"Option values cannot be used with '{op}'", kind="type")
+
+
+def seq_compare(a, b, op, spec, dom):
+    a_seq = isinstance(a, tuple) and a[0] == "seq_val"
+    b_seq = isinstance(b, tuple) and b[0] == "seq_val"
+    if not (a_seq and b_seq):
+        if a_seq or b_seq:
+            _err("Seq comparison requires two Seq values", kind="type")
+        return None
+    data1, len1, cap1 = a[1], a[2], a[4]
+    data2, len2, cap2 = b[1], b[2], b[4]
+    if cap1 != cap2:
+        _err("Seq comparison between different capacities", kind="type")
+    eq = dom.seq_eq(data1, len1, data2, len2, cap1)
+    return dom.not_(eq) if op == "!=" else eq
+
+
+def struct_compare(a, b, op, spec, dom):
+    sa, fa = _struct_info(a, spec)
+    sb, fb = _struct_info(b, spec)
+    if sa is None and sb is None:
+        return None
+    if sa is None or sb is None:
+        _err("struct comparison requires two struct values", kind="type")
+    if sa != sb:
+        _err(f"struct comparison between '{sa}' and '{sb}'", kind="type")
+    if set(fa) != set(fb):
+        _err(f"struct field mismatch in comparison of '{sa}'", kind="type")
+    fields = spec["types"][sa]["fields"]
+    parts = []
+    for k in fa:
+        if fields[k][0] == "option":
+            parts.append(option_logical_eq(fa[k], fb[k], dom))
+        else:
+            parts.append(fa[k] == fb[k])
+    eq = dom.and_all(parts)
+    return dom.not_(eq) if op == "!=" else eq
+
+
+def logical_map_access(logical, idx, state, spec, dom):
+    ty = spec["state"][logical]
+    if ty[0] != "map":
+        _err(f"'{logical}' is not a map")
+    vty = ty[2]
+    if vty[0] == "struct":
+        sname = vty[1]
+        return ("struct_map_val", logical, idx, {
+            fn: (
+                ("option_val",
+                 dom.select(state[f"{logical}__{fn}__present"], idx),
+                 dom.select(state[f"{logical}__{fn}__value"], idx))
+                if fty[0] == "option"
+                else dom.select(state[f"{logical}__{fn}"], idx)
+            )
+            for fn, fty in spec["types"][sname]["fields"].items()
+        })
+    if vty[0] == "option":
+        return ("option_val",
+                dom.select(state[f"{logical}__present"], idx),
+                dom.select(state[f"{logical}__value"], idx))
+    return dom.select(state[logical], idx)
+
+
+def eval_index(base_e, idx, state, spec, dom):
+    if isinstance(base_e, str):
+        name = base_e
+    elif base_e[0] == "var":
+        name = base_e[1]
+    else:
+        _err("complex index base not supported")
+    if name in spec["state"]:
+        return logical_map_access(name, idx, state, spec, dom)
+    if name in state:
+        return dom.select(state[name], idx)
+    _err(f"unknown map '{name}'")
+
+
+def eval_field(base, field):
+    if isinstance(base, tuple) and base[0] == "struct_map_val":
+        fields = base[3]
+        if field not in fields:
+            _err(f"unknown field '{field}'")
+        return fields[field]
+    if isinstance(base, tuple) and base[0] == "struct_val":
+        _, sname, vals = base
+        if field not in vals:
+            _err(f"unknown field '{field}' in struct {sname}")
+        return vals[field]
+    _err(f"cannot access field '{field}' on this value")
+
+
+def eval_is(inner, pat, state, binds, spec, old_state, in_ensures, dom, ev):
+    val = ev(inner, state, binds, spec, old_state, in_ensures)
+    if pat[0] == "pat_none":
+        if isinstance(val, tuple) and val[0] == "option_val":
+            return dom.not_(val[1])
+        if isinstance(val, tuple) and val[0] == "none":
+            return dom.true_()
+        _err("is none applied to non-Option value", kind="type")
+    if pat[0] == "pat_some":
+        vname = pat[1]
+        if isinstance(val, tuple) and val[0] == "option_val":
+            present, value = val[1], val[2]
+            binds[vname] = value
+            return present
+        _err("is some applied to non-Option value", kind="type")
+    _err("invalid pattern")

--- a/tests/oracle.py
+++ b/tests/oracle.py
@@ -9,6 +9,7 @@ with Monitor's concrete single-step semantics.  Bugs shared by the BMC and
 Monitor step semantics are not detectable by this oracle.
 """
 from __future__ import annotations
+import sys
 
 import copy
 import json
@@ -24,7 +25,7 @@ from fslc.runtime import Monitor, _as_bool, eval_concrete
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PYTHON = ROOT / ".venv" / "bin" / "python"
+PYTHON = sys.executable
 
 
 @dataclass(frozen=True)

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -1,0 +1,1518 @@
+{
+  "examples/consulting/asis_expense.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/consulting/tobe_expense.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/consulting/tobe_refines_asis.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/e2e/1_business.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/e2e/2_requirements.fsl": {
+    "check": {
+      "implements": "refines",
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/e2e/3_design.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/e2e/3_refines_2.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/gallery/adversarial/clever_double_assignment_placement.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/gallery/adversarial/deep_nested_if_invariant.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "last_action": "twist",
+      "name": "XNeverOne",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "invariant"
+    }
+  },
+  "examples/gallery/adversarial/option_struct_set_seq_combo.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "complete": true,
+        "enqueue": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_jobs",
+        "_bounds_active",
+        "_bounds_q",
+        "QueuedInActive",
+        "QueueRowsQueued",
+        "NoDuplicateQueue"
+      ],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/adversarial/quantifier_boundary_break.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "last_action": "clear_edge",
+      "name": "AllSeen",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "invariant"
+    }
+  },
+  "examples/gallery/adversarial/refine_mapping_boundary_abs.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/adversarial/refine_mapping_boundary_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/adversarial/refine_mapping_boundary_map.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/gallery/adversarial/seq_empty_head_boundary.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "read_empty",
+      "name": "_partial_read_empty",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "partial_op"
+    }
+  },
+  "examples/gallery/adversarial/seq_full_push_boundary.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "push_full",
+      "name": "_bounds_q",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "type_bound"
+    }
+  },
+  "examples/gallery/adversarial/simultaneous_leads_to_satisfaction.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "action_coverage": {
+        "reset": true,
+        "start_and_finish": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/errors/error_acceptance_false_expect.fsl": {
+    "check": {
+      "kind": "acceptance",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/forbidden_op_accepted.fsl": {
+    "check": {
+      "kind": "forbidden",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/parse_missing_expression.fsl": {
+    "check": {
+      "kind": "parse",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/refinement_failed_abs.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/errors/refinement_failed_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/errors/refinement_failed_map.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/semantics_duplicate_assignment.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/type_option_some_equality.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "kind": "type",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/type_struct_set_field.fsl": {
+    "check": {
+      "kind": "type",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/type_undeclared_type.fsl": {
+    "check": {
+      "kind": "type",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/vacuous_contradictory_init.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "kind": "vacuous",
+      "result": "error"
+    }
+  },
+  "examples/gallery/errors/vacuous_implication_warning.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "noop": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "NeverOne"
+      ],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "vacuous_implication"
+      ]
+    }
+  },
+  "examples/gallery/errors/violated_deadlock_terminal.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "stop",
+      "name": "deadlock",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "deadlock"
+    }
+  },
+  "examples/gallery/errors/violated_ensures_wrong_postcondition.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "inc",
+      "name": "inc",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "ensures"
+    }
+  },
+  "examples/gallery/errors/violated_invariant_counter.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "last_action": "inc",
+      "name": "StaysZero",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "invariant"
+    }
+  },
+  "examples/gallery/errors/violated_leads_to_starvation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": null,
+      "name": "EventuallyFinished",
+      "result": "violated",
+      "violated_at_step": null,
+      "violation_kind": "leadsTo"
+    }
+  },
+  "examples/gallery/errors/violated_partial_op_unchecked_pop.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "pop_empty",
+      "name": "_partial_pop_empty",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "partial_op"
+    }
+  },
+  "examples/gallery/errors/violated_type_bound_missing_guard.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "sell_without_stock",
+      "name": "_bounds_stock",
+      "result": "violated",
+      "violated_at_step": 1,
+      "violation_kind": "type_bound"
+    }
+  },
+  "examples/gallery/injected/bank__boundary_flip.fsl": {
+    "check": {
+      "kind": "acceptance",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/bank__fabricated_constraint.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/bank__guard_weakening.fsl": {
+    "check": {
+      "kind": "forbidden",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/bank__invariant_weakening.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/bank__omission.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/bank__over_strengthened_guard.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/bank__unreachable_antecedent.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/order_workflow__boundary_flip.fsl": {
+    "check": {
+      "kind": "acceptance",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/order_workflow__fabricated_constraint.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/order_workflow__guard_weakening.fsl": {
+    "check": {
+      "kind": "forbidden",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/order_workflow__invariant_weakening.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/order_workflow__omission.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/order_workflow__over_strengthened_guard.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/order_workflow__unreachable_antecedent.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/return_system__boundary_flip.fsl": {
+    "check": {
+      "kind": "acceptance",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/return_system__fabricated_constraint.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/return_system__guard_weakening.fsl": {
+    "check": {
+      "kind": "forbidden",
+      "result": "error"
+    }
+  },
+  "examples/gallery/injected/return_system__invariant_weakening.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/return_system__omission.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/injected/return_system__over_strengthened_guard.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/injected/return_system__unreachable_antecedent.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/large_order_workflow.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "approve": true,
+        "deliver": true,
+        "pack": true,
+        "pay": true,
+        "place": true,
+        "refund": true,
+        "request_return": true,
+        "ship": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_orders",
+        "_bounds_stock",
+        "PaidLedger",
+        "RefundLedger",
+        "BuyerKnownAfterPlace"
+      ],
+      "reachables": {
+        "RefundedOne": 8
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/medium_dining_philosophers_deadlock_demo.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "become_hungry": true,
+        "eat_and_release": true,
+        "take_left": true
+      },
+      "deadlock_found": true,
+      "invariants_checked": [
+        "_bounds_fork_owner",
+        "LeftFlagMatchesOwner"
+      ],
+      "reachables": {
+        "BothHoldLeft": 4
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/valid/medium_two_phase_commit.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "abort": true,
+        "apply": true,
+        "begin": true,
+        "commit": true,
+        "vote_no": true,
+        "vote_yes": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_phase",
+        "_bounds_vote",
+        "CommitRequiresYes",
+        "AppliedOnlyCommitted"
+      ],
+      "reachables": {
+        "AllApplied": 6
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/small_elevator.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "call": true,
+        "move_down": true,
+        "move_up": true,
+        "open": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_floor",
+        "_bounds_target",
+        "_bounds_door",
+        "OpenAtTarget"
+      ],
+      "reachables": {
+        "OpenAtTop": 4
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/small_forbidden_guarded_cancel.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "action_coverage": {
+        "cancel": true,
+        "pay": true,
+        "ship": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_order"
+      ],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/gallery/valid/small_tcp_handshake.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "close": true,
+        "recv_syn_ack": true,
+        "send_syn": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_client",
+        "_bounds_server",
+        "ClientServerAgree"
+      ],
+      "reachables": {
+        "ConnectedOnce": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/small_vending_machine.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "insert_coin": true,
+        "refund": true,
+        "select": true,
+        "vend": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_stock",
+        "_bounds_credit",
+        "_bounds_selected",
+        "SelectionHasStock"
+      ],
+      "reachables": {
+        "SoldItemZero": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/tiny_bounded_counter.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "dec": true,
+        "inc": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_n",
+        "NeverAboveCap"
+      ],
+      "reachables": {
+        "HitCap": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/tiny_traffic_light.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "tick": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_light",
+        "AlwaysAColor"
+      ],
+      "reachables": {
+        "SeenYellow": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/gallery/valid/tiny_turnstile.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "coin": true,
+        "push": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_entries",
+        "LockedOrOpen"
+      ],
+      "reachables": {
+        "OneEntry": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "examples/layers/return_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/layers/return_impl_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/layers/return_policy.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/layers/return_system.fsl": {
+    "check": {
+      "implements": "refines",
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/nfr/sla_worker.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/nfr/sla_worker_kernel.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/nfr/support_sla.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/pm/cancel_flow.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/pm/cancel_system.fsl": {
+    "check": {
+      "implements": "refines",
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/refinement_chain/bot.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_chain/bot_refines_mid.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/refinement_chain/mid.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_chain/mid_refines_top.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/refinement_chain/top.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_liveness/design_bypasses_control.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_liveness/design_bypasses_control_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/refinement_liveness/design_drops_liveness.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_liveness/design_drops_liveness_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/refinement_liveness/design_keeps_liveness.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/refinement_liveness/design_keeps_liveness_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/refinement_liveness/policy.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/self/fslc_monitor.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/self/fslc_session.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/self/no_actions.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/self/refinement_algebra.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/ui_spike/navstack.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/ui_spike/return_req_min.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/ui_spike/return_ui.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/ui_spike/ui_refines_req.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/validation/order_refund.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/validation/order_refund_instant.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/validation/order_refund_instant_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "examples/validation/order_refund_windowed.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/validation/order_refund_windowed_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "specs/audit_log.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "deposit": true
+      },
+      "deadlock_found": true,
+      "invariants_checked": [
+        "_bounds_log",
+        "BalanceNonNegative",
+        "EntriesPositive",
+        "BalanceMatchesLog"
+      ],
+      "reachables": {
+        "LogFull": 4
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/auth_lockout.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "admin_unlock": true,
+        "login_fail": true,
+        "login_ok": true,
+        "logout": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_accounts",
+        "LockedMeansMaxAttempts",
+        "NoSessionWhileLocked",
+        "MaxAttemptsMeansLocked"
+      ],
+      "reachables": {
+        "LockedOut": 3,
+        "RecoveredAfterLock": 5
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/bank.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "deposit": true,
+        "withdraw": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "NonNegative"
+      ],
+      "reachables": {
+        "Funded": 1
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/bank_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "settle": true,
+        "submit_deposit": true,
+        "withdraw_cleared": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "ClearedNonNegative",
+        "PendingNonNegative"
+      ],
+      "reachables": {
+        "Settled": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/bank_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "specs/bank_system.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "bank.settle": true,
+        "deposit_audited": true,
+        "withdraw_audited": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_audit.log",
+        "bank.ClearedNonNegative",
+        "bank.PendingNonNegative",
+        "audit.BalanceNonNegative",
+        "audit.EntriesPositive",
+        "audit.BalanceMatchesLog",
+        "AuditAccountsForEverything",
+        "WithdrawnNonNegative"
+      ],
+      "reachables": {
+        "FullCycle": 4,
+        "audit.LogFull": 4,
+        "bank.Settled": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/cart_buggy.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none",
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "checkout",
+      "name": "NoNegativeStock",
+      "result": "violated",
+      "violated_at_step": 4,
+      "violation_kind": "invariant"
+    }
+  },
+  "specs/cart_fixed.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none",
+        "none"
+      ]
+    },
+    "verify": {
+      "action_coverage": {
+        "add_to_cart": true,
+        "checkout": true,
+        "remove_from_cart": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "NoNegativeStock"
+      ],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none",
+        "none"
+      ]
+    }
+  },
+  "specs/cart_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "action_coverage": {
+        "add_to_cart": true,
+        "impl_checkout": true,
+        "remove_from_cart": true,
+        "reserve": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_impl_stock",
+        "_bounds_reserved",
+        "_bounds_impl_cart"
+      ],
+      "reachables": {},
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/cart_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  },
+  "specs/cart_v1.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "action_coverage": {
+        "add_to_cart": true,
+        "checkout": true,
+        "remove_from_cart": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_stock",
+        "_bounds_cart"
+      ],
+      "reachables": {
+        "SoldOut": 4
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/cart_v1_buggy.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    },
+    "verify": {
+      "last_action": "checkout",
+      "name": "_bounds_stock",
+      "result": "violated",
+      "violated_at_step": 4,
+      "violation_kind": "type_bound"
+    }
+  },
+  "specs/inventory_reservation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "confirm": true,
+        "hold": true,
+        "release": true
+      },
+      "deadlock_found": true,
+      "invariants_checked": [
+        "_bounds_available",
+        "_bounds_res",
+        "FreeIsZero",
+        "FreeHasNoItem",
+        "HeldHasItem",
+        "Conservation"
+      ],
+      "reachables": {
+        "AllHeld": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/job_pipeline.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "finish_fail": true,
+        "finish_ok": true,
+        "finish_retry": true,
+        "start": true,
+        "submit": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_jobs",
+        "_bounds_queue",
+        "_bounds_running",
+        "QueuedAreQueued",
+        "RunningMatches",
+        "NoDupQueue"
+      ],
+      "reachables": {
+        "RetriedThenFailed": 5,
+        "SomeDone": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/mutex_queue.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "acquire_free": true,
+        "enqueue": true,
+        "release_handoff": true,
+        "release_idle": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_holder",
+        "_bounds_waiters",
+        "HolderNotWaiting",
+        "WaitersImplyHolder",
+        "NoDuplicateWaiters"
+      ],
+      "reachables": {
+        "FullQueue": 3,
+        "HandoffHappened": 1
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/order_system.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "result": "reachable_failed",
+      "unreachable": []
+    }
+  },
+  "specs/order_workflow.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "cancel": true,
+        "pay": true,
+        "place": true,
+        "ship": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_orders",
+        "_bounds_shipped",
+        "ShippedWasPaid",
+        "RevenueConsistent",
+        "NonNegativeRevenue"
+      ],
+      "reachables": {
+        "FullLifecycle": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/payment.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "authorize": true,
+        "capture": true,
+        "refund": true,
+        "void": true
+      },
+      "deadlock_found": true,
+      "invariants_checked": [
+        "_bounds_payments",
+        "RefundWithinAmount",
+        "LedgerMatches",
+        "LedgerNonNegative",
+        "RefundedOnlyWhenCaptured"
+      ],
+      "reachables": {
+        "FullyRefunded": 3
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/rate_limiter.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "request_ok": true,
+        "request_rejected": true,
+        "tick": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_tokens",
+        "Counters"
+      ],
+      "reachables": {
+        "Exhausted": 4
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/repair_loop.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "check_fail": true,
+        "check_pass": true,
+        "induction_cti": true,
+        "induction_proved": true,
+        "repair": true,
+        "verify_ok": true,
+        "verify_reachfail": true,
+        "verify_violated": true
+      },
+      "deadlock_found": true,
+      "invariants_checked": [
+        "_bounds_status",
+        "_bounds_edits",
+        "ProvedWasVerified",
+        "VerifiedImpliesEver"
+      ],
+      "reachables": {
+        "ReachProved": 3,
+        "RepairedThenProved": 5
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "specs/seat_booking.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "book": true,
+        "cancel": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_seats",
+        "PerUserCap"
+      ],
+      "reachables": {
+        "TwoSoldToOne": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/seat_booking_impl.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    },
+    "verify": {
+      "action_coverage": {
+        "cancel_sold": true,
+        "confirm": true,
+        "hold": true,
+        "release": true
+      },
+      "deadlock_found": false,
+      "invariants_checked": [
+        "_bounds_slots",
+        "OpenHasNoHolder",
+        "NonOpenHasHolder",
+        "SoldPerUserCap"
+      ],
+      "reachables": {
+        "Sold": 2
+      },
+      "result": "verified",
+      "transitions_checked": [],
+      "warnings": []
+    }
+  },
+  "specs/seat_refines.fsl": {
+    "check": {
+      "kind": "semantics",
+      "result": "error"
+    }
+  }
+}

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,4 +1,5 @@
 """FSL v2.0 spec compose tests (DESIGN-compose.md §5)."""
+import sys
 import json
 import subprocess
 from pathlib import Path
@@ -11,7 +12,7 @@ from fslc.parser import parse_src
 
 ROOT = Path(__file__).resolve().parent.parent
 SPECS = ROOT / "specs"
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def _load_order_system():

--- a/tests/test_corpus_snapshot.py
+++ b/tests/test_corpus_snapshot.py
@@ -1,0 +1,207 @@
+"""Corpus differential snapshot — a behavior-preservation safety net for refactors.
+
+This test pins the *verdict-level* output of ``fslc check`` / ``fslc verify``
+across the whole ``.fsl`` corpus to a golden JSON file.  Any behavior-changing
+refactor of the evaluator surfaces immediately as a snapshot diff.
+
+We deliberately snapshot only the **stable verdict tier** (result, violation
+kind/step, declaration name, invariant/transition counts, reachable
+pass/fail, action coverage, warning kinds) and NOT the concrete counterexample
+trace: which specific witness Z3 returns can depend on constraint ordering, so
+a behavior-preserving refactor that reorders constraints could perturb the
+trace without changing semantics.  Fine-grained state semantics are pinned
+separately by ``test_evaluator_agreement.py`` (bmc vs Monitor, step by step).
+
+Regenerate after an *intended* behavior change with::
+
+    FSLC_SNAPSHOT_UPDATE=1 .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+
+import pytest
+
+from fslc.cli import run_check, run_verify
+from fslc.model import FslError
+
+ROOT = Path(__file__).resolve().parents[1]
+SPECS = ROOT / "specs"
+EXAMPLES = ROOT / "examples"
+GALLERY = EXAMPLES / "gallery"
+SNAPSHOT = Path(__file__).resolve().parent / "snapshots" / "corpus_snapshot.json"
+
+UPDATE = os.environ.get("FSLC_SNAPSHOT_UPDATE") == "1"
+
+
+# --------------------------------------------------------------------------
+# corpus enumeration
+# --------------------------------------------------------------------------
+def _all_specs() -> list[Path]:
+    return sorted({*SPECS.glob("*.fsl"), *EXAMPLES.rglob("*.fsl")})
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def _declared_verify(path: Path) -> tuple[int, str] | None:
+    """Return (depth, deadlock) if the file declares a `verify` command."""
+    command = None
+    for line in path.read_text(encoding="utf-8").splitlines()[:16]:
+        stripped = line.strip()
+        if stripped.startswith("// expected-command:"):
+            command = stripped.split(":", 1)[1].strip()
+    if not command:
+        return None
+    parts = shlex.split(command)
+    if not parts or parts[0] != "verify":
+        return None
+    depth, deadlock = 4, "warn"
+    for i, part in enumerate(parts):
+        if part == "--depth":
+            depth = int(parts[i + 1])
+        elif part == "--deadlock":
+            deadlock = parts[i + 1]
+    return depth, deadlock
+
+
+def _verify_plan(path: Path) -> tuple[int, str] | None:
+    """(depth, deadlock) to verify this spec under, or None to skip verify."""
+    if path.parent == SPECS:
+        if "refines" in path.stem:
+            return None
+        return 5, "warn"
+    if path.parent in (GALLERY / "valid", GALLERY / "errors", GALLERY / "adversarial"):
+        return _declared_verify(path)
+    return None
+
+
+# --------------------------------------------------------------------------
+# stable verdict projection
+# --------------------------------------------------------------------------
+def _warn_kinds(out: dict) -> list[str]:
+    return sorted((w.get("kind") or "none") for w in out.get("warnings", []))
+
+
+def _project_check(out: dict) -> dict:
+    proj = {"result": out.get("result")}
+    if out.get("result") == "ok":
+        proj["warnings"] = _warn_kinds(out)
+    else:
+        proj["kind"] = out.get("kind")
+    if "implements" in out:
+        impl = out["implements"]
+        proj["implements"] = impl.get("result") if isinstance(impl, dict) else impl
+    return proj
+
+
+def _project_verify(out: dict) -> dict:
+    res = out.get("result")
+    proj: dict = {"result": res}
+    if res in ("verified", "proved"):
+        proj["invariants_checked"] = out.get("invariants_checked")
+        proj["transitions_checked"] = out.get("transitions_checked")
+        dl = out.get("deadlock")
+        proj["deadlock_found"] = bool(dl.get("found")) if isinstance(dl, dict) else None
+        reach = out.get("reachables") or {}
+        proj["reachables"] = {
+            name: (info.get("witnessed_at_step") if isinstance(info, dict) else info)
+            for name, info in sorted(reach.items())
+        }
+        cov = out.get("action_coverage") or {}
+        proj["action_coverage"] = {k: cov[k] for k in sorted(cov)}
+        proj["warnings"] = _warn_kinds(out)
+    elif res == "violated":
+        proj["violation_kind"] = out.get("violation_kind")
+        proj["violated_at_step"] = out.get("violated_at_step")
+        proj["name"] = (
+            out.get("invariant")
+            or out.get("leadsTo")
+            or out.get("trans")
+            or out.get("name")
+        )
+        la = out.get("last_action")
+        proj["last_action"] = la.get("name") if isinstance(la, dict) else la
+    elif res == "reachable_failed":
+        reach = out.get("reachables") or {}
+        proj["unreachable"] = sorted(
+            name
+            for name, info in reach.items()
+            if isinstance(info, dict) and not info.get("witnessed_at_step")
+        )
+    else:  # error / unknown
+        proj["kind"] = out.get("kind")
+    return proj
+
+
+def _live_snapshot() -> dict:
+    snap: dict = {}
+    for path in _all_specs():
+        rid = _rel(path)
+        entry: dict = {}
+        try:
+            entry["check"] = _project_check(run_check(str(path)))
+        except FslError as exc:
+            entry["check"] = {"result": "error", "kind": exc.kind}
+        plan = _verify_plan(path)
+        if plan is not None and entry["check"].get("result") == "ok":
+            depth, deadlock = plan
+            try:
+                entry["verify"] = _project_verify(
+                    run_verify(str(path), depth, deadlock_mode=deadlock)
+                )
+            except FslError as exc:
+                entry["verify"] = {"result": "error", "kind": exc.kind}
+        snap[rid] = entry
+    return snap
+
+
+_SNAPSHOT_CACHE: dict | None = None
+
+
+def live_snapshot() -> dict:
+    global _SNAPSHOT_CACHE
+    if _SNAPSHOT_CACHE is None:
+        _SNAPSHOT_CACHE = _live_snapshot()
+    return _SNAPSHOT_CACHE
+
+
+def _golden() -> dict:
+    if not SNAPSHOT.exists():
+        return {}
+    return json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# update mode + comparison
+# --------------------------------------------------------------------------
+@pytest.mark.skipif(not UPDATE, reason="set FSLC_SNAPSHOT_UPDATE=1 to regenerate")
+def test_regenerate_snapshot():
+    SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT.write_text(
+        json.dumps(live_snapshot(), indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.skipif(UPDATE, reason="regenerating snapshot")
+def test_snapshot_has_no_missing_or_extra_specs():
+    golden = _golden()
+    assert golden, "snapshot missing — run with FSLC_SNAPSHOT_UPDATE=1 first"
+    live = live_snapshot()
+    assert set(live) == set(golden), {
+        "added": sorted(set(live) - set(golden)),
+        "removed": sorted(set(golden) - set(live)),
+    }
+
+
+@pytest.mark.skipif(UPDATE, reason="regenerating snapshot")
+@pytest.mark.parametrize("rid", sorted(_golden().keys()) or [pytest.param("__missing__", marks=pytest.mark.skip)])
+def test_corpus_verdict_matches_snapshot(rid):
+    expected = _golden()[rid]
+    actual = live_snapshot().get(rid)
+    assert actual == expected, {"spec": rid, "expected": expected, "actual": actual}

--- a/tests/test_e2e_example.py
+++ b/tests/test_e2e_example.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from fslc.cli import run_refine, run_scenarios, run_verify
@@ -118,8 +119,9 @@ def test_e2e_readme_commands_and_break_demo_are_current():
     ]
     assert "10 passed" in command_results[-1].stdout
 
-    broken_design = Path("/private/tmp/3_design_shortcut_test.fsl")
-    broken_mapping = Path("/private/tmp/3_refines_shortcut_test.fsl")
+    _tmp = Path(tempfile.gettempdir())
+    broken_design = _tmp / "3_design_shortcut_test.fsl"
+    broken_mapping = _tmp / "3_refines_shortcut_test.fsl"
     broken_design.write_text((E2E / "3_design.fsl").read_text(encoding="utf-8"), encoding="utf-8")
     broken_mapping.write_text((E2E / "3_refines_2.fsl").read_text(encoding="utf-8"), encoding="utf-8")
     design_src = broken_design.read_text(encoding="utf-8")

--- a/tests/test_evaluator_agreement.py
+++ b/tests/test_evaluator_agreement.py
@@ -1,0 +1,172 @@
+"""Step-level evaluator agreement — the core safety net for unifying the two
+expression evaluators.
+
+``bmc.py`` evaluates FSL expressions symbolically (into z3 terms) and
+``runtime.py`` evaluates the *same* expressions concretely (into Python
+values).  These two implementations must agree on FSL semantics — otherwise the
+verifier and the replay Monitor can disagree about the same spec.  The planned
+refactor unifies the structurally-parallel ``_eval_*`` helpers behind a single
+core; this test pins the invariant that unification must preserve.
+
+Method (expression-level differential):
+
+1. Enumerate reachable concrete states with the trusted concrete oracle
+   (``Monitor`` BFS — same machinery as ``tests/oracle.py``).
+2. Both evaluators consume the *same* physical-state layout: the concrete
+   ``Monitor._phys`` (dicts/lists/scalars) and the symbolic ``make_state``
+   (z3 Arrays/scalars) share identical phys keys and value encodings.
+3. For each reachable state we *pin* every symbolic phys variable to its
+   concrete value in a z3 solver, then evaluate each invariant / reachable
+   predicate with ``bmc.eval_expr`` inside that model and compare the result to
+   ``runtime.eval_concrete`` on the concrete state.
+
+The pinning is self-validating: an inconsistent pin makes the solver ``unsat``
+and the test fails loudly rather than silently passing.
+"""
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import z3
+
+from fslc import bmc
+from fslc.runtime import Monitor, eval_concrete
+
+from oracle import ROOT, action_key, can_monitor, normalize
+
+SPECS = ROOT / "specs"
+
+# Bound the per-spec exploration so the suite stays in the fast-loop budget.
+MAX_DEPTH = 4
+MAX_STATES = 80
+
+
+def _spec_paths() -> list[Path]:
+    return sorted(SPECS.glob("*.fsl"))
+
+
+def _lit(value):
+    # bool is a subclass of int — test bool first.
+    if isinstance(value, bool):
+        return z3.BoolVal(value)
+    if isinstance(value, int):
+        return z3.IntVal(value)
+    raise _Skip(f"non-scalar phys leaf: {value!r}")
+
+
+class _Skip(Exception):
+    pass
+
+
+def _reachable_phys_states(path: Path) -> list[dict]:
+    """BFS the concrete state space, returning a capped list of phys snapshots."""
+    mon0 = Monitor(path)
+    mon0.reset()
+    states = [copy.deepcopy(mon0._phys)]  # noqa: SLF001
+    visited = {normalize(mon0.state)}
+    frontier = [(mon0, 0)]
+    while frontier and len(states) < MAX_STATES:
+        mon, d = frontier.pop()
+        if d >= MAX_DEPTH:
+            continue
+        for act in sorted(mon.enabled(), key=action_key):
+            child = copy.deepcopy(mon)
+            result = child.step(act["action"], act.get("params", {}))
+            if not result.get("ok"):
+                continue
+            key = normalize(child.state)
+            if key in visited:
+                continue
+            visited.add(key)
+            states.append(copy.deepcopy(child._phys))  # noqa: SLF001
+            frontier.append((child, d + 1))
+            if len(states) >= MAX_STATES:
+                break
+    return states
+
+
+def _pin_state(solver: z3.Solver, st: dict, phys: dict) -> None:
+    for name, zv in st.items():
+        cv = phys[name]
+        if z3.is_array(zv):
+            items = cv.items() if isinstance(cv, dict) else enumerate(cv)
+            for k, v in items:
+                solver.add(z3.Select(zv, z3.IntVal(int(k))) == _lit(v))
+        else:
+            solver.add(zv == _lit(cv))
+
+
+def _to_py(zval):
+    if z3.is_bool(zval):
+        if z3.is_true(zval):
+            return True
+        if z3.is_false(zval):
+            return False
+        return None
+    if z3.is_int_value(zval):
+        return zval.as_long()
+    return None
+
+
+def _exprs(spec) -> list[tuple[str, dict]]:
+    out = []
+    for inv in spec.get("invariants", []):
+        out.append((f"invariant {inv['name']}", inv["expr"]))
+    for reach in spec.get("reachables", []):
+        out.append((f"reachable {reach['name']}", reach["expr"]))
+    return out
+
+
+@pytest.mark.parametrize("path", _spec_paths(), ids=lambda p: p.name)
+def test_symbolic_and_concrete_eval_agree(path: Path):
+    ok, reason = can_monitor(path)
+    if not ok:
+        pytest.skip(f"not monitorable: {reason}")
+
+    mon = Monitor(path)
+    mon.reset()
+    spec = mon.spec
+    exprs = _exprs(spec)
+    if not exprs:
+        pytest.skip("no invariant/reachable expressions to compare")
+
+    states = _reachable_phys_states(path)
+    compared = 0
+    for phys in states:
+        st = bmc.make_state(spec, 0)
+        solver = z3.Solver()
+        try:
+            _pin_state(solver, st, phys)
+        except _Skip as exc:
+            pytest.skip(str(exc))
+        # An inconsistent pin would silently invalidate the comparison.
+        assert solver.check() == z3.sat, f"pin became unsat for {path.name}"
+        model = solver.model()
+
+        for label, expr in exprs:
+            try:
+                concrete = eval_concrete(expr, phys, {}, spec)
+            except Exception:  # noqa: BLE001 — partial op / non-total on this state
+                continue
+            if not isinstance(concrete, (bool, int)):
+                continue
+            with bmc._eval_cache_scope({}, id(st)):  # noqa: SLF001
+                try:
+                    sym = bmc.eval_expr(expr, st, {}, spec)
+                except Exception:  # noqa: BLE001 — keep symbolic/concrete skips symmetric
+                    continue
+            if not (z3.is_bool(sym) or z3.is_int(sym)):
+                continue
+            got = _to_py(model.eval(sym, model_completion=True))
+            assert got == bool(concrete) if isinstance(concrete, bool) else got == concrete, {
+                "spec": path.name,
+                "expr": label,
+                "state": phys,
+                "concrete": concrete,
+                "symbolic": got,
+            }
+            compared += 1
+
+    assert compared > 0, f"no comparable (state, expr) pairs for {path.name}"

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sys
 
 import json
 import shlex
@@ -94,12 +95,12 @@ def _argv(case: GalleryCase) -> list[str]:
     path = GALLERY / case.path
     parts = shlex.split(case.command)
     if parts[0] == "check":
-        return [str(ROOT / ".venv" / "bin" / "python"), "-m", "fslc", "check", str(path), *parts[1:]]
+        return [sys.executable, "-m", "fslc", "check", str(path), *parts[1:]]
     if parts[0] == "verify":
-        return [str(ROOT / ".venv" / "bin" / "python"), "-m", "fslc", "verify", str(path), *parts[1:]]
+        return [sys.executable, "-m", "fslc", "verify", str(path), *parts[1:]]
     if parts[0] == "refine":
         return [
-            str(ROOT / ".venv" / "bin" / "python"),
+            sys.executable,
             "-m",
             "fslc",
             "refine",

--- a/tests/test_induction.py
+++ b/tests/test_induction.py
@@ -1,4 +1,5 @@
 """k-induction engine tests (DESIGN-induction.md §6)."""
+import sys
 import json
 import subprocess
 from pathlib import Path
@@ -9,7 +10,7 @@ from fslc import parse, build_spec, prove, verify
 
 SPECS = Path(__file__).resolve().parent.parent / "specs"
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 CTI_HINT = (
     "this state sequence satisfies all invariants but leads to a violation; "
     "the start state may be unreachable — add an auxiliary invariant that excludes it, "

--- a/tests/test_injection_bench.py
+++ b/tests/test_injection_bench.py
@@ -11,7 +11,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 INJECTED = ROOT / "examples" / "gallery" / "injected"
 MATRIX_PATH = INJECTED / "MATRIX.json"
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 DEPTH = "4"
 MUTATE_DEPTH = "2"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,4 +1,5 @@
 """FSL v2.0 runtime monitor, replay, and testgen tests (DESIGN-bridge §6)."""
+import sys
 import ast
 import copy
 import json
@@ -14,7 +15,7 @@ from fslc.testgen import generate_test_file
 
 ROOT = Path(__file__).resolve().parent.parent
 SPECS = ROOT / "specs"
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 SAMPLE_SPECS = [
     "cart_v1.fsl",

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,4 +1,5 @@
 """FSL v1.1: scenarios generation and coverage diagnosis."""
+import sys
 import copy
 import json
 import subprocess
@@ -10,7 +11,7 @@ from fslc import parse, build_spec, verify, scenarios
 
 SPECS = Path(__file__).resolve().parent.parent / "specs"
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def run_scenarios(name, depth=8, **kwargs):

--- a/tests/test_self_conformance.py
+++ b/tests/test_self_conformance.py
@@ -1,5 +1,6 @@
 """Implementation-conformance anchors: check that the fslc_session / fslc_monitor models match the real CLI behavior."""
 from __future__ import annotations
+import sys
 
 import json
 import os
@@ -17,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SESSION_SPEC = ROOT / "examples/self/fslc_session.fsl"
 MONITOR_SPEC = ROOT / "examples/self/fslc_monitor.fsl"
 CART_SPEC = ROOT / "specs/cart_v1.fsl"
-PY = ROOT / ".venv/bin/python"
+PY = sys.executable
 
 USER_ERROR_KINDS = frozenset({"parse", "semantics", "io", "usage", "type"})
 

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -1,4 +1,5 @@
 """FSL v1.1 Seq<T, N> tests (DESIGN-seq.md §8)."""
+import sys
 import json
 import subprocess
 from pathlib import Path
@@ -9,7 +10,7 @@ from fslc import parse, build_spec, verify, prove, scenarios, FslError
 from fslc.cli import run_check
 
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 SPECS = ROOT / "specs"
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,4 +1,5 @@
 """FSL v2.0-lite temporal: leadsTo and fair (DESIGN-temporal.md §6)."""
+import sys
 import ast
 import subprocess
 import tempfile
@@ -9,7 +10,7 @@ from fslc.cli import run_testgen
 
 SPECS = Path(__file__).resolve().parent.parent / "specs"
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def run_inline(src, depth=8, **kwargs):

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -11,7 +11,7 @@ from fslc.cli import run_check, run_verify, exit_code
 
 SPECS = Path(__file__).resolve().parent.parent / "specs"
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def run(name, depth=8, **kwargs):

--- a/tests/test_vacuity.py
+++ b/tests/test_vacuity.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sys
 
 import json
 import subprocess
@@ -10,7 +11,7 @@ from fslc.cli import run_verify
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def _spec(src: str):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import fslc
 
 ROOT = Path(__file__).resolve().parent.parent
-PY = ROOT / ".venv" / "bin" / "python"
+PY = sys.executable
 
 
 def _run(*args):


### PR DESCRIPTION
## Summary

`bmc.py` (the symbolic / z3 evaluator behind `verify`) and `runtime.py` (the concrete evaluator behind the replay `Monitor`) independently re-implemented the **same FSL expression semantics** — ~39 functions duplicated by name. This is a correctness *drift hazard*: the verifier and the Monitor could silently disagree about the same spec.

This PR unifies the semantically-clean evaluator functions into a single shared core (`src/fslc/values.py`) parameterized by a per-evaluator **domain** object, behind a new behavior-preservation safety net, then splits three over-long functions. The refactor is verdict-level **behavior-preserving**: the corpus snapshot is byte-identical before and after.

## Changes

**Safety net (new tests)**
- `tests/test_corpus_snapshot.py` — freezes verdict-level `check`/`verify` output across all 123 `.fsl` specs to a golden JSON (`tests/snapshots/corpus_snapshot.json`; regenerate with `FSLC_SNAPSHOT_UPDATE=1`).
- `tests/test_evaluator_agreement.py` — pins that the symbolic (bmc) and concrete (runtime) evaluators agree on invariant/reachable expressions over reachable states, by pinning bmc's z3 phys vars to concrete-oracle states and evaluating in the resulting model.

**Evaluator unification (`src/fslc/values.py`, `bmc.py`, `runtime.py`)**
- New shared core in `values.py`, called by both evaluators with their own domain (`bmc._SymDomain` / `runtime._ConcDomain`) + recursive eval callback.
- Unified: `count`, `sum`, `quant`, `option_logical_eq`/`option_none_cmp`/`reject_option_binop`, `seq_compare`, `struct_compare`, `eval_is`, `eval_field`, `eval_index`, `logical_map_access`, plus 7 pure helpers.
- The domain encapsulates the genuine differences: z3 vs python leaf ops, **lazy/short-circuit vs eager** boolean folds (load-bearing for partial-op avoidance), and array select.
- Net effect: ~619 lines of duplicated bodies in bmc/runtime collapse into a 263-line single source of truth.

**Structural splits (`cli.py`, `dialects.py`, `compose.py`)**
- `cli.main` 121→4 lines; `dialects.expand_business` 160→11; `compose.expand_compose` 103→20 — extracted into named private stages. No behavior change.

**Intentional, documented behavior improvements**
- Option `==`/`!=` misuse now emits the helpful hint on **both** engines (previously bmc-only).
- `is none` on a literal `none` is now handled consistently (runtime's correct behavior adopted by bmc).

## Verification

- **Full test suite: `634 passed, 76 skipped`** (was 490 pre-PR; +144 are the new safety-net cases). Run: `./.venv/bin/python -m pytest -q`.
- **Snapshot integrity**: regenerating the golden from the *post-refactor* code produces a file **byte-identical** to the *pre-refactor* golden → verdict-level behavior preserved across the whole corpus.
- Every incremental step was independently re-verified with the fast subset (`test_corpus_snapshot test_evaluator_agreement test_self_conformance test_oracle_agreement test_runtime test_trace_soundness`).
- Self-spec dogfooding unchanged: `fslc_session` / `fslc_monitor` / `refinement_algebra` all `check=ok` / `verify=verified` / `induction=proved`.

## Risk / Review Notes

- **No public contract change**: CLI flags, JSON result shape, exit codes, and grammar are untouched. No migrations, schemas, or persisted data.
- **Deliberately NOT unified** (genuinely divergent representations — *not* bugs; confirmed equivalent on the corpus): `_eval_seq_method`/`_eval_set_method`/`_apply_assign` (z3.Store chains vs in-place list/dict mutation), `compute_updates` (z3.If branch-merge vs concrete branch execution), `_eval_requires` (constraint list vs bool), display helpers (z3-model extraction vs concrete read). Forcing these together would hide the partial-op design difference behind a leaky abstraction without reducing duplication.
- **Partial-op semantics are intentionally asymmetric**: bmc defers to a separate well-definedness site check (`_collect_partial_op_sites`); runtime raises `_PartialOp` inline. Preserved as-is.
- **Import structure**: `bmc → runtime` remains a function-local deferred import (in `expand_leadsto_bindings`); there is no import-time cycle. Left as-is (benign; restructuring is low-value / higher-risk).
- Review focus: the domain method contracts in `values.py` (especially `select_int`/`quantify`/`seq_eq` lazy-vs-eager behavior) and that each `bmc`/`runtime` delegator preserves its original call signature.

## Follow-Up / Post-Merge Checks

- The two new tests are reusable regression guards for any future evaluator change; keep the golden current via `FSLC_SNAPSHOT_UPDATE=1` only for *intended* behavior changes.
- Optional future work (out of scope here): evaluate whether the seq/set method evaluators are worth unifying behind a richer array+partial-op domain — deferred because the value/risk ratio is unfavorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
