### PR TITLE
feat(verify): cross-kind --property and underscore IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- **`verify --property <Name>` now targets any property kind**, not just
+  invariants. The name is resolved across `invariant`, `trans`, `leadsTo`, and
+  `reachable` declarations and checked in isolation while the full action model
+  still steps, so a single property can be probed on its own (e.g. iterating on a
+  slow `leadsTo` without gating the safety checks).
+- **Underscores are accepted in requirement-style IDs** (`REQ_ID`): `acceptance`,
+  `forbidden`, `requirement`, `policy`, and `goal` IDs now allow `AC_DONE` in
+  addition to `AC-DONE`, matching the underscore already permitted in
+  action/invariant/trans names. Purely widens the accepted set — existing
+  hyphenated IDs are unchanged.
+
+### Changed
+- **`--property` not-found diagnostics** now read `no such property: X
+  (available: …)` and list every property kind. Under `--engine induction`
+  (k-induction proves safety invariants only), naming a `trans`/`leadsTo`/
+  `reachable` now reports that the induction engine cannot prove it and to use the
+  default `bmc` engine, instead of a misleading "no such invariant".
+- **Documented the liveness/safety scaling difference** (`skills/fsl/reference.md`
+  §7): `leadsTo` cost grows roughly exponentially in the number of concurrent
+  entities (the textbook BMC-liveness state explosion), while safety stays cheap.
+  Added the practical strategy — verify liveness on a reduced model and safety
+  separately at full size, and use `--property` to isolate one liveness property
+  while iterating.
+
 ## [1.3.1] - 2026-06-17
 
 Theme: **FSL delivery orchestration skill** — making the business → requirements →

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -168,7 +168,8 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--deadlock warn|error|ignore]
                [--vacuity warn|error|ignore]     # vacuity check (§15)
-               [--property <Name>]               # check only a single invariant (for probing)
+               [--property <Name>]               # check one named property in isolation —
+                                                 #   invariant / trans / leadsTo / reachable (for probing)
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -151,7 +151,8 @@ action that should change it). `--vacuity error` gives `result:"error"`;
 fslc check <f>                                  # syntax / names / types only
 fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--deadlock warn|error|ignore] [--vacuity warn|error|ignore]
-               [--property <Name>]                  # check a single invariant only (for probing)
+               [--property <Name>]                  # check one named property in isolation
+                                                    #   (invariant / trans / leadsTo / reachable)
                [--strict-tags] [--requirements ids.txt]
 fslc explain <f> [--depth K=8]                 # skeleton + counterfactual + witness narration
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
@@ -203,6 +204,24 @@ fslc typestate <f> [--ts]                       # state machine -> ghost-type ap
   base case.
 - coverage diagnostic: `{covered: false, blocking_requires: [{loc, text}], hint}`.
 - leadsTo violation: `pending_since` + `loop_start` (lasso) or `stutter: true`.
+
+### ⚠ Liveness scales differently from safety — verify it on a reduced model
+
+`leadsTo` is a lasso search: the cost grows roughly **exponentially in the number
+of concurrent entities** (the textbook BMC-liveness state explosion), because each
+added entity multiplies the interleavings the loop search must consider. Safety
+(`invariant` / `trans` / `reachable`) does **not** behave this way — it stays cheap
+even at large depth. Observed shape: a single entity verifies in seconds even at
+depth 16, but three concurrent entities with `leadsTo` can blow past minutes by
+depth ~12. This is a known limit, not a pathological encoding.
+
+Practical strategy:
+- Verify **liveness on the smallest model that still exhibits the interleaving** —
+  shrink the entity-count range (e.g. `0..1` instead of `0..3`) and use a shallow
+  `--depth`. One entity is often enough to find a real `leadsTo` bug.
+- Verify **safety separately on the full-size model** at the depth you need.
+- Use `--property <leadsToName>` to run a single liveness property in isolation
+  while iterating (see §7), so a slow `leadsTo` does not gate the safety checks.
 
 ## 8. Idioms (reuse them as-is)
 

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -131,6 +131,44 @@ def _select_invariants(spec, property_name=None):
     }
 
 
