### PR TITLE
feat(testgen): Dart (package:test) target (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc testgen --target dart`: a `package:test` emitter (also runs under
+  `flutter test`), the fifth harness on the pluggable emitter from #43. Same
+  `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Dynamic
+  state is `Map<String, dynamic>`; Dart's `==` is reference-based on collections, so
+  the bundled `assertPartial` recurses by the expected keys and compares leaves with
+  the `equals` matcher (re-exported by `package:test`, keeping the generated file's
+  only dependency `package:test`). `package:test`'s `skip:` is static, so a top-level
+  probe runs once in `main()` and conditionally skips every `test()` until
+  `makeAdapter()` is wired. Strings escape `$` (interpolation). Output defaults to
+  `<spec_name>_conformance_test.dart` (snake_case). Docs: `docs/LANGUAGE.md` §12,
+  `skills/fsl/reference.md` §9, `docs/DESIGN-bridge.md` §3.4. (#46)
 - `fslc testgen --target kotlin`: a kotlin.test emitter (multiplatform; the JVM
   delegates to JUnit), the fourth harness on the pluggable emitter from #43. Same
   `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Dynamic

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -124,7 +124,7 @@ exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 
 ```
-fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
+fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
 ```
 
 The scenario-collection core (`scenarios()`) is language independent, so `testgen.py`
@@ -240,6 +240,31 @@ again reusing the baked walk. The choices:
 (No `swiftc -parse`-style syntax gate in tests: kotlinc has no dependency-free
 parse-only mode — a real compile needs kotlin-test on the classpath — so the Kotlin
 tests assert on harness shape and the baked walk instead.)
+
+### 3.4 `--target dart` (package:test)
+
+The Dart emitter renders the same scenarios to a self-contained `package:test` file
+(which also runs under `flutter test`), reusing the baked walk. The choices:
+
+- **Equality is the catch.** `params`/`observe()` are `Map<String, dynamic>`, and
+  Dart's `==` is *reference* equality on `List`/`Map`, not structural. Rather than
+  pull in `package:collection`'s `DeepCollectionEquality`, `assertPartial` recurses
+  by the expected keys and compares leaves/sequences with the `equals` matcher, which
+  *is* deep and is re-exported by `package:test` — so the generated file's only
+  dependency stays `package:test`.
+- **int/float.** Unlike PHP, Dart treats `1 == 1.0` as true, so `_dart_literal`
+  renders the right syntax (`1` vs `1.0`) but the values compare equal — this is Dart
+  semantics, not a fidelity gap.
+- **Skip-when-unwired.** `package:test`'s `skip:` argument is static, so a top-level
+  `_adapterWired()` probe runs once in `main()` and every `test(..., skip: wired ?
+  null : 'Adapter not wired')` is conditionally skipped until an adapter is connected.
+- **Literals.** Strings are single-quoted with `$` escaped (interpolation); empty
+  collections carry explicit type args (`<String, dynamic>{}`); the baked walk is a
+  `List<Map<String, dynamic>>` of `{action, params, expected}`. Output defaults to
+  `<spec_name>_conformance_test.dart` (snake_case + the runner's `_test.dart` suffix).
+
+(No syntax gate in tests: `dart analyze` needs a pub package context, so there is no
+clean dependency-free parse-only mode — the Dart tests assert on shape + baked walk.)
 
 ## 4. CLI / public API
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -265,7 +265,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
-fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o out]  # implementation-conformance test scaffold (§12)
+fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
@@ -693,7 +693,7 @@ implementation (see `DESIGN-bridge.md`).
 |---|---|
 | `fslc.runtime.Monitor` | A concrete interpreter of the spec (no Z3 needed). Embed it in the implementation for runtime checking |
 | `fslc replay` | Check a real system's event-log JSON against the spec |
-| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), Swift Testing (`--target swift`), or kotlin.test (`--target kotlin`) (wire the implementation into the Adapter) |
+| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), Swift Testing (`--target swift`), kotlin.test (`--target kotlin`), or Dart `package:test` (`--target dart`) (wire the implementation into the Adapter) |
 
 Recommended workflow: **`verify` / `prove` the spec → generate the scaffold with
 `testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
@@ -723,6 +723,14 @@ from per-target emitters, so the same scenarios render to multiple harnesses:
   recursion. kotlin.test has no portable runtime skip, so until `makeAdapter()`
   is wired (it returns `null`) each test returns early. Output defaults to
   `<SpecName>ConformanceTest.kt`.
+- `--target dart`: emits a self-contained `package:test` file (also runs under
+  `flutter test`). Same baked-walk design. Dynamic state is `Map<String, dynamic>`;
+  Dart's `==` is reference-based on collections, so the bundled `assertPartial`
+  recurses by the expected keys and compares leaves/sequences with the `equals`
+  matcher (re-exported by `package:test`, so the only dependency is `package:test`).
+  A top-level probe sets `skip:` on each `test()` until `makeAdapter()` is wired.
+  Output defaults to `<spec_name>_conformance_test.dart` (snake_case, the
+  `_test.dart` suffix the runner expects).
 
 ```python
 from fslc import Monitor
@@ -738,6 +746,7 @@ fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default);
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
 fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self-contained kotlin.test scaffold
+fslc testgen specs/cart_v1.fsl --target dart -o cart_conformance_test.dart  # self-contained package:test scaffold
 ```
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -259,7 +259,7 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
-fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test)
+fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -429,6 +429,13 @@ emit the same scenarios:
   `Int`/`Double`, so the partial-match helper is a plain recursion. No portable
   runtime skip, so an unwired `makeAdapter()` returns `null` and each test
   returns early. Output defaults to `<SpecName>ConformanceTest.kt`.
+- `dart`: a self-contained `package:test` file (also runs under `flutter test`),
+  same `Adapter` contract and same baked walk. Dynamic state is
+  `Map<String, dynamic>`; Dart's `==` is reference-based on collections, so
+  `assertPartial` recurses by the expected keys and compares leaves with the
+  `equals` matcher (the only dependency stays `package:test`). A top-level probe
+  sets `skip:` on each `test()` until `makeAdapter()` is wired. Output defaults
+  to `<spec_name>_conformance_test.dart`.
 
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -681,8 +681,8 @@ def _build_arg_parser():
     tg.add_argument("file")
     tg.add_argument("--depth", type=int, default=8)
     tg.add_argument("-o", "--output", default=None)
-    tg.add_argument("--target", choices=["pytest", "vitest", "swift", "kotlin"], default="pytest",
-                    help="test harness to emit (default: pytest)")
+    tg.add_argument("--target", choices=["pytest", "vitest", "swift", "kotlin", "dart"],
+                    default="pytest", help="test harness to emit (default: pytest)")
     tg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     tg.add_argument("--strict", action="store_true")
 

--- a/src/fslc/testgen.py
+++ b/src/fslc/testgen.py
@@ -34,6 +34,15 @@ def _module_name(spec_name):
     return spec_name[0].lower() + spec_name[1:] if spec_name else "spec"
 
 
+def _snake_case(spec_name):
+    """PascalCase/camelCase -> snake_case (e.g. ShoppingCart -> shopping_cart)."""
+    if not spec_name:
+        return "spec"
+    s = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", spec_name)
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s)
+    return s.lower()
+
+
 def _collect_scenarios(spec_path, depth=8, deadlock_mode="warn", strict=False):
     """Parse, build, and run ``scenarios`` once; the result feeds every emitter."""
     path = Path(spec_path)
