### PR TITLE
chore(tooling): repo-tailored Claude Code automation (hooks, skills, agents, MCP)

### DIFF
--- a/.claude/agents/fsl-coupled-change-reviewer.md
+++ b/.claude/agents/fsl-coupled-change-reviewer.md
@@ -1,0 +1,46 @@
+---
+name: fsl-coupled-change-reviewer
+description: Use PROACTIVELY after changing FSL grammar/verifier/runtime or any .fsl under specs/examples, and before opening a PR. Audits the "a language feature moves all of its files together" rule from CLAUDE.md/CONTRIBUTING.md — flags coupled files (docs, agent reference, design note, tests, CHANGELOG, SPDX, corpus snapshot) that a change touched the code side of but forgot to update. Read-only; reports gaps, does not fix them.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a completeness reviewer for the `fslc` repository. This project has a strict,
+documented rule: **a language feature must move all of its files together.** Your job is
+to inspect the current change set and report which coupled files were missed. You do not
+edit anything — you produce a gap report.
+
+## How to inspect the change set
+
+Run `git status --porcelain` and `git diff --stat` (and `git diff` for detail) to see what
+changed. Also consider staged and unstaged changes.
+
+## The coupling rules (from CLAUDE.md / CONTRIBUTING.md / AGENTS.md)
+
+1. **Kernel/semantics change** — if any of `src/fslc/grammar.py`, `src/fslc/model.py`,
+   `src/fslc/bmc.py` changed, then check that these moved too:
+   - `docs/LANGUAGE.md` (the complete language reference must stay complete)
+   - `skills/fsl/reference.md` (agent-facing rules must track grammar changes)
+   - a `docs/DESIGN-<feature>.md` (new or updated design note)
+   - a regression test under `tests/` (`tests/test_<feature>.py` or an existing file)
+2. **Concrete semantics** — if `src/fslc/bmc.py` changed in a way that affects state/step
+   semantics, `src/fslc/runtime.py` (the concrete `Monitor`) very likely must change too,
+   or the dual evaluator will disagree. Flag a bmc-only semantic change for the
+   `fsl-soundness-reviewer` to look at.
+3. **Frontend/dialect change** — if `src/fslc/dialects.py` or `src/fslc/compose.py` changed
+   (surface syntax / desugaring), confirm `docs/LANGUAGE.md` and `skills/fsl/reference.md`
+   reflect the new surface.
+4. **Corpus snapshot** — if any `.fsl` under `specs/` or `examples/` changed, or any
+   evaluator semantics changed, `tests/snapshots/corpus_snapshot.json` will diff. Confirm
+   the change author has run/regenerated it intentionally (it must never be silently
+   skipped). Do NOT propose hand-editing it.
+5. **CHANGELOG** — confirm a bullet was added under `## [Unreleased]` in `CHANGELOG.md`.
+6. **SPDX** — confirm every *new* `.py` file starts with
+   `# SPDX-License-Identifier: Apache-2.0` and a copyright line.
+7. **Commit hygiene** — one topic per change; note if the diff bundles unrelated topics.
+
+## Output
+
+Produce a concise checklist-style report: for each rule that applies to this change set,
+mark it satisfied or **MISSING**, and for each gap name the exact file(s) the author still
+needs to touch and why. End with a one-line verdict: "coupled-change complete" or "N gaps".
+Be specific and cite `path:line` where useful. Do not modify files.

