### PR TITLE
verify: skip out-of-fit acceptance/forbidden scenarios under bounds overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- `fslc verify --instances`/`--values` overrides (#86) no longer hard-error
+  when an `acceptance`/`forbidden` scenario hardcodes an id/number from the
+  spec's original (larger) world. When an override is active, a scenario
+  whose replay fails purely because it references a value outside the
+  overridden bounds (an out-of-range action argument or an out-of-range
+  `expect` index) is downgraded per-scenario to a skip, reported via
+  `warnings` (`kind: "acceptance_skipped"`/`"forbidden_skipped"`); other
+  scenarios still replay normally. Without an override, or for any other
+  failure reason, behavior is unchanged (hard error). This makes
+  `--instances Case=1 --property <Liveness>` usable without editing
+  acceptance/forbidden scenarios written for the full-size model. (#89)
+
 ## [2.6.0] - 2026-07-03
 
 ### Added

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -95,6 +95,19 @@ error (exit code 2), as is a malformed value (`Case=abc`, `N=5..1`). The
 effective overridden bounds are echoed back in the JSON envelope's
 `bounds_overrides` field.
 
+`acceptance`/`forbidden` scenarios often hardcode ids/numbers from the spec's
+original world (`accept(2)`), which can fall outside a shrunken override
+(`--instances Case=1`). When overrides are active, a scenario whose replay
+fails *purely* because it references a value outside the overridden bounds
+(an out-of-range action argument, or an out-of-range index inside its
+`expect`) is downgraded per-scenario from a hard error to a skip, reported in
+the envelope's `warnings` (`{"kind": "acceptance_skipped"/"forbidden_skipped",
+"id": ..., "message": ...}`); the rest of the scenarios still run. Without
+overrides — or for any other failure (a false `expect`, an unmet `requires`)
+— behavior is unchanged: hard error. This is what makes `--instances Case=1
+--property <Liveness>` usable even when the spec's acceptance scenarios were
+written against the original `verify { instances Case = N }` bound.
+
 `fair` is a weak-fairness annotation: if that action instance remains
 continuously enabled, the assumption is that it will eventually be executed.
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -336,7 +336,14 @@ first failed layer and later layers are marked `skipped`.
   `entity`/`number`); an undeclared `NAME` or a malformed value (`Case=abc`,
   `N=5..1`) is a spec error, and it does not apply to a kernel `spec` whose
   domain is a raw `type X = lo..hi` literal. The effective override is echoed
-  back as `bounds_overrides` in the JSON envelope.
+  back as `bounds_overrides` in the JSON envelope. When an override is active,
+  an `acceptance`/`forbidden` scenario that no longer fits the shrunken world
+  (a hardcoded id/number outside the overridden bounds, in a step argument or
+  inside its `expect`) is skipped per-scenario instead of hard-erroring the
+  whole `verify`, with a `warnings` entry (`kind: "acceptance_skipped"` /
+  `"forbidden_skipped"`) naming it; other scenarios still replay normally.
+  Without an override, or for a failure unrelated to bounds, the scenario
+  still hard-errors as before.
 - `explain` is deterministic formatting with no LLM. JSON mode enumerates
   state/action/requires/writes/properties/implicit checks by source loc and
   structural traversal, and attaches to each user invariant the shortest
@@ -426,7 +433,11 @@ Practical strategy:
   bound is an `entity`/`number` (not a raw `type` literal), shrink it from the
   CLI with `fslc verify spec.fsl --instances Case=1` instead of editing the
   spec (see §7) — the file keeps its normal verify-block size for everything
-  else.
+  else. If the spec has `acceptance`/`forbidden` scenarios hardcoding ids from
+  the original (larger) world, they are not a blocker: under an active
+  override, a scenario that no longer fits is skipped with a `warnings` entry
+  rather than hard-erroring the run (see §7), so `--instances Case=1
+  --property <Liveness>` stays usable without editing those scenarios too.
 - Verify **safety separately on the full-size model** at the depth you need.
 - Use `--property <leadsToName>` to run a single liveness property in isolation
   while iterating (see §7), so a slow `leadsTo` does not gate the safety checks.

--- a/src/fslc/acceptance.py
+++ b/src/fslc/acceptance.py
@@ -141,14 +141,34 @@ def replay_acceptance(spec, ac):
     }
 
 
-def validate_acceptance(spec):
+def _out_of_range_failure(result):
+    """True if a replay failure is caused purely by a hardcoded id/number
+    falling outside the current (possibly CLI-overridden) domain bounds:
+    either an action-argument `bad_call` (`parameter 'x' out of range [...]`)
+    or an out-of-range index inside the `expect` expression (surfaced as the
+    _EvalError message set by runtime.py's concrete map/seq `select`)."""
+    for step_result in result.get("step_results") or []:
+        if step_result.get("kind") == "bad_call" and "out of range" in step_result.get("message", ""):
+            return True
+    message = result.get("message")
+    return bool(message and "out of range" in message)
+
+
+def validate_acceptance(spec, skip_out_of_range=False):
     scenarios = []
+    skipped = []
     for ac in spec.get("acceptance") or []:
         result = replay_acceptance(spec, ac)
         if not result.get("ok"):
+            if skip_out_of_range and _out_of_range_failure(result):
+                skipped.append(ac["id"])
+                continue
             return result
         scenarios.append(result["scenario"])
-    return {"ok": True, "scenarios": scenarios}
+    out = {"ok": True, "scenarios": scenarios}
+    if skipped:
+        out["skipped"] = skipped
+    return out
 
 
 def _param_error_result(exc, item, idx, name, args, spec, loc, kind):
@@ -258,11 +278,18 @@ def replay_forbidden(spec, fb):
     }
 
 
-def validate_forbidden(spec):
+def validate_forbidden(spec, skip_out_of_range=False):
     scenarios = []
+    skipped = []
     for fb in spec.get("forbidden") or []:
         result = replay_forbidden(spec, fb)
         if not result.get("ok"):
+            if skip_out_of_range and _out_of_range_failure(result):
+                skipped.append(fb["id"])
+                continue
             return result
         scenarios.append(result["scenario"])
-    return {"ok": True, "scenarios": scenarios}
+    out = {"ok": True, "scenarios": scenarios}
+    if skipped:
+        out["skipped"] = skipped
+    return out

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -229,22 +229,52 @@ def _governance_result(spec, depth=8):
     return out
 
 
-def _acceptance_error(spec):
-    checked = validate_acceptance(spec)
+def _acceptance_error(spec, skip_out_of_range=False):
+    """Returns (error_envelope_or_None, skipped_ids). `skipped_ids` lists
+    acceptance ids downgraded from hard-error to skip because they reference
+    ids/numbers outside CLI-overridden bounds (only possible when
+    skip_out_of_range is True, i.e. --instances/--values are active)."""
+    checked = validate_acceptance(spec, skip_out_of_range=skip_out_of_range)
     if checked.get("ok"):
-        return None
+        return None, checked.get("skipped") or []
     out = dict(checked)
     out.pop("ok", None)
-    return {"result": "error", **out}
+    out.pop("skipped", None)
+    return {"result": "error", **out}, []
 
 
-def _forbidden_error(spec):
-    checked = validate_forbidden(spec)
+def _forbidden_error(spec, skip_out_of_range=False):
+    """Mirror of `_acceptance_error` for `forbidden` scenarios."""
+    checked = validate_forbidden(spec, skip_out_of_range=skip_out_of_range)
     if checked.get("ok"):
-        return None
+        return None, checked.get("skipped") or []
     out = dict(checked)
     out.pop("ok", None)
-    return {"result": "error", **out}
+    out.pop("skipped", None)
+    return {"result": "error", **out}, []
+
+
+def _bounds_overrides_desc(bounds_overrides):
+    parts = [f"{name}={n}" for name, n in bounds_overrides["instances"].items()]
+    parts += [f"{name}={lo}..{hi}" for name, (lo, hi) in bounds_overrides["values"].items()]
+    return ", ".join(parts)
+
+
+def _bounds_skip_warnings(ids, kind, bounds_overrides):
+    if not ids:
+        return []
+    desc = _bounds_overrides_desc(bounds_overrides)
+    return [
+        {
+            "kind": f"{kind}_skipped",
+            "id": scenario_id,
+            "message": (
+                f"{kind} '{scenario_id}' skipped: references values outside "
+                f"overridden bounds ({desc})"
+            ),
+        }
+        for scenario_id in ids
+    ]
 
 
 def run_check(file, strict_tags=False, requirements=None):
@@ -252,10 +282,10 @@ def run_check(file, strict_tags=False, requirements=None):
         src = open(file, encoding="utf-8").read()
         ast, display_names = _parse_file(file, src)
         spec = build_spec(ast, display_names, semantic_check=False)
-        acc = _acceptance_error(spec)
+        acc, _ = _acceptance_error(spec)
         if acc:
             return _envelope(acc)
-        forb = _forbidden_error(spec)
+        forb, _ = _forbidden_error(spec)
         if forb:
             return _envelope(forb)
         out = {
@@ -368,11 +398,12 @@ def run_verify(
         exclude_property_names=None, instances=None, values=None):
     try:
         bounds_overrides = _build_bounds_overrides(instances, values)
+        has_bounds_overrides = bool(bounds_overrides["instances"] or bounds_overrides["values"])
         spec, source_lines = _read_spec(file, bounds_overrides)
-        acc = _acceptance_error(spec)
+        acc, acc_skipped = _acceptance_error(spec, skip_out_of_range=has_bounds_overrides)
         if acc:
             return _envelope(acc)
-        forb = _forbidden_error(spec)
+        forb, forb_skipped = _forbidden_error(spec, skip_out_of_range=has_bounds_overrides)
         if forb:
             return _envelope(forb)
         if engine == "induction":
@@ -398,7 +429,14 @@ def run_verify(
             out = dict(out)
             out["implements"] = impl
         out = _add_strict_tag_warnings(out, spec, strict_tags, requirements)
-        if bounds_overrides["instances"] or bounds_overrides["values"]:
+        skip_warnings = (
+            _bounds_skip_warnings(acc_skipped, "acceptance", bounds_overrides)
+            + _bounds_skip_warnings(forb_skipped, "forbidden", bounds_overrides)
+        )
+        if skip_warnings:
+            out = dict(out)
+            out["warnings"] = list(out.get("warnings") or []) + skip_warnings
+        if has_bounds_overrides:
             out = dict(out)
             out["bounds_overrides"] = {
                 "instances": dict(bounds_overrides["instances"]),

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -692,6 +692,11 @@ class _ConcDomain:
         return all(parts)
 
     def select(self, container, idx):
+        if isinstance(container, dict):
+            try:
+                return container[idx]
+            except KeyError:
+                raise _EvalError(f"index {idx} out of range")
         return container[idx]
 
 

--- a/tests/test_acceptance_override_skip.py
+++ b/tests/test_acceptance_override_skip.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""`fslc verify --instances`/`--values` bounds overrides (#86) redefine the
+verifiable world. Acceptance/forbidden scenarios that hardcode ids/numbers
+from the *original* world can then fall outside the shrunken one — e.g. a
+liveness run with `--instances Case=1` replaying an acceptance scenario that
+calls `accept(2)`. Before #89, `run_verify` replayed those scenarios as a
+hard gate regardless of overrides, so `--instances Case=1 --property <L>`
+errored out instead of returning the (small-model) liveness verdict.
+
+#89's fix (design "option B" from the issue): only when `--instances`/
+`--values` overrides are active, a scenario whose replay fails purely
+because it references a value outside the overridden bounds is downgraded
+per-scenario from hard-error to skip, surfaced via `warnings`. Without
+overrides, or for any other failure reason (a false `expect`, a `requires`
+that never holds), behavior is unchanged: hard error.
+"""
+from fslc.cli import exit_code, run_verify
+
+REPRO_SRC = r'''requirements Repro {
+  entity Case
+  enum St { Waiting, Accepted, Responded }
+  state { cases: Map<Case, St> }
+  init { forall c: Case { cases[c] = Waiting } }
+  requirement REQ-1 "accept" {
+    fair action accept(c: Case) { requires cases[c] == Waiting  cases[c] = Accepted }
+  }
+  requirement REQ-2 "respond" {
+    fair action respond(c: Case) { requires cases[c] == Accepted  cases[c] = Responded }
+  }
+  leadsTo EveryAcceptedGetsResponse "every accepted case eventually gets a response" {
+    forall c: Case { cases[c] == Accepted ~> cases[c] == Responded }
+  }
+  acceptance AC-1 "two cases in parallel" {
+    accept(1)
+    accept(2)
+    respond(1)
+    respond(2)
+    expect cases[1] == Responded and cases[2] == Responded
+  }
+}
+verify { instances Case = 3 }
+'''
+
+# Same shape as REPRO_SRC, but AC-1's `expect` (not its steps) is the only
+# thing that references an out-of-range id: the steps run entirely on id 0.
+EXPECT_OUT_OF_RANGE_SRC = r'''requirements ReproExpect {
+  entity Case
+  enum St { Waiting, Accepted, Responded }
+  state { cases: Map<Case, St> }
+  init { forall c: Case { cases[c] = Waiting } }
+  requirement REQ-1 "accept" {
+    fair action accept(c: Case) { requires cases[c] == Waiting  cases[c] = Accepted }
+  }
+  acceptance AC-1 "expect indexes out of range" {
+    accept(0)
+    expect cases[1] == Accepted
+  }
+}
+verify { instances Case = 3 }
+'''
+
+# In-range acceptance (only id 0) whose `expect` is genuinely false: must
+# still hard-error even with overrides active (overrides only excuse
+# out-of-range references, not wrong specs).
+GENUINE_FAILURE_SRC = r'''requirements GenuineFail {
+  entity Case
+  enum St { Waiting, Accepted, Responded }
+  state { cases: Map<Case, St> }
+  init { forall c: Case { cases[c] = Waiting } }
+  requirement REQ-1 "accept" {
+    fair action accept(c: Case) { requires cases[c] == Waiting  cases[c] = Accepted }
+  }
+  acceptance AC-2 "genuinely wrong expect" {
+    accept(0)
+    expect cases[0] == Waiting
+  }
+}
+verify { instances Case = 3 }
+'''
+
+# No CLI overrides here: the verify block itself already declares the small
+# world (Case = 1), and AC-1 hardcodes an out-of-range id. This must still
+# hard-error today's way (regression guard: skip only applies when the CLI
+# --instances/--values flags are the ones doing the shrinking).
+NO_OVERRIDE_OUT_OF_RANGE_SRC = r'''requirements NoOverrideRepro {
+  entity Case
+  enum St { Waiting, Accepted, Responded }
+  state { cases: Map<Case, St> }
+  init { forall c: Case { cases[c] = Waiting } }
+  requirement REQ-1 "accept" {
+    fair action accept(c: Case) { requires cases[c] == Waiting  cases[c] = Accepted }
+  }
+  acceptance AC-1 "uses out-of-range id" {
+    accept(1)
+    expect cases[1] == Accepted
+  }
+}
+verify { instances Case = 1 }
+'''
+
+# number-arg out-of-range under a --values shrink (rather than --instances).
+NUMBER_OVERRIDE_SRC = r'''requirements NumOverrideDemo {
+  number Amount
+  entity Claim
+  process Claim with amount: Amount {
+    stages Draft, Submitted
+    initial Draft
+    transition submit Draft -> Submitted by Employee with a: Amount when a >= 0 set amount = a
+      covers REQ-1 "submit"
+  }
+  acceptance AC-1 "submit with an amount outside the shrunken range" {
+    submit(0, 2)
+    expect Claim 0 in Submitted
+  }
+}
+verify {
+  instances Claim = 3
+  values Amount = 0..3
+}
+'''
+
+# forbidden scenario whose setup step hardcodes an out-of-range id.
+FORBIDDEN_SRC = r'''requirements ForbiddenRepro {
+  entity Case
+  enum St { Waiting, Accepted, Responded }
+  state { cases: Map<Case, St> }
+  init { forall c: Case { cases[c] = Waiting } }
+  requirement REQ-1 "accept" {
+    action accept(c: Case) { requires cases[c] == Waiting  cases[c] = Accepted }
+  }
+  requirement REQ-2 "respond" {
+    action respond(c: Case) { requires cases[c] == Accepted  cases[c] = Responded }
+  }
+  forbidden FB-1 "cannot respond twice" {
+    accept(1)
+    respond(1)
+    respond(1)
+    expect rejected
+  }
+}
+verify { instances Case = 3 }
+'''
+
+
+def _write(tmp_path, src, name="repro.fsl"):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_liveness_with_instances_override_skips_out_of_fit_acceptance(tmp_path):
+    spec = _write(tmp_path, REPRO_SRC)
+    out = run_verify(
+        str(spec), 6, "warn",
+        instances=["Case=1"], property_name="EveryAcceptedGetsResponse",
+    )
+    assert out["result"] not in ("error",)
+    assert out["result"] == "verified"
+    skip_warnings = [w for w in out["warnings"] if w.get("kind") == "acceptance_skipped"]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["id"] == "AC-1"
+    assert "AC-1" in skip_warnings[0]["message"]
+    assert "skipped" in skip_warnings[0]["message"]
+
+
+def test_in_range_acceptance_with_false_expect_still_hard_errors_under_overrides(tmp_path):
+    spec = _write(tmp_path, GENUINE_FAILURE_SRC, name="genuine_fail.fsl")
+    out = run_verify(str(spec), 6, "warn", instances=["Case=1"])
+    assert out["result"] == "error"
+    assert out["kind"] == "acceptance"
+    assert out["id"] == "AC-2"
+    assert exit_code(out) == 2
+
+
+def test_expect_only_out_of_range_is_skipped_under_overrides(tmp_path):
+    spec = _write(tmp_path, EXPECT_OUT_OF_RANGE_SRC, name="expect_oor.fsl")
+    out = run_verify(str(spec), 6, "warn", instances=["Case=1"])
+    assert out["result"] != "error"
+    skip_warnings = [w for w in out["warnings"] if w.get("kind") == "acceptance_skipped"]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["id"] == "AC-1"
+
+
+def test_values_override_out_of_range_number_arg_is_skipped(tmp_path):
+    spec = _write(tmp_path, NUMBER_OVERRIDE_SRC, name="num_override.fsl")
+    out = run_verify(str(spec), 4, "warn", values=["Amount=0..1"])
+    assert out["result"] != "error"
+    skip_warnings = [w for w in out["warnings"] if w.get("kind") == "acceptance_skipped"]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["id"] == "AC-1"
+    assert "Amount=0..1" in skip_warnings[0]["message"]
+
+
+def test_no_overrides_out_of_range_acceptance_still_hard_errors(tmp_path):
+    spec = _write(tmp_path, NO_OVERRIDE_OUT_OF_RANGE_SRC, name="no_override.fsl")
+    out = run_verify(str(spec), 4, "warn")
+    assert out["result"] == "error"
+    assert out["kind"] == "acceptance"
+    assert out["id"] == "AC-1"
+    assert exit_code(out) == 2
+    assert "bounds_overrides" not in out
+
+
+def test_forbidden_setup_out_of_range_is_skipped_under_overrides(tmp_path):
+    spec = _write(tmp_path, FORBIDDEN_SRC, name="forbidden.fsl")
+
+    # No overrides: FB-1's setup ids (1) fit the declared Case=3 world, so it
+    # replays normally and verify succeeds without any skip warning.
+    no_override_out = run_verify(str(spec), 4, "warn")
+    assert no_override_out["result"] != "error"
+    assert not [
+        w for w in no_override_out.get("warnings", []) if w.get("kind") == "forbidden_skipped"
+    ]
+
+    # With --instances Case=1, FB-1's setup step accept(1) is out of range:
+    # skipped, not a hard error.
+    out = run_verify(str(spec), 4, "warn", instances=["Case=1"])
+    assert out["result"] != "error"
+    skip_warnings = [w for w in out["warnings"] if w.get("kind") == "forbidden_skipped"]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["id"] == "FB-1"
+    assert "FB-1" in skip_warnings[0]["message"]


### PR DESCRIPTION
## Symptom

`fslc verify --instances NAME=N` / `--values NAME=LO..HI` (#86 / PR #88) shrink the model, but `run_verify` in `src/fslc/cli.py` still replayed `acceptance`/`forbidden` scenarios as a hard gate *before* verification runs. A scenario hardcoding an id/number from the spec's original (larger) world (e.g. `accept(2)` under `--instances Case=1`) hit an out-of-range replay error and the whole `verify` call errored out (exit 2) — regardless of `--property`. This made `--instances Case=1 --property <Liveness>` unusable, defeating the small-model liveness strategy documented in `skills/fsl/reference.md` §7.

```
fslc verify repro.fsl --depth 6 --instances Case=1 --property EveryAcceptedGetsResponse
→ {"result": "error", "kind": "acceptance", "id": "AC-1", ...}
```

## Design (option B from #89, as specified — not redesigned)

CLI overrides redefine the verifiable world. A scenario that no longer fits the shrunken world is "not applicable", not "failed":

- **Only when `--instances`/`--values` overrides are active**, a scenario whose replay fails *purely* because it references a value outside the overridden bounds is downgraded, per-scenario, from hard-error to skip. Detection happens at **replay time** (not static scanning), so it covers:
  - an out-of-range action argument (`bad_call`, `parameter 'c' out of range [...]`)
  - an out-of-range index inside the scenario's `expect` (`cases[1]` on a size-1 map) — `runtime.py`'s concrete map `select` now raises a distinguishable `"index ... out of range"` message instead of a bare `KeyError` so this is detectable
  - a `--values`-shrunk number argument going out of range
- The skip is surfaced in the envelope's `warnings` as `{"kind": "acceptance_skipped"/"forbidden_skipped", "id": ..., "message": "acceptance 'AC-1' skipped: references values outside overridden bounds (Case=1)"}`. Remaining scenarios still replay.
- **Without overrides, behavior is unchanged** (hard error) — genuinely broken scenarios in the spec are still caught.
- A scenario that fails for any other reason (a false `expect`, an unmet `requires`) still hard-errors, even with overrides active.
- `run_check`'s acceptance gate is untouched (`check` has no override flags).

### Plumbing
- `acceptance.py`: `validate_acceptance`/`validate_forbidden` gain an optional `skip_out_of_range=False` param; a new `_out_of_range_failure(result)` helper inspects the replay failure shape (`step_results` bad_call messages, or the top-level `message` from an `expect`-eval `_EvalError`) for the `"out of range"` marker.
- `cli.py`: `_acceptance_error`/`_forbidden_error` now return `(error_or_None, skipped_ids)`; `run_verify` threads `has_bounds_overrides` through and appends `_bounds_skip_warnings(...)` to the result's `warnings`.
- `runtime.py`: `_ConcDomain.select` (concrete map/struct-field indexing) raises `_EvalError(f"index {idx} out of range")` on a dict `KeyError` instead of leaking a bare `KeyError` string — a strict improvement to an already-useless message, and the mechanism the fix relies on to detect out-of-range `expect` indices.

## Tests

New `tests/test_acceptance_override_skip.py` (6 cases, calling `run_verify(...)` directly per the `test_cli_bounds_override.py` convention):
1. The issue's repro spec with `--instances Case=1 --property EveryAcceptedGetsResponse` → `result: "verified"`, `AC-1` skip warning.
2. In-range acceptance with a genuinely false `expect` → still hard-errors under overrides.
3. Actions in range but `expect` indexes out of range → skipped under overrides.
4. `--values` shrink making a number arg out of range → skipped under overrides.
5. No CLI overrides (verify-block-only `instances Case = 1`, id 1 used) → hard error (regression guard).
6. `forbidden` scenario with an out-of-range setup step → skipped under overrides; unaffected without overrides.

Also ran: `test_cli_bounds_override.py`, `test_acceptance_enum_args.py`, `test_forbidden.py`, `test_req_process.py`, `test_req_process_carry_enum_bool.py`, `test_strict_tags.py`, `test_req_dialect.py`, `test_verified_bugs.py`, `test_layers_chain.py`, `test_repair_fields.py` — all pass. Not touching `.fsl` under `specs/`/`examples/`, so the corpus snapshot is unaffected.

Docs updated: `docs/LANGUAGE.md` (CLI-override paragraph), `skills/fsl/reference.md` (§7 small-model liveness guidance + verify-flags list), `CHANGELOG.md`.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)