### PR TITLE
feat(testgen): Kotlin (kotlin.test) target (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc testgen --target kotlin`: a kotlin.test emitter (multiplatform; the JVM
+  delegates to JUnit), the fourth harness on the pluggable emitter from #43. Same
+  `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Dynamic
+  state is `Map<String, Any?>`, where Kotlin's structural `==` is deep on `List`/`Map`
+  and distinguishes `Int` from `Double`, so the partial-match helper is a plain
+  recursion. The one framework-forced divergence: kotlin.test has no portable runtime
+  skip, so `makeAdapter()` returns `null` until wired and each `@Test` returns early
+  rather than reporting "skipped". Strings escape `$` (Kotlin string templates).
+  Output defaults to `<SpecName>ConformanceTest.kt`. Docs: `docs/LANGUAGE.md` §12,
+  `skills/fsl/reference.md` §9, `docs/DESIGN-bridge.md` §3.3. (#45)
 - `fslc testgen --target swift`: a Swift Testing emitter (`import Testing` / `@Test` /
   `#expect`; not XCTest), the third harness on the pluggable emitter from #43. Same
   `reset`/`step`/`observe` `Adapter` contract and same baked-walk design as Vitest:

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -124,7 +124,7 @@ exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 
 ```
-fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
+fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
 ```
 
 The scenario-collection core (`scenarios()`) is language independent, so `testgen.py`
@@ -212,6 +212,34 @@ Rejected alternatives mirror Vitest's: no shell-out to `fslc`, no second `Monito
 port. An `Encodable` generated-struct model was considered over dict-plus-helper but
 deferred — the dict keeps the first version small and matches the language-independent
 scenario JSON directly.
+
+### 3.3 `--target kotlin` (kotlin.test)
+
+The Kotlin emitter renders the same scenarios to a self-contained kotlin.test file,
+again reusing the baked walk. The choices:
+
+- **Framework: kotlin.test** (over JUnit5 / Kotest). It is multiplatform and on the
+  JVM delegates to JUnit, so the generated file carries the lightest dependency. The
+  imports are fixed to `kotlin.test.{Test, assertEquals, assertFalse, assertNotNull,
+  assertTrue}`.
+- **Dynamic dict is the easy case.** `params`/`observe()` are `Map<String, Any?>`,
+  and Kotlin's structural `==` is already deep on `List`/`Map` and discriminates a
+  boxed `Int` from a `Double`, so `assertPartial` is a plain recursion that asserts
+  only the expected keys and leans on `assertEquals` for leaves.
+- **Skip-when-unwired.** kotlin.test has no portable runtime skip (no
+  `assumeTrue`), so `makeAdapter(): Adapter?` returns `null` until wired and each
+  `@Test` starts `val a = makeAdapter() ?: return` — an unwired suite no-ops rather
+  than fails. This is the one deliberate divergence from the pytest/Vitest/Swift
+  "reported as skipped" behaviour, forced by the framework.
+- **Literals.** `_kotlin_literal` renders int as `Int`, float as `Double`, `null`,
+  `listOf`/`mapOf` (empty ones carry explicit type args), and strings with Kotlin
+  escapes — notably `$` must be escaped (string templates). The baked walk is a
+  `List<Triple<String, Map<String, Any?>, Map<String, Any?>>>`. Output defaults to
+  `<SpecName>ConformanceTest.kt`.
+
+(No `swiftc -parse`-style syntax gate in tests: kotlinc has no dependency-free
+parse-only mode — a real compile needs kotlin-test on the classpath — so the Kotlin
+tests assert on harness shape and the baked walk instead.)
 
 ## 4. CLI / public API
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -265,7 +265,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
-fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift] [-o out]  # implementation-conformance test scaffold (§12)
+fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
@@ -693,7 +693,7 @@ implementation (see `DESIGN-bridge.md`).
 |---|---|
 | `fslc.runtime.Monitor` | A concrete interpreter of the spec (no Z3 needed). Embed it in the implementation for runtime checking |
 | `fslc replay` | Check a real system's event-log JSON against the spec |
-| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), or Swift Testing (`--target swift`) (wire the implementation into the Adapter) |
+| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), Swift Testing (`--target swift`), or kotlin.test (`--target kotlin`) (wire the implementation into the Adapter) |
 
 Recommended workflow: **`verify` / `prove` the spec → generate the scaffold with
 `testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
@@ -716,6 +716,13 @@ from per-target emitters, so the same scenarios render to multiple harnesses:
   Option `None` bakes as the self-contained `FSLNull.instance` sentinel (no
   Foundation). Until `makeAdapter()` is wired every test is disabled via
   `@Test(.enabled(if:))`. Output defaults to `<SpecName>ConformanceTests.swift`.
+- `--target kotlin`: emits a self-contained kotlin.test file (multiplatform; the
+  JVM delegates to JUnit). Same baked-walk design. Dynamic state is
+  `Map<String, Any?>`, where Kotlin's structural `==` is deep on `List`/`Map` and
+  distinguishes `Int` from `Double`, so the partial-match helper is a plain
+  recursion. kotlin.test has no portable runtime skip, so until `makeAdapter()`
+  is wired (it returns `null`) each test returns early. Output defaults to
+  `<SpecName>ConformanceTest.kt`.
 
 ```python
 from fslc import Monitor
