### PR TITLE
fix(business): auto-synthesize dominated-set stability invariant for precedence policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- Business-dialect no-bypass precedence policies (`every <Entity> reaching
+  <Targets> must have passed through <Waypoints>`, #75) now auto-synthesize a
+  second, stabilizing auxiliary invariant (`<PolicyId>_stability`) alongside
+  the history flag: `forall c { stage[c] in dominated(Waypoints) =>
+  visited[c] }`, where the dominated set is computed by one reachability
+  pass over the process's transition graph with the waypoint nodes removed.
+  Previously a compliant precedence policy verified under BMC but stalled at
+  `unknown_cti` under `--engine induction` on a ghost CTI (`stage[c] ==
+  Waypoint && visited[c] == false`, unreachable in practice but not provable
+  by induction alone); it now proves at k=1, including for cyclic process
+  graphs and waypoint disjunctions. Docs: `docs/DESIGN-precedence-policy.md`,
+  `docs/LANGUAGE.md`, `skills/fsl/reference.md`. (#85)
+
 ## [2.5.0] - 2026-07-02
 
 ### Added

--- a/docs/DESIGN-precedence-policy.md
+++ b/docs/DESIGN-precedence-policy.md
@@ -86,6 +86,80 @@ appended — that part runs where every other policy body is already handled, af
 and the transition loop, so it composes with #69's terminal-from-sinks derivation which runs
 right after the transition loop and needs no changes).
 
+## Stabilizing auxiliary invariant for k-induction (#85)
+
+BMC alone accepts a compliant precedence policy fine, but **k-induction stalls on a ghost CTI**:
+`stage[c] == Approved && return_stage_via_Approved[c] == false`. That combination is unreachable
+in any real run (the flag is set the instant `c` lands on the waypoint), but induction only gets to
+assume the invariant held at step `k`, not that it's structurally tied to how the flag was derived —
+so it can't rule the combination out on its own, and stuttering every *other* entity preserves it
+at any depth. `suggested_invariants` (#73) doesn't help here either: it targets monotone counters,
+not booleans.
+
+The fix synthesizes a second, auxiliary invariant alongside the history flag — the one piece of
+"why the flag is trustworthy" that k-induction needs spelled out as a property of its own:
+
+```
+forall c { stage[c] ∈ D  =>  visited[c] }
+```
+
+named `<PolicyId>_stability` (id and text carried in its `meta`, from the first policy that
+introduces the (process, waypoint-set) key — same first-seen rule the history-map dedup already
+uses), where **D is the set of stages *dominated* by the waypoint set `W`**:
+
+```
+D = W ∪ { s : s is unreachable from the process's initial stage in the transition graph
+              with every node in W (and its incident edges) deleted }
+```
+
+One reachability pass (BFS/DFS from `initial`, skipping — not stopping at, *deleting* — waypoint
+nodes) computes `D` statically at desugar time, purely from the process's declared stage graph.
+
+### Why *dominated*, not "W and its downstream"
+
+The naive alternative — "W plus everything reachable from W" — is unsound: a stage can be
+downstream of `W` in the graph *and* reachable by a different path that never touches `W`. Concrete
+counterexample: stages `R, A, B, C` with transitions `R->A, R->B, A->B, A->C`, and policy `every
+Item reaching C must have passed through A` (a compliant policy — there's no direct `R->C`).
+`B` is downstream of `A` (`A->B`), so "W and downstream" would put `B` in scope of the aux and claim
+`stage == B => visited`. But `R->B` reaches `B` without ever touching `A`, so that claim is false the
+moment that transition fires — a *sound* history flag would correctly have `visited == false` at
+that point, and the invented aux invariant would be wrong, not just weak. The dominated-set version
+excludes `B` (removing node `A` from the graph still leaves `R->B` reachable) and includes `C` (with
+`A` removed, `C` has no other path in), which is exactly the set the flag can honestly promise.
+
+### True by construction, independent of policy compliance
+
+`D` is computed from the process's transition graph alone — it does not depend on whether any
+policy holds. For a stage `s ∈ D` to be reached, every path from `initial` to `s` must pass through
+some node in `W` (that's what "unreachable with `W` deleted" means), and the flag is set-only on
+entry to `W`, never cleared — so being at `s ∈ D` implies the flag was set on the way in. This holds
+even in a spec whose *policy* is violated by a bypass elsewhere in the graph: the bypass edge
+changes what's reachable, so it can also enlarge the reachable set and shrink `D` for the bypassed
+target — but whatever `D` ends up being for that graph, the aux stays true, and diagnostics for a
+bypass still attribute to the policy invariant, not to `<PolicyId>_stability`
+(`tests/test_precedence_policy.py::test_precedence_policy_bypass_is_violated` asserts this).
+
+### Inductive at k=1, cyclic processes included
+
+For `X ∈ D`, every predecessor `P` with an edge `P -> X` is either `P ∈ D` (flag true by the
+induction hypothesis) or `P ∈ W` (flag just got set entering `W` on this very step) — if `P` were
+neither, there would be a path `initial -> ... -> P -> X` avoiding `W` entirely, contradicting
+`X ∈ D`. That argument is a property of *paths*, not of acyclicity, so it holds unchanged when the
+process graph has a cycle (e.g. an `Approved -> Requested` rework loop after the waypoint has
+already been passed) — no separate acyclic-only fast path is needed; one aux invariant covers both
+cases.
+
+### Composes with the policy invariant to close induction automatically
+
+In a compliant business spec, the policy's own target set is always a subset of `D` (if it weren't
+— if the target were reachable around every node of `W` — the *policy* itself would already be
+violated under BMC, independent of induction). So `(policy invariant ∧ aux invariant)` is inductive
+at k=1 by the argument above, and **every compliant business-layer precedence policy now proves
+under `--engine induction` with no additional user action** — see
+`tests/test_precedence_policy.py`'s `..._proves_under_induction` tests for the reproduction (linear,
+downstream-vs-dominator, cyclic, and waypoint-disjunction cases).
+
 ## Semantics notes (not "fixed", documented)
 
 - **Initial stage inside targets, not inside waypoints**: violated at init. See step 4 above.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1027,6 +1027,17 @@ fired. Both sides accept a disjunction —
 or Rejected` — and two policies over the same `(process, waypoint-set)` share
 one synthesized history flag.
 
+Alongside the history flag, a second invariant, `<PolicyId>_stability`, is
+auto-synthesized from the process's stage graph (#85; design rationale in
+`DESIGN-precedence-policy.md`) so that a **compliant** precedence policy
+proves under `--engine induction` out of the box, with no manual invariant
+needed — no ghost counterexample-to-induction from the history flag being
+"true but not yet provably so" at an arbitrary induction step.
+
+```json
+{"result": "proved", "k_used": {"CTRL-APPROVAL": 1, "CTRL-APPROVAL_stability": 1}}
+```
+
 Business has no `terminal` syntax of its own. Instead, each process's **sink
 stages** (stages with no outgoing `transition`) are collected automatically:
 if every process has at least one sink, a kernel `terminal { }` is generated

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -592,9 +592,13 @@ stage(c) == Refunded => return_stage_via_Approved[c] }`. A direct
 the bypass shown in the trace. Both sides take a disjunction (`reaching A or
 B`, `passed through X or Y`); two policies over the same `(process,
 waypoint-set)` share one history flag (dedup, name deterministic by the
-process's stage order). Design in `DESIGN-precedence-policy.md`. Limitation:
-the flag is business-layer-only synthesized state — a `requirements` spec
-refining it must map the flag explicitly or restate the rule at its own layer.
+process's stage order). Alongside the flag, a `<PolicyId>_stability`
+auxiliary invariant is auto-synthesized from the process's stage graph
+(dominated-set of the waypoints; #85), so a **compliant** precedence policy
+proves under `--engine induction` out of the box — no manual invariant, no
+ghost CTI. Design in `DESIGN-precedence-policy.md`. Limitation: the flag is
+business-layer-only synthesized state — a `requirements` spec refining it
+must map the flag explicitly or restate the rule at its own layer.
 
 `control` declarations are metadata only. Attach them to checkable business
 rules with `policy ... satisfies CTRL` or `goal ... satisfies CTRL`. Unknown

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -1376,24 +1376,70 @@ def _validate_precedence_stage(policy_id, case_name, stage, proc, loc):
         )
 
 
+def _precedence_dominated_stages(proc, waypoints):
+    """Stages dominated by waypoint set W in `proc`'s transition graph, in
+    stage-declaration order: `D = W ∪ {s : s is unreachable from proc's
+    initial stage in the transition graph with all W nodes -- and their
+    incident edges -- removed}`.
+
+    This is *not* "W and everything downstream of W": a downstream stage
+    that is also reachable by a path that never touches W is not dominated
+    (see docs/DESIGN-precedence-policy.md for the counterexample), so a
+    single reachability pass with W nodes deleted is the correct -- and
+    sufficient -- computation.
+    """
+    waypoint_set = set(waypoints)
+    adj = {}
+    for tr in proc["transitions"]:
+        if tr["src"] in waypoint_set or tr["dst"] in waypoint_set:
+            continue
+        adj.setdefault(tr["src"], []).append(tr["dst"])
+    reachable = set()
+    initial = proc["initial"]
+    if initial not in waypoint_set:
+        stack = [initial]
+        reachable.add(initial)
+        while stack:
+            node = stack.pop()
+            for nxt in adj.get(node, []):
+                if nxt not in reachable:
+                    reachable.add(nxt)
+                    stack.append(nxt)
+    return [
+        stage for stage in proc["stages"]
+        if stage in waypoint_set or stage not in reachable
+    ]
+
+
 def _collect_precedence_policies(policies, process_by_case):
     """Resolve `biz_policy_precedence` bodies and dedupe their history maps.
 
     Two policies over the same (process, waypoint-set) share one synthesized
     `Map<Entity, Bool>` history flag, named `<state_var>_via_<Waypoint...>`
     (waypoints ordered by declaration order in the process, for determinism).
+    Alongside the history map, a stabilizing auxiliary invariant is
+    synthesized once per distinct (process, waypoint-set): `forall c {
+    stage[c] in dominated(W) => visited[c] }`. It is true by construction
+    (the dominated set comes from the graph, independent of policy
+    compliance) and, paired with the policy invariant, is inductive at k=1
+    -- see docs/DESIGN-precedence-policy.md.
     Returns:
       - history_var_by_item: id(policy item) -> history var name
       - history_specs: [(proc, history_var, sorted_waypoints), ...], one per
         distinct history map, in first-seen order
       - dst_history_vars: (proc_name, stage) -> [history_var, ...] for every
         history map whose waypoint set contains that stage
+      - stability_specs: [(proc, history_var, dominated_stages, meta), ...],
+        one per distinct history map, in first-seen order; meta carries the
+        id/text of the first policy that introduced the (process,
+        waypoint-set) key so diagnostics attribute to that policy
     """
     history_var_by_item = {}
     history_var_by_key = {}
     history_specs = []
+    stability_specs = []
     for item in policies:
-        _, policy_id, _text, body, loc = item[:5]
+        _, policy_id, text, body, loc = item[:5]
         if body[0] != "biz_policy_precedence":
             continue
         _, case_name, targets, waypoints = body
@@ -1410,18 +1456,24 @@ def _collect_precedence_policies(policies, process_by_case):
             history_var = "_".join([proc["state_var"], "via", *sorted_waypoints])
             history_var_by_key[key] = history_var
             history_specs.append((proc, history_var, sorted_waypoints))
+            dominated = _precedence_dominated_stages(proc, sorted_waypoints)
+            stability_meta = _meta(
+                f"{policy_id}_stability",
+                f"stability: {text} (auto-synthesized, dominated-set invariant for k-induction)",
+            )
+            stability_specs.append((proc, history_var, dominated, stability_meta))
         history_var_by_item[id(item)] = history_var
     dst_history_vars = {}
     for proc, history_var, waypoints in history_specs:
         for stage in waypoints:
             dst_history_vars.setdefault((proc["name"], stage), []).append(history_var)
-    return history_var_by_item, history_specs, dst_history_vars
+    return history_var_by_item, history_specs, dst_history_vars, stability_specs
 
 
 def _generate_business_items(cases, processes, kpi_infos, controls, policies, goals, process_by_case):
     out = []
     control_by_id, used_controls = _validate_controls_and_satisfaction(controls, policies, goals)
-    precedence_history_by_item, precedence_history_specs, precedence_dst_history_vars = (
+    precedence_history_by_item, precedence_history_specs, precedence_dst_history_vars, precedence_stability_specs = (
         _collect_precedence_policies(policies, process_by_case)
     )
     for case_name, data in cases.items():
@@ -1574,6 +1626,13 @@ def _generate_business_items(cases, processes, kpi_infos, controls, policies, go
             visited = ("index", history_var, ("var", "c"))
             expr = ("forall", binder, ("bin", "=>", reached_target, visited))
             out.append(("invariant", policy_id, expr, loc, meta))
+
+    for proc, history_var, dominated, meta in precedence_stability_specs:
+        binder = ("binder_typed", "c", proc["name"], None)
+        in_dominated = _any_stage(proc["name"], "c", dominated, process_by_case, proc["loc"])
+        visited = ("index", history_var, ("var", "c"))
+        expr = ("forall", binder, ("bin", "=>", in_dominated, visited))
+        out.append(("invariant", meta["id"], expr, proc["loc"], meta))
 
     for item in goals:
         _, goal_id, text, body, loc = item[:5]

--- a/tests/test_precedence_policy.py
+++ b/tests/test_precedence_policy.py
@@ -9,6 +9,12 @@ a kernel invariant — the same "business already synthesizes state" pattern
 the stage enum/map/init/fair-actions synthesis already uses (see
 ``docs/DESIGN-precedence-policy.md``). Two policies over the same
 (process, waypoint-set) share one history map (dedup).
+
+#85 additionally synthesizes a stabilizing auxiliary invariant, `<PolicyId>_stability`,
+alongside the history flag: `forall c { stage[c] in dominated(W) => visited[c] }`,
+where `dominated(W)` is the set of stages dominated by the waypoint set `W` in
+the process graph. This closes k-induction (k=1) for compliant precedence
+policies without a ghost CTI.
 """
 from fslc.cli import run_check, run_verify
 from fslc.model import FslError, build_spec
@@ -53,6 +59,13 @@ def test_precedence_policy_bypass_is_violated(tmp_path):
 
     # the trace demonstrates the bypass transition, not some unrelated path
     assert result["last_action"]["name"] == "bypass"
+
+    # #85: the auto-synthesized stability aux is a *separate* invariant and
+    # must not be what the counterexample attributes to -- the bypass
+    # transition (Requested -> Refunded) also enlarges the dominated set to
+    # exclude Refunded (it's now reachable around Approved), so the aux
+    # stays true and only the real policy invariant is violated.
+    assert result["invariant"] != "CTRL-APPROVAL_stability"
 
 
 # --------------------------------------------------------------------------
@@ -313,3 +326,112 @@ def test_precedence_policy_unknown_entity_names_policy_id():
     except FslError as exc:
         assert "CTRL-BAD" in str(exc)
         assert "Invoice" in str(exc)
+
+
+# --------------------------------------------------------------------------
+# #85: auto-synthesized dominated-set stability invariant closes k-induction
+# --------------------------------------------------------------------------
+
+
+def test_precedence_policy_compliant_proves_under_induction(tmp_path):
+    # Reproduces the ghost CTI from #85: before the fix, this compliant
+    # linear-process spec verified under BMC but stalled at unknown_cti
+    # under `--engine induction`.
+    f = tmp_path / "compliant.fsl"
+    f.write_text(BIZ_COMPLIANT_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 8, "warn", engine="induction")
+    assert result["result"] == "proved"
+    assert result["invariants_checked"] == ["_bounds_return_stage", "CTRL-APPROVAL", "CTRL-APPROVAL_stability"]
+    assert result["k_used"]["CTRL-APPROVAL_stability"] == 1
+
+
+BIZ_DOWNSTREAM_DOMINATOR_SRC = r'''business DownstreamDominator {
+  actor Worker
+  entity Item
+
+  process Item {
+    stages R, A, B, C
+    initial R
+    transition toA R -> A by Worker
+    transition toB R -> B by Worker
+    transition aToB A -> B by Worker
+    transition aToC A -> C by Worker
+  }
+
+  policy CTRL-DOM "C is reached only via A"
+    every Item reaching C must have passed through A
+}
+verify {
+  instances Item = 2
+}
+'''
+
+
+def test_precedence_policy_downstream_but_reachable_around_waypoint_proves(tmp_path):
+    # B is downstream of A (A -> B) but is *also* directly reachable from the
+    # initial stage without passing through A (R -> B). "downstream of W"
+    # would wrongly include B in the aux invariant's domain and make it
+    # unsound (R -> B falsifies it); the dominated-set computation must
+    # exclude B. C, by contrast, is only reachable via A, so C IS dominated.
+    ast = parse(BIZ_DOWNSTREAM_DOMINATOR_SRC)
+    invariants = {item[1]: item[2] for item in ast[2] if item[0] == "invariant"}
+    stability_expr = invariants["CTRL-DOM_stability"]
+    # expr shape: ("forall", binder, ("bin", "=>", in_dominated, visited))
+    in_dominated = stability_expr[2][2]
+
+    def stage_names(expr):
+        if expr[0] == "bin" and expr[1] == "==":
+            return {expr[3][1]}
+        assert expr[0] == "bin" and expr[1] == "or"
+        return stage_names(expr[2]) | stage_names(expr[3])
+
+    assert stage_names(in_dominated) == {"A", "C"}
+
+    f = tmp_path / "dominator.fsl"
+    f.write_text(BIZ_DOWNSTREAM_DOMINATOR_SRC, encoding="utf-8")
+    result = run_verify(str(f), 8, "warn", engine="induction")
+    assert result["result"] == "proved"
+
+
+BIZ_CYCLIC_SRC = r'''business ReturnCycle {
+  actor Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition rework Approved -> Requested by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-APPROVAL "no completion without approval"
+    every Return reaching Refunded must have passed through Approved
+}
+verify {
+  instances Return = 3
+}
+'''
+
+
+def test_precedence_policy_cyclic_process_proves_under_induction(tmp_path):
+    # `rework` goes back upstream (Approved -> Requested) after the waypoint
+    # has already been passed; the aux invariant must still hold (and be
+    # inductive) despite the cycle.
+    f = tmp_path / "cyclic.fsl"
+    f.write_text(BIZ_CYCLIC_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 8, "warn", engine="induction")
+    assert result["result"] == "proved"
+    assert "CTRL-APPROVAL_stability" in result["invariants_checked"]
+
+
+def test_precedence_policy_waypoint_disjunction_proves_under_induction(tmp_path):
+    f = tmp_path / "disjunction.fsl"
+    f.write_text(BIZ_DISJUNCTION_SRC, encoding="utf-8")
+
+    result = run_verify(str(f), 8, "warn", engine="induction")
+    assert result["result"] == "proved"
+    assert "CTRL-DECIDED_stability" in result["invariants_checked"]


### PR DESCRIPTION
## Summary

- **Symptom**: business-dialect no-bypass precedence policies (`every <Entity> reaching <Targets> must have passed through <Waypoints>`, #75/PR #82) verify under `fslc verify` (BMC) but stall at `unknown_cti` under `--engine induction`, on a ghost CTI (`stage[c] == Waypoint && visited[c] == false`) that is unreachable in practice but not provable by k-induction alone — the induction step can't derive the correlation between the history flag and the stage from a single prior state.
- **Fix**: `_collect_precedence_policies` in `src/fslc/dialects.py` now also synthesizes, once per deduped `(process, waypoint-set)` (same dedup key as the existing history-flag map), a stabilizing auxiliary invariant `<PolicyId>_stability`:
  ```
  forall c { stage[c] ∈ D  =>  visited[c] }
  ```
  where `D` is the set of stages *dominated* by the waypoint set `W` — computed with one reachability pass (`_precedence_dominated_stages`) over the process's transition graph with the waypoint nodes (and their incident edges) removed. This is deliberately **not** "`W` and everything downstream of `W`", which is unsound when a downstream stage is also reachable by a path that never touches `W` (concrete counterexample and proof sketch in the design doc / issue #85). The pair `(policy invariant ∧ aux invariant)` is inductive at k=1 for both acyclic and cyclic process graphs, and the aux is true by construction (derived purely from the graph), so it never misattributes a real bypass violation away from the policy invariant.
  - No changes to `grammar.py`, `bmc.py`, or `runtime.py` — the synthesized aux is an ordinary kernel `forall`-invariant, same as the existing policy invariant.

## Test plan

- [x] `tests/test_precedence_policy.py` — added:
  - `test_precedence_policy_compliant_proves_under_induction`: reproduces the reported ghost CTI, now `proved` at k=1.
  - `test_precedence_policy_downstream_but_reachable_around_waypoint_proves`: the `R->A, R->B, A->B, A->C` counterexample from the issue — asserts the synthesized aux domain is exactly `{A, C}` (not `{A, B, C}`) and that induction proves.
  - `test_precedence_policy_cyclic_process_proves_under_induction`: an `Approved -> Requested` rework loop after the waypoint; proves under induction.
  - `test_precedence_policy_waypoint_disjunction_proves_under_induction`: `passed through Approved or Rejected`; proves under induction.
  - extended `test_precedence_policy_bypass_is_violated` to assert the counterexample still attributes to `CTRL-APPROVAL`, not `CTRL-APPROVAL_stability`.
  - Full file: **14 passed**.
- [x] `tests/test_biz_dialect.py`: **12 passed** (no regressions).
- [x] `tests/test_evaluator_agreement.py`: **20 passed, 3 skipped** (no regressions; dual-evaluator agreement unaffected — the synthesized aux is an ordinary kernel invariant both `bmc.py` and `runtime.py` already handle).
- [x] Corpus snapshot not run: no precedence-policy `.fsl` exists under `specs/`/`examples/` today (confirmed via grep), so `tests/test_corpus_snapshot.py` has nothing to diff.
- [x] Docs updated: `docs/DESIGN-precedence-policy.md` (new "Stabilizing auxiliary invariant for k-induction (#85)" section with the dominance argument, downstream-vs-dominator counterexample, and inductive/cyclic-safe proof sketch), `docs/LANGUAGE.md`, `skills/fsl/reference.md` (canonical; `.claude/skills/` is a symlink).
- [x] `CHANGELOG.md` `[Unreleased]` updated.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)