### PR TITLE
feat(testgen): PHPUnit target (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc testgen --target phpunit`: a PHPUnit emitter (PHP 8.1+ / PHPUnit 10+,
+  `declare(strict_types=1)`), the sixth harness on the pluggable emitter from #43.
+  Same `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Leaves
+  compare with `assertSame` (`===`), keeping `int`/`float`, `bool` and `null` from
+  coercing (PHP's loose `==` would conflate `0 == "0"`); `_php_literal` renders `int`
+  (`1`) distinct from `float` (`1.0`). `assertPartial` recurses by the expected keys
+  (maps match order-independently — sidestepping PHP's numeric-string-key coercion —
+  and list-shaped values also pin length). `setUp()` calls `markTestSkipped` until
+  `makeAdapter()` is wired. Output defaults to `<SpecName>ConformanceTest.php` (PSR-4
+  class = file name). Tests gate syntax with `php -l` (skips when php is absent).
+  Docs: `docs/LANGUAGE.md` §12, `skills/fsl/reference.md` §9,
+  `docs/DESIGN-bridge.md` §3.5. (#47)
 - `fslc testgen --target dart`: a `package:test` emitter (also runs under
   `flutter test`), the fifth harness on the pluggable emitter from #43. Same
   `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Dynamic

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -124,7 +124,7 @@ exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 
 ```
-fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
+fslc testgen <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o <out>]   # default target pytest; default file test_<spec name lowercased>.py to stdout
 ```
 
 The scenario-collection core (`scenarios()`) is language independent, so `testgen.py`
@@ -265,6 +265,35 @@ The Dart emitter renders the same scenarios to a self-contained `package:test` f
 
 (No syntax gate in tests: `dart analyze` needs a pub package context, so there is no
 clean dependency-free parse-only mode — the Dart tests assert on shape + baked walk.)
+
+### 3.5 `--target phpunit` (PHPUnit)
+
+The PHPUnit emitter targets PHP 8.1+ / PHPUnit 10+ (`declare(strict_types=1)`),
+reusing the baked walk. The choices:
+
+- **Strict leaf equality is the whole point.** PHP's loose `==` makes `0 == "0"`
+  and `1 == true` true, which is unsafe for a conformance test, so every leaf is
+  compared with `assertSame` (`===`), and `_php_literal` keeps `int` (`1`) distinct
+  from `float` (`1.0`) — `assertSame(1, 1.0)` is false.
+- **Dict vs the numeric-key trap.** `params`/`observe()` are associative `array`s,
+  but PHP coerces a numeric string key like `'0'` to int `0`, which collapses the
+  map/list distinction. `assertPartial` therefore recurses by the *expected* keys
+  (so a `Map<0..1, …>` matches by key — order-independent — and only the mentioned
+  fields are asserted) and, for a genuinely list-shaped expected (`array_is_list`),
+  also pins the length so sequences stay exact. Both sides see the same key coercion,
+  so it cancels out.
+- **Skip-when-unwired.** `makeAdapter()` throws until wired; `setUp()` probes it and
+  calls `markTestSkipped`, so the whole class is skipped (not failed) until an
+  adapter is connected — the PHPUnit analog of the pytest skip.
+- **Literals.** Strings are single-quoted (PHP single-quotes interpolate nothing;
+  only `\\`/`\'` are escaped); JSON arrays render to PHP lists, JSON objects to
+  associative arrays; the baked walk is a `private const WALK`. Output defaults to
+  `<SpecName>ConformanceTest.php` (PSR-4: class name = file name), test methods are
+  `testScenario_<name>` / `testRandomWalkConformance`.
+
+(Syntax gate in tests: `php -l` lints syntax without loading PHPUnit — a clean
+dependency-free check like swiftc -parse, so the PHP tests run it when php is present
+and skip it otherwise.)
 
 ## 4. CLI / public API
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -265,7 +265,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
-fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o out]  # implementation-conformance test scaffold (§12)
+fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
@@ -693,7 +693,7 @@ implementation (see `DESIGN-bridge.md`).
 |---|---|
 | `fslc.runtime.Monitor` | A concrete interpreter of the spec (no Z3 needed). Embed it in the implementation for runtime checking |
 | `fslc replay` | Check a real system's event-log JSON against the spec |
-| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), Swift Testing (`--target swift`), kotlin.test (`--target kotlin`), or Dart `package:test` (`--target dart`) (wire the implementation into the Adapter) |
+| `fslc testgen` | Generate a conformance-test scaffold — pytest (default), Vitest (`--target vitest`), Swift Testing (`--target swift`), kotlin.test (`--target kotlin`), Dart `package:test` (`--target dart`), or PHPUnit (`--target phpunit`) (wire the implementation into the Adapter) |
 
 Recommended workflow: **`verify` / `prove` the spec → generate the scaffold with
 `testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
@@ -731,6 +731,14 @@ from per-target emitters, so the same scenarios render to multiple harnesses:
   A top-level probe sets `skip:` on each `test()` until `makeAdapter()` is wired.
   Output defaults to `<spec_name>_conformance_test.dart` (snake_case, the
   `_test.dart` suffix the runner expects).
+- `--target phpunit`: emits a self-contained PHPUnit file (PHP 8.1+ / PHPUnit 10+,
+  `declare(strict_types=1)`). Same baked-walk design. Dynamic state is an
+  associative `array`; leaves are compared with `assertSame` (`===`), which keeps
+  `int`/`float`, `bool` and `null` from coercing (PHP's loose `==` would conflate
+  `0 == "0"` etc.). `assertPartial` recurses by the expected keys (maps match
+  order-independently; list-shaped values also pin length). `setUp()` skips every
+  test until `makeAdapter()` is wired. Output defaults to
+  `<SpecName>ConformanceTest.php` (PSR-4 class = file name).
 
 ```python
 from fslc import Monitor
