### PR TITLE
feat(testgen): Swift Testing target (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc testgen --target swift`: a Swift Testing emitter (`import Testing` / `@Test` /
+  `#expect`; not XCTest), the third harness on the pluggable emitter from #43. Same
+  `reset`/`step`/`observe` `Adapter` contract and same baked-walk design as Vitest:
+  deterministic and forbidden-rejection scenarios translate directly; the random walk
+  is baked at generation time so the file needs no `fslc`/Python at runtime. Dynamic
+  state is `[String: Any]` with a bundled `fslEqual`/`assertPartial` deep-equality
+  helper (`Int`/`Double` kept distinct); an Option `None` bakes as the self-contained
+  `FSLNull.instance` sentinel (no Foundation). Tests are disabled via
+  `@Test(.enabled(if: isAdapterWired()))` until `makeAdapter()` is wired. Output
+  defaults to `<SpecName>ConformanceTests.swift` (output naming is now a per-target
+  registry). Docs: `docs/LANGUAGE.md` §12, `skills/fsl/reference.md` §9,
+  `docs/DESIGN-bridge.md` §3.2. (#44)
 - `fslc testgen --target {pytest,vitest}` (default `pytest`): the emitter is now
   pluggable. `testgen.py` separates the language-independent scenario-collection
   core (`scenarios()`) from per-target emitters (`emit_pytest`/`emit_vitest`), so a

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -124,14 +124,14 @@ exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 
 ```
-fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
+fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
 ```
 
 The scenario-collection core (`scenarios()`) is language independent, so `testgen.py`
 splits into that shared core (`_collect_scenarios`) plus per-target emitters
-(`emit_pytest` / `emit_vitest`) chosen by `--target`. Adding a harness (Jest, Go, …)
-is a new emitter, not a redesign — the same kernel-stays-narrow principle as the
-dialect frontends.
+(`emit_pytest` / `emit_vitest` / `emit_swift`, …) chosen by `--target`. Adding a
+harness (Jest, Go, …) is a new emitter, not a redesign — the same kernel-stays-narrow
+principle as the dialect frontends.
 
 The output is a **self-contained pytest file** (the primary dependencies are
 `fslc.runtime` and `pytest`. In addition, only the standard library needed for
@@ -185,6 +185,33 @@ Rejected alternatives: (b) shelling out to `fslc` from the TS test (adds a runti
 coupling), and (c) porting `Monitor` to TS (duplicates the dual-evaluator surface
 that the agreement/oracle tests exist to protect). Output defaults to
 `<spec>.test.ts`.
+
+### 3.2 `--target swift` (Swift Testing)
+
+The Swift emitter renders the same scenarios to a self-contained Swift Testing file
+(`import Testing` / `@Test` / `#expect` / `#require` — **not XCTest**), reusing the
+language-independent baked walk. The Swift-specific points:
+
+- **Dynamic dict + equality.** `params`/`observe()` are `[String: Any]`. `Any`
+  values have no usable `==`, so the harness bundles `fslEqual` (a deep equality over
+  the JSON-normal world: `Bool`/`Int`/`Double`/`String`/`FSLNull`/`[Any]`/`[String:
+  Any]`, with `Int` and `Double` kept distinct) and an `assertPartial` that recurses
+  by the expected keys and asserts only the fields the spec mentions.
+- **Null.** An Option `None` bakes as `FSLNull.instance`, a one-line sentinel struct,
+  so the generated file depends only on `Testing` (no Foundation/`NSNull`).
+- **Skip-when-unwired.** `makeAdapter()` throws until wired; each `@Test` carries
+  `.enabled(if: isAdapterWired())`, so the suite is *disabled* (not failed) until an
+  adapter is connected — the Swift analog of the pytest skip / Vitest `test.skip`.
+- **Literals.** `_swift_literal` renders int as `Int`, float as `Double` (always with
+  a decimal point), bool/null per above, and strings with Swift escape rules
+  (`\u{XX}`, which differ from JSON). The baked walk is an inline labelled-tuple
+  array `[(action:params:expected:)]` (kept local to the test, so no global
+  non-`Sendable` state). Output defaults to `<SpecName>ConformanceTests.swift`.
+
+Rejected alternatives mirror Vitest's: no shell-out to `fslc`, no second `Monitor`
+port. An `Encodable` generated-struct model was considered over dict-plus-helper but
+deferred — the dict keeps the first version small and matches the language-independent
+scenario JSON directly.
 
 ## 4. CLI / public API
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -265,7 +265,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
-fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest] [-o out]  # implementation-conformance test scaffold (§12)
+fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
@@ -693,7 +693,7 @@ implementation (see `DESIGN-bridge.md`).
 |---|---|
 | `fslc.runtime.Monitor` | A concrete interpreter of the spec (no Z3 needed). Embed it in the implementation for runtime checking |
 | `fslc replay` | Check a real system's event-log JSON against the spec |
-| `fslc testgen` | Generate a conformance-test scaffold — pytest (default) or Vitest via `--target vitest` (wire the implementation into the Adapter) |
+| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), or Swift Testing (`--target swift`) (wire the implementation into the Adapter) |
 
 Recommended workflow: **`verify` / `prove` the spec → generate the scaffold with
 `testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
@@ -710,6 +710,12 @@ from per-target emitters, so the same scenarios render to multiple harnesses:
   the `(action, params, expected_state)` trace is embedded as a static fixture, so the
   generated tests need **no `fslc`/Python at runtime**. The output extension defaults
   to `<spec>.test.ts`.
+- `--target swift`: emits a self-contained Swift Testing file (`import Testing`,
+  `@Test`, `#expect`; **not XCTest**). Same baked-walk design as Vitest. Dynamic
+  state is `[String: Any]` with a bundled deep-equality/partial-match helper; an
+  Option `None` bakes as the self-contained `FSLNull.instance` sentinel (no
+  Foundation). Until `makeAdapter()` is wired every test is disabled via
+  `@Test(.enabled(if:))`. Output defaults to `<SpecName>ConformanceTests.swift`.
 
 ```python
 from fslc import Monitor
@@ -723,6 +729,7 @@ r = mon.step("add_to_cart", {"u": 0, "i": 0})   # ok / kind / state / changes
 fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
 fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
+fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
 ```
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -259,7 +259,7 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
-fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest)
+fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -417,6 +417,12 @@ emit the same scenarios:
   embedded as a static fixture), so the tests need no `fslc`/Python at runtime.
   Until `makeAdapter()` is wired the suite is skipped. Output defaults to
   `<spec>.test.ts`.
