### PR TITLE
[codex] add governance control catalog support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- (Governance/Business) Business specs can declare `control` metadata and attach
+  it to checkable `policy`/`goal` declarations with `satisfies`. Violations now
+  carry satisfied controls in the requirement payload. New top-level
+  `governance` catalogs validate cross-business control delegation and run
+  preservation refinements during `fslc check`.
 - (HTML report) `fslc html <file.fsl> [-o report.html]` generates a self-contained
   review report from `explain` + `verify`: status summary, state/action tables,
   an action-to-state SVG graph (arrows show the write direction), traces, witnesses,

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -179,11 +179,18 @@ business ReturnHandling {
   kpi refunded = count Return in Refunded  // → metadata projection:
                                            //   count(c: Return where stage(c) == Refunded)
 
+  control CTRL-REFUND-REVIEW
+    "refund payment must preserve review control"
+    owner Manager
+    severity high
+    applies_to Return
+
   policy PAY-1 "refunds only for approved cases" invariant {
     // stage(c) is available in expressions (c is an entity-typed bound variable)
     forall c: Return { stage(c) == Refunded => true }   // example
   }
   policy PAY-2 "every request is eventually adjudicated"
+    satisfies CTRL-REFUND-REVIEW
     every Return in Requested must eventually be Approved or Rejected or Refunded
   goal AllSettled "all cases can complete"
     all Return can be Refunded or Rejected
@@ -211,7 +218,16 @@ verify {
 3. `kpi k = count X in S` → no kernel state/action/invariant. The declaration is
    recorded as metadata for the projection
    `count(c: X where x_stage[c] == S)`.
-4. `policy <ID> "<text>" invariant { expr }` → invariant (with meta).
+4. `control <ID> "<text>" [owner NAME] [severity NAME] [applies_to NAME]...`
+   records business/governance metadata only. It does not generate kernel state
+   or properties by itself. A control becomes checkable when a policy or goal
+   declares `satisfies <ControlID>`.
+5. `policy <ID> "<text>" [satisfies <ControlID>, ...] invariant { expr }` →
+   invariant (with meta). The same optional `satisfies` clause is available on
+   all policy forms and on goals. Unknown control references are type errors;
+   declared but unused controls produce an `unused_control` warning. When a
+   satisfied policy/goal fails, the JSON `requirement` object includes
+   `controls: [{id, text}, ...]`.
    `policy ... responds { P ~> Q }` → leadsTo (with meta).
    `policy ... every <Entity> in <Stage> must eventually be <Stage> [or <Stage> ...]`
    is a readable alias for the common stage-response rule and expands to
@@ -223,16 +239,59 @@ verify {
    `stage(c)` in an expression is rewritten to `x_stage[c]` for the entity-typed
    bound variable c in question (the process is identified from the type of the
    binding; ambiguity is a type error).
-5. The `actor` declaration is a roster (used to validate the `by` of a
+6. The `actor` declaration is a roster (used to validate the `by` of a
    transition; an undeclared actor is a type error). No other semantics.
 
-### 3.3 Tests (tests/test_biz_dialect.py)
+### 3.3 Governance catalog
+
+`governance <Name> { ... }` is an optional top-level form for controls that sit
+above one business process or are reused across multiple business specs:
+
+```fsl
+governance EnterpriseRefundControls {
+  authority Finance owns CTRL-REFUND-REVIEW
+  control CTRL-REFUND-REVIEW "refund payment must preserve review control"
+    owner Finance
+    severity high
+    applies_to Return
+
+  delegates ReturnHandling from "return_policy.fsl" {
+    require CTRL-REFUND-REVIEW
+    // optional when the business file already has `policy ... satisfies CTRL-REFUND-REVIEW`
+    CTRL-REFUND-REVIEW is satisfied_by policy PAY-2
+  }
+
+  preservation AutoApproval {
+    before AsIsExpense from "asis_expense.fsl"
+    after  ToBeExpense from "tobe_expense.fsl"
+    preserve CTRL-REFUND-REVIEW
+    checked_by refinement "tobe_refines_asis.fsl"
+  }
+}
+```
+
+Expansion rules:
+
+1. A governance catalog expands to a metadata-only kernel spec with generated
+   no-op state/action/property. Kernel verification semantics are unchanged.
+2. `delegates BusinessName from "file.fsl"` parses the referenced business spec,
+   checks the name, and verifies that every `require CTRL` is satisfied either by
+   business-side `policy/goal ... satisfies CTRL` metadata or by an explicit
+   `CTRL is satisfied_by policy|goal ID` mapping. Missing references are type
+   errors.
+3. `preservation` validates the before/after/refinement file references. During
+   `fslc check governance.fsl`, fslc runs `refine(after, before, mapping)` at
+   depth 8 and reports the result under `governance.preservations`.
+
+### 3.4 Tests (tests/test_governance_business.py)
 
 Use the return process of §3.1 as a fixture: check ok / verify verified /
 induction proved / a policy-violating variant carries the requirement
-(= policy ID+text) in the counterexample / KPI projection metadata is recorded
-without generating a counter invariant / the goal is witnessed as reachable / type errors for
-an undeclared actor and a decrementing KPI / all existing tests unchanged.
+(= policy ID+text) and satisfied controls in the counterexample / KPI projection
+metadata is recorded without generating a counter invariant / the goal is
+witnessed as reachable / type errors for an undeclared actor, a decrementing KPI,
+and an unknown satisfied control / governance delegates reject unsatisfied
+controls / preservation runs the declared refinement / all existing tests unchanged.
 Furthermore, `return_policy_biz.fsl`, which rewrites examples/layers'
 return_policy.fsl in this dialect, can **be refined from the requirements layer**
 by the existing return_refines.fsl (with adjusted abs names) (= demonstration

--- a/docs/DESIGN-layers.md
+++ b/docs/DESIGN-layers.md
@@ -86,7 +86,13 @@ business ReturnHandling {
 
   kpi refunded = count Return in Refunded  // → count projection metadata
 
+  control CTRL-DECISION "every request preserves adjudication control"
+    owner Manager
+    severity high
+    applies_to Return
+
   policy EveryRequestDecided "every request is eventually decided"
+    satisfies CTRL-DECISION
     every Return in Requested must eventually be Approved or Rejected or Refunded
   goal AllSettled "all cases can be completed"
     all Return can be Refunded or Rejected
@@ -101,8 +107,37 @@ Expansion rules: `process` → enum + `Map<CaseId, Stage>` + an action per
 transition (`by <actor>` is action metadata; a transition whose actor has a
 parameter becomes a parameter of the actor type). `kpi name = count Entity in
 Stage` → declarative projection metadata only, not a ghost counter and not an
-automatic `_kpi_*` invariant. Readable `every ... must eventually ...` policies
-lower to leadsTo.
+automatic `_kpi_*` invariant. `control ID "text"` is governance metadata only;
+`policy/goal ... satisfies CTRL` attaches that control to the generated
+invariant/leadsTo/reachable so violations identify both the broken policy and the
+control it was meant to satisfy. Readable `every ... must eventually ...`
+policies lower to leadsTo.
+
+When a control is reused across processes or sits above a specific business
+flow, write an optional governance catalog:
+
+```fsl
+governance EnterpriseReturnControls {
+  authority Operations owns CTRL-DECISION
+  control CTRL-DECISION "every request preserves adjudication control"
+
+  delegates ReturnHandling from "return_policy.fsl" {
+    require CTRL-DECISION
+  }
+
+  preservation ReturnReform {
+    before AsIsReturn from "asis_return.fsl"
+    after  ToBeReturn from "tobe_return.fsl"
+    preserve CTRL-DECISION
+    checked_by refinement "tobe_refines_asis.fsl"
+  }
+}
+```
+
+`fslc check` on the governance file validates control references, confirms that
+delegated business specs satisfy required controls either via business-side
+`satisfies` metadata or explicit `CTRL is satisfied_by policy|goal ID` mappings,
+and runs preservation refinements at depth 8.
 
 **What this layer does not handle (stated explicitly)**: real time, SLA time
 values, probability, continuous quantities of money, org charts, and the prose

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -816,7 +816,14 @@ business ReturnHandling {
 
   kpi refunded = count Return in Refunded
 
+  control CTRL-DECISION
+    "Every return must preserve an adjudication control"
+    owner Manager
+    severity high
+    applies_to Return
+
   policy PAY-2 "every request is eventually decided"
+    satisfies CTRL-DECISION
     every Return in Requested must eventually be Approved or Rejected or Refunded
   goal AllSettled "all cases can be completed"
     all Return can be Refunded or Rejected
@@ -830,6 +837,44 @@ verify {
 The explicit forms remain available when the rule is not just stage progression:
 `policy ... responds { forall c: Return { stage(c) == Requested ~> ... } }` and
 `goal ... { exists c: Return { stage(c) == Refunded } }`.
+
+Governance/control metadata can be kept inside `business` or lifted into a
+standalone catalog. `control ID "text" owner NAME severity NAME applies_to Entity`
+does not generate a property by itself; it is a catalog entry. A `policy` or
+`goal` can declare `satisfies CTRL-ID`, and violations then carry both the
+policy/goal requirement and the satisfied controls in JSON:
+
+```fsl
+policy PAY-2 "every request is eventually decided"
+  satisfies CTRL-DECISION
+  every Return in Requested must eventually be Approved or Rejected or Refunded
+```
+
+For controls reused across business specs, use a `governance` catalog:
+
+```fsl
+governance EnterpriseReturnControls {
+  authority Operations owns CTRL-DECISION
+  control CTRL-DECISION "Every return must preserve an adjudication control"
+
+  delegates ReturnHandling from "return_policy.fsl" {
+    require CTRL-DECISION
+    // optional if the business policy already says `satisfies CTRL-DECISION`
+    CTRL-DECISION is satisfied_by policy PAY-2
+  }
+
+  preservation ReturnReform {
+    before AsIsReturn from "asis_return.fsl"
+    after  ToBeReturn from "tobe_return.fsl"
+    preserve CTRL-DECISION
+    checked_by refinement "tobe_refines_asis.fsl"
+  }
+}
+```
+
+`fslc check governance.fsl` validates all referenced controls, business files,
+policies/goals, and preservation files. Preservation blocks also run the declared
+refinement at depth 8 and report results under `governance.preservations`.
 
 ### 13.4 How to write non-functional requirements (NFRs)
 

--- a/examples/consulting/README.md
+++ b/examples/consulting/README.md
@@ -16,6 +16,7 @@ workflow:
 | [`asis_expense.fsl`](asis_expense.fsl) | Current operations (interview results): process + control policies CTRL-1/2 + KPI |
 | [`tobe_expense.fsl`](tobe_expense.fsl) | Reform proposal: adds an auto-approval lane, keeps the controls |
 | [`tobe_refines_asis.fsl`](tobe_refines_asis.fsl) | **Control check of the reform**: To-Be's business mapping table (auto-approval = approval act) |
+| [`governance_controls.fsl`](governance_controls.fsl) | Optional governance catalog: Finance owns CTRL-1/2, both business specs delegate to them, and the To-Be preservation refinement is checked |
 
 ## Why this is valuable (3 points)
 
@@ -45,6 +46,10 @@ fslc refine examples/consulting/tobe_expense.fsl \
             examples/consulting/asis_expense.fsl \
             examples/consulting/tobe_refines_asis.fsl --depth 6
 # → {"result": "refines", ...} = the controls are preserved
+
+# Optional governance catalog check: delegation + preservation in one place
+fslc check examples/consulting/governance_controls.fsl
+# → {"governance": {"delegates": ..., "preservations": [{"result": "refines"}]}}
 ```
 
 ## A worked example of "what it looks like when a control is broken"

--- a/examples/consulting/governance_controls.fsl
+++ b/examples/consulting/governance_controls.fsl
@@ -1,0 +1,37 @@
+// Cross-business governance catalog for the consulting As-Is/To-Be sample.
+// The existing business policies are intentionally left as business rules;
+// this file shows how enterprise/control ownership can sit one layer above them.
+governance ExpenseTransformationControls {
+  authority Finance owns CTRL-1, CTRL-2
+
+  control CTRL-1 "A submitted claim must always be adjudicated for approval or rejection"
+    owner Finance
+    severity high
+    applies_to Claim
+  control CTRL-2 "An approved claim must always be paid"
+    owner Finance
+    severity high
+    applies_to Claim
+
+  delegates AsIsExpense from "asis_expense.fsl" {
+    require CTRL-1
+    require CTRL-2
+    CTRL-1 is satisfied_by policy CTRL-1
+    CTRL-2 is satisfied_by policy CTRL-2
+  }
+
+  delegates ToBeExpense from "tobe_expense.fsl" {
+    require CTRL-1
+    require CTRL-2
+    CTRL-1 is satisfied_by policy CTRL-1
+    CTRL-2 is satisfied_by policy CTRL-2
+  }
+
+  preservation AutoApprovalPreservesControls {
+    before AsIsExpense from "asis_expense.fsl"
+    after ToBeExpense from "tobe_expense.fsl"
+    preserve CTRL-1
+    preserve CTRL-2
+    checked_by refinement "tobe_refines_asis.fsl"
+  }
+}

--- a/skills/fsl-business/SKILL.md
+++ b/skills/fsl-business/SKILL.md
@@ -19,8 +19,11 @@ repository, read `examples/consulting/` for As-Is/To-Be work,
 
 Produce business-layer artifacts only:
 
-- A `business` spec with `actor`, `entity`, `process`, `transition`, `policy`,
-  `kpi`, and `goal`, plus a top-level `verify { instances Entity = N }` bound
+- A `business` spec with `actor`, `entity`, `process`, `transition`, optional
+  `control`, `policy`, `kpi`, and `goal`, plus a top-level
+  `verify { instances Entity = N }` bound
+- Optional standalone `governance` catalog when the same controls must be traced
+  across multiple business specs
 - Verification commands/results, usually `fslc verify ... --engine induction`
 - Optional As-Is/To-Be control preservation using `fslc refine` and a mapping file
 
@@ -43,7 +46,8 @@ the work to `fsl-requirements` or `fsl-design` after the business layer is agree
 3. Write the `business` spec. Prefer readable stage syntax:
    - `entity Claim` with `verify { instances Claim = 3 }`
    - `kpi paid_claims = count Claim in Paid`
-   - `policy POL-1 "..." every Case in Source must eventually be Target`
+   - `control CTRL-1 "..." owner Finance severity high applies_to Claim`
+   - `policy POL-1 "..." satisfies CTRL-1 every Case in Source must eventually be Target`
    - `goal G "..." some Case can reach Target`
    - `goal G "..." all Case can be Target or OtherTarget`
 4. Run `fslc check`, then `fslc verify --engine induction`. Use `--deadlock ignore`
@@ -57,8 +61,12 @@ the work to `fsl-requirements` or `fsl-design` after the business layer is agree
 
 ## Guardrails
 
-- Keep IDs and source text verbatim in `policy` declarations. Diagnostics carry
-  this text back to the business reviewer.
+- Keep IDs and source text verbatim in `control` and `policy` declarations.
+  Diagnostics carry policy/goal text and satisfied control text back to the
+  business reviewer.
+- Use `control` for governance/catalog ownership and `policy`/`goal satisfies`
+  for the checkable business rule. A bare `control` does not prove anything by
+  itself.
 - Do not invent missing exception policy, SLA semantics, escalation stages, or
   ownership rules to make the verifier green.
 - A green result means the business spec is internally consistent under the stated

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -379,7 +379,7 @@ to the kernel, so verify/induction/scenarios/Monitor are used identically:
 Treat the layer boundary as part of the contract. Do not move to the lower layer
 unless the user asks for it or the relevant role skill directs it.
 
-- `business Name { process/policy/kpi/goal }` — the consulting layer. For
+- `business Name { process/control/policy/kpi/goal }` — the consulting layer. For
   PM/consulting-facing files, prefer the readable stage syntax for common rules:
   `policy ... every Case in Source must eventually be Target [or Target ...]`,
   `goal ... some Case can reach Target`, and
@@ -387,7 +387,11 @@ unless the user asks for it or the relevant role skill directs it.
   `responds { forall ... stage(c) ... ~> ... }` / `{ expr }` only when the rule is
   not simple stage progression. Regulation contradiction = invariant violation,
   dead business step = coverage diagnostic, unreachable business goal =
-  reachable_failed
+  reachable_failed. Use `control ID "..."` for governance/catalog metadata and
+  `policy/goal ... satisfies ControlID` for the actual checkable rule; violations
+  then carry both the broken policy/goal and satisfied controls. A standalone
+  `governance Name { ... }` catalog can require controls across business specs
+  and run preservation refinements during `fslc check`.
 - `requirements Name { process E with f: T {...} / kpi / acceptance /
   forbidden / implements Abs from "file" { } }` — the requirements layer. Use
   the process+data profile first for a single-entity lifecycle: transition

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -40,6 +40,8 @@ a sibling top-level `verify` block instead of inline ranges:
 ```fsl
 business <Name> {
   entity <Entity>                          // identity sort; size set by verify.instances
+  control <ID> "<text>"                    // optional governance/control metadata
+  policy <ID> "<text>" satisfies <ID> ...  // optional control traceability
 }
 requirements <Name> {
   entity <Entity>                          // optional explicit identity sort
@@ -49,6 +51,26 @@ requirements <Name> {
 verify {
   instances <Entity> = <N>
   values <Number> = <lo>..<hi>
+}
+```
+
+Optional governance catalog (metadata and cross-business checks; no new kernel
+semantics):
+
+```fsl
+governance <Name> {
+  authority <Actor> owns <ControlID>, ...
+  control <ControlID> "<text>" [owner <Actor>] [severity <Name>] [applies_to <Entity>]...
+  delegates <BusinessName> from "<business.fsl>" {
+    require <ControlID>
+    <ControlID> is satisfied_by policy <PolicyID>, goal <GoalID>
+  }
+  preservation <Name> {
+    before <AsIsBusiness> from "<asis.fsl>"
+    after  <ToBeBusiness> from "<tobe.fsl>"
+    preserve <ControlID>
+    checked_by refinement "<mapping.fsl>"
+  }
 }
 ```
 
@@ -416,7 +438,14 @@ business ReturnHandling {
     transition refund  Approved  -> Refunded by Manager
   }
   kpi refunded = count Return in Refunded     // -> metadata projection count(c: Return where stage(c) == Refunded)
+
+  control CTRL-DECISION "Every return must preserve adjudication control"
+    owner Manager
+    severity high
+    applies_to Return
+
   policy PAY-2 "every request is adjudicated"
+    satisfies CTRL-DECISION
     every Return in Requested must eventually be Approved or Rejected or Refunded
   goal AllSettled "all cases can be settled"
     all Return can be Refunded or Rejected
@@ -432,6 +461,17 @@ verify {
 The natural business forms above are aliases for `responds { forall ... ~> ... }`
 and `goal { forall/exists ... }`; the explicit expression forms remain available
 for policies that cannot be written as a simple stage progression.
+
+`control` declarations are metadata only. Attach them to checkable business
+rules with `policy ... satisfies CTRL` or `goal ... satisfies CTRL`. Unknown
+control references are type errors, unused declared controls are warnings, and a
+violated satisfied policy/goal reports `requirement.controls` in JSON.
+
+For cross-business or enterprise-level controls, use a standalone `governance`
+catalog. `fslc check governance.fsl` verifies that each delegated business spec
+exists, each `require CTRL` is satisfied by business-side `satisfies` metadata or
+an explicit `CTRL is satisfied_by policy|goal ID` mapping, and each
+`preservation` block runs its declared refinement at depth 8.
 
 ### requirements (the requirements layer)
 

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -241,7 +241,10 @@ def _requirement(source):
     meta = source.get("meta") if isinstance(source, dict) else None
     if not meta:
         return None
-    return {"id": meta["id"], "text": meta.get("text")}
+    out = {"id": meta["id"], "text": meta.get("text")}
+    if meta.get("controls"):
+        out["controls"] = meta["controls"]
+    return out
 
 
 def _attach_requirement(out, source):
@@ -3299,8 +3302,11 @@ def _frozen_tautology_candidates(spec, invariants=None):
     if invariants is None:
         invariants = spec.get("invariants", [])
     selected_invariants = {inv["name"] for inv in invariants}
+    generated = set(spec.get("generated_names") or [])
     for inv in spec.get("user_invariants", []):
         if inv["name"] not in selected_invariants:
+            continue
+        if inv["name"] in generated:
             continue
         if inv.get("implicit"):
             continue
@@ -3464,8 +3470,11 @@ def _vacuity_candidates(spec, invariants=None, leadstos=None):
     if urgency_freeze is not None:
         pending.append(urgency_freeze)
     selected_invariants = {inv["name"] for inv in invariants}
+    generated = set(spec.get("generated_names") or [])
     for inv in spec.get("user_invariants", []):
         if inv["name"] not in selected_invariants:
+            continue
+        if inv["name"] in generated:
             continue
         cand = _implication_antecedent_candidate(inv)
         if cand is not None:

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -148,6 +148,49 @@ def _implements_result(spec, depth=8):
     return {"abs": abs_spec["name"], "result": result.get("result"), "violation": result}
 
 
+def _build_spec_from_file(path):
+    src = open(path, encoding="utf-8").read()
+    ast, display_names = _parse_file(path, src)
+    return build_spec(ast, display_names)
+
+
+def _governance_result(spec, depth=8):
+    gov = spec.get("governance")
+    if not gov:
+        return None
+    out = {
+        "name": gov["name"],
+        "controls": [control["id"] for control in gov.get("controls", [])],
+        "delegates": [
+            {
+                "business": delegate["business"],
+                "required": delegate["required"],
+                "satisfied": delegate["satisfied"],
+            }
+            for delegate in gov.get("delegates", [])
+        ],
+        "preservations": [],
+    }
+    for preservation in gov.get("preservations", []):
+        before_spec = _build_spec_from_file(preservation["before"]["path"])
+        after_spec = _build_spec_from_file(preservation["after"]["path"])
+        mapping_src = open(preservation["refinement"]["path"], encoding="utf-8").read()
+        mapping_ast = parse_refinement(mapping_src)
+        mapping = build_refinement(mapping_ast, after_spec, before_spec)
+        result = refine(after_spec, before_spec, mapping, depth)
+        entry = {
+            "name": preservation["name"],
+            "before": before_spec["name"],
+            "after": after_spec["name"],
+            "preserve": preservation["preserve"],
+            "result": result.get("result"),
+        }
+        if result.get("result") != "refines":
+            entry["violation"] = result
+        out["preservations"].append(entry)
+    return out
+
+
 def _acceptance_error(spec):
     checked = validate_acceptance(spec)
     if checked.get("ok"):
@@ -185,6 +228,9 @@ def run_check(file, strict_tags=False, requirements=None):
         impl = _implements_result(spec)
         if impl:
             out["implements"] = impl
+        gov = _governance_result(spec)
+        if gov:
+            out["governance"] = gov
         out = _add_strict_tag_warnings(out, spec, strict_tags, requirements)
         return _envelope(out)
     except UnexpectedInput as e:

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -12,8 +12,8 @@ from .grammar import Ast, PARSER
 from .model import FslError, eval_const
 
 
-def _err(message, kind="type", loc=None):
-    raise FslError(message, kind=kind, loc=loc)
+def _err(message, kind="type", loc=None, hint=None):
+    raise FslError(message, kind=kind, loc=loc, hint=hint)
 
 
 def _parse_file(path):
@@ -25,6 +25,8 @@ def _parse_file(path):
         return _expand_requirements_with_display(ast, str(Path(path).parent))
     if ast[0] == "business":
         return expand_business(ast), {}
+    if ast[0] == "governance":
+        return expand_governance_with_display(ast, str(Path(path).parent))
     return ast, {}
 
 
@@ -70,6 +72,16 @@ def _expr_to_str(expr):
 
 def _meta(req_id, text):
     return {"id": req_id, "text": text}
+
+
+def _meta_with_controls(req_id, text, control_ids, control_by_id):
+    meta = _meta(req_id, text)
+    if control_ids:
+        meta["controls"] = [
+            {"id": cid, "text": control_by_id[cid]["text"]}
+            for cid in control_ids
+        ]
+    return meta
 
 
 def _collect_verify_bounds(items):
@@ -1094,6 +1106,7 @@ def _collect_business_entities(items):
     cases = {}
     process_items = []
     kpis = []
+    controls = []
     policies = []
     goals = []
     instances, values, bound_locs = _collect_verify_bounds(items)
@@ -1112,6 +1125,8 @@ def _collect_business_entities(items):
             process_items.append(item)
         elif tag == "biz_kpi":
             kpis.append(item)
+        elif tag == "biz_control":
+            controls.append(_control_info(item))
         elif tag == "biz_policy":
             policies.append(item)
         elif tag == "biz_goal":
@@ -1155,7 +1170,60 @@ def _collect_business_entities(items):
     for proc in processes:
         process_by_case.setdefault(proc["name"], []).append(proc)
 
-    return actors, cases, processes, kpis, policies, goals, process_by_case, process_by_name
+    _validate_controls_and_satisfaction(controls, policies, goals)
+
+    return actors, cases, processes, kpis, controls, policies, goals, process_by_case, process_by_name
+
+
+def _control_info(item):
+    _, control_id, text, attrs, loc = item
+    owner = None
+    severity = None
+    applies_to = []
+    for attr in attrs:
+        tag = attr[0]
+        if tag == "control_owner":
+            if owner is not None:
+                _err(f"control '{control_id}' declares owner more than once", loc=loc)
+            owner = attr[1]
+        elif tag == "control_severity":
+            if severity is not None:
+                _err(f"control '{control_id}' declares severity more than once", loc=loc)
+            severity = attr[1]
+        elif tag == "control_applies_to":
+            applies_to.append(attr[1])
+    return {
+        "id": control_id,
+        "text": text,
+        "owner": owner,
+        "severity": severity,
+        "applies_to": applies_to,
+        "loc": loc,
+    }
+
+
+def _satisfies_refs(item):
+    return item[5] if len(item) > 5 and item[5] is not None else []
+
+
+def _validate_controls_and_satisfaction(controls, policies, goals):
+    control_by_id = {}
+    for control in controls:
+        cid = control["id"]
+        if cid in control_by_id:
+            _err(f"duplicate control '{cid}'", loc=control["loc"])
+        control_by_id[cid] = control
+
+    used = set()
+    for item in list(policies) + list(goals):
+        for cid in _satisfies_refs(item):
+            if cid not in control_by_id:
+                _err(
+                    f"{item[0].replace('biz_', '')} '{item[1]}' satisfies unknown control '{cid}'",
+                    loc=item[4],
+                )
+            used.add(cid)
+    return control_by_id, used
 
 
 def _build_kpi_metadata(kpis, process_by_name):
@@ -1231,8 +1299,9 @@ def _any_stage(case_name, var_name, stages, process_by_case, loc):
     ])
 
 
-def _generate_business_items(cases, processes, kpi_infos, policies, goals, process_by_case):
+def _generate_business_items(cases, processes, kpi_infos, controls, policies, goals, process_by_case):
     out = []
+    control_by_id, used_controls = _validate_controls_and_satisfaction(controls, policies, goals)
     for case_name, data in cases.items():
         out.append(("type", case_name, data["lo"], data["hi"]))
     for proc in processes:
@@ -1282,9 +1351,55 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
     if kpi_metadata:
         out.append(("__kpis", kpi_metadata))
 
+    if controls:
+        satisfactions = []
+        for item in policies:
+            for cid in _satisfies_refs(item):
+                satisfactions.append({
+                    "element": "policy",
+                    "id": item[1],
+                    "control": cid,
+                    "loc": item[4],
+                })
+        for item in goals:
+            for cid in _satisfies_refs(item):
+                satisfactions.append({
+                    "element": "goal",
+                    "id": item[1],
+                    "control": cid,
+                    "loc": item[4],
+                })
+        out.append(("__controls", {
+            "controls": [
+                {
+                    "id": control["id"],
+                    "text": control["text"],
+                    "owner": control["owner"],
+                    "severity": control["severity"],
+                    "applies_to": list(control["applies_to"]),
+                    "loc": control["loc"],
+                }
+                for control in controls
+            ],
+            "satisfies": satisfactions,
+        }))
+        unused = sorted(set(control_by_id) - used_controls)
+        if unused:
+            out.append(("__warnings", [
+                {
+                    "kind": "unused_control",
+                    "element": "control",
+                    "name": cid,
+                    "loc": control_by_id[cid]["loc"],
+                    "hint": "no policy or goal declares `satisfies` for this control",
+                }
+                for cid in unused
+            ]))
+
     for item in policies:
-        _, policy_id, text, body, loc = item
-        meta = _meta(policy_id, text)
+        _, policy_id, text, body, loc = item[:5]
+        control_refs = _satisfies_refs(item)
+        meta = _meta_with_controls(policy_id, text, control_refs, control_by_id)
         if body[0] == "biz_policy_invariant":
             expr = _rewrite_stage_expr(body[1], {}, process_by_case)
             out.append(("invariant", policy_id, expr, loc, meta))
@@ -1299,7 +1414,8 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
             out.append(("leadsto", policy_id, [binder], p, q, loc, meta))
 
     for item in goals:
-        _, goal_id, text, body, loc = item
+        _, goal_id, text, body, loc = item[:5]
+        control_refs = _satisfies_refs(item)
         if body[0] == "biz_goal_expr":
             expr = _rewrite_stage_expr(body[1], {}, process_by_case)
         elif body[0] == "biz_goal_some_stage":
@@ -1318,7 +1434,7 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
             )
         else:
             _err(f"unknown business goal body '{body[0]}'", loc=loc)
-        out.append(("reachable", goal_id, expr, loc, _meta(goal_id, text)))
+        out.append(("reachable", goal_id, expr, loc, _meta_with_controls(goal_id, text, control_refs, control_by_id)))
 
     return out
 
@@ -1326,11 +1442,267 @@ def _generate_business_items(cases, processes, kpi_infos, policies, goals, proce
 def expand_business(ast):
     """Expand business AST to a kernel spec AST."""
     _, name, items = ast
-    _, cases, processes, kpis, policies, goals, process_by_case, process_by_name = (
+    _, cases, processes, kpis, controls, policies, goals, process_by_case, process_by_name = (
         _collect_business_entities(items)
     )
     kpi_infos = _build_kpi_metadata(kpis, process_by_name)
     out = _generate_business_items(
-        cases, processes, kpi_infos, policies, goals, process_by_case,
+        cases, processes, kpi_infos, controls, policies, goals, process_by_case,
     )
     return ("spec", name, out)
+
+
+def _resolve_relative(base_dir, path):
+    return Path(base_dir) / path
+
+
+def _collect_governance_controls(items):
+    controls = {}
+    authorities = []
+    for item in items:
+        if item[0] == "biz_control":
+            control = _control_info(item)
+            cid = control["id"]
+            if cid in controls:
+                _err(f"duplicate control '{cid}'", loc=control["loc"])
+            controls[cid] = control
+        elif item[0] == "gov_authority":
+            authorities.append({
+                "authority": item[1],
+                "owns": list(item[2]),
+                "loc": item[3],
+            })
+    for authority in authorities:
+        for cid in authority["owns"]:
+            if cid not in controls:
+                _err(
+                    f"authority '{authority['authority']}' owns unknown control '{cid}'",
+                    loc=authority["loc"],
+                )
+    return controls, authorities
+
+
+def _control_refs_from_meta(meta):
+    refs = []
+    if not isinstance(meta, dict):
+        return refs
+    for control in meta.get("controls") or []:
+        if isinstance(control, dict) and control.get("id"):
+            refs.append(control["id"])
+    return refs
+
+
+def _business_catalog_from_ast(ast):
+    if ast[0] != "spec":
+        _err("governance delegates must reference a business spec", kind="type")
+    policies = {}
+    goals = {}
+    controls = {}
+    satisfies = {}
+    for item in ast[2]:
+        tag = item[0]
+        if tag in ("invariant", "leadsto"):
+            name = item[1]
+            meta = item[4] if tag == "invariant" and len(item) > 4 else item[6] if tag == "leadsto" and len(item) > 6 else None
+            policies[name] = {"id": name, "meta": meta}
+            for cid in _control_refs_from_meta(meta):
+                satisfies.setdefault(cid, []).append({"kind": "policy", "id": name})
+        elif tag == "reachable":
+            name = item[1]
+            meta = item[4] if len(item) > 4 else None
+            goals[name] = {"id": name, "meta": meta}
+            for cid in _control_refs_from_meta(meta):
+                satisfies.setdefault(cid, []).append({"kind": "goal", "id": name})
+        elif tag == "__controls":
+            for control in item[1].get("controls", []):
+                controls[control["id"]] = control
+            for sat in item[1].get("satisfies", []):
+                kind = sat.get("element")
+                if kind in ("policy", "goal"):
+                    satisfies.setdefault(sat["control"], []).append({"kind": kind, "id": sat["id"]})
+    return {
+        "policies": policies,
+        "goals": goals,
+        "controls": controls,
+        "satisfies": satisfies,
+    }
+
+
+def _dedupe_artifacts(artifacts):
+    seen = set()
+    out = []
+    for artifact in artifacts:
+        key = (artifact["kind"], artifact["id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(artifact)
+    return out
+
+
+def _validate_delegate(item, base_dir, controls):
+    _, business_name, path, parts, loc = item
+    abs_path = _resolve_relative(base_dir, path)
+    if not abs_path.is_file():
+        _err(f"file not found: {path}", kind="io", loc=loc)
+    ast, _display_names = _parse_file(abs_path)
+    if ast[0] != "spec" or ast[1] != business_name:
+        _err(f"spec name mismatch: expected '{business_name}', got '{ast[1]}'", loc=loc)
+    catalog = _business_catalog_from_ast(ast)
+    required = []
+    explicit = {}
+    for part in parts:
+        if part[0] == "gov_require":
+            cid = part[1]
+            if cid not in controls:
+                _err(f"delegates '{business_name}' requires unknown control '{cid}'", loc=part[2])
+            required.append(cid)
+        elif part[0] == "gov_satisfaction":
+            cid = part[1]
+            if cid not in controls:
+                _err(
+                    f"delegates '{business_name}' maps unknown control '{cid}'",
+                    loc=part[3],
+                )
+            refs = []
+            for ref in part[2]:
+                kind, artifact_id, ref_loc = ref
+                collection = catalog["policies"] if kind == "policy" else catalog["goals"]
+                if artifact_id not in collection:
+                    _err(
+                        f"delegates '{business_name}' references unknown {kind} '{artifact_id}'",
+                        loc=ref_loc,
+                    )
+                refs.append({"kind": kind, "id": artifact_id})
+            explicit.setdefault(cid, []).extend(refs)
+
+    required = list(dict.fromkeys(required))
+    satisfied = {cid: list(catalog["satisfies"].get(cid, [])) for cid in required}
+    for cid, refs in explicit.items():
+        satisfied.setdefault(cid, []).extend(refs)
+
+    missing = [cid for cid in required if not satisfied.get(cid)]
+    if missing:
+        _err(
+            f"delegates '{business_name}' requires unsatisfied control(s): {', '.join(missing)}",
+            loc=loc,
+            hint="add `policy ... satisfies CTRL` in the business spec or map it with `CTRL is satisfied_by ...`",
+        )
+
+    return {
+        "business": business_name,
+        "path": str(abs_path),
+        "required": required,
+        "satisfied": {
+            cid: _dedupe_artifacts(satisfied.get(cid, []))
+            for cid in required
+        },
+        "loc": loc,
+    }
+
+
+def _validate_preservation(item, base_dir, controls):
+    _, name, parts, loc = item
+    before = None
+    after = None
+    preserves = []
+    refinement = None
+    for part in parts:
+        tag = part[0]
+        if tag == "preservation_before":
+            if before is not None:
+                _err(f"preservation '{name}' declares before more than once", loc=part[3])
+            before = {"spec": part[1], "path": str(_resolve_relative(base_dir, part[2])), "source": part[2], "loc": part[3]}
+        elif tag == "preservation_after":
+            if after is not None:
+                _err(f"preservation '{name}' declares after more than once", loc=part[3])
+            after = {"spec": part[1], "path": str(_resolve_relative(base_dir, part[2])), "source": part[2], "loc": part[3]}
+        elif tag == "preservation_preserve":
+            if part[1] not in controls:
+                _err(f"preservation '{name}' preserves unknown control '{part[1]}'", loc=part[2])
+            preserves.append(part[1])
+        elif tag == "preservation_refinement":
+            if refinement is not None:
+                _err(f"preservation '{name}' declares checked_by more than once", loc=part[2])
+            refinement = {"path": str(_resolve_relative(base_dir, part[1])), "source": part[1], "loc": part[2]}
+    if before is None:
+        _err(f"preservation '{name}' missing before spec", loc=loc)
+    if after is None:
+        _err(f"preservation '{name}' missing after spec", loc=loc)
+    if refinement is None:
+        _err(f"preservation '{name}' missing checked_by refinement", loc=loc)
+    if not preserves:
+        _err(f"preservation '{name}' must preserve at least one control", loc=loc)
+    for entry in (before, after, refinement):
+        if not Path(entry["path"]).is_file():
+            _err(f"file not found: {entry['source']}", kind="io", loc=entry["loc"])
+    for side in (before, after):
+        ast, _display_names = _parse_file(side["path"])
+        if ast[0] != "spec" or ast[1] != side["spec"]:
+            _err(f"spec name mismatch: expected '{side['spec']}', got '{ast[1]}'", loc=side["loc"])
+    return {
+        "name": name,
+        "before": before,
+        "after": after,
+        "preserve": list(dict.fromkeys(preserves)),
+        "refinement": refinement,
+        "loc": loc,
+    }
+
+
+def _governance_kernel_items(name, metadata):
+    return [
+        ("type", "_GovernanceUnit", ("num", 0), ("num", 0)),
+        ("state", [("decl", "_governance_ok", ("bool",))]),
+        ("init", [("assign", ("var", "_governance_ok"), ("bool", True), None)]),
+        (
+            "action",
+            "_governance_noop",
+            [],
+            [("requires", ("bool", False), None)],
+            None,
+            False,
+            _meta("GOV", f"governance catalog {name}"),
+        ),
+        (
+            "invariant",
+            "_governance_catalog_ok",
+            ("bin", "==", ("var", "_governance_ok"), ("bool", True)),
+            None,
+            _meta("GOV", f"governance catalog {name}"),
+        ),
+        ("terminal", ("bool", True), None),
+        ("__generated", ["_governance_noop", "_governance_catalog_ok"]),
+        ("__governance", metadata),
+    ]
+
+
+def expand_governance_with_display(ast, base_dir):
+    """Validate a governance catalog and expand it to a metadata-only kernel spec."""
+    _, name, items = ast
+    controls, authorities = _collect_governance_controls(items)
+    delegates = []
+    preservations = []
+    for item in items:
+        if item[0] == "gov_delegates":
+            delegates.append(_validate_delegate(item, base_dir, controls))
+        elif item[0] == "gov_preservation":
+            preservations.append(_validate_preservation(item, base_dir, controls))
+    metadata = {
+        "name": name,
+        "controls": [
+            {
+                "id": control["id"],
+                "text": control["text"],
+                "owner": control["owner"],
+                "severity": control["severity"],
+                "applies_to": list(control["applies_to"]),
+                "loc": control["loc"],
+            }
+            for control in controls.values()
+        ],
+        "authorities": authorities,
+        "delegates": delegates,
+        "preservations": preservations,
+    }
+    return ("spec", name, _governance_kernel_items(name, metadata)), {}

--- a/src/fslc/explain.py
+++ b/src/fslc/explain.py
@@ -99,7 +99,10 @@ def _property_source(source_lines, loc, kind, label):
 def _requirement_from_meta(meta):
     if not meta:
         return None
-    return {"id": meta["id"], "text": meta.get("text")}
+    out = {"id": meta["id"], "text": meta.get("text")}
+    if meta.get("controls"):
+        out["controls"] = meta["controls"]
+    return out
 
 
 def _actor(action):

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -8,7 +8,7 @@ from lark import Lark, Transformer, v_args
 
 GRAMMAR = r"""
 start: top_def verify_def?
-top_def: spec_def | refinement_def | compose_def | requirements_def | business_def
+top_def: spec_def | refinement_def | compose_def | requirements_def | business_def | governance_def
 
 verify_def: "verify" "{" verify_item* "}"
 verify_item: "instances" NAME "=" INT ";"? -> verify_instances
@@ -252,7 +252,7 @@ age_def: "age" NAME ["[" binder "]"] "while" expr
 deadline_def: "deadline" NAME "<=" expr
 
 business_def: "business" NAME "{" business_item* "}"
-?business_item: actor_def | entity_def | process_def | kpi_def | policy_def | goal_def
+?business_item: actor_def | entity_def | process_def | kpi_def | control_def | policy_def | goal_def
 actor_def: "actor" NAME ("," NAME)* ","?
 process_def: "process" NAME process_with? "{" process_item* "}"
 process_with: "with" proc_field ("," proc_field)*
@@ -267,17 +267,40 @@ trans_set: "set" proc_assign ("," proc_assign)*
 proc_assign: NAME "=" expr
 trans_covers: "covers" REQ_ID STRING
 kpi_def: "kpi" NAME "=" "count" NAME "in" NAME
-policy_def: "policy" REQ_ID STRING policy_body
+control_def: "control" REQ_ID STRING control_attr*
+?control_attr: control_owner | control_severity | control_applies_to
+control_owner: "owner" NAME
+control_severity: "severity" NAME
+control_applies_to: "applies_to" NAME
+satisfies_clause: "satisfies" REQ_ID ("," REQ_ID)* ","?
+policy_def: "policy" REQ_ID STRING satisfies_clause? policy_body
 ?policy_body: policy_invariant | policy_responds | policy_eventually
 policy_invariant: "invariant" "{" expr "}"
 policy_responds: "responds" "{" lt_body "}"
 policy_eventually: "every" NAME "in" NAME "must" "eventually" "be" stage_disjunction
-goal_def: "goal" REQ_ID STRING goal_body
+goal_def: "goal" REQ_ID STRING satisfies_clause? goal_body
 ?goal_body: goal_expr | goal_some_stage | goal_all_stage
 goal_expr: "{" expr "}"
 goal_some_stage: "some" NAME "can" "reach" NAME
 goal_all_stage: "all" NAME "can" "be" stage_disjunction
 stage_disjunction: NAME (_OR NAME)*
+
+governance_def: "governance" NAME "{" governance_item* "}"
+?governance_item: governance_authority | control_def | governance_delegates | governance_preservation
+governance_authority: "authority" NAME "owns" REQ_ID ("," REQ_ID)* ","?
+governance_delegates: "delegates" NAME "from" STRING "{" governance_delegate_item* "}"
+?governance_delegate_item: governance_require | governance_satisfaction
+governance_require: "require" REQ_ID
+governance_satisfaction: REQ_ID "is" "satisfied_by" governance_artifact_ref ("," governance_artifact_ref)* ","?
+?governance_artifact_ref: governance_policy_ref | governance_goal_ref
+governance_policy_ref: "policy" REQ_ID
+governance_goal_ref: "goal" REQ_ID
+governance_preservation: "preservation" NAME "{" preservation_item* "}"
+?preservation_item: preservation_before | preservation_after | preservation_preserve | preservation_refinement
+preservation_before: "before" NAME "from" STRING
+preservation_after: "after" NAME "from" STRING
+preservation_preserve: "preserve" REQ_ID
+preservation_refinement: "checked_by" "refinement" STRING
 
 CMPOP: "==" | "!=" | "<=" | ">=" | "<" | ">"
 REQ_ID: /[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*/
@@ -1030,8 +1053,30 @@ class Ast(Transformer):
     def policy_eventually(self, meta, case_name, source_stage, target_stages):
         return ("biz_policy_eventually", case_name, source_stage, target_stages)
 
-    def policy_def(self, meta, policy_id, text, body):
-        return ("biz_policy", str(policy_id), text, body, _loc(meta))
+    def control_owner(self, meta, name):
+        return ("control_owner", name)
+
+    def control_severity(self, meta, name):
+        return ("control_severity", name)
+
+    def control_applies_to(self, meta, name):
+        return ("control_applies_to", name)
+
+    def control_def(self, meta, control_id, text, *attrs):
+        return ("biz_control", str(control_id), text, [a for a in attrs if a], _loc(meta))
+
+    def satisfies_clause(self, meta, *control_ids):
+        return ("satisfies", [str(cid) for cid in control_ids], _loc(meta))
+
+    def policy_def(self, meta, policy_id, text, *parts):
+        satisfies = []
+        body = None
+        for part in parts:
+            if isinstance(part, tuple) and part[0] == "satisfies":
+                satisfies = part[1]
+            else:
+                body = part
+        return ("biz_policy", str(policy_id), text, body, _loc(meta), satisfies)
 
     def goal_expr(self, meta, expr):
         return ("biz_goal_expr", expr)
@@ -1042,11 +1087,54 @@ class Ast(Transformer):
     def goal_all_stage(self, meta, case_name, stages):
         return ("biz_goal_all_stage", case_name, stages)
 
-    def goal_def(self, meta, goal_id, text, body):
-        return ("biz_goal", str(goal_id), text, body, _loc(meta))
+    def goal_def(self, meta, goal_id, text, *parts):
+        satisfies = []
+        body = None
+        for part in parts:
+            if isinstance(part, tuple) and part[0] == "satisfies":
+                satisfies = part[1]
+            else:
+                body = part
+        return ("biz_goal", str(goal_id), text, body, _loc(meta), satisfies)
 
     def business_def(self, meta, name, *items):
         return ("business", name, [i for i in items if i])
+
+    def governance_authority(self, meta, authority, *control_ids):
+        return ("gov_authority", authority, [str(cid) for cid in control_ids], _loc(meta))
+
+    def governance_require(self, meta, control_id):
+        return ("gov_require", str(control_id), _loc(meta))
+
+    def governance_policy_ref(self, meta, policy_id):
+        return ("policy", str(policy_id), _loc(meta))
+
+    def governance_goal_ref(self, meta, goal_id):
+        return ("goal", str(goal_id), _loc(meta))
+
+    def governance_satisfaction(self, meta, control_id, *policy_refs):
+        return ("gov_satisfaction", str(control_id), [p for p in policy_refs if p], _loc(meta))
+
+    def governance_delegates(self, meta, business_name, path, *items):
+        return ("gov_delegates", business_name, path, [i for i in items if i], _loc(meta))
+
+    def preservation_before(self, meta, spec_name, path):
+        return ("preservation_before", spec_name, path, _loc(meta))
+
+    def preservation_after(self, meta, spec_name, path):
+        return ("preservation_after", spec_name, path, _loc(meta))
+
+    def preservation_preserve(self, meta, control_id):
+        return ("preservation_preserve", str(control_id), _loc(meta))
+
+    def preservation_refinement(self, meta, path):
+        return ("preservation_refinement", path, _loc(meta))
+
+    def governance_preservation(self, meta, name, *items):
+        return ("gov_preservation", name, [i for i in items if i], _loc(meta))
+
+    def governance_def(self, meta, name, *items):
+        return ("governance", name, [i for i in items if i])
 
 
 PARSER = Lark(

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -980,6 +980,8 @@ def build_spec(tree, display_names=None, semantic_check=True):
     dialect_generated_names = []
     dialect_requirement_ids = []
     dialect_kpis = []
+    dialect_controls = None
+    dialect_governance = None
     dialect_warnings = []
     for it in items:
         if it[0] == "__display_names":
@@ -998,6 +1000,10 @@ def build_spec(tree, display_names=None, semantic_check=True):
             dialect_requirement_ids.extend(it[1])
         elif it[0] == "__kpis":
             dialect_kpis.extend(it[1])
+        elif it[0] == "__controls":
+            dialect_controls = it[1]
+        elif it[0] == "__governance":
+            dialect_governance = it[1]
         elif it[0] == "__warnings":
             dialect_warnings.extend(it[1])
 
@@ -1190,6 +1196,8 @@ def build_spec(tree, display_names=None, semantic_check=True):
         "generated_names": dialect_generated_names,
         "requirement_ids": dialect_requirement_ids,
         "kpis": dialect_kpis,
+        "controls": dialect_controls,
+        "governance": dialect_governance,
         "symmetry": symmetry,
     }
 

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -14,7 +14,7 @@ from lark.exceptions import UnexpectedInput
 
 from .grammar import PARSER, Ast
 from .compose import expand_compose
-from .dialects import expand_business, expand_requirements_with_display
+from .dialects import expand_business, expand_governance_with_display, expand_requirements_with_display
 
 
 def parse_src(src, base_dir=None):
@@ -32,6 +32,8 @@ def parse_src(src, base_dir=None):
         ast, display_names = expand_requirements_with_display(ast, base_dir or ".")
     elif ast[0] == "business":
         ast = expand_business(ast)
+    elif ast[0] == "governance":
+        ast, display_names = expand_governance_with_display(ast, base_dir or ".")
     return ast, display_names
 
 

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -107,6 +107,12 @@
       "warnings": []
     }
   },
+  "examples/consulting/governance_controls.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/consulting/tobe_expense.fsl": {
     "check": {
       "result": "ok",

--- a/tests/test_governance_business.py
+++ b/tests/test_governance_business.py
@@ -1,0 +1,213 @@
+from fslc import build_spec, parse
+from fslc.cli import run_check, run_verify
+
+
+CONTROLLED_BUSINESS = r'''business RefundFlow {
+  actor Support, Finance
+  entity Refund
+
+  process Refund {
+    stages Requested, Approved, Paid
+    initial Requested
+    transition approve Requested -> Approved by Support
+    transition pay Approved -> Paid by Finance
+  }
+
+  control CTRL-NO-UNREVIEWED-PAYMENT
+    "Refund payment must preserve review control"
+    owner Finance
+    severity high
+    applies_to Refund
+
+  policy POL-APPROVAL-TO-PAY
+    "Approved refunds must eventually be paid"
+    satisfies CTRL-NO-UNREVIEWED-PAYMENT
+    every Refund in Approved must eventually be Paid
+
+  goal G-CAN-PAY
+    "A valid refund can complete"
+    some Refund can reach Paid
+}
+verify {
+  instances Refund = 2
+}
+'''
+
+
+def test_business_controls_are_metadata_and_satisfaction_is_checked(tmp_path):
+    path = tmp_path / "refund.fsl"
+    path.write_text(CONTROLLED_BUSINESS, encoding="utf-8")
+
+    checked = run_check(str(path))
+    assert checked["result"] == "ok", checked
+    assert checked["warnings"] == []
+
+    spec = build_spec(parse(CONTROLLED_BUSINESS))
+    assert spec["controls"]["controls"][0]["id"] == "CTRL-NO-UNREVIEWED-PAYMENT"
+    assert spec["controls"]["controls"][0]["owner"] == "Finance"
+    assert spec["controls"]["satisfies"] == [
+        {
+            "element": "policy",
+            "id": "POL-APPROVAL-TO-PAY",
+            "control": "CTRL-NO-UNREVIEWED-PAYMENT",
+            "loc": {"line": 18, "column": 3},
+        }
+    ]
+
+
+def test_business_policy_violation_carries_satisfied_control(tmp_path):
+    bad = CONTROLLED_BUSINESS.replace(
+        '''policy POL-APPROVAL-TO-PAY
+    "Approved refunds must eventually be paid"
+    satisfies CTRL-NO-UNREVIEWED-PAYMENT
+    every Refund in Approved must eventually be Paid''',
+        '''policy POL-APPROVAL-TO-PAY
+    "Approved refunds must never be paid"
+    satisfies CTRL-NO-UNREVIEWED-PAYMENT
+    invariant { forall r: Refund { stage(r) != Paid } }''',
+    )
+    path = tmp_path / "refund_bad.fsl"
+    path.write_text(bad, encoding="utf-8")
+
+    result = run_verify(str(path), 3, "ignore")
+
+    assert result["result"] == "violated", result
+    assert result["requirement"] == {
+        "id": "POL-APPROVAL-TO-PAY",
+        "text": "Approved refunds must never be paid",
+        "controls": [
+            {
+                "id": "CTRL-NO-UNREVIEWED-PAYMENT",
+                "text": "Refund payment must preserve review control",
+            }
+        ],
+    }
+
+
+def test_business_satisfies_unknown_control_is_type_error(tmp_path):
+    src = CONTROLLED_BUSINESS.replace(
+        "satisfies CTRL-NO-UNREVIEWED-PAYMENT",
+        "satisfies CTRL-MISSING",
+    )
+    path = tmp_path / "refund_unknown_control.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    result = run_check(str(path))
+
+    assert result["result"] == "error", result
+    assert result["kind"] == "type"
+    assert "satisfies unknown control 'CTRL-MISSING'" in result["message"]
+
+
+def test_governance_delegate_uses_business_satisfies_metadata(tmp_path):
+    (tmp_path / "refund.fsl").write_text(CONTROLLED_BUSINESS, encoding="utf-8")
+    gov = tmp_path / "governance.fsl"
+    gov.write_text(
+        r'''governance EnterpriseRefundControls {
+  authority Finance owns CTRL-NO-UNREVIEWED-PAYMENT
+  control CTRL-NO-UNREVIEWED-PAYMENT
+    "Refund payment must preserve review control"
+    owner Finance
+    severity high
+    applies_to Refund
+
+  delegates RefundFlow from "refund.fsl" {
+    require CTRL-NO-UNREVIEWED-PAYMENT
+  }
+}
+''',
+        encoding="utf-8",
+    )
+
+    result = run_check(str(gov))
+
+    assert result["result"] == "ok", result
+    delegate = result["governance"]["delegates"][0]
+    assert delegate["business"] == "RefundFlow"
+    assert delegate["required"] == ["CTRL-NO-UNREVIEWED-PAYMENT"]
+    assert delegate["satisfied"] == {
+        "CTRL-NO-UNREVIEWED-PAYMENT": [
+            {"kind": "policy", "id": "POL-APPROVAL-TO-PAY"}
+        ]
+    }
+
+
+def test_governance_delegate_requires_satisfied_control(tmp_path):
+    business = CONTROLLED_BUSINESS.replace(
+        "satisfies CTRL-NO-UNREVIEWED-PAYMENT\n    ",
+        "",
+    )
+    (tmp_path / "refund.fsl").write_text(business, encoding="utf-8")
+    gov = tmp_path / "governance.fsl"
+    gov.write_text(
+        r'''governance EnterpriseRefundControls {
+  control CTRL-NO-UNREVIEWED-PAYMENT "Refund payment must preserve review control"
+
+  delegates RefundFlow from "refund.fsl" {
+    require CTRL-NO-UNREVIEWED-PAYMENT
+  }
+}
+''',
+        encoding="utf-8",
+    )
+
+    result = run_check(str(gov))
+
+    assert result["result"] == "error", result
+    assert result["kind"] == "type"
+    assert "requires unsatisfied control(s): CTRL-NO-UNREVIEWED-PAYMENT" in result["message"]
+
+
+def test_governance_preservation_runs_refinement(tmp_path):
+    asis = r'''business AsIsRefund {
+  actor Clerk
+  entity Refund
+  process Refund {
+    stages Requested, Done
+    initial Requested
+    transition complete Requested -> Done by Clerk
+  }
+  control CTRL-COMPLETE "Requests must be completed"
+  policy POL-COMPLETE "Every request completes" satisfies CTRL-COMPLETE
+    every Refund in Requested must eventually be Done
+}
+verify { instances Refund = 2 }
+'''
+    tobe = asis.replace("AsIsRefund", "ToBeRefund")
+    mapping = r'''refinement ToBePreservesAsIs {
+  impl ToBeRefund
+  abs AsIsRefund
+  maps auto
+}
+'''
+    (tmp_path / "asis.fsl").write_text(asis, encoding="utf-8")
+    (tmp_path / "tobe.fsl").write_text(tobe, encoding="utf-8")
+    (tmp_path / "preserves.fsl").write_text(mapping, encoding="utf-8")
+    gov = tmp_path / "governance.fsl"
+    gov.write_text(
+        r'''governance RefundTransformationControls {
+  control CTRL-COMPLETE "Requests must be completed"
+
+  preservation SameFlow {
+    before AsIsRefund from "asis.fsl"
+    after ToBeRefund from "tobe.fsl"
+    preserve CTRL-COMPLETE
+    checked_by refinement "preserves.fsl"
+  }
+}
+''',
+        encoding="utf-8",
+    )
+
+    result = run_check(str(gov))
+
+    assert result["result"] == "ok", result
+    assert result["governance"]["preservations"] == [
+        {
+            "name": "SameFlow",
+            "before": "AsIsRefund",
+            "after": "ToBeRefund",
+            "preserve": ["CTRL-COMPLETE"],
+            "result": "refines",
+        }
+    ]


### PR DESCRIPTION
## Summary
Adds governance/control support above and inside the business dialect. Business specs can now declare `control` metadata, attach controls to checkable `policy`/`goal` declarations with `satisfies`, and expose satisfied controls in violation diagnostics. A new top-level `governance` catalog validates cross-business control delegation and preservation refinements.

## Why
- **Goal**: Let governance sit either inside a business process or above multiple business specs without inventing new kernel semantics.
- **Reason**: Controls are catalog/traceability metadata; the verifier should still check concrete business policies, goals, and refinement mappings.
- **Alternative rejected**: Treating `control` as a new property kind. That would duplicate `policy`/`goal` semantics and blur the existing business layer boundary.

## What Changed
- Added grammar/parser/dialect support for `control`, `satisfies`, and top-level `governance`.
- Added `fslc check` governance output for `delegates` and `preservations`; preservation runs `refine(after, before, mapping)` at depth 8.
- Extended requirement metadata so failed satisfied policies/goals include `controls` in JSON.
- Added consulting example `examples/consulting/governance_controls.fsl`.
- Updated language docs, design docs, skills, changelog, and corpus snapshot.

## Blast Radius
- **Affected**: FSL grammar, dialect expansion, `fslc check`, diagnostic metadata, business/governance examples, docs/skills.
- **Compatibility**: Existing `business`, `requirements`, `spec`, `compose`, and `refinement` syntax remains valid. `control` is metadata-only and does not alter kernel transition semantics.

## Invariants
| Must stay true | Evidence | If broken |
|---|---|---|
| Dialects still expand to ordinary kernel specs | `tests/test_req_process.py`, `tests/test_req_dialect.py`, `tests/test_layers_chain.py` | Existing layer/refinement workflows regress |
| Bare controls do not prove anything | `tests/test_governance_business.py` checks `satisfies` wiring and unused-control behavior | Governance catalog gives false confidence |
| Preservation uses existing refinement semantics | `fslc check examples/consulting/governance_controls.fsl` reports `result: refines` | As-Is/To-Be control preservation becomes ungrounded |

## Failure Modes
| Mode | Pattern | Detection |
|---|---|---|
| Unknown control reference | `policy ... satisfies CTRL-MISSING` | `test_business_satisfies_unknown_control_is_type_error` |
| Unsatisfied delegated control | `governance` requires a control no policy/goal satisfies | `test_governance_delegate_requires_satisfied_control` |
| Generated governance invariant creates vacuity noise | Metadata-only kernel scaffold appears as user invariant | Corpus/vacuity tests; generated invariants are skipped for vacuity candidates |

## Evidence
- [x] `git diff --cached --check`
- [x] `.venv/bin/python -m pytest tests/test_governance_business.py -q` -> 6 passed
- [x] `.venv/bin/python -m pytest tests/test_governance_business.py tests/test_req_process.py tests/test_req_dialect.py tests/test_layers_chain.py -q` -> 21 passed
- [x] `.venv/bin/python -m fslc check examples/consulting/governance_controls.fsl` -> `ok`, preservation `refines`
- [x] `.venv/bin/python -m fslc verify examples/consulting/asis_expense.fsl --engine induction --deadlock ignore` -> `proved`
- [x] `FSLC_SNAPSHOT_UPDATE=1 .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q` -> 1 passed, 147 skipped
- [x] `.venv/bin/python -m pytest tests/test_corpus_snapshot.py::test_snapshot_has_no_missing_or_extra_specs tests/test_vacuity.py::test_verified_sample_corpus_has_no_vacuity_false_positives -q` -> 2 passed, 1 z3 cleanup warning after an interrupt signal
- Full `.venv/bin/python -m pytest -q` was run before the final snapshot/vacuity fix and reached 724 passed / 76 skipped / 2 failed; both failures were the expected new-sample snapshot/vacuity fallout and were fixed/re-run above.

## Rollout & Rollback
- **Rollout**: Merge normally; no migration required for existing specs.
- **Rollback**: Revert this commit. Specs using `control`, `satisfies`, or `governance` would stop parsing.

## Review Focus
- `src/fslc/grammar.py` and `src/fslc/dialects.py`: syntax and expansion boundaries.
- `src/fslc/cli.py`: governance preservation behavior during `check`.
- `tests/test_governance_business.py`: negative cases for bad references and unsatisfied controls.
- `docs/LANGUAGE.md` / `skills/fsl/reference.md`: user-facing syntax contract.

## Unknowns
None blocking. Future work could add a dedicated `fslc governance` report, but this PR intentionally keeps governance as check-time metadata plus existing refinement evidence.
