### PR TITLE
[codex] add temporal and quantifier sugar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,46 @@
 name: ci
 
-# Run the full test suite on push (main) and on Pull Requests.
-# The only dependencies are lark (pure Python) and z3-solver (prebuilt wheel),
-# so no native build is needed. Tested across a Python 3.9-3.12 matrix.
+# PRs run one full suite plus a smaller cross-version smoke suite for fast
+# feedback. main, scheduled, and manual runs keep the full Python 3.9-3.12 matrix.
 
 on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: "17 18 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  test:
-    name: pytest (py${{ matrix.python-version }})
+  pr-full:
+    name: full pytest (py3.12)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install (editable + dev deps)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run full test suite
+        run: pytest -q
+
+  pr-compat-smoke:
+    name: compat smoke (py${{ matrix.python-version }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -33,5 +58,35 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Run test suite
+      - name: Run compatibility smoke tests
+        run: >
+          pytest -q
+          tests/test_version.py
+          tests/test_v1.py
+          tests/test_temporal.py
+          tests/test_logic_temporal_sugar.py
+
+  full-matrix:
+    name: full pytest (py${{ matrix.python-version }})
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install (editable + dev deps)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run full test suite
         run: pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,15 @@ pytest -q                   # Full test suite (about 8 minutes)
 pytest tests/test_v1.py -q  # A single file
 ```
 
+CI is tiered to keep pull-request feedback usable:
+
+- Pull requests run the full suite once on Python 3.12.
+- Pull requests also run a compatibility smoke suite on Python 3.9-3.12:
+  `tests/test_version.py`, `tests/test_v1.py`, `tests/test_temporal.py`, and
+  `tests/test_logic_temporal_sugar.py`.
+- Pushes to `main`, scheduled runs, and manual workflow runs execute the full
+  Python 3.9-3.12 matrix.
+
 The test suite cross-checks the Z3 and concrete Monitor evaluators against each
 other using witness diffs, and additionally validates against a Z3-independent
 brute-force oracle (`tests/oracle.py`) to catch misses (false negatives where

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -79,12 +79,15 @@ Response properties inside a `leadsTo` block:
 ```fsl
 leadsTo <Name> {
   <expr> ~> <expr>                      // once P holds (including the same instant), Q eventually holds
+  <expr> ~> within K <expr>             // Q must hold within K steps after P
   forall x: T { <expr> ~> <expr> }      // checked independently per binding (only an outer forall may nest)
   decreases <int expr>                  // optional; induction-only ranking measure
 }
 ```
 
 `~>` is **exclusive to leadsTo blocks** — it cannot be used in general expressions.
+`within K` is a bounded deadline on a response; `K` must be a non-negative
+constant expression. It is checked by BMC, not by the ranked induction proof.
 `decreases` is optional and must be an integer-valued expression. Under
 `fslc verify --engine induction`, the verifier proves the ranked response by
 checking, under the proved invariants, that whenever `P` is pending and `Q` is
@@ -135,8 +138,13 @@ scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
 - Comparison: `== != < <= > >=`
 - Logical: `and or not =>`
 - Quantification (bounded): `forall x: T { expr }` / `exists x: T { expr }` (can be filtered with `where expr`),
-  the v0 form `forall i in lo..hi: expr` is also allowed
+  the v0 form `forall i in lo..hi: expr` is also allowed. Expression quantifiers
+  can also range over a Set or Seq value: `forall x in active { ... }` /
+  `exists x in queue { ... }`; for Seq this ranges over the live prefix values.
 - Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
+- Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
+  `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
+  matching binding, while `exactlyOne` means exactly one.
 - Option: `x == none` / `x != none` / `x is some(v)` (v is bound within that expression).
   **`x == some(e)` is a type error** — extract with `x is some(v)` and compare
 - struct: literal `Order { st: Open, qty: 0 }`, field reference `o.st`,
@@ -146,7 +154,19 @@ scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
   `.contains(e)` `.size()`, `==` is equality of length and all elements
 - Inside ensures / trans only: read the pre-transition state with `old(expr)`
 - Inside a leadsTo block only: `P ~> Q` (response property. not part of the operator hierarchy of general expressions);
-  optional `decreases <int expr>` after the response body for induction ranking
+  optional `within K` before Q for a bounded deadline, and optional
+  `decreases <int expr>` after the response body for induction ranking
+
+Top-level temporal sugar:
+
+```fsl
+unless Name { P unless Q }   // while P holds and Q is false, the next state must keep P or make Q true
+until  Name { P until Q }    // unless safety plus a leadsTo P ~> Q progress obligation
+```
+
+Use this sugar for persistent workflow states such as "held until released" or
+"pending until completed". For arbitrary history facts, use an explicit ghost
+variable.
 
 ## 4. Statements (init / action bodies)
 
@@ -447,7 +467,9 @@ Since reachable / invariant look only at state, to talk about "Y after X" as a
 | What you want to write | Means |
 |---|---|
 | "Was X at least once" (a fact of the state) | Ghost variable + invariant / reachable |
+| "Keep X true until Y, and Y may or may not happen" | `unless Name { X unless Y }` |
 | "Once it becomes X, eventually Y" (a response property) | `leadsTo` + `fair action` if needed |
+| "Keep X true until Y, and Y must eventually happen" | `until Name { X until Y }` |
 
 Example: in a FIFO mutex, "a process that has entered the wait queue eventually
 obtains the lock" is

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -128,11 +128,14 @@ the formalization memo.**
 | "prohibit/constrain a change from one state to the next" (two-state safety) | `trans` (use `old()` to reference the pre-transition state) |
 | "can only do X when Y" (precondition) | an action's `requires` |
 | "once X happens, Y must eventually happen" (response, progress) | `leadsTo` + `fair` on the action that drives progress |
+| "P must become Q within K steps" (bounded response) | `leadsTo Name { P ~> within K Q }` |
+| "keep P true until Q" (safety, Q may never happen) | `unless Name { P unless Q }` |
+| "keep P true until Q, and Q must happen" (safety + progress) | `until Name { P until Q }` |
 | business-flow stage response for consultants/PMs | `policy POL-1 "..." every Case in Source must eventually be Target [or Target ...]` |
 | business-flow reachability / completion goal | `goal G "..." some Case can reach Target` or `goal G "..." all Case can be Target [or Target ...]` |
 | "once X has happened, it can never happen again" (history dependence) | ghost variable (`ever_*`) + invariant |
 | "X can be reached / X can end up being reached" (possibility) | `reachable` (witness, or detection of over-constraint) |
-| "within K times / K ticks" (deadline) | requirements `time` + `deadline` (reference §11) |
+| "within K times / K ticks" (deadline) | kernel `leadsTo ... within K` for step deadlines, or requirements `time` + `deadline` for SLA/tick semantics (reference §11) |
 | upper/lower bound or non-negativity of a number | kernel: `type T = lo..hi`; business/requirements dialects: `number T` plus `verify { values T = lo..hi }` (do not hand-write boundary invariants) |
 | "at most / less than / at least / greater than" "before / after" | `<= / < / >= / >`. **Make boundary implications explicit in the memo** (the most frequent misreading) |
 | "the total equals X" / "the count is X" (aggregate consistency) | an invariant over `sum(...)` / `count(...)` |

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -27,7 +27,9 @@ spec <Name> {
   invariant <Name> { <expr> }
   trans     <Name> { <expr> }            // two-state safety. old(expr) for the old state
   reachable <Name> { <expr> }
-  leadsTo   <Name> { <expr> ~> <expr> [decreases <int expr>] } // outer forall x: T { … } may wrap the response
+  leadsTo   <Name> { <expr> ~> [within K] <expr> [decreases <int expr>] } // outer forall x: T { … } may wrap the response
+  unless    <Name> { <expr> unless <expr> } // safety: preserve P until Q
+  until     <Name> { <expr> until <expr> }  // unless safety + progress P ~> Q
   terminal  { <expr> }                     // intended terminal state (excluded from the deadlock check)
 }
 ```
@@ -129,9 +131,13 @@ check as a type error.
   space: `a / b`)
 - Comparison: `== != < <= > >=` / logic: `and or not =>`
 - Quantification: `forall x: T { expr }`, `exists x: T { expr }` (`where expr`
-  allowed), and the v0 form `forall i in lo..hi: expr` (range is a constant
-  expression: `0..CAP-1` recommended)
+  allowed), `forall x in set_or_seq { expr }` / `exists x in set_or_seq { expr }`
+  for expression-only Set/Seq iteration, and the v0 form
+  `forall i in lo..hi: expr` (range is a constant expression: `0..CAP-1` recommended)
 - Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
+- Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
+  `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
+  matching binding; `exactlyOne` means exactly one.
 - Option: `x == none` `x != none` `x is some(v)` (v is usable afterward within that
   formula). **`x == some(e)` and arithmetic/ordering on Option are type errors**
 - struct: literal `S { f: 0, o: none }`, `s.f`, `==` (field-wise equality; for an
@@ -139,8 +145,9 @@ check as a type error.
 - Set: `Set {}` `Set { 1, 2 }`, `.add(e) .remove(e) .contains(e) .size()`
 - Seq: `Seq {}` `Seq { 1, 2 }` (element count ≤ N), `.push(e) .pop() .head() .at(i)
   .contains(e) .size()`, `==` (length + all elements)
-- ensures/trans only: `old(expr)` / leadsTo only: `P ~> Q` plus optional
-  `decreases <int expr>` for induction ranking / mapping-expression only:
+- ensures/trans only: `old(expr)` / leadsTo only: `P ~> Q`,
+  `P ~> within K Q`, plus optional `decreases <int expr>` for induction ranking /
+  mapping-expression only:
   `if c then a else b`
 
 ## 4. Statements (init / action body)

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -35,8 +35,10 @@ from .values import (
     eval_field,
     eval_index,
     eval_is,
+    eval_one,
     eval_quant,
     eval_sum,
+    iter_binder_terms,
     logical_map_access,
     option_logical_eq,
     option_none_cmp,
@@ -70,6 +72,9 @@ class _SymDomain:
 
     def and_(self, x, y):
         return z3.And(x, y)
+
+    def lt(self, x, y):
+        return x < y
 
     def implies(self, x, y):
         return z3.Implies(x, y)
@@ -651,6 +656,8 @@ def _eval_expr_uncached(e, state, binds, spec, old_state=None, in_ensures=False)
         _err(f"unknown operator '{op}'")
     if tag in ("forall", "exists"):
         return _eval_quant(e, state, binds, spec, old_state, in_ensures)
+    if tag in ("unique", "exactly_one"):
+        return _eval_one(e, state, binds, spec, old_state, in_ensures)
     if tag == "count":
         return _eval_count(e, state, binds, spec, old_state, in_ensures)
     if tag == "sum":
@@ -921,6 +928,10 @@ def _eval_is(inner, pat, state, binds, spec, old_state, in_ensures):
 
 def _eval_quant(e, state, binds, spec, old_state, in_ensures):
     return eval_quant(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
+
+
+def _eval_one(e, state, binds, spec, old_state, in_ensures):
+    return eval_one(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
 
 def _eval_count(e, state, binds, spec, old_state, in_ensures):
@@ -1632,6 +1643,10 @@ def _binder_static_type(binder, spec):
         ty_name = binder[2]
         if ty_name in spec["types"]:
             return spec["types"][ty_name]["ty"]
+    if binder[0] == "binder_collection":
+        coll_ty = _expr_static_type(binder[2], spec, {})
+        if coll_ty and coll_ty[0] in ("set", "seq"):
+            return coll_ty[1]
     return ("int",)
 
 
@@ -1724,7 +1739,7 @@ def _expr_static_type(e, spec, env):
         a_ty = _expr_static_type(e[2], spec, env)
         b_ty = _expr_static_type(e[3], spec, env)
         return _merge_ite_static_types(a_ty, b_ty)
-    if tag in ("not", "is", "forall", "exists"):
+    if tag in ("not", "is", "forall", "exists", "unique", "exactly_one"):
         return ("bool",)
     if tag in ("count", "sum", "min", "max", "abs"):
         return ("int",)
@@ -1750,7 +1765,23 @@ def _collect_pattern_binding_types(e, spec, env, out):
             where = binder[3]
             if where is not None:
                 _collect_pattern_binding_types(where, spec, env, out)
+        elif binder[0] == "binder_collection":
+            env = {**env, binder[1]: _binder_static_type(binder, spec)}
+            where = binder[3]
+            if where is not None:
+                _collect_pattern_binding_types(where, spec, env, out)
         _collect_pattern_binding_types(body, spec, env, out)
+        return
+    if tag in ("unique", "exactly_one"):
+        binder = e[1]
+        if binder[0] == "binder_collection":
+            out[binder[1]] = _binder_static_type(binder, spec)
+            if binder[3] is not None:
+                _collect_pattern_binding_types(binder[3], spec, env, out)
+        elif binder[0] == "binder_typed":
+            out[binder[1]] = _binder_static_type(binder, spec)
+            if binder[3] is not None:
+                _collect_pattern_binding_types(binder[3], spec, env, out)
         return
     for child in e[1:]:
         if isinstance(child, tuple):
@@ -1772,20 +1803,19 @@ def violating_bindings(model, inv_expr, state, spec):
     def search(e, binds, env):
         if e[0] in ("forall", "exists"):
             binder, body = e[1], e[2]
-            v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
+            v = binder[1]
             bty = _binder_static_type(binder, spec)
             env = {**env, v: bty}
             binding_types[v] = bty
             bad = []
-            for i in range(lo, hi + 1):
-                b2 = {**binds, v: i}
-                if where is not None:
-                    w = eval_expr(where, state, b2, spec)
-                    if z3.is_false(model.eval(w, model_completion=True)):
-                        continue
+            for w, b2 in iter_binder_terms(
+                binder, state, binds, spec, None, False, _SYM, eval_expr
+            ):
+                if w is not None and z3.is_false(model.eval(w, model_completion=True)):
+                    continue
                 inst = eval_expr(body, state, b2, spec)
                 if z3.is_false(model.eval(inst, model_completion=True)):
-                    bad.append(_public_model_bindings(model, {**binds, v: i}, spec, binding_types))
+                    bad.append(_public_model_bindings(model, b2, spec, binding_types))
             return bad if bad else None
         if e[0] == "bin" and e[1] == "and":
             left = search(e[2], binds, env)
@@ -2527,6 +2557,71 @@ def _check_leadsto_stutter_at_step(
         m, states, choices, instances, spec, leadsto, extra_binds, t, p_val, binding_types)
 
 
+def _check_single_leadsto_within(explored, spec, leadsto, extra_binds, binding_types):
+    within = leadsto.get("within")
+    if within is None:
+        return None
+
+    depth = explored["depth"]
+    states = explored["states"]
+    choices = explored["choices"]
+    instances = explored["instances"]
+    s = explored["solver"]
+    expr_cache = explored["expr_cache"]
+
+    candidates = []
+    meta = []
+    for p in range(depth + 1):
+        deadline = p + within
+        if deadline > depth:
+            continue
+        p_hold = _eval_at_state(leadsto["P"], states[p], extra_binds, spec, expr_cache)
+        not_q = [
+            z3.Not(_eval_at_state(leadsto["Q"], states[q], extra_binds, spec, expr_cache))
+            for q in range(p, deadline + 1)
+        ]
+        cond = z3.And(p_hold, z3.And(*not_q) if not_q else z3.BoolVal(True))
+        candidates.append(cond)
+        meta.append((p, deadline, cond))
+
+    if not candidates:
+        return None
+
+    s.push()
+    s.add(z3.Or(*candidates))
+    if s.check() != z3.sat:
+        s.pop()
+        return None
+
+    m = s.model()
+    p_val = deadline_val = None
+    for p, deadline, cond in meta:
+        if z3.is_true(m.eval(cond, model_completion=True)):
+            p_val, deadline_val = p, deadline
+            break
+    s.pop()
+    if p_val is None:
+        return None
+
+    return _attach_requirement({
+        "result": "violated",
+        "spec": spec["name"],
+        "violation_kind": "leadsTo",
+        "invariant": leadsto["name"],
+        "loc": leadsto.get("loc"),
+        "bindings": _display_leadsto_bindings(m, extra_binds, spec, binding_types),
+        "pending_since": p_val,
+        "deadline": deadline_val,
+        "within": within,
+        "stutter": False,
+        "trace": _build_trace(m, states, choices, instances, spec, deadline_val),
+        "hint": (
+            f"leadsTo deadline missed: P holds at step {p_val}, but Q does not hold "
+            f"within {within} step(s)"
+        ),
+    }, leadsto)
+
+
 def _check_single_leadsto(explored, spec, leadsto):
     depth = explored["depth"]
     states = explored["states"]
@@ -2540,6 +2635,11 @@ def _check_single_leadsto(explored, spec, leadsto):
     canonical = [_symmetry_canonical_constraint(spec, states[t]) for t in range(K + 1)]
 
     for extra_binds in expand_leadsto_bindings(leadsto, spec):
+        within_violation = _check_single_leadsto_within(
+            explored, spec, leadsto, extra_binds, binding_types)
+        if within_violation is not None:
+            return within_violation
+
         candidates = []
         meta = []
 
@@ -2612,7 +2712,12 @@ def _check_leadstos(explored, spec):
         violation = _check_single_leadsto(explored, spec, lt)
         if violation is not None:
             return violation, None
-    leads_to = {lt["name"]: {"checked_to_depth": depth} for lt in leadstos}
+    leads_to = {}
+    for lt in leadstos:
+        entry = {"checked_to_depth": depth}
+        if lt.get("within") is not None:
+            entry["within"] = lt["within"]
+        leads_to[lt["name"]] = entry
     return None, leads_to
 
 
@@ -2761,6 +2866,8 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
     proved = {}
     for leadsto in leadstos:
         binding_types = _leadsto_binding_types(leadsto, spec)
+        if leadsto.get("within") is not None:
+            continue
         if leadsto.get("decreases") is not None:
             for extra_binds in expand_leadsto_bindings(leadsto, spec):
                 failure = _prove_leadsto_rank_lower_bound(

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -1290,7 +1290,7 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
             out.append(("invariant", policy_id, expr, loc, meta))
         elif body[0] == "biz_policy_responds":
             binders, p, q = _rewrite_stage_binders(body[1], body[2], body[3], process_by_case)
-            out.append(("leadsto", policy_id, binders, p, q, loc, meta))
+            out.append(("leadsto", policy_id, binders, p, q, loc, meta, None, body[4]))
         elif body[0] == "biz_policy_eventually":
             _, case_name, source_stage, target_stages = body
             binder = ("binder_typed", "c", case_name, None)

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -1012,8 +1012,8 @@ class Ast(Transformer):
         return ("biz_policy_invariant", expr)
 
     def policy_responds(self, meta, body):
-        binders, p, q = _flatten_leadsto(body)
-        return ("biz_policy_responds", binders, p, q)
+        binders, p, q, within = _flatten_leadsto(body)
+        return ("biz_policy_responds", binders, p, q, within)
 
     def stage_disjunction(self, meta, *names):
         return list(names)

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -19,7 +19,7 @@ spec_def: "spec" NAME "{" item* "}"
 compose_def: "compose" NAME "{" compose_item* "}"
 ?compose_item: use_def | internal_def | compose_state | compose_init
              | sync_action | action_def
-             | invariant_def | trans_def | reachable_def | leadsto_def
+             | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def
 use_def: "use" NAME "as" NAME "from" STRING
 internal_def: "internal" NAME "." NAME
 compose_state: "state" "{" var_decl ("," var_decl)* ","? "}"
@@ -48,7 +48,7 @@ mapped_action_target: NAME "(" [ref_expr ("," ref_expr)*] ")"
 
 ?item: const_def | type_def | enum_def | struct_def
      | state_def | init_def | action_def
-     | invariant_def | trans_def | reachable_def | leadsto_def | terminal_def
+     | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def | terminal_def
 
 const_def: "const" NAME "=" expr
 type_def: plain_type_def | symmetric_type_def
@@ -100,18 +100,23 @@ lvalue: NAME "[" expr "]" "." NAME -> lvalue_map_field
 
 binder: NAME ":" qname ["where" expr] -> binder_typed
        | NAME "in" expr ".." expr -> binder_range
+       | NAME "in" expr ["where" expr] -> binder_collection
 
 invariant_def: "invariant" NAME meta_tag? "{" expr "}"
 trans_def: "trans" NAME meta_tag? "{" expr "}"
 reachable_def: "reachable" NAME meta_tag? "{" expr "}"
 terminal_def: "terminal" "{" expr "}"
+until_def: "until" NAME meta_tag? "{" expr _UNTIL expr "}"
+unless_def: "unless" NAME meta_tag? "{" expr _UNLESS expr "}"
 
 leadsto_def: "leadsTo" NAME meta_tag? "{" lt_body leadsto_decreases? "}"
 leadsto_decreases: "decreases" expr
 meta_tag: STRING
 ?lt_body: lt_forall | lt_implies
 lt_forall: "forall" binder [":"] "{" lt_body "}"
-lt_implies: expr "~>" expr
+lt_implies: expr "~>" lt_target
+?lt_target: _WITHIN expr expr -> lt_within
+          | expr -> lt_target
 
 ?expr: quant | implies
 quant: "forall" binder [":"] expr -> quant_forall
@@ -156,6 +161,8 @@ postfix_suffix: "[" expr "]" -> idx_suffix
      | "max" "(" expr "," expr ")" -> max_e
      | "abs" "(" expr ")" -> abs_e
      | "old" "(" expr ")" -> old_e
+     | "unique" "(" binder ")" -> unique_e
+     | "exactlyOne" "(" binder ")" -> exactly_one_e
      | NAME -> var
      | "(" expr ")"
 struct_fields: "{" NAME ":" expr ("," NAME ":" expr)* ","? "}"
@@ -204,6 +211,8 @@ ref_postfix_suffix: "[" ref_expr "]" -> idx_suffix
          | "max" "(" ref_expr "," ref_expr ")" -> max_e
          | "abs" "(" ref_expr ")" -> abs_e
          | "old" "(" ref_expr ")" -> old_e
+         | "unique" "(" binder ")" -> unique_e
+         | "exactlyOne" "(" binder ")" -> exactly_one_e
          | NAME -> var
          | "(" ref_expr ")"
 ref_struct_fields: "{" NAME ":" ref_expr ("," NAME ":" ref_expr)* ","? "}" -> struct_fields
@@ -213,7 +222,7 @@ requirements_def: "requirements" NAME "{" requirements_item* "}"
 ?requirements_item: implements_def | requirement_def | acceptance_def | forbidden_def | kpi_def
                   | const_def | type_def | enum_def | struct_def | entity_def | number_def
                   | state_def | init_def | req_action_def | process_def | time_def
-                  | invariant_def | trans_def | reachable_def | leadsto_def
+                  | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def
 implements_def: "implements" NAME "from" STRING "{" implements_item* "}"
 ?implements_item: map_def | maps_auto_def
 requirement_def: "requirement" REQ_ID STRING "{" requirement_item* "}"
@@ -275,6 +284,9 @@ _NOT: /not\b/
 _IF: /if\b/
 _ELSE: /else\b/
 _FAIR: /fair\b/
+_WITHIN: /within\b/
+_UNTIL: /until\b/
+_UNLESS: /unless\b/
 NAME: /[a-zA-Z_][a-zA-Z_0-9]*/
 INT: /[0-9]+/
 STRING: /"[^"]*"/
@@ -300,8 +312,8 @@ def _flatten_leadsto(body):
         node = inner
     if node[0] != "lt_implies":
         raise ValueError(f"expected leadsTo implication, got {node[0]}")
-    _, p, q = node
-    return binders, p, q
+    _, p, q, within = node
+    return binders, p, q, within
 
 
 def _parse_meta(s):
@@ -480,6 +492,9 @@ class Ast(Transformer):
     def binder_range(self, meta, v, lo, hi):
         return ("binder_range", v, lo, hi)
 
+    def binder_collection(self, meta, v, collection, where=None):
+        return ("binder_collection", v, collection, where)
+
     def quant_forall(self, meta, b, e):
         return ("forall", b, e)
 
@@ -491,6 +506,12 @@ class Ast(Transformer):
 
     def quant_exists_brace(self, meta, b, e):
         return ("exists", b, e)
+
+    def unique_e(self, meta, binder):
+        return ("unique", binder)
+
+    def exactly_one_e(self, meta, binder):
+        return ("exactly_one", binder)
 
     def lvalue_var(self, meta, n):
         return ("var", n)
@@ -630,6 +651,28 @@ class Ast(Transformer):
     def terminal_def(self, meta, e):
         return ("terminal", e, _loc(meta))
 
+    def until_def(self, meta, n, *rest):
+        req_meta, p, q = None, None, None
+        for r in rest:
+            if isinstance(r, dict):
+                req_meta = r
+            elif p is None:
+                p = r
+            else:
+                q = r
+        return ("until", n, p, q, _loc(meta), req_meta)
+
+    def unless_def(self, meta, n, *rest):
+        req_meta, p, q = None, None, None
+        for r in rest:
+            if isinstance(r, dict):
+                req_meta = r
+            elif p is None:
+                p = r
+            else:
+                q = r
+        return ("unless", n, p, q, _loc(meta), req_meta)
+
     def _action_parts(self, meta, name, *rest):
         params, items, req_meta = [], [], None
         for r in rest:
@@ -702,8 +745,15 @@ class Ast(Transformer):
     def req_action_def(self, meta, node):
         return node
 
-    def lt_implies(self, meta, p, q):
-        return ("lt_implies", p, q)
+    def lt_target(self, meta, q):
+        return ("lt_target", q, None)
+
+    def lt_within(self, meta, bound, q):
+        return ("lt_target", q, bound)
+
+    def lt_implies(self, meta, p, target):
+        _, q, within = target
+        return ("lt_implies", p, q, within)
 
     def lt_forall(self, meta, binder, body):
         return ("lt_forall", binder, body)
@@ -720,8 +770,8 @@ class Ast(Transformer):
                 measure = r[1]
             else:
                 body = r
-        binders, p, q = _flatten_leadsto(body)
-        return ("leadsto", name, binders, p, q, _loc(meta), req_meta, measure)
+        binders, p, q, within = _flatten_leadsto(body)
+        return ("leadsto", name, binders, p, q, _loc(meta), req_meta, measure, within)
 
     def top_def(self, meta, child):
         return child

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -409,6 +409,11 @@ def binder_range(binder, consts, types_meta):
         _, v, lo, hi = binder
         lo_i, hi_i = eval_const(lo, consts, {}), eval_const(hi, consts, {})
         return v, lo_i, hi_i, None
+    if binder[0] == "binder_collection":
+        _err(
+            "collection binders are only supported in expressions; use a typed or range binder here",
+            kind="type",
+        )
     _, v, ty_name, where = binder
     if ty_name not in types_meta:
         _err(f"unknown type '{ty_name}' in binder", kind="type")
@@ -956,6 +961,15 @@ def _with_meta(entry, meta):
     return entry
 
 
+def _unless_trans_expr(p, q):
+    return (
+        "bin",
+        "=>",
+        ("bin", "and", ("old", p), ("not", ("old", q))),
+        ("bin", "or", p, q),
+    )
+
+
 def build_spec(tree, display_names=None, semantic_check=True):
     _, name, items = tree
     dialect_display_names = {}
@@ -1040,6 +1054,11 @@ def build_spec(tree, display_names=None, semantic_check=True):
                 action["generated"] = generated
             actions.append(action)
         elif tag == "leadsto":
+            within = it[8] if len(it) > 8 else None
+            if within is not None:
+                within = eval_const(within, consts, types_meta)
+                if within < 0:
+                    _err("leadsTo within bound must be non-negative", kind="type", loc=it[5])
             leadstos.append(_with_meta({
                 "name": it[1],
                 "binders": it[2],
@@ -1047,7 +1066,29 @@ def build_spec(tree, display_names=None, semantic_check=True):
                 "Q": it[4],
                 "loc": it[5],
                 "decreases": it[7] if len(it) > 7 else None,
+                "within": within,
             }, it[6] if len(it) > 6 else None))
+        elif tag == "until":
+            transitions.append(_with_meta({
+                "name": f"{it[1]}_until_safety",
+                "expr": _unless_trans_expr(it[2], it[3]),
+                "loc": it[4],
+            }, it[5] if len(it) > 5 else None))
+            leadstos.append(_with_meta({
+                "name": it[1],
+                "binders": [],
+                "P": it[2],
+                "Q": it[3],
+                "loc": it[4],
+                "decreases": None,
+                "within": None,
+            }, it[5] if len(it) > 5 else None))
+        elif tag == "unless":
+            transitions.append(_with_meta({
+                "name": it[1],
+                "expr": _unless_trans_expr(it[2], it[3]),
+                "loc": it[4],
+            }, it[5] if len(it) > 5 else None))
         elif tag == "invariant":
             invariants.append(_with_meta({
                 "name": it[1],

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -25,6 +25,7 @@ from .values import (
     eval_field,
     eval_index,
     eval_is,
+    eval_one,
     eval_quant,
     eval_sum,
     logical_map_access,
@@ -511,6 +512,8 @@ def _eval_concrete_impl(e, state, binds, spec, old_state=None, in_ensures=False)
         _err(f"unknown operator '{op}'")
     if tag in ("forall", "exists"):
         return _eval_quant(e, state, binds, spec, old_state, in_ensures)
+    if tag in ("unique", "exactly_one"):
+        return _eval_one(e, state, binds, spec, old_state, in_ensures)
     if tag == "count":
         return _eval_count(e, state, binds, spec, old_state, in_ensures)
     if tag == "sum":
@@ -684,6 +687,9 @@ class _ConcDomain:
     def and_(self, x, y):
         return x and y
 
+    def lt(self, x, y):
+        return x < y
+
     def implies(self, x, y):
         return (not x) or y
 
@@ -705,6 +711,10 @@ _CONC = _ConcDomain()
 
 def _eval_quant(e, state, binds, spec, old_state, in_ensures):
     return eval_quant(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
+
+
+def _eval_one(e, state, binds, spec, old_state, in_ensures):
+    return eval_one(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
 
 
 def _eval_count(e, state, binds, spec, old_state, in_ensures):

--- a/src/fslc/values.py
+++ b/src/fslc/values.py
@@ -103,18 +103,66 @@ def eval_sum(e, state, binds, spec, old_state, in_ensures, dom, ev):
     return acc
 
 
+def iter_binder_terms(binder, state, binds, spec, old_state, in_ensures, dom, ev):
+    if binder[0] == "binder_collection":
+        _, v, collection, where = binder
+        value = ev(collection, state, binds, spec, old_state, in_ensures)
+        if isinstance(value, tuple) and value[0] == "set_val":
+            m, elem_ty = value[1], value[2]
+            lo, hi = domain_range(elem_ty, spec["types"])
+            for i in range(lo, hi + 1):
+                b2 = dict(binds)
+                member = dom.int_lit(i)
+                b2[v] = i
+                w = dom.select(m, member)
+                if where is not None:
+                    w = dom.and_(w, ev(where, state, b2, spec, old_state, in_ensures))
+                yield w, b2
+            return
+        parts = _seq_val_parts(value)
+        if parts is not None:
+            data, length, _elem_ty, cap = parts
+            for i in range(cap):
+                b2 = dict(binds)
+                idx = dom.int_lit(i)
+                b2[v] = dom.select(data, idx)
+                w = dom.lt(idx, length)
+                if where is not None:
+                    w = dom.and_(w, ev(where, state, b2, spec, old_state, in_ensures))
+                yield w, b2
+            return
+        _err("collection binder expects a Set or Seq expression", kind="type")
+
+    v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
+    for i in range(lo, hi + 1):
+        b2 = dict(binds)
+        b2[v] = i
+        w = ev(where, state, b2, spec, old_state, in_ensures) if where is not None else None
+        yield w, b2
+
+
 def eval_quant(e, state, binds, spec, old_state, in_ensures, dom, ev):
     qop, binder, body = e[0], e[1], e[2]
-    v, lo, hi, where = binder_range(binder, spec["consts"], spec["types"])
 
     def terms():
-        for i in range(lo, hi + 1):
-            b2 = dict(binds)
-            b2[v] = i
-            w = ev(where, state, b2, spec, old_state, in_ensures) if where is not None else None
+        for w, b2 in iter_binder_terms(
+            binder, state, binds, spec, old_state, in_ensures, dom, ev
+        ):
             yield w, (lambda b2=b2: ev(body, state, b2, spec, old_state, in_ensures))
 
     return dom.quantify(qop, terms())
+
+
+def eval_one(e, state, binds, spec, old_state, in_ensures, dom, ev):
+    tag, binder = e[0], e[1]
+    acc = dom.int_lit(0)
+    for w, _b2 in iter_binder_terms(
+        binder, state, binds, spec, old_state, in_ensures, dom, ev
+    ):
+        acc = acc + dom.select_int(w if w is not None else dom.true_(), lambda: dom.int_lit(1))
+    if tag == "unique":
+        return acc <= dom.int_lit(1)
+    return acc == dom.int_lit(1)
 
 
 def option_logical_eq(a, b, dom):

--- a/tests/test_logic_temporal_sugar.py
+++ b/tests/test_logic_temporal_sugar.py
@@ -1,0 +1,108 @@
+from fslc import build_spec, parse, verify
+
+
+def run_inline(src, depth=8):
+    return verify(build_spec(parse(src)), depth)
+
+
+def test_forall_over_set_reports_member_binding():
+    src = """
+spec SetQuant {
+  type User = 0..2
+  state { active: Set<User> }
+  init { active = Set {0, 2} }
+  action noop() { }
+  invariant NoUserTwo { forall u in active { u < 2 } }
+}
+"""
+    out = run_inline(src)
+    assert out["result"] == "violated"
+    assert out["violation_kind"] == "invariant"
+    assert out["violating_bindings"] == [{"u": 2}]
+
+
+def test_exists_over_seq_uses_live_prefix_only():
+    src = """
+spec SeqQuant {
+  const CAP = 3
+  type Item = 0..2
+  state { q: Seq<Item, CAP> }
+  init { q = Seq {0, 1} }
+  action noop() { }
+  invariant HasOne { exists x in q { x == 1 } }
+  invariant NoTwo { forall x in q { x != 2 } }
+}
+"""
+    out = run_inline(src)
+    assert out["result"] == "verified"
+
+
+def test_unique_and_exactly_one_predicates():
+    src = """
+spec OnePredicates {
+  type User = 0..2
+  state { locked: Map<User, Bool>, active: Set<User> }
+  init {
+    forall u: User { locked[u] = u < 2 }
+    active = Set {0}
+  }
+  action noop() { }
+  invariant AtMostOneLocked { unique(u: User where locked[u]) }
+  invariant ExactlyOneActive { exactlyOne(u in active) }
+}
+"""
+    out = run_inline(src)
+    assert out["result"] == "violated"
+    assert out["invariant"] == "AtMostOneLocked"
+
+
+def test_leadsto_within_reports_deadline_miss():
+    src = """
+spec WithinDeadline {
+  type Step = 0..3
+  state { x: Step }
+  init { x = 0 }
+  action inc() {
+    requires x < 3
+    x = x + 1
+  }
+  invariant Range { true }
+  leadsTo TooFast { x == 1 ~> within 1 x == 3 }
+}
+"""
+    out = run_inline(src, depth=3)
+    assert out["result"] == "violated"
+    assert out["violation_kind"] == "leadsTo"
+    assert out["within"] == 1
+    assert out["deadline"] == out["pending_since"] + 1
+
+
+def test_unless_sugar_rejects_early_drop_before_release():
+    src = """
+spec UnlessSugar {
+  state { held: Bool, released: Bool }
+  init { held = true  released = false }
+  action drop() { held = false }
+  action release() { released = true  held = false }
+  unless HeldUnlessReleased { held unless released }
+}
+"""
+    out = run_inline(src)
+    assert out["result"] == "violated"
+    assert out["violation_kind"] == "trans"
+    assert out["invariant"] == "HeldUnlessReleased"
+
+
+def test_until_sugar_adds_progress_obligation():
+    src = """
+spec UntilSugar {
+  state { held: Bool, released: Bool }
+  init { held = true  released = false }
+  action wait() { held = true }
+  until HeldUntilReleased { held until released }
+}
+"""
+    out = run_inline(src, depth=4)
+    assert out["result"] == "violated"
+    assert out["violation_kind"] == "leadsTo"
+    assert out["invariant"] == "HeldUntilReleased"


### PR DESCRIPTION
## Summary
Adds focused FSL syntax for common first-order and temporal patterns:

- `forall x in set_or_seq { ... }` / `exists x in set_or_seq { ... }`
- `unique(...)` / `exactlyOne(...)`
- `leadsTo Name { P ~> within K Q }`
- top-level `unless Name { P unless Q }` and `until Name { P until Q }`

Also tiers CI so PRs get faster feedback while main, scheduled, and manual runs still keep the full Python 3.9-3.12 matrix.

## Why
- **Goal**: make frequent FOL/temporal requirements easier to write without exposing arbitrary FOL/LTL syntax.
- **Reason**: existing idioms like Seq live-prefix quantification and bounded response deadlines are correct but verbose and easy for authors/agents to miswrite.
- **Alternative**: add broad LTL/FOL operators. Rejected for now because FSL benefits from bounded, typed, diagnosable constructs that compile into existing verifier paths.

## What Changed
- Extended grammar and AST support for collection binders, cardinality predicates, `within`, `until`, and `unless`.
- Reused finite enumeration for collection quantification and one-cardinality checks.
- Checked `within K` as a bounded `leadsTo` deadline in BMC.
- Expanded `unless` into two-state safety and `until` into safety plus `leadsTo` progress.
- Updated `docs/LANGUAGE.md`, FSL skill references, and CI policy docs.

## Blast Radius
- **Affected**: parser grammar, AST normalization, symbolic evaluator, concrete Monitor evaluator, leadsto BMC, docs, CI.
- **Compatibility**: existing syntax remains valid. `within`, `until`, and `unless` become reserved in the affected grammar positions.

## Invariants
| Condition | Evidence | Symptom if broken |
|---|---|---|
| Existing typed/range quantifiers keep semantics | Existing `test_v1`, `test_seq`, `test_temporal` coverage | Existing specs fail or bindings regress |
| Seq collection quantification ranges over live prefix values | `test_exists_over_seq_uses_live_prefix_only` | Uninitialized Seq capacity slots affect logic |
| Ranked unbounded `leadsTo` remains separate from bounded `within` deadlines | BMC code skips ranked proof for `within` leadstos | False unbounded proof claims for deadline properties |

## Failure Modes
| Pattern | Detection |
|---|---|
| Grammar ambiguity around `x in lo..hi` vs `x in set` | New parser/evaluator tests plus existing temporal tests |
| Collection binder diagnostics omit useful binding values | `test_forall_over_set_reports_member_binding` |
| CI required-check names need updating in GitHub branch protection | Branch protection settings after PR creation |

## Evidence
- [x] `PYTHONPATH=src /Users/rizumita/Workspace/fsl/.venv/bin/python -m pytest tests/test_logic_temporal_sugar.py tests/test_temporal.py -q` -> 24 passed
- [x] `PYTHONPATH=src /Users/rizumita/Workspace/fsl/.venv/bin/python -m pytest tests/test_v1.py tests/test_seq.py tests/test_runtime.py tests/test_req_dialect.py tests/test_vacuity.py -q` -> 99 passed
- [x] `PYTHONPATH=src /Users/rizumita/Workspace/fsl/.venv/bin/python -m pytest -q tests/test_version.py tests/test_v1.py tests/test_temporal.py tests/test_logic_temporal_sugar.py` -> 65 passed
- [x] `git diff --check`
- [x] CI YAML parsed with Ruby YAML loader

## Rollout & Rollback
- **Rollout**: merge normally; new syntax is additive.
- **Rollback**: revert this commit to remove parser/evaluator/docs/CI changes together.
- **Cannot rollback if**: downstream specs start relying on the new syntax without being rewritten to old idioms.

## Review Focus
- [ ] `src/fslc/grammar.py`: syntax ambiguity and reserved-word impact.
- [ ] `src/fslc/values.py` and `src/fslc/bmc.py`: collection binder semantics and `within` deadline checks.
- [ ] `.github/workflows/ci.yml`: whether the PR/full CI split matches repository policy.

## Unknowns
- Full local suite was not rerun after CI tiering; focused suites above passed. The updated CI still runs full suite on PR for Python 3.12 and full matrix outside PR.
- If branch protection requires old matrix job names, repository settings need updating after this PR is opened.