+- `swift`: a self-contained Swift Testing file (`import Testing` / `@Test` /
+  `#expect`; not XCTest), same `Adapter` contract and same baked walk. Dynamic
+  state is `[String: Any]` with a bundled deep-equality + partial-match helper;
+  Option `None` bakes as the `FSLNull.instance` sentinel (no Foundation). Tests
+  are disabled via `@Test(.enabled(if: isAdapterWired()))` until `makeAdapter()`
+  is wired. Output defaults to `<SpecName>ConformanceTests.swift`.
 
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -681,7 +681,7 @@ def _build_arg_parser():
     tg.add_argument("file")
     tg.add_argument("--depth", type=int, default=8)
     tg.add_argument("-o", "--output", default=None)
-    tg.add_argument("--target", choices=["pytest", "vitest"], default="pytest",
+    tg.add_argument("--target", choices=["pytest", "vitest", "swift"], default="pytest",
                     help="test harness to emit (default: pytest)")
     tg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     tg.add_argument("--strict", action="store_true")

--- a/src/fslc/testgen.py
+++ b/src/fslc/testgen.py
@@ -391,16 +391,264 @@ def emit_vitest(collected, spec_path, output_path=None):
 
 
 # --------------------------------------------------------------------------
+# Swift Testing emitter
+# --------------------------------------------------------------------------
+def _swift_string(s):
+    """Render a Python str as a Swift string literal (Swift escape rules, which
+    differ from JSON: ``\\u{XX}`` rather than ``\\uXXXX``, no ``\\b``/``\\f``)."""
+    out = ['"']
+    for ch in s:
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\0":
+            out.append("\\0")
+        elif ord(ch) < 0x20:
+            out.append(f"\\u{{{ord(ch):x}}}")
+        else:
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+def _swift_literal(obj):
+    """Render a JSON-serialisable scenario value as a Swift literal in the
+    ``[String: Any]`` world. ``None`` -> ``FSLNull.instance`` (a self-contained
+    sentinel so the harness depends only on ``Testing``); int and float stay
+    distinct (``1`` is ``Int``, ``1.0`` is ``Double``) and ``fslEqual``
+    discriminates them. bool is checked before int (``True`` is an ``int`` in
+    Python)."""
+    if obj is None:
+        return "FSLNull.instance"
+    if obj is True:
+        return "true"
+    if obj is False:
+        return "false"
+    if isinstance(obj, str):
+        return _swift_string(obj)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        s = repr(obj)
+        if not any(c in s for c in ".eEnN"):  # ensure a Double literal, not Int
+            s += ".0"
+        return s
+    if isinstance(obj, list):
+        return "[" + ", ".join(_swift_literal(x) for x in obj) + "]"
+    if isinstance(obj, dict):
+        if not obj:
+            return "[String: Any]()"  # `[:]` is ambiguous outside an annotated slot
+        items = ", ".join(
+            f"{_swift_string(str(k))}: {_swift_literal(v)}" for k, v in obj.items())
+        return "[" + items + "]"
+    raise TypeError(f"cannot render {type(obj).__name__} as a Swift literal")
+
+
+def _sanitize_ident(display_name, fallback="scenario"):
+    return re.sub(r"[^A-Za-z0-9_]+", "_", display_name).strip("_") or fallback
+
+
+def _unique_ident(display_name, seen_names, prefix):
+    safe = _sanitize_ident(display_name)
+    count = seen_names.get(safe, 0) + 1
+    seen_names[safe] = count
+    if count > 1:
+        safe = f"{safe}_{count}"
+    return f"{prefix}{safe}"
+
+
+_SWIFT_PREAMBLE = '''\
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auto-generated FSL conformance tests (Swift Testing).
+// Source: __SOURCE__
+//
+// Wire `makeAdapter()` to your implementation. Until it is wired every test is
+// skipped (the `.enabled(if:)` trait checks the adapter and disables the test).
+//
+// The random-walk trace below was baked at generation time by the FSL Monitor
+// (the spec's concrete interpreter) under a fixed seed, so these tests need no
+// `fslc`/Python at runtime — they replay the baked oracle states and assert.
+import Testing
+
+struct StepResult {
+    let ok: Bool
+    let kind: String?
+}
+
+// A self-contained JSON-null sentinel so the harness depends only on `Testing`
+// (no Foundation/NSNull). Project a None/absent Option state field to this.
+struct FSLNull: Equatable {
+    static let instance = FSLNull()
+}
+
+enum FSLNotWired: Error { case notWired }
+
+/// Connect your implementation to the spec actions/state.
+///  - reset(): put the implementation in the same initial state as spec `init`
+///  - step(action, params): drive one spec action; return a StepResult for
+///    forbidden-rejection scenarios (nil is fine for ordinary steps)
+///  - observe(): project implementation state onto the spec's logical-state shape
+///    (enum = name string, Option = FSLNull.instance|value, Seq = [Any],
+///     Map = [String: Any], struct = [String: Any])
+protocol Adapter {
+    func reset()
+    func step(_ action: String, _ params: [String: Any]) -> StepResult?
+    func observe() -> [String: Any]
+}
+
+// Wire your implementation here. Throwing leaves the suite skipped (not failed).
+func makeAdapter() throws -> any Adapter {
+    throw FSLNotWired.notWired
+}
+
+func isAdapterWired() -> Bool {
+    do {
+        let a = try makeAdapter()
+        a.reset()
+        _ = a.observe()
+        return true
+    } catch {
+        return false
+    }
+}
+
+// Deep equality over the JSON-normal world: Bool/Int/Double/String/FSLNull,
+// [Any] (ordered) and [String: Any] (by key). Int and Double do not cross-match.
+func fslEqual(_ a: Any, _ b: Any) -> Bool {
+    switch (a, b) {
+    case (is FSLNull, is FSLNull): return true
+    case let (x as Bool, y as Bool): return x == y
+    case let (x as Int, y as Int): return x == y
+    case let (x as Double, y as Double): return x == y
+    case let (x as String, y as String): return x == y
+    case let (x as [Any], y as [Any]):
+        return x.count == y.count && zip(x, y).allSatisfy { fslEqual($0, $1) }
+    case let (x as [String: Any], y as [String: Any]):
+        return x.count == y.count && x.allSatisfy { (k, v) in
+            guard let w = y[k] else { return false }
+            return fslEqual(v, w)
+        }
+    default: return false
+    }
+}
+
+// Assert only the fields the spec mentions; recurse into nested (Map/struct) shapes.
+func assertPartial(_ observed: [String: Any], _ expected: [String: Any]) {
+    for (key, val) in expected {
+        let seen = observed[key]
+        if let v = val as? [String: Any], let s = seen as? [String: Any] {
+            assertPartial(s, v)
+        } else {
+            #expect(seen != nil, "missing state key \\(key)")
+            if let s = seen {
+                #expect(fslEqual(s, val), "state \\(key): expected \\(val), got \\(s)")
+            }
+        }
+    }
+}
+
+func assertRejected(_ result: StepResult?, _ expectedKind: String?) {
+    #expect(result != nil, "forbidden step must return a StepResult")
+    #expect(result?.ok == false)
+    if let kind = expectedKind {
+        #expect(result?.kind == kind)
+    }
+}
+'''
+
+
+def _swift_scenario_block(scen, seen_names):
+    name = scen["name"]
+    func = _unique_ident(name, seen_names, "scenario_")
+    lines = [
+        f"@Test(.enabled(if: isAdapterWired())) func {func}() throws {{",
+        "    let a = try makeAdapter()",
+        "    a.reset()",
+    ]
+    steps = scen.get("steps", [])
+    expected_states = scen.get("expected_states", [])
+    for i, step in enumerate(steps):
+        lines.append(
+            f"    _ = a.step({_swift_string(step['action'])}, {_swift_literal(step['params'])})")
+        exp = expected_states[i] if i < len(expected_states) else {}
+        lines.append(f"    assertPartial(a.observe(), {_swift_literal(exp)})")
+    if scen.get("kind") == "forbidden" and scen.get("forbidden_step"):
+        forbidden_step = scen["forbidden_step"]
+        rejected_by = scen.get("rejected_by")
+        rejected = _swift_string(rejected_by) if rejected_by is not None else "nil"
+        lines.append(
+            f"    let result = a.step({_swift_string(forbidden_step['action'])}, "
+            f"{_swift_literal(forbidden_step['params'])})")
+        lines.append(f"    assertRejected(result, {rejected})")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def emit_swift(collected, spec_path, output_path=None):
+    spec = collected["spec"]
+    scenario_data = collected["scenarios"]
+    walk = _bake_random_walk(spec)
+
+    parts = [_SWIFT_PREAMBLE.replace("__SOURCE__", Path(spec_path).name)]
+
+    seen_names = {}
+    for scen in scenario_data:
+        parts.append(_swift_scenario_block(scen, seen_names))
+
+    walk_type = "[(action: String, params: [String: Any], expected: [String: Any])]"
+    if walk["steps"]:
+        walk_rows = ",\n".join(
+            f"        (action: {_swift_string(s['action'])}, "
+            f"params: {_swift_literal(s['params'])}, "
+            f"expected: {_swift_literal(s['expected'])})"
+            for s in walk["steps"]
+        )
+        walk_literal = "[\n" + walk_rows + ",\n    ]"
+    else:
+        walk_literal = "[]"
+    walk_section = "\n".join([
+        "@Test(.enabled(if: isAdapterWired())) func randomWalkConformance() throws {",
+        "    // random-walk conformance (baked oracle trace)",
+        "    let a = try makeAdapter()",
+        "    a.reset()",
+        f"    let initial: [String: Any] = {_swift_literal(walk['initial'])}",
+        "    assertPartial(a.observe(), initial)",
+        f"    let walk: {walk_type} = {walk_literal}",
+        "    for step in walk {",
+        "        _ = a.step(step.action, step.params)",
+        "        assertPartial(a.observe(), step.expected)",
+        "    }",
+        "}",
+    ])
+    parts.append(walk_section)
+
+    return "\n\n".join(parts) + "\n"
+
+
+# --------------------------------------------------------------------------
 # emitter dispatch + public API
 # --------------------------------------------------------------------------
 _EMITTERS = {
     "pytest": emit_pytest,
     "vitest": emit_vitest,
+    "swift": emit_swift,
 }
 
-_TARGET_EXTENSION = {
-    "pytest": "py",
-    "vitest": "test.ts",
+# How each target names its default output file. Conventions diverge (prefix vs
+# suffix, camelCase vs PascalCase), so this is a per-target function of the spec
+# name and its camelCase module form rather than a bare extension swap.
+_TARGET_OUTPUT_NAME = {
+    "pytest": lambda name, module: f"test_{module}.py",
+    "vitest": lambda name, module: f"{module}.test.ts",
+    "swift": lambda name, module: f"{name}ConformanceTests.swift",
 }
 
 
@@ -446,7 +694,6 @@ def default_output_name(spec_path, target="pytest"):
     src = path.read_text(encoding="utf-8")
     ast, display_names = parse_src(src, str(path.parent))
     spec = build_spec(ast, display_names)
-    module = _module_name(spec["name"])
-    if target == "vitest":
-        return f"{module}.test.ts"
-    return f"test_{module}.py"
+    name = spec["name"]
+    namer = _TARGET_OUTPUT_NAME.get(target, _TARGET_OUTPUT_NAME["pytest"])
+    return namer(name, _module_name(name))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -512,6 +512,119 @@ def test_testgen_unknown_target_rejected():
         generate_test_bundle(str(SPECS / "cart_v1.fsl"), depth=4, target="jest")
 
 
+# --------------------------------------------------------------------------
+# testgen --target swift (issue #44)
+# --------------------------------------------------------------------------
+def _swiftc_available():
+    return shutil.which("swiftc") is not None
+
+
+def _assert_swift_syntax_ok(content):
+    """Syntax-only gate (parse, no module resolution) — the swiftc analog of the
+    vitest `node --check`. `import Testing` need not resolve under `-parse`."""
+    if not _swiftc_available():
+        pytest.skip("swiftc not available")
+    swiftc = shutil.which("swiftc")
+    with tempfile.NamedTemporaryFile("w", suffix=".swift", delete=False, encoding="utf-8") as f:
+        f.write(content)
+        path = f.name
+    try:
+        proc = subprocess.run([swiftc, "-parse", path], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_testgen_swift_emits_swift_testing_harness():
+    content = generate_test_file(str(SPECS / "cart_v1.fsl"), depth=8, target="swift")
+
+    # Swift Testing harness shape (not XCTest, not pytest).
+    assert content.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import Testing" in content
+    assert "protocol Adapter {" in content
+    assert "func makeAdapter() throws -> any Adapter {" in content
+    assert "func assertPartial(" in content
+    assert "func assertRejected(" in content
+    assert "struct FSLNull: Equatable {" in content
+
+    # Scenarios -> @Test funcs gated by the adapter-wired trait; assert on the
+    # stable scenario names/shape, not specific witness params (the reach_/cover_
+    # witness Z3 returns varies run to run — exact steps live in the forbidden test).
+    assert "@Test(.enabled(if: isAdapterWired())) func scenario_reach_SoldOut() throws {" in content
+    assert "@Test(.enabled(if: isAdapterWired())) func scenario_cover_add_to_cart() throws {" in content
+    assert "    let a = try makeAdapter()" in content
+    assert "    a.reset()" in content
+    assert '    _ = a.step("add_to_cart"' in content
+    assert "    assertPartial(a.observe()," in content
+
+    # Acceptance: the random walk is baked, so the file needs no fslc/Python/Monitor
+    # at runtime. The only import is Testing (no Foundation); nothing is shelled out.
+    assert "func randomWalkConformance() throws {" in content
+    assert "baked oracle trace" in content
+    assert "let walk: [(action: String, params: [String: Any], expected: [String: Any])] = [" in content
+    import_lines = [ln for ln in content.splitlines() if ln.lstrip().startswith("import ")]
+    assert import_lines == ["import Testing"]
+
+    # Option None bakes as the self-contained null sentinel; enum members as strings.
+    assert "FSLNull.instance" in content
+
+    walk_actions = re.findall(r'\(action: "(\w+)"', content)
+    assert walk_actions, "cart_v1 should bake a non-empty random walk"
+    assert set(walk_actions) <= {"add_to_cart", "remove_from_cart", "checkout"}
+
+    _assert_swift_syntax_ok(content)
+
+
+def test_testgen_swift_forbidden_rejection(tmp_path):
+    src = """
+requirements ForbiddenSwift {
+  type OrderId = 0..1
+  enum OSt { Cart, Paid, Shipped, Cancelled }
+  state { order: Map<OrderId, OSt> }
+  init { forall o: OrderId { order[o] = Cart } }
+  action pay(o: OrderId) { requires order[o] == Cart order[o] = Paid }
+  action ship(o: OrderId) { requires order[o] == Paid order[o] = Shipped }
+  action cancel(o: OrderId) { requires order[o] == Paid order[o] = Cancelled }
+  forbidden FB-1 "shipped order cannot be cancelled" {
+    pay(0)
+    ship(0)
+    cancel(0)
+    expect rejected
+  }
+}
+"""
+    path = tmp_path / "forbidden_swift.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    content = generate_test_file(str(path), depth=4, target="swift")
+
+    # Hyphen in the forbidden ID is sanitized into a valid Swift identifier.
+    assert "func scenario_forbidden_FB_1() throws {" in content
+    assert 'let result = a.step("cancel", ["o": 0])' in content
+    assert 'assertRejected(result, "requires_failed")' in content
+    # Enum values are baked as their member-name strings; Map keys as strings.
+    assert 'assertPartial(a.observe(), ["order": ["0": "Paid", "1": "Cart"]])' in content
+
+    _assert_swift_syntax_ok(content)
+
+
+def test_testgen_swift_output_name_and_target(tmp_path):
+    spec = str(SPECS / "cart_v1.fsl")
+    # ShoppingCart -> ShoppingCartConformanceTests.swift; pytest/vitest unchanged.
+    assert default_output_name(spec, target="swift") == "ShoppingCartConformanceTests.swift"
+    assert default_output_name(spec, target="vitest") == "shoppingCart.test.ts"
+    assert default_output_name(spec, target="pytest") == "test_shoppingCart.py"
+
+    out = tmp_path / "Cart.swift"
+    result = run_testgen(spec, output=str(out), target="swift")
+    assert result["result"] == "generated"
+    assert result["target"] == "swift"
+    assert result["output"] == str(out)
+    written = out.read_text(encoding="utf-8")
+    assert written.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import Testing" in written
+
+
 def test_enabled_matches_guarded_instances():
     mon = Monitor(str(SPECS / "cart_v1.fsl"))
     mon.reset()


### PR DESCRIPTION
Closes #44.

Adds **Swift Testing** as the third `fslc testgen` harness on top of the pluggable emitter from #43 (after pytest and Vitest). `emit_swift` reuses the language-independent scenario-collection core (`_collect_scenarios`) and the shared `_bake_random_walk` — adding a harness stays a backend, not a redesign.

## What it emits

A self-contained Swift Testing file (`import Testing` / `@Test` / `#expect` — **not XCTest**) with the same `reset`/`step`/`observe` `Adapter` contract as the other targets:

- **Deterministic & forbidden scenarios** translate directly (`assertPartial` / `assertRejected`).
- **Random walk** is **baked at generation time** (the Python `Monitor` runs the fixed-seed `Random(0)` walk and the `(action, params, expected_state)` trace is embedded as an inline labelled-tuple array), so the file needs **no `fslc`/Python at runtime** — the single independent oracle stays in Python.
- **Skip-when-unwired**: `makeAdapter()` throws until wired and every `@Test` carries `.enabled(if: isAdapterWired())`, so the suite is *disabled* (not failed) until an adapter is connected.

## Swift-specific design

- Dynamic state is `[String: Any]`; `Any` has no usable `==`, so the harness bundles `fslEqual` (deep equality over `Bool`/`Int`/`Double`/`String`/`FSLNull`/`[Any]`/`[String: Any]`, with `Int` and `Double` kept distinct) and an `assertPartial` that recurses by the expected keys (asserts only the fields the spec mentions).
- An Option `None` bakes as `FSLNull.instance`, a one-line sentinel struct, so the generated file depends only on `Testing` (no Foundation/`NSNull`).
- `_swift_literal` renders int as `Int`, float as `Double` (always with a decimal point), and strings with Swift escape rules (`\u{XX}`, which differ from JSON's `\uXXXX`).

Output naming is now a per-target registry (`_TARGET_OUTPUT_NAME`), replacing the previously-dead `_TARGET_EXTENSION` dict and the hardcoded vitest branch. Swift defaults to `<SpecName>ConformanceTests.swift`.

## Acceptance criteria

- [x] `fslc testgen <spec> --target swift -o FooConformanceTests.swift` emits Swift Testing tests
- [x] Deterministic / forbidden scenarios expressed (partial-match + rejection asserts)
- [x] `Any` partial-match helper bundled, works on nested state
- [x] random-walk baked, no `fslc` at runtime
- [x] `docs/LANGUAGE.md` + `skills/fsl/reference.md` (and `docs/DESIGN-bridge.md` §3.2) updated
- [x] Regression tests on sample specs; corpus snapshot confirmed unaffected

## Verification

- `pytest tests/test_runtime.py` → 31 passed (3 new Swift tests; the `swiftc -parse` syntax gate runs locally — Swift 6.3 — and skips where swiftc is absent).
- `pytest tests/test_corpus_snapshot.py` → 150 passed, 1 skipped, no diff (testgen output does not feed the snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)