### PR TITLE
feat(diagnostics): suggest auxiliary invariants for monotone counters in induction CTIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- k-induction `unknown_cti` results now suggest auxiliary invariants for the
+  common monotone-counter idiom: when the CTI trace shows an `Int`/domain
+  scalar or a `Map<K, Int>` counter moving in only one direction and starting
+  on the unreachable side of the concrete initial value (a ghost/huge/negative
+  start), the result gains `"suggested_invariants": ["<expr>", ...]` and the
+  matching sentence is appended to `hint` (e.g. `"audit >= 0"` or, for a
+  uniformly-initialized map, `"forall k: Case { audit[k] >= 0 }"`).
+  Post-processing only (trace diff against `runtime.Monitor(spec).reset()`) —
+  no solver/engine semantics change, so verdicts are unaffected; the field is
+  additive and absent when no such counter is found. (`bmc.py`, `docs/LANGUAGE.md`,
+  `docs/DESIGN-induction.md`, `skills/fsl/reference.md`, `tests/test_cti_suggestions.py`) (#74)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/DESIGN-induction.md
+++ b/docs/DESIGN-induction.md
@@ -137,6 +137,20 @@ JSON (the shape finalized in §9, generalized to multiple states):
 - The §9 `cti: {state, action, next_state}` shape (for k=1) is **not** an alias
   but is **unified into this general form** (even for k=1, a `states` array of
   length 2). The JSON example in DESIGN-v1.md §9 should be updated to follow this document's shape.
+- **Monotone-counter suggestions (#74, post-processing only, no solver/engine
+  change):** after the CTI trace is built for an invariant `unknown_cti`
+  (not `leadsTo_rank`), `_suggest_monotone_invariants` (`bmc.py`) scans it for
+  a state variable — scalar `Int`/domain, or a `Map<K, Int>` key-wise — that
+  moves in only one direction across the trace *and* starts on the
+  unreachable side of the concrete initial value obtained from
+  `runtime.Monitor(spec).reset()`. When found, the result gains
+  `"suggested_invariants": ["<expr>", ...]` and one sentence is appended to
+  `hint` per suggestion, e.g. `"audit >= 0"` or, for a uniformly-initialized
+  map, `"forall k: Case { audit[k] >= 0 }"`. If `reset()` fails, the relevant
+  variable's init isn't a concrete `Int`, or the CTI start does not actually
+  violate the would-be bound, no suggestion is added for it. This is
+  trace-monotonicity, not a global-monotonicity proof, so it is phrased as a
+  suggestion — see `docs/LANGUAGE.md` §9 "Auxiliary invariants from a CTI".
 - The exit code is **not 2, not 1 of a new kind, and not 0**, but reuses `1`
   without introducing a new one (the "property not yet established" category;
   the repair loop branches on the result string, so exit-code granularity is unnecessary).

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -511,6 +511,26 @@ invariant NoDupQueue {
 }
 ```
 
+For the common "monotone counter" idiom — an `Int` or `Map<K, Int>` state
+variable that only ever moves in one direction — `unknown_cti` results carry
+an additive `suggested_invariants: [<expr>, ...]` field (and the matching
+sentence appended to `hint`) whenever the CTI's counter starts on the
+unreachable side of its concrete initial value (e.g. a huge or negative
+"ghost" start a real execution could never produce). This is a heuristic
+computed by diffing the CTI trace against the concrete init (not a proof of
+global monotonicity), so treat it as a starting point:
+
+```fsl
+// CTI: audit = -101 (only increases in this trace, but starts below its
+// init value 0) → suggested_invariants: ["audit >= 0"]
+invariant AuditNonNeg { audit >= 0 }
+```
+
+A `Map<K, Int>` counter suggests the `forall`-quantified form
+(`forall k: K { audit[k] >= 0 }`) when every key shares the same initial
+value. If no monotone counter is detected, or the CTI start does not violate
+the would-be bound, no suggestion is added and `hint` is unchanged.
+
 ## 10. Refinement (fidelity of a detailed spec)
 
 After first `verify`-ing / `prove`-ing the abstract spec (abs), check with

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -332,7 +332,12 @@ first failed layer and later layers are marked `skipped`.
   null|value / Seq as an array / composition as `alias.var` keys). Internal names
   (`__`) do not appear.
 - `unknown_cti`: `cti.states` (k+1 states) + `violated_at`. The starting state is an
-  unreachable phantom — add an auxiliary invariant to exclude it.
+  unreachable phantom — add an auxiliary invariant to exclude it. For invariant
+  CTIs (not `leadsTo_rank`), a monotone `Int`/`Map<K, Int>` counter whose CTI
+  start lies on the unreachable side of its concrete init value gets a concrete
+  candidate in `suggested_invariants: [<expr>, ...]` (also appended to `hint`) —
+  a heuristic from trace-monotonicity, not a proof; absent when no such counter
+  is found.
 - `verified` / `reachable_failed` / `violated` from BMC are bounded and include
   `completeness:"bounded"`, `checked_to_depth`, and `cost: {"elapsed_s": ...}`.
   Bounded `verified` may include a saturation `hint` when the depth-K frontier

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -408,6 +408,109 @@ _CTI_HINT = (
     "then re-run"
 )
 
+_MONOTONE_DIRECTION_OP = {"increasing": (">=", "below"), "decreasing": ("<=", "above")}
+
+
+def _monotone_direction(values):
+    diffs = [b - a for a, b in zip(values[:-1], values[1:]) if b != a]
+    if not diffs:
+        return None
+    if all(d > 0 for d in diffs):
+        return "increasing"
+    if all(d < 0 for d in diffs):
+        return "decreasing"
+    return None
+
+
+def _monotone_qualifies(direction, cti0, v0):
+    return cti0 < v0 if direction == "increasing" else cti0 > v0
+
+
+def _monotone_sentence(name, direction, v0, expr):
+    _, side = _MONOTONE_DIRECTION_OP[direction]
+    return (
+        f"'{name}' only {direction} in this CTI but starts {side} its initial "
+        f"value {v0}; adding invariant {expr} may exclude this unreachable start state"
+    )
+
+
+def _map_key_type_name(name, spec):
+    ref = (spec.get("state_type_refs") or {}).get(name)
+    if isinstance(ref, tuple) and ref[0] == "map":
+        key_ref = ref[1]
+        if isinstance(key_ref, tuple) and key_ref[0] == "named":
+            return key_ref[1]
+    return None
+
+
+def _suggest_monotone_invariants(trace, spec):
+    """Heuristically suggest auxiliary invariants for k-induction CTIs.
+
+    Scans the (already-built) CTI trace for state variables that only ever
+    move in one direction across the trace and whose CTI start value lies on
+    the unreachable side of the concrete initial value — the classic "ghost
+    counter" false start. Trace-monotonicity is not a proof of global
+    monotonicity, so this is a suggestion, not a repair.
+    """
+    if len(trace) < 2:
+        return []
+    try:
+        from .runtime import Monitor
+        init_state = Monitor(spec).reset()
+    except Exception:
+        return []
+
+    suggestions = []
+    for name, ty in spec["state"].items():
+        if ty[0] in ("int", "domain"):
+            values = [entry["state"].get(name) for entry in trace]
+            v0 = init_state.get(name)
+            if not isinstance(v0, int) or not all(isinstance(v, int) for v in values):
+                continue
+            direction = _monotone_direction(values)
+            if direction is None or not _monotone_qualifies(direction, values[0], v0):
+                continue
+            op, _ = _MONOTONE_DIRECTION_OP[direction]
+            expr = f"{name} {op} {v0}"
+            suggestions.append((expr, _monotone_sentence(name, direction, v0, expr)))
+        elif ty[0] == "map" and ty[2][0] in ("int", "domain"):
+            key_ty = _map_key_type_name(name, spec)
+            init_map = init_state.get(name)
+            if key_ty is None or not isinstance(init_map, dict) or not init_map:
+                continue
+            init_values = set(init_map.values())
+            if len(init_values) != 1 or not isinstance(next(iter(init_values)), int):
+                continue
+            v0 = next(iter(init_values))
+            keys = set()
+            for entry in trace:
+                keys.update((entry["state"].get(name) or {}).keys())
+            directions = set()
+            for key in keys:
+                values = [(entry["state"].get(name) or {}).get(key) for entry in trace]
+                if any(not isinstance(v, int) for v in values):
+                    continue
+                direction = _monotone_direction(values)
+                if direction and _monotone_qualifies(direction, values[0], v0):
+                    directions.add(direction)
+            if len(directions) != 1:
+                continue
+            direction = directions.pop()
+            op, _ = _MONOTONE_DIRECTION_OP[direction]
+            expr = f"forall k: {key_ty} {{ {name}[k] {op} {v0} }}"
+            suggestions.append((expr, _monotone_sentence(name, direction, v0, expr)))
+    return suggestions
+
+
+def _cti_hint_fields(trace, spec):
+    suggestions = _suggest_monotone_invariants(trace, spec)
+    if not suggestions:
+        return {"hint": _CTI_HINT}
+    exprs = [expr for expr, _ in suggestions]
+    sentences = " ".join(sentence for _, sentence in suggestions)
+    return {"hint": f"{_CTI_HINT} {sentences}", "suggested_invariants": exprs}
+
+
 _PARTIAL_OP_HINT = (
     "guard the action with requires q.size() > 0 (or bound the index)"
 )
@@ -4715,7 +4818,7 @@ def prove(
                         },
                         "invariants_checked": [i["name"] for i in invariants],
                         "transitions_checked": [tr["name"] for tr in transitions],
-                        "hint": _CTI_HINT,
+                        **_cti_hint_fields(trace, spec),
                     }, trans), spec, base_depth, started, completeness="bounded")
                 s.pop()
 
@@ -4737,7 +4840,7 @@ def prove(
                 "states": trace,
                 "violated_at": k,
             },
-            "hint": _CTI_HINT,
+            **_cti_hint_fields(trace, spec),
         }, inv), spec, base_depth, started, completeness="bounded")
 
     rank_failure, ranked_leadstos = _prove_ranked_leadstos(

--- a/tests/test_cti_suggestions.py
+++ b/tests/test_cti_suggestions.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Issue #74: monotone-counter auxiliary-invariant suggestions on k-induction CTIs.
+
+k-induction `unknown_cti` results often show a "ghost state" — a state
+variable that only ever moves in one direction across the CTI trace but
+starts on the unreachable side of its concrete initial value (a huge or
+negative counter no real execution could produce). The generic `_CTI_HINT`
+says to add *some* auxiliary invariant but not which one; these tests pin
+the heuristic that computes a concrete suggestion by diffing the CTI trace
+against the concrete initial state (`runtime.Monitor.reset()`), for both a
+scalar `Int` counter and a `Map<K, Int>` counter.
+
+This is post-processing only (trace analysis + one concrete `reset()`) — no
+solver/engine semantics change, so verdicts (`result`, `k_used`, ...) are
+untouched; only `hint` and the new `suggested_invariants` field are additive.
+"""
+from fslc import parse, build_spec, prove
+
+CTI_HINT = (
+    "this state sequence satisfies all invariants but leads to a violation; "
+    "the start state may be unreachable — add an auxiliary invariant that excludes it, "
+    "then re-run"
+)
+
+# `bump()` grows `audit` normally from init (audit=0) forever, so the spec is
+# non-vacuous. `step()` is the only action that can make `Sync` fail, and its
+# guard (`audit < -100`) is never satisfiable from any real execution — but
+# k-induction's k=1 step only assumes invariants hold at the prior state, not
+# reachability, so Z3 is free to pick a fictitious `audit < -100` start for
+# that prior state. That "ghost" start is exactly the false-start CTI #74
+# targets: audit only increases in the 2-state trace, and its step-0 value is
+# necessarily below the true initial value (0).
+GHOST_SCALAR = """
+spec GhostCounter {
+  state { audit: Int, y: Int }
+  init { audit = 0  y = 0 }
+
+  action bump() {
+    audit = audit + 1
+  }
+
+  action step() {
+    requires audit < -100
+    audit = audit + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}
+"""
+
+# Same idiom, but audit is a per-key Map<Case, Int> counter (the Map<Case,
+# Int> audit counter from the issue). All keys share the same init value (0),
+# and only the key touched by the CTI's `step` action is trace-monotone.
+GHOST_MAP = """
+spec GhostMapCounter {
+  type Case = 0..1
+
+  state {
+    audit: Map<Case, Int>,
+    y: Int
+  }
+
+  init {
+    forall c: Case { audit[c] = 0 }
+    y = 0
+  }
+
+  action bump(c: Case) {
+    audit[c] = audit[c] + 1
+  }
+
+  action step(c: Case) {
+    requires audit[c] < -100
+    audit[c] = audit[c] + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}
+"""
+
+# Negative fixture: x is trace-monotone (guard `x < 4`) but explicitly
+# bounded below by the guard (`x >= 0`), so its CTI start can never be below
+# its true initial value (0) — deterministically, regardless of which
+# concrete x0 Z3 happens to pick. No suggestion should fire.
+BOUNDED_NO_GHOST = """
+spec SyncBounded {
+  state { x: Int, y: Int }
+  init { x = 0  y = 0 }
+  action step() {
+    requires x >= 0 and x < 4
+    x = x + 1
+    y = y + 1
+  }
+  invariant Sync { y <= 4 }
+}
+"""
+
+
+def prove_inline(src, k_ind=1, depth=8):
+    return prove(build_spec(parse(src)), k_ind, depth)
+
+
+def test_scalar_monotone_counter_suggests_lower_bound():
+    r = prove_inline(GHOST_SCALAR)
+    assert r["result"] == "unknown_cti"
+    assert r["invariant"] == "Sync"
+    assert r["suggested_invariants"] == ["audit >= 0"]
+    assert r["hint"].startswith(CTI_HINT)
+    assert "audit" in r["hint"]
+    assert "audit >= 0" in r["hint"]
+
+    cti0 = r["cti"]["states"][0]["state"]
+    assert cti0["audit"] < 0  # the ghost start the suggestion targets
+
+
+def test_scalar_monotone_counter_suggestion_closes_the_loop():
+    """Adding the suggested invariant makes k-induction prove Sync."""
+    with_aux = GHOST_SCALAR.replace(
+        "invariant Sync { y <= 4 }",
+        "invariant Sync { y <= 4 }\n  invariant AuditNonNeg { audit >= 0 }",
+    )
+    r = prove_inline(with_aux)
+    assert r["result"] == "proved"
+    assert r["k_used"]["Sync"] == 1
+    assert r["k_used"]["AuditNonNeg"] == 1
+
+
+def test_map_monotone_counter_suggests_forall_lower_bound():
+    r = prove_inline(GHOST_MAP)
+    assert r["result"] == "unknown_cti"
+    assert r["invariant"] == "Sync"
+    assert r["suggested_invariants"] == ["forall k: Case { audit[k] >= 0 }"]
+    assert r["hint"].startswith(CTI_HINT)
+    assert "audit" in r["hint"]
+
+    cti0 = r["cti"]["states"][0]["state"]["audit"]
+    touched_key = next(k for k in r["cti"]["states"][1]["changes"] if k.startswith("audit["))
+    key = touched_key.split("[")[1].rstrip("]")
+    assert cti0[key] < 0  # the ghost start the suggestion targets
+
+
+def test_map_monotone_counter_suggestion_closes_the_loop():
+    with_aux = GHOST_MAP.replace(
+        "invariant Sync { y <= 4 }",
+        "invariant Sync { y <= 4 }\n  invariant AuditNonNeg { forall k: Case { audit[k] >= 0 } }",
+    )
+    r = prove_inline(with_aux)
+    assert r["result"] == "proved"
+    assert r["k_used"]["Sync"] == 1
+    assert r["k_used"]["AuditNonNeg"] == 1
+
+
+def test_bounded_counter_yields_no_suggestion():
+    """x is trace-monotone but never below its true init — no ghost start."""
+    r = prove_inline(BOUNDED_NO_GHOST)
+    assert r["result"] == "unknown_cti"
+    assert r["invariant"] == "Sync"
+    assert "suggested_invariants" not in r
+    assert r["hint"] == CTI_HINT

--- a/tests/test_induction.py
+++ b/tests/test_induction.py
@@ -88,7 +88,12 @@ spec Sync {
     assert r["completeness"] == "bounded"
     assert r["checked_to_depth"] == 8
     assert r["invariant"] == "Sync"
-    assert r["hint"] == CTI_HINT
+    # x is a free, monotonically-increasing counter in this CTI (no invariant
+    # bounds it) — depending on which shortest CTI Z3 picks, the
+    # monotone-counter heuristic (#74) may append a concrete suggestion to
+    # the generic hint; see tests/test_cti_suggestions.py for a fixture that
+    # pins this deterministically.
+    assert r["hint"].startswith(CTI_HINT)
     assert r["k"] == 1
     cti = r["cti"]
     assert cti["violated_at"] == 1


### PR DESCRIPTION
## Summary

- k-induction `unknown_cti` results for invariant CTIs (not `leadsTo_rank`) now attach a `"suggested_invariants": [<expr>, ...]` field, and append a matching sentence to `hint`, when the CTI trace shows a state variable moving in only one direction and starting on the unreachable side of its concrete initial value (a "ghost counter" false start — a huge or negative start no real execution could produce).
- Covers both `Int`/domain scalars (`audit >= 0`) and `Map<K, Int>` counters, key-wise, generalized to a `forall` bound when every key shares the same initial value (`forall k: Case { audit[k] >= 0 }`).
- Post-processing only — no solver/engine semantics change. The CTI trace and `_CTI_HINT` machinery are untouched; `leadsTo_rank` CTIs (which already have specific hints) are out of scope.

## Algorithm sketch

`_suggest_monotone_invariants(trace, spec)` (`src/fslc/bmc.py`):
1. Skip if the trace has fewer than 2 states.
2. Get the concrete initial state via `runtime.Monitor(spec).reset()` (lazy-imported to avoid the `bmc.py` ↔ `runtime.py` circular import — `runtime.py` already imports from `bmc.py` at module load). If `reset()` raises, or a variable's init/CTI value isn't a concrete `Int`, skip that variable — no guessing.
3. For each `Int`/domain scalar and each key of a `Map<K, Int>`: collect its values across the CTI trace steps; it's "trace-monotone" if it changes at least once and every nonzero step has the same sign.
4. Emit a suggestion only when the CTI's step-0 value is on the unreachable side of the true init value `v0`: increasing + `cti0 < v0` → `name >= v0` (or `forall k: K { name[k] >= v0 }` when every map key shares `v0`); decreasing + `cti0 > v0` → the mirror `<=` form.
5. Both fields are additive; `hint` still starts with the existing generic `_CTI_HINT` text.

## Corpus snapshot

`pytest tests/test_corpus_snapshot.py -q` passed with **no diff** — no corpus spec's `unknown_cti` output changed, so no regeneration was needed.

## Test plan

- [x] `tests/test_cti_suggestions.py` (new): scalar suggestion + closes-the-loop (`--engine induction` proves after adding the suggested invariant), `Map<Case, Int>` suggestion + closes-the-loop, and a deterministic negative case (guard bounds the counter from below, so the CTI start can never be a ghost value) asserting no `suggested_invariants` field and an unchanged `hint`.
- [x] `tests/test_induction.py`: updated `test_sync_unknown_cti_then_aux_proved`'s exact-hint assertion to `hint.startswith(CTI_HINT)`, since that pre-existing fixture's free counter can (and does, with the current Z3 build) trigger the new suggestion — the exact Z3-picked CTI value isn't something this codebase pins (see the existing note on shortest-CTI binding non-determinism a few lines below).
- [x] `.venv/bin/pytest tests/test_cti_suggestions.py tests/test_induction.py -q` → 14 passed
- [x] `.venv/bin/pytest tests/test_evaluator_agreement.py tests/test_repair_fields.py -q` → 28 passed, 3 skipped
- [x] `.venv/bin/pytest tests/test_corpus_snapshot.py -q` → 152 passed, 1 skipped, no diff

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)