### PR TITLE
[codex] add readable business stage syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- **Readable fsl-biz stage syntax for PM/consulting-facing policies and goals**:
+  `policy ... every Case in Stage must eventually be Target [or Target ...]`,
+  `goal ... some Case can reach Stage`, and
+  `goal ... all Case can be Stage [or Stage ...]`. These are AST sugar for the
+  existing `responds` / `reachable` forms, so kernel semantics and JSON output
+  remain unchanged while common business-flow rules no longer require reading
+  `stage(c) == ... ~> ...` formulas.
+
 ## [1.3.0] - 2026-06-16
 
 Theme: **propagation review for layer chains (fsl-design-review)** — establishing that

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -179,12 +179,10 @@ business ReturnHandling {
     // stage(c) is available in expressions (c is a case-type bound variable)
     forall c: Return { stage(c) == Refunded => true }   // example
   }
-  policy PAY-2 "every request is eventually adjudicated" responds {
-    forall c: Return { stage(c) == Requested ~> not (stage(c) == Requested) }
-  }
-  goal AllSettled "all cases can complete" {
-    forall c: Return { stage(c) == Refunded or stage(c) == Rejected }
-  }
+  policy PAY-2 "every request is eventually adjudicated"
+    every Return in Requested must eventually be Approved or Rejected or Refunded
+  goal AllSettled "all cases can complete"
+    all Return can be Refunded or Rejected
 }
 ```
 
@@ -209,7 +207,13 @@ business ReturnHandling {
    `invariant _kpi_k { k == count(c: X where x_stage(c) == S) }` (automatic).
 4. `policy <ID> "<text>" invariant { expr }` → invariant (with meta).
    `policy ... responds { P ~> Q }` → leadsTo (with meta).
+   `policy ... every <Case> in <Stage> must eventually be <Stage> [or <Stage> ...]`
+   is a readable alias for the common stage-response rule and expands to
+   `forall c: Case { stage(c) == Source ~> stage(c) == Target1 or ... }`.
    `goal <ID> "<text>" { expr }` → reachable (with meta).
+   `goal ... some <Case> can reach <Stage>` and
+   `goal ... all <Case> can be <Stage> [or <Stage> ...]` are readable aliases
+   for the common existential/all-cases reachability checks.
    `stage(c)` in an expression is rewritten to `x_stage[c]` for the case-type
    bound variable c in question (the process is identified from the type of the
    binding; ambiguity is a type error).

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -591,6 +591,32 @@ an invariant violation, a dead process step = a coverage diagnosis, an
 unreachable business goal = reachable_failed, and a case left unattended = a
 leadsTo counterexample — all can be detected mechanically.
 
+For PM/consulting-facing files, use the readable stage syntax for common
+response policies and goals:
+
+```fsl
+business ReturnHandling {
+  actor Customer, Manager
+  case Return = 0..2
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy PAY-2 "every request is eventually decided"
+    every Return in Requested must eventually be Approved or Rejected or Refunded
+  goal AllSettled "all cases can be completed"
+    all Return can be Refunded or Rejected
+}
+```
+
+The explicit forms remain available when the rule is not just stage progression:
+`policy ... responds { forall c: Return { stage(c) == Requested ~> ... } }` and
+`goal ... { exists c: Return { stage(c) == Refunded } }`.
+
 ### 13.4 How to write non-functional requirements (NFRs)
 
 The majority of NFRs can be written with the same machinery as functional

--- a/examples/consulting/asis_expense.fsl
+++ b/examples/consulting/asis_expense.fsl
@@ -42,18 +42,13 @@ business AsIsExpense {
   //   two below are "do not leave unattended" controls that the structure
   //   alone cannot express.
 
-  policy CTRL-1 "A submitted claim must always be adjudicated for approval or rejection" responds {
-    forall c: Claim {
-      stage(c) == Submitted ~> (stage(c) == Approved or stage(c) == Rejected)
-    }
-  }
+  policy CTRL-1 "A submitted claim must always be adjudicated for approval or rejection"
+    every Claim in Submitted must eventually be Approved or Rejected
 
-  policy CTRL-2 "An approved claim must always be paid" responds {
-    forall c: Claim { stage(c) == Approved ~> stage(c) == Paid }
-  }
+  policy CTRL-2 "An approved claim must always be paid"
+    every Claim in Approved must eventually be Paid
 
   // ── Goal (confirming the current process can complete the business) ────
-  goal CanComplete "The process can complete from claim to payment" {
-    exists c: Claim { stage(c) == Paid }
-  }
+  goal CanComplete "The process can complete from claim to payment"
+    some Claim can reach Paid
 }

--- a/examples/consulting/tobe_expense.fsl
+++ b/examples/consulting/tobe_expense.fsl
@@ -35,16 +35,11 @@ business ToBeExpense {
   kpi paid_claims counts Claim in Paid
 
   // The controls are kept identical to As-Is (not weakened)
-  policy CTRL-1 "A submitted claim must always be adjudicated for approval or rejection" responds {
-    forall c: Claim {
-      stage(c) == Submitted ~> (stage(c) == Approved or stage(c) == Rejected)
-    }
-  }
-  policy CTRL-2 "An approved claim must always be paid" responds {
-    forall c: Claim { stage(c) == Approved ~> stage(c) == Paid }
-  }
+  policy CTRL-1 "A submitted claim must always be adjudicated for approval or rejection"
+    every Claim in Submitted must eventually be Approved or Rejected
+  policy CTRL-2 "An approved claim must always be paid"
+    every Claim in Approved must eventually be Paid
 
-  goal CanComplete "The process can complete from claim to payment" {
-    exists c: Claim { stage(c) == Paid }
-  }
+  goal CanComplete "The process can complete from claim to payment"
+    some Claim can reach Paid
 }

--- a/examples/e2e/1_business.fsl
+++ b/examples/e2e/1_business.fsl
@@ -59,23 +59,16 @@ business ExpenseToBe {
   // counterexample carries this ID and original text, so the auditor, the
   // PM, and the engineer all see the same failure.
 
-  policy CTRL-1 "A submitted claim must always be adjudicated" responds {
-    forall c: Claim {
-      stage(c) == Submitted ~> (stage(c) == Approved or stage(c) == Rejected)
-    }
-  }
+  policy CTRL-1 "A submitted claim must always be adjudicated"
+    every Claim in Submitted must eventually be Approved or Rejected
 
-  policy CTRL-2 "An approved claim must always be paid" responds {
-    forall c: Claim {
-      stage(c) == Approved ~> stage(c) == Paid
-    }
-  }
+  policy CTRL-2 "An approved claim must always be paid"
+    every Claim in Approved must eventually be Paid
 
   // ── Goal ─────────────────────────────────────────────────────────
   // Confirm "whether it is even possible to reach Paid from Draft".
   // A transformation proposal where this becomes reachable_failed is
   // stuck as a business process before controls even come into play.
-  goal CanPay "There exists a case that reaches completed payment via approval from a claim" {
-    exists c: Claim { stage(c) == Paid }
-  }
+  goal CanPay "There exists a case that reaches completed payment via approval from a claim"
+    some Claim can reach Paid
 }

--- a/examples/layers/return_policy.fsl
+++ b/examples/layers/return_policy.fsl
@@ -12,10 +12,8 @@ business ReturnHandling {
 
   kpi refunded counts Return in Refunded
 
-  policy PAY-2 "Every request is eventually decided" responds {
-    forall c: Return { stage(c) == Requested ~> not (stage(c) == Requested) }
-  }
-  goal AllSettled "All cases can be completed" {
-    forall c: Return { stage(c) == Refunded or stage(c) == Rejected }
-  }
+  policy PAY-2 "Every request is eventually decided"
+    every Return in Requested must eventually be Approved or Rejected or Refunded
+  goal AllSettled "All cases can be completed"
+    all Return can be Refunded or Rejected
 }

--- a/examples/pm/cancel_flow.fsl
+++ b/examples/pm/cancel_flow.fsl
@@ -45,24 +45,18 @@ business CancelFlow {
 
   // "Do not leave requests unattended" — under any order of progression,
   // a cancellation request eventually proceeds to showing an offer (an SLA-style response rule)
-  policy POL-1 "A cancellation request must always be met with a retention offer" responds {
-    forall c: Sub { stage(c) == CancelRequested ~> stage(c) == OfferShown }
-  }
+  policy POL-1 "A cancellation request must always be met with a retention offer"
+    every Sub in CancelRequested must eventually be OfferShown
 
   // "Do not leave a shown offer unattended" — once shown, it must always be resolved
-  policy POL-2 "A shown offer must always be resolved by acceptance or decline" responds {
-    forall c: Sub {
-      stage(c) == OfferShown ~> (stage(c) == Retained or stage(c) == Churned)
-    }
-  }
+  policy POL-2 "A shown offer must always be resolved by acceptance or decline"
+    every Sub in OfferShown must eventually be Retained or Churned
 
   // ── Goals (states that should be reachable) ─────────────────────────
   // Machine-confirm "can this process even reach retention in the first place?".
   // If a rule change makes the goal unreachable, it is detected as reachable_failed.
-  goal CanRetain "There exists a case that reaches retention via a retention offer" {
-    exists c: Sub { stage(c) == Retained }
-  }
-  goal CanChurn "There also exists a case that declines and reaches cancellation" {
-    exists c: Sub { stage(c) == Churned }
-  }
+  goal CanRetain "There exists a case that reaches retention via a retention offer"
+    some Sub can reach Retained
+  goal CanChurn "There also exists a case that declines and reaches cancellation"
+    some Sub can reach Churned
 }

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: fsl
-description: >-
-  Write, verify, and repair specifications in FSL (AI-Native Formal
-  Specification Language). Use this when creating/editing/checking .fsl files,
-  running fslc commands (check/verify/explain/mutate/typestate/scenarios/replay/
-  testgen/refine), or doing formal specification, model checking, invariant
-  proofs, spec-driven test generation, refinement checking, or implementation
-  conformance checking. Also covers consistency checking of business flows and
-  business processes, As-Is/To-Be control checks, formalizing requirements and
-  requirement definitions, turning acceptance criteria into tests, and checking
-  SLAs and non-functional requirements. Triggers include "write a spec",
-  "formally verify", "verify this business flow", "define requirements", and
-  "FSL".
+description: Write, verify, and repair FSL specs and run fslc check/verify/explain/mutate/typestate/scenarios/replay/testgen/refine. Covers business-flow consistency, As-Is/To-Be controls, requirements formalization, acceptance criteria, SLAs, NFRs, refinement, implementation conformance, and FSL syntax.
 ---
 
 # FSL — How to Write Specs and the write→verify→repair Loop
@@ -100,6 +89,8 @@ the formalization memo.**
 | "prohibit/constrain a change from one state to the next" (two-state safety) | `trans` (use `old()` to reference the pre-transition state) |
 | "can only do X when Y" (precondition) | an action's `requires` |
 | "once X happens, Y must eventually happen" (response, progress) | `leadsTo` + `fair` on the action that drives progress |
+| business-flow stage response for consultants/PMs | `policy POL-1 "..." every Case in Source must eventually be Target [or Target ...]` |
+| business-flow reachability / completion goal | `goal G "..." some Case can reach Target` or `goal G "..." all Case can be Target [or Target ...]` |
 | "once X has happened, it can never happen again" (history dependence) | ghost variable (`ever_*`) + invariant |
 | "X can be reached / X can end up being reached" (possibility) | `reachable` (witness, or detection of over-constraint) |
 | "within K times / K ticks" (deadline) | requirements `time` + `deadline` (reference §11) |
@@ -306,9 +297,15 @@ A spec can be written in three layers. Chain **business ⊒ requirements ⊒ des
 implementation** via refinement (syntax in reference.md §10). Every layer expands
 to the kernel, so verify/induction/scenarios/Monitor are used identically:
 
-- `business Name { process/policy/kpi/goal }` — the consulting layer. Regulation
-  contradiction = invariant violation, dead business step = coverage diagnostic,
-  unreachable business goal = reachable_failed
+- `business Name { process/policy/kpi/goal }` — the consulting layer. For
+  PM/consulting-facing files, prefer the readable stage syntax for common rules:
+  `policy ... every Case in Source must eventually be Target [or Target ...]`,
+  `goal ... some Case can reach Target`, and
+  `goal ... all Case can be Target [or Target ...]`. Use explicit
+  `responds { forall ... stage(c) ... ~> ... }` / `{ expr }` only when the rule is
+  not simple stage progression. Regulation contradiction = invariant violation,
+  dead business step = coverage diagnostic, unreachable business goal =
+  reachable_failed
 - `requirements Name { requirement REQ-1 "source" {...} / acceptance / branches /
   implements Abs from "file" {map ...} }` — the requirements layer. With
   `implements`, verify simultaneously runs the refine to the upper layer (the

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -276,15 +276,18 @@ business ReturnHandling {
     transition refund  Approved  -> Refunded by Manager
   }
   kpi refunded counts Return in Refunded      // -> ghost + auto-consistency invariant (+1 on an inflow transition; an outflow transition is a type error)
-  policy PAY-2 "every request is adjudicated" responds {
-    forall c: Return { stage(c) == Requested ~> not (stage(c) == Requested) }
-  }                                           // the invariant { expr } form is also allowed
-  goal AllSettled "all cases can be settled" { forall c: Return { ... } }   // -> reachable
+  policy PAY-2 "every request is adjudicated"
+    every Return in Requested must eventually be Approved or Rejected or Refunded
+  goal AllSettled "all cases can be settled"
+    all Return can be Refunded or Rejected
 }
 ```
 
 `stage(c)` expands from the type of the bound c into the process's state Map
 (`return_stage[c]`).