--- a/.claude/agents/fsl-soundness-reviewer.md
+++ b/.claude/agents/fsl-soundness-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: fsl-soundness-reviewer
+description: Use PROACTIVELY after changing src/fslc/bmc.py, runtime.py, model.py, or refine.py. Reasons about whether the change could make the symbolic BMC evaluator and the concrete Monitor disagree, or introduce a false negative (reporting something truly violated/refinement_failed as verified/proved/refines) — the failure mode Z3 bugs hide. Recommends and runs the specific cross-check tests. Read-only on source; may run tests.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a soundness reviewer for the `fslc` verifier. The core correctness invariant of
+this repo is a **dual evaluator that must agree**, guarded by a **Z3-independent oracle**:
+
+- `src/fslc/bmc.py` — symbolic: unrolls transitions into Z3 and solves (`verify` / `prove`).
+- `src/fslc/runtime.py` `Monitor` — a concrete, Z3-free interpreter (also powers `replay`,
+  `testgen`).
+- `tests/test_evaluator_agreement.py` cross-checks the two step-by-step on witness replay.
+- `tests/oracle.py` is a Z3-independent BFS brute-forcer driving `Monitor` to catch **false
+  negatives** — something truly violated being reported verified/proved/refines. This is
+  the failure mode Z3 encoding bugs hide, and the one that matters most.
+
+The dangerous change is not one that crashes — it is one that makes the tool confidently
+*wrong* (green when it should be red). Weight your review toward that.
+
+## What to check
+
+1. **Read the diff** (`git diff` on the changed evaluator files). Identify whether it
+   changes state/step semantics, transition encoding, invariant/temporal-operator handling,
+   ranking/`decreases` logic, or refinement (`refine.py`) simulation.
+2. **Symbolic ↔ concrete parity.** If `bmc.py` changed how a construct evaluates, does
+   `runtime.py`'s `Monitor` change to match (and vice versa)? A change to one and not the
+   other is the classic disagreement bug. Explain concretely how they could diverge.
+3. **False-negative risk.** Could the change cause a real violation / failed refinement to
+   be reported as verified/proved/refines? Consider: dropped constraints, over-broad
+   simplifications, off-by-one unrolling, an over-permissive `implements`/refinement mapping,
+   or a same-world-size assumption. Refinement is a same-world-size forward simulation —
+   watch bounds/`--instances` handling especially.
+4. **Vacuity/tautology risk** introduced in the encoding (a constraint that is trivially SAT).
+
+## Then run the guards
+
+Prefer the working-tree venv (the global `fslc` points at a different tree):
+
+- `.venv/bin/python -m pytest tests/test_evaluator_agreement.py tests/test_oracle_agreement.py -q`
+- If refinement changed: add `tests/test_refine_oracle.py tests/test_trace_soundness.py`.
+- The corpus snapshot (`tests/test_corpus_snapshot.py`) will diff on any semantics change —
+  run it and report whether the diff is intended (never advise silently skipping it).
+
+## Output
+
+Report: (a) a concrete risk assessment for BMC↔Monitor divergence and false negatives, with
+specific scenarios; (b) which guard tests you ran and their results; (c) a verdict —
+"sound: guards pass, no divergence risk found" or the specific concern to resolve. Do not
+edit source; you may run tests.

