### PR TITLE
fix(verify): propagate --instances/--values into inline implements abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- `fslc verify --instances`/`--values` overrides (#86) now propagate into an
+  inline `implements` abstract spec, restricted to the entity/number names the
+  abstract declares. Refinement is a same-world-size forward simulation, so a
+  shrunken impl (`--instances Claim=1`) against a still-full-size abstract
+  previously failed the refinement with `map_out_of_bounds` (surfaced only in
+  the `implements` sub-field, with the overall `result` staying `verified`).
+  Both sides now shrink together; an impl-only carried number (e.g. `Amount`,
+  absent from a business abstract) applies to the impl only. (#94)
+
 ## [2.6.2] - 2026-07-03
 
 ### Fixed

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -95,6 +95,14 @@ error (exit code 2), as is a malformed value (`Case=abc`, `N=5..1`). The
 effective overridden bounds are echoed back in the JSON envelope's
 `bounds_overrides` field.
 
+When the spec has an inline `implements`, the override also propagates into the
+abstract spec — restricted to the entity/number names the abstract itself
+declares — so the refinement check runs at the same world size on both sides
+(refinement is a same-size forward simulation; without this, a shrunken impl
+and a full-size abstract would fail with `map_out_of_bounds`). An impl-only
+carried number (e.g. `Amount`, absent from a business abstract) applies to the
+impl only.
+
 `acceptance`/`forbidden` scenarios often hardcode ids/numbers from the spec's
 original world (`accept(2)`), which can fall outside a shrunken override
 (`--instances Case=1`). When overrides are active, a scenario whose replay

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -345,7 +345,12 @@ first failed layer and later layers are marked `skipped`.
   whole `verify`, with a `warnings` entry (`kind: "acceptance_skipped"` /
   `"forbidden_skipped"`) naming it; other scenarios still replay normally.
   Without an override, or for a failure unrelated to bounds, the scenario
-  still hard-errors as before.
+  still hard-errors as before. When the spec has an inline `implements`, the
+  override also propagates into the abstract spec (restricted to the
+  entity/number names the abstract declares) so refinement is checked at the
+  same world size on both sides — otherwise a shrunken impl vs a full-size
+  abstract fails `map_out_of_bounds`; an impl-only carried number applies to
+  the impl only.
 - `explain` is deterministic formatting with no LLM. JSON mode enumerates
   state/action/requires/writes/properties/implicit checks by source loc and
   structural traversal, and attaches to each user invariant the shortest

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -16,13 +16,16 @@ def _err(message, kind="type", loc=None, hint=None):
     raise FslError(message, kind=kind, loc=loc, hint=hint)
 
 
-def _parse_file(path):
+def _parse_file(path, bounds_overrides=None):
     src = Path(path).read_text(encoding="utf-8")
     ast = Ast().transform(PARSER.parse(src))
+    filtered = _overrides_for_declared_names(ast, bounds_overrides)
+    if filtered is not None:
+        ast = apply_verify_bounds_overrides(ast, filtered)
     if ast[0] == "compose":
         return expand_compose(ast, str(Path(path).parent))
     if ast[0] == "requirements":
-        return _expand_requirements_with_display(ast, str(Path(path).parent))
+        return _expand_requirements_with_display(ast, str(Path(path).parent), bounds_overrides)
     if ast[0] == "business":
         return expand_business(ast), {}
     if ast[0] == "governance":
@@ -156,6 +159,26 @@ def apply_verify_bounds_overrides(ast, overrides):
             merged.append(("verify_values", bname, lo, hi, None))
         out_items.append(("verify_bounds", merged, None))
     return (tag, name, out_items)
+
+
+def _overrides_for_declared_names(ast, overrides):
+    """Restrict CLI bounds overrides to names this AST declares as
+    `entity`/`number`. Used when propagating a `fslc verify` override into an
+    inline-implements *abstract* spec: the impl already validated the full
+    override against its own declarations, and the abstract must be shrunk to
+    the same world size for the refinement check to stay well-posed — but only
+    for the entities/numbers it shares (an impl-only name like a carried
+    `Amount` has no counterpart in the abstract and must not reach it)."""
+    if not overrides:
+        return None
+    declared = {it[1] for it in ast[2] if it[0] in ("entity", "number")}
+    filtered = {
+        "instances": {n: v for n, v in (overrides.get("instances") or {}).items() if n in declared},
+        "values": {n: v for n, v in (overrides.get("values") or {}).items() if n in declared},
+    }
+    if not filtered["instances"] and not filtered["values"]:
+        return None
+    return filtered
 
 
 def _collect_verify_bounds(items):
@@ -896,7 +919,7 @@ def _expand_time(out, time_block, deadlines, action_aliases, action_maps, implem
     return generated_names
 
 
-def _expand_requirements_with_display(ast, base_dir):
+def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
     _, name, items = ast
     out = []
     display_names = {}
@@ -944,7 +967,7 @@ def _expand_requirements_with_display(ast, base_dir):
             abs_path = Path(base_dir) / path
             if not abs_path.is_file():
                 _err(f"file not found: {path}", kind="io", loc=loc)
-            abs_ast, abs_display_names = _parse_file(abs_path)
+            abs_ast, abs_display_names = _parse_file(abs_path, bounds_overrides)
             if abs_ast[0] != "spec" or abs_ast[1] != abs_name:
                 _err(f"spec name mismatch: expected '{abs_name}', got '{abs_ast[1]}'", loc=loc)
             implements = {
@@ -1046,9 +1069,13 @@ def expand_requirements(ast, base_dir):
     return expanded
 
 
-def expand_requirements_with_display(ast, base_dir):
-    """Expand requirements AST and return display names for parser plumbing."""
-    return _expand_requirements_with_display(ast, base_dir)
+def expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
+    """Expand requirements AST and return display names for parser plumbing.
+
+    ``bounds_overrides`` (from ``fslc verify --instances``/``--values``) is
+    propagated into any inline-implements *abstract* spec so the refinement
+    check runs at the same overridden world size on both sides (#94)."""
+    return _expand_requirements_with_display(ast, base_dir, bounds_overrides)
 
 
 def _type_name_from_binder(binder):

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -42,7 +42,8 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
     if ast[0] == "compose":
         ast, display_names = expand_compose(ast, base_dir or ".")
     elif ast[0] == "requirements":
-        ast, display_names = expand_requirements_with_display(ast, base_dir or ".")
+        ast, display_names = expand_requirements_with_display(
+            ast, base_dir or ".", bounds_overrides)
     elif ast[0] == "business":
         ast = expand_business(ast)
     elif ast[0] == "governance":

--- a/tests/test_implements_bounds_override.py
+++ b/tests/test_implements_bounds_override.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""`fslc verify --instances`/`--values` overrides (#86) must propagate into an
+inline-implements *abstract* spec (#94).
+
+Refinement is a same-world-size forward simulation: `refine(impl, abs, ...)`
+maps impl entity `c` to abstract entity `c`. A bounds override redefines the
+impl's world size, but the abstract is parsed independently during the impl's
+desugaring and, before this fix, kept its own (larger) size — so the identity
+mapping referenced abstract indices the shrunken impl never produced and the
+refinement failed with `map_out_of_bounds`. The overall `result` stayed
+`verified` (the failure was confined to the `implements` sub-field), which is
+exactly why it was easy to miss.
+
+The fix propagates the override into the abstract, restricted to the
+entity/number names the abstract itself declares (an impl-only carried number
+like `Amount` has no abstract counterpart and must not reach it).
+"""
+from fslc.cli import run_verify
+
+ABS_SRC = r'''business ClaimFlow {
+  actor Employee, Manager
+  entity Claim
+  process Claim {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+    transition approve Submitted -> Approved  by Manager
+  }
+}
+verify {
+  instances Claim = 3
+}
+'''
+
+IMPL_SRC = r'''requirements ClaimReq {
+  implements ClaimFlow from "abs.fsl" { }
+
+  process Claim {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+      covers REQ-1 "employee submits"
+    transition approve Submitted -> Approved  by Manager
+      covers REQ-2 "manager approves"
+  }
+}
+verify {
+  instances Claim = 3
+}
+'''
+
+# Impl carries an amount the business abstract does not model — the override
+# for it must apply to the impl only and must not error against the abstract.
+IMPL_WITH_AMOUNT_SRC = r'''requirements ClaimReqAmount {
+  implements ClaimFlow from "abs.fsl" { }
+
+  number Amount
+
+  process Claim with amount: Amount {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+      with a: Amount
+      when a >= 0
+      set amount = a
+      covers REQ-1 "employee submits"
+    transition approve Submitted -> Approved  by Manager
+      covers REQ-2 "manager approves"
+  }
+}
+verify {
+  instances Claim = 3
+  values Amount = 0..3
+}
+'''
+
+
+def _pair(tmp_path, impl_src):
+    (tmp_path / "abs.fsl").write_text(ABS_SRC, encoding="utf-8")
+    impl = tmp_path / "impl.fsl"
+    impl.write_text(impl_src, encoding="utf-8")
+    return impl
+
+
+def test_instances_override_propagates_to_abstract(tmp_path):
+    # Before #94 this returned implements.result == "refinement_failed"
+    # (kind "map_out_of_bounds"); the abstract must shrink to match.
+    impl = _pair(tmp_path, IMPL_SRC)
+    out = run_verify(str(impl), 6, "warn", instances=["Claim=1"])
+    assert out["result"] == "verified"
+    assert out["implements"]["result"] == "refines"
+    assert out["bounds_overrides"] == {"instances": {"Claim": 1}, "values": {}}
+
+
+def test_no_override_refinement_unchanged(tmp_path):
+    impl = _pair(tmp_path, IMPL_SRC)
+    out = run_verify(str(impl), 6, "warn")
+    assert out["result"] == "verified"
+    assert out["implements"]["result"] == "refines"
+    assert "bounds_overrides" not in out
+
+
+def test_impl_only_number_override_does_not_reach_abstract(tmp_path):
+    # `Amount` exists only in the impl; overriding it must not error against
+    # the abstract (which declares no `Amount`) and the refinement still holds.
+    impl = _pair(tmp_path, IMPL_WITH_AMOUNT_SRC)
+    out = run_verify(str(impl), 6, "warn", instances=["Claim=1"], values=["Amount=0..1"])
+    assert out["result"] == "verified"
+    assert out["implements"]["result"] == "refines"


### PR DESCRIPTION
## Symptom

`fslc verify --instances Claim=1` on a requirements spec with an inline `implements` returned `implements: refinement_failed` (`kind: map_out_of_bounds`) even though the same spec `refines` at the default size. The overall `result` stayed `verified` — the refinement failure was confined to the `implements` sub-field — which made it easy to miss.

```
fslc verify examples/e2e/2_requirements.fsl --depth 6 --instances Claim=1
# before: implements.result == "refinement_failed" (map_out_of_bounds, at init)
# after:  implements.result == "refines"
```

## Root cause

Refinement is a **same-world-size** forward simulation: `refine(impl, abs, mapping)` maps impl entity `c` to abstract entity `c`. The bounds override (#86) was applied only to the impl's top AST in `parse_src`; the abstract is parsed independently during the impl's desugaring (`dialects._parse_file`) and desugared to a kernel AST, so it kept its original size. impl(1) vs abs(3) is an ill-posed check — the identity mapping references abstract indices `1,2` the shrunken impl never produces.

## Fix

Thread `bounds_overrides` through the requirements expansion to the abstract parse and apply it there **before desugaring**, restricted to the entity/number names the abstract itself declares (via a new `_overrides_for_declared_names` filter). Both sides shrink to the same size, so the refinement stays well-posed and is checked at the smaller model — exactly the small-model intent of #86. An impl-only carried number (e.g. `Amount`, absent from a business abstract) is filtered out and applies to the impl only. No changes to `bmc.py`/`runtime.py`/`refine.py`.

## Tests

New `tests/test_implements_bounds_override.py` (3 cases): `--instances Claim=1` now refines; no-override behavior unchanged; impl-only `Amount` override doesn't reach the abstract. The minimal pair was verified to reproduce `map_out_of_bounds` pre-fix (git stash) and `refines` post-fix.

- `test_implements_bounds_override.py` + `test_cli_bounds_override.py` + `test_acceptance_override_skip.py` + `test_req_dialect.py` + `test_layers_chain.py`: **25 passed**
- `test_corpus_snapshot.py`: **152 passed, 1 skipped — no diff** (override-less parsing is unchanged)

Scope: inline `implements` under `fslc verify` (requirements-only). The `refine`/`chain` subcommands take separate file args and have no `--instances` flag; out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)