+The natural business forms above are aliases for `responds { forall ... ~> ... }`
+and `goal { forall/exists ... }`; the explicit expression forms remain available
+for policies that cannot be written as a simple stage progression.
 
 ### requirements (the requirements layer)
 

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -796,6 +796,37 @@ def _build_kpi_metadata(kpis, process_by_name):
     return kpi_infos
 
 
+def _process_for_case(case_name, process_by_case, loc):
+    processes = process_by_case.get(case_name, [])
+    if not processes:
+        _err(f"case '{case_name}' has no process", loc=loc)
+    if len(processes) > 1:
+        _err(
+            f"case '{case_name}' has multiple processes; natural stage syntax is ambiguous",
+            loc=loc,
+        )
+    return processes[0]
+
+
+def _stage_is(case_name, var_name, stage, process_by_case, loc):
+    proc = _process_for_case(case_name, process_by_case, loc)
+    if stage not in proc["stages"]:
+        _err(f"stage '{stage}' is not declared for process '{case_name}'", loc=loc)
+    return (
+        "bin",
+        "==",
+        ("index", ("var", proc["state_var"]), ("var", var_name)),
+        ("var", stage),
+    )
+
+
+def _any_stage(case_name, var_name, stages, process_by_case, loc):
+    return _or_all([
+        _stage_is(case_name, var_name, stage, process_by_case, loc)
+        for stage in stages
+    ])
+
+
 def _generate_business_items(cases, processes, kpi_infos, policies, goals, process_by_case):
     out = []
     generated_names = []