@@ -834,6 +843,216 @@ def emit_kotlin(collected, spec_path, output_path=None):
 
 
 # --------------------------------------------------------------------------
+# Dart emitter (package:test — also runs under `flutter test`)
+# --------------------------------------------------------------------------
+def _dart_string(s):
+    """Render a Python str as a Dart single-quoted string literal. Dart needs
+    ``$`` escaped (string interpolation) and uses ``\\u{XX}``."""
+    out = ["'"]
+    for ch in s:
+        if ch == "'":
+            out.append("\\'")
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "$":
+            out.append("\\$")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ord(ch) < 0x20:
+            out.append(f"\\u{{{ord(ch):x}}}")
+        else:
+            out.append(ch)
+    out.append("'")
+    return "".join(out)
+
+
+def _dart_literal(obj):
+    """Render a JSON-serialisable scenario value as a Dart literal in the
+    ``Map<String, dynamic>`` world. None -> null; int -> int, float -> double
+    (Dart's ``==`` treats ``1 == 1.0`` as true, so they compare equal — this is
+    language semantics, not a bug); list/map literals (empty ones carry explicit
+    type args). bool is checked before int (``True`` is an ``int`` in Python)."""
+    if obj is None:
+        return "null"
+    if obj is True:
+        return "true"
+    if obj is False:
+        return "false"
+    if isinstance(obj, str):
+        return _dart_string(obj)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        s = repr(obj)
+        if not any(c in s for c in ".eEnN"):
+            s += ".0"
+        return s
+    if isinstance(obj, list):
+        if not obj:
+            return "<dynamic>[]"
+        return "[" + ", ".join(_dart_literal(x) for x in obj) + "]"
+    if isinstance(obj, dict):
+        if not obj:
+            return "<String, dynamic>{}"
+        items = ", ".join(
+            f"{_dart_string(str(k))}: {_dart_literal(v)}" for k, v in obj.items())
+        return "{" + items + "}"
+    raise TypeError(f"cannot render {type(obj).__name__} as a Dart literal")
+
+
+_DART_PREAMBLE = '''\
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auto-generated FSL conformance tests (package:test).
+// Source: __SOURCE__
+//
+// Wire `makeAdapter()` to your implementation. Until it is wired every test is
+// skipped (a top-level probe sets `skip:` on each test), mirroring the other
+// targets' skip-when-unwired behaviour.
+//
+// The random-walk trace below was baked at generation time by the FSL Monitor
+// (the spec's concrete interpreter) under a fixed seed, so these tests need no
+// `fslc`/Python at runtime — they replay the baked oracle states and assert.
+import 'package:test/test.dart';
+
+class StepResult {
+  final bool ok;
+  final String? kind;
+  StepResult(this.ok, [this.kind]);
+}
+
+/// Connect your implementation to the spec actions/state.
+///  - reset(): put the implementation in the same initial state as spec `init`
+///  - step(action, params): drive one spec action; return a StepResult for
+///    forbidden-rejection scenarios (null is fine for ordinary steps)
+///  - observe(): project implementation state onto the spec's logical-state shape
+///    (enum = name string, Option = null|value, Seq = List, Map = Map with string
+///     keys, struct = Map)
+abstract class Adapter {
+  void reset();
+  StepResult? step(String action, Map<String, dynamic> params);
+  Map<String, dynamic> observe();
+}
+
+// Wire your implementation here. Return your adapter instead of throwing.
+Adapter makeAdapter() =>
+    throw UnimplementedError('wire your implementation: implement makeAdapter()');
+
+bool _adapterWired() {
+  try {
+    final a = makeAdapter();
+    a.reset();
+    a.observe();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Assert only the fields the spec mentions; recurse into nested (Map/struct)
+// shapes. `equals` (from package:test's matcher) is deep on List/Map, so leaves
+// and sequences are compared structurally with the generated file depending only
+// on package:test.
+void assertPartial(Map<String, dynamic> observed, Map<String, dynamic> expected) {
+  expected.forEach((key, value) {
+    expect(observed.containsKey(key), isTrue, reason: 'missing state key $key');
+    final seen = observed[key];
+    if (value is Map && seen is Map) {
+      assertPartial(
+        Map<String, dynamic>.from(seen),
+        Map<String, dynamic>.from(value),
+      );
+    } else {
+      expect(seen, equals(value), reason: 'state $key');
+    }
+  });
+}
+
+void assertRejected(StepResult? result, String? expectedKind) {
+  expect(result, isNotNull, reason: 'forbidden step must return a StepResult');
+  expect(result!.ok, isFalse);
+  if (expectedKind != null) {
+    expect(result.kind, equals(expectedKind));
+  }
+}
+'''
+
+
+def _dart_scenario_block(scen):
+    name = scen["name"]
+    lines = [
+        f"  test({_dart_string('scenario: ' + name)}, () {{",
+        "    final a = makeAdapter();",
+        "    a.reset();",
+    ]
+    steps = scen.get("steps", [])
+    expected_states = scen.get("expected_states", [])
+    for i, step in enumerate(steps):
+        lines.append(
+            f"    a.step({_dart_string(step['action'])}, {_dart_literal(step['params'])});")
+        exp = expected_states[i] if i < len(expected_states) else {}
+        lines.append(f"    assertPartial(a.observe(), {_dart_literal(exp)});")
+    if scen.get("kind") == "forbidden" and scen.get("forbidden_step"):
+        forbidden_step = scen["forbidden_step"]
+        rejected_by = scen.get("rejected_by")
+        rejected = _dart_string(rejected_by) if rejected_by is not None else "null"
+        lines.append(
+            f"    final result = a.step({_dart_string(forbidden_step['action'])}, "
+            f"{_dart_literal(forbidden_step['params'])});")
+        lines.append(f"    assertRejected(result, {rejected});")
+    lines.append("  }, skip: wired ? null : 'Adapter not wired');")
+    return "\n".join(lines)
+
+
+def emit_dart(collected, spec_path, output_path=None):
+    spec = collected["spec"]
+    scenario_data = collected["scenarios"]
+    walk = _bake_random_walk(spec)
+
+    parts = [_DART_PREAMBLE.replace("__SOURCE__", Path(spec_path).name)]
+
+    main_lines = ["void main() {", "  final wired = _adapterWired();"]
+    for scen in scenario_data:
+        main_lines.append("")
+        main_lines.append(_dart_scenario_block(scen))
+
+    if walk["steps"]:
+        walk_rows = ",\n".join(
+            "      {"
+            f"'action': {_dart_string(s['action'])}, "
+            f"'params': {_dart_literal(s['params'])}, "
+            f"'expected': {_dart_literal(s['expected'])}"
+            "}"
+            for s in walk["steps"]
+        )
+        walk_literal = "<Map<String, dynamic>>[\n" + walk_rows + ",\n    ]"
+    else:
+        walk_literal = "<Map<String, dynamic>>[]"
+    main_lines.extend([
+        "",
+        "  test('random-walk conformance (baked oracle trace)', () {",
+        "    final a = makeAdapter();",
+        "    a.reset();",
+        f"    final initial = {_dart_literal(walk['initial'])};",
+        "    assertPartial(a.observe(), Map<String, dynamic>.from(initial));",
+        f"    final walk = {walk_literal};",
+        "    for (final step in walk) {",
+        "      a.step(step['action'] as String, step['params'] as Map<String, dynamic>);",
+        "      assertPartial(a.observe(), step['expected'] as Map<String, dynamic>);",
+        "    }",
+        "  }, skip: wired ? null : 'Adapter not wired');",
+        "}",
+    ])
+    parts.append("\n".join(main_lines))
+
+    return "\n\n".join(parts) + "\n"
+
+
+# --------------------------------------------------------------------------
 # emitter dispatch + public API
 # --------------------------------------------------------------------------
 _EMITTERS = {
@@ -841,6 +1060,7 @@ _EMITTERS = {
     "vitest": emit_vitest,
     "swift": emit_swift,
     "kotlin": emit_kotlin,
+    "dart": emit_dart,
 }
 
 # How each target names its default output file. Conventions diverge (prefix vs
@@ -851,6 +1071,7 @@ _TARGET_OUTPUT_NAME = {
     "vitest": lambda name, module: f"{module}.test.ts",
     "swift": lambda name, module: f"{name}ConformanceTests.swift",
     "kotlin": lambda name, module: f"{name}ConformanceTest.kt",
+    "dart": lambda name, module: f"{_snake_case(name)}_conformance_test.dart",
 }
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -716,6 +716,97 @@ def test_testgen_kotlin_output_name_and_target(tmp_path):
     assert "import kotlin.test.Test" in written
 
 
+# --------------------------------------------------------------------------
+# testgen --target dart (issue #46)
+# --------------------------------------------------------------------------
+# No compiler gate: `dart analyze` needs a pub package context (package:test
+# resolved), so there is no clean dependency-free parse-only mode like swiftc
+# -parse / node --check. We assert on harness shape and the baked walk.
+def test_testgen_dart_emits_package_test_harness():
+    content = generate_test_file(str(SPECS / "cart_v1.fsl"), depth=8, target="dart")
+
+    # package:test harness shape.
+    assert content.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import 'package:test/test.dart';" in content
+    assert "class StepResult {" in content
+    assert "abstract class Adapter {" in content
+    assert "Adapter makeAdapter() =>" in content
+    assert "void assertPartial(" in content
+    assert "void assertRejected(" in content
+    assert "void main() {" in content
+    assert "final wired = _adapterWired();" in content
+
+    # Scenarios -> test(...) blocks; assert on stable names/shape.
+    assert "test('scenario: reach_SoldOut', () {" in content
+    assert "test('scenario: cover_add_to_cart', () {" in content
+    assert "final a = makeAdapter();" in content
+    assert "a.step('add_to_cart'," in content
+    assert "assertPartial(a.observe()," in content
+    # Skip-when-unwired: every test carries the conditional skip.
+    assert "}, skip: wired ? null : 'Adapter not wired');" in content
+
+    # Acceptance: random walk baked, no fslc/Python at runtime. The only import is
+    # package:test; nothing is shelled out.
+    assert "test('random-walk conformance (baked oracle trace)', () {" in content
+    assert "final walk = <Map<String, dynamic>>[" in content
+    import_lines = [ln for ln in content.splitlines() if ln.lstrip().startswith("import ")]
+    assert import_lines == ["import 'package:test/test.dart';"]
+
+    # Option None bakes as Dart null; Map keys as strings.
+    assert "'cart': {'0': null" in content
+
+    walk_actions = re.findall(r"'action': '(\w+)'", content)
+    assert walk_actions, "cart_v1 should bake a non-empty random walk"
+    assert set(walk_actions) <= {"add_to_cart", "remove_from_cart", "checkout"}
+
+
+def test_testgen_dart_forbidden_rejection(tmp_path):
+    src = """
+requirements ForbiddenDart {
+  type OrderId = 0..1
+  enum OSt { Cart, Paid, Shipped, Cancelled }
+  state { order: Map<OrderId, OSt> }
+  init { forall o: OrderId { order[o] = Cart } }
+  action pay(o: OrderId) { requires order[o] == Cart order[o] = Paid }
+  action ship(o: OrderId) { requires order[o] == Paid order[o] = Shipped }
+  action cancel(o: OrderId) { requires order[o] == Paid order[o] = Cancelled }
+  forbidden FB-1 "shipped order cannot be cancelled" {
+    pay(0)
+    ship(0)
+    cancel(0)
+    expect rejected
+  }
+}
+"""
+    path = tmp_path / "forbidden_dart.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    content = generate_test_file(str(path), depth=4, target="dart")
+
+    assert "test('scenario: forbidden_FB-1', () {" in content
+    assert "final result = a.step('cancel', {'o': 0});" in content
+    assert "assertRejected(result, 'requires_failed');" in content
+    # Enum values baked as member-name strings; Map keys as strings.
+    assert "assertPartial(a.observe(), {'order': {'0': 'Paid', '1': 'Cart'}});" in content
+
+
+def test_testgen_dart_output_name_and_target(tmp_path):
+    spec = str(SPECS / "cart_v1.fsl")
+    # ShoppingCart -> shopping_cart_conformance_test.dart (snake_case + _test.dart).
+    assert default_output_name(spec, target="dart") == "shopping_cart_conformance_test.dart"
+    assert default_output_name(spec, target="kotlin") == "ShoppingCartConformanceTest.kt"
+    assert default_output_name(spec, target="pytest") == "test_shoppingCart.py"
+
+    out = tmp_path / "cart_test.dart"
+    result = run_testgen(spec, output=str(out), target="dart")
+    assert result["result"] == "generated"
+    assert result["target"] == "dart"
+    assert result["output"] == str(out)
+    written = out.read_text(encoding="utf-8")
+    assert written.startswith("// SPDX-License-Identifier: Apache-2.0")
+    assert "import 'package:test/test.dart';" in written
+
+
 def test_enabled_matches_guarded_instances():
     mon = Monitor(str(SPECS / "cart_v1.fsl"))
     mon.reset()


### PR DESCRIPTION
Closes #46. **Stacked on #52 (#45 Kotlin) → #51 (#44 Swift)** — review/merge those first; GitHub retargets this PR up the chain as each base lands.

Adds **Dart `package:test`** as the fifth `fslc testgen` harness (also runs under `flutter test`). `emit_dart` reuses the language-independent scenario core and the shared `_bake_random_walk`.

## What it emits

A self-contained `package:test` file with the same `reset`/`step`/`observe` `Adapter` contract:

- **Deterministic & forbidden scenarios** translate directly (`assertPartial` / `assertRejected`).
- **Random walk** is **baked at generation time** as a `List<Map<String, dynamic>>` of `{action, params, expected}`, so the file needs **no `fslc`/Python at runtime**.

## Dart-specific design

- **Equality is the catch**: Dart's `==` is *reference* equality on `List`/`Map`, not structural. Rather than depend on `package:collection`'s `DeepCollectionEquality`, `assertPartial` recurses by the expected keys and compares leaves/sequences with the `equals` matcher — which *is* deep and is re-exported by `package:test`, so the generated file's **only dependency stays `package:test`** (matches the issue's "自前ヘルパ推奨" intent).
- **int/float**: unlike PHP, Dart treats `1 == 1.0` as true, so `_dart_literal` renders the right syntax (`1` vs `1.0`) but values compare equal — Dart language semantics, not a fidelity gap (documented).
- **Skip-when-unwired**: `package:test`'s `skip:` is static, so a top-level `_adapterWired()` probe runs once in `main()` and conditionally skips every `test()` until `makeAdapter()` is wired.
- `_dart_literal` single-quotes strings with `$` escaped (interpolation).

Output defaults to `<spec_name>_conformance_test.dart` (snake_case, via a new `_snake_case` helper).

## Acceptance criteria

- [x] `fslc testgen <spec> --target dart -o foo_conformance_test.dart` emits Dart tests
- [x] Deterministic / forbidden scenarios expressed (partial-match + rejection asserts)
- [x] Deep partial-match helper bundled; generated dependency is `package:test` only
- [x] random-walk baked, no `fslc` at runtime
- [x] `docs/LANGUAGE.md` + `skills/fsl/reference.md` (and `docs/DESIGN-bridge.md` §3.4) updated
- [x] Regression tests on sample specs; corpus snapshot confirmed unaffected

## Verification

- `pytest tests/test_runtime.py -k testgen` → 16 passed (3 new Dart tests).
- No compiler gate for Dart: `dart analyze` needs a pub package context (no clean dependency-free parse-only mode), so the tests assert on harness shape + the baked walk. Output was hand-reviewed for syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)