### PR TITLE
feat(refine): arity-changing action correspondences in inline implements (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- The requirements-dialect inline `implements Abs from "file" { }` block now
+  accepts `action <impl>(<params>) -> <abs>(<args>) | stutter` items (grammar.py
+  `?implements_item` gains `refinement_action`), the same action-correspondence
+  syntax as a separate refinement file, including an arity change between the
+  impl and abs action's parameters. The inline desugar already merged the
+  block's items into the same mapping AST a separate-file `refinement` parses,
+  so `dialects.py`/`refine.py` needed no changes — including duplicate-map
+  detection (`kind: "type"`, `"duplicate action map for '<name>'"`) when an
+  inline `action ...` item and a requirement action's `maps` clause both target
+  the same impl action. (#73; docs: `docs/DESIGN-refinement.md` §1.2,
+  `docs/LANGUAGE.md`, `skills/fsl/reference.md`)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -108,6 +108,56 @@ Observed result: `fslc check refine_impl.fsl` returned `result:"ok"` with
 `fslc verify refine_impl.fsl --depth 1` returned `result:"verified"` with the
 same implements result.
 
+### 1.2 Inline `implements { }` action items (v2.x — #73)
+
+The requirements-dialect inline `implements Abs from "file" { }` block
+originally only accepted `map`/`maps auto`/`preserve progress` — an
+arity-changing action correspondence had to go through `maps` on the
+requirement action (§1.1, same arity/argument shape as the impl action's own
+params) or a separate refinement file's `action <impl>(...) -> <abs>(...)`
+item (§1).
+
+`implements_item` now also accepts `refinement_action` (grammar.py), i.e. the
+block can contain:
+
+```fsl
+requirements Impl {
+  implements Abs from "abs.fsl" {
+    map done[c: CaseId] = paid[c]
+    action pay(c: CaseId, m: Method) -> refund(c)   // arity change: drops m
+  }
+  ...
+}
+```
+
+This is not a new mechanism: `refinement_action`'s transformer output
+(`("action_map", name, params, target, loc)`) is the same AST node the
+separate-file parser already produces, and the inline desugar
+(dialects.py `_expand_requirements_with_display`) already merges
+`implements["maps"]` (the block's items) into the same `mapping_items` list
+as the auto-derived action maps from requirement-action `maps` clauses and
+process transitions, before building the same `("refinement", ...)` AST that
+`refine.py.build_refinement` consumes for both the inline and separate-file
+paths. Adding the grammar alternative was the entire change; `dialects.py`
+and `refine.py` needed none.
+
+Two consequences fall out of reusing the same merge, not from new logic:
+
+- **Duplicate correspondence.** `build_refinement` already rejects a second
+  `action_map` entry for the same impl action name
+  (`kind: "type"`, `"duplicate action map for '<name>'"`). Since the inline
+  block's items are merged ahead of the auto-derived ones, an impl action that
+  has *both* a `maps` clause and a matching inline `action ...` item now hits
+  that same pre-existing check — mirroring what a separate-file mapping that
+  lists an action twice already does.
+- **Branch-split action names.** `branches` splits an action into aliased
+  kernel actions (`name__b1`, `name__b2`, ...; dialects.py
+  `_split_branch_action`), so the impl spec `build_refinement` type-checks
+  against never has an action under the pre-split name. An inline
+  `action <pre_split_name>(...) -> ...` item is therefore `"unknown impl
+  action '<pre_split_name>'"` — reference the generated alias instead, same as
+  a separate-file mapping would need to.
+
 ## 2. Checking Semantics (Bounded Forward Simulation)
 
 α(s) := the mapping that defines the impl state → abs state mapping.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -835,12 +835,18 @@ verify {
   simultaneously**, and the result carries `implements: {abs, result}`. An empty
   body (`implements X from "..." { }`) auto-generates identity refinement when
   process/action/stage names match. Inside the `implements { }` block you write
-  only state `map` entries, `maps auto`, and `preserve progress` — not `action`;
-  action↔action correspondence is the `maps <abs_act>(...)` clause on the
-  requirement-level action. `maps auto` covers same-name kernel-wrapper
-  state/actions, and explicit maps override it. Auto-mapped process transitions
-  are actor-checked; a transition whose actor differs from the business action's
-  actor is a check-time error.
+  state `map` entries, `maps auto`, `preserve progress`, and — since #73 —
+  `action <impl_act>(<params>) -> <abs_act>(<args>) | stutter`, the same
+  correspondence syntax as a separate refinement file's `refinement_action`
+  (`docs/DESIGN-refinement.md` §1), including an arity change between the impl
+  and abs action. Action↔action correspondence can also still be written as the
+  `maps <abs_act>(...)` clause on the requirement-level action; `maps auto`
+  covers same-name kernel-wrapper state/actions, and explicit maps override it.
+  An impl action with both a `maps` clause and a matching inline `action ...`
+  item is a duplicate-correspondence, `kind: "type"` check-time error (same as
+  a mapping file that lists the same action twice). Auto-mapped process
+  transitions are actor-checked; a transition whose actor differs from the
+  business action's actor is a check-time error.
 - `acceptance` is replay-verified at check time by the concrete Monitor (a
   failure is `kind: "acceptance"`). It supports `expect <Entity> <id> in
   <Stage>` alongside `expect <expr>` and flows directly into scenarios / testgen

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -611,12 +611,19 @@ verify {
   `_kpi_*` invariant.
 - When `implements Abs from "file" { }` is present and process/action/stage names
   match, fslc synthesizes the identity refinement mapping. Inside the
-  `implements { }` block you write only state `map` entries, `maps auto`, and
-  `preserve progress` — **not `action`** (the grammar rejects an action there).
-  Action↔action correspondence is instead the `maps <abs_act>(...)` clause **on
-  the requirement-level action** (auto-synthesized for matching names; `maps auto`
-  covers same-name kernel-wrapper actions). Auto-mapped process transitions are
-  statically actor-checked; an actor mismatch is a check-time type error.
+  `implements { }` block you write state `map` entries, `maps auto`,
+  `preserve progress`, and `action <impl>(<params>) -> <abs>(<args>) | stutter`
+  (same syntax as a separate refinement file's `action` item, including an
+  arity change between impl and abs params — #73). Action↔action
+  correspondence can also still be written as the `maps <abs_act>(...)` clause
+  **on the requirement-level action** (auto-synthesized for matching names;
+  `maps auto` covers same-name kernel-wrapper actions). Writing both a `maps`
+  clause on an action and a matching inline `action ...` item for the same impl
+  action name is a duplicate-correspondence error (`kind: "type"`,
+  "duplicate action map for '<name>'"). An inline `action` item cannot target
+  a `branches`-split action by its pre-split name — reference the generated
+  `name__b<N>` alias. Auto-mapped process transitions are statically
+  actor-checked; an actor mismatch is a check-time type error.
 - `acceptance` is replay-checked at check time with the concrete Monitor (failure is
   `kind: "acceptance"`). It supports the readable stage form
   `expect <Entity> <id> in <Stage>` alongside `expect <expr>`, is output to

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -182,7 +182,7 @@ requirements_def: "requirements" NAME "{" requirements_item* "}"
                   | state_def | init_def | req_action_def | process_def | time_def
                   | invariant_def | trans_def | reachable_def | leadsto_def | until_def | unless_def
 implements_def: "implements" NAME "from" STRING "{" implements_item* "}"
-?implements_item: map_def | maps_auto_def | preserve_progress_def
+?implements_item: map_def | maps_auto_def | refinement_action | preserve_progress_def
 requirement_def: "requirement" REQ_ID STRING "{" requirement_item* "}"
 ?requirement_item: req_action_def | invariant_def | trans_def | reachable_def | leadsto_def | deadline_def
 req_action_def: req_fair_action | req_plain_action

--- a/tests/test_inline_implements_action.py
+++ b/tests/test_inline_implements_action.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Inline `implements { }` action correspondence (#73).
+
+Confirms `refinement_action` can appear inside the requirements-dialect
+inline `implements { }` block (grammar.py `?implements_item`), including
+arity-changing correspondences that previously required a separate
+refinement file + `fslc refine`. The inline desugar (dialects.py
+`_expand_requirements_with_display`) merges the block's items into the
+same `("refinement", ..., mapping_items)` AST that the separate-file path
+parses, so `refine.py` needs no changes.
+"""
+from fslc.cli import run_check, run_refine, run_verify
+
+
+def _write(tmp_path, files):
+    for name, src in files.items():
+        (tmp_path / name).write_text(src, encoding="utf-8")
+
+
+ABS_SAME_ARITY = '''spec Abs73Same {
+  type CaseId = 0..1
+  state { done: Map<CaseId, Bool> }
+  init { forall c: CaseId { done[c] = false } }
+  fair action settle(c: CaseId) { requires done[c] == false  done[c] = true }
+}
+'''
+
+IMPL_SAME_ARITY = '''requirements Impl73Same {
+  implements Abs73Same from "abs.fsl" {
+    map done[c: CaseId] = paid[c]
+    action approve(c: CaseId) -> settle(c)
+  }
+  type CaseId = 0..1
+  state { paid: Map<CaseId, Bool> }
+  init { forall c: CaseId { paid[c] = false } }
+  fair action approve(c: CaseId) { requires paid[c] == false  paid[c] = true }
+}
+'''
+
+
+def test_inline_action_map_same_arity_baseline(tmp_path):
+    _write(tmp_path, {"abs.fsl": ABS_SAME_ARITY, "impl.fsl": IMPL_SAME_ARITY})
+
+    checked = run_check(str(tmp_path / "impl.fsl"))
+    assert checked["result"] == "ok"
+    assert checked["implements"] == {"abs": "Abs73Same", "result": "refines"}
+
+
+ABS_ARITY_CHANGE = '''spec Abs73 {
+  type CaseId = 0..1
+  state { done: Map<CaseId, Bool> }
+  init { forall c: CaseId { done[c] = false } }
+  fair action refund(c: CaseId) { requires done[c] == false  done[c] = true }
+}
+'''
+
+IMPL_ARITY_CHANGE_INLINE = '''requirements Impl73 {
+  implements Abs73 from "abs.fsl" {
+    map done[c: CaseId] = paid[c]
+    action pay(c: CaseId, m: Method) -> refund(c)
+  }
+  type CaseId = 0..1
+  enum Method { Card, Cash }
+  state { paid: Map<CaseId, Bool> }
+  init { forall c: CaseId { paid[c] = false } }
+  fair action pay(c: CaseId, m: Method) { requires paid[c] == false  paid[c] = true }
+}
+'''
+
+# The impl side of the separate-file path is the same state/action shape the
+# requirements dialect desugars `Impl73` to (same spec name — `build_refinement`
+# requires `impl <NAME>` to match `impl_spec["name"]`).
+IMPL_ARITY_CHANGE_KERNEL = '''spec Impl73 {
+  type CaseId = 0..1
+  enum Method { Card, Cash }
+  state { paid: Map<CaseId, Bool> }
+  init { forall c: CaseId { paid[c] = false } }
+  fair action pay(c: CaseId, m: Method) { requires paid[c] == false  paid[c] = true }
+}
+'''
+
+MAPPING_ARITY_CHANGE = '''refinement Impl73RefinesAbs73 {
+  impl Impl73
+  abs Abs73
+  map done[c: CaseId] = paid[c]
+  action pay(c: CaseId, m: Method) -> refund(c)
+}
+'''
+
+
+def test_inline_action_map_arity_change_matches_separate_file_refine(tmp_path):
+    _write(tmp_path, {
+        "abs.fsl": ABS_ARITY_CHANGE,
+        "impl_inline.fsl": IMPL_ARITY_CHANGE_INLINE,
+        "impl_kernel.fsl": IMPL_ARITY_CHANGE_KERNEL,
+        "mapping.fsl": MAPPING_ARITY_CHANGE,
+    })
+
+    checked = run_check(str(tmp_path / "impl_inline.fsl"))
+    assert checked["result"] == "ok"
+    inline_verdict = checked["implements"]["result"]
+
+    verified = run_verify(str(tmp_path / "impl_inline.fsl"), 4, "warn")
+    assert verified["result"] == "verified"
+    assert verified["implements"]["result"] == inline_verdict
+
+    separate = run_refine(
+        str(tmp_path / "impl_kernel.fsl"),
+        str(tmp_path / "abs.fsl"),
+        str(tmp_path / "mapping.fsl"),
+        depth=4,
+    )
+    assert separate["result"] == inline_verdict == "refines"
+    assert separate["action_map"] == {"pay": "refund"}
+
+
+ABS_STUTTER = '''spec AbsStutter73 {
+  type K = 0..1
+  state { x: K }
+  init { x = 0 }
+  fair action tick() { x = 1 }
+}
+'''
+
+IMPL_STUTTER = '''requirements ImplStutter73 {
+  implements AbsStutter73 from "abs.fsl" {
+    map x = y
+    action internal_tick() -> stutter
+  }
+  type K = 0..1
+  state { y: K }
+  init { y = 0 }
+  fair action internal_tick() { y = y }
+}
+'''
+
+
+def test_inline_action_map_stutter(tmp_path):
+    _write(tmp_path, {"abs.fsl": ABS_STUTTER, "impl.fsl": IMPL_STUTTER})
+
+    checked = run_check(str(tmp_path / "impl.fsl"))
+    assert checked["result"] == "ok"
+    assert checked["implements"] == {"abs": "AbsStutter73", "result": "refines"}
+
+
+IMPL_DUPLICATE = '''requirements Impl73Dup {
+  implements Abs73 from "abs.fsl" {
+    map done[c: CaseId] = paid[c]
+    action pay(c: CaseId, m: Method) -> refund(c)
+  }
+  type CaseId = 0..1
+  enum Method { Card, Cash }
+  state { paid: Map<CaseId, Bool> }
+  init { forall c: CaseId { paid[c] = false } }
+  fair action pay(c: CaseId, m: Method) maps refund(c) {
+    requires paid[c] == false
+    paid[c] = true
+  }
+}
+'''
+
+
+def test_inline_action_map_conflicts_with_requirement_maps_clause_is_an_error(tmp_path):
+    # Pinned conflict semantics: an explicit inline `action ... -> ...` item and
+    # an auto-derived correspondence (here, the requirement action's own `maps`
+    # clause) for the *same* impl action name both land in `build_refinement`'s
+    # `items` list. `build_refinement` (refine.py) already rejects a second
+    # entry for the same name with `kind: "type"`, "duplicate action map for
+    # '<name>'" — this is the same error the separate-file path raises when a
+    # mapping file lists an action twice, so no new conflict handling was added;
+    # the pre-existing duplicate check just now also sees inline vs. auto-derived
+    # duplicates.
+    _write(tmp_path, {"abs.fsl": ABS_ARITY_CHANGE, "impl.fsl": IMPL_DUPLICATE})
+
+    checked = run_check(str(tmp_path / "impl.fsl"))
+    assert checked["result"] == "error"
+    assert checked["kind"] == "type"
+    assert "duplicate action map for 'pay'" in checked["message"]
+
+
+ABS_BRANCH = '''spec AbsBranch73 {
+  type CaseId = 0..1
+  state { done: Map<CaseId, Bool> }
+  init { forall c: CaseId { done[c] = false } }
+  fair action settle(c: CaseId) { requires done[c] == false  done[c] = true }
+}
+'''
+
+IMPL_BRANCH_ORIGINAL_NAME = '''requirements ImplBranch73 {
+  implements AbsBranch73 from "abs.fsl" {
+    map done[c: CaseId] = paid[c]
+    action decide(c: CaseId) -> settle(c)
+  }
+  type CaseId = 0..1
+  state { paid: Map<CaseId, Bool> }
+  init { forall c: CaseId { paid[c] = false } }
+  fair action decide(c: CaseId) {
+    requires paid[c] == false
+    branches {
+      when true { paid[c] = true } maps settle(c)
+    }
+  }
+}
+'''
+
+
+def test_inline_action_map_referencing_pre_split_branch_name_is_an_error(tmp_path):
+    # Documents current behavior: `branches` splits `decide` into aliased kernel
+    # actions (`decide__b1`, ...; dialects.py `_split_branch_action`), so the
+    # impl spec `build_refinement` type-checks against never has a `decide`
+    # action. An inline `action decide(...) -> ...` item referencing the
+    # pre-split name is therefore "unknown impl action", matching what the
+    # separate-file path would raise for the same reference.
+    _write(tmp_path, {"abs.fsl": ABS_BRANCH, "impl.fsl": IMPL_BRANCH_ORIGINAL_NAME})
+
+    checked = run_check(str(tmp_path / "impl.fsl"))
+    assert checked["result"] == "error"
+    assert checked["kind"] == "type"
+    assert "unknown impl action 'decide'" in checked["message"]


### PR DESCRIPTION
## Summary

- The requirements-dialect inline `implements Abs from "file" { }` block now accepts `action <impl>(<params>) -> <abs>(<args>) | stutter` items (`grammar.py` `?implements_item` gains `refinement_action`) — the same action-correspondence syntax as a separate refinement file, including an arity change between the impl and abs action's parameters.
- No `dialects.py`/`refine.py` changes were needed: `refinement_action`'s transformer output (`("action_map", name, params, target, loc)`) is the exact same AST node the separate-file parser already produces, and the inline desugar already merges the block's items into the same `mapping_items` list that both paths pass to `refine.py`'s `build_refinement`. The grammar alternative was the entire fix.

## Conflict semantics (pinned by test)

- **Duplicate correspondence**: an impl action with *both* a requirement-action `maps` clause and a matching inline `action ...` item hits `build_refinement`'s pre-existing duplicate check unchanged — `kind: "type"`, `"duplicate action map for '<name>'"`. This is the same error a separate-file mapping raises when it lists an action twice; no new conflict-detection code was added.
- **Branch-split action names**: `branches` splits an action into aliased kernel actions (`name__b1`, ...). An inline `action <pre_split_name>(...) -> ...` item referencing the original name is `"unknown impl action '<name>'"` — documented as current behavior, matching what the separate-file path would need.

## Changed files

- `src/fslc/grammar.py` — add `refinement_action` to `?implements_item`
- `tests/test_inline_implements_action.py` (new) — same-arity baseline, arity-changing map cross-checked against separate-file `fslc refine` on an identical mapping, `stutter`, duplicate-conflict error, branch-alias error
- `docs/DESIGN-refinement.md` §1.2 (new), `docs/LANGUAGE.md`, `skills/fsl/reference.md` — update the "inline implements is state-only" note
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] `tests/test_inline_implements_action.py` — 5/5 passed
- [x] `tests/test_req_dialect.py`, `tests/test_refine.py`, `tests/test_refine_oracle.py`, `tests/test_refinement_chain_example.py`, `tests/test_refinement_liveness_example.py`, `tests/test_req_process.py` — all pass
- [x] `tests/test_corpus_snapshot.py` — passes without regenerating (no corpus spec uses the new syntax)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)