### PR TITLE
feat(lang): sum aggregate expression for instances-independent liveness measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- `sum k: T [where expr] { expr }` aggregate expression: enumerates the
+  binder's bounded domain (same machinery as `forall`/`exists`, including
+  range/collection binders and `where`) and folds with `+`. Fixes the
+  documented per-entity `decreases` trap (`rank_failure:
+  "non_decreasing_action"` under interleaving) without hand-writing
+  `decreases level[0] + level[1] + ...`, and — unlike that idiom — is
+  instances-independent: the measure text doesn't change when `instances
+  Case = N` changes or is overridden via `--instances`/`--values` (#86).
+  General expression, usable anywhere `expr` is legal, not special-cased to
+  `decreases`. Phase 1 of #72; Phase 2 (fairness-aware "helpful action"
+  ranking) remains open. (#91)
+
 ## [2.6.1] - 2026-07-03
 
 ### Fixed

--- a/docs/DESIGN-sum-aggregate.md
+++ b/docs/DESIGN-sum-aggregate.md
@@ -1,0 +1,134 @@
+# `sum` Aggregate Expression — Design (#91, Phase 1 of #72)
+
+## 1. Problem
+
+`forall c: Case { P(c) ~> Q(c) }` liveness proofs need a `decreases` measure.
+A per-entity measure (`decreases level[c]`) always fails the ranking
+discipline under interleaving: the discipline requires *every* enabled
+action to strictly decrease the measure, but an action that advances a
+*different* entity leaves `level[c]` for the pending binding unchanged
+(`rank_failure: "non_decreasing_action"` — see `docs/LANGUAGE.md` §1 and
+`skills/fsl/reference.md` rule 7). The documented workaround was a
+hand-written global-sum measure, `decreases level[0] + level[1] + level[2]`,
+which has to be rewritten by hand every time `instances Case = N` changes.
+
+## 2. Design: bounded-domain expansion
+
+FSL domains are always bounded (`type T = lo..hi`, an `entity`'s
+`instances` bound, or a `number`'s `values` bound). This means a "sum over a
+domain" is not a new solving primitive — it is exactly the hand-written
+idiom above, generalized: enumerate the binder's domain at build/eval time
+and fold the instantiated bodies with `+`. No new Z3 theory, no new
+transition-relation shape; `sum` is evaluated the same way `forall`/`exists`
+already are (instantiate over a finite index set), just accumulated with `+`
+instead of `And`/`Or`.
+
+```fsl
+leadsTo Responds {
+  forall c: Case { level[c] > 0 ~> level[c] == 0 }
+  decreases sum k: Case { level[k] }
+}
+```
+
+Because the enumeration happens at evaluation time against the spec's actual
+bound (`instances Case = N`, or a `--instances`/`--values` CLI override,
+#86), the measure text never needs to change when `N` changes — this is the
+concrete fix for the "rewrite the measure by hand" problem, not just a
+syntax convenience.
+
+## 3. Why a new brace-only grammar form, alongside the existing `sum(...)`
+
+The kernel already had an aggregate spelled `sum(v: T of expr [where expr])`
+(`grammar.py` `sum_e`, kernel AST tag `"sum"`, 5-tuple
+`("sum", v, ty_name, body, cond)`). It is unconditionally usable in general
+expressions and is left completely unchanged by this feature — it's a fine,
+already-shipped way to fold a `Seq` via an `Idx` domain (see
+`specs/audit_log.fsl`), and existing code across `compose.py`, `dialects.py`,
+`mutate.py`, and `explain.py` pattern-matches its exact 5-tuple shape.
+
+The new construct instead sits in the `quant` grammar rule alongside
+`forall`/`exists` (`"sum" binder [":"] "{" expr "}" -> quant_sum`), reusing
+the *general* `binder` production — typed (`k: T`), range (`k in lo..hi`),
+and collection (`k in someSet`) binders, each with an optional `where`
+clause — exactly like `forall`/`exists` already do. The old `sum(...)` form
+only ever accepted a `NAME : qname` binder with no range/collection support.
+Since the AST tag `"sum"` was already load-bearing with a fixed 5-tuple
+shape across five modules, reusing that tag for a binder-shaped 3-tuple
+would have made every existing `tag == "sum"` call site silently misparse
+call sites; the new form uses its own kernel AST tag, `"quant_sum"`
+(`("quant_sum", binder, body)`), instead. `count`/`sum` themselves set this
+precedent: `unique`/`exactlyOne`, which are also binder-shaped cardinality
+predicates, got their own tags (`"unique"`, `"exactly_one"`) rather than
+overloading `"count"`.
+
+One consequence of sitting at the `quant` grammar tier (like `forall`/
+`exists`) rather than at the arithmetic `atom` tier (like `min`/`max`/the old
+`sum(...)`): `sum k: T { ... }` is not directly reachable from an arithmetic
+comparison without parentheses, e.g. `invariant B { (sum k: T { m[k] }) <= N
+}` needs the parens that `min(a, b) <= N` would not. This mirrors
+`forall`/`exists` placement exactly, as directed by the issue design; moving
+it to the `atom` tier is a possible follow-up but out of scope here (it does
+not affect the `decreases <expr>` use case, which places `sum` directly at
+the top level with no wrapping needed).
+
+## 4. `where`-clause semantics
+
+`sum k: T where cond { body }` filters the fold: each domain member's
+contribution is `body` when `cond` holds for that member, and `0` otherwise
+— i.e. symbolically `z3.Sum(z3.If(cond_i, body_i, 0) for i in domain)`, and
+concretely the Python equivalent. This reuses `values.iter_binder_terms`
+exactly as `forall`/`exists`/`unique`/`exactlyOne` do (the `w` "where" term
+each of those already threads through), so `sum`'s where-filtering is
+implemented with the same machinery, not a parallel one. An empty domain (or
+a `where` that admits no members) sums to `0`.
+
+## 5. Type checking
+
+The bound variable's type resolves the same way a `forall`/`exists` binder's
+does (unknown type name -> `kind: "type"` error naming the type). `where`
+must be Bool. The body must be Int-family (`Int`, a domain type, or an enum
+member reference); a Bool body is a `kind: "type"` error — summing a Bool
+silently coercing true/false to 1/0 was judged more likely to hide a typo
+(`sum k: Case { flag[k] }` meaning "count of flag[k]") than to be an intended
+use, so it is rejected rather than accepted as an implicit count. (`count(x:
+T where expr)` remains the spelling for that.) This check runs eagerly
+during `build_spec` (so `fslc check` catches it, not just `verify`) via a
+generic recursive walk over the built spec's expression trees — the same
+`FslError`-based error the rest of the type checker uses; there is no
+separate "sum type checker" theory to keep in sync elsewhere.
+
+## 6. Dual-evaluator obligation
+
+This repo's core correctness invariant is that `bmc.py` (symbolic) and
+`runtime.py` `Monitor` (concrete) agree on every construct. `sum` is
+implemented once, in `values.py` (`eval_sum_binder`), parameterized over the
+same `dom`/`ev` abstraction `eval_quant`/`eval_one`/`eval_count` already use;
+`bmc.py` and `runtime.py` each add a one-line dispatch (`tag == "quant_sum"`)
+plus a one-line wrapper binding `_SYM`/`eval_expr` or `_CONC`/
+`eval_concrete` respectively. There is exactly one enumeration/fold
+implementation, not two — the dual-evaluator agreement is structural, not a
+property that has to be independently verified and kept in sync by hand.
+`tests/test_sum_aggregate.py` additionally cross-checks `bmc.eval_expr` and
+`runtime.eval_concrete` directly on a pinned state, following the pattern in
+`tests/test_evaluator_agreement.py`.
+
+## 7. Relation to #72 Phase 2
+
+`sum` fully resolves the case where every enabled action moves the tracked
+total in the same direction (the case in the original bug report: entities
+sharing one pool of "work remaining"). It does **not** resolve the case
+where some enabled action touches neither the pending binding nor the sum at
+all (a bookkeeping action unrelated to any `level[c]`) — the sum then does
+not strictly decrease and ranking still fails. That is Phase 2 of #72: a
+fairness-aware "helpful action" discipline (`decreases M by <action>`),
+which stays a separate, larger piece of work (see the design comment on
+#72). Phase 1 (`sum`) ships first because it has no solver-side novelty and
+directly fixes the reported instances-independence problem.
+
+## 8. Out of scope
+
+`count`/`min`/`max`-style *binder-shaped* aggregates (a hypothetical
+`count k: T { ... }` / `min k: T { ... }` mirroring `sum`'s new binder form)
+are not requested by #91 and are not added here — `count(x: T where expr)`
+already exists and was not reported as having the instances-independence
+problem `sum` was solving. Add them only if a concrete use case shows up.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -180,15 +180,32 @@ per-entity liveness under interleaving needs a fairness-aware discipline
 (only the binding's own "helpful" action must decrease); that is not
 implemented and is tracked separately (issue #72).
 
-**Working idiom: a global sum measure.** Sum the tracked quantity across a
-fixed, small domain, e.g. `decreases level[0] + level[1]` for a 2-element
-`Case` domain — every action then strictly decreases the total, and
-induction returns `"proved"` with `"completeness": "unbounded"`. There is no
-`sum()` aggregate over a domain type usable here, so this idiom only scales
-to domains small enough to enumerate by hand. (Conditional expressions can't
-substitute for a per-branch measure either: `if/then/else` is legal only in
-refinement-mapping expressions (§10), not in the general expression grammar
-that `decreases` draws from.)
+**Working idiom: a `sum` measure.** Sum the tracked quantity across the
+binder's whole (always-bounded) domain:
+
+```fsl
+leadsTo Responds {
+  forall c: Case { level[c] > 0 ~> level[c] == 0 }
+  decreases sum k: Case { level[k] }
+}
+```
+
+`sum k: T [where expr] { expr }` enumerates `T`'s bounded domain (the same
+binder machinery `forall`/`exists` use, including range/collection binders
+and an optional `where` filter) and folds the body with `+` — no solver-side
+novelty, just the generalization of hand-enumerating
+`decreases level[0] + level[1] + level[2]`. Because the sum ranges over the
+*whole* domain, every action still strictly decreases the total (the
+discipline in the paragraph above is unaffected), and — unlike the
+hand-written idiom — the measure does not need to be rewritten when
+`instances Case = N` changes: `sum` is instances-independent by
+construction. See `docs/DESIGN-sum-aggregate.md` for the design rationale,
+and note Phase 2 of #72 (a fairness-aware "helpful action" discipline) is
+still open for the cases `sum` doesn't reach — where some other entity's
+action neither resolves the pending binding nor changes the sum at all.
+(Conditional expressions can't substitute for a per-branch measure either:
+`if/then/else` is legal only in refinement-mapping expressions (§10), not in
+the general expression grammar that `decreases` draws from.)
 
 ## 2. Types
 
@@ -238,7 +255,12 @@ scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
   the v0 form `forall i in lo..hi: expr` is also allowed. Expression quantifiers
   can also range over a Set or Seq value: `forall x in active { ... }` /
   `exists x in queue { ... }`; for Seq this ranges over the live prefix values.
-- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
+- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`, and the
+  quantifier-shaped `sum x: T [where expr] { expr }` (brace form, reuses the same
+  `binder` grammar as `forall`/`exists`, incl. range/collection binders — see
+  §1 for its role as a `decreases` measure and `docs/DESIGN-sum-aggregate.md`
+  for the design rationale). The body must be Int-valued; a Bool body is a
+  check-time type error.
 - Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
   `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
   matching binding, while `exactlyOne` means exactly one.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
 | [`DESIGN-html-report.md`](DESIGN-html-report.md) | `fslc html` (self-contained visual review report from explain + verify evidence) |
 | [`DESIGN-typestate.md`](DESIGN-typestate.md) | `fslc typestate` (applicability check for state machine → typestate + TS scaffold) |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
+| [`DESIGN-sum-aggregate.md`](DESIGN-sum-aggregate.md) | `sum k: T [where expr] { expr }` aggregate expression (bounded-domain expansion, instances-independent `decreases` measures, relation to #72 Phase 2) |
 
 ## Dogfooding records (DOGFOOD-*)
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -172,7 +172,11 @@ check as a type error.
   allowed), `forall x in set_or_seq { expr }` / `exists x in set_or_seq { expr }`
   for expression-only Set/Seq iteration, and the v0 form
   `forall i in lo..hi: expr` (range is a constant expression: `0..CAP-1` recommended)
-- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
+- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`,
+  and `sum x: T [where expr] { expr }` (brace form; same `binder` as
+  forall/exists incl. range/collection binders; body must be Int — a Bool
+  body is a check-time type error). This is the recommended form for a
+  `decreases` measure (see rule 7 below).
 - Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
   `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
   matching binding; `exactlyOne` means exactly one.
@@ -239,9 +243,13 @@ check as a type error.
      every enabled action must decrease M, so an action advancing a
      *different* entity (`step(c=1)` while `c=0` is pending) violates it.
      Reported as `rank_failure: "non_decreasing_action"`. Working idiom:
-     a **global sum measure** over a fixed small domain, e.g.
-     `decreases level[0] + level[1]`, since there is no `sum()` aggregate to
-     generalize it. Fairness-aware per-entity ranking is future work (#72).
+     `decreases sum k: Case { level[k] }` — sums the quantity over the
+     binder's whole bounded domain (generalizes the old hand-written
+     `decreases level[0] + level[1] + …` idiom) and is **instances-independent**:
+     it doesn't need editing when `instances Case = N` changes. Every enabled
+     action must still strictly decrease the *total*; the discipline itself is
+     unchanged. Fairness-aware per-entity ranking (for actions that touch
+     neither the pending binding nor the sum) is future work (#72 Phase 2).
 8. `symmetric type` / `symmetric enum` means those values are interchangeable
    entity identities. For leadsTo lasso/stall search, fslc symmetry-breaks the
    representative state using canonical rows from `Map<SymmetricType, V>` and

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -38,6 +38,7 @@ from .values import (
     eval_one,
     eval_quant,
     eval_sum,
+    eval_sum_binder,
     iter_binder_terms,
     logical_map_access,
     option_logical_eq,
@@ -770,6 +771,8 @@ def _eval_expr_uncached(e, state, binds, spec, old_state=None, in_ensures=False)
         return _eval_count(e, state, binds, spec, old_state, in_ensures)
     if tag == "sum":
         return _eval_sum(e, state, binds, spec, old_state, in_ensures)
+    if tag == "quant_sum":
+        return _eval_sum_binder(e, state, binds, spec, old_state, in_ensures)
     if tag == "min":
         a, b = eval_expr(e[1], state, binds, spec, old_state, in_ensures), \
                eval_expr(e[2], state, binds, spec, old_state, in_ensures)
@@ -1048,6 +1051,10 @@ def _eval_count(e, state, binds, spec, old_state, in_ensures):
 
 def _eval_sum(e, state, binds, spec, old_state, in_ensures):
     return eval_sum(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
+
+
+def _eval_sum_binder(e, state, binds, spec, old_state, in_ensures):
+    return eval_sum_binder(e, state, binds, spec, old_state, in_ensures, _SYM, eval_expr)
 
 
 
@@ -1877,7 +1884,7 @@ def _expr_static_type(e, spec, env):
         return _merge_ite_static_types(a_ty, b_ty)
     if tag in ("not", "is", "forall", "exists", "unique", "exactly_one"):
         return ("bool",)
-    if tag in ("count", "sum", "min", "max", "abs"):
+    if tag in ("count", "sum", "quant_sum", "min", "max", "abs"):
         return ("int",)
     return None
 
@@ -2269,6 +2276,13 @@ def _leadsto_measure_label(expr):
         cond_label = _leadsto_measure_label(cond)
         if cond_label is not None:
             return f"count({v}: {ty} where {cond_label})"
+    if tag == "quant_sum":
+        _, binder, body = expr
+        body_label = _leadsto_measure_label(body)
+        if body_label is not None and binder[0] == "binder_typed":
+            v, ty, where = binder[1], binder[2], binder[3]
+            where_label = f" where {_leadsto_measure_label(where)}" if where is not None else ""
+            return f"sum {v}: {ty}{where_label} {{ {body_label} }}"
     return "decreases expression"
 
 

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -126,6 +126,7 @@ quant: "forall" binder [":"] expr -> quant_forall
      | "forall" binder [":"] "{" expr "}" -> quant_forall_brace
      | "exists" binder [":"] expr -> quant_exists
      | "exists" binder [":"] "{" expr "}" -> quant_exists_brace
+     | "sum" binder [":"] "{" expr "}" -> quant_sum
 ?implies: or_e | or_e "=>" implies -> imp
 ?or_e: and_e | or_e _OR and_e -> or_op
 ?and_e: not_e | and_e _AND not_e -> and_op
@@ -493,6 +494,9 @@ class Ast(Transformer):
 
     def quant_exists_brace(self, meta, b, e):
         return ("exists", b, e)
+
+    def quant_sum(self, meta, b, e):
+        return ("quant_sum", b, e)
 
     def unique_e(self, meta, binder):
         return ("unique", binder)

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -23,8 +23,8 @@ def _err(message, kind="semantics", loc=None, expected=None, hint=None):
 # Bare-atom literals in the grammar that collide unconditionally with identifiers.
 # Keywords that only act as keywords when immediately followed by "(" (count, sum,
 # stage, min, max, abs, old, unique, exactlyOne, some) or by a binder (forall,
-# exists) are contextual — they parse unambiguously as bare identifiers, so they
-# are NOT reserved.
+# exists, and sum in its `sum k: T { ... }` aggregate form) are contextual —
+# they parse unambiguously as bare identifiers, so they are NOT reserved.
 _RESERVED = frozenset({"true", "false", "none"})
 
 
@@ -450,6 +450,104 @@ def binder_range(binder, consts, types_meta):
     ty = types_meta[ty_name]["ty"]
     lo, hi = domain_range(ty, types_meta)
     return v, lo, hi, where
+
+
+# --- `sum k: T [where ...] { body }` type checking -------------------------
+#
+# A minimal, self-contained Bool/Int static typing used only to validate
+# `quant_sum` (the `sum` aggregate) nodes at check time: the bound variable's
+# type must resolve like a forall/exists binder does, `where` must be Bool,
+# and `body` must be Int-family. Returns "bool" / "int" / None (type unknown
+# to this narrow checker, e.g. structs — such expressions are left unchecked
+# rather than rejected).
+
+def _sum_binder_var_type(binder, types_meta):
+    if binder[0] == "binder_typed":
+        ty_name = binder[2]
+        if ty_name not in types_meta:
+            _err(f"unknown type '{ty_name}' in binder", kind="type")
+        return "int"
+    if binder[0] == "binder_range":
+        return "int"
+    # binder_collection: element type isn't tracked by this narrow checker.
+    return None
+
+
+def _sum_expr_type(e, types_meta, state, env):
+    if not isinstance(e, tuple):
+        return None
+    tag = e[0]
+    if tag == "num":
+        return "int"
+    if tag == "bool":
+        return "bool"
+    if tag in ("neg", "abs", "min", "max", "count", "old"):
+        return "int"
+    if tag in ("not", "is", "forall", "exists", "unique", "exactly_one"):
+        return "bool"
+    if tag == "bin":
+        return "int" if e[1] in ("+", "-", "*", "/", "%") else "bool"
+    if tag == "quant_sum":
+        _check_quant_sum(e, types_meta, state, env)
+        return "int"
+    if tag == "var":
+        n = e[1]
+        if n in env:
+            return env[n]
+        if n in state:
+            vty = state[n]
+            if vty[0] == "bool":
+                return "bool"
+            if vty[0] in ("int", "domain", "enum"):
+                return "int"
+            return None
+        for info in types_meta.values():
+            if info["kind"] == "enum" and n in info.get("members", ()):
+                return "int"
+        return None
+    if tag == "index":
+        base = e[1]
+        name = base if isinstance(base, str) else (base[1] if base[0] == "var" else None)
+        vty = state.get(name) if name else None
+        if vty and vty[0] == "map":
+            inner = vty[2]
+            if inner[0] == "bool":
+                return "bool"
+            if inner[0] in ("int", "domain", "enum"):
+                return "int"
+        return None
+    return None
+
+
+def _check_quant_sum(e, types_meta, state, env):
+    _, binder, body = e
+    v = binder[1]
+    where = binder[3] if len(binder) > 3 else None
+    inner_env = {**env, v: _sum_binder_var_type(binder, types_meta)}
+    if where is not None:
+        where_ty = _sum_expr_type(where, types_meta, state, inner_env)
+        if where_ty is not None and where_ty != "bool":
+            _err("sum where clause must be Bool", kind="type")
+    body_ty = _sum_expr_type(body, types_meta, state, inner_env)
+    if body_ty is not None and body_ty != "int":
+        _err(f"sum body must be Int, got {body_ty}", kind="type")
+
+
+def _find_sum_nodes(node, types_meta, state):
+    """Recursively locate every `quant_sum` node in `node` and type-check it,
+    regardless of how deeply it's nested (mirrors _check_no_stage_expr's
+    generic tuple/list/dict walk)."""
+    if isinstance(node, tuple):
+        if node and node[0] == "quant_sum":
+            _check_quant_sum(node, types_meta, state, {})
+        for part in node[1:]:
+            _find_sum_nodes(part, types_meta, state)
+    elif isinstance(node, list):
+        for item in node:
+            _find_sum_nodes(item, types_meta, state)
+    elif isinstance(node, dict):
+        for item in node.values():
+            _find_sum_nodes(item, types_meta, state)
 
 
 def normalize_params(params, consts, types_meta):
@@ -1201,6 +1299,11 @@ def build_spec(tree, display_names=None, semantic_check=True):
         _err("spec has no actions", kind="semantics")
 
     check_seq_literal_sizes(state, init, actions, types_meta)
+
+    for _coll in (actions, all_invariants, transitions, reachables, leadstos, init):
+        _find_sum_nodes(_coll, types_meta, state)
+    if terminal is not None:
+        _find_sum_nodes(terminal, types_meta, state)
 
     all_display_names = dict(display_names or {})
     all_display_names.update(dialect_display_names)

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -28,6 +28,7 @@ from .values import (
     eval_one,
     eval_quant,
     eval_sum,
+    eval_sum_binder,
     logical_map_access,
     option_logical_eq,
     option_none_cmp,
@@ -507,6 +508,8 @@ def _eval_concrete_impl(e, state, binds, spec, old_state=None, in_ensures=False)
         return _eval_count(e, state, binds, spec, old_state, in_ensures)
     if tag == "sum":
         return _eval_sum(e, state, binds, spec, old_state, in_ensures)
+    if tag == "quant_sum":
+        return _eval_sum_binder(e, state, binds, spec, old_state, in_ensures)
     if tag == "min":
         a = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
         b = eval_concrete(e[2], state, binds, spec, old_state, in_ensures)
@@ -717,6 +720,10 @@ def _eval_count(e, state, binds, spec, old_state, in_ensures):
 
 def _eval_sum(e, state, binds, spec, old_state, in_ensures):
     return eval_sum(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
+
+
+def _eval_sum_binder(e, state, binds, spec, old_state, in_ensures):
+    return eval_sum_binder(e, state, binds, spec, old_state, in_ensures, _CONC, eval_concrete)
 
 
 

--- a/src/fslc/values.py
+++ b/src/fslc/values.py
@@ -153,6 +153,21 @@ def eval_quant(e, state, binds, spec, old_state, in_ensures, dom, ev):
     return dom.quantify(qop, terms())
 
 
+def eval_sum_binder(e, state, binds, spec, old_state, in_ensures, dom, ev):
+    """Evaluate the `sum k: T [where ...] { body }` aggregate: enumerate the
+    binder's bounded domain (the same iter_binder_terms machinery forall /
+    exists / unique use) and fold with +, filtering each term through `where`
+    via dom.select_int (symbolically If(where, body, 0)). Empty domain -> 0."""
+    binder, body = e[1], e[2]
+    acc = dom.int_lit(0)
+    for w, b2 in iter_binder_terms(
+        binder, state, binds, spec, old_state, in_ensures, dom, ev
+    ):
+        term = lambda b2=b2: ev(body, state, b2, spec, old_state, in_ensures)
+        acc = acc + (dom.select_int(w, term) if w is not None else term())
+    return acc
+
+
 def eval_one(e, state, binds, spec, old_state, in_ensures, dom, ev):
     tag, binder = e[0], e[1]
     acc = dom.int_lit(0)

--- a/tests/test_sum_aggregate.py
+++ b/tests/test_sum_aggregate.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""`sum k: T [where ...] { body }` aggregate expression (#91, Phase 1 of #72).
+
+Per-entity liveness measures (`decreases level[c]` inside
+`forall c: Case { level[c] > 0 ~> level[c] == 0 }`) always fail the ranking
+discipline under interleaving: an action that advances a *different* entity
+leaves the bound entity's measure unchanged, which the discipline forbids
+(`rank_failure: "non_decreasing_action"`). The documented workaround was a
+hand-written global-sum measure (`level[0] + level[1] + level[2]`) that has to
+be rewritten every time the entity count changes. `sum` generalizes that
+idiom: FSL domains are always bounded, so `sum` enumerates the binder's
+domain and folds `+` — no solver-side novelty, and instances-independent.
+
+These tests do NOT touch any `.fsl` under specs/ or examples/, so the corpus
+snapshot is unaffected by this file.
+"""
+from __future__ import annotations
+
+import z3
+
+from fslc import build_spec, parse, prove, verify, FslError
+from fslc.cli import run_verify
+from fslc.bmc import eval_expr, make_state
+from fslc.runtime import Monitor, eval_concrete
+
+
+def _spec(src):
+    return build_spec(parse(src))
+
+
+def _write(tmp_path, src, name="spec.fsl"):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-entity measure fails ranking (regression baseline); sum measure
+#    proves the SAME leadsTo unbounded.
+# ---------------------------------------------------------------------------
+
+PER_CASE_REQ = """
+requirements SumDemoBaseline {{
+  entity Case
+
+  state {{ level: Map<Case, Int> }}
+  init {{ forall c: Case {{ level[c] = 2 }} }}
+
+  action step(c: Case) {{
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }}
+
+  invariant NonNeg {{ forall c: Case {{ level[c] >= 0 }} }}
+
+  leadsTo Responds {{
+    forall c: Case {{ level[c] > 0 ~> level[c] == 0 }}
+    decreases {measure}
+  }}
+}}
+verify {{
+  instances Case = 3
+}}
+"""
+
+
+def test_percase_measure_fails_ranking_baseline():
+    """Regression: the documented per-entity trap still fails this way."""
+    spec = _spec(PER_CASE_REQ.format(measure="level[c]"))
+    r = prove(spec, 1, 8)
+    assert r["result"] == "unknown_cti"
+    assert r["violation_kind"] == "leadsTo_rank"
+    assert r["rank_failure"] == "non_decreasing_action"
+
+
+def test_sum_measure_proves_unbounded_leadsto():
+    """The escape: `sum` over the same per-entity quantity proves unbounded."""
+    spec = _spec(PER_CASE_REQ.format(measure="sum k: Case { level[k] }"))
+    r = prove(spec, 1, 8)
+    assert r["result"] == "proved"
+    assert r["completeness"] == "unbounded"
+    entry = r["leads_to"]["Responds"]
+    assert entry["proved"] is True
+    assert entry["proof"] == "ranking"
+    assert entry["completeness"] == "unbounded"
+    assert entry["decreases"] == "sum k: Case { level[k] }"
+
+
+# ---------------------------------------------------------------------------
+# 2. Instances-independence: same spec, same measure, different entity
+#    counts — via the `verify { instances Case = N }` block and via the
+#    #86 CLI `--instances` override. No measure edit either way.
+# ---------------------------------------------------------------------------
+
+SUM_MEASURE_REQ = PER_CASE_REQ.format(measure="sum k: Case { level[k] }")
+
+
+def test_sum_measure_instances_independent_via_verify_block(tmp_path):
+    five_instances = SUM_MEASURE_REQ.replace(
+        "instances Case = 3", "instances Case = 5"
+    )
+    for src in (SUM_MEASURE_REQ, five_instances):
+        spec = _spec(src)
+        r = prove(spec, 1, 8)
+        assert r["result"] == "proved"
+        assert r["leads_to"]["Responds"]["completeness"] == "unbounded"
+        assert r["leads_to"]["Responds"]["decreases"] == "sum k: Case { level[k] }"
+
+
+def test_sum_measure_instances_independent_via_cli_override(tmp_path):
+    path = _write(tmp_path, SUM_MEASURE_REQ)
+    out = run_verify(str(path), 8, "warn", engine="induction", k_ind=1, instances=["Case=5"])
+    assert out["result"] == "proved"
+    assert out["bounds_overrides"] == {"instances": {"Case": 5}, "values": {}}
+    assert out["leads_to"]["Responds"]["completeness"] == "unbounded"
+    assert out["leads_to"]["Responds"]["decreases"] == "sum k: Case { level[k] }"
+
+
+# ---------------------------------------------------------------------------
+# 3. `where` clause: conditional sum, checked via `verify` on an invariant,
+#    and cross-checked directly between bmc.eval_expr (symbolic) and
+#    runtime.eval_concrete (concrete) on the same pinned state.
+# ---------------------------------------------------------------------------
+
+SUM_WHERE_INVARIANT = """
+spec SumWhereInvariant {
+  type Case = 0..2
+  state { level: Map<Case, Int> }
+  init { forall c: Case { level[c] = 0 } }
+  action bump(c: Case) {
+    requires level[c] < 2
+    level[c] = level[c] + 1
+  }
+  invariant Bound { (sum k: Case where level[k] > 0 { level[k] }) <= 6 }
+}
+"""
+
+
+def test_sum_where_clause_invariant_verifies():
+    spec = _spec(SUM_WHERE_INVARIANT)
+    r = verify(spec, 6)
+    assert r["result"] == "verified"
+    assert r["invariants_checked"] == ["Bound"]
+
+
+def _assert_bmc_monitor_agree(src, expr, tmp_path, name="agree.fsl"):
+    """Pin the Monitor's concrete init state into a z3 solver and check that
+    bmc.eval_expr and runtime.eval_concrete cannot disagree on `expr` there —
+    the dual-evaluator invariant this repo requires for every new construct."""
+    path = _write(tmp_path, src, name)
+    mon = Monitor(str(path))
+    mon.reset()
+    phys = mon._phys  # noqa: SLF001 - internal, but this is exactly what both evaluators consume
+    spec = mon.spec
+
+    concrete = eval_concrete(expr, phys, {}, spec)
+
+    sym_state = make_state(spec, 0)
+    solver = z3.Solver()
+    for name, value in phys.items():
+        if isinstance(value, dict):
+            for k, v in value.items():
+                solver.add(z3.Select(sym_state[name], k) == (z3.BoolVal(v) if isinstance(v, bool) else v))
+        elif isinstance(value, bool):
+            solver.add(sym_state[name] == z3.BoolVal(value))
+        else:
+            solver.add(sym_state[name] == value)
+    symbolic = eval_expr(expr, sym_state, {}, spec)
+
+    solver.push()
+    solver.add(symbolic != concrete)
+    assert solver.check() == z3.unsat, "bmc.eval_expr and runtime.eval_concrete disagree on sum"
+    return concrete
+
+
+def test_sum_where_clause_bmc_monitor_agree(tmp_path):
+    expr = (
+        "quant_sum",
+        ("binder_typed", "k", "Case", ("bin", ">", ("index", ("var", "level"), ("var", "k")), ("num", 0))),
+        ("index", ("var", "level"), ("var", "k")),
+    )
+    concrete = _assert_bmc_monitor_agree(SUM_WHERE_INVARIANT, expr, tmp_path)
+    assert concrete == 0  # init state: every level[k] == 0, so the where filter admits nothing
+
+
+# ---------------------------------------------------------------------------
+# 4. Type errors: Bool body and unknown binder type are check-time errors.
+# ---------------------------------------------------------------------------
+
+SUM_BOOL_BODY_REQ = """
+spec SumBoolBody {
+  type Case = 0..2
+  state { flag: Map<Case, Bool> }
+  init { forall c: Case { flag[c] = false } }
+  action set(c: Case) {
+    requires not flag[c]
+    flag[c] = true
+  }
+  leadsTo Responds {
+    forall c: Case { not flag[c] ~> flag[c] }
+    decreases sum k: Case { flag[k] }
+  }
+}
+"""
+
+
+def test_sum_bool_body_is_type_error():
+    try:
+        _spec(SUM_BOOL_BODY_REQ)
+        assert False, "expected FslError for Bool sum body"
+    except FslError as e:
+        assert e.kind == "type"
+        assert "Int" in str(e) or "bool" in str(e)
+
+
+SUM_UNKNOWN_BINDER_TYPE = """
+spec SumUnknownBinder {
+  type Case = 0..2
+  state { level: Map<Case, Int> }
+  init { forall c: Case { level[c] = 0 } }
+  action step(c: Case) {
+    requires level[c] >= 0
+    level[c] = level[c] + 1
+  }
+  invariant Bad { (sum k: Bogus { level[k] }) >= 0 }
+}
+"""
+
+
+def test_sum_unknown_binder_type_is_type_error():
+    try:
+        _spec(SUM_UNKNOWN_BINDER_TYPE)
+        assert False, "expected FslError for unknown binder type"
+    except FslError as e:
+        assert e.kind == "type"
+        assert "Bogus" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# 5. Nested sum: fixed, hand-computed expectation.
+# ---------------------------------------------------------------------------
+
+NESTED_SUM_SPEC = """
+spec NestedSum {
+  type A = 0..1
+  type B = 0..1
+  state { m: Map<A, Int> }
+  init { forall a: A { m[a] = 1 } }
+  action touch() {
+    requires true
+    m[0] = m[0]
+  }
+  invariant NestedCheck { (sum i: A { sum j: B { m[i] } }) == 4 }
+}
+"""
+
+
+def test_nested_sum_evaluates_correctly():
+    # m[i] == 1 for i in {0, 1}; inner `sum j: B { m[i] }` is m[i] * |B| == 2;
+    # outer sum over A of that is 2 + 2 == 4.
+    spec = _spec(NESTED_SUM_SPEC)
+    r = verify(spec, 1)
+    assert r["result"] == "verified"
+    assert r["invariants_checked"] == ["NestedCheck"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Kernel spec (non-dialect) usage over a `type Id = 0..2` domain.
+# ---------------------------------------------------------------------------
+
+KERNEL_SUM_SPEC = """
+spec KernelSumDemo {
+  type Id = 0..2
+  state { v: Map<Id, Int> }
+  init { forall i: Id { v[i] = i } }
+  action touch() {
+    requires true
+    v[0] = v[0]
+  }
+  invariant SumCheck { (sum i: Id { v[i] }) == 3 }
+}
+"""
+
+
+def test_kernel_spec_sum_over_domain_type():
+    spec = _spec(KERNEL_SUM_SPEC)
+    r = verify(spec, 1)
+    assert r["result"] == "verified"
+    assert r["invariants_checked"] == ["SumCheck"]
+
+
+# ---------------------------------------------------------------------------
+# 7. `sum` is a contextual keyword (like forall/exists/count): a state
+#    variable literally named `sum` still checks cleanly when it never
+#    appears immediately before `(` or a binder.
+# ---------------------------------------------------------------------------
+
+SUM_NAMED_STATE_VAR = """
+spec SumNamedVar {
+  state { sum: Int }
+  init { sum = 0 }
+  action step() {
+    requires sum < 5
+    sum = sum + 1
+  }
+  invariant NonNeg { sum >= 0 }
+}
+"""
+
+
+def test_state_var_named_sum_does_not_crash():
+    spec = _spec(SUM_NAMED_STATE_VAR)
+    r = verify(spec, 3)
+    assert r["result"] == "verified"


### PR DESCRIPTION
## Motivation

Per-entity liveness measures (`decreases level[c]` inside `forall c: Case { level[c] > 0 ~> level[c] == 0 }`) structurally fail the ranking discipline under interleaving: every enabled action must strictly decrease the measure, but an action advancing a *different* entity leaves `level[c]` unchanged (`rank_failure: "non_decreasing_action"`). The documented escape was a hand-written global-sum measure (`level[0] + level[1] + level[2]`) that must be rewritten whenever `instances Case = N` changes — and doesn't compose with the #86 `--instances` CLI override. This kept requirements-layer liveness stuck at bounded verification (#71, #72).

## Design (fixed in #91 / the #72 design comment)

`sum k: T [where expr] { expr }` — a general kernel expression, not special-cased to `decreases`:

```fsl
leadsTo Responds {
  forall c: Case { level[c] > 0 ~> level[c] == 0 }
  decreases sum k: Case { level[k] }
}
```

- **Grammar**: added to the `quant` rule (brace-only form) reusing the existing `binder` production, so typed/range/collection binders and the optional `where` clause come along for free. Kernel AST tag is `("quant_sum", binder, body)` — the existing `sum(v: T of e [where c])` atom and its load-bearing 5-tuple `("sum", ...)` shape (matched across compose/dialects/mutate/explain) are untouched.
- **Semantics**: FSL domains are always bounded, so `sum` enumerates the binder domain at eval time and folds `+`. `where` filters each term as `If(where_i, body_i, 0)`; empty domain → 0. Zero solver-side novelty — it is exactly the hand-written idiom, generalized and instances-independent.
- **Dual evaluator**: one shared implementation in `values.py` (`eval_sum_binder`), parameterized over the same `dom`/`ev` abstraction as `eval_quant`/`eval_count`; `bmc.py` (symbolic) and `runtime.py` Monitor (concrete) each add a one-line dispatch — agreement is structural.
- **Typing** (check-time, in `build_spec`): binder type resolves like a forall binder (unknown type → `kind:"type"` error naming it); `where` must be Bool; body must be Int-family — a Bool body is a clear type error (`sum body must be Int, got bool`).
- **Nested sums** work by recursion; no special case.
- Docs: `docs/LANGUAGE.md` (expressions + decreases sections), `skills/fsl/reference.md` rule 7 (per-entity trap now points at `sum` instead of the hand-written idiom), new `docs/DESIGN-sum-aggregate.md`, `CHANGELOG.md` [Unreleased].

## Tests

New `tests/test_sum_aggregate.py` (11 tests, all passing):

1. Regression baseline: `decreases level[c]` still fails with `rank_failure: "non_decreasing_action"`; the same spec with `decreases sum k: Case { level[k] }` gets an **unbounded** ranking proof (`proved` / `completeness: "unbounded"`).
2. Instances-independence: proved with `instances Case = 3` and `instances Case = 5`, and via the #86 CLI override `instances=["Case=5"]` — no measure edit.
3. `where` clause: verifies in an invariant, plus a direct bmc.eval_expr vs runtime.eval_concrete cross-check on a pinned state (unsat disagreement query, per `test_evaluator_agreement.py`'s approach).
4. Type errors: Bool body and unknown binder type are check-time `FslError`s with messages naming the problem.
5. Nested sum with a fixed hand-computed expectation.
6. Kernel (non-dialect) spec over `type Id = 0..2`.
7. A state variable literally named `sum` still parses/verifies (contextual keyword, like count/forall).

Fast signals: `test_ranking_synthesis.py` + `test_induction.py` + `test_evaluator_agreement.py` → 32 passed, 3 skipped. Broader sweep (`test_v1.py`, `test_cli_bounds_override.py`, `test_biz_dialect.py`, `test_compose.py`, `test_dialect_terminal.py`, `test_explain.py`, `test_governance_business.py`, `test_mutate.py`, `test_req_dialect.py`) → 118 passed. Corpus snapshot (`test_corpus_snapshot.py`) → **152 passed, 1 skipped, unchanged** (no `.fsl` under specs//examples/ touched; snapshot not regenerated).

Closes #91. Phase 1 of #72; Phase 2 (fairness-aware helpful-action discipline, `decreases M by <action>`) stays open on #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)