### PR TITLE
[codex] FSLスキルの不足文脈確認ルールを明確化

### DIFF
--- a/skills/fsl-design-review/SKILL.md
+++ b/skills/fsl-design-review/SKILL.md
@@ -30,16 +30,23 @@ proposals / adding a variant or extension / reviewing a change to an existing de
   (invariants, guards, externally observable state)
 
 Lens — OCP: decide the "range you close" here. DIP: what abstraction should the
-design proposals all depend on in common. It is recommended to align with the user
-on the candidate contracts as a bullet list before proceeding (do not create a
-deliverable file; chat is fine).
+design proposals all depend on in common. Align with the user on the candidate
+contracts as a bullet list before proceeding (do not create a deliverable file;
+chat is fine).
+
+Do not infer the open/closed boundary, extension points, substitutability contract,
+variant roster, or action correspondence from general design taste. If the source
+material does not say what must remain stable or how a detail action maps to an
+abstract action, ask. A refinement proof is only meaningful for the contract the
+human agreed to freeze.
 
 ### Step 2 — Freeze the contract as an abstract spec
 
-Write the contract as an abstract `spec` and push it through the fsl skill's
-standard workflow up to `check` → `verify` → `--engine induction` (proved
-recommended). If the contract itself is contradictory, the design exploration cannot
-even begin — a `violated` here is a defect in the contract, not in a design proposal.
+After the contract boundary is confirmed, write the contract as an abstract `spec`
+and push it through the fsl skill's standard workflow up to `check` → `verify` →
+`--engine induction` (proved recommended). If the contract itself is contradictory,
+the design exploration cannot even begin — a `violated` here is a defect in the
+contract, not in a design proposal.
 
 Lens — DbC: `requires`/`ensures`/`invariant` are the contract directly. Leave
 defense of boundaries and partial operations to the automatic checks
@@ -56,10 +63,12 @@ later)**:
 ### Step 3 — Write each design proposal as a refinement
 
 Describe each design proposal / variant as a "detail `spec` + mapping file". Do not
-edit the abstract spec's file. Correspond actions that exist only in the detail layer
-to `stutter`. A module-addition-style extension is `compose`, not refinement
-(synchronize/compose without editing the existing files, and write the cross-cutting
-invariant in the composite layer).
+edit the abstract spec's file. Correspond actions that exist only in the detail
+layer to `stutter` only when they are confirmed not to affect observable abstract
+state. When a correspondence is unclear, ask before writing the mapping. A
+module-addition-style extension is `compose`, not refinement (synchronize/compose
+without editing the existing files, and write the cross-cutting invariant in the
+composite layer).
 
 Lens — LSP: the content of the refine check (do not strengthen preconditions, do not
 weaken postconditions, preserve invariants) is the definition of LSP itself.
@@ -72,7 +81,9 @@ but **they are not checked** (fslc says nothing even if you violate them).
 The mechanical repair steps for the result follow the fsl skill's repair protocol
 table, but in design exploration you must always decide, before fixing, "**is the
 design proposal bad, or is the contract excessive?**" — either conclusion is a
-legitimate outcome of a design review.
+legitimate outcome of a design review. If the answer is not explicit in the source
+or prior confirmation, present the counterexample and ask; do not silently change
+the abstract contract, mapping, or detail guards to obtain a green result.
 
 | Check result | Design meaning | Report in principle vocabulary |
 |---|---|---|

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -43,7 +43,25 @@ Output is always a single JSON document on stdout. exit: 0=success
 (violated/reachable_failed/unknown_cti/nonconformant), 2=spec error
 (parse/type/semantics/io), 3=internal error.
 