@@ -747,6 +755,7 @@ fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
 fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self-contained kotlin.test scaffold
 fslc testgen specs/cart_v1.fsl --target dart -o cart_conformance_test.dart  # self-contained package:test scaffold
+fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # self-contained PHPUnit scaffold
 ```
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -259,7 +259,7 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
-fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test)
+fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test / PHPUnit)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -436,6 +436,13 @@ emit the same scenarios:
   `equals` matcher (the only dependency stays `package:test`). A top-level probe
   sets `skip:` on each `test()` until `makeAdapter()` is wired. Output defaults
   to `<spec_name>_conformance_test.dart`.
+- `phpunit`: a self-contained PHPUnit file (PHP 8.1+ / PHPUnit 10+,
+  `strict_types`), same `Adapter` contract and same baked walk. Dynamic state is
+  an associative `array`; leaves compare with `assertSame` (`===`) so int/float,
+  bool and null never coerce (loose `==` would conflate `0 == "0"`).
+  `assertPartial` recurses by the expected keys (maps order-independent; lists
+  pin length). `setUp()` skips every test until `makeAdapter()` is wired. Output
+  defaults to `<SpecName>ConformanceTest.php`.
 
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -681,7 +681,8 @@ def _build_arg_parser():
     tg.add_argument("file")
     tg.add_argument("--depth", type=int, default=8)
     tg.add_argument("-o", "--output", default=None)
-    tg.add_argument("--target", choices=["pytest", "vitest", "swift", "kotlin", "dart"],
+    tg.add_argument("--target",
+                    choices=["pytest", "vitest", "swift", "kotlin", "dart", "phpunit"],
                     default="pytest", help="test harness to emit (default: pytest)")
     tg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
     tg.add_argument("--strict", action="store_true")

--- a/src/fslc/testgen.py
+++ b/src/fslc/testgen.py
@@ -1053,6 +1053,210 @@ def emit_dart(collected, spec_path, output_path=None):
 
 
 # --------------------------------------------------------------------------
+# PHPUnit emitter (PHP 8.1+ / PHPUnit 10+)
+# --------------------------------------------------------------------------
+def _php_string(s):
+    """Render a Python str as a PHP single-quoted string literal. Single-quoted
+    PHP interpolates nothing and only recognises ``\\\\`` and ``\\'``."""
+    return "'" + s.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _php_literal(obj):
+    """Render a JSON-serialisable scenario value as a PHP literal. int and float
+    are kept distinct (``1`` vs ``1.0``) because leaves are compared with
+    ``assertSame`` (``===``), which treats them as unequal — the whole point of the
+    PHP target. JSON array -> PHP list, JSON object -> associative array (PHP
+    coerces numeric string keys like ``'0'`` to int, consistently on both sides).
+    bool is checked before int (``True`` is an ``int`` in Python)."""
+    if obj is None:
+        return "null"
+    if obj is True:
+        return "true"
+    if obj is False:
+        return "false"
+    if isinstance(obj, str):
+        return _php_string(obj)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        s = repr(obj)
+        if not any(c in s for c in ".eEnN"):
+            s += ".0"
+        return s
+    if isinstance(obj, list):
+        return "[" + ", ".join(_php_literal(x) for x in obj) + "]"
+    if isinstance(obj, dict):
+        if not obj:
+            return "[]"
+        items = ", ".join(
+            f"{_php_string(str(k))} => {_php_literal(v)}" for k, v in obj.items())
+        return "[" + items + "]"
+    raise TypeError(f"cannot render {type(obj).__name__} as a PHP literal")
+
+
+_PHP_PREAMBLE = '''\
+<?php
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auto-generated FSL conformance tests (PHPUnit, PHP 8.1+ / PHPUnit 10+).
+// Source: __SOURCE__
+//
+// Wire `makeAdapter()` to your implementation. Until it is wired, setUp() marks
+// every test skipped (mirroring the other targets' skip-when-unwired behaviour).
+//
+// The random-walk trace below was baked at generation time by the FSL Monitor
+// (the spec's concrete interpreter) under a fixed seed, so these tests need no
+// `fslc`/Python at runtime — they replay the baked oracle states and assert.
+declare(strict_types=1);
+
+use PHPUnit\\Framework\\TestCase;
+
+interface Adapter
+{
+    public function reset(): void;
+    // Return ['ok' => bool, 'kind' => ?string] for forbidden-rejection scenarios;
+    // null is fine for ordinary steps.
+    public function step(string $action, array $params): ?array;
+    public function observe(): array;
+}
+'''
+
+
+_PHP_CLASS_HELPERS = '''\
+    private ?Adapter $adapter = null;
+
+    // Wire your implementation here: return your adapter instead of throwing.
+    protected function makeAdapter(): Adapter
+    {
+        throw new \\RuntimeException('wire your implementation: implement makeAdapter()');
+    }
+
+    protected function setUp(): void
+    {
+        try {
+            $a = $this->makeAdapter();
+            $a->reset();
+            $a->observe();
+            $this->adapter = $a;
+        } catch (\\Throwable $e) {
+            $this->markTestSkipped('Adapter not wired: ' . $e->getMessage());
+        }
+    }
+
+    // Compare the spec's expected state against the observed state. Recurse into
+    // arrays by the EXPECTED keys (so maps match by key — order-independent, and
+    // only the fields the spec mentions are asserted; PHP coerces numeric string
+    // keys like '0' to int consistently on both sides). A list-shaped expected
+    // also pins the length, so sequences are exact. Leaves use assertSame (===),
+    // so int/float, bool and null never coerce — the point of the PHP target.
+    private function assertPartial(mixed $expected, mixed $observed, string $path = 'state'): void
+    {
+        if (is_array($expected) && is_array($observed)) {
+            if (array_is_list($expected)) {
+                $this->assertCount(count($expected), $observed, "length at $path");
+            }
+            foreach ($expected as $key => $value) {
+                $this->assertArrayHasKey($key, $observed, "missing $path.$key");
+                $this->assertPartial($value, $observed[$key], "$path.$key");
+            }
+        } else {
+            $this->assertSame($expected, $observed, "at $path");
+        }
+    }
+
+    private function assertRejected(?array $result, ?string $expectedKind): void
+    {
+        $this->assertIsArray($result, 'forbidden step must return a result array');
+        $this->assertFalse($result['ok']);
+        if ($expectedKind !== null) {
+            $this->assertSame($expectedKind, $result['kind']);
+        }
+    }
+'''
+
+
+def _php_scenario_block(scen, seen_names):
+    name = scen["name"]
+    method = _unique_ident(name, seen_names, "testScenario_")
+    lines = [
+        f"    public function {method}(): void",
+        "    {",
+        "        $a = $this->adapter;",
+        "        $a->reset();",
+    ]
+    steps = scen.get("steps", [])
+    expected_states = scen.get("expected_states", [])
+    for i, step in enumerate(steps):
+        lines.append(
+            f"        $a->step({_php_string(step['action'])}, {_php_literal(step['params'])});")
+        exp = expected_states[i] if i < len(expected_states) else {}
+        lines.append(f"        $this->assertPartial({_php_literal(exp)}, $a->observe());")
+    if scen.get("kind") == "forbidden" and scen.get("forbidden_step"):
+        forbidden_step = scen["forbidden_step"]
+        rejected_by = scen.get("rejected_by")
+        rejected = _php_string(rejected_by) if rejected_by is not None else "null"
+        lines.append(
+            f"        $result = $a->step({_php_string(forbidden_step['action'])}, "
+            f"{_php_literal(forbidden_step['params'])});")
+        lines.append(f"        $this->assertRejected($result, {rejected});")
+    lines.append("    }")
+    return "\n".join(lines)
+
+
+def emit_phpunit(collected, spec_path, output_path=None):
+    spec = collected["spec"]
+    spec_name = collected["spec_name"]
+    scenario_data = collected["scenarios"]
+    walk = _bake_random_walk(spec)
+
+    parts = [_PHP_PREAMBLE.replace("__SOURCE__", Path(spec_path).name)]
+
+    class_lines = [
+        f"final class {spec_name}ConformanceTest extends TestCase",
+        "{",
+        _PHP_CLASS_HELPERS.rstrip("\n"),
+    ]
+    seen_names = {}
+    for scen in scenario_data:
+        class_lines.append("")
+        class_lines.append(_php_scenario_block(scen, seen_names))
+
+    if walk["steps"]:
+        walk_rows = ",\n".join(
+            "        ["
+            f"'action' => {_php_string(s['action'])}, "
+            f"'params' => {_php_literal(s['params'])}, "
+            f"'expected' => {_php_literal(s['expected'])}"
+            "]"
+            for s in walk["steps"]
+        )
+        walk_literal = "[\n" + walk_rows + ",\n    ]"
+    else:
+        walk_literal = "[]"
+    class_lines.extend([
+        "",
+        f"    private const INITIAL = {_php_literal(walk['initial'])};",
+        f"    private const WALK = {walk_literal};",
+        "",
+        "    public function testRandomWalkConformance(): void",
+        "    {",
+        "        // random-walk conformance (baked oracle trace)",
+        "        $a = $this->adapter;",
+        "        $a->reset();",
+        "        $this->assertPartial(self::INITIAL, $a->observe());",
+        "        foreach (self::WALK as $step) {",
+        "            $a->step($step['action'], $step['params']);",
+        "            $this->assertPartial($step['expected'], $a->observe());",
+        "        }",
+        "    }",
+        "}",
+    ])
+    parts.append("\n".join(class_lines))
+
+    return "\n\n".join(parts) + "\n"
+
+
+# --------------------------------------------------------------------------
 # emitter dispatch + public API
 # --------------------------------------------------------------------------
 _EMITTERS = {
@@ -1061,6 +1265,7 @@ _EMITTERS = {
     "swift": emit_swift,
     "kotlin": emit_kotlin,
     "dart": emit_dart,
+    "phpunit": emit_phpunit,
 }
 
 # How each target names its default output file. Conventions diverge (prefix vs
@@ -1072,6 +1277,7 @@ _TARGET_OUTPUT_NAME = {
     "swift": lambda name, module: f"{name}ConformanceTests.swift",
     "kotlin": lambda name, module: f"{name}ConformanceTest.kt",
     "dart": lambda name, module: f"{_snake_case(name)}_conformance_test.dart",
+    "phpunit": lambda name, module: f"{name}ConformanceTest.php",
 }
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -807,6 +807,123 @@ def test_testgen_dart_output_name_and_target(tmp_path):
     assert "import 'package:test/test.dart';" in written
 
 
+# --------------------------------------------------------------------------
+# testgen --target phpunit (issue #47)
+# --------------------------------------------------------------------------
+def _assert_php_syntax_ok(content):
+    """Syntax-only gate via `php -l` (a lint that does NOT load PHPUnit), the PHP
+    analog of swiftc -parse / node --check. Skips when php is absent."""
+    php = shutil.which("php")
+    if php is None:
+        pytest.skip("php not available")
+    with tempfile.NamedTemporaryFile("w", suffix=".php", delete=False, encoding="utf-8") as f:
+        f.write(content)
+        path = f.name
+    try:
+        proc = subprocess.run([php, "-l", path], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_testgen_phpunit_emits_phpunit_harness():
+    content = generate_test_file(str(SPECS / "cart_v1.fsl"), depth=8, target="phpunit")
+
+    # PHPUnit harness shape.
+    assert content.startswith("<?php\n")
+    assert "// SPDX-License-Identifier: Apache-2.0" in content
+    assert "declare(strict_types=1);" in content
+    assert "use PHPUnit\\Framework\\TestCase;" in content
+    assert "interface Adapter" in content
+    assert "final class ShoppingCartConformanceTest extends TestCase" in content
+    assert "protected function makeAdapter(): Adapter" in content
+    assert "protected function setUp(): void" in content
+    assert "$this->markTestSkipped(" in content
+    assert "private function assertPartial(" in content
+    assert "private function assertRejected(" in content
+    # Strict, type-discriminating leaf comparison.
+    assert "$this->assertSame(" in content
+    assert "array_is_list(" in content
+
+    # Scenarios -> test methods; assert on stable names/shape (witness params vary).
+    assert "public function testScenario_reach_SoldOut(): void" in content
+    assert "public function testScenario_cover_add_to_cart(): void" in content
+    assert "$a = $this->adapter;" in content
+    assert "$a->step('add_to_cart'," in content
+    assert "$this->assertPartial(" in content
+    # int params render bare (not quoted) so assertSame keeps them int.
+    assert "'u' => 1" in content
+
+    # Acceptance: random walk baked, no fslc/Python at runtime. The only `use` is
+    # PHPUnit and nothing shells out / loads extra files.
+    assert "public function testRandomWalkConformance(): void" in content
+    assert "private const WALK = [" in content
+    assert "foreach (self::WALK as $step)" in content
+    assert "baked oracle trace" in content
+    use_lines = [ln for ln in content.splitlines() if ln.strip().startswith("use ")]
+    assert use_lines == ["use PHPUnit\\Framework\\TestCase;"]
+    assert "exec(" not in content and "shell_exec" not in content
+
+    # Option None bakes as PHP null; Map keys as (numeric) strings in the literal.
+    assert "'cart' => ['0' => null" in content
+
+    walk_actions = re.findall(r"'action' => '(\w+)'", content)
+    assert walk_actions, "cart_v1 should bake a non-empty random walk"
+    assert set(walk_actions) <= {"add_to_cart", "remove_from_cart", "checkout"}
+
+    _assert_php_syntax_ok(content)
+
+
+def test_testgen_phpunit_forbidden_rejection(tmp_path):
+    src = """
+requirements ForbiddenPhpUnit {
+  type OrderId = 0..1
+  enum OSt { Cart, Paid, Shipped, Cancelled }
+  state { order: Map<OrderId, OSt> }
+  init { forall o: OrderId { order[o] = Cart } }
+  action pay(o: OrderId) { requires order[o] == Cart order[o] = Paid }
+  action ship(o: OrderId) { requires order[o] == Paid order[o] = Shipped }
+  action cancel(o: OrderId) { requires order[o] == Paid order[o] = Cancelled }
+  forbidden FB-1 "shipped order cannot be cancelled" {
+    pay(0)
+    ship(0)
+    cancel(0)
+    expect rejected
+  }
+}
+"""
+    path = tmp_path / "forbidden_phpunit.fsl"
+    path.write_text(src, encoding="utf-8")
+
+    content = generate_test_file(str(path), depth=4, target="phpunit")
+
+    assert "final class ForbiddenPhpUnitConformanceTest extends TestCase" in content
+    assert "public function testScenario_forbidden_FB_1(): void" in content
+    assert "$result = $a->step('cancel', ['o' => 0]);" in content
+    assert "$this->assertRejected($result, 'requires_failed');" in content
+    # Enum values baked as member-name strings; Map keys as strings.
+    assert ("$this->assertPartial(['order' => ['0' => 'Paid', '1' => 'Cart']], $a->observe());"
+            in content)
+
+    _assert_php_syntax_ok(content)
+
+
+def test_testgen_phpunit_output_name_and_target(tmp_path):
+    spec = str(SPECS / "cart_v1.fsl")
+    assert default_output_name(spec, target="phpunit") == "ShoppingCartConformanceTest.php"
+    assert default_output_name(spec, target="dart") == "shopping_cart_conformance_test.dart"
+    assert default_output_name(spec, target="pytest") == "test_shoppingCart.py"
+
+    out = tmp_path / "Cart.php"
+    result = run_testgen(spec, output=str(out), target="phpunit")
+    assert result["result"] == "generated"
+    assert result["target"] == "phpunit"
+    assert result["output"] == str(out)
+    written = out.read_text(encoding="utf-8")
+    assert written.startswith("<?php\n")
+    assert "use PHPUnit\\Framework\\TestCase;" in written
+
+
 def test_enabled_matches_guarded_instances():
     mon = Monitor(str(SPECS / "cart_v1.fsl"))
     mon.reset()


### PR DESCRIPTION
Closes #47. **Stacked on #53 (#46 Dart) → #52 (#45 Kotlin) → #51 (#44 Swift)** — review/merge down the chain; GitHub retargets this PR up as each base lands.

Adds **PHPUnit** as the sixth `fslc testgen` harness (PHP 8.1+ / PHPUnit 10+, `declare(strict_types=1)`). `emit_phpunit` reuses the language-independent scenario core and the shared `_bake_random_walk`.

## What it emits

A self-contained PHPUnit file with the same `reset`/`step`/`observe` `Adapter` contract:

- **Deterministic & forbidden scenarios** translate directly (`assertPartial` / `assertRejected`).
- **Random walk** is **baked at generation time** as a `private const WALK`, so the file needs **no `fslc`/Python at runtime**.

## PHP-specific design

- **Strict leaf equality is the whole point**: PHP's loose `==` makes `0 == "0"` and `1 == true` true — unsafe for a conformance test. Every leaf compares with `assertSame` (`===`), and `_php_literal` keeps `int` (`1`) distinct from `float` (`1.0`).
- **The numeric-key trap**: associative arrays, but PHP coerces a numeric string key `'0'` → int `0`, collapsing the map/list distinction. `assertPartial` recurses by the *expected* keys (so a `Map<0..1, …>` matches **by key, order-independent**, asserting only mentioned fields) and pins length for genuinely list-shaped expected (`array_is_list`). The coercion cancels out (both sides see it). *(This fixes the naive `!array_is_list` switch, which would compare dense int-keyed maps whole with `assertSame` — order-sensitive, and could false-fail a correct implementation.)*
- **Skip-when-unwired**: `makeAdapter()` throws until wired; `setUp()` probes it and calls `markTestSkipped`, so the class is skipped (not failed) until an adapter connects.

Output defaults to `<SpecName>ConformanceTest.php` (PSR-4: class = file name); methods are `testScenario_<name>` / `testRandomWalkConformance`.

## Acceptance criteria

- [x] `fslc testgen <spec> --target phpunit -o FooConformanceTest.php` emits PHPUnit tests
- [x] Deterministic / forbidden scenarios expressed (partial-match + rejection asserts)
- [x] Leaves compared with `===`/`assertSame`; int/float, bool, null discriminated
- [x] Deep partial-match helper bundled; dependency is PHPUnit only
- [x] random-walk baked, no `fslc` at runtime
- [x] `docs/LANGUAGE.md` + `skills/fsl/reference.md` (and `docs/DESIGN-bridge.md` §3.5) updated
- [x] Regression tests on sample specs; corpus snapshot confirmed unaffected

## Verification

- `pytest tests/test_runtime.py` → 38 passed, 2 skipped (the 2 skipped are the `php -l` syntax gates — `php` is absent in this environment; their content assertions ran and passed first, a wrong-content failure would still fail before the gate). `php -l` lints syntax without loading PHPUnit, the same dependency-free approach as swiftc `-parse`.
- `pytest tests/test_corpus_snapshot.py` → 150 passed, 1 skipped, no diff (all six emitters leave the verifier verdicts untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)