@@ -878,10 +909,34 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
         elif body[0] == "biz_policy_responds":
             binders, p, q = _rewrite_stage_binders(body[1], body[2], body[3], process_by_case)
             out.append(("leadsto", policy_id, binders, p, q, loc, meta))
+        elif body[0] == "biz_policy_eventually":
+            _, case_name, source_stage, target_stages = body
+            binder = ("binder_typed", "c", case_name, None)
+            p = _stage_is(case_name, "c", source_stage, process_by_case, loc)
+            q = _any_stage(case_name, "c", target_stages, process_by_case, loc)
+            out.append(("leadsto", policy_id, [binder], p, q, loc, meta))
 
     for item in goals:
-        _, goal_id, text, expr, loc = item
-        out.append(("reachable", goal_id, _rewrite_stage_expr(expr, {}, process_by_case), loc, _meta(goal_id, text)))
+        _, goal_id, text, body, loc = item
+        if body[0] == "biz_goal_expr":
+            expr = _rewrite_stage_expr(body[1], {}, process_by_case)
+        elif body[0] == "biz_goal_some_stage":
+            _, case_name, stage = body
+            expr = (
+                "exists",
+                ("binder_typed", "c", case_name, None),
+                _stage_is(case_name, "c", stage, process_by_case, loc),
+            )
+        elif body[0] == "biz_goal_all_stage":
+            _, case_name, stages = body
+            expr = (
+                "forall",
+                ("binder_typed", "c", case_name, None),
+                _any_stage(case_name, "c", stages, process_by_case, loc),
+            )
+        else:
+            _err(f"unknown business goal body '{body[0]}'", loc=loc)
+        out.append(("reachable", goal_id, expr, loc, _meta(goal_id, text)))
 
     if generated_names:
         out.append(("__generated", generated_names))

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -236,10 +236,16 @@ process_initial: "initial" NAME
 process_transition: "transition" NAME NAME "->" NAME "by" NAME
 kpi_def: "kpi" NAME "counts" NAME "in" NAME
 policy_def: "policy" REQ_ID STRING policy_body
