### PR TITLE
feat: allow Bool as an action parameter type (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- Allow the builtin `Bool` as an action parameter type (`p: Bool`), matching
+  its existing use as a state `Map` value/key. `Bool` params are first-class
+  z3/concrete booleans in expressions — usable bare as a guard
+  (`requires b` / `requires not b`) or assigned into `Bool`-typed state
+  (`flag[i] = b`) — not a 0/1 int carrier, keeping BMC and the concrete
+  `Monitor` in agreement. `Int` stays rejected (unbounded, can't be
+  enumerated); the error now hints at a range parameter
+  (`p in <lo>..<hi>`). (#68)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -79,6 +79,15 @@ domain size that is really a model bound). See `docs/DESIGN-spec-domains.md`.
 `fair` is a weak-fairness annotation: if that action instance remains
 continuously enabled, the assumption is that it will eventually be executed.
 
+**Action parameter types** (`<p>: <type name>`): a domain type, enum, or the
+builtin `Bool` — anything BMC can enumerate. `Bool` behaves exactly like a
+`Bool` state variable: use it bare as a boolean guard (`requires b`,
+`requires not b`) or assign it into `Bool`-typed state
+(`flag[i] = b`). The builtin `Int` is rejected (an unbounded parameter can't
+be enumerated); use a range parameter instead: `p in <lo>..<hi>` (an inline
+alternative to `<p>: <type name>` that doesn't require declaring a named
+domain type).
+
 The hierarchy of properties: `invariant` is one-state safety, `trans` is
 two-state safety (the pre-transition state can be referenced with `old()`), and
 `leadsTo` is response liveness. Without a ranking function, `leadsTo` is checked

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -34,6 +34,14 @@ spec <Name> {
 }
 ```
 
+Action parameter types (`<p>: <type name>`): domain type, enum, or builtin
+`Bool` — anything BMC can enumerate. `Bool` params behave like `Bool` state:
+usable bare as a guard (`requires b`, `requires not b`) or assigned into
+`Bool`-typed state (`flag[i] = b`). Builtin `Int` is rejected (unbounded,
+can't be enumerated) — use a range parameter instead:
+`action f(p in <lo>..<hi>) { ... }` (inline alternative to `<p>: <type name>`,
+no named domain type required).
+
 Business/requirements dialects also have type-kinds whose finite bounds live in
 a sibling top-level `verify` block instead of inline ranges:
 

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -562,6 +562,8 @@ def _eval_expr_uncached(e, state, binds, spec, old_state=None, in_ensures=False)
         n = e[1]
         if n in binds:
             b = binds[n]
+            if isinstance(b, bool):
+                return z3.BoolVal(b)
             return b if not isinstance(b, int) else z3.IntVal(b)
         if n in consts:
             return z3.IntVal(consts[n])
@@ -1307,13 +1309,18 @@ def build_instances(spec):
     instances = []
     for act in spec["actions"]:
         names = [p[0] for p in act["params"]]
+        is_bool = [p[3] == "Bool" for p in act["params"]]
         ranges = [range(p[1], p[2] + 1) for p in act["params"]]
         combos = itertools.product(*ranges) if ranges else [()]
         for combo in combos:
+            binds = {
+                n: (bool(v) if b else v)
+                for n, v, b in zip(names, combo, is_bool)
+            }
             instances.append({
                 "action": act["name"],
                 "action_def": act,
-                "binds": dict(zip(names, combo)),
+                "binds": binds,
                 "requires": act["requires"],
                 "lets": act["lets"],
                 "stmts": act["stmts"],
@@ -1895,7 +1902,7 @@ def _build_trace(model, states, choices, instances, spec, upto):
 def _display_param(name, val, act, spec):
     for p in act["params"]:
         if p[0] == name and p[3]:
-            ty = spec["types"][p[3]]["ty"]
+            ty = ("bool",) if p[3] == "Bool" else spec["types"][p[3]]["ty"]
             return _display_value(ty, val, spec)
     return val
 

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -467,7 +467,7 @@ def normalize_params(params, consts, types_meta):
                         f"unknown parameter type '{ty_name}'",
                         kind="type",
                         hint="Int parameters cannot be enumerated; use a range "
-                        "parameter (p: lo..hi) or declare a number/domain type",
+                        "parameter (p in lo..hi) or declare a number/domain type",
                     )
                 _err(f"unknown parameter type '{ty_name}'", kind="type")
             ty = types_meta[ty_name]["ty"]

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -458,7 +458,17 @@ def normalize_params(params, consts, types_meta):
         if p[0] == "param_typed":
             _, n, ty_name = p
             _check_reserved(n, "parameter")
+            if ty_name == "Bool":
+                out.append((n, 0, 1, ty_name))
+                continue
             if ty_name not in types_meta:
+                if ty_name == "Int":
+                    _err(
+                        f"unknown parameter type '{ty_name}'",
+                        kind="type",
+                        hint="Int parameters cannot be enumerated; use a range "
+                        "parameter (p: lo..hi) or declare a number/domain type",
+                    )
                 _err(f"unknown parameter type '{ty_name}'", kind="type")
             ty = types_meta[ty_name]["ty"]
             lo, hi = domain_range(ty, types_meta)

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -1051,7 +1051,7 @@ def _logical_val(state, name, ty, spec):
 def _display_param(name, val, act, spec):
     for p in act["params"]:
         if p[0] == name and p[3]:
-            ty = spec["types"][p[3]]["ty"]
+            ty = ("bool",) if p[3] == "Bool" else spec["types"][p[3]]["ty"]
             return _display_value(ty, val, spec)
     return val
 
@@ -1254,6 +1254,8 @@ class Monitor:
                     "kind": "bad_call",
                     "message": f"parameter '{pname}' out of range [{lo}..{hi}]",
                 }
+            if pdef[3] == "Bool":
+                val = bool(val)
             binds[pname] = val
 
         inst = {

--- a/tests/test_bool_param.py
+++ b/tests/test_bool_param.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Tests for the builtin `Bool` action parameter type (#68).
+
+`normalize_params` in `fslc.model` used to only resolve user-declared types
+(`types_meta`), so `Bool` — already a first-class scalar type for state
+(`is_scalar_type`, `domain_range`) — was rejected as a parameter type. This
+exercises the fix end to end: parsing, BMC enumeration/verification, the
+bare-boolean idiom in `requires` (`b` / `not b`), assignment into
+`Map<_, Bool>` state, trace display, and concrete-Monitor replay agreement.
+
+`Int` stays rejected (unbounded, cannot be enumerated) but with an improved
+hint pointing at range parameters.
+"""
+from __future__ import annotations
+
+from fslc.cli import run_check, run_verify
+from fslc.model import build_spec
+from fslc.parser import parse_src
+from fslc.runtime import Monitor
+
+
+def _spec_from(src):
+    ast, display = parse_src(src, ".")
+    return build_spec(ast, display)
+
+
+def _write(tmp_path, src, name="spec.fsl"):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+# `setFlag`'s guard uses the Bool param bare (`b`) and negated (`not b`) —
+# exactly the idiom that must be a first-class z3 Bool at BMC-eval time, not
+# an Int carrier, or `requires` blows up combining it with `and`/`or`/`z3.And`.
+UNSAFE_SRC = """\
+spec BoolParamUnsafe {
+  type Id = 0..0
+
+  state {
+    flag: Map<Id, Bool>
+  }
+
+  init {
+    forall i: Id {
+      flag[i] = false
+    }
+  }
+
+  action setFlag(i: Id, b: Bool) {
+    requires b or not flag[i]
+    flag[i] = b
+  }
+
+  invariant NeverSet {
+    forall i: Id { not flag[i] }
+  }
+}
+"""
+
+# Same shape, but the guard only ever allows `b = false`, so the invariant
+# can never be violated: a true-negative check that verify doesn't cry wolf
+# just because a Bool param is in play.
+SAFE_SRC = """\
+spec BoolParamSafe {
+  type Id = 0..0
+
+  state {
+    flag: Map<Id, Bool>
+  }
+
+  init {
+    forall i: Id {
+      flag[i] = false
+    }
+  }
+
+  action setFlag(i: Id, b: Bool) {
+    requires not b
+    flag[i] = b
+  }
+
+  invariant NeverSet {
+    forall i: Id { not flag[i] }
+  }
+}
+"""
+
+INT_PARAM_SRC = """\
+spec IntParam {
+  action noop(x: Int) {
+    requires true
+  }
+}
+"""
+
+
+def test_bool_param_action_passes_check(tmp_path):
+    path = _write(tmp_path, UNSAFE_SRC)
+    result = run_check(str(path))
+    assert result["result"] == "ok", result
+
+
+def test_bool_guarded_invariant_is_violated_with_bool_param_in_counterexample(tmp_path):
+    path = _write(tmp_path, UNSAFE_SRC)
+    result = run_verify(str(path), 3, "warn")
+
+    assert result["result"] == "violated", result
+    assert result["invariant"] == "NeverSet"
+
+    trace = result["trace"]
+    action_steps = [e for e in trace if "action" in e]
+    assert action_steps, trace
+    last = action_steps[-1]["action"]
+    assert last["name"] == "setFlag"
+    assert last["params"] == {"i": 0, "b": True}
+
+
+def test_bool_guarded_invariant_holds_when_bool_param_is_constrained_false(tmp_path):
+    path = _write(tmp_path, SAFE_SRC)
+    result = run_verify(str(path), 3, "warn")
+
+    assert result["result"] == "verified", result
+
+
+def test_bool_param_map_assignment_and_trace_replay_agree(tmp_path):
+    """The BMC witness trace for the violation above, replayed step by step
+    through the concrete Monitor, must reach the same state BMC reports and —
+    on the final, invariant-violating step — the concrete Monitor must
+    independently flag the *same* invariant with the *same* Bool param value.
+    This is the dual-evaluator agreement invariant this repo pins for every
+    feature (see tests/test_evaluator_agreement.py and tests/oracle.py, which
+    exists specifically to catch a symbolic-only false negative)."""
+    path = _write(tmp_path, UNSAFE_SRC)
+    result = run_verify(str(path), 3, "warn")
+    assert result["result"] == "violated", result
+
+    action_steps = [e for e in result["trace"] if "action" in e]
+    assert action_steps
+
+    mon = Monitor(str(path))
+    mon.reset()
+    for entry in action_steps[:-1]:
+        step_result = mon.step(entry["action"]["name"], entry["action"]["params"])
+        assert step_result["ok"], step_result
+        assert mon.state == entry["state"]
+
+    last = action_steps[-1]
+    step_result = mon.step(last["action"]["name"], last["action"]["params"])
+    assert step_result["ok"] is False
+    assert step_result["kind"] == "invariant"
+    assert step_result["name"] == result["invariant"]
+    assert step_result["params"] == last["action"]["params"]
+
+
+def test_int_param_still_errors_with_range_parameter_hint(tmp_path):
+    path = _write(tmp_path, INT_PARAM_SRC)
+    result = run_check(str(path))
+
+    assert result["result"] == "error"
+    assert result["kind"] == "type"
+    assert "unknown parameter type 'Int'" in result["message"]
+    assert "range parameter" in result["hint"]
+
+
+def test_bool_param_normalized_to_zero_one_range():
+    spec = _spec_from(UNSAFE_SRC)
+    act = next(a for a in spec["actions"] if a["name"] == "setFlag")
+    b_param = next(p for p in act["params"] if p[0] == "b")
+    assert b_param == ("b", 0, 1, "Bool")


### PR DESCRIPTION
## Summary

- `Bool` was already a first-class scalar type for state (`Map` value/key), but `normalize_params` in `src/fslc/model.py` only resolved user-declared types (`types_meta`) for action parameters, so `p: Bool` was rejected with `unknown parameter type 'Bool'`. This adds a builtin-type special case ahead of the `types_meta` lookup, appending `(n, 0, 1, "Bool")` — BMC's parameter enumeration is `range(lo, hi+1)`, so `Bool` enumerates `[0, 1]` with no engine changes.
- `Int` stays rejected (unbounded — can't be enumerated), but the error now hints at the existing range-parameter form: `p in <lo>..<hi>`.

## Semantics decision: Bool params are real booleans, not a 0/1 int carrier

The risk investigated before coding: how does a Bool param behave *in expressions* — bare in `requires b` / `requires not b`, or assigned into `Bool`-typed state (`flag[i] = b`) — both symbolically (BMC/z3) and concretely (the `Monitor` interpreter), which must stay in step-for-step agreement (this repo's core correctness invariant, per `tests/test_evaluator_agreement.py`)?

Investigation found the fallback ("Bool params are 0/1 ints, usable as `b == 1`") would have been a **real regression**, not just an inelegant option:
- `runtime.py`'s `_as_bool` (used to evaluate every `requires` guard concretely) **strictly** requires `isinstance(v, bool)` — it raises `_EvalError` on a plain int `1`/`0`. A bare `requires b` with an int-carrier Bool param would crash the concrete Monitor.
- BMC's `eval_expr` "var" branch fed a param's bound value straight into `z3.And(...)`/`z3.Not(...)` etc. Depending on z3's debug-assertion setting, a raw `z3.IntVal` there is either a hard type error or (worse) silently wrong.

So the fix binds Bool params as genuine Python `bool` at the single point where BMC enumerates concrete param combinations (`build_instances` in `bmc.py`, shared by both `Monitor` and BMC's `transition`), and:
- `bmc.py` `eval_expr`'s `var` branch: coerce a bound Python `bool` to `z3.BoolVal` (checked *before* the existing `isinstance(b, int)` branch, since `bool` is an `int` subclass in Python — without this, `True`/`False` would silently fall into the `z3.IntVal` branch).
- `runtime.py`'s `_find_action` (params supplied externally via `replay`/`testgen`/CLI): coerce to `bool` too, so a hand-written trace with raw `1`/`0` for a Bool param doesn't crash `_as_bool`.
- `_display_param` in both `bmc.py` and `runtime.py` special-cases `ty_name == "Bool"` (previously did `spec["types"][p[3]]["ty"]`, which would `KeyError` since `"Bool"` isn't a user-declared type) so counterexample traces show `true`/`false`.

This means Bool params behave exactly like Bool state variables in expressions — no `== 1`/`== 0` idiom needed, consistent with how the issue itself frames the ask ("state で通るなら param でも通るのが自然").

`src/fslc/refine.py`'s `_param_type`/`_annotation_matches_param` already special-cased `Bool`/`Int` param type names for refinement checks — no change needed there.

One known, deliberately out-of-scope gap: `forall`/`exists` **binders** over the builtin `Bool` (`model.py`'s `binder_range`, a separate function from `normalize_params` with the same `types_meta`-only lookup shape) still reject `Bool` — this only matters for the requirements-dialect `time { urgent <action> }` SLA sugar when the `urgent` action has a Bool param, and it already degrades gracefully (a clean `FslError`, not a crash). Fixing it fully would require threading bool-vs-int carrier typing through several more concrete/symbolic binder-iteration call sites — a larger, separate change outside this issue's stated scope (action parameter types).

## Test plan

- [x] `tests/test_bool_param.py` (new): action with `b: Bool` passes `check`; `verify` finds a violation only when the Bool-guarded invariant is actually reachable (a "safe" variant with `requires not b` verifies clean — true-negative check); the counterexample shows `"b": true`; `flag[i] = b` into `Map<Id, Bool>` state; BMC-witness trace replayed step-by-step through the concrete `Monitor` agrees on state, and independently reproduces the same invariant violation with the same Bool param on the final step; `p: Int` still errors, now with the range-parameter hint.
- [x] `.venv/bin/pytest tests/test_bool_param.py tests/test_evaluator_agreement.py -q` — 26 passed, 3 skipped.
- [x] `.venv/bin/pytest tests/test_corpus_snapshot.py -q` — 152 passed, 1 skipped, **no diff** (nothing in the corpus uses Bool params, as expected — not regenerated).
- [x] Manual `fslc check` / `fslc verify --depth 3` smoke test against a small Bool-param spec.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)