### PR TITLE
feat: allow enum member names in acceptance/forbidden action arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- `acceptance`/`forbidden` action arguments now accept enum member names (and
+  const names) in addition to numeric ordinals, matching the name resolution
+  already used by `requires`/`invariant`/`expect` expressions
+  (`_is_enum_member` in `values.py`). An undefined name is still a
+  `kind: "acceptance"`/`"forbidden"` check-time error, now reported as
+  "undefined const or enum member". (#67)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -845,6 +845,10 @@ verify {
   failure is `kind: "acceptance"`). It supports `expect <Entity> <id> in
   <Stage>` alongside `expect <expr>` and flows directly into scenarios / testgen
   (= the acceptance criteria become conformance tests for the implementation).
+  Action arguments in `acceptance`/`forbidden` steps accept enum member names
+  and const names in addition to numeric literals (e.g. `answer(0, Triggered)`
+  is equivalent to `answer(0, 1)` when `Triggered` is `Trigger`'s second
+  member) — an undefined name is a check-time error.
 - Use the kernel-wrapper form only for hard cases: multi-entity requirements,
   conservation rules, SLA/time, history not expressible as a carried field, or
   behavior that needs explicit kernel state. That fallback still supports

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -620,7 +620,9 @@ verify {
 - `acceptance` is replay-checked at check time with the concrete Monitor (failure is
   `kind: "acceptance"`). It supports the readable stage form
   `expect <Entity> <id> in <Stage>` alongside `expect <expr>`, is output to
-  scenarios as `acceptance_<ID>`, and flows to testgen.
+  scenarios as `acceptance_<ID>`, and flows to testgen. Step action arguments accept
+  enum member names and const names, not just numeric literals (`answer(0, Triggered)`
+  == `answer(0, 1)`); an undefined name is a check-time error.
 - `forbidden FB-1 "source" { <steps> expect rejected }` is must-forbid (the dual of
   acceptance). The premise steps (all but the last) are all ok, and it succeeds if
   **the last step is rejected** (not-enabled, or an

--- a/src/fslc/acceptance.py
+++ b/src/fslc/acceptance.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from .model import FslError, resolve_action_name
 from .runtime import Monitor, _EvalError, _as_bool, eval_concrete
+from .values import _is_enum_member
 
 
 def _err(message, loc=None, kind="acceptance"):
@@ -24,7 +25,10 @@ def _literal_value(expr, spec, loc=None, kind="acceptance"):
         name = expr[1]
         if name in spec["consts"]:
             return spec["consts"][name]
-        _err(f"undefined const '{name}' in {kind} action argument", loc=loc, kind=kind)
+        ordinal = _is_enum_member(name, spec)
+        if ordinal is not None:
+            return ordinal
+        _err(f"undefined const or enum member '{name}' in {kind} action argument", loc=loc, kind=kind)
     _err(f"{kind} action arguments must be literals", loc=loc, kind=kind)
 
 

--- a/tests/test_acceptance_enum_args.py
+++ b/tests/test_acceptance_enum_args.py
@@ -1,0 +1,102 @@
+"""Tests for enum member names (and const/bool literals) as acceptance/forbidden
+action arguments (#67). Grammar already parsed these as `ref_expr`; the only
+rejection point was `_literal_value` in `fslc.acceptance`, whose `var` branch
+only resolved `spec["consts"]`."""
+from fslc.acceptance import _literal_value, validate_acceptance, validate_forbidden
+from fslc.cli import run_check
+from fslc.model import build_spec
+from fslc.parser import parse_src
+
+
+def _spec_from(src):
+    ast, display = parse_src(src, ".")
+    return build_spec(ast, display)
+
+
+SIGNAL_SRC = r'''requirements Signal {{
+  type Id = 0..0
+  enum Trigger {{ Idle, Triggered }}
+  enum Auth {{ Pending, Authorized }}
+  state {{ trig: Map<Id, Trigger>, auth: Map<Id, Auth> }}
+  init {{ forall i: Id {{ trig[i] = Idle  auth[i] = Pending }} }}
+
+  requirement REQ-1 "answer records trigger and auth" {{
+    action answer(i: Id, t: Trigger, a: Auth) {{
+      requires trig[i] == Idle
+      trig[i] = t
+      auth[i] = a
+    }}
+  }}
+
+  acceptance AC-1 "answer" {{
+    answer({args})
+    expect trig[0] == Triggered and auth[0] == Authorized
+  }}
+
+  forbidden FB-1 "answering twice is rejected" {{
+    answer({args})
+    answer({args})
+    expect rejected
+  }}
+}}'''
+
+ENUM_NAMES_SRC = SIGNAL_SRC.format(args="0, Triggered, Authorized")
+ORDINALS_SRC = SIGNAL_SRC.format(args="0, 1, 1")
+
+BAD_NAME_SRC = SIGNAL_SRC.format(args="0, Bogus, Authorized")
+
+
+def test_acceptance_enum_member_names_equivalent_to_ordinals():
+    enum_spec = _spec_from(ENUM_NAMES_SRC)
+    ordinal_spec = _spec_from(ORDINALS_SRC)
+
+    enum_result = validate_acceptance(enum_spec)
+    ordinal_result = validate_acceptance(ordinal_spec)
+
+    assert enum_result["ok"] is True
+    assert ordinal_result["ok"] is True
+    assert enum_result["scenarios"][0]["steps"] == ordinal_result["scenarios"][0]["steps"]
+    assert enum_result["scenarios"][0]["steps"][0]["params"] == {"i": 0, "t": 1, "a": 1}
+
+
+def test_forbidden_enum_member_names_equivalent_to_ordinals():
+    enum_spec = _spec_from(ENUM_NAMES_SRC)
+    ordinal_spec = _spec_from(ORDINALS_SRC)
+
+    enum_result = validate_forbidden(enum_spec)
+    ordinal_result = validate_forbidden(ordinal_spec)
+
+    assert enum_result["ok"] is True
+    assert ordinal_result["ok"] is True
+    assert enum_result["scenarios"][0]["steps"] == ordinal_result["scenarios"][0]["steps"]
+    assert enum_result["scenarios"][0]["rejected_by"] == ordinal_result["scenarios"][0]["rejected_by"]
+
+
+def test_acceptance_and_forbidden_pass_check_with_enum_member_names(tmp_path):
+    path = tmp_path / "signal.fsl"
+    path.write_text(ENUM_NAMES_SRC, encoding="utf-8")
+
+    assert run_check(str(path))["result"] == "ok"
+
+
+def test_undefined_name_in_acceptance_arg_still_errors_with_updated_message(tmp_path):
+    path = tmp_path / "signal.fsl"
+    path.write_text(BAD_NAME_SRC, encoding="utf-8")
+
+    result = run_check(str(path))
+
+    assert result["result"] == "error"
+    assert result["kind"] == "acceptance"
+    assert result["id"] == "AC-1"
+    assert "undefined const or enum member 'Bogus'" in result["message"]
+
+
+def test_literal_value_accepts_bool_literal():
+    # Bool-typed action parameters are not implemented yet (tracked separately
+    # as #68), so a bool literal can't reach `_literal_value` through a real
+    # acceptance/forbidden action argument today. This exercises the `bool`
+    # branch directly to confirm it already accepts `true`/`false` literals,
+    # unaffected by the const/enum fallback added for enum member names.
+    spec = _spec_from(ENUM_NAMES_SRC)
+    assert _literal_value(("bool", True), spec) is True
+    assert _literal_value(("bool", False), spec) is False


### PR DESCRIPTION
## Summary
- In `acceptance { … }` / `forbidden { … }` blocks, action arguments could only be ordinals; enum member names were rejected with `undefined const 'X'`, even though expressions (`requires`/`invariant`/`expect`) already resolve enum names. `_literal_value`'s `var` branch in `src/fslc/acceptance.py` now falls back to `_is_enum_member` (`src/fslc/values.py`, the same helper `bmc.py` uses for expressions) after the const lookup fails, so acceptance/forbidden args and expressions resolve names identically.
- If both const and enum lookups fail, the error message is now `undefined const or enum member '<name>' in ... action argument` (kind unchanged: `acceptance` / `forbidden` / `forbidden_setup`).
- No type-aware checking was added (e.g. validating a member belongs to the parameter's declared enum) — out of scope; the existing runtime range check still catches out-of-range ordinals.

## Test plan
- [x] `tests/test_acceptance_enum_args.py` (new): acceptance step with enum member names is equivalent to the same step with ordinals (same resolved params); forbidden block with enum member names is equivalent to ordinals; `check` passes end-to-end with enum member names; undefined name still errors with the new `kind`-unchanged message; direct unit check that the `bool` literal branch in `_literal_value` already accepts `true`/`false` (Bool-typed action parameters aren't implemented yet — separate issue #68 — so a bool literal can't reach this path through a real action argument today).
- [x] `.venv/bin/pytest tests/test_acceptance_enum_args.py tests/test_forbidden.py tests/test_req_dialect.py tests/test_req_process.py -q` → 25 passed
- [x] `.venv/bin/pytest tests/test_corpus_snapshot.py -q` → 152 passed, 1 skipped, **no snapshot diff** (this change doesn't alter any existing corpus verdict, so the snapshot was not regenerated)

Docs updated to match (`docs/LANGUAGE.md`, `skills/fsl/reference.md`) and `CHANGELOG.md` under `[Unreleased]`.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)