### PR TITLE
feat(kernel): accept entity/number in spec; author design+requirements as readable docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Kernel `spec` now accepts `entity`/`number` declarations (previously dialect-only),
+  desugared to `type X = lo..hi` via the `verify` block (`instances`/`values`). This
+  separates domain identity from the verification world size so a design-layer spec
+  reads as documentation instead of asserting a domain size that is only a model
+  bound. Reuses the requirements desugar path (no new semantics); see
+  `docs/DESIGN-spec-domains.md`. A new "Authoring specs as readable documentation"
+  section in `skills/fsl/reference.md` records the doc-first conventions, and
+  `examples/e2e/3_design.fsl` / `examples/e2e/2_requirements.fsl` are rewritten to it.
 - examples/structural: Step 1 demand-validation specs for issue #35 (Alloy-style structural discovery via the populate+reachable idiom)
 - (Docs) New manual chapter "When to Use FSL" (`docs/intro/when-to-use.{ja,en}.html`,
   wired into the chapter nav as #2, after Concept): criteria for deciding whether to

--- a/docs/DESIGN-spec-domains.md
+++ b/docs/DESIGN-spec-domains.md
@@ -1,0 +1,65 @@
+# DESIGN: `entity` / `number` in the kernel `spec` (domain vs verification bound)
+
+## Problem
+
+A kernel `spec` could only declare a finite domain as `type X = lo..hi`. That one
+form fuses two different things:
+
+- the **domain** fact — "there are some `Claim`s", "an `Amount` is a non-negative
+  number", and
+- the **verification world size** — "check the model for up to 3 claims and
+  amounts 0..3".
+
+When a design-layer spec is read as documentation, `type Claim = 0..2` reads as a
+*domain* statement ("there are exactly three claims"), which is false — the `0..2`
+is only the bounded-model-checking world size. This is the "domain lie": the text
+that is read does not mean what it appears to mean.
+
+The `business` and `requirements` dialects already avoid this. They declare
+`entity Claim` / `number Amount` and put the sizes in a sibling `verify` block
+(`instances Claim = 3`, `values Amount = 0..3`). The kernel `spec` — i.e. the
+design layer — lacked both `entity`/`number` and any way to move the bound out of
+`type`, so design specs were forced back into the conflated form.
+
+## Change
+
+`entity` and `number` are now accepted as kernel `spec` items (`?item` in
+`grammar.py`). Before the spec reaches `model.build_spec`, a frontend pass
+(`expand_spec_domains` in `dialects.py`, invoked from `parser.parse_src` and from
+`dialects._parse_file` for `implements ... from` targets) lowers them to
+`type X = lo..hi` using the `verify` block:
+
+- `entity X` + `verify { instances X = N }` → `type X = 0..N-1`
+- `number X` + `verify { values X = lo..hi }` → `type X = lo..hi`
+
+A spec that declares no `entity`/`number` is returned unchanged, so existing
+kernel specs are completely unaffected.
+
+The lowering and its validation (missing-bound errors, entity/number conflict,
+`instances >= 1`, verify bounds that reference an undeclared sort) are the **same
+code** the requirements dialect uses: the shared helpers `_collect_entity_number_locs`
+and `_entity_number_to_types` were extracted from `_expand_requirements_with_display`
+and are now called by both paths. There is no second implementation and no new
+error class.
+
+## Why frontend desugar, not a kernel change
+
+The kernel (`model.build_spec`, `bmc.py`, `runtime.py`) still only ever sees
+`type X = lo..hi`. `entity`/`number` are pure surface syntax that disappears in
+desugaring, exactly like the dialects. This keeps the verifier semantics, the
+dual evaluator, and refinement unchanged, and follows the repository rule of
+"prefer adding to the frontend over widening the kernel".
+
+Rejected alternatives:
+
+- **Annotate `type Claim = 0..2`** with a comment/tag explaining the bound — does
+  not remove the lie, only documents it; and the prose is unverified.
+- **Drop the range from `type Claim`** and read it from `verify` — smaller grammar,
+  but it erases the useful distinction between an identity sort (`entity`, lower
+  bound pinned to 0) and a numeric sort (`number`, arbitrary `lo..hi`).
+
+## See also
+
+- `docs/DESIGN-dialects.md` — the requirements/business desugaring this reuses.
+- `docs/DESIGN-layers.md` — the business ⊒ requirements ⊒ design chain.
+- `examples/e2e/3_design.fsl` — the design layer authored as readable documentation.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -47,10 +47,16 @@ spec <Name> {
 }
 ```
 
-Business and requirements dialects also have type-kinds whose finite domains are
-set by a sibling top-level `verify` block rather than by inline ranges:
+Any layer — including a kernel `spec` — may declare identity/number sorts whose
+finite sizes come from a sibling top-level `verify` block instead of an inline
+`type X = lo..hi` range. This keeps the domain declaration (what exists) separate
+from the verification world size (how much is checked):
 
 ```fsl
+spec <Name> {
+  entity <Entity>          // identity sort; size from verify { instances <Entity> = N }
+  number <Number>          // numeric sort; range from verify { values <Number> = lo..hi }
+}
 business <Name> {
   entity <Entity>
 }
@@ -64,6 +70,11 @@ verify {
   values <Number> = <lo>..<hi>
 }
 ```
+
+`entity`/`number` desugar to `type <Name> = lo..hi` before verification, so they
+are exactly equivalent to writing the bounded type directly — the difference is
+only readability (a design spec reads as documentation instead of asserting a
+domain size that is really a model bound). See `docs/DESIGN-spec-domains.md`.
 
 `fair` is a weak-fairness annotation: if that action instance remains
 continuously enabled, the assumption is that it will eventually be executed.
@@ -102,8 +113,8 @@ used for the base BMC check and reachable/coverage evidence.
 |---|---|---|
 | `Int` / `Bool` | `count: Int` | Unbounded integer / boolean |
 | Domain type | `type Qty = 0..5` | Bounded integer. **The range is checked automatically** (§6) |
-| Entity kind (dialects) | `entity Claim` / `process Claim ...` | Finite identity sort for business/requirements. Size is set by `verify { instances Claim = N }` |
-| Number kind (dialects) | `number Amount` | Finite numeric sort for business/requirements. Range is set by `verify { values Amount = lo..hi }` |
+| Entity kind | `entity Claim` / `process Claim ...` | Finite identity sort. Allowed in any layer incl. kernel `spec`; size set by `verify { instances Claim = N }`; desugars to `type Claim = 0..N-1` |
+| Number kind | `number Amount` | Finite numeric sort. Allowed in any layer incl. kernel `spec`; range set by `verify { values Amount = lo..hi }`; desugars to `type` |
 | enum | `enum St { Open, Closed }` | Members are referenced by their bare name in expressions |
 | struct | `struct Order { st: St, item: Option<ItemId>, qty: Qty }` | Fields are scalars or `Option<scalar>` |
 | `Option<T>` | `cart: Option<ItemId>` | `none` / `some(e)`. Used instead of a sentinel value |

--- a/examples/e2e/2_requirements.fsl
+++ b/examples/e2e/2_requirements.fsl
@@ -26,11 +26,27 @@ requirements ExpenseRequirements {
   process Claim with amount: Amount {
     stages Draft, Submitted, Approved, Rejected, Paid
     initial Draft
-    transition submit       Draft     -> Submitted by Employee with a: Amount when a > 0 set amount = a covers REQ-1 "The applicant submits an expense claim by entering an amount"
-    transition auto_approve Submitted -> Approved  by System  when amount <= AUTO_LIMIT covers REQ-2 "Claims at or below AUTO_LIMIT are auto-approved by the system"
-    transition mgr_approve  Submitted -> Approved  by Manager when amount >  AUTO_LIMIT covers REQ-3 "Claims above AUTO_LIMIT are approved by a manager"
-    transition reject       Submitted -> Rejected  by Manager when amount >  AUTO_LIMIT covers REQ-3 "Claims above AUTO_LIMIT may be rejected by a manager"
-    transition pay          Approved  -> Paid      by Finance covers REQ-4 "Only approved claims are paid"
+
+    transition submit       Draft     -> Submitted by Employee
+      with a: Amount
+      when a > 0
+      set amount = a
+      covers REQ-1 "The applicant submits an expense claim by entering an amount"
+
+    transition auto_approve Submitted -> Approved  by System
+      when amount <= AUTO_LIMIT
+      covers REQ-2 "Claims at or below AUTO_LIMIT are auto-approved by the system"
+
+    transition mgr_approve  Submitted -> Approved  by Manager
+      when amount >  AUTO_LIMIT
+      covers REQ-3 "Claims above AUTO_LIMIT are approved by a manager"
+
+    transition reject       Submitted -> Rejected  by Manager
+      when amount >  AUTO_LIMIT
+      covers REQ-3 "Claims above AUTO_LIMIT may be rejected by a manager"
+
+    transition pay          Approved  -> Paid      by Finance
+      covers REQ-4 "Only approved claims are paid"
   }
 
   kpi paid_claims = count Claim in Paid

--- a/examples/e2e/3_design.fsl
+++ b/examples/e2e/3_design.fsl
@@ -13,14 +13,19 @@
 //   payment count matches".
 //
 // How to read it:
-//   From here on, the granularity is close to APIs, jobs, and notification
-//   queues. The FSL-independent Python implementation connects to the
-//   conformance harness generated from this spec.
+//   This file IS the design document — every rule is both prose and a
+//   machine-checked constraint, so reading it never drifts from what is
+//   verified. Domain identity is declared with `entity`/`number` (the
+//   verification world sizes live in the `verify` block, not in the types);
+//   the real handle for each rule is its declaration name. Each rule also
+//   carries a traceability tag: "REQ-n: ..." when it realizes a requirement
+//   (checkable with `fslc check --strict-tags --requirements <ids>`), or
+//   "MODEL: ..." when it is design-internal scaffolding absent from the
+//   requirements. The outbox invariant quantifies over members directly.
 // ════════════════════════════════════════════════════════════════
 spec ExpenseDesign {
-  type Claim = 0..2
-  type Amount = 0..3
-  type OutboxIndex = 0..2
+  entity Claim
+  number Amount
   const AUTO_LIMIT = 1
   const OUTBOX_CAP = 3
 
@@ -38,8 +43,8 @@ spec ExpenseDesign {
 
   state {
     design: Map<Claim, DesignClaim>,
-    paid_count: Int,
-    outbox: Seq<Claim, OUTBOX_CAP>
+    paid_count: Int,                 // ghost counter for the no-double-pay rule (CountsMatchSubmittedOrPaid)
+    outbox: Seq<Claim, OUTBOX_CAP>   // pending payment-notification queue
   }
   init {
     forall c: Claim { design[c] = DesignClaim { st: DesignDraft, amount: 0 } }
@@ -47,38 +52,44 @@ spec ExpenseDesign {
     outbox = Seq {}
   }
 
-  fair action submit_small(c: Claim, a: Amount) {
+  fair action submit_small(c: Claim, a: Amount)
+      "REQ-1: an employee files a low-amount claim (at or below the auto-approval limit); it enters automatic review" {
     requires design[c].st == DesignDraft
     requires a > 0
     requires a <= AUTO_LIMIT
     design[c] = DesignClaim { st: DesignAutoReview, amount: a }
   }
 
-  fair action submit_large(c: Claim, a: Amount) {
+  fair action submit_large(c: Claim, a: Amount)
+      "REQ-1: an employee files a high-amount claim (above the auto-approval limit); it enters manager review" {
     requires design[c].st == DesignDraft
     requires a > AUTO_LIMIT
     design[c] = DesignClaim { st: DesignManagerReview, amount: a }
   }
 
-  fair action auto_approve(c: Claim) {
+  fair action auto_approve(c: Claim)
+      "REQ-2: the system auto-approves a low-amount claim that is in automatic review" {
     requires design[c].st == DesignAutoReview
     requires design[c].amount <= AUTO_LIMIT
     design[c].st = DesignAutoApproved
   }
 
-  fair action mgr_approve(c: Claim) {
+  fair action mgr_approve(c: Claim)
+      "REQ-3: a manager approves a high-amount claim that is in manager review" {
     requires design[c].st == DesignManagerReview
     requires design[c].amount > AUTO_LIMIT
     design[c].st = DesignManagerApproved
   }
 
-  fair action mgr_reject(c: Claim) {
+  fair action mgr_reject(c: Claim)
+      "REQ-3: a manager rejects a high-amount claim that is in manager review" {
     requires design[c].st == DesignManagerReview
     requires design[c].amount > AUTO_LIMIT
     design[c].st = DesignRejected
   }
 
-  fair action pay_submit(c: Claim) {
+  fair action pay_submit(c: Claim)
+      "REQ-4: Finance submits an approved claim for payment, bumps the payment count, and queues a notification" {
     requires design[c].st == DesignAutoApproved or design[c].st == DesignManagerApproved
     requires outbox.size() < OUTBOX_CAP
     design[c].st = DesignPaymentSubmitted
@@ -86,24 +97,29 @@ spec ExpenseDesign {
     outbox = outbox.push(c)
   }
 
-  fair action pay_confirm(c: Claim) {
+  fair action pay_confirm(c: Claim)
+      "REQ-4: a payment that was submitted is confirmed as paid" {
     requires design[c].st == DesignPaymentSubmitted
     design[c].st = DesignPaid
   }
 
-  fair action outbox_send() {
+  fair action outbox_send()
+      "MODEL: the oldest queued payment notification is sent and leaves the outbox (notification dispatch is design-internal, absent from the requirements)" {
     requires outbox.size() > 0
     outbox = outbox.pop()
   }
 
-  invariant CountsMatchSubmittedOrPaid {
+  invariant CountsMatchSubmittedOrPaid
+      "MODEL: the recorded payment count always equals the number of claims that have entered payment (submitted for payment or already paid) — no under-counting, no double-counting (ghost-counter integrity)" {
     paid_count == count(c: Claim where design[c].st == DesignPaymentSubmitted or design[c].st == DesignPaid)
   }
 
-  invariant OutboxOnlyForPaymentSubmittedOrPaid {
-    forall i in 0..2 {
-      i < outbox.size() =>
-        (design[outbox.at(i)].st == DesignPaymentSubmitted or design[outbox.at(i)].st == DesignPaid)
-    }
+  invariant OutboxOnlyForPaymentSubmittedOrPaid
+      "MODEL: every claim sitting in the notification outbox has genuinely entered payment (submitted for payment or paid)" {
+    forall c in outbox { design[c].st == DesignPaymentSubmitted or design[c].st == DesignPaid }
   }
+}
+verify {
+  instances Claim = 3
+  values Amount = 0..3
 }

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -66,7 +66,7 @@ Reproduction commands:
 ```bash
 cp examples/e2e/3_design.fsl /private/tmp/3_design_shortcut.fsl
 cp examples/e2e/3_refines_2.fsl /private/tmp/3_refines_shortcut.fsl
-perl -0pi -e 's/\n  fair action pay_submit\(c: Claim\) \{/\n  fair action pay_without_approval(c: Claim) {\n    requires design[c].st == DesignDraft\n    requires outbox.size() < OUTBOX_CAP\n    design[c].st = DesignPaymentSubmitted\n    paid_count = paid_count + 1\n    outbox = outbox.push(c)\n  }\n\n  fair action pay_submit(c: Claim) {/s' /private/tmp/3_design_shortcut.fsl
+perl -0pi -e 's/\n  fair action pay_submit\(c: Claim\)/\n  fair action pay_without_approval(c: Claim) {\n    requires design[c].st == DesignDraft\n    requires outbox.size() < OUTBOX_CAP\n    design[c].st = DesignPaymentSubmitted\n    paid_count = paid_count + 1\n    outbox = outbox.push(c)\n  }\n\n  fair action pay_submit(c: Claim)/s' /private/tmp/3_design_shortcut.fsl
 perl -0pi -e 's/\n  action pay_submit\(c\)      -> pay\(c\)/\n  action pay_without_approval(c) -> pay(c)\n  action pay_submit(c)      -> pay(c)/' /private/tmp/3_refines_shortcut.fsl
 ./.venv/bin/python -m fslc refine /private/tmp/3_design_shortcut.fsl examples/e2e/2_requirements.fsl /private/tmp/3_refines_shortcut.fsl --depth 4
 ```
@@ -87,7 +87,7 @@ The output actually obtained:
       "c": 0
     },
     "loc": {
-      "line": 81,
+      "line": 91,
       "column": 3
     }
   },
@@ -142,7 +142,7 @@ The output actually obtained:
           "c": 0
         },
         "loc": {
-          "line": 81,
+          "line": 91,
           "column": 3
         }
       },

--- a/skills/fsl-design/SKILL.md
+++ b/skills/fsl-design/SKILL.md
@@ -69,3 +69,8 @@ for a contract decision.
 - Report proof categories separately: design invariants proved, refinement to
   requirements proved, implementation conformance not yet proved unless `testgen`
   or `replay` has been anchored to real code/logs.
+- Author the design spec as documentation: declare domains with `entity`/`number`
+  (sizes in the `verify` block, not in `type X = 0..N`), tag every action/invariant
+  with `"ID: intent"` (prefix verification-only invariants `MODEL-`/`ASSUME-`), and
+  prefer `forall x in coll { … }` over index quantifiers in invariant bodies. See
+  `skills/fsl/reference.md` → "Authoring specs as readable documentation".

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -424,6 +424,33 @@ leadsTo / action:
 `invariant PaidLedger "REQ-3: ledger consistency" { ... }` →
 `requirement: {id, text}` in violated / unknown_cti / coverage diagnostic / scenarios.
 
+### Authoring specs as readable documentation (requirements + design)
+
+The spec source IS the documentation: a rule you can read is also the rule that is
+verified, so it never drifts. In the requirements and design (kernel) layers:
+
+1. **Tag every invariant/action/property** with `"ID: one-sentence intent"` — the only
+   in-source prose that flows into all output (explain / html / counterexamples). It is
+   NOT verified, so keep it a faithful paraphrase of the expression, not a rival truth.
+2. **Quarantine verification scaffolding by ID prefix.** Domain rules: `REQ-…` / `INV-…`.
+   Verification-only artifacts (k-induction CTI auxiliary invariants, ghost-counter
+   relations): `MODEL-…` / `ASSUME-…`, so a reader can skip them.
+3. **Prefer member-quantification** `forall x in coll { P(x) }` over the index idiom
+   `forall i in 0..N { i < coll.size() => P(coll.at(i)) }` — but ONLY (a) in expression
+   position (invariant/property bodies; NOT action/init `forall` *statements*, which
+   reject collection binders) and (b) for element-wise properties. Keep explicit indices
+   for position, ordering, adjacency, or no-duplicates.
+4. **Separate domain from verification bound.** Declare `entity X` / `number X` and put
+   sizes in `verify { instances/values }` instead of `type X = lo..hi`. Allowed in a
+   kernel `spec` too (desugars to `type`), so `type Claim = 0..2` no longer has to read
+   as a false domain fact.
+5. **Multi-line transitions** (requirements): `with` / `when` / `set` / `covers` each on
+   their own indented line.
+6. **Order:** domain content first, proof scaffolding last.
+
+`fslc explain --readable` then renders the whole spec (state, tagged actions,
+properties) as a structured digest — a view of the source, not a separate document.
+
 ### business (the consulting layer)
 
 ```fsl

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -27,6 +27,8 @@ def _parse_file(path):
         return expand_business(ast), {}
     if ast[0] == "governance":
         return expand_governance_with_display(ast, str(Path(path).parent))
+    if ast[0] == "spec":
+        return expand_spec_domains(ast), {}
     return ast, {}
 
 
@@ -111,6 +113,75 @@ def _collect_verify_bounds(items):
                 values[name] = (lo, hi)
                 locs["values"][name] = loc
     return instances, values, locs
+
+
+def _collect_entity_number_locs(items):
+    """Scan `entity`/`number` declarations into name->loc maps, with duplicate and
+    entity/number-conflict checks. Shared by the requirements dialect and `spec`."""
+    entity_locs = {}
+    number_locs = {}
+    for item in items:
+        tag = item[0]
+        if tag == "entity":
+            _, entity_name, loc = item
+            if entity_name in entity_locs:
+                _err(f"duplicate entity '{entity_name}'", loc=loc)
+            if entity_name in number_locs:
+                _err(f"'{entity_name}' cannot be both entity and number", loc=loc)
+            entity_locs[entity_name] = loc
+        elif tag == "number":
+            _, number_name, loc = item
+            if number_name in number_locs:
+                _err(f"duplicate number '{number_name}'", loc=loc)
+            if number_name in entity_locs:
+                _err(f"'{number_name}' cannot be both entity and number", loc=loc)
+            number_locs[number_name] = loc
+    return entity_locs, number_locs
+
+
+def _entity_number_to_types(entity_locs, number_locs, instances, values, bound_locs):
+    """Lower `entity`/`number` declarations to kernel `type X = lo..hi` decls using
+    the verify-block bounds. Shared by the requirements dialect and kernel `spec`."""
+    out = []
+    for entity_name, loc in entity_locs.items():
+        if entity_name not in instances:
+            _err(f"entity '{entity_name}' has no 'instances' bound in verify block", loc=loc)
+        n = instances[entity_name]
+        if n < 1:
+            _err(f"entity '{entity_name}' instances bound must be >= 1", loc=bound_locs["instances"][entity_name])
+        out.append(("type", entity_name, ("num", 0), ("num", n - 1)))
+    for number_name, loc in number_locs.items():
+        if number_name not in values:
+            _err(f"number '{number_name}' has no 'values' bound in verify block", loc=loc)
+        lo, hi = values[number_name]
+        out.append(("type", number_name, lo, hi))
+    for entity_name in instances:
+        if entity_name not in entity_locs:
+            _err(
+                f"verify instances for undeclared entity '{entity_name}'",
+                loc=bound_locs["instances"][entity_name],
+            )
+    for number_name in values:
+        if number_name not in number_locs:
+            _err(
+                f"verify values for undeclared number '{number_name}'",
+                loc=bound_locs["values"][number_name],
+            )
+    return out
+
+
+def expand_spec_domains(ast):
+    """Desugar `entity`/`number` declarations in a kernel `spec` into `type` decls
+    using the `verify` block bounds. A spec without `entity`/`number` is returned
+    unchanged, so existing kernel specs are unaffected."""
+    _, name, items = ast
+    if not any(it[0] in ("entity", "number") for it in items):
+        return ast
+    instances, values, bound_locs = _collect_verify_bounds(items)
+    entity_locs, number_locs = _collect_entity_number_locs(items)
+    type_items = _entity_number_to_types(entity_locs, number_locs, instances, values, bound_locs)
+    rest = [it for it in items if it[0] not in ("entity", "number", "verify_bounds")]
+    return ("spec", name, type_items + rest)
 
 
 def _with_meta(item, meta):
@@ -744,27 +815,10 @@ def _expand_requirements_with_display(ast, base_dir):
     generated_names = []
     consts = _collect_consts(items)
     instances, values, bound_locs = _collect_verify_bounds(items)
-    entity_locs = {}
-    number_locs = {}
+    entity_locs, number_locs = _collect_entity_number_locs(items)
     process_entity_locs = {}
-
     for item in items:
-        tag = item[0]
-        if tag == "entity":
-            _, entity_name, loc = item
-            if entity_name in entity_locs:
-                _err(f"duplicate entity '{entity_name}'", loc=loc)
-            if entity_name in number_locs:
-                _err(f"'{entity_name}' cannot be both entity and number", loc=loc)
-            entity_locs[entity_name] = loc
-        elif tag == "number":
-            _, number_name, loc = item
-            if number_name in number_locs:
-                _err(f"duplicate number '{number_name}'", loc=loc)
-            if number_name in entity_locs:
-                _err(f"'{number_name}' cannot be both entity and number", loc=loc)
-            number_locs[number_name] = loc
-        elif tag == "biz_process":
+        if item[0] == "biz_process":
             _, entity_name, _fields, _parts, loc = item
             process_entity_locs.setdefault(entity_name, loc)
 
@@ -773,30 +827,7 @@ def _expand_requirements_with_display(ast, base_dir):
             _err(f"'{entity_name}' cannot be both process entity and number", loc=loc)
         entity_locs.setdefault(entity_name, loc)
 
-    for entity_name, loc in entity_locs.items():
-        if entity_name not in instances:
-            _err(f"entity '{entity_name}' has no 'instances' bound in verify block", loc=loc)
-        n = instances[entity_name]
-        if n < 1:
-            _err(f"entity '{entity_name}' instances bound must be >= 1", loc=bound_locs["instances"][entity_name])
-        out.append(("type", entity_name, ("num", 0), ("num", n - 1)))
-    for number_name, loc in number_locs.items():
-        if number_name not in values:
-            _err(f"number '{number_name}' has no 'values' bound in verify block", loc=loc)
-        lo, hi = values[number_name]
-        out.append(("type", number_name, lo, hi))
-    for entity_name in instances:
-        if entity_name not in entity_locs:
-            _err(
-                f"verify instances for undeclared entity '{entity_name}'",
-                loc=bound_locs["instances"][entity_name],
-            )
-    for number_name in values:
-        if number_name not in number_locs:
-            _err(
-                f"verify values for undeclared number '{number_name}'",
-                loc=bound_locs["values"][number_name],
-            )
+    out.extend(_entity_number_to_types(entity_locs, number_locs, instances, values, bound_locs))
 
     processes, process_by_name = _collect_requirements_processes(items, entity_locs, number_locs)
     process_by_ast_name = {proc["name"]: proc for proc in processes}

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -48,7 +48,7 @@ preserve_progress_def: "preserve" "progress" "{" progress_item* "}"
 ?progress_item: progress_respond
 progress_respond: "respond" NAME "by" NAME ("," NAME)* ","?
 
-?item: const_def | type_def | enum_def | struct_def
+?item: const_def | type_def | enum_def | struct_def | entity_def | number_def
      | state_def | init_def | action_def
      | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def | terminal_def
 

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -14,7 +14,12 @@ from lark.exceptions import UnexpectedInput
 
 from .grammar import PARSER, Ast
 from .compose import expand_compose
-from .dialects import expand_business, expand_governance_with_display, expand_requirements_with_display
+from .dialects import (
+    expand_business,
+    expand_governance_with_display,
+    expand_requirements_with_display,
+    expand_spec_domains,
+)
 
 
 def parse_src(src, base_dir=None):
@@ -34,6 +39,8 @@ def parse_src(src, base_dir=None):
         ast = expand_business(ast)
     elif ast[0] == "governance":
         ast, display_names = expand_governance_with_display(ast, base_dir or ".")
+    elif ast[0] == "spec":
+        ast = expand_spec_domains(ast)
     return ast, display_names
 
 

--- a/tests/test_e2e_example.py
+++ b/tests/test_e2e_example.py
@@ -126,7 +126,7 @@ def test_e2e_readme_commands_and_break_demo_are_current():
     design_src = broken_design.read_text(encoding="utf-8")
     broken_design.write_text(
         design_src.replace(
-            "\n  fair action pay_submit(c: Claim) {",
+            "\n  fair action pay_submit(c: Claim)",
             "\n  fair action pay_without_approval(c: Claim) {\n"
             "    requires design[c].st == DesignDraft\n"
             "    requires outbox.size() < OUTBOX_CAP\n"
@@ -134,7 +134,7 @@ def test_e2e_readme_commands_and_break_demo_are_current():
             "    paid_count = paid_count + 1\n"
             "    outbox = outbox.push(c)\n"
             "  }\n\n"
-            "  fair action pay_submit(c: Claim) {",
+            "  fair action pay_submit(c: Claim)",
         ),
         encoding="utf-8",
     )

--- a/tests/test_spec_domains.py
+++ b/tests/test_spec_domains.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Kernel `spec` accepts `entity`/`number`, desugared to `type` via verify bounds.
+
+This separates domain identity (an entity/number declaration) from the
+verification world size (the `verify` block), so a design-layer spec reads as
+documentation without the `type X = 0..N` "domain lie". The desugar reuses the
+requirements-dialect path, so a spec written either way must behave identically.
+"""
+from fslc.cli import run_check, run_verify
+
+DOMAIN_SRC = '''spec DomainKernel {
+  entity Item
+  number Qty
+  state { stock: Map<Item, Qty> }
+  init { forall i: Item { stock[i] = 0 } }
+  fair action restock(i: Item, q: Qty) {
+    requires q > 0
+    stock[i] = q
+  }
+  invariant NonNeg { forall i: Item { stock[i] >= 0 } }
+}
+verify {
+  instances Item = 2
+  values Qty = 0..3
+}
+'''
+
+# Identical model, but with the world size inlined in the types (the old style).
+EXPLICIT_SRC = '''spec DomainKernel {
+  type Item = 0..1
+  type Qty = 0..3
+  state { stock: Map<Item, Qty> }
+  init { forall i: Item { stock[i] = 0 } }
+  fair action restock(i: Item, q: Qty) {
+    requires q > 0
+    stock[i] = q
+  }
+  invariant NonNeg { forall i: Item { stock[i] >= 0 } }
+}
+'''
+
+
+def _write(tmp_path, name, src):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    return str(p)
+
+
+def test_entity_number_in_kernel_spec_matches_explicit_type(tmp_path):
+    dom = _write(tmp_path, "dom.fsl", DOMAIN_SRC)
+    exp = _write(tmp_path, "exp.fsl", EXPLICIT_SRC)
+    assert run_check(dom)["result"] == "ok"
+    # entity/number form must verify exactly like the explicit `type` form.
+    assert run_verify(dom, 4, "warn")["result"] == "verified"
+    assert run_verify(dom, 4, "warn")["result"] == run_verify(exp, 4, "warn")["result"]
+
+
+def test_entity_without_instances_bound_is_spec_error(tmp_path):
+    src = '''spec NoBound {
+  entity Item
+  state { seen: Map<Item, Bool> }
+  init { forall i: Item { seen[i] = false } }
+  fair action mark(i: Item) { seen[i] = true }
+  invariant T { forall i: Item { seen[i] == true or seen[i] == false } }
+}
+'''
+    res = run_check(_write(tmp_path, "nobound.fsl", src))
+    assert res["result"] == "error"
+    assert res["kind"] == "type"
+    assert "has no 'instances' bound" in res["message"]
+
+
+def test_number_without_values_bound_is_spec_error(tmp_path):
+    src = '''spec NoVals {
+  entity Item
+  number Qty
+  state { stock: Map<Item, Qty> }
+  init { forall i: Item { stock[i] = 0 } }
+  fair action restock(i: Item, q: Qty) {
+    requires q > 0
+    stock[i] = q
+  }
+  invariant NonNeg { forall i: Item { stock[i] >= 0 } }
+}
+verify {
+  instances Item = 2
+}
+'''
+    res = run_check(_write(tmp_path, "novals.fsl", src))
+    assert res["result"] == "error"
+    assert "has no 'values' bound" in res["message"]


### PR DESCRIPTION
## What & why

Goal: make an FSL spec readable **as** documentation, so the spec source is the single verifiable document (no separate doc to drift). The friction was concentrated in the **design (kernel) and requirements layers**, where verification scaffolding (bounded-int world sizes, index quantifiers, intent-free invariants) drowns out the domain content.

### Kernel `spec` accepts `entity` / `number` (frontend desugar)

`type Claim = 0..2` fuses *domain identity* with the *verification world size*, so it reads as a false domain fact. The requirements/business dialects already separate these (`entity`/`number` + a `verify { instances/values }` block); this brings the same to the kernel `spec`:

- `entity X` + `verify { instances X = N }` → `type X = 0..N-1`
- `number X` + `verify { values X = lo..hi }` → `type X = lo..hi`

It is a **pure frontend desugar** — `model.build_spec` / `bmc` / `runtime` are unchanged. The requirements expansion is factored into shared helpers (`_collect_entity_number_locs`, `_entity_number_to_types`) reused by a new `expand_spec_domains`, wired into `parser.parse_src` and `dialects._parse_file`. A spec with no `entity`/`number` is returned unchanged. Rationale and rejected alternatives: `docs/DESIGN-spec-domains.md`.

### Doc-grade authoring conventions + examples

`skills/fsl/reference.md` gains **"Authoring specs as readable documentation"**: per-declaration `"ID: intent"` tags (the only in-source prose that flows into all verifier output), `MODEL-`/`ASSUME-` prefixes to quarantine verification scaffolding, member-quantification `forall x in coll { … }` over the index idiom (expression position only, element-wise only), domain/bound separation, and multi-line transitions.

- `examples/e2e/3_design.fsl` — rewritten with `entity`/`number`, a member-quantified outbox invariant, per-rule traceability tags (`REQ-n` for requirement-realizing rules, `MODEL` for design-internal scaffolding), dead `OutboxIndex` removed. The real per-rule handle stays the declaration name.
- `examples/e2e/2_requirements.fsl` — dense transitions reformatted across labeled `with`/`when`/`set`/`covers` lines.

## Verification

- `fslc check`/`verify` on both examples: **verdicts unchanged** (`verified`, `refines`).
- Corpus snapshot: **byte-identical** (only the stable verdict tier is snapshotted, and verdicts are preserved) — no regeneration needed.
- `fslc check examples/e2e/3_design.fsl --strict-tags --requirements <REQ-1..4>`: **0** unreferenced-requirement warnings — the `REQ-n` tags are real references, so coverage is satisfied.
- Non-vacuity: a mutant that queues a claim without advancing its state → `violated`.
- Suites green: corpus snapshot, req/biz dialect, dual-evaluator agreement, explain, and the new `tests/test_spec_domains.py` (entity/number ↔ explicit-`type` equivalence + missing-bound errors).

## Note (pre-existing, out of scope)

`cli._read_requirement_ids` reads each line of the `--requirements` file as a literal ID (it expects a plain ID list, not a spec). Flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
