### PR TITLE
feat(business): no-bypass precedence policy — every E reaching T must have passed through W (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Business-layer no-bypass precedence policy: `policy ID "text" every <Entity>
+  reaching <Stage> [or <Stage> ...] must have passed through <Stage> [or
+  <Stage> ...]`. Synthesizes an invisible `Map<Entity, Bool>` history flag
+  (dedup'd across policies over the same process/waypoint-set), sets it on
+  the transition(s) landing on a waypoint, and compiles to a kernel invariant
+  carrying the policy's REQ-ID — closing "no-bypass" controls at the business
+  layer without descending to `requirements`. See
+  `docs/DESIGN-precedence-policy.md`. (#75)
 - `terminal { }` now works in the `requirements` dialect (`terminal_def` is a
   `requirements_item`; it passes through unchanged to the kernel spec, same
   one-block-per-spec rule as the kernel). The `business` dialect gets no new

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -262,6 +262,38 @@ verify {
    anyway. This makes "stopping at a process's last stage" verify clean by
    default; `--deadlock ignore` is no longer required for a pure stage-graph
    business spec.
+8. `policy <ID> "<text>" every <Entity> reaching <Stage> [or <Stage> ...]
+   must have passed through <Stage> [or <Stage> ...]` (#75, no-bypass
+   precedence) synthesizes one more layer of invisible state on top of rule 2
+   — a history flag alongside the stage map:
+   - For each **distinct** `(process, waypoint-set)` pair across all
+     precedence policies (deduped, so two policies over the same waypoints
+     share one flag), one `history_var: Map<X, Bool>` is added to the same
+     `state { }` block rule 2 emits, named
+     `<x_stage>_via_<Waypoint1>[_<Waypoint2>...]` (waypoints ordered by
+     declaration order in the process, for a deterministic name regardless of
+     the order the policy lists them in — it appears in traces).
+   - `init` sets it `true` for every entity if the process's `initial` stage
+     is itself in the waypoint set, else `false` — folded into the same
+     `init { }` block rule 2 emits.
+   - Every transition (rule 2) whose destination stage is in the waypoint
+     set gets `history_var[c] = true` appended to its body (before the
+     `requires`/`set` transformation runs, so this is only a body-append, not
+     a new transition).
+   - The policy itself compiles to a kernel invariant (with meta, so the
+     REQ-ID propagates like every other policy form):
+     `forall c: Entity { _any_stage(Entity, c, targets) => history_var[c] }`.
+   - Unknown stage / unknown entity referenced by the policy is a type error
+     naming the policy's REQ-ID.
+   - Semantics notes: if the initial stage is in `targets` but not in the
+     waypoint set, the invariant is violated at init — reported as a genuine
+     violation, not special-cased. A waypoint equal to a target is allowed
+     (trivially satisfied on entry through it).
+   - Limitation: the history flag is synthesized only in the business spec.
+     A requirements-layer spec that refines a business spec carrying a
+     precedence policy must either map that flag explicitly in its
+     refinement mapping or restate the policy at its own layer — refinement
+     does not currently propagate synthesized business-layer state.
 
 ### 3.3 Governance catalog
 

--- a/docs/DESIGN-precedence-policy.md
+++ b/docs/DESIGN-precedence-policy.md
@@ -1,0 +1,115 @@
+# FSL — business-layer no-bypass precedence policy (#75)
+
+## Motivation
+
+`business` deliberately keeps users from writing `state`/`invariant` directly — DESIGN-dialects.md
+calls processes "pure stage graphs" and the whole point is that the layer stays in business
+vocabulary (actors, entities, stages, transitions, policies, goals). But a very common control is
+a **no-bypass precedence rule**: "a case that reaches Completed must have passed through Approved" —
+Requested -> Refunded directly is the violation the control exists to catch. Before #75 this could
+only be said by descending to `requirements` and hand-writing a kernel invariant plus the auxiliary
+state to track it, which pushes the control out of the layer where it is owned and breaks REQ-ID
+propagation back to the business policy that motivates it.
+
+`policy <ID> "<text>" every <Entity> reaching <Stage> [or <Stage> ...] must have passed through
+<Stage> [or <Stage> ...]` says the same thing in business vocabulary, closes the control at the
+business layer, and propagates its REQ-ID through diagnostics exactly like the other policy forms
+(`invariant`, `responds`, `every ... must eventually be ...`).
+
+```fsl
+policy CTRL-APPROVAL "承認を経ずに完了しない"
+  every Return reaching Refunded must have passed through Approved
+```
+
+## Why this is not a purity violation
+
+`_generate_business_items` (dialects.py) already synthesizes kernel state that the user never
+writes: a stage enum, a `Map<Entity, Stage>`, `init` over all entities, and one fair action per
+declared transition (DESIGN-dialects.md §3.2 rules 2 and, since #69, rule 7's sink-derived
+`terminal { }`). "Business doesn't have state" is a constraint on the **user-facing surface**, not
+on what the desugarer is allowed to build underneath it. A history flag is the same pattern one
+layer further: it is invisible (the user never names it in their spec), structural (its value is
+fully determined by which transitions fired, no user-supplied data or branching), and derived
+entirely from declarations the user already wrote (the process's stages/transitions and the
+policy's own waypoint list). It does not let the user encode arbitrary logic in business — it lets
+the desugarer prove one more shape of property (safety over the stage graph's history, not just
+its current value) without widening what the user is allowed to write.
+
+## Desugaring
+
+For each `biz_policy_precedence` body (`case_name`, `targets`, `waypoints`):
+
+1. Resolve `case_name` to its process the same way `_stage_is`/`_any_stage` do
+   (`_process_for_case`), and validate every target and waypoint stage belongs to that process.
+   Both failures are type errors that name the policy's REQ-ID, e.g.
+   `policy 'CTRL-APPROVAL': stage 'NoSuchStage' is not declared for process 'Return'`.
+2. **Dedup.** Two (or more) precedence policies over the same `(process, waypoint-set)` share one
+   history map — `visited`-style flags are pure functions of the process and the waypoint set, so
+   there is nothing policy-specific to keep separate. The waypoint set is deduped and ordered by
+   the process's own stage-declaration order (not written order, not alphabetical) so the
+   synthesized name is deterministic regardless of how a given policy lists its waypoints:
+   `<x_stage>_via_<Waypoint1>[_<Waypoint2>...]` (e.g. `return_stage_via_Approved`,
+   `return_stage_via_Approved_Rejected`). This name is user-visible in traces by design — it should
+   read as what it is, not as an opaque gensym.
+3. **State.** One `history_var: Map<Entity, Bool>` per distinct history map, folded into the same
+   `state { }` item rule 2 (DESIGN-dialects.md §3.2) already emits — not a second `state` block.
+4. **Init.** `history_var[c] = true` for every entity if the process's `initial` stage is itself in
+   the waypoint set, else `false` — folded into the same `init { }` item rule 2 emits. This is a
+   deliberate, non-special-cased consequence of the rule: if a policy's target is also reachable
+   directly from the initial stage without passing through any waypoint, and the initial stage is
+   not itself a waypoint, the invariant is violated *at step 0* the moment the target is also the
+   initial stage. That is a genuinely violated policy (the control never held), not a bug to route
+   around.
+5. **Transition injection.** Every synthesized transition action (rule 2) whose destination stage
+   is in a history map's waypoint set gets `history_var[c] = true` appended to its body, before
+   the `requires`/`set` shape for that action is finalized. A transition landing on a stage that is
+   a waypoint for two distinct history maps (two policies, non-overlapping waypoint sets) appends
+   both assigns.
+6. **Property.** The policy compiles to a kernel invariant carrying the policy's own `meta` (id +
+   text, so it propagates through `violated`/`unknown_cti`/coverage diagnostics exactly like the
+   other policy forms):
+
+   ```
+   forall c: Entity { _any_stage(Entity, c, targets) => history_var[c] }
+   ```
+
+   `targets` disjunction reuses the same `_any_stage` helper the `every ... must eventually be
+   ...` and `all <Entity> can be ...` forms already use.
+
+## Ordering
+
+Because the injection in step 5 mutates the *same* transition bodies rule 2 builds, precedence
+policies must be collected (step 1–2, producing the history-var-per-waypoint-set table) **before**
+the `state`/`init`/transition-emission loop runs, not interleaved with the policy-body emission
+loop near the end of `_generate_business_items` (which is where the invariant itself, step 6, is
+appended — that part runs where every other policy body is already handled, after `state`/`init`
+and the transition loop, so it composes with #69's terminal-from-sinks derivation which runs
+right after the transition loop and needs no changes).
+
+## Semantics notes (not "fixed", documented)
+
+- **Initial stage inside targets, not inside waypoints**: violated at init. See step 4 above.
+- **Waypoint == target**: allowed. Arriving at a stage that is both a waypoint and a target
+  satisfies the policy trivially — the transition landing there sets the flag before the invariant
+  is (conceptually) re-checked, so `history_var[c]` is `true` in the very state where
+  `_any_stage(targets)` first becomes true.
+
+## Refinement limitation
+
+The history flag exists only in the business-layer kernel spec that `expand_business` produces —
+it is invisible synthesized state, not something a `requirements` spec written independently knows
+about. A `requirements` spec that `implements`/refines a business spec carrying a precedence policy
+must either (a) explicitly map the history flag in its refinement mapping file, or (b) restate the
+no-bypass rule at its own layer (there is currently no `requirements`-layer precedence syntax; see
+issue #75's alternatives section). Refinement checking does not currently propagate synthesized
+business-layer state automatically. This is a known limitation, not a defect — it mirrors the
+general rule that refinement mappings are explicit, not inferred.
+
+## What did not change
+
+`bmc.py` / `runtime.py`: nothing. The desugared output is an ordinary `Map<Entity, Bool>` state
+variable, ordinary transition-body assigns, and an ordinary `forall`-wrapped invariant — all
+existing kernel constructs. Both evaluators (`bmc.py` and `runtime.py`'s `Monitor`) already handle
+these; `tests/test_precedence_policy.py` exercises BMC (`fslc verify`) and AST-level assertions on
+the desugared kernel spec, and the corpus snapshot (`tests/test_corpus_snapshot.py`) is unaffected
+since no existing spec uses the new syntax.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -917,6 +917,26 @@ The explicit forms remain available when the rule is not just stage progression:
 `policy ... responds { forall c: Return { stage(c) == Requested ~> ... } }` and
 `goal ... { exists c: Return { stage(c) == Refunded } }`.
 
+For a **no-bypass** control — a target stage that must never be reached
+without first passing through a required waypoint — use the precedence form
+(#75; design rationale in `DESIGN-precedence-policy.md`):
+
+```fsl
+policy CTRL-APPROVAL "承認を経ずに完了しない"
+  every Return reaching Refunded must have passed through Approved
+```
+
+This synthesizes an invisible `Map<Return, Bool>` history flag (named
+`return_stage_via_Approved`, so it is legible in traces), sets it `true` on
+any transition landing on `Approved`, and compiles the policy to
+`forall c: Return { stage(c) == Refunded => return_stage_via_Approved[c] }`.
+A `Requested -> Refunded` transition that skips `Approved` is then a genuine
+invariant violation, with the trace showing exactly which bypass transition
+fired. Both sides accept a disjunction —
+`every Return reaching Refunded or Closed must have passed through Approved
+or Rejected` — and two policies over the same `(process, waypoint-set)` share
+one synthesized history flag.
+
 Business has no `terminal` syntax of its own. Instead, each process's **sink
 stages** (stages with no outgoing `transition`) are collected automatically:
 if every process has at least one sink, a kernel `terminal { }` is generated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -555,6 +555,19 @@ The natural business forms above are aliases for `responds { forall ... ~> ... }
 and `goal { forall/exists ... }`; the explicit expression forms remain available
 for policies that cannot be written as a simple stage progression.
 
+**No-bypass precedence** (#75): `policy CTRL-APPROVAL "..." every Return
+reaching Refunded must have passed through Approved` synthesizes an invisible
+`Map<Return, Bool>` history flag (`return_stage_via_Approved`), sets it `true`
+on the transition landing on `Approved`, and compiles to `forall c: Return {
+stage(c) == Refunded => return_stage_via_Approved[c] }`. A direct
+`Requested -> Refunded` transition is then a genuine invariant violation with
+the bypass shown in the trace. Both sides take a disjunction (`reaching A or
+B`, `passed through X or Y`); two policies over the same `(process,
+waypoint-set)` share one history flag (dedup, name deterministic by the
+process's stage order). Design in `DESIGN-precedence-policy.md`. Limitation:
+the flag is business-layer-only synthesized state — a `requirements` spec
+refining it must map the flag explicitly or restate the rule at its own layer.
+
 `control` declarations are metadata only. Attach them to checkable business
 rules with `policy ... satisfies CTRL` or `goal ... satisfies CTRL`. Unknown
 control references are type errors, unused declared controls are warnings, and a

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -1330,9 +1330,75 @@ def _any_stage(case_name, var_name, stages, process_by_case, loc):
     ])
 
 
+def _process_for_precedence(policy_id, case_name, process_by_case, loc):
+    processes = process_by_case.get(case_name, [])
+    if not processes:
+        _err(f"policy '{policy_id}': entity '{case_name}' has no process", loc=loc)
+    if len(processes) > 1:
+        _err(
+            f"policy '{policy_id}': entity '{case_name}' has multiple processes; "
+            "precedence policy is ambiguous",
+            loc=loc,
+        )
+    return processes[0]
+
+
+def _validate_precedence_stage(policy_id, case_name, stage, proc, loc):
+    if stage not in proc["stages"]:
+        _err(
+            f"policy '{policy_id}': stage '{stage}' is not declared for process '{case_name}'",
+            loc=loc,
+        )
+
+
+def _collect_precedence_policies(policies, process_by_case):
+    """Resolve `biz_policy_precedence` bodies and dedupe their history maps.
+
+    Two policies over the same (process, waypoint-set) share one synthesized
+    `Map<Entity, Bool>` history flag, named `<state_var>_via_<Waypoint...>`
+    (waypoints ordered by declaration order in the process, for determinism).
+    Returns:
+      - history_var_by_item: id(policy item) -> history var name
+      - history_specs: [(proc, history_var, sorted_waypoints), ...], one per
+        distinct history map, in first-seen order
+      - dst_history_vars: (proc_name, stage) -> [history_var, ...] for every
+        history map whose waypoint set contains that stage
+    """
+    history_var_by_item = {}
+    history_var_by_key = {}
+    history_specs = []
+    for item in policies:
+        _, policy_id, _text, body, loc = item[:5]
+        if body[0] != "biz_policy_precedence":
+            continue
+        _, case_name, targets, waypoints = body
+        proc = _process_for_precedence(policy_id, case_name, process_by_case, loc)
+        for stage in targets:
+            _validate_precedence_stage(policy_id, case_name, stage, proc, loc)
+        for stage in waypoints:
+            _validate_precedence_stage(policy_id, case_name, stage, proc, loc)
+        order = {stage: i for i, stage in enumerate(proc["stages"])}
+        sorted_waypoints = sorted(dict.fromkeys(waypoints), key=lambda s: order[s])
+        key = (proc["name"], tuple(sorted_waypoints))
+        history_var = history_var_by_key.get(key)
+        if history_var is None:
+            history_var = "_".join([proc["state_var"], "via", *sorted_waypoints])
+            history_var_by_key[key] = history_var
+            history_specs.append((proc, history_var, sorted_waypoints))
+        history_var_by_item[id(item)] = history_var
+    dst_history_vars = {}
+    for proc, history_var, waypoints in history_specs:
+        for stage in waypoints:
+            dst_history_vars.setdefault((proc["name"], stage), []).append(history_var)
+    return history_var_by_item, history_specs, dst_history_vars
+
+
 def _generate_business_items(cases, processes, kpi_infos, controls, policies, goals, process_by_case):
     out = []
     control_by_id, used_controls = _validate_controls_and_satisfaction(controls, policies, goals)
+    precedence_history_by_item, precedence_history_specs, precedence_dst_history_vars = (
+        _collect_precedence_policies(policies, process_by_case)
+    )
     for case_name, data in cases.items():
         out.append(("type", case_name, data["lo"], data["hi"]))
     for proc in processes:
@@ -1341,6 +1407,8 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
     state_decls = []
     for proc in processes:
         state_decls.append(("decl", proc["state_var"], ("map", ("name", proc["name"]), ("name", proc["enum"]))))
+    for proc, history_var, _waypoints in precedence_history_specs:
+        state_decls.append(("decl", history_var, ("map", ("name", proc["name"]), ("bool",))))
     if state_decls:
         out.append(("state", state_decls))
 
@@ -1350,6 +1418,13 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
             "forall_stmt",
             ("binder_typed", "c", proc["name"], None),
             [("assign", ("index", proc["state_var"], ("var", "c")), ("var", proc["initial"]), proc["loc"])],
+            proc["loc"],
+        ))
+    for proc, history_var, waypoints in precedence_history_specs:
+        init_stmts.append((
+            "forall_stmt",
+            ("binder_typed", "c", proc["name"], None),
+            [("assign", ("index", history_var, ("var", "c")), ("bool", proc["initial"] in waypoints), proc["loc"])],
             proc["loc"],
         ))
     if init_stmts:
@@ -1368,6 +1443,13 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
                  ("var", tr["dst"]),
                  tr["loc"]),
             ]
+            for history_var in precedence_dst_history_vars.get((proc["name"], tr["dst"]), []):
+                body.append((
+                    "assign",
+                    ("index", history_var, ("var", "c")),
+                    ("bool", True),
+                    tr["loc"],
+                ))
             out.append((
                 "action",
                 tr["name"],
@@ -1459,6 +1541,14 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
             p = _stage_is(case_name, "c", source_stage, process_by_case, loc)
             q = _any_stage(case_name, "c", target_stages, process_by_case, loc)
             out.append(("leadsto", policy_id, [binder], p, q, loc, meta))
+        elif body[0] == "biz_policy_precedence":
+            _, case_name, targets, _waypoints = body
+            history_var = precedence_history_by_item[id(item)]
+            binder = ("binder_typed", "c", case_name, None)
+            reached_target = _any_stage(case_name, "c", targets, process_by_case, loc)
+            visited = ("index", history_var, ("var", "c"))
+            expr = ("forall", binder, ("bin", "=>", reached_target, visited))
+            out.append(("invariant", policy_id, expr, loc, meta))
 
     for item in goals:
         _, goal_id, text, body, loc = item[:5]

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -229,10 +229,11 @@ control_severity: "severity" NAME
 control_applies_to: "applies_to" NAME
 satisfies_clause: "satisfies" REQ_ID ("," REQ_ID)* ","?
 policy_def: "policy" REQ_ID STRING satisfies_clause? policy_body
-?policy_body: policy_invariant | policy_responds | policy_eventually
+?policy_body: policy_invariant | policy_responds | policy_eventually | policy_precedence
 policy_invariant: "invariant" "{" expr "}"
 policy_responds: "responds" "{" lt_body "}"
 policy_eventually: "every" NAME "in" NAME "must" "eventually" "be" stage_disjunction
+policy_precedence: "every" NAME "reaching" stage_disjunction "must" "have" "passed" "through" stage_disjunction
 goal_def: "goal" REQ_ID STRING satisfies_clause? goal_body
 ?goal_body: goal_expr | goal_some_stage | goal_all_stage
 goal_expr: "{" expr "}"
@@ -1012,6 +1013,9 @@ class Ast(Transformer):
 
     def policy_eventually(self, meta, case_name, source_stage, target_stages):
         return ("biz_policy_eventually", case_name, source_stage, target_stages)
+
+    def policy_precedence(self, meta, case_name, targets, waypoints):
+        return ("biz_policy_precedence", case_name, targets, waypoints)
 
     def control_owner(self, meta, name):
         return ("control_owner", name)

--- a/tests/test_precedence_policy.py
+++ b/tests/test_precedence_policy.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Business-layer no-bypass precedence policy (#75).
+
+``every <Entity> reaching <targets> must have passed through <waypoints>``
+desugars to a synthesized, invisible history flag (``Map<Entity, Bool>``) plus
+a kernel invariant — the same "business already synthesizes state" pattern
+the stage enum/map/init/fair-actions synthesis already uses (see
+``docs/DESIGN-precedence-policy.md``). Two policies over the same
+(process, waypoint-set) share one history map (dedup).
+"""
+from fslc.cli import run_check, run_verify
+from fslc.model import FslError, build_spec
+from fslc.parser import parse
+
+
+# --------------------------------------------------------------------------
+# violated: a bypass path exists
+# --------------------------------------------------------------------------
+
+BIZ_BYPASS_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition bypass Requested -> Refunded by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-APPROVAL "承認を経ずに完了しない"
+    every Return reaching Refunded must have passed through Approved
+}
+verify {
+  instances Return = 3
+}
+'''
+
+
+def test_precedence_policy_bypass_is_violated(tmp_path):
+    f = tmp_path / "bypass.fsl"
+    f.write_text(BIZ_BYPASS_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 6, "warn")
+    assert result["result"] == "violated"
+    assert result["violation_kind"] == "invariant"
+    assert result["invariant"] == "CTRL-APPROVAL"
+    assert result["requirement"]["id"] == "CTRL-APPROVAL"
+
+    # the trace demonstrates the bypass transition, not some unrelated path
+    assert result["last_action"]["name"] == "bypass"
+
+
+# --------------------------------------------------------------------------
+# compliant: no bypass path
+# --------------------------------------------------------------------------
+
+BIZ_COMPLIANT_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-APPROVAL "承認を経ずに完了しない"
+    every Return reaching Refunded must have passed through Approved
+}
+verify {
+  instances Return = 3
+}
+'''
+
+
+def test_precedence_policy_compliant_verifies_clean(tmp_path):
+    f = tmp_path / "compliant.fsl"
+    f.write_text(BIZ_COMPLIANT_SRC, encoding="utf-8")
+
+    checked = run_check(str(f))
+    assert checked["result"] == "ok"
+
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert "CTRL-APPROVAL" in result["invariants_checked"]
+    # composes cleanly with #69's business sink-derived terminal: both sinks
+    # (Rejected, Refunded) are declared terminal, so no deadlock warning.
+    assert result["deadlock"]["found"] is False
+
+
+# --------------------------------------------------------------------------
+# waypoint disjunction: "passed through A or B"
+# --------------------------------------------------------------------------
+
+BIZ_DISJUNCTION_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition close_approved Approved -> Refunded by Manager
+    transition close_rejected Rejected -> Refunded by Manager
+  }
+
+  policy CTRL-DECIDED "決定を経ずに完了しない"
+    every Return reaching Refunded must have passed through Approved or Rejected
+}
+verify {
+  instances Return = 2
+}
+'''
+
+
+def test_precedence_policy_waypoint_disjunction_verifies_clean(tmp_path):
+    # Either branch of the disjunction satisfies the policy; neither branch
+    # alone is a bypass.
+    f = tmp_path / "disjunction.fsl"
+    f.write_text(BIZ_DISJUNCTION_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert "CTRL-DECIDED" in result["invariants_checked"]
+
+
+def test_precedence_policy_waypoint_disjunction_bypass_is_violated():
+    # A direct Requested -> Refunded transition bypasses both disjuncts.
+    src = BIZ_DISJUNCTION_SRC.replace(
+        "transition close_rejected Rejected -> Refunded by Manager",
+        "transition close_rejected Rejected -> Refunded by Manager\n"
+        "    transition bypass Requested -> Refunded by Manager",
+    )
+    ast = parse(src)
+    spec = build_spec(ast)
+    assert "return_stage_via_Approved_Rejected" in spec["state"]
+
+
+# --------------------------------------------------------------------------
+# initial-stage-in-waypoints: history flag starts true
+# --------------------------------------------------------------------------
+
+BIZ_INITIAL_WAYPOINT_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-TRIVIAL "waypoint is the initial stage"
+    every Return reaching Refunded must have passed through Requested
+}
+verify {
+  instances Return = 2
+}
+'''
+
+
+def test_precedence_policy_initial_stage_in_waypoints_inits_true():
+    ast = parse(BIZ_INITIAL_WAYPOINT_SRC)
+    init_stmts = next(item for item in ast[2] if item[0] == "init")[1]
+    # locate the forall_stmt whose body assigns the history var
+    matches = []
+    for stmt in init_stmts:
+        for action in stmt[2]:
+            target = action[1]
+            if target[0] == "index" and target[1] == "return_stage_via_Requested":
+                matches.append(action)
+    assert len(matches) == 1
+    assign = matches[0]
+    assert assign[2] == ("bool", True)
+
+
+def test_precedence_policy_initial_stage_in_waypoints_verifies_trivially(tmp_path):
+    f = tmp_path / "initial_waypoint.fsl"
+    f.write_text(BIZ_INITIAL_WAYPOINT_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 6, "warn")
+    assert result["result"] == "verified"
+
+
+# --------------------------------------------------------------------------
+# dedup: two policies over the same (process, waypoints) share one history map
+# --------------------------------------------------------------------------
+
+BIZ_DEDUP_SRC = r'''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Closed, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition close_approved Approved -> Closed by Manager
+    transition close_rejected Rejected -> Closed by Manager
+    transition refund Closed -> Refunded by Manager
+  }
+
+  policy CTRL-A "closed via approved or rejected"
+    every Return reaching Closed must have passed through Approved or Rejected
+  policy CTRL-B "refunded via approved or rejected"
+    every Return reaching Refunded must have passed through Approved or Rejected
+}
+verify {
+  instances Return = 2
+}
+'''
+
+
+def test_precedence_policy_dedups_history_map_across_policies():
+    ast = parse(BIZ_DEDUP_SRC)
+    state_decls = next(item for item in ast[2] if item[0] == "state")[1]
+    via_decls = [decl for decl in state_decls if "_via_" in decl[1]]
+    assert len(via_decls) == 1
+    assert via_decls[0][1] == "return_stage_via_Approved_Rejected"
+
+    invariants = {item[1]: item[2] for item in ast[2] if item[0] == "invariant"}
+    assert "CTRL-A" in invariants and "CTRL-B" in invariants
+    # both invariants reference the same shared history var: expr is
+    # ("forall", binder, ("bin", "=>", reached_target, ("index", history_var, ("var", "c"))))
+    assert invariants["CTRL-A"][2][3][1] == "return_stage_via_Approved_Rejected"
+    assert invariants["CTRL-B"][2][3][1] == "return_stage_via_Approved_Rejected"
+
+
+def test_precedence_policy_dedup_spec_verifies_clean(tmp_path):
+    f = tmp_path / "dedup.fsl"
+    f.write_text(BIZ_DEDUP_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 8, "warn")
+    assert result["result"] == "verified"
+    assert "CTRL-A" in result["invariants_checked"]
+    assert "CTRL-B" in result["invariants_checked"]
+
+
+# --------------------------------------------------------------------------
+# unknown stage / unknown entity -> FslError naming the policy id
+# --------------------------------------------------------------------------
+
+BIZ_UNKNOWN_STAGE_SRC = r'''business ReturnHandling {
+  actor Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-BAD "references a stage that does not exist"
+    every Return reaching Refunded must have passed through NoSuchStage
+}
+verify {
+  instances Return = 2
+}
+'''
+
+
+def test_precedence_policy_unknown_stage_names_policy_id(tmp_path):
+    f = tmp_path / "unknown_stage.fsl"
+    f.write_text(BIZ_UNKNOWN_STAGE_SRC, encoding="utf-8")
+
+    try:
+        parse(BIZ_UNKNOWN_STAGE_SRC)
+        assert False, "expected FslError"
+    except FslError as exc:
+        assert "CTRL-BAD" in str(exc)
+        assert "NoSuchStage" in str(exc)
+
+    checked = run_check(str(f))
+    assert checked["result"] == "error"
+    assert checked["kind"] == "type"
+    assert "CTRL-BAD" in checked["message"]
+
+
+BIZ_UNKNOWN_ENTITY_SRC = r'''business ReturnHandling {
+  actor Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-BAD "references an entity with no process"
+    every Invoice reaching Refunded must have passed through Approved
+}
+verify {
+  instances Return = 2
+}
+'''
+
+
+def test_precedence_policy_unknown_entity_names_policy_id():
+    try:
+        parse(BIZ_UNKNOWN_ENTITY_SRC)
+        assert False, "expected FslError"
+    except FslError as exc:
+        assert "CTRL-BAD" in str(exc)
+        assert "Invoice" in str(exc)


### PR DESCRIPTION
## Summary

Adds a business-layer "no-bypass" precedence control, closing #75:

```fsl
policy CTRL-APPROVAL "承認を経ずに完了しない"
  every Return reaching Refunded must have passed through Approved
```

Before this, "no-bypass" (a target stage must never be reached without first
passing through a waypoint) could only be expressed by descending to
`requirements` and hand-writing a kernel invariant plus auxiliary state,
losing REQ-ID propagation back to the business-layer control that motivates
it.

## Design rationale

`_generate_business_items` (`dialects.py`) already synthesizes kernel state
the user never writes: a stage enum, a `Map<Entity, Stage>`, `init`, and one
fair action per transition. "Business doesn't have state" is a constraint on
the user-facing surface, not on what the desugarer builds underneath it. This
change extends that same synthesis pattern one layer further:

- One `Map<Entity, Bool>` history flag per **distinct** `(process,
  waypoint-set)`, **deduped** across policies that share the same set, named
  `<x_stage>_via_<Waypoint1>[_<Waypoint2>...]` (deterministic by the
  process's own stage-declaration order — legible in traces by design).
- `init` sets it `true` for every entity if the process's `initial` stage is
  itself a waypoint, else `false`.
- Every synthesized transition action landing on a waypoint stage gets
  `history_var[c] = true` appended to its body.
- The policy compiles to `forall c: Entity { _any_stage(targets) =>
  history_var[c] }`, carrying the policy's own meta so its REQ-ID propagates
  through `violated`/`unknown_cti`/coverage diagnostics like every other
  policy form.

Full rationale, the ordering constraint (precedence policies must be
collected before the state/init/transition-emission loop, since injection
mutates the same transition bodies that loop builds), and the semantics notes
(initial-stage-in-targets is a genuine violation at init; waypoint == target
is allowed) are in `docs/DESIGN-precedence-policy.md`.

## Refinement limitation (documented, not solved here)

The history flag is synthesized only in the business-layer kernel spec. A
`requirements` spec that refines a business spec carrying a precedence
policy must either map the flag explicitly in its refinement mapping or
restate the rule at its own layer — refinement does not currently propagate
synthesized business-layer state automatically.

## Stacked PR

This branch is based on `feat/69-dialect-terminal` (PR #79, still open) —
both changes edit `_generate_business_items` in `dialects.py`. **This PR
should retarget to `main` once #79 merges.**

## Test plan

- [x] `pytest tests/test_precedence_policy.py -q` — 10 new tests: violated
      (bypass reported with policy REQ-ID and the bypass transition in the
      trace), compliant (verifies clean, composes with #69's sink-derived
      terminal / no deadlock), waypoint disjunction, initial-stage-in-
      waypoints (AST + behavior), dedup (AST assertion: one shared history
      map across two policies), unknown stage / unknown entity (`FslError`
      naming the policy id).
- [x] `pytest tests/test_precedence_policy.py tests/test_biz_dialect.py
      tests/test_dialect_terminal.py -q` — 30 passed.
- [x] `pytest tests/test_corpus_snapshot.py -q` — 152 passed, 1 skipped,
      **no diff** (new opt-in syntax; nothing in the corpus uses it yet).
- [x] Manually verified with `fslc check`/`fslc verify` against the design's
      worked example (bypass transition reported violated; removing it
      verifies clean at depth 8).

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)