### PR TITLE
verify: add --instances/--values CLI overrides for verify-block bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- `fslc verify --instances NAME=N` / `--values NAME=LO..HI` (both repeatable)
+  override a `verify { ... }` block's `entity`/`number` bounds from the CLI,
+  so liveness/induction runs can shrink the model without editing the spec.
+  An undeclared `NAME` or a malformed value is a spec error (exit 2); the
+  effective override is echoed back as `bounds_overrides` in the JSON
+  envelope. (#86)
+
 ## [2.5.0] - 2026-07-02
 
 ### Added

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -78,6 +78,23 @@ are exactly equivalent to writing the bounded type directly — the difference i
 only readability (a design spec reads as documentation instead of asserting a
 domain size that is really a model bound). See `docs/DESIGN-spec-domains.md`.
 
+`fslc verify` can override a `verify` block's `instances`/`values` bounds from
+the command line, without editing the spec:
+
+```bash
+fslc verify spec.fsl --instances Case=1 --property EventuallyLeavesInProgress
+fslc verify spec.fsl --values Amount=0..3
+```
+
+Both flags are repeatable (`--instances A=1 --instances B=2`) and replace the
+bound of the matching `entity`/`number` name — handy for shrinking to a
+1-entity model for liveness/induction runs (see §7) without touching the file.
+A `NAME` with no matching `entity`/`number` declaration, or a spec whose bounds
+are not `entity`/`number`-backed (a kernel `type X = lo..hi` literal), is a spec
+error (exit code 2), as is a malformed value (`Case=abc`, `N=5..1`). The
+effective overridden bounds are echoed back in the JSON envelope's
+`bounds_overrides` field.
+
 `fair` is a weak-fairness annotation: if that action instance remains
 continuously enabled, the assumption is that it will eventually be executed.
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -281,6 +281,8 @@ fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--property <Name>]                  # check one named property in isolation
                                                     #   (invariant / trans / leadsTo / reachable)
                [--exclude-property <Name>]...       # skip named invariant/trans/leadsTo/reachable
+               [--instances NAME=N]...              # override verify-block `instances NAME = N`
+               [--values NAME=LO..HI]...            # override verify-block `values NAME = LO..HI`
                [--strict-tags] [--requirements ids.txt]
 fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emits a text review view
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
@@ -326,6 +328,15 @@ first failed layer and later layers are marked `skipped`.
   it removes named invariants, `trans`, `leadsTo`, and `reachable` checks from
   the run and from checked-property outputs. If both options name the same
   property, exclusion wins.
+- `verify --instances NAME=N` / `--values NAME=LO..HI` (both repeatable)
+  override the matching `entity`/`number` bound from a `verify { ... }` block
+  without editing the spec — the CLI equivalent of hand-shrinking the model
+  for the liveness strategy above. `NAME` must be a declared `entity`/`number`
+  (in the business/requirements dialects, or a kernel `spec` using
+  `entity`/`number`); an undeclared `NAME` or a malformed value (`Case=abc`,
+  `N=5..1`) is a spec error, and it does not apply to a kernel `spec` whose
+  domain is a raw `type X = lo..hi` literal. The effective override is echoed
+  back as `bounds_overrides` in the JSON envelope.
 - `explain` is deterministic formatting with no LLM. JSON mode enumerates
   state/action/requires/writes/properties/implicit checks by source loc and
   structural traversal, and attaches to each user invariant the shortest
@@ -411,7 +422,11 @@ depth ~12. This is a known limit, not a pathological encoding.
 Practical strategy:
 - Verify **liveness on the smallest model that still exhibits the interleaving** —
   shrink the entity-count range (e.g. `0..1` instead of `0..3`) and use a shallow
-  `--depth`. One entity is often enough to find a real `leadsTo` bug.
+  `--depth`. One entity is often enough to find a real `leadsTo` bug. If the
+  bound is an `entity`/`number` (not a raw `type` literal), shrink it from the
+  CLI with `fslc verify spec.fsl --instances Case=1` instead of editing the
+  spec (see §7) — the file keeps its normal verify-block size for everything
+  else.
 - Verify **safety separately on the full-size model** at the depth you need.
 - Use `--property <leadsToName>` to run a single liveness property in isolation
   while iterating (see §7), so a slow `leadsTo` does not gate the safety checks.

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -148,8 +148,8 @@ def _parse_error_result(e):
     })
 
 
-def _parse_file(file, src):
-    return parse_src(src, str(Path(file).parent))
+def _parse_file(file, src, bounds_overrides=None):
+    return parse_src(src, str(Path(file).parent), bounds_overrides)
 
 
 def _read_requirement_ids(path):
@@ -315,18 +315,60 @@ def run_typestate(file):
                           "message": f"file not found: {file}"})
 
 
