### PR TITLE
docs(skill): over-constraint mirror in the repair protocol (#22 dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Documentation
+- `skills/fsl/SKILL.md` repair protocol: added the over-constraint mirror of the
+  hollowing warning — after fixing a `forbidden`/`violated` by tightening a guard,
+  re-run `verify` and confirm the action's `action_coverage` is still `true` (and
+  affected `reachable`s still witnessed), since an over-tight guard surfaces as a
+  *new* `reachable_failed`/`covered:false`. (Surfaced by the #22 repair DOGFOOD,
+  where fslc-arm agents did exactly this self-check.)
 - Documented the cross-layer discrete-time SLA rule: a `deadline` is a safety
   property of the clock that declares it, so a refinement carries it only across a
   *shared* clock (a finer-clock design fails `fslc refine` with

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -356,7 +356,12 @@ the source material or the human confirms it. If the counterexample exposes a
 missing requirement or design decision, ask instead of choosing the repair on the
 user's behalf. The shortest path to verified is often "weakening the spec," so
 without confirmation and a record of what was weakened and why, you later cannot
-distinguish a hollowing-out repair from a legitimate fix.
+distinguish a hollowing-out repair from a legitimate fix. The mirror failure is
+**over-constraining**: a guard added to fix a `forbidden`/`violated` can tighten
+the action into a dead one. After such a fix, re-run `verify` and confirm the
+repaired action's `action_coverage` is still `true` (and any affected `reachable`
+still witnessed) — over-tightening surfaces as a *new* `reachable_failed` /
+`covered:false`, not as a failure of the original fix.
 
 ## Minimal syntax (details and the full catalog are in reference.md)
 


### PR DESCRIPTION
A small skill refinement distilled from the #22 repair DOGFOOD (12 agent-runs, fslc-arm vs NL-arm).

## Why
The experiment's main outcome was that fslc-repair and NL-reread **tie** on small clear-intent specs (across strong and weak models) — so there is no big "how to repair with fslc" residual to encode; the existing `SKILL.md` repair table is **validated** (the fslc-arm agents succeeded by following it: `reachable_failed` → `action_coverage`/`blocking_requires`; `forbidden` → `accepted_trace`; the anti-hollow discipline).

The **one** behavior that the agents performed but the skill did not state explicitly is the **over-constraint dual** of the existing hollowing (under-constraint) warning: a guard added to fix a `forbidden`/`violated` can over-tighten the action into a *dead* one. The fslc-arm agents self-checked this by re-running `verify` and confirming `action_coverage[action]: true` after the fix (e.g. `cancel:true`, or `FullLifecycle` still witnessed).

## Change
One sentence appended to the anti-hollow paragraph of `skills/fsl/SKILL.md`:
> After fixing a `forbidden`/`violated` by tightening a guard, re-run `verify` and confirm the action's `action_coverage` is still `true` (and affected `reachable`s still witnessed) — over-tightening surfaces as a *new* `reachable_failed`/`covered:false`, not as a failure of the original fix.

Falsifiable and output-specifiable (not an attitude prompt). Honest caveat: the agents did this with/without explicit priming, so it is a *safe explicitation*, not a cleanly-measured residual — added because it is concrete and low-cost, per the residual-skill-engineering bar.

Does not close #22 (the go/no-go conclusion — "don't bet on repair-superiority; keep fslc as a localization/audit tool" — is recorded separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)