### PR TITLE
feat(cli): add trace_type repair-routing discriminator to JSON output (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `tick()`. (#58)
 
 ### Added
+- `fslc` JSON results now carry a `trace_type` repair-routing discriminator on
+  every counterexample/failure (`invariant` | `sla` | `type_bound` | `trans` |
+  `ensures` | `partial_op` | `deadlock` | `leadsTo` | `leadsTo_rank` | `reachable`
+  | `refinement` | `acceptance` | `forbidden` | `vacuity` | `conformance` |
+  `induction_cti`), so an agent can route a fix by channel and tell an SLA
+  deadline from a structural invariant. Derived in the CLI envelope from existing
+  fields (no engine change); passing/spec-error results carry none. `requirement`
+  is now also hoisted to the `refinement_failed` root, for parity with verify
+  violations. The other repair inputs the issue proposed already exist (`trace`,
+  `checked_to_depth`+`completeness`, `hint`/`recommended_action`,
+  `unreached[].blocking_requires`) and are documented as the repair-field map in
+  `skills/fsl/reference.md` §7. Backward compatible (additive). (#23)
 - `init` blocks now support statement-level `if`/`else` in both the symbolic
   verifier and concrete runtime monitor. (#55)
 - State declarations may now use inline anonymous range types such as

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -337,6 +337,18 @@ first failed layer and later layers are marked `skipped`.
 - faithfulness diagnostics may add `faithfulness_class` and
   `recommended_action`: `partial_op_unguarded`, `frozen_only_invariant`,
   `intent_unexercised`, or `liveness_not_refined`.
+- **repair routing (`trace_type`)**: every counterexample/failure result carries a
+  `trace_type` discriminator — one of `invariant` | `sla` | `type_bound` | `trans`
+  | `ensures` | `partial_op` | `deadlock` | `leadsTo` | `leadsTo_rank` |
+  `reachable` | `refinement` | `acceptance` | `forbidden` | `vacuity` |
+  `conformance` | `induction_cti` — so an agent can route a fix by channel (and
+  tell an `sla` deadline from a structural `invariant`). Passing results and spec
+  (parse/type/…) errors carry no `trace_type`. The remaining repair inputs already
+  exist — no separate field is added for them: `requirement: {id, text}` (now also
+  at the `refinement_failed` root) localizes intent; `trace` / `impl_trace` /
+  `cti.states` / `accepted_trace` are the counterexample steps; `checked_to_depth`
+  + `completeness` are the guarantee bound; `hint` / `recommended_action` are the
+  suggested fix; `unreached[].blocking_requires` is the dead-reachable core.
 - coverage diagnostic:
   `{covered: false, name, display_name?, blocking_requires: [{loc, text}], hint}`.
 - leadsTo violation: `pending_since` + `loop_start` (lasso) or `stutter: true`.
@@ -464,7 +476,8 @@ in §7 work as-is.
 `"ID: source"` immediately before the `{` of an invariant / trans / reachable /
 leadsTo / action:
 `invariant PaidLedger "REQ-3: ledger consistency" { ... }` →
-`requirement: {id, text}` in violated / unknown_cti / coverage diagnostic / scenarios.
+`requirement: {id, text}` in violated / unknown_cti / coverage diagnostic /
+scenarios / `refinement_failed` (root).
 
 ### Authoring specs as readable documentation (requirements + design)
 

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -11,7 +11,7 @@ from lark.exceptions import UnexpectedInput, VisitError
 
 from pathlib import Path
 
-from .diagnostics import with_faithfulness
+from .diagnostics import with_faithfulness, trace_type_for
 from .parser import parse, parse_src, parse_refinement
 from .model import build_spec, check_spec, FslError, strict_tag_warnings
 from .bmc import verify, prove, scenarios
@@ -33,7 +33,11 @@ FSL_VERSION = "1.0"
 def _envelope(result):
     out = {"fsl": FSL_VERSION}
     out.update(result)
-    return with_faithfulness(out)
+    out = with_faithfulness(out)
+    tt = trace_type_for(out)
+    if tt is not None:
+        out.setdefault("trace_type", tt)
+    return out
 
 
 def _error_envelope(kind, message, loc=None, expected=None, hint=None):

--- a/src/fslc/diagnostics.py
+++ b/src/fslc/diagnostics.py
@@ -50,6 +50,52 @@ def recommended_action_for(faithfulness_class):
     return FAITHFULNESS_ACTIONS.get(faithfulness_class)
 
 
+# Vacuity finding kinds that surface as `{"result": "error", "kind": <here>}`
+# under `--vacuity error` (see bmc._finalize_vacuity_findings).
+_VACUITY_KINDS = frozenset({
+    "vacuous_implication", "vacuous_leadsto", "tautology_over_frozen",
+    "urgency_freeze", "always_true_requires",
+})
+
+
+def trace_type_for(diagnostic):
+    """Unified repair-routing discriminator for a top-level result.
+
+    Derived from fields the result already carries — no engine change — so an
+    agent can route a fix by channel (and tell an SLA deadline from a structural
+    invariant). Returns None for non-counterexample results (verified/ok/spec
+    errors), so it is only set where there is something to repair.
+    """
+    if not isinstance(diagnostic, dict):
+        return None
+    result = diagnostic.get("result")
+    if result == "refinement_failed":
+        return "refinement"
+    if result == "reachable_failed":
+        return "reachable"
+    if result == "nonconformant":
+        return "conformance"
+    if result == "unknown_cti":
+        return "induction_cti"
+    if result == "violated":
+        vk = diagnostic.get("violation_kind")
+        # SLA deadlines are generated invariants named `_deadline_<req>_<age>_<n>`
+        # (dialects._deadline_invariant_name); the `_` prefix is reserved, so the
+        # match is unambiguous.
+        if vk == "invariant" and str(diagnostic.get("invariant", "")).startswith("_deadline_"):
+            return "sla"
+        return vk or "invariant"
+    if result == "error":
+        kind = diagnostic.get("kind")
+        if kind == "acceptance":
+            return "acceptance"
+        if kind in ("forbidden", "forbidden_setup"):
+            return "forbidden"
+        if kind in _VACUITY_KINDS:
+            return "vacuity"
+    return None
+
+
 def with_faithfulness(value):
     """Return value with additive faithfulness routing fields on diagnostics."""
     if isinstance(value, list):

--- a/src/fslc/refine.py
+++ b/src/fslc/refine.py
@@ -1368,7 +1368,7 @@ def _failure(
         model, explored["states"], explored["choices"],
         explored["instances"], impl_spec, step,
     )
-    return with_faithfulness({
+    out = {
         "result": "refinement_failed",
         "impl": impl_spec["name"],
         "abs": abs_spec["name"],
@@ -1382,4 +1382,10 @@ def _failure(
         "abs_after_actual": alpha_after_actual,
         "mismatch": mismatch,
         "hint": _REFINE_HINT,
-    })
+    }
+    # Hoist the involved impl action's requirement to the root, for parity with
+    # verify violations (which carry `requirement` at the top level).
+    req = impl_action.get("requirement") if isinstance(impl_action, dict) else None
+    if req:
+        out["requirement"] = req
+    return with_faithfulness(out)

--- a/tests/test_repair_fields.py
+++ b/tests/test_repair_fields.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Issue #23: the `trace_type` repair-routing discriminator + requirement parity.
+
+`trace_type` is added by the CLI envelope (cli._envelope), so these go through
+the `run_*` wrappers, not the core `verify()`/`refine()` functions.
+"""
+from pathlib import Path
+
+from fslc.cli import run_check, run_verify, run_refine
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NFR = ROOT / "examples" / "nfr"
+INJECTED = ROOT / "examples" / "gallery" / "injected"
+
+
+def _write(tmp_path, name, src):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    return p
+
+
+def test_trace_type_sla_violation(tmp_path):
+    src = (NFR / "sla_worker.fsl").read_text(encoding="utf-8").replace(
+        "    urgent start, finish\n", "")
+    p = _write(tmp_path, "sla_no_urgent.fsl", src)
+    r = run_verify(str(p), 10, "ignore")
+    assert r["result"] == "violated"
+    # an SLA deadline is distinguished from a structural invariant
+    assert r["trace_type"] == "sla"
+    # backward-compat: existing fields untouched
+    assert r["requirement"] == {"id": "NFR-1", "text": "submitted requests finish within 4 ticks"}
+    assert r["violation_kind"] == "invariant"
+    assert r["trace"]
+
+
+def test_trace_type_plain_invariant(tmp_path):
+    p = _write(tmp_path, "inv.fsl", """
+spec PlainInv {
+  state { x: Int }
+  init { x = 0 }
+  action bump() { x = 1 }
+  invariant StaysZero { x == 0 }
+}
+""")
+    r = run_verify(str(p), 2, "warn")
+    assert r["result"] == "violated"
+    assert r["trace_type"] == "invariant"
+
+
+def test_trace_type_reachable_failed(tmp_path):
+    p = _write(tmp_path, "unreach.fsl", """
+spec Unreach {
+  state { x: Bool }
+  init { x = false }
+  action noop() { requires x  x = true }
+  reachable XTrue { x }
+}
+""")
+    r = run_verify(str(p), 5, "warn")
+    assert r["result"] == "reachable_failed"
+    assert r["trace_type"] == "reachable"
+
+
+def test_trace_type_refinement_failed_and_requirement_hoisted(tmp_path):
+    impl = _write(tmp_path, "impl.fsl", """
+spec ImplR {
+  type N = 0..2
+  state { x: N }
+  init { x = 0 }
+  action bump() "REQ-9: bump advances x" { requires x < 2  x = x + 1 }
+}
+""")
+    abs_ = _write(tmp_path, "abs.fsl", """
+spec AbsR {
+  type N = 0..2
+  state { x: N }
+  init { x = 0 }
+  action bump() { requires x == 0  x = 1 }
+}
+""")
+    mapping = _write(tmp_path, "m.fsl", """
+refinement M { impl ImplR  abs AbsR
+  map x = x
+  action bump() -> bump()
+}
+""")
+    r = run_refine(str(impl), str(abs_), str(mapping), depth=4)
+    assert r["result"] == "refinement_failed"
+    assert r["trace_type"] == "refinement"
+    # requirement is hoisted to the root (parity with verify violations)
+    assert r["requirement"] == {"id": "REQ-9", "text": "bump advances x"}
+
+
+def test_trace_type_acceptance_channel():
+    # boundary-flip lands in the acceptance lane (DOGFOOD-10 F19)
+    r = run_check(str(INJECTED / "return_system__boundary_flip.fsl"))
+    assert r["result"] == "error"
+    assert r["trace_type"] == "acceptance"
+
+
+def test_trace_type_forbidden_channel():
+    # guard-weakening lands in the forbidden lane (DOGFOOD-10 F19)
+    r = run_check(str(INJECTED / "return_system__guard_weakening.fsl"))
+    assert r["result"] == "error"
+    assert r["trace_type"] == "forbidden"
+
+
+def test_no_trace_type_on_passing_results():
+    # a clean verify has no counterexample → no trace_type
+    r = run_verify(str(NFR / "sla_worker.fsl"), 8, "ignore")
+    assert r["result"] == "verified"
+    assert "trace_type" not in r
+
+
+def test_no_trace_type_on_spec_error(tmp_path):
+    p = _write(tmp_path, "bad.fsl", "spec X { state { a: Bogus } init {} }")
+    r = run_check(str(p))
+    assert r["result"] == "error"
+    # parse/type/semantics errors are not counterexamples
+    assert "trace_type" not in r


### PR DESCRIPTION
Closes #23.

## What & why

LLM/agent repair localizes far better when a counterexample says **which channel** caught it (DOGFOOD-10 F18/F19: each detector has a non-overlapping lane). This adds a single **`trace_type`** discriminator to every counterexample/failure result, so a fix can be routed by channel — and crucially, an **`sla`** deadline is distinguished from a structural **`invariant`**.

Values: `invariant` | `sla` | `type_bound` | `trans` | `ensures` | `partial_op` | `deadlock` | `leadsTo` | `leadsTo_rank` | `reachable` | `refinement` | `acceptance` | `forbidden` | `vacuity` | `conformance` | `induction_cti`. Passing results and spec (parse/type/…) errors carry none.

## Scope decision (refuting redundancy)

The issue proposed **8** fields. A full map of the current JSON output (per result type) found **6 already exist** under other names — adding them would duplicate the contract:

| Proposed | Already emitted as |
|---|---|
| `requirement_id` | `requirement: {id, text}` (now also at the `refinement_failed` root) |
| `counterexample_steps` | `trace` / `impl_trace` / `cti.states` / `accepted_trace` |
| `dead_reachable_path` | `unreached[].{classification, blocking_requires, hint}` |
| `repair_hint` | `hint` + `recommended_action` + `faithfulness_class` |
| `guarantee_limit` | `checked_to_depth` + `completeness` |
| `suspected_missing_trace` | `action_coverage` + `faithfulness_class:intent_unexercised` (registry-dependent — DOGFOOD-10 F20) |

So only the unified **`trace_type`** discriminator is net-new; the rest are documented as a **repair-field map** in `skills/fsl/reference.md` §7 rather than re-emitted. The one consistency gap — `requirement` missing at the `refinement_failed` root — is fixed by hoisting it (parity with verify violations).

## Implementation (no engine change)

- `src/fslc/diagnostics.py`: `trace_type_for()` derives the discriminator from existing fields.
- `src/fslc/cli.py`: `_envelope` sets it once at the top level (additive `setdefault`).
- `src/fslc/refine.py`: hoist the impl action's `requirement` to the `refinement_failed` root.

`trace_type` lives in the CLI envelope (the `fslc --json` contract), so internal `verify()`/`refine()` callers are untouched.

## Acceptance criteria

- ✅ Backward compatible (additive only; **corpus snapshot unchanged** — the projection ignores the new key).
- ✅ Each detection type fills the relevant field — `trace_type` discriminates invariant/sla/leadsTo/reachable/refinement/acceptance/forbidden/… ; per-type detail already present.
- ✅ Requirement id transparent — now also at the refinement root.

## Deferred (out of this minimal scope)

- `violated_guard` unsat-core on **invariant** violations — mostly covered by `last_action`/`mismatch`/`accepted_step`; a true unsat-core-on-violation is a heavier, separable follow-up.
- `suspected_missing_trace` — omission detection is registry-dependent (the `--requirements ids.txt` lane), a different mechanism.

## Test plan

- `tests/test_repair_fields.py` (new) — `trace_type` for sla/invariant/reachable/refinement/acceptance/forbidden, requirement-hoist on refinement, and *absence* on passing/spec-error results — **8 passed**.
- JSON-key regression (`test_meta`, `test_refine`, `test_forbidden`, `test_nfr`, `test_explain`, `test_repair_fields`) — **65 passed**; chain (`test_chain` + `test_layers_chain`) — **5 passed**.
- `tests/test_corpus_snapshot.py` — **152 passed, 1 skipped** (snapshot unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)