-def _read_spec(file):
+def _read_spec(file, bounds_overrides=None):
     src = open(file, encoding="utf-8").read()
-    ast, display_names = _parse_file(file, src)
+    ast, display_names = _parse_file(file, src, bounds_overrides)
     return build_spec(ast, display_names), src.splitlines()
+
+
+def _parse_instances_override(raw):
+    name, sep, val = raw.partition("=")
+    name = name.strip()
+    if not sep or not name:
+        raise FslError(
+            f"invalid --instances value '{raw}': expected NAME=N", kind="semantics")
+    try:
+        n = int(val.strip())
+    except ValueError:
+        raise FslError(
+            f"invalid --instances value '{raw}': '{val.strip()}' is not an integer",
+            kind="semantics")
+    return name, n
+
+
+def _parse_values_override(raw):
+    name, sep, rng = raw.partition("=")
+    name = name.strip()
+    lo_s, dots, hi_s = rng.partition("..")
+    if not sep or not name or not dots:
+        raise FslError(
+            f"invalid --values value '{raw}': expected NAME=LO..HI", kind="semantics")
+    try:
+        lo, hi = int(lo_s.strip()), int(hi_s.strip())
+    except ValueError:
+        raise FslError(
+            f"invalid --values value '{raw}': bounds must be integers", kind="semantics")
+    return name, (lo, hi)
+
+
+def _build_bounds_overrides(instances, values):
+    overrides = {"instances": {}, "values": {}}
+    for raw in instances or []:
+        name, n = _parse_instances_override(raw)
+        overrides["instances"][name] = n
+    for raw in values or []:
+        name, bounds = _parse_values_override(raw)
+        overrides["values"][name] = bounds
+    return overrides
 
 
 def run_verify(
         file, depth, deadlock_mode, engine="bmc", k_ind=1, vacuity_mode="warn",
         strict_tags=False, requirements=None, property_name=None,
-        exclude_property_names=None):
+        exclude_property_names=None, instances=None, values=None):
     try:
-        spec, source_lines = _read_spec(file)
+        bounds_overrides = _build_bounds_overrides(instances, values)
+        spec, source_lines = _read_spec(file, bounds_overrides)
         acc = _acceptance_error(spec)
         if acc:
             return _envelope(acc)
@@ -356,6 +398,12 @@ def run_verify(
             out = dict(out)
             out["implements"] = impl
         out = _add_strict_tag_warnings(out, spec, strict_tags, requirements)
+        if bounds_overrides["instances"] or bounds_overrides["values"]:
+            out = dict(out)
+            out["bounds_overrides"] = {
+                "instances": dict(bounds_overrides["instances"]),
+                "values": {k: [lo, hi] for k, (lo, hi) in bounds_overrides["values"].items()},
+            }
         return _envelope(out)
     except UnexpectedInput as e:
         return _parse_error_result(e)
@@ -741,6 +789,12 @@ def _build_arg_parser():
                    action="append", default=None,
                    help="skip a named property; repeat to omit invariants/trans/"
                         "leadsTo/reachable declarations")
+    v.add_argument("--instances", action="append", default=None,
+                   help="override a verify-block 'instances NAME = N' bound "
+                        "(NAME=N; repeatable) — e.g. shrink to 1 entity for liveness")
+    v.add_argument("--values", action="append", default=None,
+                   help="override a verify-block 'values NAME = LO..HI' bound "
+                        "(NAME=LO..HI; repeatable)")
     v.add_argument("--strict-tags", action="store_true")
     v.add_argument("--requirements", default=None)
 
@@ -896,7 +950,9 @@ def _dispatch(args):
                             strict_tags=args.strict_tags,
                             requirements=args.requirements,
                             property_name=args.property_name,
-                            exclude_property_names=args.exclude_property_names)
+                            exclude_property_names=args.exclude_property_names,
+                            instances=args.instances,
+                            values=args.values)
         print(json.dumps(result, indent=2, ensure_ascii=False))
 
     sys.exit(exit_code(result))

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -86,6 +86,78 @@ def _meta_with_controls(req_id, text, control_ids, control_by_id):
     return meta
 
 
