### PR TITLE
fix(lsp): support refinement mapping files (diagnostics + cross-file jump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   links `fslc-lsp` into `~/.local/bin` alongside `fslc`, so the VSCode extension
   finds it on `PATH`.
 
+### Fixed
+- (LSP) Refinement mapping files are parsed without the standalone-spec state
+  block diagnostic, and their `impl`/`abs`, mapped action, and state map
+  references resolve across workspace `.fsl` files by spec name.
+
 ## [2.2.0] - 2026-06-21
 
 ### Changed

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -104,6 +104,7 @@ class Reference:
     range: Range
     qualifier: Optional[str] = None
     target_path: Optional[str] = None
+    target_spec: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -129,6 +130,7 @@ class Location:
 
 
 LoadIndex = Callable[[str], Optional["DocumentIndex"]]
+NameResolver = Callable[[str], Optional[str]]
 
 
 @dataclass
@@ -190,6 +192,7 @@ class DocumentIndex:
         self,
         ref: Reference,
         load_index: Optional[LoadIndex] = None,
+        name_resolver: Optional[NameResolver] = None,
     ) -> Optional[Location]:
         if ref.qualifier:
             binding = self.import_for_alias(ref.qualifier)
@@ -202,6 +205,23 @@ class DocumentIndex:
             if sym is None:
                 return None
             return Location(target.path, sym.selection_range)
+
+        if ref.target_spec and ref.role != "spec":
+            scoped = self._resolve_scoped(ref)
+            if scoped is not None:
+                return Location(self.path, scoped.selection_range)
+
+        if ref.target_spec and name_resolver is not None:
+            target_path = name_resolver(ref.target_spec)
+            if target_path:
+                target = _load_import_index(target_path, load_index)
+                if target is not None:
+                    sym = target.find_exported_symbol(ref.name, ref.role)
+                    if sym is None and ref.role == "spec":
+                        top = _top_symbol(target)
+                        sym = top if top and top.name == ref.name else None
+                    if sym is not None:
+                        return Location(target.path, sym.selection_range)
 
         if ref.target_path:
             target = _load_import_index(ref.target_path, load_index)
@@ -229,16 +249,21 @@ class DocumentIndex:
         line: int,
         character: int,
         load_index: Optional[LoadIndex] = None,
+        name_resolver: Optional[NameResolver] = None,
     ) -> Optional[Location]:
         ref = self.reference_at(line, character)
         if ref is not None:
-            return self.resolve_reference(ref, load_index)
+            return self.resolve_reference(ref, load_index, name_resolver)
         sym = self.symbol_at(line, character)
         if sym is not None:
             return Location(self.path, sym.selection_range)
         return None
 
     def _resolve_local(self, ref: Reference) -> Optional[Symbol]:
