### PR TITLE
feat(vscode): package the extension as a .vsix and release it on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,32 @@ jobs:
           files: |
             dist/${{ matrix.asset }}
             dist/${{ matrix.asset }}.sha256
+
+  vsix:
+    name: build vscode extension (.vsix)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build .vsix
+        # vscode:prepublish compiles TypeScript before packaging.
+        working-directory: editors/vscode
+        run: |
+          npm install
+          npx --yes @vscode/vsce package --out fsl-vscode.vsix
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fsl-vscode-vsix
+          path: editors/vscode/fsl-vscode.vsix
+
+      - name: Attach to Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: editors/vscode/fsl-vscode.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ venv/
 # VSCode extension build artifacts
 node_modules/
 editors/vscode/out/
+editors/vscode/package-lock.json
+*.vsix
 
 # Claude Code local config (not part of the project)
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 - (Install) `install.sh` now installs the LSP server (the `[lsp]` extra) and
   links `fslc-lsp` into `~/.local/bin` alongside `fslc`, so the VSCode extension
   finds it on `PATH`.
+- (VSCode) The extension is now packageable as a `.vsix` (`vsce package`): added
+  `.vscodeignore`, a `vscode:prepublish` compile step, and a `repository` field.
+  The `release-binaries` workflow builds the `.vsix` and attaches it to the
+  GitHub Release on a `v*` tag.
 
 ## [2.2.0] - 2026-06-21
 

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+src/**
+**/*.ts
+**/*.map
+tsconfig.json
+.gitignore
+.vscodeignore
+package-lock.json
+**/*.vsix

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,28 @@
+# FSL for VS Code
+
+Language support for [FSL](https://github.com/ymm-oss/fsl) specification files (`.fsl`):
+
+- Syntax highlighting (TextMate grammar — approximate, since most FSL keywords are contextual)
+- Diagnostics (parse and type errors)
+- Document outline (symbols)
+- Go to definition, including `compose` `use ... from` cross-file resolution
+
+## Requirements
+
+This extension is a thin LSP client. It launches the **`fslc-lsp`** language server,
+which must be available on your `PATH`. Install it with the project's `install.sh`
+(it links `fslc-lsp` into `~/.local/bin`) or with `pip install "fslc[lsp]"`.
+
+To point the extension at a specific server binary instead of `PATH`, set the
+`FSLC_LSP_COMMAND` environment variable (e.g. to a virtualenv's `fslc-lsp`).
+
+## Install
+
+Download the `.vsix` from the [GitHub Releases](https://github.com/ymm-oss/fsl/releases)
+page and install it:
+
+```bash
+code --install-extension fsl-vscode-<version>.vsix
+```
+
+or use **Extensions: Install from VSIX…** from the Command Palette.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -5,6 +5,11 @@
   "version": "0.1.0",
   "publisher": "fslc",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ymm-oss/fsl.git",
+    "directory": "editors/vscode"
+  },
   "engines": {
     "vscode": "^1.84.0"
   },
@@ -37,7 +42,8 @@
     ]
   },
   "scripts": {
-    "compile": "tsc -p ./"
+    "compile": "tsc -p ./",
+    "vscode:prepublish": "npm run compile"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"


### PR DESCRIPTION
## How the VSCode extension is distributed

A VSCode extension ships as a single **`.vsix`** file. This PR makes the `editors/vscode` extension packageable and wires it into the existing tag-driven release so the `.vsix` is attached to each **GitHub Release**.

## Changes

- **`package.json`**: `vscode:prepublish` (compiles TS before packaging) + `repository` field.
- **`.vscodeignore`**: keeps the package lean — ships `out/`, `syntaxes/`, `language-configuration.json`, `README`, and the *production* `node_modules` (`vscode-languageclient` + transitive); drops `src/`, `*.ts`, `tsconfig.json`, the lockfile.
- **`editors/vscode/README.md`**: extension detail page; documents that **`fslc-lsp` must be on `PATH`** (via `install.sh` — see #31 — or `pip install "fslc[lsp]"`) and the `FSLC_LSP_COMMAND` override. The extension does not bundle the Python server.
- **`release.yml`**: new `vsix` job builds `fsl-vscode.vsix` with `@vscode/vsce` and attaches it to the Release on a `v*` tag (kept as a CI artifact on manual runs).
- **`.gitignore`**: ignore `*.vsix` and the extension lockfile.

## Consumption

```bash
# maintainer (or CI on a v* tag):
cd editors/vscode && npm install && npx @vscode/vsce package

# user:
code --install-extension fsl-vscode-<version>.vsix   # or "Install from VSIX…"
```

## Verification

Ran `vsce package` locally: produces a **209-file, ~294 KB** `.vsix` containing `out/extension.js`, `syntaxes/`, `language-configuration.json`, `README`, and `node_modules/vscode-languageclient` (+ `vscode-jsonrpc`, `vscode-languageserver-protocol/types`). **No** `src/`, `*.ts`, or `tsconfig` leakage; devDependencies excluded.

> Note: distribution is GitHub Releases only — not the VS Code Marketplace / Open VSX (no publisher account needed). Those can be added later via `vsce publish` / `ovsx publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)