-## Before writing a spec: the formalization memo (post it in chat; do not make a separate file)
+## Before writing a spec: source fidelity and the formalization memo
+
+FSL is a specification language, not a requirements generator. Encode only facts
+that are present in the source material or assumptions the human has explicitly
+confirmed. **Do not fill missing requirements, business rules, error handling,
+timing, priorities, actors, lifecycle states, design boundaries, or refinement
+mappings just to make a complete or verified `.fsl`.** If a missing choice affects
+the state schema, an action's enabledness, a transition target, an invariant,
+`leadsTo`, a deadline, or a refinement mapping, stop at the memo and ask a
+question before writing or changing the spec.
+
+It is acceptable to make representation-only assumptions that do not change
+behavior (for example, choosing small finite domain sizes for model checking), but
+label them as modeling assumptions and keep them separate from business/design
+assumptions. If the user asks for a draft despite open questions, write only the
+confirmed fragment and mark the rest as questions; do not invent guards or
+invariants to close the gap.
+
+### Formalization memo (post it in chat; do not make a separate file)
 
 When deriving FSL from natural-language requirements, business rules, or code,
 **do not jump straight to writing `.fsl`**. First post a **formalization memo** in
@@ -60,21 +78,25 @@ for it (keep the loop lightweight; the only deliverable is the `.fsl` itself):
   constraint / exception / **boundary implications** (at-least vs. greater-than,
   before vs. after, inclusive vs. exclusive). This is where misreadings most
   frequently occur
-- **Assumption ledger**: places where the source was ambiguous, the interpretation
-  taken, and the reason (carried over into the spec as described below)
+- **Assumption ledger**: confirmed assumptions and representation-only modeling
+  choices. Do not use this ledger to silently decide missing product, business, or
+  design policy
 - **Questions for the human**: judgments that cannot be decided during
-  formalization (priority of business rules, precedence of exceptions, etc.)
+  formalization (priority of business rules, precedence of exceptions, lifecycle
+  states, retry/error behavior, timing/deadline semantics, ownership of actions,
+  abstraction boundaries, refinement correspondences, etc.)
 
 The human only needs to read this memo and the verifier's counterexamples —
 **do not make them review logical formulas directly**. Write the `.fsl` only after
-the memo has received human confirmation or correction.
+the memo has received human confirmation or correction for any choice that changes
+behavior.
 
-### Keep only the assumptions in the spec (fold them into the .fsl, not a separate memo file)
+### Keep only confirmed assumptions in the spec (fold them into the .fsl, not a separate memo file)
 
-Most of the memo can disappear into chat, but **if the assumption ledger is
-discarded, you later cannot trace "why this interpretation was chosen," which is a
-problem**. A separate file would drift out of sync with the spec, so **keep it in
-the `.fsl` itself as comments / tags**:
+Most of the memo can disappear into chat, but **if the confirmed assumption ledger
+is discarded, you later cannot trace "why this interpretation was chosen," which
+is a problem**. A separate file would drift out of sync with the spec, so **keep
+confirmed assumptions in the `.fsl` itself as comments / tags**:
 
 - Global assumptions → a ledger block at the top of the spec:
   `// ASSUME-1: stock is reserved by only one user at a time`
@@ -173,10 +195,12 @@ requires is blocking it" on a per-clause basis. Do not silently ignore it.
 
 When a counterexample makes you **change an interpretation** (added a guard,
 loosened an invariant, decided how to handle an exception), record that judgment in
-the assumption ledger (the `// ASSUME-n:` comments / tags in the `.fsl`). The
-shortest path to verified is often "weakening the spec," so without a record of
-what was weakened and why, you later cannot distinguish a hollowing-out repair from
-a legitimate fix.
+the assumption ledger (the `// ASSUME-n:` comments / tags in the `.fsl`) only after
+the source material or the human confirms it. If the counterexample exposes a
+missing requirement or design decision, ask instead of choosing the repair on the
+user's behalf. The shortest path to verified is often "weakening the spec," so
+without confirmation and a record of what was weakened and why, you later cannot
+distinguish a hollowing-out repair from a legitimate fix.
 
 ## Minimal syntax (details and the full catalog are in reference.md)
 


