### PR TITLE
docs(skill): clarify implements-block contents and generated tick (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Documentation
+- Clarified in `docs/LANGUAGE.md` and `skills/fsl/reference.md`: the `implements { }`
+  block takes only state `map` / `maps auto` / `preserve progress` (action↔action
+  correspondence goes on the requirement-level action's `maps` clause, not inside
+  `implements`), and the `time`-block `tick` is generated (declaring `action tick` is a
+  check error), advances age only, auto-maps to `stutter`, and is referenced as
+  `tick()`. (#58)
+
 ### Added
 - `fslc testgen --target phpunit`: a PHPUnit emitter (PHP 8.1+ / PHPUnit 10+,
   `declare(strict_types=1)`), the sixth harness on the pluggable emitter from #43.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -830,10 +830,13 @@ verify {
 - With `implements`, `fslc verify` **also runs the refine to the upper layer
   simultaneously**, and the result carries `implements: {abs, result}`. An empty
   body (`implements X from "..." { }`) auto-generates identity refinement when
-  process/action/stage names match. `maps auto` is allowed inside `implements`
-  for same-name kernel-wrapper state/actions, and explicit maps override it.
-  Auto-mapped process transitions are actor-checked; a transition whose actor
-  differs from the business action's actor is a check-time error.
+  process/action/stage names match. Inside the `implements { }` block you write
+  only state `map` entries, `maps auto`, and `preserve progress` — not `action`;
+  action↔action correspondence is the `maps <abs_act>(...)` clause on the
+  requirement-level action. `maps auto` covers same-name kernel-wrapper
+  state/actions, and explicit maps override it. Auto-mapped process transitions
+  are actor-checked; a transition whose actor differs from the business action's
+  actor is a check-time error.
 - `acceptance` is replay-verified at check time by the concrete Monitor (a
   failure is `kind: "acceptance"`). It supports `expect <Entity> <id> in
   <Stage>` alongside `expect <expr>` and flows directly into scenarios / testgen
@@ -967,6 +970,10 @@ requirement NFR-1 "complete within 4 ticks of acceptance" {
   inside a requirement (the requirement ID is tied to the violation). An age is
   +1 per tick (reset to 0 if while is false) and can be read from guards as an
   ordinary state variable.
+- `tick` is generated — do not declare your own `action tick` (it is a check
+  error). It advances age counters only and auto-maps to `stutter` under
+  refinement; reference it as `tick()` (e.g. in an `acceptance` scenario).
+  Tick-side work (service time, etc.) needs the kernel-wrapper form.
 - **⚠ The vacuous-SLA trap**: making an action that can always be enabled urgent
   freezes time, and any K satisfies the deadline vacuously (even `<= 0` is
   green). The correct form is **to make urgent only the guarded action that

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -582,11 +582,13 @@ verify {
   business and requirements; it does not create a ghost counter or an automatic
   `_kpi_*` invariant.
 - When `implements Abs from "file" { }` is present and process/action/stage names
-  match, fslc synthesizes the identity refinement mapping. `maps auto` is also
-  allowed inside an `implements` block for same-name kernel-wrapper state/actions,
-  and explicit `map` / action correspondences override it. Auto-mapped process
-  transitions are statically actor-checked; an actor mismatch is a check-time
-  type error.
+  match, fslc synthesizes the identity refinement mapping. Inside the
+  `implements { }` block you write only state `map` entries, `maps auto`, and
+  `preserve progress` — **not `action`** (the grammar rejects an action there).
+  Action↔action correspondence is instead the `maps <abs_act>(...)` clause **on
+  the requirement-level action** (auto-synthesized for matching names; `maps auto`
+  covers same-name kernel-wrapper actions). Auto-mapped process transitions are
+  statically actor-checked; an actor mismatch is a check-time type error.
 - `acceptance` is replay-checked at check time with the concrete Monitor (failure is
   `kind: "acceptance"`). It supports the readable stage form
   `expect <Entity> <id> in <Stage>` alongside `expect <expr>`, is output to
@@ -637,6 +639,12 @@ in each layer's documents).
   **age is readable from guards as an ordinary state variable** (`requires m[c] >= K`).
 - **urgent semantics = time freeze**: while any of the listed actions is enabled,
   `tick` cannot fire.
+- **`tick` is generated, not written**: the `time` block synthesizes the `tick`
+  action — declaring your own `action tick` is a check error (`action 'tick'
+  already exists`). It advances age counters only and auto-maps to `stutter` under
+  refinement; reference it as `tick()` (e.g. to advance time in an `acceptance`
+  scenario). Modeling tick-side work (service time, etc.) needs the kernel-wrapper
+  form (§10).
 
 ### ⚠ The vacuous-SLA trap and the deadline-urgency pattern
 


### PR DESCRIPTION
Closes #58.

Documentation-only. Most of the notation papercuts flagged in #58 turned out to be **already documented** (the refinement action↔`stutter` correspondence, `maps auto`, and `tick` auto-generation), so this is a targeted correction of the two genuine gaps rather than a broad addition. The init-if idiom and inline-range items moved to their own feature PRs (#55 → #59, #57 → #60).

## Fixes
- **`implements { }` vs `action`** (`docs/LANGUAGE.md`, `skills/fsl/reference.md`): the reference card implied action correspondences go *inside* `implements { }`. They don't — the grammar (`implements_def: map_def | maps_auto_def | preserve_progress_def`) accepts only state `map`, `maps auto`, and `preserve progress`. Action↔action correspondence is the `maps <abs_act>(...)` clause **on the requirement-level action**. This was the exact friction in #58 (“implements で action 不可”).
- **Generated `tick`**: documented that the `time` block synthesizes `tick` (declaring `action tick` is a check error — `dialects.py:711`), it advances age counters only, auto-maps to `stutter` under refinement (`dialects.py:786`), and is referenced as `tick()`.

No code change, so no gates. `skills/` is canonical (`.claude/skills` are symlinks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
