### PR TITLE
feat(testgen): プラガブルなエミッタ化と Vitest ターゲット追加 (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc testgen --target {pytest,vitest}` (default `pytest`): the emitter is now
+  pluggable. `testgen.py` separates the language-independent scenario-collection
+  core (`scenarios()`) from per-target emitters (`emit_pytest`/`emit_vitest`), so a
+  new harness is a backend, not a redesign. The first new target is **Vitest**: a
+  self-contained TypeScript file with the same `reset`/`step`/`observe` `Adapter`
+  contract. Deterministic and forbidden-rejection scenarios translate directly; the
+  `random-walk` oracle is **baked at generation time** — the Python `Monitor` runs the
+  fixed-seed (`Random(0)`) walk and the `(action, params, expected_state)` trace is
+  embedded as a static fixture, so the generated tests require no `fslc`/Python at
+  runtime (the single independent oracle stays in Python). pytest output is unchanged
+  (byte-for-byte on identical scenario input). Vitest output defaults to
+  `<spec>.test.ts`; `--target` and `target` flow through `cli.py`/`run_testgen`.
+  Docs: `docs/LANGUAGE.md` §12 and `skills/fsl/reference.md` §9. (#43)
 - Kernel `spec` now accepts `entity`/`number` declarations (previously dialect-only),
   desugared to `type X = lo..hi` via the `verify` block (`instances`/`values`). This
   separates domain identity from the verification world size so a design-layer spec

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -124,8 +124,14 @@ exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 
 ```
-fslc testgen <file.fsl> [--depth K] [--strict] [-o <out.py>]    # default: test_<spec name lowercased>.py to stdout
+fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
 ```
+
+The scenario-collection core (`scenarios()`) is language independent, so `testgen.py`
+splits into that shared core (`_collect_scenarios`) plus per-target emitters
+(`emit_pytest` / `emit_vitest`) chosen by `--target`. Adding a harness (Jest, Go, …)
+is a new emitter, not a redesign — the same kernel-stays-narrow principle as the
+dialect frontends.
 
 The output is a **self-contained pytest file** (the primary dependencies are
 `fslc.runtime` and `pytest`. In addition, only the standard library needed for
@@ -154,6 +160,31 @@ pseudorandom walk and `pathlib` for resolving the SPEC path):
    the fail message as **a bug in the spec itself**.
 4. While the Adapter is unimplemented (NotImplementedError), make all tests
    `pytest.skip`, so that pytest does not error even right after generation.
+
+### 3.1 `--target vitest` (TypeScript / Vitest)
+
+The Vitest emitter renders the **same scenarios** to a self-contained TypeScript
+file with the same `reset`/`step`/`observe` `Adapter` contract. Parts 1, 2, and 4
+above port directly: an `Adapter` interface + `makeAdapter()` stub, deterministic
+scenario tests (`assertPartial`), forbidden-rejection tests (`assertRejected`), and
+skip-when-unwired (a top-level guard flips `test` to `test.skip`).
+
+Part 3 — the random walk — is the one real design point, because TypeScript has no
+`Monitor`. The chosen approach **bakes the trace at generation time**: the Python
+Monitor runs the fixed-seed (`Random(0)`) walk and the resulting
+`(action, params, expected_state)` sequence is embedded as a static fixture; the
+Vitest test only replays it and asserts. Rationale:
+
+- The walk is already deterministic (`Random(0)` + deterministic Monitor), so baking
+  under the same seed yields the identical trace — equal coverage, nothing lost.
+- It keeps the **single independent oracle** invariant: there is still exactly one
+  Monitor (in Python), not a second reimplementation in TypeScript.
+- The generated file is `fslc`-free at runtime — no shell-out, no Python dependency.
+
+Rejected alternatives: (b) shelling out to `fslc` from the TS test (adds a runtime
+coupling), and (c) porting `Monitor` to TS (duplicates the dual-evaluator surface
+that the agreement/oracle tests exist to protect). Output defaults to
+`<spec>.test.ts`.
 
 ## 4. CLI / public API
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -265,7 +265,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
-fslc testgen   <file.fsl> [--depth K] [--strict] [-o out.py]  # implementation-conformance pytest scaffold (§12)
+fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
@@ -693,11 +693,23 @@ implementation (see `DESIGN-bridge.md`).
 |---|---|
 | `fslc.runtime.Monitor` | A concrete interpreter of the spec (no Z3 needed). Embed it in the implementation for runtime checking |
 | `fslc replay` | Check a real system's event-log JSON against the spec |
-| `fslc testgen` | Generate a pytest conformance-test scaffold (wire the implementation into the Adapter) |
+| `fslc testgen` | Generate a conformance-test scaffold — pytest (default) or Vitest via `--target vitest` (wire the implementation into the Adapter) |
 
 Recommended workflow: **`verify` / `prove` the spec → generate the scaffold with
-`testgen` → wire the implementation into the `Adapter` → pytest**. `Monitor` is
-used as an oracle in random-walk testing.
+`testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
+is used as an oracle in random-walk testing.
+
+`testgen` separates a language-independent scenario-collection core (`scenarios`)
+from per-target emitters, so the same scenarios render to multiple harnesses:
+
+- `--target pytest` (default): emits Python tests that import `fslc.runtime.Monitor`
+  and drive the random walk live as the oracle.
+- `--target vitest`: emits a self-contained TypeScript (Vitest) file. Deterministic
+  scenarios and forbidden-rejection assertions translate directly; the random walk
+  is **baked at generation time** — the Python `Monitor` runs the fixed-seed walk and
+  the `(action, params, expected_state)` trace is embedded as a static fixture, so the
+  generated tests need **no `fslc`/Python at runtime**. The output extension defaults
+  to `<spec>.test.ts`.
 
 ```python
 from fslc import Monitor
@@ -709,7 +721,8 @@ r = mon.step("add_to_cart", {"u": 0, "i": 0})   # ok / kind / state / changes
 
 ```bash
 fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
-fslc testgen specs/cart_v1.fsl -o test_cart_v1.py   # partial reachability warnings unless --strict
+fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
+fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 ```
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -259,7 +259,7 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
-fslc testgen <f> [--depth K] [--strict] [-o out.py]  # Adapter skeleton + conformance pytest
+fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -405,6 +405,18 @@ The random-walk test uses the Monitor (the spec's concrete interpreter) as the
 oracle, stepping through the implementation one step at a time. A failure = a
 divergence between implementation and spec (read the trace to decide which one is
 correct).
+
+`--target` chooses the harness; the scenario-collection core is shared, so both
+emit the same scenarios:
+- `pytest` (default): Python tests; the random walk imports `fslc.runtime.Monitor`
+  and runs the fixed-seed walk live as the oracle. Output defaults to `test_<spec>.py`.
+- `vitest`: a self-contained TypeScript (Vitest) file with the same `Adapter`
+  contract (`reset`/`step`/`observe`). Deterministic and forbidden scenarios map
+  directly; the random walk is **baked at generation time** (the Python Monitor
+  runs the seed-fixed walk and the `(action, params, expected_state)` trace is
+  embedded as a static fixture), so the tests need no `fslc`/Python at runtime.
+  Until `makeAdapter()` is wired the suite is skipped. Output defaults to
+  `<spec>.test.ts`.
 
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -481,15 +481,17 @@ def run_refine(impl_file, abs_file, mapping_file, depth=8, rest=None):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
-def run_testgen(file, depth=8, output=None, deadlock_mode="warn", write_file=True, strict=False):
+def run_testgen(file, depth=8, output=None, deadlock_mode="warn", write_file=True, strict=False,
+                target="pytest"):
     try:
-        out_path = output or default_output_name(file)
+        out_path = output or default_output_name(file, target=target)
         bundle = generate_test_bundle(
             file,
             depth=depth,
             deadlock_mode=deadlock_mode,
             output_path=output if output else None,
             strict=strict,
+            target=target,
         )
         content = bundle["content"]
         if write_file and output:
@@ -497,6 +499,7 @@ def run_testgen(file, depth=8, output=None, deadlock_mode="warn", write_file=Tru
         result = {
             "result": "generated",
             "spec": bundle["spec"],
+            "target": bundle.get("target", target),
             "output": out_path,
             "content": content,
         }
@@ -678,6 +681,8 @@ def _build_arg_parser():
     tg.add_argument("file")
     tg.add_argument("--depth", type=int, default=8)
     tg.add_argument("-o", "--output", default=None)
+    tg.add_argument("--target", choices=["pytest", "vitest"], default="pytest",
+                    help="test harness to emit (default: pytest)")
     tg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     tg.add_argument("--strict", action="store_true")
 
@@ -752,7 +757,8 @@ def _dispatch(args):
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "testgen":
         result = run_testgen(args.file, args.depth, args.output, args.deadlock,
-                            write_file=bool(args.output), strict=args.strict)
+                            write_file=bool(args.output), strict=args.strict,
+                            target=args.target)
         if result.get("result") == "generated":
             content = result.pop("content")
             out = result.get("output")

--- a/src/fslc/testgen.py
+++ b/src/fslc/testgen.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Generate pytest conformance test stubs from FSL specs."""
+"""Generate conformance test scaffolds from FSL specs.
+
+The language-independent core is ``scenarios()`` in :mod:`fslc.bmc`; this module
+is the *emitter* layer that renders that JSON into a concrete test harness.
+``--target pytest`` (default) and ``--target vitest`` share one scenario-collection
+pass (:func:`_collect_scenarios`) and differ only in how they render it.
+"""
 from __future__ import annotations
 
 import json
 import os
+import random
 import re
-import textwrap
 from pathlib import Path
 
 from .parser import parse_src
@@ -21,6 +27,42 @@ class TestgenScenarioError(RuntimeError):
         super().__init__(f"cannot generate tests: scenarios returned {scenario_result.get('result')}")
 
 
+# --------------------------------------------------------------------------
+# shared scenario-collection core (language independent)
+# --------------------------------------------------------------------------
+def _module_name(spec_name):
+    return spec_name[0].lower() + spec_name[1:] if spec_name else "spec"
+
+
+def _collect_scenarios(spec_path, depth=8, deadlock_mode="warn", strict=False):
+    """Parse, build, and run ``scenarios`` once; the result feeds every emitter."""
+    path = Path(spec_path)
+    src = path.read_text(encoding="utf-8")
+    ast, display_names = parse_src(src, str(path.parent))
+    spec = build_spec(ast, display_names)
+    sc = scenarios(
+        spec,
+        depth,
+        deadlock_mode=deadlock_mode,
+        source_lines=src.splitlines(),
+        allow_unreached=not strict,
+    )
+    if sc.get("result") != "scenarios":
+        raise TestgenScenarioError(sc)
+    spec_name = spec["name"]
+    return {
+        "spec": spec,
+        "spec_name": spec_name,
+        "module_name": _module_name(spec_name),
+        "scenarios": sc.get("scenarios", []),
+        "warnings": sc.get("warnings", []),
+        "src": src,
+    }
+
+
+# --------------------------------------------------------------------------
+# pytest emitter (output intentionally byte-for-byte stable — see CHANGELOG)
+# --------------------------------------------------------------------------
 def _py_literal(obj):
     return repr(obj)
 
@@ -41,25 +83,9 @@ def _spec_path_line(spec_path, output_path=None):
     return f"SPEC_PATH = Path(__file__).resolve().parent / {str(relative)!r}"
 
 
-def generate_test_bundle(spec_path, depth=8, deadlock_mode="warn", output_path=None, strict=False):
-    path = Path(spec_path)
-    src = path.read_text(encoding="utf-8")
-    ast, display_names = parse_src(src, str(path.parent))
-    spec = build_spec(ast, display_names)
-    sc = scenarios(
-        spec,
-        depth,
-        deadlock_mode=deadlock_mode,
-        source_lines=src.splitlines(),
-        allow_unreached=not strict,
-    )
-    if sc.get("result") != "scenarios":
-        raise TestgenScenarioError(sc)
-
-    spec_name = spec["name"]
-    module_name = spec_name[0].lower() + spec_name[1:] if spec_name else "spec"
-    scenario_data = sc.get("scenarios", [])
-    warnings = sc.get("warnings", [])
+def emit_pytest(collected, spec_path, output_path=None):
+    spec_name = collected["spec_name"]
+    scenario_data = collected["scenarios"]
 
     lines = [
         '"""Auto-generated conformance tests for FSL spec.',
@@ -178,28 +204,249 @@ def generate_test_bundle(spec_path, depth=8, deadlock_mode="warn", output_path=N
         "",
     ])
 
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------
+# vitest emitter (TypeScript)
+# --------------------------------------------------------------------------
+def _ts_inline(obj):
+    """Render a JSON-serialisable scenario value as a compact TS/JS literal."""
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _ts_array(items):
+    """Render a list as a TS/JS array literal, one compact element per line."""
+    if not items:
+        return "[]"
+    body = ",\n".join("  " + _ts_inline(item) for item in items)
+    return "[\n" + body + ",\n]"
+
+
+def _bake_random_walk(spec, steps=100, seed=0):
+    """Replay the seed-fixed random walk against the Python Monitor (the oracle)
+    and bake the ``(action, params, expected_state)`` sequence as a static
+    fixture, so the generated Vitest file needs no ``fslc`` at runtime.
+
+    The pytest scaffold runs this same walk live with ``random.Random(0)``; the
+    Monitor is deterministic, so baking under the same seed yields the identical
+    trace — equal coverage, no live oracle dependency.
+    """
+    from .runtime import Monitor  # lazy: keep module import graph free of cycles
+
+    mon = Monitor(spec)
+    mon.reset()
+    walk = {"initial": mon.state, "steps": []}
+    rng = random.Random(seed)
+    for _ in range(steps):
+        enabled = mon.enabled()
+        if not enabled:
+            break
+        choice = enabled[rng.randrange(len(enabled))]
+        action, params = choice["action"], dict(choice["params"])
+        result = mon.step(action, params)
+        if not result.get("ok"):
+            # The oracle rejected an action it reported as enabled — bake only the
+            # consistent prefix rather than emit a step the spec itself refuses.
+            break
+        walk["steps"].append({"action": action, "params": params, "expected": mon.state})
+    return walk
+
+
+_VITEST_PREAMBLE = '''\
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Auto-generated FSL conformance tests (Vitest).
+ * Source: __SOURCE__
+ *
+ * Wire `makeAdapter()` to your implementation. Until it is wired, every test is
+ * skipped (mirroring the pytest scaffold's skip-when-unwired behaviour).
+ *
+ * The random-walk trace below was baked at generation time by the FSL Monitor
+ * (the spec's concrete interpreter) under a fixed seed, so these tests need no
+ * `fslc`/Python at runtime — they replay the baked oracle states and assert.
+ */
+import { test, expect } from "vitest";
+
+export interface StepResult {
+  ok: boolean;
+  kind?: string;
+}
+
+/**
+ * Connect your implementation to the spec actions/state.
+ *  - reset(): put the implementation in the same initial state as spec `init`
+ *  - step(action, params): drive one spec action on the implementation
+ *  - observe(): project implementation state onto the spec's logical-state shape
+ *    (enum = name string, Option = null|value, Seq = array, Map = object with
+ *     string keys, struct = object)
+ */
+export interface Adapter {
+  reset(): void;
+  step(action: string, params: Record<string, unknown>): StepResult | void;
+  observe(): Record<string, unknown>;
+}
+
+// Wire your implementation here. Throwing leaves the suite skipped (not failed).
+function makeAdapter(): Adapter {
+  throw new Error("wire your implementation: implement makeAdapter()");
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+// Assert only the fields the spec mentions; recurse into nested (Map/struct) shapes.
+function assertPartial(observed: Record<string, unknown>, expected: Record<string, unknown>): void {
+  for (const [key, val] of Object.entries(expected)) {
+    const seen = observed[key];
+    if (isPlainObject(val) && isPlainObject(seen)) {
+      assertPartial(seen, val);
+    } else {
+      expect(seen).toStrictEqual(val);
+    }
+  }
+}
+
+function assertRejected(result: StepResult | void, expectedKind: string | null): void {
+  expect(isPlainObject(result), "forbidden step must return a result object").toBe(true);
+  const r = result as StepResult;
+  expect(r.ok).toBe(false);
+  if (expectedKind !== null) {
+    expect(r.kind).toBe(expectedKind);
+  }
+}
+
+let adapter: Adapter;
+let wired = false;
+try {
+  adapter = makeAdapter();
+  adapter.reset();
+  adapter.observe();
+  wired = true;
+} catch {
+  // Adapter not wired yet — every test below is skipped.
+}
+const scenario = wired ? test : test.skip;
+'''
+
+
+def _vitest_scenario_block(scen):
+    name = scen["name"]
+    lines = [
+        f"scenario({_ts_inline(f'scenario: {name}')}, () => {{",
+        "  adapter.reset();",
+    ]
+    steps = scen.get("steps", [])
+    expected_states = scen.get("expected_states", [])
+    for i, step in enumerate(steps):
+        lines.append(f"  adapter.step({_ts_inline(step['action'])}, {_ts_inline(step['params'])});")
+        exp = expected_states[i] if i < len(expected_states) else {}
+        lines.append(f"  assertPartial(adapter.observe(), {_ts_inline(exp)});")
+    if scen.get("kind") == "forbidden" and scen.get("forbidden_step"):
+        forbidden_step = scen["forbidden_step"]
+        rejected_by = scen.get("rejected_by")
+        rejected = _ts_inline(rejected_by) if rejected_by is not None else "null"
+        lines.append(
+            f"  const result = adapter.step({_ts_inline(forbidden_step['action'])}, "
+            f"{_ts_inline(forbidden_step['params'])});"
+        )
+        lines.append(f"  assertRejected(result, {rejected});")
+    lines.append("});")
+    return "\n".join(lines)
+
+
+def emit_vitest(collected, spec_path, output_path=None):
+    spec = collected["spec"]
+    scenario_data = collected["scenarios"]
+    walk = _bake_random_walk(spec)
+
+    parts = [_VITEST_PREAMBLE.replace("__SOURCE__", Path(spec_path).name)]
+
+    for scen in scenario_data:
+        parts.append(_vitest_scenario_block(scen))
+
+    walk_section = "\n".join([
+        "interface WalkStep {",
+        "  action: string;",
+        "  params: Record<string, unknown>;",
+        "  expected: Record<string, unknown>;",
+        "}",
+        "",
+        f"const RANDOM_WALK_INITIAL: Record<string, unknown> = {_ts_inline(walk['initial'])};",
+        f"const RANDOM_WALK: WalkStep[] = {_ts_array(walk['steps'])};",
+        "",
+        'scenario("random-walk conformance (baked oracle trace)", () => {',
+        "  adapter.reset();",
+        "  assertPartial(adapter.observe(), RANDOM_WALK_INITIAL);",
+        "  for (const step of RANDOM_WALK) {",
+        "    adapter.step(step.action, step.params);",
+        "    assertPartial(adapter.observe(), step.expected);",
+        "  }",
+        "});",
+    ])
+    parts.append(walk_section)
+
+    return "\n\n".join(parts) + "\n"
+
+
+# --------------------------------------------------------------------------
+# emitter dispatch + public API
+# --------------------------------------------------------------------------
+_EMITTERS = {
+    "pytest": emit_pytest,
+    "vitest": emit_vitest,
+}
+
+_TARGET_EXTENSION = {
+    "pytest": "py",
+    "vitest": "test.ts",
+}
+
+
+def available_targets():
+    return tuple(_EMITTERS)
+
+
+def generate_test_bundle(
+        spec_path, depth=8, deadlock_mode="warn", output_path=None, strict=False,
+        target="pytest"):
+    emit = _EMITTERS.get(target)
+    if emit is None:
+        raise ValueError(
+            f"unknown testgen target '{target}'; choose one of {', '.join(available_targets())}"
+        )
+    collected = _collect_scenarios(
+        spec_path, depth=depth, deadlock_mode=deadlock_mode, strict=strict)
+    content = emit(collected, spec_path, output_path)
     return {
-        "content": "\n".join(lines) + "\n",
-        "spec": spec_name,
-        "module": module_name,
-        "warnings": warnings,
+        "content": content,
+        "spec": collected["spec_name"],
+        "module": collected["module_name"],
+        "warnings": collected["warnings"],
+        "target": target,
     }
 
 
-def generate_test_file(spec_path, depth=8, deadlock_mode="warn", output_path=None, strict=False):
+def generate_test_file(
+        spec_path, depth=8, deadlock_mode="warn", output_path=None, strict=False,
+        target="pytest"):
     return generate_test_bundle(
         spec_path,
         depth=depth,
         deadlock_mode=deadlock_mode,
         output_path=output_path,
         strict=strict,
+        target=target,
     )["content"]
 
 
-def default_output_name(spec_path):
+def default_output_name(spec_path, target="pytest"):
     path = Path(spec_path)
     src = path.read_text(encoding="utf-8")
     ast, display_names = parse_src(src, str(path.parent))
     spec = build_spec(ast, display_names)
-    name = spec["name"]
-    return f"test_{name[0].lower()}{name[1:]}.py"
+    module = _module_name(spec["name"])
+    if target == "vitest":
+        return f"{module}.test.ts"
+    return f"test_{module}.py"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,6 +3,8 @@ import sys
 import ast
 import copy
 import json
+import re
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -11,7 +13,7 @@ import pytest
 
 from fslc import parse, build_spec, verify, scenarios, FslError, Monitor
 from fslc.cli import run_replay, run_testgen, exit_code
-from fslc.testgen import generate_test_file
+from fslc.testgen import generate_test_file, generate_test_bundle, default_output_name
 
 ROOT = Path(__file__).resolve().parent.parent
 SPECS = ROOT / "specs"
@@ -375,6 +377,139 @@ def adapter():
         )
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "failed" not in proc.stdout.lower()
+
+
+# --------------------------------------------------------------------------
+# testgen --target vitest (issue #43)
+# --------------------------------------------------------------------------
+def _node_supports_ts_check():
+    """True if a local `node --check` can syntax-check a typed .ts file."""
+    node = shutil.which("node")
+    if node is None:
+        return False
+    with tempfile.NamedTemporaryFile("w", suffix=".ts", delete=False, encoding="utf-8") as f:
+        # ESM probe with a type annotation: node only strips TS types when the
+        # file is detected as a module (the generated harness always imports vitest).
+        f.write('import { a } from "b";\nconst x: number = 1;\nvoid a;\nvoid x;\n')
+        probe = f.name
+    try:
+        proc = subprocess.run([node, "--check", probe], capture_output=True, text=True)
+        return proc.returncode == 0
+    finally:
+        Path(probe).unlink(missing_ok=True)
+
+
+def _assert_ts_syntax_ok(content):
+    if not _node_supports_ts_check():
+        pytest.skip("node with TypeScript stripping not available")
+    node = shutil.which("node")
+    with tempfile.NamedTemporaryFile("w", suffix=".test.ts", delete=False, encoding="utf-8") as f:
+        f.write(content)
+        path = f.name
+    try:
+        proc = subprocess.run([node, "--check", path], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_testgen_vitest_emits_typescript_harness():
+    content = generate_test_file(str(SPECS / "cart_v1.fsl"), depth=8, target="vitest")
+
+    # Vitest harness shape, not pytest.
+    assert 'import { test, expect } from "vitest";' in content
+    assert "export interface Adapter {" in content
+    assert "function makeAdapter(): Adapter {" in content
+    assert "function assertPartial(" in content
+    assert "function assertRejected(" in content
+
+    # Scenarios are emitted as reset + step + partial-match assertions. The
+    # concrete witness Z3 returns for reach_/cover_ varies run to run, so assert
+    # on the stable scenario names and shape, not on specific step params
+    # (exact-step assertions live in the deterministic forbidden test below).
+    assert 'scenario("scenario: reach_SoldOut", () => {' in content
+    assert 'scenario("scenario: cover_add_to_cart", () => {' in content
+    assert 'scenario("scenario: cover_checkout", () => {' in content
+    assert "adapter.reset();" in content
+    assert 'adapter.step("add_to_cart"' in content
+    assert "assertPartial(adapter.observe()," in content
+
+    # Acceptance criterion: the random walk is baked, so the file needs no fslc
+    # / Python / Monitor at runtime. The only import is vitest; nothing is
+    # require()'d or shelled out to.
+    assert "const RANDOM_WALK: WalkStep[] = [" in content
+    assert "baked oracle trace" in content
+    import_lines = [ln for ln in content.splitlines() if ln.lstrip().startswith("import ")]
+    assert import_lines == ['import { test, expect } from "vitest";']
+    assert "require(" not in content
+
+    # The baked literals are well-formed JSON (language independent).
+    initial = re.search(
+        r"const RANDOM_WALK_INITIAL: Record<string, unknown> = (\{.*?\});", content)
+    assert initial, "missing baked initial state"
+    json.loads(initial.group(1))
+    walk = re.search(r"const RANDOM_WALK: WalkStep\[\] = (\[.*?\n\]);", content, re.DOTALL)
+    assert walk, "missing baked walk array"
+    steps = json.loads(re.sub(r",(\s*\])", r"\1", walk.group(1)))  # drop TS trailing comma
+    assert steps, "cart_v1 should bake a non-empty random walk"
+    assert all({"action", "params", "expected"} <= set(s) for s in steps)
+    assert {s["action"] for s in steps} <= {"add_to_cart", "remove_from_cart", "checkout"}
+
+    _assert_ts_syntax_ok(content)
+
+
+def test_testgen_vitest_forbidden_rejection(tmp_path):
+    src = """
+requirements ForbiddenVitest {
+  type OrderId = 0..1
+  enum OSt { Cart, Paid, Shipped, Cancelled }
+  state { order: Map<OrderId, OSt> }
+  init { forall o: OrderId { order[o] = Cart } }
+  action pay(o: OrderId) { requires order[o] == Cart order[o] = Paid }
+  action ship(o: OrderId) { requires order[o] == Paid order[o] = Shipped }
+  action cancel(o: OrderId) { requires order[o] == Paid order[o] = Cancelled }
+  forbidden FB-1 "shipped order cannot be cancelled" {
+    pay(0)
+    ship(0)
+    cancel(0)
+    expect rejected
+  }
+}
+"""
+    path = tmp_path / "forbidden_vitest.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    content = generate_test_file(str(path), depth=4, target="vitest")
+
+    assert 'scenario("scenario: forbidden_FB-1", () => {' in content
+    assert 'const result = adapter.step("cancel", {"o": 0});' in content
+    assert 'assertRejected(result, "requires_failed");' in content
+    # Enum values are baked as their member-name strings.
+    assert 'assertPartial(adapter.observe(), {"order": {"0": "Paid", "1": "Cart"}});' in content
+
+    _assert_ts_syntax_ok(content)
+
+
+def test_testgen_vitest_output_name_and_target(tmp_path):
+    spec = str(SPECS / "cart_v1.fsl")
+    # ShoppingCart -> shoppingCart.test.ts (vitest) ; test_shoppingCart.py (pytest, unchanged)
+    assert default_output_name(spec, target="vitest") == "shoppingCart.test.ts"
+    assert default_output_name(spec, target="pytest") == "test_shoppingCart.py"
+    assert default_output_name(spec) == "test_shoppingCart.py"  # default stays pytest
+
+    out = tmp_path / "cart.test.ts"
+    result = run_testgen(spec, output=str(out), target="vitest")
+    assert result["result"] == "generated"
+    assert result["target"] == "vitest"
+    assert result["output"] == str(out)
+    written = out.read_text(encoding="utf-8")
+    assert written.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert 'import { test, expect } from "vitest";' in written
+
+
+def test_testgen_unknown_target_rejected():
+    with pytest.raises(ValueError):
+        generate_test_bundle(str(SPECS / "cart_v1.fsl"), depth=4, target="jest")
 
 
 def test_enabled_matches_guarded_instances():


### PR DESCRIPTION
Closes #43

## 概要

`fslc testgen` を **「言語非依存のシナリオ収集コア＋ターゲット別エミッタ」** に分離し、`--target {pytest,vitest}`（既定 `pytest`）で出力ハーネスを選べるようにしました。第一弾として **Vitest** ターゲットを実装しています。カーネルを広げずバックエンドに足す、という本リポの思想に沿った構成です（Jest / Go なども将来エミッタ追加だけで対応可能）。

- `testgen.py`: `_collect_scenarios`（共通コア、`scenarios()` をラップ）＋ `emit_pytest` / `emit_vitest` に分割。`_EMITTERS` レジストリで dispatch。
- `cli.py`: `--target` フラグ、`run_testgen(..., target=)`、`default_output_name(..., target=)` の拡張子分岐、JSON envelope に `target` フィールド追加。

## 設計上の論点 — random-walk オラクル（採用案 (a)）

TS 側に `Monitor` は存在しないため、**生成時にトレースを焼き込む** 方式を採用しました。Python Monitor で seed 固定（`Random(0)`）ウォークを回し、`(action, params, expected_state)` 列を静的フィクスチャとして TS に埋め込みます。

- 現状のウォークは既に決定的（同 seed → 同ウォーク）なので、焼き込んでもカバレッジは等価。
- 独立オラクルは Python に1つ、という不変条件を壊さない（TS への Monitor 移植 (c) は不採用）。
- 生成物は `fslc` 非依存で自己完結（シェルアウト (b) も不採用）。

rationale と不採用案は `docs/DESIGN-bridge.md` §3.1 に記録しています。

## 受け入れ条件

- [x] `fslc testgen <spec> --target vitest -o foo.test.ts` が Vitest テストを出力する
- [x] 決定的シナリオ／forbidden シナリオが TS でそのまま表現される（`assertPartial` 部分一致・`assertRejected` 拒否 assert、enum はメンバ名文字列で焼き込み）
- [x] random-walk は生成時トレース焼き込みで、Vitest 実行時に `fslc` を要求しない（import は `vitest` のみ／`require` 無し）
- [x] `--target pytest`（既定）の出力は不変（同一シナリオ入力で **byte-for-byte 一致** を確認。コーパス全体での見かけ上の差分は Z3 witness の非決定性で、リファクタとは無関係＝old 同士でも発生）
- [x] `docs/LANGUAGE.md` §12 と `skills/fsl/reference.md` §9 を更新
- [x] サンプル spec に対する Vitest 出力の回帰テストを追加（`tests/test_runtime.py`）

## 検証

ローカルで実際に Vitest を導入し、生成物を実走で確認しました（CI には node/vitest 依存を持ち込まず、回帰テストは構文・構造・JSON 妥当性ベース＋`node --check` 任意ゲート）。

| アダプタ | 結果 |
|---|---|
| 仕様を忠実に移植 | **5 passed**（シナリオ4＋random-walk） |
| わざとバグを混入（checkout で在庫を減らし忘れ） | **3 failed**（reach_SoldOut / cover_checkout / random-walk が乖離を検出） |
| 未配線（既定スタブ） | **5 skipped**（クリーンに skip、exit 0） |

その他: `pytest`（既定）回帰テスト・コーパススナップショット・e2e いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)