+# Property declarations that `verify --property` can target, in the order they
+# appear in `available:` diagnostics. Each names a spec collection whose items
+# carry a "name" field.
+_PROPERTY_KINDS = ("invariants", "transitions", "leadstos", "reachables")
+
+
+def _select_property(spec, property_name=None):
+    """Resolve `--property` across invariant/trans/leadsTo/reachable declarations.
+
+    Returns (filtered_spec, error). When property_name is None the spec is
+    returned unchanged. Otherwise a shallow-copied spec is returned in which
+    every property collection keeps only items whose name matches, so the BMC
+    explorer checks the named property in isolation while still stepping the
+    full action model. The error is a usage dict when the name resolves to no
+    declaration.
+    """
+    if property_name is None:
+        return spec, None
+    available = []
+    matched = False
+    filtered = dict(spec)
+    for key in _PROPERTY_KINDS:
+        items = spec.get(key, []) or []
+        available.extend(item["name"] for item in items)
+        kept = [item for item in items if item["name"] == property_name]
+        if kept:
+            matched = True
+        filtered[key] = kept
+    if not matched:
+        avail = ", ".join(sorted(dict.fromkeys(available)))
+        return None, {
+            "result": "error",
+            "kind": "usage",
+            "message": f"no such property: {property_name} (available: {avail})",
+        }
+    return filtered, None
+
+
 _VACUOUS_IMPLICATION_HINT = (
     "the antecedent is not reachable within this depth; check whether an action "
     "that should establish it is missing, or whether the antecedent expression is wrong"
@@ -3001,12 +3039,15 @@ def _bmc_explore(
 def verify(
         spec, depth, deadlock_mode="warn", source_lines=None, vacuity_mode="warn",
         property_name=None):
+    filtered, property_error = _select_property(spec, property_name)
+    if property_error is not None:
+        return _display_output(property_error, spec)
+    spec = filtered
     explored = _bmc_explore(
         spec,
         depth,
         deadlock_mode=deadlock_mode,
         vacuity_mode=vacuity_mode,
-        property_name=property_name,
     )
     if explored["result"] != "explored":
         return _display_output(explored, spec)
@@ -3229,6 +3270,24 @@ def prove(
     """k-induction: base BMC then step-case invariant proof."""
     invariants, property_error = _select_invariants(spec, property_name)
     if property_error is not None:
+        # k-induction proves safety invariants only. If the name resolves to a
+        # trans/leadsTo/reachable, say so instead of "no such invariant".
+        other = next(
+            (kind for kind in ("transitions", "leadstos", "reachables")
+             for item in spec.get(kind, []) or [] if item["name"] == property_name),
+            None,
+        )
+        if other is not None:
+            label = {"transitions": "trans", "leadstos": "leadsTo",
+                     "reachables": "reachable"}[other]
+            property_error = {
+                "result": "error",
+                "kind": "usage",
+                "message": (
+                    f"--property {property_name} is a {label}, which the induction "
+                    f"engine cannot prove; check it with the default bmc engine"
+                ),
+            }
         return _display_output(property_error, spec)
     transitions = spec.get("transitions", [])
 

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -563,7 +563,9 @@ def _build_arg_parser():
                    help="max induction depth (induction engine only)")
     v.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     v.add_argument("--vacuity", choices=["warn", "error", "ignore"], default="warn")
-    v.add_argument("--property", dest="property_name", default=None)
+    v.add_argument("--property", dest="property_name", default=None,
+                   help="check a single named property in isolation; resolves "
+                        "across invariant/trans/leadsTo/reachable declarations")
     v.add_argument("--strict-tags", action="store_true")
     v.add_argument("--requirements", default=None)
 

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -248,7 +248,7 @@ goal_all_stage: "all" NAME "can" "be" stage_disjunction
 stage_disjunction: NAME (_OR NAME)*
 
 CMPOP: "==" | "!=" | "<=" | ">=" | "<" | ">"
-REQ_ID: /[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/
+REQ_ID: /[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*/
 _AND: /and\b/
 _OR: /or\b/
 _NOT: /not\b/

--- a/tests/test_self_examples.py
+++ b/tests/test_self_examples.py
@@ -84,4 +84,44 @@ def test_verify_property_missing_invariant_is_usage_error():
     out = json.loads(proc.stdout)
     assert out["result"] == "error"
     assert out["kind"] == "usage"
-    assert out["message"].startswith("no such invariant: NoSuchInv")
+    assert out["message"].startswith("no such property: NoSuchInv")
+
+
+def test_verify_property_targets_a_trans():
+    """--property resolves a `trans` declaration, not just invariants."""
+    proc = _run_fslc_verify(
+        str(E / "fslc_monitor.fsl"), "--depth", "8", "--property", "RejectIsSticky",
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["result"] == "verified"
+    assert out["transitions_checked"] == ["RejectIsSticky"]
+    # the other property kinds are not checked when one trans is selected
+    assert out["invariants_checked"] == []
+
+
+def test_induction_property_on_non_invariant_explains_engine_limit():
+    """`--engine induction --property <trans>` gives a clear engine-scope error."""
+    proc = _run_fslc_verify(
+        str(E / "fslc_monitor.fsl"), "--engine", "induction",
+        "--property", "RejectIsSticky",
+    )
+    assert proc.returncode == 2
+    out = json.loads(proc.stdout)
+    assert out["result"] == "error"
+    assert out["kind"] == "usage"
+    assert "is a trans" in out["message"]
+    assert "induction engine cannot prove" in out["message"]
+
+
+def test_verify_property_targets_a_reachable():
+    """--property resolves a `reachable` declaration in isolation."""
+    proc = _run_fslc_verify(
+        str(E / "fslc_monitor.fsl"), "--depth", "8", "--property", "ReachConformant",
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["result"] == "verified"
+    assert list(out["reachables"]) == ["ReachConformant"]
+    assert out["invariants_checked"] == []
+    assert out["transitions_checked"] == []


### PR DESCRIPTION
Addresses three pieces of FSL review feedback.

## 1. `--property` targets any property kind (was invariants-only)
`verify --property <Name>` now resolves the name across `invariant`, `trans`,
`leadsTo`, and `reachable` declarations and checks it in isolation, while the
full action model still steps. A new `_select_property` shallow-copies the spec
and empties the non-selected property collections — the model body
(actions/init/state) is untouched.

- not-found error → `no such property: X (available: …)` listing every kind.
- `--engine induction` stays invariant-only (k-induction proves safety
  invariants); naming a `trans`/`leadsTo`/`reachable` now explains the engine
  cannot prove it instead of a misleading "no such invariant".

## 2. Underscores allowed in requirement-style IDs
`REQ_ID` (acceptance/forbidden/requirement/policy/goal) widened from
`[-]`-only to `[-_]`, so `AC_DONE` parses alongside `AC-DONE`, matching the
underscore already allowed in action/invariant/trans names. Purely additive —
existing hyphenated IDs are unchanged.

## 3. Liveness scaling documented (skill)
`skills/fsl/reference.md` §7 now states that `leadsTo` cost grows ~exponentially
in concurrent entities (BMC-liveness state explosion) while safety stays cheap,
with the practical strategy: verify liveness on a reduced model, safety
separately at full size, and isolate one liveness property with `--property`.

## Tests
Full suite green (638 passed / 76 skipped). Added 3 targeted tests in
`tests/test_self_examples.py`: trans target, reachable target, and the
induction-engine scope message. Underscore IDs smoke-checked via `fslc check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)