### PR TITLE
docs(language): decreases placement, ranking discipline, and the global-sum measure idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Documentation
+- Documented `leadsTo ... decreases` placement and ranking discipline in
+  `docs/LANGUAGE.md` and `skills/fsl/reference.md`: `decreases` sits outside
+  the `forall` wrapper (nesting it inside is a parse error, not a "ranking
+  doesn't work under forall" limitation); a per-entity measure
+  (`decreases level[c]`) always fails under interleaving
+  (`rank_failure: "non_decreasing_action"`) because every enabled action must
+  strictly decrease it; the working idiom is a global sum measure over a
+  fixed small domain (`decreases level[0] + level[1]`), since there is no
+  `sum()` aggregate to generalize it (fairness-aware per-entity ranking is
+  tracked separately as #72). Also added a targeted parse-error hint in
+  `cli.py` for `decreases` nested inside a `forall` body. (#71)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -107,6 +107,48 @@ action either makes `Q` true or keeps `P` true while strictly decreasing the
 measure. Ranked proof success is independent of `--depth`; `--depth` is still
 used for the base BMC check and reachable/coverage evidence.
 
+**Placement.** `decreases` is a sibling of the response body inside the
+`leadsTo` block, *outside* any `forall` wrapper — never nested inside the
+forall's braces. Nesting it inside `forall` is a parse error, not a
+limitation of ranking under `forall`:
+
+```fsl
+// valid: decreases after the forall's closing }
+leadsTo Responds {
+  forall c: Case { level[c] > 0 ~> level[c] == 0 }
+  decreases level[0] + level[1]
+}
+
+// parse error: decreases nested inside the forall body
+leadsTo Responds {
+  forall c: Case { level[c] > 0 ~> level[c] == 0 decreases level[0] + level[1] }
+}
+```
+
+**Per-entity measures fail under interleaving.** The ranking discipline
+above applies to *every* enabled action, not just the one that resolves the
+pending binding. A measure that mentions only the bound entity, e.g.
+`decreases level[c]` inside `forall c: Case { level[c] > 0 ~> level[c] == 0 }`,
+therefore always fails: an action that advances a *different* entity (say
+`step(c=1)` while the pending binding is `c=0`) leaves `level[c=0]`
+unchanged, and the discipline requires every enabled action to strictly
+decrease the measure. The verifier reports this as
+`rank_failure: "non_decreasing_action"`, with the CTI's `last_action`
+showing the other entity's binding — this is by design, not a bug. Proving
+per-entity liveness under interleaving needs a fairness-aware discipline
+(only the binding's own "helpful" action must decrease); that is not
+implemented and is tracked separately (issue #72).
+
+**Working idiom: a global sum measure.** Sum the tracked quantity across a
+fixed, small domain, e.g. `decreases level[0] + level[1]` for a 2-element
+`Case` domain — every action then strictly decreases the total, and
+induction returns `"proved"` with `"completeness": "unbounded"`. There is no
+`sum()` aggregate over a domain type usable here, so this idiom only scales
+to domains small enough to enumerate by hand. (Conditional expressions can't
+substitute for a per-branch measure either: `if/then/else` is legal only in
+refinement-mapping expressions (§10), not in the general expression grammar
+that `decreases` draws from.)
+
 ## 2. Types
 
 | Type | Example | Description |

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -219,6 +219,19 @@ check as a type error.
    false, M is non-negative, some action is enabled, and every enabled action
    either makes Q true or keeps P true while strictly decreasing M. Without
    `decreases`, leadsTo remains bounded to `--depth`.
+   - **Placement**: `decreases` is a sibling of the forall wrapper, *outside*
+     its braces — `leadsTo L { forall c: Case { P ~> Q } decreases M }`.
+     Nesting it inside the forall body is a **parse error**
+     (`fslc` reports `unexpected 'decreases' here` with a placement hint),
+     not "ranking doesn't work under forall".
+   - **Per-entity measure trap**: `decreases level[c]` inside
+     `forall c: Case { level[c] > 0 ~> level[c] == 0 }` always fails —
+     every enabled action must decrease M, so an action advancing a
+     *different* entity (`step(c=1)` while `c=0` is pending) violates it.
+     Reported as `rank_failure: "non_decreasing_action"`. Working idiom:
+     a **global sum measure** over a fixed small domain, e.g.
+     `decreases level[0] + level[1]`, since there is no `sum()` aggregate to
+     generalize it. Fairness-aware per-entity ranking is future work (#72).
 8. `symmetric type` / `symmetric enum` means those values are interchangeable
    entity identities. For leadsTo lasso/stall search, fslc symmetry-breaks the
    representative state using canonical rows from `Map<SymmetricType, V>` and

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -96,6 +96,24 @@ def _invalid_identifier_near(e):
     return src[start:end]
 
 
+def _decreases_inside_forall(e):
+    """True if the error token is a standalone 'decreases' keyword — the
+    signature left when someone nests it inside a leadsTo's forall braces
+    instead of placing it directly inside the leadsTo block."""
+    src = getattr(e, "source", None)
+    pos = getattr(e, "pos_in_stream", None)
+    if src is None or pos is None or pos < 0:
+        return False
+    end = pos + len("decreases")
+    if src[pos:end] != "decreases":
+        return False
+    if pos > 0 and _IDENTIFIER_CHARS.fullmatch(src[pos - 1]):
+        return False
+    if end < len(src) and _IDENTIFIER_CHARS.fullmatch(src[end]):
+        return False
+    return True
+
+
 def _parse_error_result(e):
     loc = {"line": e.line, "column": e.column}
     near = _invalid_identifier_near(e)
@@ -107,6 +125,18 @@ def _parse_error_result(e):
             "message": (
                 f"invalid identifier near '{near}': identifiers may contain "
                 "letters, digits and '_', and must start with a letter or '_'"
+            ),
+        })
+    if _decreases_inside_forall(e):
+        return _envelope({
+            "result": "error",
+            "kind": "parse",
+            "loc": loc,
+            "message": "unexpected 'decreases' here",
+            "hint": (
+                "decreases belongs directly inside the leadsTo block, after the "
+                "closing '}' of forall — not inside the forall body. Example: "
+                "leadsTo L { forall c: Case { P ~> Q } decreases M }"
             ),
         })
     return _envelope({

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -466,6 +466,24 @@ def test_parse_error_invalid_identifier_message():
     assert "STRING" not in out["message"]
 
 
+def test_parse_error_decreases_inside_forall_hint():
+    out = check_inline(
+        "spec X { type Case = 0..1 state { level: Map<Case, 0..2> } "
+        "init { forall c: Case { level[c] = 2 } } "
+        "action step(c: Case) { requires level[c] > 0 level[c] = level[c] - 1 } "
+        "leadsTo L { forall c: Case { level[c] > 0 ~> level[c] == 0 "
+        "decreases level[0] + level[1] } } }"
+    )
+    assert out["result"] == "error"
+    assert out["kind"] == "parse"
+    assert out["message"] == "unexpected 'decreases' here"
+    assert out["hint"] == (
+        "decreases belongs directly inside the leadsTo block, after the "
+        "closing '}' of forall — not inside the forall body. Example: "
+        "leadsTo L { forall c: Case { P ~> Q } decreases M }"
+    )
+
+
 def test_parse_error_includes_expected_tokens():
     broken = ROOT / "specs" / "_parse_break.fsl"
     broken.write_text("spec X { state {", encoding="utf-8")


### PR DESCRIPTION
## Summary

`decreases` (ranking measure for proving `leadsTo` unbounded via `--engine induction`) has three non-obvious behaviors that weren't documented, leading users to misread a parse error as "ranking doesn't work under forall" (#71):

- **Placement**: `decreases` sits directly inside the `leadsTo` block, *outside* the `forall` wrapper (`grammar.py:115-122`, `leadsto_def: "leadsTo" NAME meta_tag? "{" lt_body leadsto_decreases? "}"`). Nesting it inside `forall`'s braces is a parse error.
- **Per-entity measures fail under interleaving**: `decreases level[c]` inside a `forall c: Case { ... }` always fails, since the ranking discipline requires *every* enabled action (not just the one resolving the pending binding) to strictly decrease the measure. Reported as `rank_failure: "non_decreasing_action"`.
- **Working idiom**: a global sum measure over a fixed small domain (`decreases level[0] + level[1]`) — every action then decreases the total. No `sum()` aggregate exists, so this only scales to domains small enough to enumerate. Fairness-aware per-entity ranking is future work (#72).

## Changes

- `docs/LANGUAGE.md`: extended the leadsTo/decreases section (§1) with placement rule + valid/parse-error examples, the ranking discipline restated from the verifier's own hint text, the per-entity trap with its exact failure signature, and the global-sum idiom with its fixed-small-domain limitation and a pointer to #72.
- `skills/fsl/reference.md` (canonical; `.claude/skills/fsl` is a symlink to it): compact version of the same in the existing §5 numbered-list style.
- `src/fslc/cli.py`: added a targeted parse-error hint (`_decreases_inside_forall`) for `decreases` nested inside a `forall` body — the generic Lark "no terminal matches" message gives no clue about the actual mistake. Precedent: `_invalid_identifier_near`, the existing bespoke targeted-hint pattern in `_parse_error_result`.
- `tests/test_v1.py`: regression test for the new parse-error hint.
- `CHANGELOG.md`: `[Unreleased]` → Documentation bullet.

## Verification

All three documented facts were reproduced locally with `.venv/bin/fslc verify <file> --engine induction --depth 2` against the reference spec from the issue before writing them into docs:

- `decreases level[0] + level[1]` (global sum, outside forall) → `"result": "proved"`, `"completeness": "unbounded"`, note `"invariants and ranked leadsTo proved for all depths"`.
- `decreases level[c]` (per-entity, outside forall) → `"result": "unknown_cti"`, `"violation_kind": "leadsTo_rank"`, `"rank_failure": "non_decreasing_action"`, `last_action: step(c=1)` while pending binding is `c=0` — matches the brief exactly.
- `decreases ...` nested inside the forall braces → parse error (`"No terminal matches 'd'..."` before this change; now `"unexpected 'decreases' here"` with the placement hint).

Full test suite: `pytest tests/test_v1.py tests/test_corpus_snapshot.py -q` → 191 passed, 1 skipped (unrelated). Corpus snapshot is unaffected — no verifier semantics changed, only a parse-error message/hint and docs.

## Deviations from the brief

- The optional parse-error hint (item 3 in the brief) **was implemented**, not skipped — a precedent mechanism already existed (`_invalid_identifier_near` in `cli.py`, feeding into `_error_envelope`'s existing `hint` field), so a comparably-sized, single-choke-point addition (`_parse_error_result`, used by all 11 subcommands that parse specs) was cheap and low-risk. No new grammar/parser machinery was added.
- No new `.fsl` files were added under `specs/`/`examples/`; the reference spec was only run from a scratch temp directory, so the corpus snapshot is untouched by content, and its test run confirms that.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)