@@ -730,6 +737,7 @@ fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
 fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
+fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self-contained kotlin.test scaffold
 ```
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -259,7 +259,7 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
-fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing)
+fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -423,6 +423,12 @@ emit the same scenarios:
   Option `None` bakes as the `FSLNull.instance` sentinel (no Foundation). Tests
   are disabled via `@Test(.enabled(if: isAdapterWired()))` until `makeAdapter()`
   is wired. Output defaults to `<SpecName>ConformanceTests.swift`.
+- `kotlin`: a self-contained kotlin.test file (multiplatform; JVM delegates to
+  JUnit), same `Adapter` contract and same baked walk. Dynamic state is
+  `Map<String, Any?>` — Kotlin's `==` is deep on `List`/`Map` and distinguishes
+  `Int`/`Double`, so the partial-match helper is a plain recursion. No portable
+  runtime skip, so an unwired `makeAdapter()` returns `null` and each test
+  returns early. Output defaults to `<SpecName>ConformanceTest.kt`.
 
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -681,7 +681,7 @@ def _build_arg_parser():
     tg.add_argument("file")
     tg.add_argument("--depth", type=int, default=8)
     tg.add_argument("-o", "--output", default=None)
-    tg.add_argument("--target", choices=["pytest", "vitest", "swift"], default="pytest",
+    tg.add_argument("--target", choices=["pytest", "vitest", "swift", "kotlin"], default="pytest",
                     help="test harness to emit (default: pytest)")
     tg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     tg.add_argument("--strict", action="store_true")

--- a/src/fslc/testgen.py
+++ b/src/fslc/testgen.py
@@ -634,12 +634,213 @@ def emit_swift(collected, spec_path, output_path=None):
 
 
 # --------------------------------------------------------------------------
+# Kotlin emitter (kotlin.test — multiplatform, delegates to JUnit on the JVM)
+# --------------------------------------------------------------------------
+def _kotlin_string(s):
+    """Render a Python str as a Kotlin string literal. Kotlin needs ``$`` escaped
+    (it starts a string template) and uses ``\\uXXXX`` (4 hex) like JSON."""
+    out = ['"']
+    for ch in s:
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "$":
+            out.append("\\$")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ord(ch) < 0x20:
+            out.append(f"\\u{ord(ch):04x}")
+        else:
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+def _kotlin_literal(obj):
+    """Render a JSON-serialisable scenario value as a Kotlin literal in the
+    ``Map<String, Any?>`` world. None -> null; int -> Int, float -> Double (kept
+    distinct — boxed ``Int`` and ``Double`` are unequal); list -> listOf, dict ->
+    mapOf. Empty collections carry explicit type args for inference in ``Any?``
+    slots. bool is checked before int (``True`` is an ``int`` in Python)."""
+    if obj is None:
+        return "null"
+    if obj is True:
+        return "true"
+    if obj is False:
+        return "false"
+    if isinstance(obj, str):
+        return _kotlin_string(obj)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        s = repr(obj)
+        if not any(c in s for c in ".eEnN"):
+            s += ".0"
+        return s
+    if isinstance(obj, list):
+        if not obj:
+            return "listOf<Any?>()"
+        return "listOf(" + ", ".join(_kotlin_literal(x) for x in obj) + ")"
+    if isinstance(obj, dict):
+        if not obj:
+            return "mapOf<String, Any?>()"
+        items = ", ".join(
+            f"{_kotlin_string(str(k))} to {_kotlin_literal(v)}" for k, v in obj.items())
+        return "mapOf(" + items + ")"
+    raise TypeError(f"cannot render {type(obj).__name__} as a Kotlin literal")
+
+
+_KOTLIN_PREAMBLE = '''\
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auto-generated FSL conformance tests (kotlin.test).
+// Source: __SOURCE__
+//
+// Wire `makeAdapter()` to your implementation. Until it is wired it returns null
+// and every test returns early (kotlin.test has no portable runtime skip), so the
+// suite passes trivially rather than failing — mirroring the other targets.
+//
+// The random-walk trace below was baked at generation time by the FSL Monitor
+// (the spec's concrete interpreter) under a fixed seed, so these tests need no
+// `fslc`/Python at runtime — they replay the baked oracle states and assert.
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+data class StepResult(val ok: Boolean, val kind: String? = null)
+
+/**
+ * Connect your implementation to the spec actions/state.
+ *  - reset(): put the implementation in the same initial state as spec `init`
+ *  - step(action, params): drive one spec action; return a StepResult for
+ *    forbidden-rejection scenarios (null is fine for ordinary steps)
+ *  - observe(): project implementation state onto the spec's logical-state shape
+ *    (enum = name string, Option = null|value, Seq = List, Map = Map with string
+ *     keys, struct = Map)
+ */
+interface Adapter {
+    fun reset()
+    fun step(action: String, params: Map<String, Any?>): StepResult?
+    fun observe(): Map<String, Any?>
+}
+
+// Wire your implementation here. Return your adapter instead of null.
+fun makeAdapter(): Adapter? = null
+
+// Assert only the fields the spec mentions; recurse into nested (Map/struct)
+// shapes. Kotlin's `==` is deep on List/Map and discriminates Int from Double, so
+// leaf assertEquals does the right thing.
+fun assertPartial(observed: Map<String, Any?>, expected: Map<String, Any?>) {
+    for ((key, value) in expected) {
+        assertTrue(observed.containsKey(key), "missing state key $key")
+        val seen = observed[key]
+        if (value is Map<*, *> && seen is Map<*, *>) {
+            @Suppress("UNCHECKED_CAST")
+            assertPartial(seen as Map<String, Any?>, value as Map<String, Any?>)
+        } else {
+            assertEquals(value, seen, "state $key")
+        }
+    }
+}
+
+fun assertRejected(result: StepResult?, expectedKind: String?) {
+    assertNotNull(result, "forbidden step must return a StepResult")
+    assertFalse(result.ok)
+    if (expectedKind != null) {
+        assertEquals(expectedKind, result.kind)
+    }
+}
+'''
+
+
+def _kotlin_scenario_block(scen, seen_names):
+    name = scen["name"]
+    func = _unique_ident(name, seen_names, "scenario_")
+    lines = [
+        f"    @Test fun {func}() {{",
+        "        val a = makeAdapter() ?: return",
+        "        a.reset()",
+    ]
+    steps = scen.get("steps", [])
+    expected_states = scen.get("expected_states", [])
+    for i, step in enumerate(steps):
+        lines.append(
+            f"        a.step({_kotlin_string(step['action'])}, {_kotlin_literal(step['params'])})")
+        exp = expected_states[i] if i < len(expected_states) else {}
+        lines.append(f"        assertPartial(a.observe(), {_kotlin_literal(exp)})")
+    if scen.get("kind") == "forbidden" and scen.get("forbidden_step"):
+        forbidden_step = scen["forbidden_step"]
+        rejected_by = scen.get("rejected_by")
+        rejected = _kotlin_string(rejected_by) if rejected_by is not None else "null"
+        lines.append(
+            f"        val result = a.step({_kotlin_string(forbidden_step['action'])}, "
+            f"{_kotlin_literal(forbidden_step['params'])})")
+        lines.append(f"        assertRejected(result, {rejected})")
+    lines.append("    }")
+    return "\n".join(lines)
+
+
+def emit_kotlin(collected, spec_path, output_path=None):
+    spec = collected["spec"]
+    spec_name = collected["spec_name"]
+    scenario_data = collected["scenarios"]
+    walk = _bake_random_walk(spec)
+
+    body = [_KOTLIN_PREAMBLE.replace("__SOURCE__", Path(spec_path).name)]
+
+    class_lines = [f"class {spec_name}ConformanceTest {{"]
+    seen_names = {}
+    for scen in scenario_data:
+        class_lines.append("")
+        class_lines.append(_kotlin_scenario_block(scen, seen_names))
+
+    walk_type = "List<Triple<String, Map<String, Any?>, Map<String, Any?>>>"
+    if walk["steps"]:
+        walk_rows = ",\n".join(
+            f"            Triple({_kotlin_string(s['action'])}, "
+            f"{_kotlin_literal(s['params'])}, "
+            f"{_kotlin_literal(s['expected'])})"
+            for s in walk["steps"]
+        )
+        walk_literal = "listOf(\n" + walk_rows + ",\n        )"
+    else:
+        walk_literal = "listOf<Triple<String, Map<String, Any?>, Map<String, Any?>>>()"
+    class_lines.extend([
+        "",
+        "    @Test fun randomWalkConformance() {",
+        "        // random-walk conformance (baked oracle trace)",
+        "        val a = makeAdapter() ?: return",
+        "        a.reset()",
+        f"        val initial: Map<String, Any?> = {_kotlin_literal(walk['initial'])}",
+        "        assertPartial(a.observe(), initial)",
+        f"        val walk: {walk_type} = {walk_literal}",
+        "        for ((action, params, expected) in walk) {",
+        "            a.step(action, params)",
+        "            assertPartial(a.observe(), expected)",
+        "        }",
+        "    }",
+        "}",
+    ])
+    body.append("\n".join(class_lines))
+
+    return "\n\n".join(body) + "\n"
+
+
+# --------------------------------------------------------------------------
 # emitter dispatch + public API
 # --------------------------------------------------------------------------
 _EMITTERS = {
     "pytest": emit_pytest,
     "vitest": emit_vitest,
     "swift": emit_swift,
+    "kotlin": emit_kotlin,
 }
 
 # How each target names its default output file. Conventions diverge (prefix vs
@@ -649,6 +850,7 @@ _TARGET_OUTPUT_NAME = {
     "pytest": lambda name, module: f"test_{module}.py",
     "vitest": lambda name, module: f"{module}.test.ts",
     "swift": lambda name, module: f"{name}ConformanceTests.swift",
+    "kotlin": lambda name, module: f"{name}ConformanceTest.kt",
 }
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -625,6 +625,97 @@ def test_testgen_swift_output_name_and_target(tmp_path):
     assert "import Testing" in written
 
 
+# --------------------------------------------------------------------------
+# testgen --target kotlin (issue #45)
+# --------------------------------------------------------------------------
+# No compiler gate: kotlinc has no dependency-free parse-only mode (a real
+# compile needs kotlin-test on the classpath), unlike swiftc -parse / node
+# --check. We assert on harness shape and the baked walk instead.
+def test_testgen_kotlin_emits_kotlin_test_harness():
+    content = generate_test_file(str(SPECS / "cart_v1.fsl"), depth=8, target="kotlin")
+
+    # kotlin.test harness shape.
+    assert content.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import kotlin.test.Test" in content
+    assert "data class StepResult(val ok: Boolean, val kind: String? = null)" in content
+    assert "interface Adapter {" in content
+    assert "fun makeAdapter(): Adapter? = null" in content
+    assert "fun assertPartial(" in content
+    assert "fun assertRejected(" in content
+    assert "class ShoppingCartConformanceTest {" in content
+
+    # Scenarios -> @Test funcs; assert on stable names/shape (witness params vary).
+    assert "@Test fun scenario_reach_SoldOut() {" in content
+    assert "@Test fun scenario_cover_add_to_cart() {" in content
+    assert "val a = makeAdapter() ?: return" in content
+    assert 'a.step("add_to_cart"' in content
+    assert "assertPartial(a.observe()," in content
+
+    # Acceptance: random walk baked, no fslc/Python at runtime. The only imports
+    # are kotlin.test.* (no fslc/runtime), so nothing is shelled out.
+    assert "@Test fun randomWalkConformance() {" in content
+    assert "baked oracle trace" in content
+    assert ("val walk: List<Triple<String, Map<String, Any?>, Map<String, Any?>>> = listOf("
+            in content)
+    import_lines = [ln for ln in content.splitlines() if ln.lstrip().startswith("import ")]
+    assert import_lines and all(ln.startswith("import kotlin.test.") for ln in import_lines)
+
+    # Option None bakes as Kotlin null; Map keys as strings.
+    assert '"cart" to mapOf("0" to null' in content
+
+    walk_actions = re.findall(r'Triple\("(\w+)"', content)
+    assert walk_actions, "cart_v1 should bake a non-empty random walk"
+    assert set(walk_actions) <= {"add_to_cart", "remove_from_cart", "checkout"}
+
+
+def test_testgen_kotlin_forbidden_rejection(tmp_path):
+    src = """
+requirements ForbiddenKotlin {
+  type OrderId = 0..1
+  enum OSt { Cart, Paid, Shipped, Cancelled }
+  state { order: Map<OrderId, OSt> }
+  init { forall o: OrderId { order[o] = Cart } }
+  action pay(o: OrderId) { requires order[o] == Cart order[o] = Paid }
+  action ship(o: OrderId) { requires order[o] == Paid order[o] = Shipped }
+  action cancel(o: OrderId) { requires order[o] == Paid order[o] = Cancelled }
+  forbidden FB-1 "shipped order cannot be cancelled" {
+    pay(0)
+    ship(0)
+    cancel(0)
+    expect rejected
+  }
+}
+"""
+    path = tmp_path / "forbidden_kotlin.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    content = generate_test_file(str(path), depth=4, target="kotlin")
+
+    assert "class ForbiddenKotlinConformanceTest {" in content
+    assert "@Test fun scenario_forbidden_FB_1() {" in content
+    assert 'val result = a.step("cancel", mapOf("o" to 0))' in content
+    assert 'assertRejected(result, "requires_failed")' in content
+    # Enum values baked as member-name strings; Map keys as strings.
+    assert ('assertPartial(a.observe(), mapOf("order" to mapOf("0" to "Paid", "1" to "Cart")))'
+            in content)
+
+
+def test_testgen_kotlin_output_name_and_target(tmp_path):
+    spec = str(SPECS / "cart_v1.fsl")
+    assert default_output_name(spec, target="kotlin") == "ShoppingCartConformanceTest.kt"
+    assert default_output_name(spec, target="swift") == "ShoppingCartConformanceTests.swift"
+    assert default_output_name(spec, target="pytest") == "test_shoppingCart.py"
+
+    out = tmp_path / "Cart.kt"
+    result = run_testgen(spec, output=str(out), target="kotlin")
+    assert result["result"] == "generated"
+    assert result["target"] == "kotlin"
+    assert result["output"] == str(out)
+    written = out.read_text(encoding="utf-8")
+    assert written.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import kotlin.test.Test" in written
+
+
 def test_enabled_matches_guarded_instances():
     mon = Monitor(str(SPECS / "cart_v1.fsl"))
     mon.reset()


### PR DESCRIPTION
Closes #45. **Stacked on #51 (#44 Swift)** — review/merge that first; GitHub will retarget this PR to `main` once #51 lands.

Adds **kotlin.test** as the fourth `fslc testgen` harness. `emit_kotlin` reuses the language-independent scenario core and the shared `_bake_random_walk`.

## What it emits

A self-contained kotlin.test file (multiplatform; the JVM delegates to JUnit) with the same `reset`/`step`/`observe` `Adapter` contract:

- **Deterministic & forbidden scenarios** translate directly (`assertPartial` / `assertRejected`).
- **Random walk** is **baked at generation time** as a `List<Triple<String, Map<String, Any?>, Map<String, Any?>>>`, so the file needs **no `fslc`/Python at runtime**.

## Kotlin-specific design

- **Framework: kotlin.test** (over JUnit5 / Kotest) — multiplatform and lightest dependency; imports fixed to `kotlin.test.{Test, assertEquals, assertFalse, assertNotNull, assertTrue}`. *(This resolves the issue's open question on which framework to default to.)*
- Dynamic state is `Map<String, Any?>`. Kotlin's structural `==` is already deep on `List`/`Map` and distinguishes boxed `Int` from `Double`, so the partial-match helper is a plain recursion.
- **Skip-when-unwired**: kotlin.test has no portable runtime skip, so `makeAdapter(): Adapter?` returns `null` until wired and each `@Test` starts `val a = makeAdapter() ?: return` (an unwired suite no-ops rather than fails). This is the one framework-forced divergence from the other targets' "reported as skipped".
- `_kotlin_literal` escapes `$` (Kotlin string templates) and keeps `Int`/`Double` distinct.

Output defaults to `<SpecName>ConformanceTest.kt`.

## Acceptance criteria

- [x] `fslc testgen <spec> --target kotlin -o FooConformanceTest.kt` emits Kotlin tests
- [x] Deterministic / forbidden scenarios expressed (partial-match + rejection asserts)
- [x] Framework chosen (kotlin.test) and imports fixed
- [x] random-walk baked, no `fslc` at runtime
- [x] `docs/LANGUAGE.md` + `skills/fsl/reference.md` (and `docs/DESIGN-bridge.md` §3.3) updated
- [x] Regression tests on sample specs; corpus snapshot confirmed unaffected

## Verification

- `pytest tests/test_runtime.py -k testgen` → 13 passed (3 new Kotlin tests).
- No compiler gate for Kotlin: `kotlinc` has no dependency-free parse-only mode (a real compile needs kotlin-test on the classpath), so the tests assert on harness shape + the baked walk. The output was hand-reviewed for syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)