### PR TITLE
feat(init): allow if/else in init blocks (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `init` blocks now support statement-level `if`/`else` in both the symbolic
+  verifier and concrete runtime monitor. (#55)
 - `fslc testgen --target phpunit`: a PHPUnit emitter (PHP 8.1+ / PHPUnit 10+,
   `declare(strict_types=1)`), the sixth harness on the pluggable emitter from #43.
   Same `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Leaves

--- a/docs/DESIGN-init-if.md
+++ b/docs/DESIGN-init-if.md
@@ -1,0 +1,21 @@
+# Init If Design
+
+`init` supports statement-level `if` with the same branch shape as action bodies.
+The verifier lowers it to path-conditional initial-state constraints instead of
+introducing a separate transition.
+
+For:
+
+```fsl
+init { if C { S1 } else { S2 } }
+```
+
+the BMC evaluates `C` over the initial symbolic state `s0` and the current binder
+environment. It collects constraints from the then branch and adds each as
+`Implies(C, constraint)`. If an else branch exists, it collects those constraints
+and adds each as `Implies(Not(C), constraint)`.
+
+Nested `if` and `forall ... where` compose by nesting the same implication
+wrappers. The concrete monitor mirrors this semantics by evaluating the condition
+over the current initial valuation and applying assignments from only the taken
+branch.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -183,7 +183,8 @@ variable.
 
 - Assignment: `x = expr`, `m[k] = expr`, `m[k].field = expr`, `o.field = expr`
 - Updating a Set/Seq uses the **reassignment idiom**: `s = s.add(x)`, `q = q.pop()`
-- `if expr { stmt... } else { stmt... }` (can be nested with an if inside the else)
+- `if expr { stmt... } else { stmt... }` is allowed in both `init` and action bodies
+  (can be nested with an if inside the else)
 - `forall x: T { stmt... }` (bulk initialization / bulk update)
 
 ## 5. Semantics

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -179,7 +179,8 @@ check as a type error.
 
 - Assignment: `x = e`, `m[k] = e`, `m[k].f = e`, `o.f = e`, `o.f = some(e)`
 - Set/Seq are re-assigned: `s = s.add(x)`, `q = q.pop().push(y)` (chaining allowed)
-- `if expr { stmt... } [else { stmt... }]` (may nest with an if inside else)
+- `if expr { stmt... } [else { stmt... }]` is allowed in both `init` and action
+  bodies (may nest with an if inside else)
 - `forall x: T { stmt... }` (bulk assignment)
 
 ## 5. Semantic rules

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -1215,6 +1215,25 @@ def compute_updates(stmts, state, binds, spec):
 def init_constraints(spec, s0):
     cons = []
 
+    def require_bool(term):
+        if not isinstance(term, z3.ExprRef) or term.sort().kind() != z3.Z3_BOOL_SORT:
+            _err("if condition must be Bool", kind="type")
+        return term
+
+    def append_if_constraints(cond, then_stmts, else_stmts, binds, out):
+        c0 = require_bool(eval_expr(cond, s0, binds, spec))
+        then_saved = []
+        for s2 in then_stmts:
+            run_collect(s2, binds, s0, then_saved)
+        for c in then_saved:
+            out.append(z3.Implies(c0, c))
+        if else_stmts:
+            else_saved = []
+            for s2 in else_stmts:
+                run_collect(s2, binds, s0, else_saved)
+            for c in else_saved:
+                out.append(z3.Implies(z3.Not(c0), c))
+
     def run(st, binds):
         tag = st[0]
         if tag == "assign":
@@ -1238,7 +1257,8 @@ def init_constraints(spec, s0):
                     for s2 in body:
                         run(s2, b2)
         elif tag == "if":
-            _err("if in init is not supported", kind="semantics")
+            _, cond, then_stmts, else_stmts, _ = st
+            append_if_constraints(cond, then_stmts, else_stmts, binds, cons)
 
     def run_collect(st, binds, s0, out):
         if st[0] == "assign":
@@ -1261,6 +1281,9 @@ def init_constraints(spec, s0):
                 else:
                     for s2 in body:
                         run_collect(s2, b2, s0, out)
+        elif st[0] == "if":
+            _, cond, then_stmts, else_stmts, _ = st
+            append_if_constraints(cond, then_stmts, else_stmts, binds, out)
 
     for st in spec["init"]:
         run(st, {})

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -175,12 +175,11 @@ def _collect_state_refs(expr, spec, out=None):
 
 
 def _check_deterministic_init(spec):
-    assigned = set()
-    allowed = set(spec["consts"].keys())
+    consts = set(spec["consts"].keys())
 
-    def check_rhs(rhs):
-        refs = _collect_state_refs(rhs, spec)
-        bad = refs - allowed
+    def check_expr(expr, definitely_assigned):
+        refs = _collect_state_refs(expr, spec)
+        bad = refs - (consts | definitely_assigned)
         if bad:
             _err(
                 f"init references state variable '{sorted(bad)[0]}' before it is assigned",
@@ -188,72 +187,62 @@ def _check_deterministic_init(spec):
                 hint=_INIT_HINT,
             )
 
-    def walk(stmts, in_forall=False):
+    def duplicate_assignment(logical, in_forall):
+        scope = "init forall" if in_forall else "init"
+        _err(
+            f"state variable '{logical}' assigned more than once in {scope}",
+            kind="semantics",
+            hint=_INIT_HINT,
+        )
+
+    def walk(stmts, definitely_assigned, possibly_assigned, in_forall=False):
+        definitely_assigned = set(definitely_assigned)
+        possibly_assigned = set(possibly_assigned)
         for st in stmts:
             tag = st[0]
             if tag == "assign":
                 logical = _logical_var_from_lv(st[1])
                 if logical is None:
                     _err("invalid init assignment target", kind="semantics", hint=_INIT_HINT)
-                if logical in assigned and not in_forall:
-                    _err(
-                        f"state variable '{logical}' assigned more than once in init",
-                        kind="semantics",
-                        hint=_INIT_HINT,
-                    )
-                check_rhs(st[2])
-                if not in_forall:
-                    assigned.add(logical)
-                    allowed.add(logical)
+                if logical in possibly_assigned:
+                    duplicate_assignment(logical, in_forall)
+                check_expr(st[2], definitely_assigned)
+                definitely_assigned.add(logical)
+                possibly_assigned.add(logical)
             elif tag == "forall_stmt":
                 if in_forall:
                     _err("nested forall in init is not supported", kind="semantics", hint=_INIT_HINT)
                 _, binder, body, _ = st
-                targets = []
-                for s2 in body:
-                    if s2[0] == "forall_stmt":
-                        _err("nested forall in init is not supported", kind="semantics", hint=_INIT_HINT)
-                    if s2[0] == "if":
-                        _err("if in init is not supported", kind="semantics", hint=_INIT_HINT)
-                    if s2[0] != "assign":
-                        continue
-                    logical = _logical_var_from_lv(s2[1])
-                    if logical is None:
-                        _err("invalid init assignment target", kind="semantics", hint=_INIT_HINT)
-                    if logical in assigned:
-                        _err(
-                            f"state variable '{logical}' assigned more than once in init",
-                            kind="semantics",
-                            hint=_INIT_HINT,
-                        )
-                    if logical in targets:
-                        _err(
-                            f"state variable '{logical}' assigned more than once in init forall",
-                            kind="semantics",
-                            hint=_INIT_HINT,
-                        )
-                    targets.append(logical)
-                body_allowed = set(allowed)
-                for s2 in body:
-                    if s2[0] != "assign":
-                        continue
-                    refs = _collect_state_refs(s2[2], spec)
-                    bad = refs - body_allowed
-                    if bad:
-                        _err(
-                            f"init references state variable '{sorted(bad)[0]}' before it is assigned",
-                            kind="semantics",
-                            hint=_INIT_HINT,
-                        )
-                    logical = _logical_var_from_lv(s2[1])
-                    body_allowed.add(logical)
-                for logical in targets:
-                    assigned.add(logical)
-                    allowed.add(logical)
+                if binder[0] in ("binder_typed", "binder_collection") and binder[3] is not None:
+                    check_expr(binder[3], definitely_assigned)
+                body_definite, body_possible = walk(
+                    body,
+                    definitely_assigned,
+                    possibly_assigned,
+                    in_forall=True,
+                )
+                definitely_assigned = body_definite
+                possibly_assigned = body_possible
             elif tag == "if":
-                _err("if in init is not supported", kind="semantics", hint=_INIT_HINT)
+                _, cond, then_stmts, else_stmts, _ = st
+                check_expr(cond, definitely_assigned)
+                then_definite, then_possible = walk(
+                    then_stmts,
+                    definitely_assigned,
+                    possibly_assigned,
+                    in_forall=in_forall,
+                )
+                else_definite, else_possible = walk(
+                    else_stmts,
+                    definitely_assigned,
+                    possibly_assigned,
+                    in_forall=in_forall,
+                )
+                definitely_assigned = then_definite & else_definite
+                possibly_assigned = then_possible | else_possible
+        return definitely_assigned, possibly_assigned
 
-    walk(spec["init"])
+    assigned, _ = walk(spec["init"], set(), set())
     missing = set(spec["state"]) - assigned
     if missing:
         _err(
@@ -986,7 +975,11 @@ def _exec_init(spec):
                 for s2 in body:
                     run(s2, b2)
         elif tag == "if":
-            _err("if in init is not supported", kind="semantics")
+            _, cond, then_stmts, else_stmts, _ = st
+            c = eval_concrete(cond, state, binds, spec)
+            branch = then_stmts if _as_bool(c) else else_stmts
+            for s2 in branch:
+                run(s2, binds)
 
     for st in spec["init"]:
         run(st, binds)

--- a/tests/test_init_if.py
+++ b/tests/test_init_if.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+import pytest
+
+from fslc import FslError, build_spec, parse, verify
+from fslc.runtime import Monitor
+
+
+def _verify(src, depth=2):
+    return verify(build_spec(parse(src)), depth, deadlock_mode="ignore")
+
+
+def _monitor(src):
+    return Monitor(build_spec(parse(src)))
+
+
+def test_init_if_else_picks_then_branch_in_monitor_and_verifier():
+    src = """
+spec IfInit {
+  type R = 0..3
+  state { x: R }
+  init { if true { x = 1 } else { x = 2 } }
+  action bump() { requires true  x = x }
+  invariant Chosen { x == 1 }
+}
+"""
+    mon = _monitor(src)
+
+    assert mon.reset()["x"] == 1
+    assert _verify(src)["result"] == "verified"
+
+
+def test_nested_init_if_composes_branch_conditions():
+    src = """
+spec NestedIfInit {
+  type R = 0..3
+  state { x: R }
+  init {
+    if true {
+      if false { x = 1 } else { x = 2 }
+    } else {
+      x = 3
+    }
+  }
+  action stay() { requires true  x = x }
+  invariant Chosen { x == 2 }
+}
+"""
+    mon = _monitor(src)
+
+    assert mon.reset()["x"] == 2
+    assert _verify(src)["result"] == "verified"
+
+
+def test_init_if_inside_forall_range():
+    src = """
+spec ForallIfInit {
+  type I = 0..2
+  type R = 0..3
+  state { m: Map<I, R> }
+  init {
+    forall i in 0..2 {
+      if i == 1 { m[i] = 2 } else { m[i] = 1 }
+    }
+  }
+  action stay() { requires true  m[0] = m[0] }
+  invariant Chosen { m[0] == 1 and m[1] == 2 and m[2] == 1 }
+}
+"""
+    mon = _monitor(src)
+
+    assert mon.reset()["m"] == {"0": 1, "1": 2, "2": 1}
+    assert _verify(src)["result"] == "verified"
+
+
+def test_init_if_chosen_branch_controls_invariant_result():
+    good = """
+spec IfInitGood {
+  type R = 0..3
+  state { x: R }
+  init { if false { x = 1 } else { x = 2 } }
+  action stay() { requires true  x = x }
+  invariant Chosen { x == 2 }
+}
+"""
+    bad = good.replace("IfInitGood", "IfInitBad").replace("x == 2", "x == 1")
+
+    assert _verify(good)["result"] == "verified"
+    out = _verify(bad)
+    assert out["result"] == "violated"
+    assert out["violation_kind"] == "invariant"
+    assert out["violated_at_step"] == 0
+
+
+def test_init_if_non_bool_condition_deferred_to_verify():
+    # Init expression types are not checked at model-build time (consistent with
+    # every other init type error); a non-Bool condition is caught symbolically
+    # at verify via require_bool.
+    src = """
+spec InitIfType {
+  type R = 0..3
+  state { x: R }
+  init { if 0 { x = 1 } else { x = 2 } }
+  action stay() { requires true  x = x }
+}
+"""
+    spec = build_spec(parse(src))  # model check passes
+
+    with pytest.raises(FslError) as exc:
+        verify(spec, 2, deadlock_mode="ignore")
+
+    assert exc.value.kind == "type"
+    assert "if condition must be Bool" in str(exc.value)


### PR DESCRIPTION
Closes #55.

## Problem
`init` blocks already parsed `if`/`else` (grammar `?stmt: assign | if_stmt | forall_stmt`), but BMC rejected them at verify time (`if in init is not supported`) — so `fslc check` returned ok and only `fslc verify` failed. The check-pass / verify-fail trap that costs the most time early on.

## Change
Lower init `if C { S1 } else { S2 }` to path-conditional initial-state constraints, reusing the existing `forall ... where` `Implies` machinery:

- **bmc.py** — `append_if_constraints` evaluates `C` over the initial state `s0` and adds then-branch constraints as `Implies(C, k)`, else-branch as `Implies(Not(C), k)`; wired into both `run` and `run_collect`, so nested `if` / `forall` compose. A non-Bool condition is rejected at verify (`require_bool`, `kind: type`).
- **runtime.py** — the concrete Monitor selects the taken branch; deterministic-init analysis now tracks `definitely_assigned` (∩ across branches) vs `possibly_assigned` (∪). This folds the previously duplicated forall validation into one recursive walk (net −7 lines).
- Docs/skill/CHANGELOG + `docs/DESIGN-init-if.md`.

Scope note: this PR does **not** add a check-time init type-checker — a non-Bool condition surfaces at verify, consistent with how init type errors already behave. (Comprehensive check-time init typing is a separate concern.)

## Tests / gates
- `tests/test_init_if.py`: then/else selection (Monitor + verifier), nested `if`, `if` inside `forall` over a range, invariant-depends-on-chosen-init (verified + violated).
- `pytest tests/test_init_if.py tests/test_evaluator_agreement.py tests/test_v1.py tests/test_corpus_snapshot.py` green; corpus snapshot unchanged (no `specs/`/`examples/` files added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