--- a/.claude/agents/fsl-vacuity-reviewer.md
+++ b/.claude/agents/fsl-vacuity-reviewer.md
@@ -1,0 +1,33 @@
+---
+name: fsl-vacuity-reviewer
+description: Use PROACTIVELY after adding or changing a .fsl spec under specs/ or examples/. Checks the spec is not hollow (vacuously verifying) by running fslc mutate for a kill-rate and fslc --vacuity, and flags invariants that look weakened to dodge a counterexample. Read-only on specs; runs the verifier.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a non-vacuity reviewer for FSL specs. A spec that verifies is worthless if it
+verifies *vacuously* — the repo rule is: **do not hollow out specs to make them go green.**
+Your job is to check that changed `.fsl` specs still say something.
+
+Use the working-tree venv (`.venv/bin/python -m fslc …`); the global `fslc` is a different tree.
+
+## What to do
+
+1. **Find the changed specs.** From `git status --porcelain` / `git diff`, list `.fsl` files
+   under `specs/` or `examples/` that were added or modified.
+2. **Read the diff of each spec.** Look specifically for invariants that were *weakened*
+   (a bound loosened, a conjunct dropped, a guard broadened, a property turned into a
+   near-tautology) between the old and new version — that is the hollowing smell, especially
+   if it coincides with making a previously-failing check pass.
+3. **Mutation kill-rate — the primary signal.** Run `.venv/bin/python -m fslc mutate <spec>`
+   for each changed spec and report the kill-rate. A very low kill-rate (roughly <10%) means
+   the spec barely constrains anything and mutants survive — treat that as hollow and say so.
+4. **Vacuity check.** Run `.venv/bin/python -m fslc verify <spec> --vacuity error` (or the
+   spec's configured vacuity handling). Note: `--vacuity` alone misses dead-ghost
+   tautologies, which is why the mutation kill-rate is the stronger gate — report both.
+
+## Output
+
+For each changed spec: the mutation kill-rate, the vacuity result, and a verdict
+("meaningful" / "**looks hollow** — <which invariant, why>"). If you flag a spec, point at
+the specific invariant or diff hunk and explain what real behavior it fails to constrain.
+Recommend strengthening the property rather than accepting the green. Do not edit specs.

--- a/.claude/hooks/changelog_reminder.py
+++ b/.claude/hooks/changelog_reminder.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+"""Stop hook: nudge if src/fslc changed without a CHANGELOG entry.
+
+Non-blocking. When a turn ends, if the working tree has changes under ``src/fslc/`` but
+``CHANGELOG.md`` is untouched, it prints a reminder — the repo convention is one bullet
+per change under ``## [Unreleased]``. Always exits 0: this nudges, it never blocks the
+stop (so it cannot loop).
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+    # Avoid re-entrancy if a prior stop hook already kept the turn alive.
+    if data.get("stop_hook_active"):
+        return 0
+    root = data.get("cwd") or os.getcwd()
+    try:
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        ).stdout
+    except Exception:
+        return 0
+    files = [line[3:].strip() for line in out.splitlines() if line.strip()]
+    touched_src = any(f.startswith("src/fslc/") for f in files)
+    touched_changelog = any(f.endswith("CHANGELOG.md") for f in files)
+    if touched_src and not touched_changelog:
+        sys.stderr.write(
+            "Reminder: src/fslc changed but CHANGELOG.md was not. "
+            "Add a bullet under ## [Unreleased] (one topic per change).\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/fslc_check.py
+++ b/.claude/hooks/fslc_check.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+"""PostToolUse hook: run ``fslc check`` on an edited ``.fsl`` file.
+
+This is the fast inner-loop signal the repo relies on (parse + type check), not the
+slow full ``pytest`` suite. Reads the Claude Code hook JSON from stdin; if the
+edited/written file is a ``.fsl`` spec, it runs the *working-tree* verifier
+(``.venv/bin/python -m fslc check``) on it. On failure it forwards the fslc output to
+stderr and exits 2 so Claude sees the diagnostics and can repair. On success — or when
+there is no working-tree venv (e.g. CI) or the file is not a ``.fsl`` — it exits 0
+quietly.
+
+Note: the global ``fslc`` on PATH points at ``~/.fsl``, a different tree, so this hook
+deliberately uses the repo venv's interpreter.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    path = (data.get("tool_input") or {}).get("file_path") or ""
+    if not path.endswith(".fsl"):
+        return 0
+    root = data.get("cwd") or os.getcwd()
+    py = os.path.join(root, ".venv", "bin", "python")
+    if not os.path.exists(py):
+        return 0  # no working-tree venv; nothing to check against
+    proc = subprocess.run(
+        [py, "-m", "fslc", "check", path],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(
+            "fslc check failed for {}:\n{}{}".format(path, proc.stdout, proc.stderr)
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/snapshot_guard.py
+++ b/.claude/hooks/snapshot_guard.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+"""PreToolUse hook: block hand-edits to the corpus snapshot.
+
+``tests/snapshots/corpus_snapshot.json`` is a generated golden file and the repo's
+core behavior-preservation safety net. It must only change via
+``FSLC_SNAPSHOT_UPDATE=1 pytest tests/test_corpus_snapshot.py`` — a direct Edit/Write is
+almost always a mistake (hollowing the net to dodge a diff). This hook blocks such a
+write (exit 2) and points at the regeneration command. The legitimate regeneration path
+goes through pytest, not an editing tool, so it is unaffected.
+"""
+import json
+import os
+import sys
+
+TARGET = os.path.join("tests", "snapshots", "corpus_snapshot.json")
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    path = (data.get("tool_input") or {}).get("file_path") or ""
+    if not path:
+        return 0
+    if os.path.normpath(path).endswith(TARGET):
+        sys.stderr.write(
+            "Refusing to hand-edit the corpus snapshot ({}).\n".format(TARGET)
+            + "Regenerate it only after an intended behavior change (review the diff first):\n"
+            + "  FSLC_SNAPSHOT_UPDATE=1 .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q\n"
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/spdx_guard.py
+++ b/.claude/hooks/spdx_guard.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+"""PostToolUse hook: require an SPDX header on written ``.py`` files.
+
+Mirrors the repo convention (CONTRIBUTING.md / CLAUDE.md): new Python source files
+carry ``# SPDX-License-Identifier: Apache-2.0`` plus a copyright line. Reads the Claude
+Code hook JSON from stdin; if a written ``.py`` file lacks the SPDX line near its top,
+it exits 2 with a reminder so Claude adds the header. Otherwise exits 0.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0
+    path = (data.get("tool_input") or {}).get("file_path") or ""
+    if not path.endswith(".py"):
+        return 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            head = fh.read(1000)
+    except OSError:
+        return 0
+    if "SPDX-License-Identifier" in head:
+        return 0
+    sys.stderr.write(
+        "{}: missing SPDX header. Add these two lines at the very top:\n".format(path)
+        + "# SPDX-License-Identifier: Apache-2.0\n"
+        + "# Copyright <year> <name>\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/snapshot_guard.py" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/fslc_check.py" }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/spdx_guard.py" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "python3 .claude/hooks/changelog_reminder.py" }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-language-feature/SKILL.md
+++ b/.claude/skills/add-language-feature/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: add-language-feature
+description: Scaffold and checklist a new FSL kernel language feature so every file the repo requires to move together actually moves. Use when adding or changing FSL surface syntax or kernel semantics (grammar, model, verifier, or runtime behavior) — it enforces the "a language feature moves all of its files together" rule from CLAUDE.md/CONTRIBUTING.md and the corpus-snapshot discipline.
+---
+
+# add-language-feature — move all the coupled files together
+
+CLAUDE.md and CONTRIBUTING.md require that a language feature move **all** of its files
+in one change. The single most common mistake is landing the grammar/verifier edit and
+forgetting a doc, the agent-facing reference, the design note, the regression test, or
+the snapshot regeneration. This skill turns that rule into a checklist and does the
+scaffolding.
+
+## First decide: frontend or kernel?
+
+The pipeline is `parser → (dialects/compose desugar) → model.build_spec → bmc/runtime`.
+**Prefer adding to the frontend over widening the kernel.** A new *surface syntax* is
+usually a desugaring in `dialects.py` / `compose.py` that lowers to existing kernel AST —
+the kernel, model, and bmc never change. Only widen the kernel when the feature genuinely
+needs new semantics. Say which path this feature takes before editing.
+
+## The coupled-file checklist
+
+Kernel-AST change (new semantics):
+- [ ] `src/fslc/grammar.py` — grammar rule + `Ast` transformer producing the kernel tuple AST
+- [ ] `src/fslc/model.py` — `build_spec` validation + type→Z3 sort handling for the new node
+- [ ] `src/fslc/bmc.py` — symbolic evaluation (unroll into Z3)
+- [ ] `src/fslc/runtime.py` — **concrete `Monitor` evaluation, if concrete semantics change**
+      (the dual evaluator must agree; see the `fsl-soundness-reviewer` agent)
+
+Frontend-only change (desugaring):
+- [ ] `src/fslc/dialects.py` and/or `src/fslc/compose.py` — desugar to existing kernel AST
+
+Always, regardless of path:
+- [ ] `docs/LANGUAGE.md` — the complete language reference (must stay complete)
+- [ ] `skills/fsl/reference.md` — the agent-facing rules (must track grammar changes;
+      `.claude/skills/fsl` is a symlink to `skills/fsl`, so edit the canonical file)
+- [ ] `docs/DESIGN-<feature>.md` — a new design note recording the decision and rationale
+- [ ] `tests/test_<feature>.py` — a regression test for the new behavior
+- [ ] `CHANGELOG.md` — a bullet under `## [Unreleased]`
+- [ ] SPDX header on any *new* `.py` file (`# SPDX-License-Identifier: Apache-2.0` + copyright)
+
+## Verify (fast loop first, snapshot last)
+
+1. Iterate with `.venv/bin/python -m fslc check <spec>` and
+   `… verify <spec> --depth N` on a spec that exercises the feature — this is the fast
+   signal, not the full suite.
+2. Prove the infinite-depth case where relevant: `… verify <spec> --engine induction`.
+3. Run the targeted tests: `pytest tests/test_<feature>.py tests/test_evaluator_agreement.py -q`.
+4. **The corpus snapshot will diff.** Never skip `tests/test_corpus_snapshot.py`. If the
+   diff reflects the intended behavior change, regenerate it (and eyeball the diff first):
+   `FSLC_SNAPSHOT_UPDATE=1 .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q`
+5. Final confirmation before wrapping up: `pytest -q` (slow, ~8 min).
+
+## Don't
+
+- Don't weaken/hollow a spec to make it pass. Confirm non-vacuity (`fslc mutate` kill-rate,
+  `--vacuity`) — see the `new-spec` skill.
+- Don't let bmc and runtime disagree; that is a real regression the agreement test and the
+  Z3-independent oracle exist to catch.

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: new-spec
+description: Author a new .fsl spec and take it through the repo's non-vacuity gate before calling it done — fslc check, then verify, then --engine induction, then a hollowness check via fslc mutate kill-rate / --vacuity. Use when creating or substantially changing a spec under specs/ or examples/.
+---
+
+# new-spec — author a spec that actually says something
+
+A spec that verifies is worthless if it verifies *vacuously*. This skill is the gate a
+new or changed `.fsl` should pass. Read `skills/fsl/reference.md` before writing syntax —
+FSL is not in training data, so write from the reference, not memory.
+
+## Gate
+
+1. **Parse + types (fast loop).** `.venv/bin/python -m fslc check <spec>`. Fix errors
+   here first; this is the tight iteration signal.
+2. **Bounded model check.** `… verify <spec> --depth 8` (raise depth as needed). Read the
+   JSON: `verified` with a witness, or a shortest counterexample to reason about.
+3. **Unbounded proof where it applies.** `… verify <spec> --engine induction` for an
+   infinite-depth guarantee (supply a `decreases` ranking / `invariant` if induction needs
+   it; `sum(x: T of …)` is allowed in a `decreases` measure).
+4. **Non-vacuity — the step people skip.** A green spec can be hollow (a dead ghost, a
+   tautological invariant). `--vacuity` catches some cases but misses dead-ghost
+   tautologies, so gate on **mutation kill-rate**: `… mutate <spec>`. A very low kill-rate
+   (roughly <10%) means the spec barely constrains anything — strengthen the invariants
+   until mutants die.
+
+## Rules
+
+- **Never hollow out a spec to dodge a counterexample.** Weakening an invariant to go
+  green defeats the purpose. If a counterexample is real, fix the modeled behavior, not
+  the property.
+- If a spec lives under `specs/` or `examples/`, changing it will move the corpus snapshot
+  (`tests/test_corpus_snapshot.py`). Review the diff; regenerate only if the behavior
+  change is intended (`FSLC_SNAPSHOT_UPDATE=1 .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q`).
+- If FSL is the wrong tool for what you're modeling, say so and recommend ordinary tests
+  instead of forcing a spec (see the self-check in `skills/fsl/SKILL.md`).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: release
+description: Cut a new fslc release. Bumps the version in pyproject.toml, rolls the CHANGELOG.md [Unreleased] section into a dated version section, commits it as chore(release), creates an annotated v* git tag, and pushes so the release-binaries and publish-pypi workflows fire. Invoke only when the user explicitly asks to release/tag/publish a version.
+disable-model-invocation: true
+---
+
+# release — cut an fslc version
+
+A release here is a fixed ritual driven by a `v*` git tag. Pushing the tag triggers
+`.github/workflows/release.yml` (PyInstaller binaries + the VS Code `.vsix`, attached
+to a freshly created GitHub Release) which in turn publishes the Release, firing
+`.github/workflows/publish.yml` (build sdist/wheel + PyPI trusted publishing). So the
+tag is the trigger for the whole public release — get the pre-tag steps right first.
+
+## Inputs
+
+- **Version**: taken from the invocation argument (e.g. `/release 2.6.4`). If none is
+  given, read the current `version` in `pyproject.toml` and the contents of the
+  CHANGELOG `[Unreleased]` block, propose the next SemVer bump (patch for fixes only,
+  minor for new features, major for breaking changes), and confirm it before continuing.
+- **Date**: use today's date in `YYYY-MM-DD`.
+
+## Procedure
+
+1. **Pre-flight.** Confirm the working tree is clean (`git status --porcelain` empty)
+   and you are on `main` and up to date with `origin/main`. If not, stop and report —
+   do not release from a dirty tree or a feature branch.
+2. **Confirm `[Unreleased]` is non-empty.** A release with no changelog entries is
+   almost always a mistake; if it is empty, stop and ask.
+3. **Bump the version** in `pyproject.toml` — the single `version = "x.y.z"` line under
+   `[project]`. This is the only place the version string lives (runtime version comes
+   from `importlib.metadata`).
+4. **Roll the CHANGELOG.** In `CHANGELOG.md`, insert a new `## [x.y.z] - YYYY-MM-DD`
+   heading immediately below `## [Unreleased]`, move every entry currently under
+   `[Unreleased]` into it, and leave `[Unreleased]` present but empty. Preserve the
+   Keep-a-Changelog subsection order (Added / Changed / Fixed / …).
+5. **Sanity check.** Run the fast gate — `.venv/bin/python -m fslc --version` reflects
+   the install, and a quick `pytest tests/test_version.py -q` — before tagging. (A full
+   `pytest -q` is ~8 min; run it if the release contains verifier-semantics changes.)
+6. **Commit** exactly the two files with the conventional-commit subject the history
+   uses: `chore(release): vX.Y.Z`.
+7. **Tag.** Create an *annotated* tag matching the history convention:
+   `git tag -a vX.Y.Z -m "vX.Y.Z"`. (Each version corresponds to an annotated `v*` tag.)
+8. **Push — the point of no return.** `git push origin main` then
+   `git push origin vX.Y.Z`. State clearly, before pushing, that this triggers the
+   binary build + GitHub Release + PyPI publish, and that the tag/PyPI version cannot be
+   reused once published. Pushing changes the outside world, so do it only when the user
+   has confirmed this run (they invoked `/release`, but confirm the exact version).
+9. **Report** the tag, the commit, and links to the two Actions runs to watch
+   (`release-binaries`, `publish-pypi`).
+
+## Guardrails
+
+- Never reuse or force-move a published tag — PyPI rejects a re-uploaded version, and a
+  moved tag desyncs the binaries from the source. If step 8 already ran and something is
+  wrong, cut a new patch version instead.
+- Do not edit `CHANGELOG.md` history for already-released versions; only touch
+  `[Unreleased]` and the new section.
+- If `pyproject.toml` version and the new CHANGELOG heading disagree, stop — they must match.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Claude Code automation tuned to this repo's invariants: the fast write→`fslc check` loop, the "a language feature moves all of its coupled files together" rule (CLAUDE.md/CONTRIBUTING.md), the corpus-snapshot safety net, and the dual-evaluator / Z3-independent-oracle soundness invariant.
- **Tooling/config only** — no change to `src/fslc`, `tests/`, `specs/`, or `docs/`. The verifier behavior, the JSON/exit-code contract, and the FSL language are untouched.

## Changes
- **Hooks** (`.claude/hooks/*`, wired in `.claude/settings.json`):
  - `fslc_check` — run `fslc check` (repo venv, not the `~/.fsl` tree) on edited `.fsl`, the fast inner-loop signal instead of the slow full suite
  - `spdx_guard` — require the Apache-2.0 SPDX header on written `.py`
  - `snapshot_guard` — block hand-edits to `tests/snapshots/corpus_snapshot.json`
  - `changelog_reminder` — nudge when `src/fslc` changed but `CHANGELOG.md` did not
- **Skills** (`.claude/skills/`): `release` (user-invoked only), `add-language-feature`, `new-spec`
- **Agents** (`.claude/agents/`): `fsl-coupled-change-reviewer`, `fsl-soundness-reviewer`, `fsl-vacuity-reviewer`
- **MCP** (`.mcp.json`): `context7` for live Z3 Python API / Lark documentation

## Verification
- **Hooks**: exercised with synthetic hook-JSON — 9/9 (broken `.fsl` → exit 2; valid `cart_v1.fsl` → pass; missing SPDX flagged; snapshot hand-edit blocked; changelog reminder non-blocking, always exit 0).
- **context7**: connected after a Claude Code restart; resolved Z3 docs (`/microsoft/z3guide`, `/z3prover/z3`).
- **Config**: `.mcp.json` and `settings.json` are parse-valid; agent frontmatter validated and loaded as Agent types after restart.
- **Full `pytest -q`**: Not run — no `src/fslc`/tests/specs change, so there is no verifier behavior to cover (tooling/config only).

## Risk / Review Notes
- **Team-wide effect**: `.gitignore` excludes only `settings.local.json`, so all 12 files are tracked — merging applies them to every contributor. To keep this opt-in per person instead, the same content can live in `settings.local.json` / a local MCP scope.
- **`.mcp.json`**: prompts each contributor to approve the context7 server on first start (runs via `npx`, fetches over the network).
- **Hook scope**: hooks act on every Edit/Write. `snapshot_guard` (PreToolUse) blocks *direct* edits to the snapshot; the legitimate `FSLC_SNAPSHOT_UPDATE=1 pytest …` regeneration goes through pytest (not an editing tool) and is unaffected.
- **Reversible**: removing the files fully reverts. No migrations, schema, credentials, or persisted-data changes; no public API / CLI / language change.
- **Z3/SMT MCP intentionally omitted**: no PyPI-published, check-in-friendly server exists (candidates require cloning); context7 covers the Z3/Lark doc-lookup need.

## Follow-Up / Post-Merge Checks
- Each contributor restarts Claude Code to activate hooks/MCP/agents (skills load immediately); `/hooks` lists the wired hooks.
- The `spdx_guard` reminder prints a `<year> <name>` template, so it stays contributor-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