+        scoped = self._resolve_scoped(ref)
+        if scoped is not None:
+            return scoped
+
         roles = _roles_for_reference(ref.role)
         candidates = [
             sym for sym in self.symbols
@@ -247,19 +272,25 @@ class DocumentIndex:
         if not candidates:
             return None
 
-        scoped = [
-            sym for sym in candidates
-            if sym.scope_range is not None and sym.scope_range.contains_range_start(ref.range)
-        ]
-        if scoped:
-            return min(scoped, key=lambda sym: _scope_sort_key(sym))
-
         globals_ = [
             sym for sym in candidates
             if sym.scope_range is None and sym.selection_range != ref.range
         ]
         if globals_:
             return min(globals_, key=lambda sym: sym.selection_range.start_tuple)
+        return None
+
+    def _resolve_scoped(self, ref: Reference) -> Optional[Symbol]:
+        roles = _roles_for_reference(ref.role)
+        scoped = [
+            sym for sym in self.symbols
+            if sym.name == ref.name
+            and sym.role in roles
+            and sym.scope_range is not None
+            and sym.scope_range.contains_range_start(ref.range)
+        ]
+        if scoped:
+            return min(scoped, key=lambda sym: _scope_sort_key(sym))
         return None
 
 
@@ -294,10 +325,16 @@ def definition_at(
     line: int,
     character: int,
     load_index: Optional[LoadIndex] = None,
+    name_resolver: Optional[NameResolver] = None,
 ) -> Optional[Location]:
     """Convenience wrapper for one-shot go-to-definition lookup."""
 
-    return build_index(source, path).definition_at(line, character, load_index)
+    return build_index(source, path).definition_at(
+        line,
+        character,
+        load_index,
+        name_resolver,
+    )
 
 
 class _IndexBuilder:
@@ -307,6 +344,9 @@ class _IndexBuilder:
         self.symbols: List[Symbol] = []
         self.references: List[Reference] = []
         self.imports: List[ImportBinding] = []
+        self._refinement_impl_name: Optional[str] = None
+        self._refinement_abs_name: Optional[str] = None
+        self._reference_target_spec: Optional[str] = None
 
     def visit(
         self,
@@ -394,6 +434,7 @@ class _IndexBuilder:
         role: str,
         qualifier: Optional[str] = None,
         target_path: Optional[str] = None,
+        target_spec: Optional[str] = None,
     ) -> None:
         self.references.append(
             Reference(
@@ -402,8 +443,23 @@ class _IndexBuilder:
                 range=_token_range(token),
                 qualifier=qualifier,
                 target_path=target_path,
+                target_spec=target_spec or self._reference_target_spec,
             )
         )
+
+    def _visit_with_target(
+        self,
+        node: object,
+        parent: Optional[int],
+        local_scope: Optional[Range],
+        target_spec: Optional[str],
+    ) -> None:
+        previous = self._reference_target_spec
+        self._reference_target_spec = target_spec
+        try:
+            self.visit(node, parent, local_scope)
+        finally:
+            self._reference_target_spec = previous
 
     def _visit_start(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         self._visit_children(node, parent, local_scope)
@@ -427,7 +483,14 @@ class _IndexBuilder:
         self._visit_named_container(node, "governance", None)
 
     def _visit_refinement_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
-        self._visit_named_container(node, "refinement", None, exported=False)
+        previous_impl = self._refinement_impl_name
+        previous_abs = self._refinement_abs_name
+        self._refinement_impl_name, self._refinement_abs_name = _refinement_spec_names(node)
+        try:
+            self._visit_named_container(node, "refinement", None, exported=False)
+        finally:
+            self._refinement_impl_name = previous_impl
+            self._refinement_abs_name = previous_abs
 
     def _visit_named_container(
         self,
@@ -795,25 +858,42 @@ class _IndexBuilder:
     def _visit_refinement_impl(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
         if token is not None:
-            self._add_ref(token, "spec")
+            self._add_ref(token, "spec", target_spec=str(token))
 
     def _visit_refinement_abs(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
         if token is not None:
-            self._add_ref(token, "spec")
+            self._add_ref(token, "spec", target_spec=str(token))
 
     def _visit_map_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
+        map_scope = _tree_range(node)
         if token is not None:
-            self._add_ref(token, "value")
-        self._visit_children_after_first_token(node, parent, local_scope)
+            self._add_ref(token, "value", target_spec=self._refinement_abs_name)
+        skipped_name = False
+        for child in node.children:
+            if not skipped_name and isinstance(child, Token) and child.type == "NAME":
+                skipped_name = True
+                continue
+            if _tree_data(child) in {"binder_typed", "binder_range", "binder_collection"}:
+                self.visit(child, parent, map_scope)
+            else:
+                self._visit_with_target(child, parent, map_scope, self._refinement_impl_name)
 
     def _visit_refinement_action(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
         action_scope = _tree_range(node)
         if token is not None:
-            self._add_ref(token, "action")
-        self._visit_children_after_first_token(node, parent, action_scope)
+            self._add_ref(token, "action", target_spec=self._refinement_impl_name)
+        skipped_name = False
+        for child in node.children:
+            if not skipped_name and isinstance(child, Token) and child.type == "NAME":
+                skipped_name = True
+                continue
+            if _tree_data(child) in {"action_target", "mapped_action_target"}:
+                self._visit_with_target(child, parent, action_scope, self._refinement_abs_name)
+            else:
+                self.visit(child, parent, action_scope)
 
     def _visit_mapped_action_target(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         self._visit_action_target_ref(node, parent, local_scope)
@@ -830,9 +910,9 @@ class _IndexBuilder:
     def _visit_progress_respond(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         first = _name_token_at(node, 0)
         if first is not None:
-            self._add_ref(first, "property")
+            self._add_ref(first, "property", target_spec=self._refinement_abs_name)
         for token in _name_tokens(node)[1:]:
-            self._add_ref(token, "action")
+            self._add_ref(token, "action", target_spec=self._refinement_impl_name)
 
     def _visit_verify_instances(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
@@ -1231,6 +1311,22 @@ def _load_import_index(path: str, load_index: Optional[LoadIndex]) -> Optional[D
         if loaded is not None:
             return loaded
     return default_load_index(path)
+
+
+def _refinement_spec_names(tree: Tree) -> Tuple[Optional[str], Optional[str]]:
+    impl_name = None
+    abs_name = None
+    for child in tree.children:
+        if not isinstance(child, Tree):
+            continue
+        token = _first_token(child)
+        if token is None:
+            continue
+        if child.data == "refinement_impl":
+            impl_name = str(token)
+        elif child.data == "refinement_abs":
+            abs_name = str(token)
+    return impl_name, abs_name
 
 
 def _top_symbol(index: DocumentIndex) -> Optional[Symbol]:

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -4,20 +4,31 @@
 """pygls language server for FSL files."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
 from lark.exceptions import UnexpectedInput, VisitError
 
-from fslc.lsp.index import DocumentIndex, Range, Symbol, build_index
+from fslc.lsp.index import DocumentIndex, NameResolver, Range, Symbol, build_index
 
 
 SERVER_NAME = "fslc-lsp"
 SERVER_VERSION = "0.1.0"
 
 
-def check_source(source: str, path: Optional[str]) -> Dict[str, Any]:
+_TOP_LEVEL_NAME = re.compile(
+    r"^\s*(?:spec|compose|requirements|business|governance)\s+([A-Za-z_][A-Za-z0-9_]*)\b",
+    re.MULTILINE,
+)
+
+
+def check_source(
+    source: str,
+    path: Optional[str],
+    name_resolver: Optional[NameResolver] = None,
+) -> Dict[str, Any]:
     """Run the same in-process check path as ``fslc check`` for editor text."""
 
     from fslc.acceptance import validate_acceptance, validate_forbidden
@@ -32,6 +43,7 @@ def check_source(source: str, path: Optional[str]) -> Dict[str, Any]:
     )
     from fslc.model import FslError, build_spec
     from fslc.parser import parse_src
+    from fslc.refine import build_refinement
 
     def acceptance_error(spec):
         checked = validate_acceptance(spec)
@@ -52,6 +64,17 @@ def check_source(source: str, path: Optional[str]) -> Dict[str, Any]:
     try:
         base_dir = str(Path(path).parent) if path else "."
         ast, display_names = parse_src(source, base_dir)
+        if ast[0] == "refinement":
+            impl_name, abs_name = _refinement_ast_names(ast)
+            impl_spec = _build_resolved_spec(impl_name, name_resolver, parse_src, build_spec)
+            abs_spec = _build_resolved_spec(abs_name, name_resolver, parse_src, build_spec)
+            if impl_spec is not None and abs_spec is not None:
+                build_refinement(ast, impl_spec, abs_spec)
+            return _envelope({
+                "result": "ok",
+                "refinement": ast[1],
+                "warnings": [],
+            })
         spec = build_spec(ast, display_names, semantic_check=False)
         acc = acceptance_error(spec)
         if acc:
@@ -98,6 +121,35 @@ def check_source(source: str, path: Optional[str]) -> Dict[str, Any]:
         })
 
 
+def _refinement_ast_names(ast) -> Tuple[Optional[str], Optional[str]]:
+    impl_name = None
+    abs_name = None
+    for item in ast[2]:
+        if item[0] == "impl":
+            impl_name = item[1]
+        elif item[0] == "abs":
+            abs_name = item[1]
+    return impl_name, abs_name
+
+
+def _build_resolved_spec(name, name_resolver, parse_src, build_spec):
+    if not name or name_resolver is None:
+        return None
+    try:
+        target_path = name_resolver(name)
+    except Exception:
+        return None
+    if not target_path:
+        return None
+    target = Path(target_path)
+    try:
+        target_source = target.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    ast, display_names = parse_src(target_source, str(target.parent))
+    return build_spec(ast, display_names)
+
+
 def _create_server():
     try:
         from pygls.server import LanguageServer
@@ -110,6 +162,7 @@ def _create_server():
 
     server = LanguageServer(SERVER_NAME, SERVER_VERSION)
     server.fsl_index_cache = {}
+    server.fsl_name_cache = None
 
     def publish(uri: str) -> None:
         source = _source_for_uri(server, uri)
@@ -117,27 +170,31 @@ def _create_server():
             return
         path = _uri_to_path(uri)
         index = _index_for_uri(server, uri)
-        result = check_source(source, path)
+        result = check_source(source, path, _name_resolver_for_server(server, path))
         diagnostics = _result_to_diagnostics(types, source, result, index)
         server.publish_diagnostics(uri, diagnostics)
 
     @server.feature("textDocument/didOpen")
     def did_open(ls, params):
+        _drop_name_cache(server)
         publish(params.text_document.uri)
 
     @server.feature("textDocument/didChange")
     def did_change(ls, params):
         _drop_index(server, params.text_document.uri)
+        _drop_name_cache(server)
         publish(params.text_document.uri)
 
     @server.feature("textDocument/didSave")
     def did_save(ls, params):
         _drop_index(server, params.text_document.uri)
+        _drop_name_cache(server)
         publish(params.text_document.uri)
 
     @server.feature("textDocument/didClose")
     def did_close(ls, params):
         _drop_index(server, params.text_document.uri)
+        _drop_name_cache(server)
         server.publish_diagnostics(params.text_document.uri, [])
 
     @server.feature("textDocument/documentSymbol")
@@ -161,6 +218,7 @@ def _create_server():
             params.position.line,
             params.position.character,
             _loader_for_server(server),
+            _name_resolver_for_server(server, _uri_to_path(uri)),
         )
         if loc is None:
             return None
@@ -208,6 +266,111 @@ def _index_for_uri(server, uri: str) -> Optional[DocumentIndex]:
 
 def _drop_index(server, uri: str) -> None:
     server.fsl_index_cache.pop(uri, None)
+
+
+def _drop_name_cache(server) -> None:
+    server.fsl_name_cache = None
+
+
+def _name_resolver_for_server(server, current_path: Optional[str]) -> NameResolver:
+    def resolve(name: str) -> Optional[str]:
+        return _workspace_spec_name_map(server, current_path).get(name)
+
+    return resolve
+
+
+def _workspace_spec_name_map(server, current_path: Optional[str]) -> Dict[str, str]:
+    roots = _workspace_roots(server, current_path)
+    current_dir = _normalize_dir(Path(current_path).parent) if current_path else None
+    cache_key = (
+        tuple(str(root) for root in roots),
+        str(current_dir) if current_dir is not None else None,
+    )
+    cached = getattr(server, "fsl_name_cache", None)
+    if cached is not None and cached[0] == cache_key:
+        return cached[1]
+
+    candidates: Dict[str, List[Path]] = {}
+    for root in roots:
+        try:
+            files = sorted(root.rglob("*.fsl"))
+        except OSError:
+            continue
+        for file_path in files:
+            if not file_path.is_file():
+                continue
+            name = _extract_top_level_name(file_path)
+            if name is None:
+                continue
+            candidates.setdefault(name, []).append(file_path)
+
+    name_map = {
+        name: str(min(paths, key=lambda path: _resolver_path_rank(path, current_dir)))
+        for name, paths in candidates.items()
+    }
+    server.fsl_name_cache = (cache_key, name_map)
+    return name_map
+
+
+def _workspace_roots(server, current_path: Optional[str]) -> List[Path]:
+    roots: List[Path] = []
+    workspace = getattr(server, "workspace", None)
+    folders = getattr(workspace, "folders", None)
+    if folders:
+        values = folders.values() if isinstance(folders, dict) else folders
+        for folder in values:
+            uri = getattr(folder, "uri", None)
+            path = _uri_to_path(uri) if uri else getattr(folder, "path", None)
+            if path:
+                roots.append(Path(path))
+
+    root_uri = getattr(workspace, "root_uri", None)
+    if root_uri:
+        root_path = _uri_to_path(root_uri)
+        if root_path:
+            roots.append(Path(root_path))
+    root_path = getattr(workspace, "root_path", None)
+    if root_path:
+        roots.append(Path(root_path))
+
+    if current_path:
+        roots.append(Path(current_path).parent)
+    if not roots:
+        roots.append(Path.cwd())
+
+    deduped: List[Path] = []
+    seen = set()
+    for root in roots:
+        normalized = _normalize_dir(root)
+        if normalized in seen or not normalized.exists():
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _extract_top_level_name(path: Path) -> Optional[str]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _TOP_LEVEL_NAME.search(source)
+    return match.group(1) if match else None
+
+
+def _resolver_path_rank(path: Path, current_dir: Optional[Path]) -> Tuple[int, int, int, str]:
+    normalized = _normalize_dir(path)
+    same_dir = current_dir is not None and normalized.parent == current_dir
+    return (
+        0 if same_dir else 1,
+        len(normalized.stem),
+        len(str(normalized)),
+        str(normalized),
+    )
+
+
+def _normalize_dir(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
 
 
 def _loader_for_server(server):

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 from fslc.lsp.index import build_index, default_load_index
+from fslc.lsp.server import check_source
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -34,6 +35,57 @@ def _reference(index, name, role, qualifier=None):
         if ref.name == name and ref.role == role and ref.qualifier == qualifier
     ]
     assert matches, f"missing reference {role}:{qualifier or ''}.{name}"
+    return matches[0]
+
+
+def _refinement_fixture_indexes():
+    paths = {
+        "refinement": SPECS / "cart_refines.fsl",
+        "impl": SPECS / "cart_impl.fsl",
+        "abs": SPECS / "cart_v1.fsl",
+    }
+    indexes = {
+        str(path.resolve()): build_index(path.read_text(encoding="utf-8"), str(path))
+        for path in paths.values()
+    }
+    resolver = {
+        "CartImpl": str(paths["impl"].resolve()),
+        "ShoppingCart": str(paths["abs"].resolve()),
+    }
+
+    def load_index(path):
+        return indexes.get(str(Path(path).resolve()))
+
+    def name_resolver(name):
+        return resolver.get(name)
+
+    return paths, indexes[str(paths["refinement"].resolve())], load_index, name_resolver
+
+
+def _definition_for_ref(index, ref, load_index, name_resolver):
+    loc = index.definition_at(
+        ref.range.start.line,
+        ref.range.start.character,
+        load_index,
+        name_resolver,
+    )
+    assert loc is not None, f"unresolved reference {ref.role}:{ref.name}"
+    return loc
+
+
+def _target_text(loc):
+    assert loc.path is not None
+    return _slice(Path(loc.path).read_text(encoding="utf-8"), loc.range)
+
+
+def _ref(index, name, role, target_spec=None):
+    matches = [
+        ref for ref in index.references
+        if ref.name == name
+        and ref.role == role
+        and (target_spec is None or ref.target_spec == target_spec)
+    ]
+    assert matches, f"missing reference {role}:{target_spec or ''}.{name}"
     return matches[0]
 
 
@@ -107,3 +159,112 @@ def test_compose_definition_resolution_crosses_use_imports():
     assert payments_loc is not None
     assert payments_loc.path == str((SPECS / "payment.fsl").resolve())
     assert _slice((SPECS / "payment.fsl").read_text(encoding="utf-8"), payments_loc.range) == "payments"
+
+
+def test_lsp_check_accepts_refinement_mapping_without_state_block_diagnostic():
+    paths, _, _, name_resolver = _refinement_fixture_indexes()
+    source = paths["refinement"].read_text(encoding="utf-8")
+
+    result = check_source(source, str(paths["refinement"]), name_resolver)
+
+    assert result["result"] == "ok"
+    assert "spec has no state block" not in str(result)
+
+
+def test_refinement_spec_definitions_resolve_across_workspace_names():
+    paths, index, load_index, name_resolver = _refinement_fixture_indexes()
+
+    impl_loc = _definition_for_ref(
+        index,
+        _ref(index, "CartImpl", "spec", "CartImpl"),
+        load_index,
+        name_resolver,
+    )
+    assert impl_loc.path == str(paths["impl"].resolve())
+    assert _target_text(impl_loc) == "CartImpl"
+
+    abs_loc = _definition_for_ref(
+        index,
+        _ref(index, "ShoppingCart", "spec", "ShoppingCart"),
+        load_index,
+        name_resolver,
+    )
+    assert abs_loc.path == str(paths["abs"].resolve())
+    assert _target_text(abs_loc) == "ShoppingCart"
+
+
+def test_refinement_action_definitions_resolve_to_impl_and_abs_specs():
+    paths, index, load_index, name_resolver = _refinement_fixture_indexes()
+
+    checkout_loc = _definition_for_ref(
+        index,
+        _ref(index, "checkout", "action", "ShoppingCart"),
+        load_index,
+        name_resolver,
+    )
+    assert checkout_loc.path == str(paths["abs"].resolve())
+    assert _target_text(checkout_loc) == "checkout"
+
+    impl_checkout_loc = _definition_for_ref(
+        index,
+        _ref(index, "impl_checkout", "action", "CartImpl"),
+        load_index,
+        name_resolver,
+    )
+    assert impl_checkout_loc.path == str(paths["impl"].resolve())
+    assert _target_text(impl_checkout_loc) == "impl_checkout"
+
+    reserve_loc = _definition_for_ref(
+        index,
+        _ref(index, "reserve", "action", "CartImpl"),
+        load_index,
+        name_resolver,
+    )
+    assert reserve_loc.path == str(paths["impl"].resolve())
+    assert _target_text(reserve_loc) == "reserve"
+
+
+def test_refinement_map_definitions_resolve_lhs_to_abs_and_rhs_to_impl():
+    paths, index, load_index, name_resolver = _refinement_fixture_indexes()
+
+    for name in ("stock", "cart"):
+        loc = _definition_for_ref(
+            index,
+            _ref(index, name, "value", "ShoppingCart"),
+            load_index,
+            name_resolver,
+        )
+        assert loc.path == str(paths["abs"].resolve())
+        assert _target_text(loc) == name
+
+    for name in ("impl_stock", "impl_cart"):
+        loc = _definition_for_ref(
+            index,
+            _ref(index, name, "value", "CartImpl"),
+            load_index,
+            name_resolver,
+        )
+        assert loc.path == str(paths["impl"].resolve())
+        assert _target_text(loc) == name
+
+
+def test_refinement_local_binders_still_resolve_in_file():
+    paths, index, load_index, name_resolver = _refinement_fixture_indexes()
+
+    i_loc = _definition_for_ref(
+        index,
+        _ref(index, "i", "value", "CartImpl"),
+        load_index,
+        name_resolver,
+    )
+    assert i_loc.path == str(paths["refinement"].resolve())
+    assert _target_text(i_loc) == "i"
+
+    u_loc = _definition_for_ref(
+        index,
+        _ref(index, "u", "value", "ShoppingCart"),
+        load_index,
+        name_resolver,
+    )
+    assert u_loc.path == str(paths["refinement"].resolve())
+    assert _target_text(u_loc) == "u"


### PR DESCRIPTION
## The bug

Opening a `refinement` mapping file (e.g. `specs/cart_refines.fsl`) in VSCode showed a spurious **"spec has no state block"** diagnostic, and **go-to-definition failed** for every cross-file reference (`impl CartImpl`, `abs ShoppingCart`, `stock`, `checkout`, `impl_checkout`, …). Only local binder vars jumped.

## Root cause

1. `server.py` `check_source()` ran `build_spec()` on **every** parsed AST. A `refinement {...}` file is not a standalone spec, so `build_spec` raised `FslError("spec has no state block")`. (`fslc check` has the same limitation — refinements are checked via `fslc refine impl abs mapping`.)
2. The index had no way to resolve specs referenced **by name** (`impl CartImpl` / `abs ShoppingCart`); only compose path imports (`use ... from`) were resolvable.

## Fix

- **`server.py`**: refinement files skip `build_spec`. A workspace **spec-name→path resolver** scans `.fsl` files (same-directory preferred when a name is declared in multiple files). When both impl/abs resolve, `build_refinement()` runs for real structural diagnostics; otherwise parse-only OK — never the spurious error.
- **`index.py`**: refinement references are tagged **IMPL vs ABS** at walk time; `definition_at()` gains an injectable `name_resolver` for cross-file lookup; `action_target` node unwrapped; local binders still shadow cross-file symbols.
- **tests**: 5 new cases — impl/abs spec jump, abs-action vs impl-action direction, map LHS/RHS var direction, and in-file binder no-regression.

## Verification (end-to-end over the LSP stdio protocol)

`tests/test_lsp_index.py`: **7 passed**. `fslc check specs/cart_v1.fsl`: ok. Imports clean. Driving the real server on `cart_refines.fsl`:

| reference | jumps to |
|---|---|
| `CartImpl` / `ShoppingCart` | `cart_impl.fsl` / `cart_v1.fsl` |
| `checkout` (abs action) | `cart_v1.fsl` |
| `impl_checkout` (impl action) | `cart_impl.fsl` |
| `stock` (abs map LHS) / `impl_stock` (impl map RHS) | `cart_v1.fsl` / `cart_impl.fsl` |
| `i` (local binder) | in-file (no regression) |

…and **no** "spec has no state block" diagnostic is emitted.

## Notes

- Disambiguation of duplicate spec names is deterministic (same-directory first, then shorter name) — necessary because the corpus declares some spec names in multiple files; it is not speculative fallback.
- Live diagnostics run structural `build_refinement` only, not the Z3 `refine()` solve (too slow per keystroke).
- Kernel grammar/model/bmc and all `.fsl` specs untouched (corpus snapshot unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)