### PR TITLE
docs(skill): add a faithfulness gate to fsl-requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   (the one test + three gates, framed as a recommendation rather than a gate) so the
   agent filters out non-FSL-shaped tasks and recommends tests instead of writing a
   hollow spec.
+- (Skill) `skills/fsl-requirements/SKILL.md` now defines an explicit faithfulness
+  gate (definition of done): a step-1 coverage map from every source requirement to
+  an FSL element, mandatory provenance tags (`covers` or `MODEL:`/`ASSUME-n:`) on
+  every declaration, and a `fslc check --strict-tags` gate that must report zero
+  `untagged` and zero `unreferenced_requirement`. Closes the gap where specs derived
+  from a requirements document came out both thin (dropped requirements) and
+  over-reaching (invented rules).
 
 ### Changed
 - Removed the maintainer contact email from `SECURITY.md` and `pyproject.toml`;

--- a/skills/fsl-requirements/SKILL.md
+++ b/skills/fsl-requirements/SKILL.md
@@ -16,6 +16,27 @@ repository, read `examples/pm/`, `examples/layers/return_system.fsl`, and
 `examples/e2e/2_requirements.fsl` for the requirements dialect. Read
 `examples/nfr/` only when SLA/deadline behavior is in scope.
 
+## Faithfulness gate (definition of done)
+
+The two failures this layer exists to prevent are **dropping** a requirement (a
+thin spec) and **inventing** a rule the source never stated. Hold both ends:
+
+- **Cover the source.** Every requirement in the document maps to at least one
+  transition / invariant / acceptance / forbidden, or is recorded in the memo as
+  out-of-scope or needs-decision. The step-1 coverage map forces the hard
+  requirements in instead of stopping at the happy path.
+- **Ground the spec.** Every declaration carries provenance — `covers REQ-n "..."`
+  to source text, or a `MODEL:` / `ASSUME-n:` tag for an explicit modeling choice.
+  An untagged declaration is an ungrounded guess, not a style nit.
+- **Do not invent to reach green.** If `check`/`verify` needs a guard, bound,
+  state, actor, deadline, or exception the source does not state, that is a step-1
+  question for the human — not a default you may pick to reach `verified`.
+- **Make it mechanical.** `fslc check <file> --strict-tags` flags every `untagged`
+  declaration (an invented rule) and every `unreferenced_requirement` (a
+  requirement nothing checks); **done = zero of both**. Add `--requirements <ids>`
+  (the memo's source-ID list) to also catch requirements omitted entirely. Keep
+  provenance in the `.fsl` as tags, not a separate file.
+
 ## Boundary
 
 Produce requirements-layer artifacts only:
@@ -38,13 +59,18 @@ design decision but does not state it, ask rather than choosing.
    - glossary: externally visible entities, states, actors, operations, enums
    - requirement normalization: trigger, constraint, exception, boundary
      implication for each requirement
+   - coverage map: every source requirement ID → the FSL element that will carry
+     it; mark anything you cannot cover out-of-scope or needs-decision (this is
+     what keeps the spec from silently dropping requirements)
    - acceptance and forbidden traces, with expected outcome
    - upper business contract, if any, and candidate `implements` mapping
    - assumptions and questions that affect behavior
 2. Preserve source fidelity. Requirement IDs and verbatim text belong in
    `covers REQ-n "..."` on process transitions, or in
    `requirement REQ-n "..."` for kernel-wrapper declarations, so diagnostics and
-   scenarios trace back to the PM document.
+   scenarios trace back to the PM document. Tag any declaration that is not a
+   direct source requirement `MODEL:` or `ASSUME-n:` so the strict-tags gate can
+   tell intended modeling from fabrication.
 3. Encode only externally observable product behavior. State names should describe
    product/system states, not engineering mechanisms.
 4. Use the process+data profile first for a single-entity lifecycle:
@@ -74,12 +100,19 @@ design decision but does not state it, ask rather than choosing.
    - audit/capacity/reliability: ordinary invariants and response properties
    - SLA/deadline: use requirements `time` and `deadline`; confirm non-vacuity by
      checking that a tighter deadline fails
-9. Run `fslc check`, `fslc verify`, and for stable requirements
+9. Run `fslc check --strict-tags` as the faithfulness gate — not done until it
+   reports zero `untagged` and zero `unreferenced_requirement` (add
+   `--requirements <ids>` from the memo to also catch fully omitted requirements).
+   Then `fslc verify`, and for stable requirements
    `fslc verify --engine induction`. Run `fslc scenarios` to hand development the
    acceptance/forbidden skeletons.
 
 ## Guardrails
 
+- Completeness is part of the contract: a spec that formalizes only some
+  requirements is not "minimal," it is unfinished. Cover every source requirement
+  or record why not (out-of-scope / needs-decision) — but never close a gap by
+  inventing a rule the source does not state.
 - Stop at the requirements contract. Do not continue into design just because a
   design could be inferred.
 - Do not add retries, storage rules, asynchronous jobs, queues, screen internals,


### PR DESCRIPTION
## Problem

When the `fsl-requirements` skill is used to turn a requirements document into an
FSL spec, the result tends to fail in **two opposite directions at once**:

- **Thin** — only the happy-path transitions get formalized; requirements from the
  source are silently dropped.
- **Over-reaching** — guards, bounds, states, and exceptions that the source never
  states get invented to make the spec type-check / verify.

## Diagnosis

This is **not** a missing skill. `fsl-requirements` is the right skill and the
verifier already ships the exact detector for both symptoms —
`model.strict_tag_warnings`, surfaced by `fslc check --strict-tags`:

| warning | meaning | symptom |
|---|---|---|
| `untagged` | a declaration with no provenance tag (an invented rule) | over-reaching |
| `unreferenced_requirement` | a source requirement ID nothing checks (a dropped requirement) | thin |

The gap was **enforcement**: the skill mentioned `--strict-tags` only in passing,
the anti-invention rules lived mostly in `fsl/SKILL.md` behind a soft pointer, and
the guardrails were all prohibitions with no positive coverage obligation — so the
model minimized output *and* invented to reach green.

## Change (docs only)

`skills/fsl-requirements/SKILL.md`:

1. New **"Faithfulness gate (definition of done)"** section — promotes the
   two-direction rule into the body so it survives progressive disclosure.
2. **Coverage map** added to the step-1 memo: every source requirement → an FSL
   element, or marked out-of-scope / needs-decision (a positive completeness
   obligation to counter the prohibitions).
3. **Mandatory provenance** in step 2: tag any non-source declaration `MODEL:` /
   `ASSUME-n:` so the gate can tell intent from fabrication.
4. **Gate wired into step 9**: `fslc check --strict-tags` must report zero
   `untagged` and zero `unreferenced_requirement` (add `--requirements <ids>` for
   fully omitted IDs).
5. A balancing **completeness guardrail**: "a partial spec is not minimal, it is
   unfinished — but never close a gap by inventing a rule."

Provenance stays in the `.fsl` as tags (no derived doc that drifts); the coverage
map and the source-ID list are ephemeral chat/scratch artifacts.

## Proof the gate catches both

A minimal spec seeded with one invented declaration and one uncovered requirement:

```
$ fslc check demo.fsl --strict-tags --requirements ids.txt
{ "result": "ok", "warnings": [
  { "kind": "untagged", "element": "reachable", "name": "Top" },
  { "kind": "unreferenced_requirement", "element": "requirement", "name": "REQ-2" }
]}
```

Both fire in one command; `result: ok` with warnings means it works as a
"warnings-must-be-empty" definition of done.

## Scope / safety

Docs only — no grammar, model, or verifier change. No `.fsl` under `specs/` or
`examples/` touched, so the corpus snapshot is unaffected. CHANGELOG `[Unreleased]`
updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
