### PR TITLE
docs(skills): track #67-#75 features in workflow skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `sum()` aggregate to generalize it (fairness-aware per-entity ranking is
   tracked separately as #72). Also added a targeted parse-error hint in
   `cli.py` for `decreases` nested inside a `forall` body. (#71)
+- Updated the workflow skills (`skills/fsl/SKILL.md`, `skills/fsl-business/SKILL.md`,
+  `skills/fsl-requirements/SKILL.md`) to track the v2.5 feature set:
+  auto-derived business `terminal` and the requirements-layer `terminal`
+  passthrough (#69), `Bool`/enum carried fields with initializers (#70),
+  `unknown_cti`'s `suggested_invariants` (#74), the no-bypass precedence
+  `policy` form (#75), inline `implements { action ... }` correspondence with
+  arity changes (#73), `Bool` action params (#68), and enum member names in
+  `acceptance`/`forbidden` arguments (#67). `skills/fsl/reference.md` already
+  covered these; the workflow skills had not. (#67 #68 #69 #70 #73 #74 #75)
 
 ## [2.4.0] - 2026-06-29
 

--- a/skills/fsl-business/SKILL.md
+++ b/skills/fsl-business/SKILL.md
@@ -48,11 +48,17 @@ the work to `fsl-requirements` or `fsl-design` after the business layer is agree
    - `kpi paid_claims = count Claim in Paid`
    - `control CTRL-1 "..." owner Finance severity high applies_to Claim`
    - `policy POL-1 "..." satisfies CTRL-1 every Case in Source must eventually be Target`
+   - `policy POL-2 "..." satisfies CTRL-1 every Case reaching Completed must have passed
+     through AwaitingApproval` — the no-bypass form; desugars to an invisible history
+     flag plus a kernel invariant, without descending to `requirements`
    - `goal G "..." some Case can reach Target`
    - `goal G "..." all Case can be Target or OtherTarget`
-4. Run `fslc check`, then `fslc verify --engine induction`. Use `--deadlock ignore`
-   only for business process models where terminal stops are intentionally handled
-   by goals/policies rather than kernel `terminal`.
+4. Run `fslc check`, then `fslc verify --engine induction`. A pure stage-graph
+   business spec needs no flag for intentional stops: `terminal { }` is derived
+   automatically from each process's sink stages (stages with no outgoing
+   `transition`), so a spec that ends cleanly at those stages verifies with no
+   flag. `--deadlock ignore` is not the tool for intended stops — it silences all
+   deadlock detection, including unintended ones.
 5. If comparing As-Is and To-Be, keep them in separate files. Write an explicit
    mapping that states the business interpretation, then run `fslc refine
    tobe.fsl asis.fsl mapping.fsl`.

--- a/skills/fsl-requirements/SKILL.md
+++ b/skills/fsl-requirements/SKILL.md
@@ -77,17 +77,25 @@ design decision but does not state it, ask rather than choosing.
    `number Amount`, `process Claim with amount: Amount`, transition `with`
    inputs, `when` guards, `set` field updates, and `covers` traceability. Put
    finite bounds in a top-level `verify` block with `instances Claim = N` and
-   `values Amount = lo..hi`.
+   `values Amount = lo..hi`. Carried fields also accept `Bool` and enum types
+   declared in the spec: `number` keeps an optional initializer
+   (`f: Amount = <const-expr>`, defaults to the domain's `lo`), `Bool`/enum
+   fields require one (`retried: Bool = false`, `f: T = Member`) — this covers
+   simple history flags without routing to kernel-wrapper.
 5. Use the kernel-wrapper form (`struct` / `state` / `init`, `fair action`,
    `branches`, explicit `maps`) only for hard cases: multi-entity behavior,
-   conservation rules, SLA/time, history not expressible as a carried field, or
-   a user-visible operation whose data-dependent outcomes need separate upper
+   conservation rules, SLA/time, history that needs kernel state (multiple
+   entities, sequences, etc. — a simple flag fits in a carried field, see step 4),
+   or a user-visible operation whose data-dependent outcomes need separate upper
    correspondences.
 6. Put positive examples in `acceptance`; put must-reject procedures in
    `forbidden`. Use `forbidden` for missing-guard risk because a safety invariant
    often stays silent when an invalid operation is accepted. Prefer
    `expect Entity id in Stage` for process-stage checks; use `expect <expr>` for
-   other predicates.
+   other predicates. `acceptance`/`forbidden` action arguments accept enum member
+   names (not just numeric ordinals); an action parameter may also be typed
+   `Bool` (a first-class boolean, not a 0/1 int — `Int` is still rejected as
+   unbounded).
 7. For `implements`:
    - `implements BusinessName from "business.fsl" { }` auto-generates identity
      refinement when process/action/stage names match
@@ -95,6 +103,9 @@ design decision but does not state it, ask rather than choosing.
      state/actions; explicit `map` and action correspondences override it
    - auto-mapped process transitions are actor-checked; a requirements transition
      whose actor differs from the business action's actor is a check-time error
+   - the inline block also accepts action correspondence items —
+     `action impl(...) -> abs(...) | stutter` — including an arity change
+     between impl and abs params, the same syntax a separate refinement file uses
 8. For NFRs:
    - permissions: role guard plus invariant when needed
    - audit/capacity/reliability: ordinary invariants and response properties

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -316,7 +316,7 @@ existing result/kind fields:
 | `violated` / `ensures` | Postcondition not satisfied | Decide whether the body or the ensures is correct, and fix accordingly |
 | `violated` / `leadsTo` | Response-property counterexample (lasso / stall) | Check the trace's `loop_start`. Either add `fair` to the action that drives progress, or fix the spec |
 | `reachable_failed` | A state you want to reach is unreachable | Read `action_coverage`'s `blocking_requires` (unsat core). Loosen a guard / add an action / increase `--depth` |
-| `unknown_cti` | The invariant is true but not inductive | **The CTI's starting state = a phantom state satisfying all invariants. Add an auxiliary invariant (one that is a domain truth) that excludes it, then re-run.** Track record: converges in one round (e.g. "no duplicates in the queue," "refunds only from Captured") |
+| `unknown_cti` | The invariant is true but not inductive | **The CTI's starting state = a phantom state satisfying all invariants. Add an auxiliary invariant (one that is a domain truth) that excludes it, then re-run.** Check `suggested_invariants` first — for the monotone-counter idiom the result carries ready-made candidate expressions. Track record: converges in one round (e.g. "no duplicates in the queue," "refunds only from Captured") |
 | warning / `vacuous_implication` | The antecedent of an implication invariant is never reached within depth | Check whether an action / reachable witness that makes the antecedent hold is missing, or whether the antecedent expression is reversed or too strong relative to intent. Do not simply weaken the consequent |
 | warning / `vacuous_leadsto` | The leadsTo trigger is not reached within depth | Check the action / guard / initial condition for entering the trigger state. Look first at whether P (not the response target Q) actually occurs in the spec |
 | warning / `always_true_requires` | Under the context of the preceding requires, this requires clause is not effective as a constraint | Decide whether the clause is redundant or whether a path to the state where the clause bites is missing. Do not delete it automatically |
@@ -451,6 +451,12 @@ spec Cart {
   stopping is correct) would become a deadlock warning → declare it with
   `terminal { <predicate> }` (applying `--deadlock ignore` globally hides even
   unintended deadlocks). Stops not included in terminal continue to be detected.
+  `terminal { }` also passes through unchanged at the `requirements` layer (write
+  it against the synthesized `<entity>_stage` map when using `process`, e.g.
+  `terminal { forall c: Case { case_stage[c] == Closed } }`); the `business`
+  dialect needs no `terminal` syntax at all — it derives the predicate
+  automatically from each process's sink stages (stages with no outgoing
+  `transition`).
 
 ## Recommended practices (optional — by risk; may be skipped for small specs)
 
@@ -509,7 +515,9 @@ the relevant role skill directs it.
 - `business Name { process/control/policy/kpi/goal }` — the consulting layer. For
   PM/consulting-facing files, prefer the readable stage syntax for common rules:
   `policy ... every Case in Source must eventually be Target [or Target ...]`,
-  `goal ... some Case can reach Target`, and
+  `policy ... every Case reaching Target [or Target ...] must have passed
+  through Waypoint [or Waypoint ...]` (no-bypass; desugars to an invisible
+  history flag + kernel invariant), `goal ... some Case can reach Target`, and
   `goal ... all Case can be Target [or Target ...]`. Use explicit
   `responds { forall ... stage(c) ... ~> ... }` / `{ expr }` only when the rule is
   not simple stage progression. Regulation contradiction = invariant violation,
@@ -528,14 +536,19 @@ the relevant role skill directs it.
   to the upper layer (the `implements` field in the result JSON); an empty body
   auto-generates identity refinement when names match, `maps auto` is allowed for
   same-name kernel-wrapper state/actions, and auto-mapped process transitions are
-  actor-checked. `acceptance` is replay-checked at check time and supports
-  `expect E id in Stage` as well as `expect <expr>`, then flows scenarios →
-  testgen. `forbidden` (must-forbid) conversely writes an "operation sequence
-  that should be rejected" and verifies at check time that the last step is
-  rejected (not-enabled or a violation) — if accepted, `kind: "forbidden"`. Use
-  kernel-wrapper `struct` / `state` / `init`, `fair action`, `branches`, and
-  explicit `maps` only for hard cases such as multi-entity behavior,
-  conservation rules, SLA/time, or history not expressible as a carried field.
+  actor-checked; the inline block also takes action-correspondence items
+  (`action impl(..) -> abs(..) | stutter`), including an arity change, the same
+  syntax a separate refinement file uses. `acceptance` is replay-checked at
+  check time and supports `expect E id in Stage` as well as `expect <expr>`,
+  then flows scenarios → testgen; action arguments in `acceptance`/`forbidden`
+  accept enum member names as well as numeric ordinals. `forbidden` (must-forbid)
+  conversely writes an "operation sequence that should be rejected" and
+  verifies at check time that the last step is rejected (not-enabled or a
+  violation) — if accepted, `kind: "forbidden"`. Carried fields (`f: T`) accept
+  `number` (optional initializer, default `lo`), or `Bool`/enum (initializer
+  required). Use kernel-wrapper `struct` / `state` / `init`, `fair action`,
+  `branches`, and explicit `maps` only for hard cases such as multi-entity
+  behavior, conservation rules, SLA/time, or history that needs kernel state.
   An independent channel for catching under-constraint (missing guards) that a
   safety invariant stays silent about (a receptacle for cross-validation where a
   separate agent writes positive/negative traces from NL)


### PR DESCRIPTION
## Summary

`skills/fsl/reference.md` was updated in PRs #76-#83 (issues #67-#75) but the
workflow-facing SKILL.md files were not. This brings them into sync.

## Stale claims fixed, per file

**`skills/fsl-business/SKILL.md`**
- Step 4 told the user to use `--deadlock ignore` for business models with
  intentional terminal stops. Stale: business now auto-derives `terminal { }`
  from each process's sink stages (#69), so a pure stage-graph spec verifies
  clean with no flag. Rewrote the guidance; `--deadlock ignore` is no longer
  positioned as the tool for intended stops.
- Added the no-bypass precedence `policy` form (#75) as a second policy
  example alongside the existing `must eventually be` form.

**`skills/fsl-requirements/SKILL.md`**
- Step 4 (process+data profile): added carried field kinds — `number` keeps
  its optional initializer, `Bool`/enum fields require one (#70).
- Step 5 (kernel-wrapper escape hatch): "history not expressible as a carried
  field" was partially stale now that `Bool`/enum carried fields exist.
  Reworded so only history needing genuine kernel state (multi-entity,
  sequences, etc.) routes to kernel-wrapper.
- Step 6 (acceptance/forbidden): added that action arguments accept enum
  member names (#67) and that action params may be typed `Bool` (#68).
- Step 7 (implements): added that the inline block also accepts action
  correspondence items with arity changes (#73).

**`skills/fsl/SKILL.md`**
- The `unknown_cti` repair-table row told the user to find an auxiliary
  invariant unaided. Added: check `suggested_invariants` first for the
  monotone-counter idiom (#74).
- The intended-terminal-state note only described kernel `terminal { }`.
  Added that it now passes through at the requirements layer (with a
  verified example against the synthesized `<entity>_stage` map) and that
  business derives it automatically from sink stages (#69).
- The business-layer and requirements-layer quick-reference bullets in the
  three-layer dialects section had the same staleness as the two role
  skills above (no-bypass policy form, carried field kinds, inline
  `implements` action items, enum-name acceptance/forbidden args, Bool
  params) — updated to match.

## Sweep findings

Grepped all of `skills/` (every SKILL.md + README.md, excluding
`reference.md`) for `--deadlock ignore`, `ordinal`, ` terminal`, `passed
through`, `carried`, `implements`, `decreases`, `Bool`, `acceptance`.

- `skills/README.md` — checked, clean (only generic layer-description text).
- `skills/fsl-delivery/SKILL.md` — checked, clean (stays at the orchestration
  level, no syntax claims to go stale).
- `skills/fsl-design/SKILL.md` — checked, clean (no hits).
- `skills/fsl-design-review/SKILL.md` — checked, clean (no hits).
- `skills/fsl-from-code/SKILL.md` — checked, clean (no hits).

## Verification

Every new syntax line was checked against the real grammar in a scratchpad
spec with `.venv/bin/fslc check`/`verify` (not committed to the repo):
- Business `terminal` auto-derivation from sink stages, verified clean with
  no `--deadlock ignore`.
- No-bypass `policy ... must have passed through ...`, verified with the
  synthesized invariant appearing in `invariants_checked`.
- Requirements-layer `terminal { }` passthrough — confirmed it must be
  written against the synthesized `<entity>_stage` map per-instance
  (`forall c: Case { case_stage[c] == Closed }`, not a bare scalar
  comparison, which hits an internal "sort mismatch" error) and updated the
  wording to show the correct form.
- `Bool`/enum carried fields with initializers, `Bool` action params, and
  enum member names as `acceptance`/`forbidden` call arguments — all
  verified together in one spec.
- Inline `implements { action impl(...) -> abs(...) }` with an arity change
  (2 impl params -> 1 abs param), verified with `"implements": {"result":
  "refines"}` in the `verify` output.

## Test plan

- [x] `.venv/bin/fslc check`/`verify` against scratchpad specs for every new
      syntax line added to the skills (see above)
- [x] `git diff` reviewed for absolute paths — none found
- No `src/`/`tests/` changes; corpus snapshot not run (out of scope per task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)