### PR TITLE
docs(intro): reframe "When to Use FSL" around cross-layer connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `implements`), and the `time`-block `tick` is generated (declaring `action tick` is a
   check error), advances age only, auto-maps to `stutter`, and is referenced as
   `tick()`. (#58)
+- Reframed the "When to Use FSL" manual chapter (`docs/intro/when-to-use.{ja,en}.html`)
+  and the `skills/fsl/SKILL.md` self-check toward FSL's distinctive edge: cross-layer
+  alignment is a **primary use**, not an optional "second lens." The page now leads
+  with two payoffs — ① a single spec's way of breaking (the classic island check) and
+  ② layer-spanning alignment (write the contract layers in FSL and the machine keeps
+  catching cross-layer drift) — so it no longer reads as generic formal-methods
+  adoption guidance. Brakes kept intact (abstraction tax, hollow-spec / mutate
+  kill-rate, judgment-aid-not-mandate, "contract spine, not the entire product
+  process").
 
 ### Added
 - `fslc ledger <spec.fsl> [--impl-log run.json] [-o ledger.md]`: a business

--- a/docs/intro/when-to-use.en.html
+++ b/docs/intro/when-to-use.en.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>When to Use FSL — deciding where it fits</title>
-<meta name="description" content="Where FSL pays off and where it doesn't. The one test (interaction of state, order, and flags), three gates, the fit / low-priority / out-of-scope split, the preconditions for real value, and which layer to write." />
+<meta name="description" content="Where FSL pays off and where it doesn't. Two payoffs (a single spec's way of breaking / cross-layer alignment, FSL's edge), three gates, the fit / low-priority / out-of-scope split, the preconditions for real value, and which layer to write." />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="when-to-use">
@@ -20,9 +20,9 @@
 <section class="hero">
   <div class="wrap narrow center">
     <p class="kicker reveal">When to use it</p>
-    <h1 class="reveal">Whether to use FSL<br>isn't about <span class="hl">how many states</span> you have.</h1>
-    <p class="lead reveal">It's about how it breaks. Can some <b>order of operations</b> or <b>combination of flags</b><br>slip into a state that must never happen? That's the whole test.</p>
-    <p class="reveal" style="margin-top:24px">FSL is not a tool to apply to everything.<br>This page is the line you take home: <b>where it pays off, and where you don't need it</b>. <span class="dim">(10 min, no jargon)</span></p>
+    <h1 class="reveal">"Should we use FSL?" turns on <span class="hl">two ways it pays off</span>.</h1>
+    <p class="lead reveal">One is a single spec's <b>way of breaking</b> — can order or flags interact into a state that must never happen?<br>The other is FSL's real edge: because you write <b>business, requirements, and design</b> in it, it catches the <b>drift between layers</b> too.</p>
+    <p class="reveal" style="margin-top:24px">That second one is what classic formal methods don't give you — so <b>the more of the contract layers you write, the more it manages your app's alignment</b>. Still, it isn't a tool for everything — you also take home <b>where it pays off and where you don't need it</b>. <span class="dim">(10 min, no jargon)</span></p>
     <div class="scroll-hint reveal">▽ Scroll</div>
   </div>
 </section>
@@ -32,9 +32,9 @@
 <!-- 1. The one test -->
 <section>
   <div class="wrap">
-    <p class="kicker reveal">The one test</p>
+    <p class="kicker reveal">Payoff ①: within a single spec</p>
     <h2 class="reveal">Decide by how it breaks, not how many states</h2>
-    <p class="lead narrow reveal">The number of states is irrelevant. Ask one thing —<br>can some <b>order of operations</b> or <b>combination of flags</b> slip into a state that can't legitimately exist?</p>
+    <p class="lead narrow reveal">First, the within-one-spec question. The number of states is irrelevant. Ask —<br>can some <b>order of operations</b> or <b>combination of flags</b> slip into a state that can't legitimately exist?</p>
     <div class="vs reveal" style="margin-top:24px">
       <div class="card">
         <h3>❌ Not "many states → use it"</h3>
@@ -49,12 +49,34 @@
   </div>
 </section>
 
+<hr class="soft" />
+
+<!-- 1b. Payoff ②: cross-layer alignment (FSL's edge) -->
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Payoff ②: cross-layer alignment — FSL's edge</p>
+    <h2 class="reveal">It doesn't stop at verifying one island</h2>
+    <p class="lead narrow reveal">Classic formal methods take <b>one</b> hard spot and verify it in isolation (the island model).<br>FSL is different: it stitches <b>business, requirements, design, and implementation</b> with refinement and checks whether <b>the layers still mean the same thing</b>.</p>
+    <div class="vs reveal" style="margin-top:24px">
+      <div class="card">
+        <h3>🏝 Classic formal methods = islands</h3>
+        <p class="dim" style="margin-top:10px">Model one hard spot and ask "is this spec correct?" Keeping the layers aligned stays a manual job.</p>
+      </div>
+      <div class="card">
+        <h3>🔗 FSL = across the layers</h3>
+        <p class="dim" style="margin-top:10px">Connect business ⊒ requirements ⊒ design ⊒ implementation and verify that <b>a requirement is honored by the design / a control still bites at the lowest layer / an As-Is→To-Be change preserves a control</b>. The question becomes "do these layers still mean the same thing?"</p>
+      </div>
+    </div>
+    <p class="narrow reveal" style="margin-top:28px">So <b>the more of the contract layers (business, requirements, design) you write in FSL</b>, the more the machine keeps catching cross-layer drift — spec-vs-implementation mismatch. That is <b>FSL managing your app's alignment</b>. Verifying the connection is not an advanced topic — it is <b>one of FSL's primary uses</b>.</p>
+  </div>
+</section>
+
 <!-- 2. Decision flow: three gates -->
 <section style="background:var(--surface-2)">
   <div class="wrap">
-    <p class="kicker reveal">Decision flow</p>
+    <p class="kicker reveal">Decision flow (sizing up payoff ①)</p>
     <h2 class="reveal">Pass three gates, top to bottom</h2>
-    <p class="lead narrow reveal">Work down in order. Wherever you get stuck — that's your answer.</p>
+    <p class="lead narrow reveal">First decide whether it pays off <b>as a single spec</b>. Work down in order; wherever you get stuck — that's your answer.<br>(Cross-layer alignment — payoff ② — is the "second lens" just below.)</p>
     <div class="layers reveal" style="margin-top:24px">
       <div class="layer">
         <h3>① Is there a state machine?</h3>
@@ -77,10 +99,10 @@
       </div>
     </div>
     <div class="callout reveal" style="margin-top:28px;text-align:left">
-      <p style="margin:0 0 10px"><b>A second lens (recommended, optional): is there connectivity value?</b></p>
-      <p style="margin:0 0 10px">The three gates above score a spec as a single island. But FSL can also verify <b>cross-layer alignment</b> — <b>a requirement provably honored by the design, a regulatory control that still bites at the lowest layer, an As-Is→To-Be change that preserves a control</b>. When that alignment is the point, even a thin single spec can be high-value through <code>chain</code>.</p>
-      <p style="margin:0 0 10px">The converse is the <b>abstraction tax</b>: if there is really only one hard altitude, don't manufacture three layers (you'd just write the same thing three times at different verbosity). Island-shaped hard spots stay single-spec, as before.</p>
-      <p style="margin:0" class="dim">This is a judgment aid, not a mandate to make every task three-layered.</p>
+      <p style="margin:0 0 10px"><b>The second lens: is there connectivity value? (sizing up payoff ②)</b></p>
+      <p style="margin:0 0 10px">Even if the three gates don't all pass — even if a spec is "low priority (thin)" on its own — it is high-value when <b>cross-layer alignment</b> is the point: <b>a requirement provably honored by the design, a regulatory control that still bites at the lowest layer, an As-Is→To-Be change that preserves a control</b>. When that's the goal, write the layers and verify the seams with <code>chain</code>. This is not an advanced topic — it is a <b>primary use of FSL</b>.</p>
+      <p style="margin:0 0 10px">The same lens also says <b>when to stop</b>: the <b>abstraction tax</b>. If there is really only one hard altitude, don't manufacture three layers (you'd just write the same thing three times at different verbosity). Island-shaped hard spots stay single-spec, as before.</p>
+      <p style="margin:0" class="dim">The wider you write, the more alignment management pays off — but this is a judgment aid, not a mandate to make every task three-layered (FSL is the contract <em>spine</em>, not the entire product process).</p>
     </div>
   </div>
 </section>
@@ -113,7 +135,7 @@
           <li>UI decoration with few constraints</li>
           <li>Processing with almost no transitions</li>
         </ul>
-        <p style="margin-top:10px">On a linear path, existing tests usually suffice.</p>
+        <p style="margin-top:10px">On a linear path, existing tests usually suffice.<br><span class="dim">But if it's part of <b>alignment with an upper layer</b> (payoff ②), it can be worth writing even when thin on its own.</span></p>
       </div>
       <div class="syntax-card">
         <h3 style="color:var(--danger)">⛔ Out of scope (not expressible)</h3>
@@ -214,7 +236,7 @@
     <p class="kicker reveal">In one line</p>
     <h2 class="reveal">Remember this sentence</h2>
     <div class="callout reveal" style="margin-top:20px;text-align:left">
-      <p style="margin:0;font-size:18px"><b>It's a state machine, the interaction of order/flags/permissions can reach a dangerous state, it's expressible as finite &amp; discrete, and there's a human owner of the rules</b> — that's when FSL pays off.<br><span class="dim">Size (the number of states) is not a deciding factor.</span></p>
+      <p style="margin:0;font-size:18px"><b>You can detect a single spec's "way of breaking," and/or the "cross-layer drift" from business to design</b> — that's when FSL pays off. The latter is the edge classic formal methods lack: <b>the more of the contract layers you write, the more it manages your app's alignment</b>.<br><span class="dim">Size (the number of states) is not a deciding factor.</span></p>
     </div>
     <div class="cta reveal" style="margin-top:32px">
       <h2>Now run it</h2>

--- a/docs/intro/when-to-use.ja.html
+++ b/docs/intro/when-to-use.ja.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>使いどころ — FSLを使うべきか見極める</title>
-<meta name="description" content="FSLをどこに使い、どこには要らないか。状態×操作順×フラグの相互作用という判断軸、3つのゲート、効く/低優先/対象外の切り分け、価値の前提、層の選び方。" />
+<meta name="description" content="FSLをどこに使い、どこには要らないか。2つの効きどころ（単一仕様の壊れ方／層をまたぐ整合というFSLの差別化）、3ゲート、効く/低優先/対象外、価値の前提、層の選び方。" />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="when-to-use">
@@ -20,9 +20,9 @@
 <section class="hero">
   <div class="wrap narrow center">
     <p class="kicker reveal">いつ使うべきか</p>
-    <h1 class="reveal">「使うべき？」の答えは、<br><span class="hl">状態の数</span>では決まらない。</h1>
-    <p class="lead reveal">決め手は「壊れ方」。ある<b>操作の順番</b>や<b>フラグの組み合わせ</b>で、<br>あってはならない状態に滑り込めるか——基準はそれだけです。</p>
-    <p class="reveal" style="margin-top:24px">FSL は全部に使う道具ではありません。<br>このページは、<b>どこに効いて、どこは要らないか</b>の線引きを持ち帰るためのものです。<span class="dim">（10分・専門用語なし）</span></p>
+    <h1 class="reveal">「使うべき？」は、<span class="hl">2つの効きどころ</span>で決まる。</h1>
+    <p class="lead reveal">ひとつは単一仕様の<b>壊れ方</b>——順序やフラグの相互作用で危険状態に入り得るか。<br>もうひとつが FSL の真価：<b>業務・要件・設計を貫いて書ける</b>から、層と層のズレまで機械が検出する。</p>
+    <p class="reveal" style="margin-top:24px">後者は一般的な形式手法にない差別化。だから<b>契約の層を広く書くほど、アプリの整合管理</b>になります。とはいえ全部に使う道具ではありません——<b>どこに効いて、どこは要らないか</b>の線引きまで持ち帰る。<span class="dim">（10分・専門用語なし）</span></p>
     <div class="scroll-hint reveal">▽ スクロール</div>
   </div>
 </section>
@@ -32,9 +32,9 @@
 <!-- 1. 核心：たったひとつの判断軸 -->
 <section>
   <div class="wrap">
-    <p class="kicker reveal">たったひとつの判断軸</p>
+    <p class="kicker reveal">効きどころ ①：単一仕様</p>
     <h2 class="reveal">「状態の多さ」ではなく「壊れ方」で決める</h2>
-    <p class="lead narrow reveal">状態がいくつあるかは関係ありません。問うのはひとつ——<br>ある<b>操作の順番</b>や<b>フラグの組み合わせ</b>で、本来あり得ない状態に滑り込めるか。</p>
+    <p class="lead narrow reveal">まずは仕様ひとつの中の話。状態がいくつあるかは関係ありません。問うのは——<br>ある<b>操作の順番</b>や<b>フラグの組み合わせ</b>で、本来あり得ない状態に滑り込めるか。</p>
     <div class="vs reveal" style="margin-top:24px">
       <div class="card">
         <h3>❌ 「状態が多い＝使う」ではない</h3>
@@ -49,12 +49,34 @@
   </div>
 </section>
 
+<hr class="soft" />
+
+<!-- 1b. 効きどころ②：層をまたぐ整合（FSLの差別化） -->
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">効きどころ ②：層をまたぐ整合 — ここがFSLの差別化</p>
+    <h2 class="reveal">「島をひとつ検証する」では終わらない</h2>
+    <p class="lead narrow reveal">一般的な形式手法は、難所を<b>ひとつ</b>取り出して検証します（島モデル）。<br>FSLが違うのは、<b>業務・要件・設計・実装</b>を refinement で縫い合わせ、<b>層と層が同じ意味を保っているか</b>まで機械検証できること。</p>
+    <div class="vs reveal" style="margin-top:24px">
+      <div class="card">
+        <h3>🏝 一般的な形式手法＝島モデル</h3>
+        <p class="dim" style="margin-top:10px">難所をひとつモデル化して「この仕様は正しいか」を問う。層をまたぐ整合は、人手の管理に残る。</p>
+      </div>
+      <div class="card">
+        <h3>🔗 FSL＝層を貫く</h3>
+        <p class="dim" style="margin-top:10px">業務⊒要件⊒設計⊒実装をつなぎ、<b>要件が設計に守られる／規制が下層まで効く／As-Is→To-Beが統制を保存する</b>かを検証。問いは「これらの層はまだ同じ意味か」へ。</p>
+      </div>
+    </div>
+    <p class="narrow reveal" style="margin-top:28px">だから<b>契約の層（業務・要件・設計）を広くFSLで書くほど</b>、層間の不整合＝仕様と実装のズレを機械が拾い続けます。これが<b>FSLによるアプリの整合管理</b>。連結の検証は応用編ではなく、<b>FSLの主用途のひとつ</b>です。</p>
+  </div>
+</section>
+
 <!-- 2. 判断フロー：3つのゲート -->
 <section style="background:var(--surface-2)">
   <div class="wrap">
-    <p class="kicker reveal">判断フロー</p>
+    <p class="kicker reveal">判断フロー（効きどころ①の見極め）</p>
     <h2 class="reveal">3つのゲートを、上から順に通す</h2>
-    <p class="lead narrow reveal">上から順に通します。どこかで詰まったら、そこが答えです。</p>
+    <p class="lead narrow reveal">まず<b>単一仕様として</b>効くかを見極めます。上から順に通し、どこかで詰まったら、そこが答えです。<br>（層をまたぐ整合＝効きどころ②は、この下の「もうひとつのレンズ」で。）</p>
     <div class="layers reveal" style="margin-top:24px">
       <div class="layer">
         <h3>① 状態遷移があるか</h3>
@@ -77,10 +99,10 @@
       </div>
     </div>
     <div class="callout reveal" style="margin-top:28px;text-align:left">
-      <p style="margin:0 0 10px"><b>もうひとつのレンズ（推奨・任意）：連結に価値があるか。</b></p>
-      <p style="margin:0 0 10px">上の3ゲートは「単一スペックとしての難所」を測ります。けれど FSL は<b>層をまたぐ整合</b>も検証できます——<b>要件が設計に確かに守られる／規制が下層まで効く／As-Is→To-Be が統制を保存する</b>、といった整合が要点なら、単発では薄くても <code>chain</code> で高価値になりえます。</p>
-      <p style="margin:0 0 10px">逆に<b>本当の高度がひとつ</b>なら3層を作らないこと（<b>抽象化税</b>：同じものを冗長度違いで3回書くだけになる）。島型の難所はこれまで通り単一スペックで。</p>
-      <p style="margin:0" class="dim">これは判断の補助であって、全タスクを3層に強制する規則ではありません。</p>
+      <p style="margin:0 0 10px"><b>もうひとつのレンズ：連結に価値があるか（効きどころ②の見極め）。</b></p>
+      <p style="margin:0 0 10px">3ゲートが○でなくても——単発では「低優先（薄い）」でも——<b>層をまたぐ整合</b>が要点なら高価値です。<b>要件が設計に確かに守られる／規制が下層まで効く／As-Is→To-Be が統制を保存する</b>、これらが狙いなら各層を書いて <code>chain</code> でつなぎ目を検証する。これは応用編ではなく、<b>FSLの主用途</b>です。</p>
+      <p style="margin:0 0 10px">ただし<b>やりすぎ防止</b>も同じレンズで測ります。<b>本当の高度がひとつ</b>なら3層を作らないこと（<b>抽象化税</b>：同じものを冗長度違いで3回書くだけになる）。島型の難所はこれまで通り単一スペックで。</p>
+      <p style="margin:0" class="dim">広く書くほど整合管理は効きますが、これは判断の補助であって、全タスクを3層に強制する規則ではありません（FSLは“契約の背骨”であって、製品プロセス全体ではない）。</p>
     </div>
   </div>
 </section>
@@ -113,7 +135,7 @@
           <li>制約の少ないUI装飾</li>
           <li>状態遷移がほぼない処理</li>
         </ul>
-        <p style="margin-top:10px">一本道なら、既存テストで足りることが多い。</p>
+        <p style="margin-top:10px">一本道なら、既存テストで足りることが多い。<br><span class="dim">ただし<b>上位層との整合</b>（効きどころ②）の一部なら、単発で薄くても書く価値がある。</span></p>
       </div>
       <div class="syntax-card">
         <h3 style="color:var(--danger)">⛔ 対象外（表現できない）</h3>
@@ -214,7 +236,7 @@
     <p class="kicker reveal">まとめ</p>
     <h2 class="reveal">覚えるのは、この一文</h2>
     <div class="callout reveal" style="margin-top:20px;text-align:left">
-      <p style="margin:0;font-size:18px"><b>状態機械であり、順序・フラグ・権限の相互作用で危険状態に入り得て、有限・離散で書けて、ルールの責任者がいる</b>——このときFSLが効く。<br><span class="dim">サイズ（状態の多さ）は判断材料ではない。</span></p>
+      <p style="margin:0;font-size:18px"><b>単一仕様の「壊れ方」を検出でき、かつ／または 業務〜設計の「層をまたぐズレ」を検出できる</b>——このときFSLが効く。後者は一般的な形式手法にない差別化で、<b>契約の層を広く書くほどアプリの整合管理</b>になる。<br><span class="dim">サイズ（状態の多さ）は判断材料ではない。</span></p>
     </div>
     <div class="cta reveal" style="margin-top:32px">
       <h2>では、動かしてみる</h2>

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -51,18 +51,23 @@ inventory/allocation, permissions/audit, queues/async, SLA/timeout/retry, screen
 transitions / double-submit / unsaved-changes. Out of scope: real time, probability,
 continuous money, free-text correctness, absolute latency.
 
-**A recommended second lens (optional — not a fourth gate): is there connectivity
-value?** The three gates score a spec *as a single island*. But FSL can also verify
-*cross-layer alignment*, so a spec that rates "low priority (possible but thin)" on
-its own can be high-value once connection is the point — a requirement provably
-honored by the design, a regulatory control that still bites at the lowest layer, an
-As-Is→To-Be change that preserves a control. When that alignment is the deliverable,
-author the layers and gate the seams with `chain` (the connected workflow below) even
-if any single layer is thin. The converse is the **abstraction tax**: if there is
-really only one hard altitude, do *not* manufacture three layers — you would just
-write the same thing three times at different verbosity. Island-shaped hard spots
-stay single-spec, exactly as before. This is a judgment lens, never a mandate to make
-every task three-layered. (Same criterion in the manual's "When to Use FSL" chapter.)
+**The second lens — one of FSL's primary uses, not a fourth gate: is there
+connectivity value?** The three gates score a spec *as a single island*, but that is
+only half of when FSL pays off. FSL's distinctive edge over classic formal methods is
+that it *also* verifies *cross-layer alignment*, so a spec that rates "low priority
+(possible but thin)" on its own can be high-value once connection is the point — a
+requirement provably honored by the design, a regulatory control that still bites at
+the lowest layer, an As-Is→To-Be change that preserves a control. When that alignment
+is the deliverable, author the layers and gate the seams with `chain` (the connected
+workflow below) even if any single layer is thin; verifying the connection is a
+primary use, not a tail-end advanced topic. The converse — the brake on writing *too*
+much — is the **abstraction tax**: if there is really only one hard altitude, do *not*
+manufacture three layers — you would just write the same thing three times at
+different verbosity. Island-shaped hard spots stay single-spec, exactly as before. So
+the wider you write across genuine layers, the more alignment you can mechanically
+manage — but this stays a judgment lens, never a mandate to make every task
+three-layered (FSL is the contract spine, not the entire product process). (Same
+criterion in the manual's "When to Use FSL" chapter.)
 
 Even past the gates, the value is conditional: **FSL checks the spec, not the
 product.** If no human owns the rules, or (for conformance) no faithful Adapter/log


### PR DESCRIPTION
## What

Reframes the "When to Use FSL" manual chapter (`docs/intro/when-to-use.{ja,en}.html`) and the `skills/fsl/SKILL.md` self-check so **cross-layer alignment (connectivity) is the main axis**, not an optional afterthought.

## Why

The page's center of gravity was *island-style selective adoption* — the framing a generic formal-methods language would use (pick one hard spot, verify it in isolation). But FSL's distinctive value is that business / requirements / design are all writable, so **the more of the contract layers you write, the more the machine catches cross-layer drift** — i.e. it manages the app's alignment. `skills/README.md` already states this is *"one of FSL's primary uses, not a tail-end advanced topic"*, yet the page contradicted it by demoting connectivity to a "recommended, optional second lens."

Reported by the repo owner: the chapter "reads like a generic formal-methods language and doesn't reflect what the skills say."

## Changes

- **HERO**: "decided by how it breaks, not state count" → **"two payoffs"** (① a single spec's way of breaking / ② cross-layer alignment = FSL's edge)
- **New section** "Payoff ②: cross-layer alignment — FSL's edge" (island model 🏝 vs. layer-spanning 🔗; "the more contract layers you write, the more it manages your app's alignment"; "a primary use, not an advanced topic")
- **3 gates** reframed as "sizing up payoff ①" (single-spec judgment)
- **Callout** promoted from "optional second lens" → "a primary use of FSL"
- **Summary** sentence now covers both payoffs
- `skills/fsl/SKILL.md` self-check: matching promotion to "one of FSL's primary uses"
- `CHANGELOG.md`: `[Unreleased]` entry

ja/en kept fully in sync.

## Brakes preserved

So "write it widely" doesn't run away: abstraction tax (don't manufacture three layers for one hard altitude), hollow-spec / `mutate` kill-rate, judgment-aid-not-mandate, and "FSL is the contract *spine*, not the entire product process" (from `fsl-delivery`).

## Verification

`<section>` / `<div>` tag counts balanced in both files; heading flow is ① → ② → 3 gates → … as intended; ja/en structurally in sync (both 9 sections / 37 divs). Static HTML — published site updates on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
