### PR TITLE
feat(types): allow inline range types in state declarations (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- State declarations may now use inline anonymous range types such as
+  `state { x: 0..3 }`, desugared to the existing domain type machinery. (#57)
 - `fslc testgen --target phpunit`: a PHPUnit emitter (PHP 8.1+ / PHPUnit 10+,
   `declare(strict_types=1)`), the sixth harness on the pluggable emitter from #43.
   Same `reset`/`step`/`observe` `Adapter` contract and same baked-walk design. Leaves

--- a/docs/DESIGN-inline-range.md
+++ b/docs/DESIGN-inline-range.md
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+# Design: Inline Anonymous Range Types (`x: lo..hi`)
+
+## Problem
+
+Writing `state { x: 0..3 }` required a two-step dance: declare a named domain type
+(`type R = 0..3`), then reference it (`state { x: R }`). The anonymous form was not
+accepted by the grammar.
+
+## Solution
+
+Pure syntactic sugar. The `?type` grammar rule gains one alternative:
+
+```
+| expr ".." expr -> t_range
+```
+
+The AST transformer produces `("range", lo_expr, hi_expr)`. The two `resolve_type` /
+`resolve_type_ref` functions in `model.py` handle the `"range"` tag by evaluating both
+bounds with `eval_const` (same path as `collect_types` uses for named domain types) and
+returning `("domain", lo_i, hi_i)`.
+
+No new kernel concept is introduced. Everything downstream — `expand_phys_var`, Z3 sort
+construction, bounds invariants — already handles `("domain", lo, hi)`.
+
+## Scope
+
+State variable declarations only. Action parameter ranges (`action a(x in 0..3)`) already
+had their own syntax via `param_range` and are unchanged.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -113,6 +113,7 @@ used for the base BMC check and reachable/coverage evidence.
 |---|---|---|
 | `Int` / `Bool` | `count: Int` | Unbounded integer / boolean |
 | Domain type | `type Qty = 0..5` | Bounded integer. **The range is checked automatically** (§6) |
+| Inline state domain | `state { qty: 0..5 }` | Shorthand for a named domain type in a state-variable declaration |
 | Entity kind | `entity Claim` / `process Claim ...` | Finite identity sort. Allowed in any layer incl. kernel `spec`; size set by `verify { instances Claim = N }`; desugars to `type Claim = 0..N-1` |
 | Number kind | `number Amount` | Finite numeric sort. Allowed in any layer incl. kernel `spec`; range set by `verify { values Amount = lo..hi }`; desugars to `type` |
 | enum | `enum St { Open, Closed }` | Members are referenced by their bare name in expressions |
@@ -122,7 +123,9 @@ used for the base BMC check and reachable/coverage evidence.
 | `Set<T>` | `shipped: Set<OrderId>` | T is a bounded scalar |
 | `Seq<T, N>` | `queue: Seq<JobId, 3>` | A sequence (FIFO) of capacity N. T is a scalar, N is a constant |
 
-**Scalar** = Int / Bool / domain type / enum.
+**Scalar** = Int / Bool / domain type / enum. In a `state` declaration,
+`x: lo..hi` is accepted as an anonymous domain type and is equivalent to
+declaring `type X = lo..hi` and writing `x: X`.
 
 **Types legal as state variables** (anything else is rejected by `check` as a type error):
 scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -132,6 +132,7 @@ refinement <Name> {
 |---|---|---|
 | Int / Bool | `n: Int` | Int is unbounded |
 | Domain type | `type Qty = 0..5` | **automatic bound check** (violated/type_bound) |
+| Inline state domain | `state { qty: 0..5 }` | Shorthand for a named domain type in a state-variable declaration |
 | symmetric domain | `symmetric type TaskId = 0..2` | Same as a domain type, plus liveness symmetry reduction |
 | entity kind (dialects) | `entity Claim` / `process Claim ...` | Finite identity sort for business/requirements; bound by `verify { instances Claim = N }` |
 | number kind (dialects) | `number Amount` | Finite numeric sort for business/requirements; bound by `verify { values Amount = lo..hi }` |
@@ -143,7 +144,9 @@ refinement <Name> {
 | Set<T> | `s: Set<OrderId>` | T is a bounded scalar |
 | Seq<T, N> | `q: Seq<JobId, CAP>` | T is a scalar, N is a positive constant. FIFO |
 
-Scalar = Int / Bool / domain type / enum.
+Scalar = Int / Bool / domain type / enum. In a `state` declaration,
+`x: lo..hi` is an anonymous domain type and is equivalent to declaring
+`type X = lo..hi` and writing `x: X`.
 **State-variable whitelist**: scalar | Option<scalar> | struct |
 Map<bounded scalar, scalar|Option|struct> | Set<bounded scalar> | Seq<scalar, N>.
 Anything else (nested structs, Set/Map/Seq as a Map value, etc.) is rejected by

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -69,6 +69,7 @@ state_def: "state" "{" var_decl ("," var_decl)* ","? "}"
 var_decl: NAME ":" type
 ?type: "Int"  -> t_int
      | "Bool" -> t_bool
+     | expr ".." expr -> t_range
      | "Map" "<" type "," type ">" -> t_map
      | "Set" "<" type ">" -> t_set
      | "Seq" "<" type "," cap ">" -> t_seq
@@ -545,6 +546,9 @@ class Ast(Transformer):
 
     def t_bool(self, meta):
         return ("bool",)
+
+    def t_range(self, meta, lo, hi):
+        return ("range", lo, hi)
 
     def t_map(self, meta, k, v):
         return ("map", k, v)

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -100,6 +100,14 @@ def resolve_seq_capacity(cap_ast, consts):
     return cap
 
 
+def _resolve_inline_range(ty, consts):
+    lo_i = eval_const(ty[1], consts)
+    hi_i = eval_const(ty[2], consts)
+    if lo_i > hi_i:
+        _err(f"inline range type has empty range {lo_i}..{hi_i}", kind="type")
+    return ("domain", lo_i, hi_i)
+
+
 def resolve_type(ty, types, consts=None):
     if ty[0] in ("int", "bool"):
         return ty
@@ -108,6 +116,8 @@ def resolve_type(ty, types, consts=None):
         if n not in types:
             _err(f"unknown type '{n}'", kind="type")
         return types[n]["ty"]
+    if ty[0] == "range":
+        return _resolve_inline_range(ty, consts)
     if ty[0] == "map":
         return ("map", resolve_type(ty[1], types, consts), resolve_type(ty[2], types, consts))
     if ty[0] == "set":
@@ -170,6 +180,8 @@ def resolve_type_ref(ty, types, consts=None):
         if n not in types:
             _err(f"unknown type '{n}'", kind="type")
         return ("named", n)
+    if ty[0] == "range":
+        return _resolve_inline_range(ty, consts)
     if ty[0] == "map":
         return (
             "map",

--- a/tests/test_inline_range.py
+++ b/tests/test_inline_range.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Inline anonymous range types in state declarations."""
+
+import pytest
+
+from fslc import FslError, build_spec, parse, verify
+
+
+INLINE_SRC = """
+spec InlineRange {
+  state { x: 0..3 }
+  init { x = 0 }
+  action up() {
+    requires x < 3
+    x = x + 1
+  }
+  invariant B { x <= 3 }
+}
+"""
+
+NAMED_SRC = """
+spec NamedRange {
+  type R = 0..3
+  state { x: R }
+  init { x = 0 }
+  action up() {
+    requires x < 3
+    x = x + 1
+  }
+  invariant B { x <= 3 }
+}
+"""
+
+
+def test_inline_range_state_type_parses_builds_and_verifies():
+    spec = build_spec(parse(INLINE_SRC))
+
+    assert spec["state"]["x"] == ("domain", 0, 3)
+    assert spec["state_type_refs"]["x"] == ("domain", 0, 3)
+
+    out = verify(spec, 5)
+    assert out["result"] == "verified"
+    assert "B" in out["invariants_checked"]
+    assert "_bounds_x" in out["invariants_checked"]
+
+
+def test_inline_range_matches_named_domain_verdict():
+    inline = verify(build_spec(parse(INLINE_SRC)), 5)
+    named = verify(build_spec(parse(NAMED_SRC)), 5)
+
+    assert inline["result"] == named["result"] == "verified"
+
+
+def test_inline_range_empty_range_is_type_error():
+    src = """
+spec EmptyInlineRange {
+  state { x: 3..0 }
+  init { x = 0 }
+}
+"""
+
+    with pytest.raises(FslError) as exc:
+        build_spec(parse(src))
+
+    assert exc.value.kind == "type"
+    assert "inline range type has empty range 3..0" in str(exc.value)


### PR DESCRIPTION
Closes #57.

## Problem
`state { x: 0..3 }` failed to parse — `var_decl: NAME ":" type` and `?type` only accepted `Int | Bool | Map | Set | Seq | Option | NAME` (grammar.py). You had to declare `type R = 0..3` then `state { x: R }`.

## Change
Allow an inline anonymous range as a state-variable type, desugared to the existing `("domain", lo, hi)` kernel type — pure sugar, no new kernel concept:

- **grammar.py** — one `?type` alternative `expr ".." expr -> t_range` + the `t_range` transformer (`("range", lo, hi)`).
- **model.py** — `resolve_type` / `resolve_type_ref` handle the `"range"` tag via a shared `_resolve_inline_range` helper (eval both bounds with `eval_const` — the same path named domains use — reject empty ranges, return `("domain", lo, hi)`). Everything downstream (`expand_phys_var`, Z3 sort, the auto `_bounds_x` invariant) already handles domains.

Scope: state declarations only. Action parameter ranges already exist (`action a(x in 0..3)` via `param_range`) and are unchanged.

## Tests / gates
- `tests/test_inline_range.py`: parses/builds/verifies (`x` resolves to `("domain", 0, 3)`, `_bounds_x` enforced), inline ≡ named-domain verdict, empty range `3..0` → `kind: type` error.
- `pytest tests/test_inline_range.py tests/test_v1.py tests/test_corpus_snapshot.py` → 191 passed, corpus snapshot unchanged (no `specs/`/`examples/` files added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
