### PR TITLE
feat(dialects): terminal in requirements; derive business terminal from sink stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- `terminal { }` now works in the `requirements` dialect (`terminal_def` is a
+  `requirements_item`; it passes through unchanged to the kernel spec, same
+  one-block-per-spec rule as the kernel). The `business` dialect gets no new
+  syntax: `terminal { }` is instead derived automatically from each process's
+  sink stages (stages with no outgoing `transition`) — if every process has
+  at least one sink, the generated predicate is the conjunction, over
+  processes, of "every entity of that process is at one of its sinks". A
+  process with no sink at all (a genuine cycle) still generates no terminal,
+  matching prior behavior exactly. Previously, neither dialect could declare
+  intended stop states, so `--deadlock ignore` was the only way to silence
+  the deadlock check at a completed stage — discarding detection of
+  unintended deadlocks along with it. (#69)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -144,6 +144,14 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
    naturally into testgen.
 9. The name of the expanded spec is the name of `requirements`. All other items
    (type/enum/struct/state/init/top-level actions, etc.) pass through unchanged.
+10. `terminal { <expr> }` is one of these pass-through items (added as a
+    `requirements_item` grammar alternative, #69) — it takes the generic
+    `_expand_item` fallback (`return [item], []`), so no dialects.py case was
+    added for it specifically. Only one `terminal` block is allowed per spec
+    (the kernel's own rule, unchanged). If the spec uses `process E { ... }`,
+    the predicate is written against the synthesized stage map
+    (`e_stage[c]`, rule 2 above) — the natural-language `stage(c)` form is
+    business-only (§3.2 rule 7).
 
 ### 2.3 Tests (tests/test_req_dialect.py)
 
@@ -241,6 +249,19 @@ verify {
    binding; ambiguity is a type error).
 6. The `actor` declaration is a roster (used to validate the `by` of a
    transition; an undeclared actor is a type error). No other semantics.
+7. No `terminal` syntax exists in business (#69). Instead, after all
+   processes are expanded, each process's **sink stages** — stages that are
+   never a transition's source (`tr["src"]`) — are collected. If every
+   process has >=1 sink, one kernel `terminal { }` item is generated: the
+   conjunction (`and`), over processes, of
+   `forall c: X { _any_stage(X, c, sinks) }` (reusing the same `_stage_is` /
+   `_any_stage` helpers rule 5's `all <Entity> can be <Stage>` goal uses). If
+   any process is cyclic (no sink at all), no terminal is generated for the
+   whole spec and deadlock checking is unaffected — a cyclic process always
+   has an enabled transition, so it can never contribute to a real deadlock
+   anyway. This makes "stopping at a process's last stage" verify clean by
+   default; `--deadlock ignore` is no longer required for a pure stage-graph
+   business spec.
 
 ### 3.3 Governance catalog
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -250,6 +250,15 @@ variable.
   be detected. Whereas `--deadlock ignore` uniformly ignores **all stopping
   states**, `terminal` lets you select **which stops are intentional**.
   Example: `terminal { status == Done or status == Failed }`.
+  - **requirements**: `terminal { }` is a `requirements_item` and passes
+    through unchanged to the kernel spec (§13.2). Inside a spec that uses
+    `process E { ... }`, write the predicate against the synthesized stage
+    map — the lowercased process/entity name + `_stage` (e.g. `process Claim`
+    → `claim_stage`), so `terminal { forall c: Claim { claim_stage[c] ==
+    Approved or claim_stage[c] == Rejected } }`.
+  - **business**: no `terminal` syntax exists at all — it is derived
+    automatically from each process's sink stages (stages with no outgoing
+    `transition`); see §13.3.
 - **Do not write** an invariant like "inventory is at least 0" — make it
   `type Qty = 0..N` and it is detected automatically.
 - A full `push` into a Seq is also detected automatically as `type_bound`
@@ -852,6 +861,12 @@ verify {
   `branches` automatically splits an action by each when condition (displayed as
   `submit[a <= AUTO_LIMIT]`), and the `maps` clause provides the action
   correspondence to the upper layer.
+- `terminal { <expr> }` is allowed at the top level of a `requirements` spec
+  and passes through to the kernel unchanged (§6) — there is exactly one
+  `terminal` block per spec, same as the kernel. If the spec uses
+  `process E { ... }`, the predicate must reference the synthesized stage map
+  (`<entity-lowercased>_stage`, e.g. `claim_stage` for `process Claim`), not
+  `stage(c)` (that natural-language form is business-only, §13.3).
 
 ### 13.3 Consulting layer: `business` (the fsl-biz dialect)
 
@@ -901,6 +916,18 @@ verify {
 The explicit forms remain available when the rule is not just stage progression:
 `policy ... responds { forall c: Return { stage(c) == Requested ~> ... } }` and
 `goal ... { exists c: Return { stage(c) == Refunded } }`.
+
+Business has no `terminal` syntax of its own. Instead, each process's **sink
+stages** (stages with no outgoing `transition`) are collected automatically:
+if every process has at least one sink, a kernel `terminal { }` is generated
+as the conjunction, over processes, of `forall c: <Entity> { stage(c) in
+{Sink1, Sink2, ...} }` — so a deadlock is "intended" only once every entity of
+every process is simultaneously parked at one of its own sinks. `ReturnHandling`
+above therefore verifies clean at `Rejected`/`Refunded` without
+`--deadlock ignore`. If any process is cyclic (every stage has an outgoing
+transition, so it has no sink), no terminal is generated at all and deadlock
+checking is unaffected — cyclic processes never deadlock in the first place,
+since some transition is always enabled.
 
 Governance/control metadata can be kept inside `business` or lifted into a
 standalone catalog. `control ID "text" owner NAME severity NAME applies_to Entity`

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -566,6 +566,16 @@ exists, each `require CTRL` is satisfied by business-side `satisfies` metadata o
 an explicit `CTRL is satisfied_by policy|goal ID` mapping, and each
 `preservation` block runs its declared refinement at depth 8.
 
+No `terminal` syntax exists in business — it is derived automatically. Each
+process's sink stages (stages with no outgoing `transition`, e.g.
+`Rejected`/`Refunded` above) are collected; if every process has >=1 sink, one
+kernel `terminal { }` is generated as the conjunction (over processes) of
+`forall c: X { stage(c) in {sinks...} }` — so `ReturnHandling` above verifies
+clean at its two sinks with no `--deadlock ignore`. If any process is cyclic
+(every stage has an outgoing edge, so no sink), no terminal is generated for
+the whole spec and deadlock checking is unchanged (a cyclic process always has
+an enabled transition, so it can never deadlock anyway).
+
 ### requirements (the requirements layer)
 
 ```fsl
@@ -638,6 +648,11 @@ verify {
   `submit[a <= AUTO_LIMIT]`; diagnostics keep the internal name (`submit__b1`)
   and add `display_name`.
 - Elements inside a requirement automatically get {id, text} metadata.
+- `terminal { <expr> }` is allowed at the top level (pass-through to the
+  kernel, one block per spec, same as the kernel). In the process+data
+  profile, write the predicate against the synthesized stage map
+  (`<entity-lowercased>_stage`, e.g. `claim_stage` for `process Claim`) — not
+  `stage(c)`, which is business-only.
 
 ### Drawing the layer boundary
 

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -1378,6 +1378,22 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
                 _meta(tr["name"], f"by {tr['actor']}"),
             ))
 
+    if processes:
+        sink_exprs = []
+        for proc in processes:
+            outgoing = {tr["src"] for tr in proc["transitions"]}
+            sinks = [stage for stage in proc["stages"] if stage not in outgoing]
+            if not sinks:
+                sink_exprs = None
+                break
+            sink_exprs.append((
+                "forall",
+                ("binder_typed", "c", proc["name"], None),
+                _any_stage(proc["name"], "c", sinks, process_by_case, proc["loc"]),
+            ))
+        if sink_exprs:
+            out.append(("terminal", _and_all(sink_exprs), None))
+
     kpi_metadata = _project_kpi_metadata(kpi_infos)
     if kpi_metadata:
         out.append(("__kpis", kpi_metadata))

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -180,7 +180,7 @@ requirements_def: "requirements" NAME "{" requirements_item* "}"
 ?requirements_item: implements_def | requirement_def | acceptance_def | forbidden_def | kpi_def
                   | const_def | type_def | enum_def | struct_def | entity_def | number_def
                   | state_def | init_def | req_action_def | process_def | time_def
-                  | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def
+                  | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def | terminal_def
 implements_def: "implements" NAME "from" STRING "{" implements_item* "}"
 ?implements_item: map_def | maps_auto_def | preserve_progress_def
 requirement_def: "requirement" REQ_ID STRING "{" requirement_item* "}"

--- a/tests/test_dialect_terminal.py
+++ b/tests/test_dialect_terminal.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""terminal { } across the requirements and business dialects (#69).
+
+Requirements: `terminal_def` is now a `requirements_item` alternative
+(grammar.py) and passes through the existing dialects.py fallback
+(`_expand_item`'s ``return [item], []``) unchanged into the kernel AST — no
+dialects.py case was added for it. The kernel (model.py) still only accepts
+one `terminal { }` block per spec.
+
+Business: no new syntax. `_generate_business_items` derives one kernel
+`terminal { }` from each process's *sink stages* (stages with no outgoing
+transition): if every process has >=1 sink, the generated predicate is the
+conjunction over processes of `forall c: <Entity> { stage(c) in {Sink...} }`.
+If any process is cyclic (no sink), no terminal is generated at all and
+deadlock checking is unchanged from before this feature.
+"""
+from fslc.cli import run_check, run_verify
+from fslc.model import FslError, build_spec
+from fslc.parser import parse
+
+
+# --------------------------------------------------------------------------
+# requirements layer: explicit terminal { } (Part 1 — pass-through)
+# --------------------------------------------------------------------------
+
+# Uses `process Claim { ... }`, so the terminal predicate is written against
+# the synthesized stage map: the lowercased process/entity name + "_stage"
+# (`_process_state_var` in dialects.py), i.e. `claim_stage` here.
+REQ_PROCESS_TERMINAL_SRC = r'''requirements ClaimTerminal {
+  entity Claim
+  process Claim {
+    stages Draft, Approved, Rejected
+    initial Draft
+    transition approve Draft -> Approved by Manager
+    transition reject Draft -> Rejected by Manager
+  }
+  terminal { forall c: Claim { claim_stage[c] == Approved or claim_stage[c] == Rejected } }
+}
+verify {
+  instances Claim = 2
+}
+'''
+
+
+def test_requirements_terminal_parses_and_flows_to_kernel_spec():
+    spec = build_spec(parse(REQ_PROCESS_TERMINAL_SRC))
+    assert spec["terminal"] is not None
+    # the synthesized stage map name is <process-name-lowercased>_stage
+    assert spec["state"]["claim_stage"]
+
+
+def test_requirements_terminal_verifies_clean_at_declared_stop(tmp_path):
+    f = tmp_path / "claim_terminal.fsl"
+    f.write_text(REQ_PROCESS_TERMINAL_SRC, encoding="utf-8")
+
+    checked = run_check(str(f))
+    assert checked["result"] == "ok"
+
+    # default --deadlock mode ("warn"): both sinks are declared terminal, so
+    # no deadlock warning is produced without needing --deadlock ignore.
+    result = run_verify(str(f), 6, "warn")
+    assert result["result"] == "verified"
+    assert result["deadlock"]["found"] is False
+
+
+# Raw kernel-style requirements (no `process`) so a transition can exist that
+# is NOT covered by the declared terminal predicate — demonstrates that
+# `terminal` only excludes the states it names; a different, un-declared
+# stuck state is still reported.
+REQ_PARTIAL_TERMINAL_SRC = r'''requirements TerminalReq {
+  type Id = 0..1
+  enum St { Working, Done, Stuck }
+  state { x: Map<Id, St> }
+  init { forall i: Id { x[i] = Working } }
+
+  requirement REQ-1 "finish moves working items to done" {
+    action finish(i: Id) { requires x[i] == Working  x[i] = Done }
+  }
+  requirement REQ-2 "a bug: items can get stuck without finishing" {
+    action drop(i: Id) { requires x[i] == Working  x[i] = Stuck }
+  }
+
+  terminal { forall i: Id { x[i] == Done } }
+}
+'''
+
+
+def test_requirements_terminal_still_reports_unintended_deadlock(tmp_path):
+    f = tmp_path / "terminal_partial.fsl"
+    f.write_text(REQ_PARTIAL_TERMINAL_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 5, "error")
+    assert result["result"] == "violated"
+    assert result["violation_kind"] == "deadlock"
+
+
+REQ_DUP_TERMINAL_SRC = r'''requirements DupTerminal {
+  type Id = 0..1
+  enum St { Working, Done }
+  state { x: Map<Id, St> }
+  init { forall i: Id { x[i] = Working } }
+
+  requirement REQ-1 "finish" {
+    action finish(i: Id) { requires x[i] == Working  x[i] = Done }
+  }
+
+  terminal { forall i: Id { x[i] == Done } }
+  terminal { forall i: Id { x[i] == Done } }
+}
+'''
+
+
+def test_requirements_duplicate_terminal_block_errors(tmp_path):
+    # Mirrors the kernel's own duplicate-terminal-block rule (model.py) —
+    # requirements gets no special-case handling of its own.
+    f = tmp_path / "dup_terminal.fsl"
+    f.write_text(REQ_DUP_TERMINAL_SRC, encoding="utf-8")
+
+    try:
+        build_spec(parse(REQ_DUP_TERMINAL_SRC))
+        assert False, "expected FslError"
+    except FslError as exc:
+        assert "duplicate terminal block" in str(exc)
+
+    checked = run_check(str(f))
+    assert checked["result"] == "error"
+    assert checked["kind"] == "semantics"
+
+
+# --------------------------------------------------------------------------
+# business layer: sink-derived terminal (Part 2 — no new syntax)
+# --------------------------------------------------------------------------
+
+BIZ_LINEAR_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+}
+verify {
+  instances Return = 3
+}
+'''
+
+
+def test_business_linear_process_derives_terminal_from_sinks():
+    spec = build_spec(parse(BIZ_LINEAR_SRC))
+    assert spec["terminal"] is not None
+
+
+def test_business_linear_process_verifies_clean_without_deadlock_ignore(tmp_path):
+    f = tmp_path / "return_handling.fsl"
+    f.write_text(BIZ_LINEAR_SRC, encoding="utf-8")
+
+    checked = run_check(str(f))
+    assert checked["result"] == "ok"
+
+    # default --deadlock mode ("warn"): Rejected/Refunded (the sinks) are the
+    # only reachable stuck states, so they no longer need --deadlock ignore.
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert result["deadlock"]["found"] is False
+
+
+BIZ_CYCLIC_SRC = r'''business PingPong {
+  actor System
+  entity Token
+
+  process Token {
+    stages A, B
+    initial A
+    transition to_b A -> B by System
+    transition to_a B -> A by System
+  }
+}
+verify {
+  instances Token = 2
+}
+'''
+
+
+def test_business_cyclic_process_generates_no_terminal(tmp_path):
+    # Every stage has an outgoing transition (a genuine cycle) -> no sink on
+    # this process -> no terminal item is generated at all, matching
+    # pre-#69 behavior exactly (deadlock checking is unaffected).
+    ast = parse(BIZ_CYCLIC_SRC)
+    assert not any(item[0] == "terminal" for item in ast[2])
+
+    spec = build_spec(ast)
+    assert spec["terminal"] is None
+
+    f = tmp_path / "ping_pong.fsl"
+    f.write_text(BIZ_CYCLIC_SRC, encoding="utf-8")
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert result["deadlock"]["found"] is False
+
+
+BIZ_MULTI_PROCESS_SRC = r'''business TwoProcs {
+  actor Manager, Finance
+  entity Order
+  entity Invoice
+
+  process Order {
+    stages Placed, Shipped
+    initial Placed
+    transition ship Placed -> Shipped by Manager
+  }
+
+  process Invoice {
+    stages Issued, Paid
+    initial Issued
+    transition pay Issued -> Paid by Finance
+  }
+}
+verify {
+  instances Order = 2
+  instances Invoice = 2
+}
+'''
+
+
+def test_business_multi_process_terminal_is_conjunction_of_sinks(tmp_path):
+    # Deadlock is only "intended" once BOTH entities are simultaneously at
+    # their own sink -- the conjunction, not a per-process disjunction.
+    spec = build_spec(parse(BIZ_MULTI_PROCESS_SRC))
+    term = spec["terminal"]
+    assert term[0] == "bin" and term[1] == "and"
+    branches = {term[2][0], term[3][0]}
+    assert branches == {"forall"}
+
+    f = tmp_path / "two_procs.fsl"
+    f.write_text(BIZ_MULTI_PROCESS_SRC, encoding="utf-8")
+    checked = run_check(str(f))
+    assert checked["result"] == "ok"
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert result["deadlock"]["found"] is False


### PR DESCRIPTION
## Summary

- **Requirements (Part 1):** `terminal { <expr> }` is now a `requirements_item` alternative in `grammar.py`. It is pure pass-through — the existing `_expand_item` fallback in `dialects.py` (`return [item], []`) already forwards unrecognized items to the kernel AST unchanged, so no dialects.py case was added. The kernel's existing one-terminal-block-per-spec rule (`model.py`) applies as-is; a second `terminal { }` block still errors with `duplicate terminal block`. Inside a spec that uses `process E { ... }`, the predicate must reference the synthesized stage map (`<entity-lowercased>_stage`, e.g. `claim_stage` for `process Claim`), documented in `docs/LANGUAGE.md` §6/§13.2, `docs/DESIGN-dialects.md` §2.2 rule 10, and `skills/fsl/reference.md`.
- **Business (Part 2, no new syntax):** `_generate_business_items` (`dialects.py`) now derives each process's **sink stages** (stages that are never a transition's source) after expanding transitions. If every process has at least one sink, it generates one kernel `terminal { }` item: the conjunction, over processes, of `forall c: <Entity> { stage(c) in {sink1, sink2, ...} }` (reusing the existing `_stage_is`/`_any_stage` helpers used by the `every ... must eventually be` policy alias). If any process is cyclic (no sink), no terminal is generated at all — deadlock checking for that spec is byte-for-byte unchanged from before this feature, since a cyclic process always has an enabled transition and can never contribute to a real deadlock.

This closes the gap described in the issue: business/requirements specs previously had no way to mark a completed stage as an intended stop, so `--deadlock ignore` was the only way to silence the "deadlock" at a legitimate final stage — discarding detection of genuinely unintended deadlocks along with it.

## A structural note on the business derivation

Business transitions carry no guard beyond stage equality (pure stage graphs — `dialects.py` explicitly rejects `when`/`set`/inputs there). Given that, a state is a true global deadlock (no action enabled for *any* entity of *any* process) if and only if every entity of every process is at a stage with no outgoing transition — i.e. iff the derived `terminal` predicate holds. This equivalence is exact for the current business grammar, which is why `tests/test_dialect_terminal.py` doesn't include a "business spec with an unintended stuck stage still reports deadlock" case: it isn't constructible in pure business syntax — any missing-transition bug is structurally indistinguishable from an intended final stage. That distinguishing case *is* covered, correctly, at the requirements layer, which does support guards (`test_requirements_terminal_still_reports_unintended_deadlock`).

## Corpus snapshot

`.venv/bin/pytest tests/test_corpus_snapshot.py -q` → **152 passed, 1 skipped, no diff, no regeneration needed.** This is expected: the snapshot only runs `verify` (not just `check`) on `specs/*.fsl` and on `examples/gallery/{valid,errors,adversarial}/*.fsl` with an `// expected-command:` verify annotation. No file in that verify-checked set is a `business` spec, so the business auto-derivation (the only behavior-changing part of this PR) never fires within the snapshot's scope. The requirements-layer change is purely additive grammar (opt-in `terminal`), so it doesn't affect any spec that doesn't already use the keyword.

(Business examples that *would* benefit, e.g. `examples/pm/cancel_flow.fsl`, `examples/layers/return_policy.fsl`, `examples/consulting/*.fsl`, still document `--deadlock ignore` in their headers/READMEs — updating those is a follow-up, out of scope here since it touches several READMEs across example directories that weren't part of this issue's deliverable list.)

## Test plan
- [x] `tests/test_dialect_terminal.py` (new, 8 tests): requirements explicit `terminal` parses/flows to the kernel spec dict, verifies clean at the declared stop without `--deadlock ignore`, still reports an unintended deadlock elsewhere, and errors on a duplicate `terminal` block; business linear process derives and verifies clean at its sinks, cyclic process generates no terminal (unchanged deadlock behavior), multi-process spec's terminal is the conjunction across processes.
- [x] `tests/test_req_dialect.py` + `tests/test_biz_dialect.py` (existing, unmodified — no existing assertions referenced business/requirements deadlock or `--deadlock ignore`, so nothing needed updating)
- [x] `tests/test_governance_business.py`, `tests/test_meta.py`, `tests/test_nfr.py` — unaffected, all pass
- [x] `tests/test_corpus_snapshot.py` — no diff

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)