### PR TITLE
feat(skills): add fsl-from-code skill for code→FSL design extraction

### DIFF
--- a/.claude/skills/fsl-from-code
+++ b/.claude/skills/fsl-from-code
@@ -1,0 +1,1 @@
+../../skills/fsl-from-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- (Skill) `skills/fsl-from-code/` — reverse-engineers an FSL design-layer spec from
+  existing source code. Encodes the three-zone extraction (mechanical skeleton vs.
+  human-confirmed invariants vs. mechanical truth-check), a formalization-memo
+  question set that forces cross-action invariant discovery, and a two-axis
+  anti-hollow gate (`fslc mutate` for invariant teeth + the `testgen` harness
+  replayed against the real code for fidelity). Anchored downward via conformance,
+  not upward via refinement; specgraphen evaluated and not adopted.
 - examples/structural: Step 1 demand-validation specs for issue #35 (Alloy-style structural discovery via the populate+reachable idiom)
 - (Docs) New manual chapter "When to Use FSL" (`docs/intro/when-to-use.{ja,en}.html`,
   wired into the chapter nav as #2, after Concept): criteria for deciding whether to

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,7 @@ artifacts by accident:
 | [`fsl-requirements/`](fsl-requirements/) | PM/PdM requirements, acceptance criteria, forbidden flows, NFR/SLA | `requirements` spec |
 | [`fsl-design/`](fsl-design/) | engineering design, internal state/actions, refinement mapping, testgen/replay handoff | kernel `spec` + mapping |
 | [`fsl-design-review/`](fsl-design-review/) | design review, variants, SOLID/LSP/OCP/substitutability judgment | contract-conformance report |
+| [`fsl-from-code/`](fsl-from-code/) | reverse-engineering a design spec from existing code, anchored by conformance back to that code | kernel `spec` + conformance harness |
 | [`fsl-delivery/`](fsl-delivery/) | end-to-end FSL delivery orchestration from planning through implementation conformance | lifecycle status and gated handoff |
 
 The role-specific skills delegate syntax and verifier details to `fsl/`. Use the
@@ -37,6 +38,9 @@ layers and needs lifecycle coordination.
   refinement guardrails
 - [`fsl-design-review/SKILL.md`](fsl-design-review/SKILL.md) — review procedure and
   design-principle interpretation
+- [`fsl-from-code/SKILL.md`](fsl-from-code/SKILL.md) — code→design extraction
+  procedure, the formalization-memo question set, and the two-axis anti-hollow
+  conformance gate
 - [`fsl-delivery/SKILL.md`](fsl-delivery/SKILL.md) — lifecycle orchestration
   across business, requirements, design, verification, and implementation
   conformance

--- a/skills/fsl-from-code/SKILL.md
+++ b/skills/fsl-from-code/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: fsl-from-code
+description: Reverse-engineer an FSL design-layer spec from existing source code. Scope the stateful subsystem, harvest state/actions/guards/effects with source-line witnesses, surface invariants and forbidden flows as confirmation questions (never fabricated), then verify, mutation-test for hollowness, and prove conformance by replaying the generated harness against the real code. Use when the input is code and the deliverable is a spec. Do not use when starting from a requirements contract (use fsl-design), nor for business/PM requirements discovery.
+---
+
+# FSL From Code — extracting a design spec from an implementation
+
+Use this skill when the input is **existing code** and the deliverable is an FSL
+**design-layer** spec. The direction is the reverse of `fsl-design`: there is no
+upper requirements contract to refine to, so the spec is anchored **downward** —
+its faithfulness is proved by replaying the generated conformance harness against
+the very code it was read from. If the user later wants an upper requirements
+contract, that is `fsl-design`'s job, not this skill's.
+
+Before writing syntax, read `../fsl/SKILL.md` and `../fsl/reference.md` for the
+shared language rules, verifier workflow, and repair protocol. Inside this
+repository, study the canonical triple **in reverse**: `examples/e2e/impl/expense.py`
+(plain code) → `examples/e2e/3_design.fsl` (the spec) → `examples/e2e/impl/test_conformance.py`
+(the generated Adapter + random-walk Monitor). That triple is exactly the artifact
+this skill produces, read backwards.
+
+## Boundary
+
+Produce only:
+
+- A design-layer kernel `spec` whose state/actions/guards/effects are read from the
+  code, each tagged with a `// SRC: file:line` witness
+- Invariants and forbidden flows that the human **confirmed**, tagged with
+  `// ASSUME-n:` ledger comments
+- The `fslc testgen` conformance harness, with the Adapter wired to the real code
+
+Do not:
+
+- Invent invariants, guards, states, or transition targets to make the spec look
+  complete or to make it verify. A missing rule is a question, not a default.
+- Produce a requirements or business layer, or refine upward.
+- Claim implementation conformance unless the harness actually ran green against the
+  code (a spec that only `verify`s is internally consistent, not faithful to code).
+
+## Why this is not a transpiler — three zones
+
+Extraction is not uniform. It splits into three zones at different confidence
+levels, and conflating them is what produces a worthless spec:
+
+- **Zone A — mechanical, high-recall, traceable.** `state` (member variables and
+  their types, narrowed to bounded domain types), `action` (a method), `requires`
+  (its leading guard clauses), effects (its assignments). Read directly off the
+  code.
+- **Zone B — NOT present in the code; the actual value, and the trap.** Cross-action
+  invariants (conservation laws), forbidden interaction sequences, and `leadsTo`
+  responses. `3_design.fsl`'s `CountsMatchSubmittedOrPaid` appears on no line of
+  `expense.py` — it is a rule a human recognizes. These must be **discovered and
+  confirmed**, never read off and never fabricated.
+- **Zone C — mechanical truth-check.** `fslc mutate` (do the invariants have teeth?)
+  and the conformance harness (does the modeled behavior match the code?).
+
+A spec mirrored from code alone is **hollow**: it restates what the code does, so it
+passes conformance trivially while asserting nothing a mutation can kill. The whole
+job of this skill is to force Zone B and gate the hollow result.
+
+## Workflow
+
+```
+0. Gate        Apply fsl's state-machine self-check. Reject CRUD / display / glue —
+               FSL only pays off when interaction (order/flags/permissions/async/
+               retry) can reach a forbidden state. Recommend ordinary tests instead.
+1. Harvest     Read the code into a Zone-A skeleton: state vars + types, the methods
+               that are actions, their guard clauses, their effects. Record a
+               // SRC: file:line for each.
+2. Memo        Post the formalization memo (below) in chat. Zone-B is QUESTIONS, not
+               assertions; finite bounds are labeled modeling assumptions. Get human
+               confirmation before writing.  <─────────────────────────────┐
+3. Write       Write the .fsl after confirmation. Fold confirmed Zone-B rules in     │
+               as invariant/forbidden/leadsTo; carry every // SRC: and // ASSUME-n:.  │
+4. Verify      fslc check → verify --depth 8 → --engine induction. Repair via the     │
+               fsl repair protocol (decide: code misread, or rule wrong?).            │
+5. Anti-hollow fslc mutate (kill-rate) + reachable witnesses. A survivor or an        │
+               `empty_formalization` requirement is a missing rule → back to Memo ────┘
+               with a SPECIFIC question for that survivor (not a vague redo).
+6. Conformance fslc testgen → wire the Adapter's observe()/step() to the real code →
+               run the random-walk + replay. Drift means the modeled behavior left
+               the code; fix the spec (or record a deliberate abstraction).
+```
+
+## Formalization memo (the crux — post in chat, do not make a file)
+
+This is the only stage where insight emerges; stages 4–6 merely *test* what you
+already claimed. Read the full memo discipline in `../fsl/SKILL.md`; this skill adds
+the code-extraction question set. Ask these explicitly — a free-form "what invariants
+exist?" reliably yields a Zone-A-only (hollow) spec.
+
+**Zone-B discovery questions (these find the invariants):**
+
+1. **Conservation laws.** For each state variable written by more than one action:
+   is there a global aggregate (`sum` / `count`) that must always hold? (e.g. a
+   counter equals the count of records in certain states.)
+2. **Forbidden sequences.** Is there a state that each action's guard allows
+   individually, but that a *sequence* of otherwise-valid actions must never reach?
+   (a `forbidden` flow or a cross-action `invariant`, the kind a single `requires`
+   stays silent about.)
+3. **Relational / ordering constraints.** Regardless of which action fires, is there
+   an ordering or relation between state values that is globally true?
+
+**Scoping questions (get these wrong and the spec is valid but mis-modeled):**
+
+4. **Action vs. helper boundary.** Which methods are entry points callable by
+   external callers without depending on a prior call? Private-by-convention helpers,
+   cron/queue-triggered steps, and cross-class internal calls all blur this. Only
+   entry points become `action`s.
+5. **Concurrency.** Does the code use locks / transactions / async? FSL models
+   interleaving. Decide explicitly: are we modeling single-threaded correctness, or
+   concurrent properties? A sequential model of concurrent code silently loses the
+   races — often the whole reason to reach for FSL.
+6. **Domain sizing.** Where the real system has no natural capacity limit (an
+   unbounded list, arbitrary ints), bounding to `0..N` is **not** purely
+   representational: it decides which interaction bugs are findable at depth 8.
+   Record in `// ASSUME-n:` what bounding to N gives up — which bugs need more than N
+   instances to appear.
+7. **Multi-entity shape.** Is this one instance (→ a single `struct` in `state`), a
+   collection (→ `Map<Id, Data>` over a bounded key type), or multiple actors (→
+   `compose`)? Real code often does not align as cleanly as the `Map`-shaped example.
+
+## Two-axis anti-hollow gate
+
+Faithfulness has two orthogonal axes; they catch different failures, so run both.
+
+| | `mutate` kills | `mutate` kills **nothing** |
+|---|---|---|
+| **conformance passes** | good | **hollow** — code faithfully mirrored, zero rules captured |
+| conformance fails | invariants have teeth, but the model is a different machine | doubly broken |
+
+The dangerous quadrant for code-extraction is *conformance-passes + kills-nothing*:
+exactly where a naive transpile lands. The exit from it is `mutate --by-requirement`'s
+`empty_formalization` warning driving a specific Zone-B question back into the memo.
+
+When the implementation is **runnable**, prefer the stronger check: mutate the
+**code** (remove an update, flip a branch) and confirm the conformance run goes red —
+this proves the spec catches what the code gets wrong, which model mutation cannot.
+Fall back to `fslc mutate` only when no runnable implementation exists (typical for
+legacy reverse-engineering). A blind second agent writing invariants from the spec's
+natural-language rendering is an option for high-stakes specs, too costly to mandate.
+
+## Guardrails
+
+- **Gate first.** Most code is not a state machine worth specifying. Recommending
+  ordinary tests is a valid, common outcome — do not force a spec.
+- **Confirm before encoding.** Every Zone-B rule and every non-representational bound
+  is a question for the human first, then an `// ASSUME-n:` tag, never a silent
+  default. Treat a low `mutate` kill-rate as evidence Zone B is unfinished, not as a
+  reason to weaken the spec.
+- **Trace everything.** `// SRC: file:line` on each action and each invariant keeps
+  the spec auditable against the code it came from.
+- **Conformance honesty.** Report "design invariants proved" and "conforms to code"
+  as separate claims; make the second only after the harness ran green against the
+  real implementation.


### PR DESCRIPTION
## What

Adds a new agent skill, **`fsl-from-code`**, that reverse-engineers an FSL
**design-layer** spec from existing source code. It is the inverse of `fsl-design`:
there is no upper requirements contract to refine to, so the spec is anchored
**downward** — its faithfulness is proved by replaying the generated conformance
harness against the very code it was read from.

## Why a separate skill (not a section in `fsl-design`)

The two loops would contaminate each other. `fsl-design` derives a design from a
requirements contract and refines **up**; its guardrail ("don't rewrite business
policies to make the design pass") is meaningless when extracting from code. This
skill extracts from code and anchors **down** via conformance. Different trigger,
different direction, opposite guardrails — so a new, narrow skill that delegates
syntax/verifier/repair to `fsl`.

## The design it encodes

- **Three-zone extraction.** Mechanical skeleton (state / actions / `requires` /
  effects, each with a `// SRC: file:line` witness) **vs.** human-confirmed
  invariants and forbidden flows (absent from the code — the FSL value-add *and* the
  hollow-spec trap) **vs.** the mechanical truth-check.
- **Formalization-memo question set** (the crux — it is the only stage where insight
  emerges; everything downstream only *tests*). Forces cross-action invariant
  discovery (conservation laws, forbidden sequences, ordering/relations) plus scoping
  questions (action-vs-helper boundary, concurrency, domain sizing, multi-entity
  shape).
- **Two-axis anti-hollow gate.** `fslc mutate` (do the invariants have teeth?) ×
  conformance (does the model match the code?). The dangerous quadrant —
  *conformance passes, mutate kills nothing* — is exactly where a naive transpile
  lands. Prefer **code-mutation differential** when the implementation is runnable.

## specgraphen

Evaluated and **not adopted**. Java-only in practice (Python/TS unimplemented), and
structural rather than behavioral — it extracts call graphs / CRUD / decision tables
but no invariants or transition semantics, and its `extract_core_rules` decision
tables flatten the `requires` / type-bound / effect distinction, so they are unsound
as a primary guard source. Not worth the `lift` + jdtls operational weight for this
skill.

## Files

- `skills/fsl-from-code/SKILL.md` — new skill
- `.claude/skills/fsl-from-code` — symlink (in-repo activation, matching the others)
- `skills/README.md` — index table + Files list
- `CHANGELOG.md` — `[Unreleased] / Added`

## Test impact

None. Docs/skill only; no `.fsl`, grammar, or verifier change, so the corpus snapshot
and verifier suites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
