### PR TITLE
feat(install): install fslc-lsp via install.sh and link it onto PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbols, and go-to-definition over raw Lark parse trees, including compose
   `use ... from` cross-file resolution. Added a VSCode extension scaffold with
   `.fsl` language registration, TextMate highlighting, and an LSP client.
+- (Install) `install.sh` now installs the LSP server (the `[lsp]` extra) and
+  links `fslc-lsp` into `~/.local/bin` alongside `fslc`, so the VSCode extension
+  finds it on `PATH`.
 
 ## [2.2.0] - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ the Claude Code skills in `~/.claude/skills/`
 What gets installed:
 
 - the `fslc` command (used from `~/.local/bin/fslc`)
+- the `fslc-lsp` language server (`~/.local/bin/fslc-lsp`) — the VSCode extension in
+  `editors/vscode/` launches it from `PATH`
 - the Claude Code skills (`~/.claude/skills/fsl*`)
 - samples for PMs and consultants (`examples/pm/`, `examples/consulting/`)
 
@@ -171,7 +173,7 @@ Windows users should use WSL or refer to the developer instructions (PowerShell)
 Uninstall:
 
 ```bash
-rm -rf ~/.fsl ~/.local/bin/fslc ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
+rm -rf ~/.fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
 ```
 
 ## Developer setup

--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,7 @@ fi
 VENV_DIR="$REPO_DIR/.venv"
 VENV_PYTHON="$VENV_DIR/bin/python"
 FSL_BIN="$VENV_DIR/bin/fslc"
+FSL_LSP_BIN="$VENV_DIR/bin/fslc-lsp"
 
 echo "Preparing the Python virtual environment: $VENV_DIR"
 PYTHONPATH= "$PYTHON_BIN" -m venv "$VENV_DIR" || fail "Failed to create the Python virtual environment. On Linux where python3-venv is required, install it via your OS package manager and re-run."
@@ -141,9 +142,11 @@ PYTHONPATH= "$PYTHON_BIN" -m venv "$VENV_DIR" || fail "Failed to create the Pyth
 echo "Upgrading pip."
 PYTHONPATH= "$VENV_PYTHON" -m pip install --upgrade pip || fail "Failed to upgrade pip. Check your network connection or Python environment and re-run."
 
-echo "Installing fslc."
+echo "Installing fslc (with the LSP server)."
 PIP_INSTALL_LOG=$(mktemp)
-if PYTHONPATH= "$VENV_PYTHON" -m pip install "$REPO_DIR" >"$PIP_INSTALL_LOG" 2>&1; then
+# Use a relative spec via a subshell cd: pip silently no-ops on an absolute
+# path combined with extras ("/abs/path[lsp]"), whereas ".[lsp]" is reliable.
+if ( cd "$REPO_DIR" && PYTHONPATH= "$VENV_PYTHON" -m pip install ".[lsp]" ) >"$PIP_INSTALL_LOG" 2>&1; then
   rm -f "$PIP_INSTALL_LOG"
 else
   rm -f "$PIP_INSTALL_LOG"
@@ -181,22 +184,31 @@ fi
 [ -x "$FSL_BIN" ] || fail "$FSL_BIN not found. Check the result of pip install and re-run."
 
 LOCAL_BIN="$HOME/.local/bin"
-LINK_PATH="$LOCAL_BIN/fslc"
 mkdir -p "$LOCAL_BIN"
 
-if [ -L "$LINK_PATH" ]; then
-  LINK_TARGET=$(readlink "$LINK_PATH" || true)
-  if [ "$LINK_TARGET" = "$FSL_BIN" ]; then
-    echo "The fslc command link is already set up: $LINK_PATH"
+link_command() {
+  cmd_name="$1"
+  target="$2"
+  link_path="$LOCAL_BIN/$cmd_name"
+  if [ -L "$link_path" ]; then
+    link_target=$(readlink "$link_path" || true)
+    if [ "$link_target" = "$target" ]; then
+      echo "The $cmd_name command link is already set up: $link_path"
+    else
+      echo "Warning: $link_path points to a different location (${link_target}). Not overwriting."
+    fi
+  elif [ -e "$link_path" ]; then
+    echo "Warning: $link_path already exists. Not overwriting. If needed, remove it manually and re-run."
   else
-    echo "Warning: $LINK_PATH points to a different location (${LINK_TARGET}). Not overwriting."
+    ln -s "$target" "$link_path"
+    echo "Created the $cmd_name command link: $link_path"
   fi
-elif [ -e "$LINK_PATH" ]; then
-  echo "Warning: $LINK_PATH already exists. Not overwriting. If needed, remove it manually and re-run."
-else
-  ln -s "$FSL_BIN" "$LINK_PATH"
-  echo "Created the fslc command link: $LINK_PATH"
-fi
+}
+
+link_command fslc "$FSL_BIN"
+# The VSCode extension launches `fslc-lsp` from PATH; link it when present
+# (the offline fallback above installs fslc only, without the LSP server).
+[ -x "$FSL_LSP_BIN" ] && link_command fslc-lsp "$FSL_LSP_BIN"
 
 case ":$PATH:" in
   *":$LOCAL_BIN:"*)


### PR DESCRIPTION
## Why

The VSCode extension launches `fslc-lsp` from `PATH` (`editors/vscode/src/extension.ts`), but after the LSP merge `install.sh` left the server unusable:

1. `pip install "$REPO_DIR"` omitted the `[lsp]` extra, so **pygls was never installed** → `fslc-lsp` raised `RuntimeError: requires the optional LSP dependencies` at startup.
2. Only `fslc` was symlinked into `~/.local/bin`; `fslc-lsp` was not on `PATH`.

## What

- **Install the `[lsp]` extra** so pygls is present. Uses a subshell `cd` + relative `.[lsp]` spec — discovered that `pip install "/abs/path[lsp]"` (absolute path + extras) **silently no-ops with exit 0** on pip 26, whereas `.[lsp]` installs reliably.
- **Extract the symlink logic into `link_command()`** and link both `fslc` and `fslc-lsp` (DRY; the latter only when the binary exists, so the offline fallback that installs `fslc` alone is unaffected).
- Document `fslc-lsp` in README (install list + uninstall line) and CHANGELOG.

## Verification

- `bash -n install.sh` clean.
- `pip install ".[lsp]"` in a fresh venv installs `fslc`, `fslc-lsp`, and `pygls 1.3.1`; the `fslc-lsp` console script completes an LSP `initialize` handshake advertising `documentSymbolProvider` + `definitionProvider`.
- **Full isolated `install.sh` run** (copied repo, overridden `HOME`): creates both `~/.local/bin/fslc` and `~/.local/bin/fslc-lsp` symlinks and passes the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)