### PR DESCRIPTION
## Summary
FSLスキルとFSL design reviewスキルに、不足している要件・設計境界・refinement mappingを推測で補完しないルールを明記しました。

## Why
- **Goal**: 自然言語や設計案からFSLへ落とすときに、未確認の業務判断や設計判断を仕様へ混入させない。
- **Reason**: verifiedな`.fsl`を作るために仕様を弱めたり補完したりすると、検証結果が人間の合意した契約ではなくAIの推測に対する証明になるため。
- **Alternatives**: assumption ledgerで曖昧な判断を保持する運用もあり得ますが、未確認のプロダクト/設計判断をledgerへ入れると暗黙の決定になるため、確認済み仮定と表現上のモデリング仮定に限定しました。

## What Changed
- `skills/fsl/SKILL.md` に、FSLは要件生成器ではなく仕様記述言語であり、欠落した要件・例外・期限・状態・境界などを補完しない方針を追加しました。
- formalization memoのassumption ledgerを、確認済み仮定と表現上のモデリング仮定に限定するよう整理しました。
- counterexample修正時に、未確認の解釈変更でgreenにせず、人間確認を挟むルールを追加しました。
- `skills/fsl-design-review/SKILL.md` に、open/closed boundary、extension point、substitutability contract、variant roster、action correspondenceを推測しないルールを追加しました。
- refinement mappingで`stutter`を使う条件を、抽象状態に影響しないことが確認済みの場合に限定しました。

## Blast Radius
- **Affected**: FSLスキルを使う仕様化フロー、design reviewでのrefinement/compose判断、レビュー時の修正プロトコル。
- **Compatibility**: 実行コードやFSL構文の変更はありません。スキル運用上は、曖昧な入力に対して質問が増える可能性があります。

## Invariants (Must Stay True)
| 条件 | 根拠 | 破ったときの症状 |
|------|------|-----------------|
| 未確認の業務・設計判断を`.fsl`へ混入させない | `skills/fsl/SKILL.md` | verified結果が人間の合意した仕様を表さなくなる |
| refinementは合意済みcontractに対して評価する | `skills/fsl-design-review/SKILL.md` | 設計案の可否ではなく、推測した抽象仕様との差分を評価してしまう |
| 表現上のモデリング仮定と業務/設計仮定を分ける | `skills/fsl/SKILL.md` | model checking都合の仮定が仕様判断として固定される |

## Failure Modes
| 種類 | パターン | 検知手段 |
|------|---------|---------|
| 起きやすい | スキル利用時の質問が増え、従来より作業が止まりやすくなる | 実利用時の会話ログレビュー |
| 致命的 | 文言が強すぎて、表現上必要な有限化まで禁止されたように読める | `representation-only assumptions` の扱いをレビュー |
| 気づきにくい | design review側だけ/通常FSL側だけでルール差が残る | 両方の`SKILL.md`の対応関係レビュー |

## Evidence
- [x] `git diff --check`
- [x] 変更範囲確認: Markdownスキル文書2ファイルのみ
- 自動テストは未実行です。実行コードではなくドキュメント変更のためです。

## Rollout & Rollback
- **Rollout**: マージ後、FSL関連スキル利用時に新しい確認ルールが適用されます。
- **Rollback**: このPRのコミットをrevertすれば戻せます。
- **Cannot rollback if**: なし。

## Review Focus
- [ ] `skills/fsl/SKILL.md`: 「質問すべき不足文脈」と「許容する表現上の仮定」の境界が明確か。
- [ ] `skills/fsl-design-review/SKILL.md`: refinement/compose判断時に推測を止める条件が十分か。
- [ ] 全体: 質問を要求する条件が過剰で、スキルの実用性を落としすぎていないか。

## Unknowns
| 項目 | 解消手段 | ブロッカー? |
|------|---------|-------------|
| 実利用時に質問頻度が過剰にならないか | 次回以降のFSLスキル利用ログで確認 | No |