-?policy_body: policy_invariant | policy_responds
+?policy_body: policy_invariant | policy_responds | policy_eventually
 policy_invariant: "invariant" "{" expr "}"
 policy_responds: "responds" "{" lt_body "}"
-goal_def: "goal" REQ_ID STRING "{" expr "}"
+policy_eventually: "every" NAME "in" NAME "must" "eventually" "be" stage_disjunction
+goal_def: "goal" REQ_ID STRING goal_body
+?goal_body: goal_expr | goal_some_stage | goal_all_stage
+goal_expr: "{" expr "}"
+goal_some_stage: "some" NAME "can" "reach" NAME
+goal_all_stage: "all" NAME "can" "be" stage_disjunction
+stage_disjunction: NAME (_OR NAME)*
 
 CMPOP: "==" | "!=" | "<=" | ">=" | "<" | ">"
 REQ_ID: /[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/
@@ -858,11 +864,26 @@ class Ast(Transformer):
         binders, p, q = _flatten_leadsto(body)
         return ("biz_policy_responds", binders, p, q)
 
+    def stage_disjunction(self, meta, *names):
+        return list(names)
+
+    def policy_eventually(self, meta, case_name, source_stage, target_stages):
+        return ("biz_policy_eventually", case_name, source_stage, target_stages)
+
     def policy_def(self, meta, policy_id, text, body):
         return ("biz_policy", str(policy_id), text, body, _loc(meta))
 
-    def goal_def(self, meta, goal_id, text, expr):
-        return ("biz_goal", str(goal_id), text, expr, _loc(meta))
+    def goal_expr(self, meta, expr):
+        return ("biz_goal_expr", expr)
+
+    def goal_some_stage(self, meta, case_name, stage):
+        return ("biz_goal_some_stage", case_name, stage)
+
+    def goal_all_stage(self, meta, case_name, stages):
+        return ("biz_goal_all_stage", case_name, stages)
+
+    def goal_def(self, meta, goal_id, text, body):
+        return ("biz_goal", str(goal_id), text, body, _loc(meta))
 
     def business_def(self, meta, name, *items):
         return ("business", name, [i for i in items if i])

--- a/tests/test_biz_dialect.py
+++ b/tests/test_biz_dialect.py
@@ -35,6 +35,29 @@ BIZ_SRC = r'''business ReturnHandling {
 '''
 
 
+NATURAL_BIZ_SRC = r'''business NaturalReturnHandling {
+  actor Customer, Manager
+  case Return = 0..2
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  kpi refunded counts Return in Refunded
+
+  policy PAY-2 "requests are eventually decided"
+    every Return in Requested must eventually be Approved or Rejected or Refunded
+
+  goal HasRefund "a return can be refunded" some Return can reach Refunded
+  goal AllSettled "all returns can settle" all Return can be Refunded or Rejected
+}
+'''
+
+
 def _write_biz(tmp_path, src=BIZ_SRC, name="return_biz.fsl"):
     path = tmp_path / name
     path.write_text(src, encoding="utf-8")
@@ -56,6 +79,32 @@ def test_biz_dialect_check_verify_and_induction(tmp_path):
     proved = run_verify(str(biz), 8, "ignore", engine="induction")
     assert proved["result"] == "proved"
     assert "_kpi_refunded" in proved["invariants_checked"]
+
+
+def test_biz_natural_policy_and_goal_syntax(tmp_path):
+    biz = _write_biz(tmp_path, NATURAL_BIZ_SRC)
+
+    checked = run_check(str(biz))
+    assert checked["result"] == "ok"
+
+    verified = run_verify(str(biz), 8, "warn")
+    assert verified["result"] == "verified"
+    assert "PAY-2" in verified["leads_to"]
+    assert set(verified["reachables"]) == {"AllSettled", "HasRefund"}
+
+
+def test_biz_natural_syntax_rejects_unknown_stage(tmp_path):
+    bad = NATURAL_BIZ_SRC.replace(
+        "must eventually be Approved",
+        "must eventually be Missing",
+    )
+    biz = _write_biz(tmp_path, bad)
+
+    result = run_check(str(biz))
+
+    assert result["result"] == "error"
+    assert result["kind"] == "type"
+    assert "stage 'Missing' is not declared" in result["message"]
 
 
 def test_biz_policy_violation_carries_policy_requirement_meta(tmp_path):


### PR DESCRIPTION
## Summary
Adds readable stage-oriented syntax to the `business` dialect so PM/consulting-facing FSL files can express common response policies and goals without reading `stage(c) == ... ~> ...` formulas.

## Why
- **Goal**: Make fsl-biz specifications readable by consultants and PMs while preserving the existing kernel semantics.
- **Reason**: The existing dialect was technically correct but still exposed logical formulas for common business-flow rules.
- **Alternative**: Keep only comments/natural-language explanations around formulas. Rejected because the `.fsl` itself should be readable at the business layer.

## What Changed
- Added parser support for:
  - `policy ... every Case in Source must eventually be Target [or Target ...]`
  - `goal ... some Case can reach Target`
  - `goal ... all Case can be Target [or Target ...]`
- Expanded those forms into the existing `leadsTo` / `reachable` AST shapes.
- Updated PM/consulting examples and language docs to prefer the readable syntax for common stage progression.
- Updated the FSL skill and reference so agents prefer the readable business syntax when writing consultant/PM-facing specs.

## Blast Radius
- **Affected**: `business` dialect parsing/expansion, business examples, FSL documentation, and the FSL skill.
- **Compatibility**: Existing `{ expr }` and `responds { ... }` forms remain supported. Kernel semantics and JSON output are unchanged because this is AST sugar.

## Invariants
| Condition | Basis | Symptom if broken |
| --- | --- | --- |
| Existing business specs still parse and verify | Full test suite | Existing examples/tests fail |
| New readable syntax expands to existing property forms | `tests/test_biz_dialect.py` | Missing `leads_to` / `reachables` entries or wrong verification result |
| Unknown stages are rejected as type errors | `test_biz_natural_syntax_rejects_unknown_stage` | Misspelled stage names silently accepted |

## Failure Modes
| Type | Pattern | Detection |
| --- | --- | --- |
| Parse ambiguity | New keywords collide with existing identifiers | Full pytest suite and parser tests |
| Semantic drift | Sugar does not match equivalent `responds` / `goal` expression | Business dialect tests and updated examples |
| Skill drift | Agents keep writing formula-heavy business specs | Updated `skills/fsl/SKILL.md` and `skills/fsl/reference.md` |

## Evidence
- [x] `.venv/bin/python -m pytest tests -q` -> `636 passed, 76 skipped`
- [x] `.venv/bin/python -m pytest tests/test_biz_dialect.py -q` -> `10 passed`
- [x] `python3 /Users/rizumita/.codex/skills/skill-creator/scripts/validate_skill.py skills/fsl` -> `[OK] Skill is valid!`
- [x] `git diff --check`

## Rollout & Rollback
- **Rollout**: Merge normally; examples and docs already use the new syntax.
- **Rollback**: Revert this commit. Existing explicit formula syntax remains available either way.

## Review Focus
- `src/fslc/grammar.py`: grammar shape and keyword interactions
- `src/fslc/dialects.py`: expansion into existing AST nodes
- `tests/test_biz_dialect.py`: coverage of readable syntax and error handling
- `skills/fsl/SKILL.md`: agent guidance now prefers readable syntax for business specs

## Unknowns
None known.
