### PR TITLE
feat(dialects): enum/Bool carried process fields with explicit initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- Requirements-layer `process E with f: T { ... }` carried fields now accept
+  `Bool` and enum types declared in the same spec, not just `number`. Number
+  fields keep the original default (the domain's `lo` bound) and gained an
+  optional explicit initializer (`f: T = <const-expr>`); `Bool`/enum fields
+  have no invented default and **require** an explicit initializer
+  (`f: Bool = true/false`, `f: T = Member`) — a missing one is a check-time
+  error. Docs: `docs/LANGUAGE.md`, `docs/DESIGN-dialects.md`,
+  `skills/fsl/reference.md`. (#70)
+
 ## [2.4.0] - 2026-06-29
 
 ### Documentation

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -105,6 +105,25 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
    action per transition. Transition `with a: T` becomes an action parameter,
    `when` becomes a requires clause, `set f = expr` becomes a field-map
    assignment for that entity, and `covers REQ-n "text"` attaches traceability.
+   A carried field's type `T` is one of three kinds, each with its own
+   initialization rule (no invented default for Bool/enum):
+   - `number` (declared via `number T` + `verify { values T = lo..hi }`):
+     unchanged from the original profile — defaults to the domain's `lo`
+     when `f: T` has no initializer; `f: T = <const-expr>` is an optional
+     explicit initializer, const-evaluated at desugar time (out-of-bounds
+     values are caught by the kernel's ordinary type-bound invariant, not by
+     a separate desugar-time bounds check).
+   - `Bool`: **requires** an explicit initializer, `f: Bool = true` or
+     `f: Bool = false`; the field-map value type is the kernel `Bool`, not a
+     0/1 domain. Missing the initializer is a check-time error.
+   - an `enum` declared in the same requirements spec: **requires** an
+     explicit initializer that is one of that enum's members, `f: T = Member`;
+     the assignment reuses the same `("var", Member)` pattern the synthesized
+     stage-init already uses. An initializer that names a non-member, or a
+     missing initializer, is a check-time error.
+   Any other type is rejected with "carried process field must be a number,
+   Bool, or enum type". Carried fields are never auto-mapped for refinement —
+   only the stage map (`e_stage`) participates in `maps auto`.
 3. `kpi k = count E in S` → no kernel state/action/invariant. The declaration is
    recorded as metadata for the projection
    `count(c: E where e_stage[c] == S)`.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -63,7 +63,9 @@ business <Name> {
 requirements <Name> {
   entity <Entity>          // optional explicit identity sort
   number <Number>
-  process <Entity> with f: <Number> { ... }  // process also declares the entity kind
+  process <Entity> with f: <Number>, g: Bool = <bool>, h: <Enum> = <Member> { ... }
+                            // process also declares the entity kind; Bool/enum
+                            // carried fields require an explicit `= ...` initializer
 }
 verify {
   instances <Entity> = <N>
@@ -824,7 +826,14 @@ verify {
 - The process+data profile is the primary requirements form for a single-entity
   lifecycle. `process E with f: T { ... }` creates the entity stage map and
   carried fields; transitions can add an input (`with a: T`), guard (`when`),
-  field update (`set f = expr`), and traceability (`covers REQ-n "text"`).
+  field update (`set f = expr`), and traceability (`covers REQ-n "text"`). A
+  carried field's type `T` is a `number`, `Bool`, or an enum declared in the
+  same requirements spec:
+  - `number` fields default to the domain's `lo` bound; `f: T = <expr>` is an
+    optional explicit initializer (a compile-time constant expression).
+  - `Bool` and enum fields have no invented default — `f: Bool = true/false`
+    and `f: T = Member` are **required**; omitting the initializer is a
+    check-time error (no silently-chosen `false` or first enum member).
 - `number Amount` declares a value kind; the finite verifier range lives in
   `verify { values Amount = lo..hi }`. Entity sizes live in
   `verify { instances Entity = N }`.

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -46,7 +46,9 @@ business <Name> {
 requirements <Name> {
   entity <Entity>                          // optional explicit identity sort
   number <Number>                          // numeric sort; range set by verify.values
-  process <Entity> with f: <Number> { ... } // process also declares the entity kind
+  process <Entity> with f: <Number>, g: Bool = <bool>, h: <Enum> = <Member> { ... }
+                                             // process also declares the entity kind; Bool/enum
+                                             // carried fields require an explicit `= ...` initializer
 }
 verify {
   instances <Entity> = <N>
@@ -605,7 +607,12 @@ verify {
 - The process+data profile is the default requirements form for a single-entity
   lifecycle. `process E with f: T { ... }` creates the entity stage map and
   carried fields; transition clauses add input (`with a: T`), guards (`when`),
-  field updates (`set f = expr`), and traceability (`covers REQ-n "text"`).
+  field updates (`set f = expr`), and traceability (`covers REQ-n "text"`). A
+  carried field's type `T` is a `number`, `Bool`, or an enum declared in the
+  same requirements spec. Numbers default to the domain's `lo` bound and may
+  take an optional explicit `f: T = <const-expr>` initializer; `Bool` and enum
+  fields have no invented default and **require** an explicit initializer
+  (`f: Bool = true/false`, `f: T = Member`) — omitting it is a check-time error.
 - `kpi NAME = count ENTITY in STAGE` is a declarative projection in both
   business and requirements; it does not create a ghost counter or an automatic
   `_kpi_*` invariant.

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -452,6 +452,7 @@ def _param_name(param):
 
 
 def _collect_requirements_processes(items, entity_locs, number_locs):
+    enum_members = {item[1]: set(item[2]) for item in items if item[0] == "enum"}
     process_items = [item for item in items if item[0] == "biz_process"]
     processes = []
     process_by_name = {}
@@ -469,15 +470,34 @@ def _collect_requirements_processes(items, entity_locs, number_locs):
         field_names = set()
         fields = []
         for field in proc["fields"]:
-            _, fname, ty = field
+            _, fname, ty, init = field
             if fname in field_names:
                 _err(f"duplicate carried process field '{fname}'", loc=proc["loc"])
             field_names.add(fname)
-            if not isinstance(ty, str) or ty not in number_locs:
-                _err("carried process field must be a number type", loc=proc["loc"])
+            if isinstance(ty, str) and ty in number_locs:
+                kind = "number"
+            elif ty == "Bool":
+                kind = "bool"
+                if init is None or init[0] != "bool":
+                    _err(
+                        "carried Bool field requires an explicit initializer (= true / = false)",
+                        loc=proc["loc"],
+                    )
+            elif isinstance(ty, str) and ty in enum_members:
+                kind = "enum"
+                if init is None or init[0] != "var" or init[1] not in enum_members[ty]:
+                    _err(
+                        f"carried enum field '{fname}' requires an explicit initializer "
+                        f"that is a member of enum '{ty}'",
+                        loc=proc["loc"],
+                    )
+            else:
+                _err("carried process field must be a number, Bool, or enum type", loc=proc["loc"])
             fields.append({
                 "name": fname,
                 "type": ty,
+                "kind": kind,
+                "init": init,
                 "state_var": _process_field_state_var(proc["name"], fname),
             })
         proc["fields"] = fields
@@ -535,10 +555,11 @@ def _expand_requirements_process(proc, values, consts):
         ("decl", proc["state_var"], ("map", ("name", proc["name"]), ("name", proc["enum"]))),
     ]
     for field in proc["fields"]:
+        value_ty = ("bool",) if field["kind"] == "bool" else ("name", field["type"])
         state_decls.append((
             "decl",
             field["state_var"],
-            ("map", ("name", proc["name"]), ("name", field["type"])),
+            ("map", ("name", proc["name"]), value_ty),
         ))
     out.append(("state", state_decls))
 
@@ -551,11 +572,15 @@ def _expand_requirements_process(proc, values, consts):
         )
     ]
     for field in proc["fields"]:
-        lo_expr, _hi_expr = values[field["type"]]
+        if field["kind"] == "number":
+            src_expr = field["init"] if field["init"] is not None else values[field["type"]][0]
+            init_value = ("num", eval_const(src_expr, consts, {}))
+        else:
+            init_value = field["init"]
         init_body.append((
             "assign",
             ("index", field["state_var"], ("var", "c")),
-            ("num", eval_const(lo_expr, consts, {})),
+            init_value,
             proc["loc"],
         ))
     _merge_init(out, [(

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -211,7 +211,7 @@ business_def: "business" NAME "{" business_item* "}"
 actor_def: "actor" NAME ("," NAME)* ","?
 process_def: "process" NAME process_with? "{" process_item* "}"
 process_with: "with" proc_field ("," proc_field)*
-proc_field: NAME ":" qname
+proc_field: NAME ":" qname ["=" expr]
 ?process_item: process_stages | process_initial | process_transition
 process_stages: "stages" NAME ("," NAME)* ","?
 process_initial: "initial" NAME
@@ -951,8 +951,8 @@ class Ast(Transformer):
     def process_initial(self, meta, name):
         return ("biz_initial", name, _loc(meta))
 
-    def proc_field(self, meta, n, ty):
-        return ("proc_field", n, ty)
+    def proc_field(self, meta, n, ty, init=None):
+        return ("proc_field", n, ty, init)
 
     def process_with(self, meta, *fields):
         return ("proc_fields", list(fields), _loc(meta))

--- a/tests/test_req_process_carry_enum_bool.py
+++ b/tests/test_req_process_carry_enum_bool.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Bool/enum carried process fields (requirements `process ... with`, #70).
+
+Carried fields historically had to be a `number` type — a single history flag
+or classification needed the full kernel-wrapper form. Bool/enum fields are
+now allowed, but only with an explicit initializer: there is no invented
+default for a Bool or an enum member, matching the numeric-field default
+(domain `lo`) only ever being implicit for numbers.
+"""
+import pytest
+
+from fslc import FslError, build_spec, parse, verify
+from fslc.runtime import Monitor
+
+
+BOOL_ENUM_SRC = r'''requirements CaseReq {
+  entity Case
+  enum Kind { Statement, Question }
+
+  process Case with retried: Bool = false, kind: Kind = Statement {
+    stages New, Done
+    initial New
+
+    transition finish New -> Done by System
+      when retried == false
+      set retried = true, kind = Question
+  }
+
+  requirement REQ-1 "finishing flips retried and kind" {
+    reachable Finished {
+      case_retried[0] == true and case_kind[0] == Question
+    }
+  }
+
+  acceptance AC-1 "finish flips retried and kind" {
+    finish(0)
+    expect case_retried[0] == true and case_kind[0] == Question
+  }
+}
+verify {
+  instances Case = 2
+}
+'''
+
+
+def test_bool_and_enum_carry_check_and_verify_agree():
+    spec = build_spec(parse(BOOL_ENUM_SRC))
+
+    result = verify(spec, 4, deadlock_mode="ignore")
+
+    assert result["result"] == "verified", result
+    witness = result["reachables"]["Finished"]["witness"]
+    assert witness[-1]["state"]["case_retried"]["0"] is True
+    assert witness[-1]["state"]["case_kind"]["0"] == "Question"
+
+
+def test_bool_and_enum_carry_witness_replays_the_same_in_monitor():
+    """BMC's witness for REQ-1 and the concrete Monitor must agree step by step."""
+    spec = build_spec(parse(BOOL_ENUM_SRC))
+    result = verify(spec, 4, deadlock_mode="ignore")
+    witness = result["reachables"]["Finished"]["witness"]
+
+    mon = Monitor(spec)
+    mon.reset()
+    for entry in witness[1:]:
+        action = entry["action"]
+        step = mon.step(action["name"], action["params"])
+        assert step["ok"], step
+        assert step["state"] == entry["state"], (step["state"], entry["state"])
+
+
+def test_bool_carry_without_initializer_is_an_error():
+    src = r'''requirements CaseReq {
+  entity Case
+  process Case with retried: Bool {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+  }
+}
+verify {
+  instances Case = 1
+}
+'''
+    with pytest.raises(FslError) as exc:
+        parse(src)
+    assert exc.value.kind == "type"
+    assert str(exc.value) == "carried Bool field requires an explicit initializer (= true / = false)"
+
+
+def test_enum_carry_without_initializer_is_an_error():
+    src = r'''requirements CaseReq {
+  entity Case
+  enum Kind { Statement, Question }
+  process Case with kind: Kind {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+  }
+}
+verify {
+  instances Case = 1
+}
+'''
+    with pytest.raises(FslError) as exc:
+        parse(src)
+    assert exc.value.kind == "type"
+    assert "carried enum field 'kind' requires an explicit initializer" in str(exc.value)
+    assert "member of enum 'Kind'" in str(exc.value)
+
+
+def test_enum_carry_initializer_must_be_a_member():
+    src = r'''requirements CaseReq {
+  entity Case
+  enum Kind { Statement, Question }
+  process Case with kind: Kind = Bogus {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+  }
+}
+verify {
+  instances Case = 1
+}
+'''
+    with pytest.raises(FslError) as exc:
+        parse(src)
+    assert exc.value.kind == "type"
+    assert "carried enum field 'kind' requires an explicit initializer" in str(exc.value)
+
+
+def test_unknown_carry_type_error_message_lists_all_three_kinds():
+    src = r'''requirements CaseReq {
+  entity Case
+  process Case with foo: NoSuchType {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+  }
+}
+verify {
+  instances Case = 1
+}
+'''
+    with pytest.raises(FslError) as exc:
+        parse(src)
+    assert exc.value.kind == "type"
+    assert str(exc.value) == "carried process field must be a number, Bool, or enum type"
+
+
+def test_number_carry_without_initializer_is_unchanged():
+    """Regression guard: the pre-#70 numeric carry (implicit domain `lo` default)."""
+    src = r'''requirements CaseReq {
+  entity Case
+  number Amount
+  process Case with amount: Amount {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+      set amount = amount
+  }
+}
+verify {
+  instances Case = 1
+  values Amount = 2..5
+}
+'''
+    spec = build_spec(parse(src))
+    mon = Monitor(spec)
+    state = mon.reset()
+    assert state["case_amount"]["0"] == 2
+
+
+def test_number_carry_with_explicit_const_initializer():
+    src = r'''requirements CaseReq {
+  entity Case
+  number Amount
+  const START = 3
+  process Case with amount: Amount = START {
+    stages New, Done
+    initial New
+    transition finish New -> Done by System
+      set amount = amount
+  }
+}
+verify {
+  instances Case = 1
+  values Amount = 0..5
+}
+'''
+    spec = build_spec(parse(src))
+    mon = Monitor(spec)
+    state = mon.reset()
+    assert state["case_amount"]["0"] == 3


### PR DESCRIPTION
## Summary
- Requirements-layer `process E with f: T { ... }` carried fields now accept `Bool` and enum types declared in the same spec, not just `number`. `proc_field` gained an optional initializer: `f: T = <expr>`.
- **Design decision (no invented defaults):** `number` fields keep the pre-existing behavior — default to the domain's `lo` bound when no initializer is given, with an optional explicit const-evaluated initializer now allowed. `Bool` and enum fields have **no invented default**: an explicit initializer (`= true`/`= false`, or `= Member`) is **required**; omitting it is a check-time type error ("carried Bool field requires an explicit initializer (= true / = false)" / "carried enum field 'f' requires an explicit initializer that is a member of enum 'T'"). An unrecognized carried type errors with "carried process field must be a number, Bool, or enum type".
- `Bool` fields desugar to `Map<Entity, Bool>` state using the plain kernel `Bool` type (not a `types_meta` name lookup, since `Bool` isn't a user-declared type there). Enum fields desugar to `Map<Entity, TheEnum>` state with the same `("var", Member)` init-assign pattern the synthesized process-stage init already uses.
- Carried fields were never auto-mapped for refinement (`maps auto` only maps the stage var), so `implements`/refinement needed no change — verified with a test.

## Test plan
- [x] New `tests/test_req_process_carry_enum_bool.py` (8 tests): Bool/enum carry with explicit init (check + BMC `verify` + a BMC-witness-vs-concrete-Monitor replay-agreement test), missing-initializer errors for both Bool and enum, non-member enum initializer error, unknown-type error message, number-carry-without-initializer regression guard, number-carry-with-explicit-const-initializer.
- [x] Existing `tests/test_req_process.py` — all 6 passing (unchanged).
- [x] `tests/test_corpus_snapshot.py` — passes without regeneration (corpus specs only use number carries; behavior unchanged).
- [x] Full suite: `pytest -q` → 166 passed, 1 skipped (pre-existing, unrelated).
- Docs updated: `docs/LANGUAGE.md`, `docs/DESIGN-dialects.md`, `skills/fsl/reference.md`, `CHANGELOG.md`.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)