+_BOUNDS_OVERRIDE_TAGS = ("spec", "business", "requirements")
+
+
+def apply_verify_bounds_overrides(ast, overrides):
+    """Merge CLI ``--instances``/``--values`` overrides (``fslc verify``) into the
+    parsed AST's ``verify { ... }`` block, replacing any existing bound of the same
+    name (or adding one) before dialect desugaring runs `_collect_verify_bounds`.
+
+    Only applies to `spec`/`business`/`requirements` ASTs whose bounds are backed
+    by `entity`/`number` declarations. An override naming something that is not
+    declared as `entity`/`number` is not checked here — it surfaces via the
+    existing undeclared-entity/undeclared-number checks in
+    `_entity_number_to_types` / `_collect_business_entities` once desugaring runs.
+    """
+    new_instances = dict(overrides.get("instances") or {})
+    new_values = dict(overrides.get("values") or {})
+    if not new_instances and not new_values:
+        return ast
+    tag, name, items = ast
+    if tag not in _BOUNDS_OVERRIDE_TAGS:
+        _err(
+            "--instances/--values only apply to business/requirements specs, or "
+            "a kernel spec with entity/number declarations",
+            kind="semantics",
+        )
+    if tag == "spec" and not any(it[0] in ("entity", "number") for it in items):
+        _err(
+            "--instances/--values only apply to specs with entity/number "
+            "declarations; this spec declares neither",
+            kind="semantics",
+        )
+
+    def _values_expr(bound_range):
+        lo, hi = bound_range
+        return ("num", lo), ("num", hi)
+
+    out_items = []
+    found_block = False
+    for item in items:
+        if item[0] != "verify_bounds":
+            out_items.append(item)
+            continue
+        found_block = True
+        merged = []
+        for bound in item[1]:
+            if bound[0] == "verify_instances":
+                _, bname, n, bloc = bound
+                if bname in new_instances:
+                    n = new_instances.pop(bname)
+                merged.append(("verify_instances", bname, n, bloc))
+            elif bound[0] == "verify_values":
+                _, bname, lo, hi, bloc = bound
+                if bname in new_values:
+                    lo, hi = _values_expr(new_values.pop(bname))
+                merged.append(("verify_values", bname, lo, hi, bloc))
+            else:
+                merged.append(bound)
+        for bname, n in new_instances.items():
+            merged.append(("verify_instances", bname, n, None))
+        for bname, bound_range in new_values.items():
+            lo, hi = _values_expr(bound_range)
+            merged.append(("verify_values", bname, lo, hi, None))
+        out_items.append(("verify_bounds", merged, item[2]))
+    if not found_block:
+        merged = [("verify_instances", bname, n, None) for bname, n in new_instances.items()]
+        for bname, bound_range in new_values.items():
+            lo, hi = _values_expr(bound_range)
+            merged.append(("verify_values", bname, lo, hi, None))
+        out_items.append(("verify_bounds", merged, None))
+    return (tag, name, out_items)
+
+
 def _collect_verify_bounds(items):
     instances = {}
     values = {}

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -15,6 +15,7 @@ from lark.exceptions import UnexpectedInput
 from .grammar import PARSER, Ast
 from .compose import expand_compose
 from .dialects import (
+    apply_verify_bounds_overrides,
     expand_business,
     expand_governance_with_display,
     expand_requirements_with_display,
@@ -22,14 +23,21 @@ from .dialects import (
 )
 
 
-def parse_src(src, base_dir=None):
-    """Parse FSL source; expand compose specs when ``base_dir`` is set."""
+def parse_src(src, base_dir=None, bounds_overrides=None):
+    """Parse FSL source; expand compose specs when ``base_dir`` is set.
+
+    ``bounds_overrides`` (``{"instances": {name: n}, "values": {name: (lo, hi)}}``)
+    comes from ``fslc verify --instances``/``--values`` and replaces the matching
+    ``verify { ... }`` bounds before dialect desugaring runs.
+    """
     try:
         tree = PARSER.parse(src)
     except UnexpectedInput as e:
         e.source = src
         raise
     ast = Ast().transform(tree)
+    if bounds_overrides:
+        ast = apply_verify_bounds_overrides(ast, bounds_overrides)
     display_names = {}
     if ast[0] == "compose":
         ast, display_names = expand_compose(ast, base_dir or ".")

--- a/tests/test_cli_bounds_override.py
+++ b/tests/test_cli_bounds_override.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""`fslc verify --instances`/`--values` bounds overrides (#86).
+
+`verify { instances Item = 3  values Amount = 0..5 }` bounds are hardcoded in
+the spec; these flags let the CLI shrink them (e.g. to 1 entity for liveness
+runs) without editing the file. The override is applied as an AST rewrite in
+`dialects.apply_verify_bounds_overrides`, before dialect desugaring runs
+`_collect_verify_bounds` — so an unknown NAME (no matching `entity`/`number`
+declaration) surfaces through the *existing* undeclared-entity/-number checks,
+and a malformed value (non-integer, or `LO..HI` with `LO > HI`) surfaces
+through the existing integer parsing / empty-range checks. Both come back as
+a spec-error JSON envelope (exit code 2), never an argparse crash or an
+"internal" (exit 3) error.
+"""
+from fslc.cli import exit_code, run_verify
+
+REQ_SRC = r'''requirements SizeOverrideDemo {
+  entity Item
+  number Amount
+
+  process Item {
+    stages Idle, Done
+    initial Idle
+    transition finish Idle -> Done by Worker
+      covers REQ-1 "finish completes the item"
+  }
+}
+verify {
+  instances Item = 3
+  values Amount = 0..5
+}
+'''
+
+KERNEL_SRC = r'''spec KernelDemo {
+  type CaseId = 0..2
+  state { x: Int }
+  init { x = 0 }
+  fair action bump() { requires x < 5  x = x + 1 }
+  invariant NonNeg { x >= 0 }
+}
+'''
+
+
+def _write(tmp_path, src, name="size_override_demo.fsl"):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_instances_override_shrinks_model(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn", instances=["Item=1"])
+    assert out["result"] == "verified"
+    assert out["bounds_overrides"] == {"instances": {"Item": 1}, "values": {}}
+
+
+def test_values_override_shrinks_model(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn", values=["Amount=0..1"])
+    assert out["result"] == "verified"
+    assert out["bounds_overrides"] == {"instances": {}, "values": {"Amount": [0, 1]}}
+
+
+def test_unknown_name_is_spec_error(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn", instances=["Bogus=1"])
+    assert out["result"] == "error"
+    assert exit_code(out) == 2
+    assert "Bogus" in out["message"]
+
+
+def test_malformed_instances_value_is_spec_error(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn", instances=["Item=abc"])
+    assert out["result"] == "error"
+    assert exit_code(out) == 2
+    assert out["kind"] != "internal"
+
+
+def test_malformed_values_range_is_spec_error(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn", values=["Amount=5..1"])
+    assert out["result"] == "error"
+    assert exit_code(out) == 2
+    assert out["kind"] != "internal"
+
+
+def test_kernel_spec_without_entity_number_rejects_override(tmp_path):
+    spec = _write(tmp_path, KERNEL_SRC, name="kernel_demo.fsl")
+    out = run_verify(str(spec), 6, "warn", instances=["CaseId=1"])
+    assert out["result"] == "error"
+    assert exit_code(out) == 2
+
+
+def test_no_flags_behavior_unchanged(tmp_path):
+    spec = _write(tmp_path, REQ_SRC)
+    out = run_verify(str(spec), 6, "warn")
+    assert out["result"] == "verified"
+    assert "bounds_overrides" not in out


### PR DESCRIPTION
## Summary
- `verify { instances Case = 3 }` sizes are hardcoded in the spec, so shrinking a model for liveness/induction (reference.md §7 recommends 1-entity models) meant editing the file. Add repeatable `fslc verify --instances NAME=N` / `--values NAME=LO..HI` flags that override the matching `entity`/`number` bound without touching the spec.
- Design: the override is applied as a pre-desugar AST rewrite (`dialects.apply_verify_bounds_overrides`, threaded through `parser.parse_src` → `cli._read_spec`/`_parse_file`) that merges into the `verify_bounds` AST item *before* `_collect_verify_bounds` runs. This reuses all existing validation for free: an unknown `NAME` (no matching `entity`/`number` declaration) surfaces through the existing undeclared-entity/-number checks in `_entity_number_to_types`/`_collect_business_entities`, and `LO > HI` surfaces through the existing empty-range check in `model.collect_types`. Only genuinely new validation (missing `=`, non-integer) is added in `cli.py`, raised as `FslError` so it lands in the normal JSON error envelope (exit 2) rather than an argparse crash or an "internal" (exit 3) error.
- A kernel `spec` whose bound is a raw `type X = lo..hi` literal (no `entity`/`number`) rejects the override with a clear spec error, per the issue's scope (out of scope to rewrite kernel `type` literals).
- The effective override is echoed back as `bounds_overrides: {instances: {...}, values: {...}}` in the JSON envelope, added conditionally (only when flags are used) so the envelope shape is unchanged when no flags are passed.
- Docs: `docs/LANGUAGE.md` (verify-block section), `skills/fsl/reference.md` §7 (CLI list + the "shrink for liveness" strategy), `CHANGELOG.md`.

## Test plan
- [x] New `tests/test_cli_bounds_override.py`: `--instances` override shrinks the model and is echoed in the envelope; `--values` override does the same; unknown `NAME` → spec error (exit 2); malformed `NAME=abc` → exit 2 (not internal); malformed `LO > HI` → exit 2; kernel spec without `entity`/`number` rejects the flag; no flags → envelope unchanged (no `bounds_overrides` key).
- [x] `pytest tests/test_cli_bounds_override.py tests/test_req_dialect.py tests/test_biz_dialect.py -q` → 27 passed.
- [x] No `.fsl` files under `specs/`/`examples/` changed → corpus snapshot untouched, not run.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)