### PR TITLE
docs: correct false "no sum() aggregate" claim in decreases guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- `docs/LANGUAGE.md` and `skills/fsl/reference.md` wrongly claimed there is
+  no `sum()` aggregate usable in a `decreases` ranking measure, steering
+  readers toward hand-written sums (`decreases level[0] + level[1]`) that
+  only scale to domains small enough to enumerate by hand. The kernel's
+  bounded `sum(x: T of expr [where expr])` aggregate has always been usable
+  there (`decreases sum(k: Case of level[k])`), proves `unbounded`
+  completeness under `--engine induction`, and is instances-count
+  independent (composes with `--instances` overrides, #86). Corrected both
+  docs and added regression coverage in `tests/test_sum_decreases.py`. (#91,
+  see also the still-open per-entity fairness gap, #72)
+
 ## [2.6.1] - 2026-07-03
 
 ### Fixed

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -180,13 +180,19 @@ per-entity liveness under interleaving needs a fairness-aware discipline
 (only the binding's own "helpful" action must decrease); that is not
 implemented and is tracked separately (issue #72).
 
-**Working idiom: a global sum measure.** Sum the tracked quantity across a
-fixed, small domain, e.g. `decreases level[0] + level[1]` for a 2-element
-`Case` domain — every action then strictly decreases the total, and
-induction returns `"proved"` with `"completeness": "unbounded"`. There is no
-`sum()` aggregate over a domain type usable here, so this idiom only scales
-to domains small enough to enumerate by hand. (Conditional expressions can't
-substitute for a per-branch measure either: `if/then/else` is legal only in
+**Working idiom: a global sum measure.** Sum the tracked quantity across the
+domain with the built-in `sum()` aggregate (§3): `decreases sum(k: Case of
+level[k])`. `sum()` enumerates the bounded `Case` domain itself, so the
+measure is instances-count independent — the same `decreases` clause works
+unchanged whether `Case` is sized via `verify { instances Case = N }` or
+shrunk with a CLI `--instances` override. Because every fair `step` decrements
+exactly one `level[k]`, every enabled action strictly decreases the total, so
+induction returns `"proved"` with `"completeness": "unbounded"`. This idiom
+only covers designs where *every* enabled action decreases the total; a
+design where some enabled action advances the domain without shrinking the
+sum is still an open case, needing the fairness-aware "helpful action"
+discipline from issue #72 above. (Conditional expressions can't substitute
+for a per-branch measure either: `if/then/else` is legal only in
 refinement-mapping expressions (§10), not in the general expression grammar
 that `decreases` draws from.)
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -239,9 +239,11 @@ check as a type error.
      every enabled action must decrease M, so an action advancing a
      *different* entity (`step(c=1)` while `c=0` is pending) violates it.
      Reported as `rank_failure: "non_decreasing_action"`. Working idiom:
-     a **global sum measure** over a fixed small domain, e.g.
-     `decreases level[0] + level[1]`, since there is no `sum()` aggregate to
-     generalize it. Fairness-aware per-entity ranking is future work (#72).
+     a **global sum measure** with the built-in `sum()` aggregate, e.g.
+     `decreases sum(k: Case of level[k])` — instances-count independent,
+     works with `--instances` overrides too. Only covers designs where every
+     enabled action decreases the total; fairness-aware per-entity ranking
+     is future work (#72).
 8. `symmetric type` / `symmetric enum` means those values are interchangeable
    entity identities. For leadsTo lasso/stall search, fslc symmetry-breaks the
    representative state using canonical rows from `Map<SymmetricType, V>` and

--- a/tests/test_sum_decreases.py
+++ b/tests/test_sum_decreases.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Regression coverage for `decreases sum(...)` (#91).
+
+`docs/LANGUAGE.md` and `skills/fsl/reference.md` wrongly claimed no `sum()`
+aggregate is usable in a ranking `decreases` measure, steering readers to
+hand-written sums (`decreases level[0] + level[1]`) that only scale to
+domains small enough to enumerate by hand. The kernel's bounded
+`sum(x: T of expr [where expr])` aggregate (§3 of both docs) has always been
+usable there — this file is the regression coverage that was missing when
+that false claim was written, using only *existing* syntax (no source
+changes accompany this fix).
+
+Contrast: the per-entity trap the docs correctly describe (`decreases
+level[c]`) still fails under interleaving — see
+`test_per_entity_measure_still_fails_under_interleaving` below, mirroring
+the assertion shape in `tests/test_induction.py`.
+"""
+from fslc.cli import run_verify
+
+KERNEL_SUM_SRC = r'''spec SumRankKernel {
+  type Case = 0..2
+  state { level: Map<Case, 0..3> }
+  init { forall c: Case { level[c] = 3 } }
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    decreases sum(k: Case of level[k])
+  }
+}
+'''
+
+KERNEL_SUM_PER_ENTITY_SRC = r'''spec SumRankKernelPerEntity {
+  type Case = 0..2
+  state { level: Map<Case, 0..3> }
+  init { forall c: Case { level[c] = 3 } }
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    decreases level[c]
+  }
+}
+'''
+
+KERNEL_SUM_WHERE_SRC = r'''spec SumWhereKernel {
+  type Case = 0..2
+  state { level: Map<Case, 0..3> }
+  init { forall c: Case { level[c] = 3 } }
+  action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant BoundedSum { sum(k: Case of level[k] where level[k] > 0) <= 9 }
+}
+'''
+
+REQ_SUM_SRC = r'''requirements SumRankRequirements {
+  entity Case
+  number Level
+
+  state { level: Map<Case, Level> }
+
+  init {
+    forall c: Case { level[c] = 2 }
+  }
+
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    decreases sum(k: Case of level[k])
+  }
+}
+verify {
+  instances Case = 3
+  values Level = 0..3
+}
+'''
+
+
+def _write(tmp_path, src, name):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_kernel_sum_measure_proves_unbounded(tmp_path):
+    spec = _write(tmp_path, KERNEL_SUM_SRC, "sum_kernel.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "proved"
+    entry = out["leads_to"]["Responds"]
+    assert entry["proved"] is True
+    assert entry["proof"] == "ranking"
+    assert entry["completeness"] == "unbounded"
+    assert entry["decreases"] == "sum(k: Case of level[k])"
+
+
+def test_requirements_dialect_sum_measure_proves_unbounded(tmp_path):
+    spec = _write(tmp_path, REQ_SUM_SRC, "sum_req.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "proved"
+    entry = out["leads_to"]["Responds"]
+    assert entry["proved"] is True
+    assert entry["completeness"] == "unbounded"
+
+
+def test_requirements_dialect_sum_measure_composes_with_instances_override(tmp_path):
+    # The measure is instances-count independent (#86): overriding the CLI
+    # instance count still proves unbounded with the same decreases clause.
+    spec = _write(tmp_path, REQ_SUM_SRC, "sum_req_override.fsl")
+    out = run_verify(
+        str(spec), 1, "warn", engine="induction", k_ind=1, instances=["Case=5"]
+    )
+    assert out["result"] == "proved"
+    entry = out["leads_to"]["Responds"]
+    assert entry["proved"] is True
+    assert entry["completeness"] == "unbounded"
+    assert out["bounds_overrides"] == {"instances": {"Case": 5}, "values": {}}
+
+
+def test_sum_where_aggregate_verified_under_bmc(tmp_path):
+    spec = _write(tmp_path, KERNEL_SUM_WHERE_SRC, "sum_where.fsl")
+    out = run_verify(str(spec), 3, "warn")
+    assert out["result"] == "verified"
+
+
+def test_per_entity_measure_still_fails_under_interleaving(tmp_path):
+    # Contrast regression (kept honest by docs/LANGUAGE.md): a per-entity
+    # measure is a different, still-broken idiom from the sum measure above.
+    spec = _write(tmp_path, KERNEL_SUM_PER_ENTITY_SRC, "sum_kernel_per_entity.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "unknown_cti"
+    assert out["violation_kind"] == "leadsTo_rank"
+    assert out["rank_failure"] == "non_decreasing_action"
+    assert out["invariant"] == "Responds"
+    assert out["measure"] == "level[c]"
+    assert out["last_action"]["name"] == "step"
+    assert out["measure_after"] >= out["measure_before"]


### PR DESCRIPTION
## What was wrong

`docs/LANGUAGE.md` and `skills/fsl/reference.md` both claimed there is no
`sum()` aggregate usable inside a `decreases` ranking measure, steering
readers toward hand-written sums (`decreases level[0] + level[1]`) that
"only scale to domains small enough to enumerate by hand." This was false:
the kernel has always had a bounded `sum(x: T of expr [where expr])`
aggregate (documented two lines above the offending passage in
`skills/fsl/reference.md`, which the passage directly contradicted).

## What's corrected

Both docs now recommend the canonical measure `decreases sum(k: Case of
level[k])`:

- It's the built-in aggregate, not a hand-rolled sum, so it scales to any
  domain size instead of only ones small enough to write out by hand.
- It's instances-count independent: the same `decreases` clause works
  unchanged with `verify { instances Case = N }` and with a CLI
  `--instances` override (#86).
- The correction keeps the surrounding truth intact: the ranking discipline
  still requires *every* enabled action to strictly decrease the measure, so
  per-entity measures (`decreases level[c]`) still fail under interleaving
  with `rank_failure: non_decreasing_action`, and generalizing beyond
  "every action shrinks the sum" remains the open fairness-aware
  "helpful action" discipline tracked as #72.

## New regression tests

`tests/test_sum_decreases.py` (no source changes in this PR — this exercises
existing, already-working syntax that had zero test coverage, which is how
the docs error survived):

- Kernel spec with `decreases sum(k: Case of level[k])` → `proved` /
  `completeness: "unbounded"` under `--engine induction`.
- Same shape in the requirements dialect (`entity`/`number` + `verify {
  instances / values }`) → proved unbounded, both with and without an
  `--instances` CLI override (composition with #86).
- `where`-filtered `sum(...)` in an invariant → verified under BMC.
- Contrast regression: the same kernel spec with a per-entity
  `decreases level[c]` measure → still fails with
  `rank_failure: "non_decreasing_action"`, confirming the docs' still-correct
  claim about that trap.

```
tests/test_sum_decreases.py .....                                     [100%]
5 passed
tests/test_ranking_synthesis.py + tests/test_induction.py ............ [100%]
12 passed
```

Refs #91, #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)