### PR TITLE
chore(security): remove maintainer contact email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   agent filters out non-FSL-shaped tasks and recommends tests instead of writing a
   hollow spec.
 
+### Changed
+- Removed the maintainer contact email from `SECURITY.md` and `pyproject.toml`;
+  vulnerability reports are now routed solely through GitHub Security Advisories
+  (Private Vulnerability Reporting).
+
 ## [2.3.0] - 2026-06-22
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,8 @@ untrusted input (`.fsl` files, trace JSON). If you find an issue that could lead
 to a parser or evaluator crash, an infinite loop, or arbitrary code execution,
 please report it privately **before opening a public issue**.
 
-- Preferred: a private report via GitHub **Security Advisories** (the repository's
+- Please file a private report via GitHub **Security Advisories** (the repository's
   "Security" → "Report a vulnerability").
-- Or by email: ryoichi.a.izumita@accenture.com
 
 Please include a minimal reproducing `.fsl` (or trace), the command you ran, and
 the observed vs. expected behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 authors = [
-    { name = "Ryoichi Izumita", email = "ryoichi.a.izumita@accenture.com" },
+    { name = "Ryoichi Izumita" },
 ]
 keywords = [
     "formal-methods",


### PR DESCRIPTION
## Summary

Ran a confidentiality sweep over the repository (tracked files, git history, CI config, and examples). No secrets, credentials, connection strings, or project/client-confidential data were found. The only personal data exposed was a corporate contact email, which this PR removes.

## Changes
- **`SECURITY.md`** — drop the `accenture.com` email; vulnerability reports now route solely through GitHub **Security Advisories** (Private Vulnerability Reporting). The reporting channel is preserved.
- **`pyproject.toml`** — remove `email` from the author entry, keeping `{ name = "Ryoichi Izumita" }`. Verified the file still parses as valid TOML.
- **`CHANGELOG.md`** — note under `[Unreleased] → Changed`.

## Verification
- `git grep` confirms no remaining `accenture` / maintainer-email occurrences.
- `pyproject.toml` parses: `authors = [{'name': 'Ryoichi Izumita'}]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)