### PR TITLE
feat(cli): `fslc ledger` — business audit ledger by requirement id (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `tick()`. (#58)
 
 ### Added
+- `fslc ledger <spec.fsl> [--impl-log run.json] [-o ledger.md]`: a business
+  **audit ledger** (Markdown) that re-organizes `verify` / `scenarios` / `replay`
+  findings **by requirement id** so a PM / governance / internal-audit reader can
+  decide approve/reject/risk-accept per requirement from the ledger alone. A
+  presentation layer over the verifier (no new evaluation): the `trace_type`
+  discriminator (#23) drives a per-finding business translation, governance
+  columns (risk/decider) come from `control` metadata when present (fill-in
+  otherwise), the guarantee limit is stated in positive form, and raw JSON is
+  demoted to a collapsed appendix. Docs: `docs/DESIGN-ledger.md`,
+  `skills/fsl/reference.md` §7. (#24)
 - `fslc` JSON results now carry a `trace_type` repair-routing discriminator on
   every counterexample/failure (`invariant` | `sla` | `type_bound` | `trans` |
   `ensures` | `partial_op` | `deadlock` | `leadsTo` | `leadsTo_rank` | `reachable`

--- a/docs/DESIGN-ledger.md
+++ b/docs/DESIGN-ledger.md
@@ -1,0 +1,70 @@
+# FSL — `fslc ledger` business audit ledger
+
+## Goal
+
+`fslc ledger <file.fsl> [-o ledger.md]` turns verifier evidence into a Markdown
+**audit ledger organized by requirement id**, so a PM / development-governance /
+internal-audit reader can decide **approve / reject / risk-accept per requirement
+from the ledger alone** — without reading raw JSON or formulas. It is the
+business-audience analogue of `fslc html` (a presentation layer over the
+verifier; it introduces no second parser, evaluator, or verifier).
+
+The reframe (issue #24): the ledger does not assert "correctness guaranteed". It
+surfaces **intent drift / dead paths / forbidden paths / boundary gaps** as items
+a human must confirm, and states the guarantee limit in positive form so it never
+reads as "guarantees nothing".
+
+## Inputs
+
+- `run_verify(file, depth, deadlock)` — violations (with `requirement` +
+  `trace_type` from #23), dead `reachable`s (`unreached[]`), uncovered actions,
+  vacuity warnings, failed acceptance/forbidden (as errors), and the guarantee
+  bound (`checked_to_depth` + `completeness`).
+- `run_scenarios(file, depth, deadlock)` — passing acceptance / forbidden /
+  reachable confirmations per requirement.
+- `--impl-log <trace.json>` (optional) → `run_replay` — implementation-log
+  conformance (`conformant` / `nonconformant`).
+- The built `spec` — the requirement registry (every `requirement` id + text) and
+  `control` governance (owner / severity) when present.
+
+## CLI contract
+
+```
+fslc ledger spec.fsl --depth 8 --impl-log run.json -o ledger.md
+```
+
+- With `-o`, writes the Markdown file and prints the JSON envelope with
+  `result:"generated"`, `kind:"audit_ledger"`. Without `-o`, writes the Markdown
+  to stdout (mirroring `html` / `testgen`). Parse/type/semantic/io errors use the
+  standard CLI error envelope and exit codes. Defaults to `--deadlock ignore`
+  (an audit focuses on intent drift, not terminal-state deadlock; run
+  `verify --deadlock warn` separately for that).
+
+## Structure
+
+1. **Header** — the guarantee limit in positive form ("BMC: depth N までの全実行を
+   網羅" / "k帰納法で全実行を証明") + the honesty line ("保証するのは内部整合;
+   intent fidelity is borne by the per-row 判断").
+2. **リスク一覧** — one row per requirement id: 業務目的 / 状態 (🔴 要確認 / 🟢
+   確認済) / 検出種別 (`trace_type`) / リスク (`control.severity`) / 判断者
+   (`control.owner`) / 次アクション.
+3. **要件ID別詳細** — per requirement: the raw counterexample **translated into a
+   business sentence** (dispatched on `trace_type`), the next action, and a
+   decision line (☐承認 ☐差戻し ☐リスク受容 / 判断者 / 期限).
+4. **付録** — the raw JSON findings, collapsed (`<details>`), demoted off page 1.
+
+## Column → source map
+
+Most columns are derived from fields the JSON already carries (issue #23):
+`requirement.{id,text}`, `trace_type`, `recommended_action`/`hint`,
+`checked_to_depth`+`completeness`. Governance columns (risk / decider) come from
+`control` metadata when the spec declares it, and are left as fill-in fields
+(`____`) otherwise — the ledger never fabricates a loss figure or a deadline.
+
+## Non-goals
+
+- No new verification. Hollowness depth (mutate kill-rate) and full multi-layer
+  refinement aggregation are out of this first cut; `fslc mutate` / `fslc chain`
+  remain the deeper audits. `verify` reports the first invariant violation only,
+  so a ledger row may under-count simultaneous invariant breaks (noted in the
+  guarantee limit).

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -267,7 +267,18 @@ fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dar
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
+fslc html <f> [--depth K] [-o report.html]      # self-contained HTML review report (dev audience)
+fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md]  # business audit ledger by requirement id (PM/audit)
 ```
+
+`ledger` (issue #24) re-organizes `verify`/`scenarios`/`replay` findings **by
+requirement id** into a Markdown audit ledger a PM / governance / internal-audit
+reader can decide approve/reject/risk-accept from. It is a presentation layer
+(no new verification): the `trace_type` discriminator drives a per-finding
+business translation, governance columns (risk/decider) come from `control`
+metadata when present (fill-in otherwise), and the guarantee limit is stated in
+positive form. Raw JSON is demoted to a collapsed appendix. See
+`docs/DESIGN-ledger.md`.
 
 `chain` reads `fsl-project.toml` by default. Each `[business]`,
 `[requirements]`, and `[design]` table has `file = "..."`; adding `depth = K`

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -26,6 +26,10 @@ from .html_report import (
     default_output_name as default_html_output_name,
     render_html_report,
 )
+from .ledger import (
+    default_output_name as default_ledger_output_name,
+    render_ledger,
+)
 
 FSL_VERSION = "1.0"
 
@@ -623,6 +627,44 @@ def run_html(file, depth=8, output=None, deadlock_mode="warn", write_file=True):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
+def run_ledger(file, depth=8, output=None, deadlock_mode="ignore", impl_log=None, write_file=True):
+    """Generate a business audit ledger (markdown) from verifier evidence (#24)."""
+    try:
+        src = Path(file).read_text(encoding="utf-8")
+        ast, display_names = parse_src(src, str(Path(file).parent))
+        spec = build_spec(ast, display_names)
+        verification = run_verify(file, depth, deadlock_mode)
+        scenarios_result = run_scenarios(file, depth, deadlock_mode)
+        replay_result = run_replay(file, impl_log) if impl_log else None
+        content = render_ledger(file, spec, verification, scenarios_result, replay_result)
+        out_path = output or default_ledger_output_name(file)
+        if write_file and output:
+            open(output, "w", encoding="utf-8").write(content)
+        return _envelope({
+            "result": "generated",
+            "kind": "audit_ledger",
+            "spec": spec["name"],
+            "output": out_path,
+            "content": content,
+        })
+    except UnexpectedInput as e:
+        return _parse_error_result(e)
+    except VisitError as e:
+        orig = e.orig_exc
+        return _error_envelope(
+            getattr(orig, "kind", "semantics"), str(orig), _loc_from_exc(orig),
+            getattr(orig, "expected", None), getattr(orig, "hint", None),
+        )
+    except FslError as e:
+        return _error_envelope(e.kind, str(e), _loc_from_exc(e),
+                               getattr(e, "expected", None), getattr(e, "hint", None))
+    except FileNotFoundError:
+        return _envelope({"result": "error", "kind": "io",
+                          "message": f"file not found: {file}"})
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
 def exit_code(result):
     r = result.get("result")
     if r in ("verified", "proved", "scenarios", "conformant", "generated",
@@ -708,6 +750,15 @@ def _build_arg_parser():
     hr.add_argument("-o", "--output", default=None)
     hr.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
 
+    lg = sub.add_parser("ledger",
+                        help="generate a business audit ledger (markdown) by requirement id")
+    lg.add_argument("file")
+    lg.add_argument("--depth", type=int, default=8)
+    lg.add_argument("-o", "--output", default=None)
+    lg.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="ignore")
+    lg.add_argument("--impl-log", default=None,
+                    help="optional implementation trace JSON to score conformance (fslc replay)")
+
     rf = sub.add_parser("refine")
     rf.add_argument("impl")
     rf.add_argument("abs")
@@ -787,6 +838,18 @@ def _dispatch(args):
     elif args.cmd == "html":
         result = run_html(args.file, args.depth, args.output, args.deadlock,
                           write_file=bool(args.output))
+        if result.get("result") == "generated":
+            content = result.pop("content")
+            if args.output:
+                print(json.dumps(result, indent=2, ensure_ascii=False))
+            else:
+                sys.stdout.write(content)
+                sys.exit(0)
+        else:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif args.cmd == "ledger":
+        result = run_ledger(args.file, args.depth, args.output, args.deadlock,
+                            impl_log=args.impl_log, write_file=bool(args.output))
         if result.get("result") == "generated":
             content = result.pop("content")
             if args.output:

--- a/src/fslc/ledger.py
+++ b/src/fslc/ledger.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Audit-ledger renderer (issue #24).
+
+A business-facing presentation layer over the verifier evidence, the audit
+analogue of ``html_report``: it re-organizes ``verify`` / ``scenarios`` /
+``replay`` findings **by requirement id** so a PM / governance / internal-audit
+reader can decide approve / reject / risk-accept per requirement from the ledger
+alone, without reading raw JSON or formulas. It introduces no second evaluator.
+
+Most columns are derived from fields the JSON already carries: ``requirement``
+and ``trace_type`` (issue #23), ``recommended_action``, ``checked_to_depth`` +
+``completeness``. Governance columns (risk / decider) come from ``control``
+metadata when present and are left as fill-in fields otherwise.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def default_output_name(file: str) -> str:
+    return f"{Path(file).stem}_ledger.md"
+
+
+# --------------------------------------------------------------------------
+# requirement registry (id -> business context) from the built spec
+# --------------------------------------------------------------------------
+_META_GROUPS = ("invariants", "actions", "leadstos", "reachables", "transitions")
+
+
+def _requirement_registry(spec: dict) -> dict:
+    """{req_id: {text, controls, owner, severity}} for every tagged element."""
+    control_by_id = {c["id"]: c for c in (spec.get("controls") or [])}
+    reg: dict = {}
+    for group in _META_GROUPS:
+        for item in spec.get(group) or []:
+            meta = item.get("meta") if isinstance(item, dict) else None
+            if not meta or not meta.get("id"):
+                continue
+            rid = meta["id"]
+            entry = reg.setdefault(
+                rid, {"text": meta.get("text"), "controls": [], "owner": None, "severity": None}
+            )
+            if entry["text"] is None:
+                entry["text"] = meta.get("text")
+            for ctrl in meta.get("controls") or []:
+                cid = ctrl.get("id")
+                if cid and cid not in [c["id"] for c in entry["controls"]]:
+                    entry["controls"].append(ctrl)
+                    info = control_by_id.get(cid)
+                    if info:
+                        entry["owner"] = entry["owner"] or info.get("owner")
+                        entry["severity"] = entry["severity"] or info.get("severity")
+    return reg
+
+
+# --------------------------------------------------------------------------
+# finding collection — the "needs human review" signals, grouped by requirement
+# --------------------------------------------------------------------------
+def _req_of(obj: dict):
+    r = obj.get("requirement") if isinstance(obj, dict) else None
+    if isinstance(r, dict):
+        return r.get("id"), r.get("text")
+    return None, None
+
+
+def _finding(req_id, req_text, trace_type, name, summary, raw, next_action=None):
+    return {
+        "req_id": req_id,
+        "req_text": req_text,
+        "trace_type": trace_type,
+        "name": name,
+        "summary": summary,
+        "next_action": next_action,
+        "raw": raw,
+    }
+
+
+def _summarize_violation(v: dict) -> str:
+    bindings = v.get("violating_bindings")
+    last = v.get("last_action")
+    parts = []
+    if last:
+        ln = last.get("name") if isinstance(last, dict) else last
+        parts.append(f"アクション `{ln}` 実行後 (step {v.get('violated_at_step')})")
+    if bindings:
+        parts.append(f"binding {json.dumps(bindings, ensure_ascii=False)}")
+    return "; ".join(parts) or "反例トレースあり（付録参照）"
+
+
+def _collect_findings(verification: dict) -> list:
+    findings = []
+    result = verification.get("result")
+    tt = verification.get("trace_type")
+
+    if result == "violated":
+        name = verification.get("invariant") or verification.get("leadsTo") or verification.get("trans") or verification.get("name")
+        rid, rtext = _req_of(verification)
+        findings.append(_finding(
+            rid, rtext, tt or "invariant", name,
+            _summarize_violation(verification), verification,
+            verification.get("recommended_action"),
+        ))
+    elif result == "reachable_failed":
+        for u in verification.get("unreached") or []:
+            rid, rtext = _req_of(u)
+            cls = u.get("classification")
+            blocking = u.get("blocking_requires")
+            summary = {
+                "insufficient_depth": f"深さ {verification.get('checked_to_depth')} までに到達 trace なし（より深い探索が必要かもしれない）",
+                "over_constrained": "型境界/不変条件により到達不能（ガードが過剰）",
+            }.get(cls, "到達不能")
+            if blocking:
+                summary += f"／阻害: {json.dumps(blocking, ensure_ascii=False)}"
+            findings.append(_finding(
+                rid, rtext, "reachable", u.get("name"), summary, u, u.get("hint"),
+            ))
+    elif result == "error" and tt in ("acceptance", "forbidden"):
+        rid, rtext = _req_of(verification)
+        name = verification.get("id") or verification.get("name")
+        if tt == "forbidden":
+            summary = "禁止フローが仕様上許容されている（accepted_trace あり）"
+        else:
+            summary = f"受入シナリオが不成立（step {verification.get('failed_step')}）"
+        findings.append(_finding(
+            rid or name, rtext or verification.get("text"), tt, name, summary,
+            verification, verification.get("hint"),
+        ))
+
+    # uncovered actions surface on any verify result (incl. verified)
+    for action, info in (verification.get("action_coverage") or {}).items():
+        if isinstance(info, dict) and info.get("covered") is False:
+            rid, rtext = _req_of(info)
+            blocking = info.get("blocking_requires")
+            summary = "深さ内で一度も実行可能にならない（死アクション）"
+            if blocking:
+                summary += f"／阻害: {json.dumps(blocking, ensure_ascii=False)}"
+            findings.append(_finding(
+                rid, rtext, "coverage", action, summary, info, info.get("hint"),
+            ))
+
+    for w in verification.get("warnings") or []:
+        if not isinstance(w, dict):
+            continue
+        rid, rtext = _req_of(w)
+        findings.append(_finding(
+            rid, rtext, "vacuity", w.get("name") or w.get("kind"),
+            f"空虚性の疑い（{w.get('kind')}）: {w.get('message', '')}", w, w.get("hint"),
+        ))
+    return findings
+
+
+# --------------------------------------------------------------------------
+# business translation — dispatch on trace_type (issue #23 is what makes this work)
+# --------------------------------------------------------------------------
+def _translate(f: dict) -> str:
+    t = f["trace_type"]
+    name = f.get("name") or ""
+    table = {
+        "reachable": f"業務経路『{name}』が仕様上到達できない。受入条件に到達 trace を追加し、責任者が期待経路を承認する（死経路でないことの確認）。",
+        "forbidden": f"禁止フロー『{name}』が許容されている。ガードを追加するか、許容するなら責任者がリスク受容を判断する。",
+        "acceptance": f"受入シナリオ『{name}』が成立しない。仕様か受入条件のどちらが正かを責任者が確定する。",
+        "sla": "SLA 期限を超過しうる。スケジューリング前提（urgent）か期限値を見直し、責任者が承認する。",
+        "leadsTo": f"応答性『{name}』が保証されない経路がある。fair 指定または進行ロジックを見直す。",
+        "leadsTo_rank": f"応答性『{name}』の停止性（ランキング）が示せない。進行が単調に進むことを確認する。",
+        "refinement": "詳細仕様が上位契約から逸脱している。対応付け（mapping）かガードを修正する。",
+        "conformance": "実装ログが仕様に非適合。実装か仕様のどちらが正かを確定する。",
+        "coverage": f"アクション『{name}』が一度も実行可能にならない（死アクション）。ガードを緩めるか前提アクションを追加する。",
+        "vacuity": f"性質『{name}』が空虚に成立している疑い（中身がない可能性）。`fslc mutate` で実効性を確認する。",
+    }
+    if t == "sla":
+        return table["sla"]
+    if t in ("invariant", "type_bound", "trans", "ensures", "partial_op", "deadlock"):
+        return f"不変条件『{name}』が破れる経路がある。ガード修正かルール見直しを責任者が承認する。"
+    return table.get(t, f"検出種別 {t}（付録の生 JSON を参照）。")
+
+
+_DEFAULT_ACTION = {
+    "reachable": "受入条件に到達 trace を追加 / ガードを緩める",
+    "forbidden": "ガードを追加 / 責任者がリスク受容",
+    "acceptance": "仕様 or 受入条件を修正",
+    "sla": "urgent 前提 or 期限値を見直し",
+    "refinement": "mapping / ガードを修正",
+    "conformance": "実装 or 仕様を一致させる",
+    "coverage": "ガードを緩める / 前提アクションを追加",
+    "vacuity": "fslc mutate で実効性を確認",
+}
+
+
+def _next_action(f: dict) -> str:
+    return f.get("next_action") or _DEFAULT_ACTION.get(f["trace_type"]) or "責任者が対応方針を決定"
+
+
+# --------------------------------------------------------------------------
+# rendering
+# --------------------------------------------------------------------------
+def _guarantee_line(verification: dict) -> str:
+    completeness = verification.get("completeness")
+    depth = verification.get("checked_to_depth", verification.get("depth"))
+    if completeness == "unbounded":
+        return "k帰納法で **全実行を証明済み**（深さ無制限）"
+    return f"BMC（有界モデル検査）: **深さ {depth} までの全実行を網羅**。それ以遠の反例は本台帳の対象外"
+
+
+def _esc(text) -> str:
+    return str(text or "").replace("|", "\\|").replace("\n", " ")
+
+
+def _confirmed_reqs(scenarios_result: dict) -> dict:
+    """req_id -> list of passing scenario names (acceptance/forbidden/reachable)."""
+    out: dict = {}
+    for sc in scenarios_result.get("scenarios") or []:
+        rid, _ = _req_of(sc)
+        if rid:
+            out.setdefault(rid, []).append(f"{sc.get('kind')}:{sc.get('name')}")
+    return out
+
+
+def render_ledger(file, spec, verification, scenarios_result, replay_result=None) -> str:
+    registry = _requirement_registry(spec)
+    findings = _collect_findings(verification)
+    confirmed = _confirmed_reqs(scenarios_result or {})
+
+    by_req: dict = {}
+    spec_level = []
+    for f in findings:
+        (by_req.setdefault(f["req_id"], []).append(f) if f["req_id"] else spec_level.append(f))
+
+    # every requirement id that exists or has a finding
+    all_ids = list(registry.keys())
+    for rid in by_req:
+        if rid not in all_ids:
+            all_ids.append(rid)
+
+    L = []
+    L.append(f"# 意図ずれ監査台帳: {spec.get('name', Path(file).stem)}")
+    L.append("")
+    L.append(f"- 対象: `{file}`")
+    L.append(f"- 保証限界: {_guarantee_line(verification)}")
+    L.append("- この台帳が保証するのは **書かれた仕様の内部整合**。仕様が現実の意図に忠実かは各行の **判断** 欄で人間が担保する。")
+    if replay_result is not None:
+        rr = replay_result.get("result")
+        if rr == "nonconformant":
+            L.append(f"- ⚠ 実装ログ適合: **非適合**（イベント {replay_result.get('failed_at_event')} で乖離）")
+        elif rr == "conformant":
+            L.append(f"- 実装ログ適合: 適合（{replay_result.get('steps_checked')} ステップ）")
+    L.append("")
+
+    # page 1 — risk list
+    L.append("## リスク一覧（要件ID別）")
+    L.append("")
+    L.append("| 要件ID | 業務目的 | 状態 | 検出種別 | リスク | 判断者 | 次アクション |")
+    L.append("|---|---|---|---|---|---|---|")
+    for rid in all_ids:
+        reg = registry.get(rid, {})
+        fs = by_req.get(rid, [])
+        purpose = _esc(reg.get("text") or (fs[0]["req_text"] if fs else "") or "—")
+        if fs:
+            status = "🔴 要確認"
+            types = ", ".join(sorted({f["trace_type"] for f in fs}))
+            action = " / ".join(sorted({_next_action(f) for f in fs}))
+        else:
+            status = "🟢 確認済（承認可）" if rid in confirmed else "🟢 反例なし"
+            types = "—"
+            action = "—"
+        risk = _esc(reg.get("severity") or ("要確認" if fs else "—"))
+        owner = _esc(reg.get("owner") or ("____" if fs else "—"))
+        L.append(f"| {_esc(rid)} | {purpose} | {status} | {_esc(types)} | {risk} | {owner} | {_esc(action)} |")
+    if spec_level:
+        types = ", ".join(sorted({f["trace_type"] for f in spec_level}))
+        L.append(f"| （仕様全体） | 要件ID未付与の検出 | 🔴 要確認 | {_esc(types)} | 要確認 | ____ | 下記詳細 |")
+    L.append("")
+
+    # page 2+ — per-requirement detail
+    L.append("## 要件ID別詳細")
+    L.append("")
+    detail_ids = [r for r in all_ids if by_req.get(r)] + (["（仕様全体）"] if spec_level else [])
+    if not detail_ids:
+        L.append("検出された意図ずれ・死経路・禁止経路はありません（深さ内）。受入確認の対象は上表の「確認済」行。")
+        L.append("")
+    for rid in detail_ids:
+        fs = spec_level if rid == "（仕様全体）" else by_req.get(rid, [])
+        reg = registry.get(rid, {})
+        L.append(f"### {rid}" + (f" — {reg.get('text')}" if reg.get("text") else ""))
+        if reg.get("controls"):
+            cids = ", ".join(c.get("id") for c in reg["controls"])
+            gov = f"統制: {cids}"
+            if reg.get("owner"):
+                gov += f"（owner: {reg['owner']}"
+                gov += f", severity: {reg['severity']}）" if reg.get("severity") else "）"
+            L.append(f"- {gov}")
+        for f in fs:
+            L.append(f"- **検出**: `{f['trace_type']}` — {_esc(f.get('name'))}")
+            L.append(f"  - 反例要約: {_esc(f['summary'])}")
+            L.append(f"  - 業務翻訳: {_translate(f)}")
+            L.append(f"  - 次アクション: {_esc(_next_action(f))}")
+        L.append(f"- 判断: ☐ 承認　☐ 差戻し　☐ リスク受容　／　判断者: {reg.get('owner') or '____'}　期限: ____")
+        L.append("")
+
+    # appendix — raw JSON demoted
+    L.append("## 付録: 生 JSON 反例（証跡）")
+    L.append("")
+    L.append("<details><summary>raw findings</summary>")
+    L.append("")
+    L.append("```json")
+    L.append(json.dumps([f["raw"] for f in findings], indent=2, ensure_ascii=False))
+    L.append("```")
+    L.append("")
+    L.append("</details>")
+    L.append("")
+    return "\n".join(L)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Issue #24: the business audit ledger (`fslc ledger`)."""
+from pathlib import Path
+
+from fslc.cli import run_ledger
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NFR = ROOT / "examples" / "nfr"
+INJECTED = ROOT / "examples" / "gallery" / "injected"
+
+
+def _write(tmp_path, name, src):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    return p
+
+
+def _ledger(path, **kw):
+    r = run_ledger(str(path), **kw)
+    assert r["result"] == "generated", r
+    assert r["kind"] == "audit_ledger"
+    return r["content"]
+
+
+def test_ledger_sla_violation_groups_by_requirement(tmp_path):
+    src = (NFR / "sla_worker.fsl").read_text(encoding="utf-8").replace(
+        "    urgent start, finish\n", "")
+    p = _write(tmp_path, "sla_no_urgent.fsl", src)
+    md = _ledger(p, depth=10)
+    assert "意図ずれ監査台帳" in md
+    assert "NFR-1" in md                      # grouped by requirement id
+    assert "🔴 要確認" in md
+    assert "| sla |" in md or "`sla`" in md    # trace_type drives the row
+    assert "スケジューリング前提" in md          # sla business translation
+    # decision affordances a PM can act on
+    assert "☐ 承認" in md and "☐ 差戻し" in md and "☐ リスク受容" in md
+
+
+def test_ledger_guarantee_limit_is_positive_framing(tmp_path):
+    src = (NFR / "sla_worker.fsl").read_text(encoding="utf-8").replace(
+        "    urgent start, finish\n", "")
+    p = _write(tmp_path, "sla_no_urgent.fsl", src)
+    md = _ledger(p, depth=10)
+    # the guarantee limit states what IS covered, not "nothing is guaranteed"
+    assert "全実行を網羅" in md or "全実行を証明" in md
+    assert "内部整合" in md
+
+
+def test_ledger_verified_spec_all_confirmed():
+    md = _ledger(NFR / "support_sla.fsl", depth=8)
+    assert "🟢" in md
+    assert "🔴 要確認" not in md               # nothing needs review
+    for rid in ("REQ-1", "REQ-3", "REQ-5"):
+        assert rid in md
+
+
+def test_ledger_forbidden_flow_flagged():
+    md = _ledger(INJECTED / "order_workflow__guard_weakening.fsl", depth=6)
+    assert "🔴 要確認" in md
+    assert "forbidden" in md
+    assert "OR-FB-CANCEL-SHIPPED" in md
+
+
+def test_ledger_reachable_dead_path_spec_level(tmp_path):
+    p = _write(tmp_path, "unreach.fsl", """
+spec Unreach {
+  state { x: Bool }
+  init { x = false }
+  action noop() { requires x  x = true }
+  reachable XTrue { x }
+}
+""")
+    md = _ledger(p, depth=5)
+    assert "（仕様全体）" in md                 # untagged findings grouped at spec level
+    assert "reachable" in md
+    assert "到達" in md                         # dead-path translation
+
+
+def test_ledger_raw_json_demoted_to_appendix(tmp_path):
+    src = (NFR / "sla_worker.fsl").read_text(encoding="utf-8").replace(
+        "    urgent start, finish\n", "")
+    p = _write(tmp_path, "sla_no_urgent.fsl", src)
+    md = _ledger(p, depth=10)
+    assert "## 付録" in md
+    assert "<details>" in md                    # raw JSON is collapsed, not page 1
+    # the risk list precedes the raw JSON
+    assert md.index("リスク一覧") < md.index("付録")
+
+
+def test_ledger_writes_file(tmp_path):
+    out = tmp_path / "led.md"
+    r = run_ledger(str(NFR / "support_sla.fsl"), depth=8, output=str(out))
+    assert r["result"] == "generated"
+    assert r["output"] == str(out)
+    assert out.exists() and "監査台帳" in out.read_text(encoding="utf-8")
+
+
+def test_ledger_impl_log_nonconformance(tmp_path):
+    # a trace that violates the spec → the ledger surfaces non-conformance
+    log = tmp_path / "log.json"
+    log.write_text('[{"action": "submit", "params": {"r": 0}},'
+                   ' {"action": "submit", "params": {"r": 0}}]', encoding="utf-8")
+    md = _ledger(NFR / "sla_worker.fsl", depth=8, impl_log=str(log))
+    assert "実装ログ適合" in md


### PR DESCRIPTION
Closes #24.

## What & why

A Markdown **audit ledger** for PM / development-governance / internal-audit. It re-organizes `verify` / `scenarios` / `replay` findings **by requirement id** so a non-engineer can decide **approve / reject / risk-accept per requirement from the ledger alone** — without reading raw JSON or formulas. The business-audience analogue of `fslc html` (a presentation layer over the verifier; **no new evaluator/parser**).

The reframe the issue asks for: not "correctness guaranteed" but **intent-drift / dead-paths / forbidden-paths / boundary-gaps as items a human must confirm**, with the guarantee limit stated in *positive* form so it never reads as "guarantees nothing".

## Built directly on #23

- `trace_type` drives a per-finding **business translation** (`sla` → "SLA期限を超過しうる…責任者が承認"; `reachable` → "業務経路が到達できない…受入条件に追加"; `forbidden`, `coverage`, `refinement`, …).
- `requirement.{id,text}` is the **grouping key**; `recommended_action`/`hint` → 次アクション; `checked_to_depth`+`completeness` → 保証限界.
- Governance columns (risk/decider) come from `control` metadata **when present**, fill-in (`____`) otherwise — the ledger never fabricates a loss figure or deadline.

## Output shape

1. Header — guarantee limit (positive) + "保証するのは内部整合; intent fidelity は各行の判断で担保".
2. **リスク一覧** — one row per requirement id (🔴 要確認 / 🟢 確認済, 検出種別, リスク, 判断者, 次アクション).
3. **要件ID別詳細** — counterexample → business sentence + decision line (☐承認 ☐差戻し ☐リスク受容 / 判断者 / 期限).
4. **付録** — raw JSON, collapsed (`<details>`), demoted off page 1.

```
fslc ledger spec.fsl --depth 8 [--impl-log run.json] [-o ledger.md]
```
Artifact-to-stdout without `-o` (mirrors `html`/`testgen`); `result:"generated"`, `kind:"audit_ledger"`.

## Acceptance criteria

- ✅ Decidable from the ledger alone (per-requirement status + 判断 affordances + owner + next action).
- ✅ Doesn't devolve into raw-JSON explanation (raw demoted to collapsed appendix).
- ✅ Guarantee limit doesn't read as "guarantees nothing" (states depth-bounded coverage / inductive proof + the intent-fidelity honesty line).

## Test plan

- `tests/test_ledger.py` (new) — sla-violation grouping, all-confirmed verified spec, forbidden flag, reachable dead-path (spec-level), positive guarantee framing, raw-JSON appendix, file output, impl-log conformance — **8 passed**.
- CLI integrity: `test_html_report` + `test_self_conformance` (real CLI pipeline) — **47 passed**; `test_meta` + `test_repair_fields` — green.
- `tests/test_corpus_snapshot.py` — **152 passed, snapshot unchanged** (additive; `check`/`verify` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)