### PR TITLE
feat(lsp): serve hover, references, completion, and semantic tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- (LSP) `fslc-lsp` now serves four more `textDocument/*` features as thin
+  lsprotocol adapters over the existing raw-tree index
+  (`src/fslc/lsp/server.py`, `src/fslc/lsp/index.py` unchanged): `hover`,
+  `references` (same-file plus cross-file, following `use`-imported aliases
+  and workspace spec-name resolution), `completion` (triggered on `.` for
+  alias-member completion, alongside local symbols and keywords), and
+  `semanticTokens/full` (legend-registered token types/modifiers).
+
+### Fixed
+- (LSP) The raw-tree symbol/reference indexer (`src/fslc/lsp/index.py`) now
+  covers three parse-tree shapes it previously fell through to generic
+  child-recursion for: a `policy ... every <Case> reaching ... must have
+  passed through ...` precedence policy's case name (`type` reference), a
+  struct literal's field keys (`field` references), and every `field_suffix`
+  beyond the first in a multi-level `a.b.c` postfix chain (`field`
+  references) — the pre-existing `a.b` alias.member `value` reference is
+  unchanged.
+
 ## [2.6.3] - 2026-07-03
 
 ### Fixed

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -10,6 +10,7 @@ position, not by spelling.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -39,6 +40,67 @@ ACTION_ROLES = {"action", "transition"}
 PROPERTY_ROLES = {"property", "policy", "goal"}
 SPEC_ROLES = {"business", "compose", "governance", "requirements", "spec"}
 CONTROL_ROLES = {"control", "goal", "policy", "requirement"}
+
+# Semantic-token legend (index = position in the list; server registers the same order)
+SEMANTIC_TOKEN_TYPES = [
+    "namespace", "type", "class", "struct", "enum", "enumMember",
+    "function", "variable", "parameter", "property", "event", "keyword",
+]
+SEMANTIC_TOKEN_MODIFIERS = ["declaration", "definition", "readonly"]
+
+# Symbol.role / Reference.role -> semantic token type name.
+# Covers every role emitted by _add_symbol/_add_ref. Unknown roles fall back to "variable".
+_ROLE_TO_TOKEN_TYPE = {
+    # spec containers / namespaces
+    "spec": "namespace", "compose": "namespace", "requirements": "namespace",
+    "business": "namespace", "governance": "namespace", "refinement": "namespace",
+    "alias": "namespace",
+    # types
+    "type": "type", "number": "type", "entity": "class", "struct": "struct",
+    "enum": "enum", "enum_member": "enumMember",
+    # callables
+    "action": "function", "transition": "function",
+    # values
+    "const": "variable", "state_var": "variable", "binder": "variable",
+    "let": "variable", "actor": "variable", "kpi": "variable", "authority": "variable",
+    "value": "variable",
+    "parameter": "parameter",
+    "field": "property",
+    "process": "class", "stage": "enumMember",
+    # properties / obligations (declared-name highlighting)
+    "property": "event", "requirement": "event", "acceptance": "event",
+    "forbidden": "event", "control": "event", "policy": "event", "goal": "event",
+}
+
+# Roles that are synthetic block markers whose selection_range is a keyword, not an
+# identifier -- excluded from semantic tokens (they'd double-color the keyword).
+_NON_IDENTIFIER_SYMBOL_ROLES = {"state", "init", "time"}
+
+# Roles that get the "readonly" modifier when they appear as a definition.
+_READONLY_SYMBOL_ROLES = {"const"}
+
+# FSL keywords for completion (from grammar.py). Order not important.
+FSL_KEYWORDS = [
+    "spec", "compose", "requirements", "business", "governance", "refinement",
+    "verify", "instances", "values", "use", "as", "from", "internal",
+    "const", "type", "symmetric", "enum", "struct", "entity", "number",
+    "state", "init", "action", "fair", "requires", "ensures", "let",
+    "if", "else", "forall", "exists", "invariant", "trans", "reachable",
+    "terminal", "until", "unless", "leadsTo", "decreases", "within",
+    "map", "maps", "auto", "impl", "abs", "preserve", "progress", "respond", "by",
+    "implements", "requirement", "acceptance", "forbidden", "expect", "rejected",
+    "time", "urgent", "age", "while", "deadline",
+    "actor", "process", "with", "stages", "initial", "transition", "when", "set", "covers",
+    "kpi", "count", "in", "control", "owner", "severity", "applies_to",
+    "satisfies", "policy", "responds", "every", "reaching", "must", "have",
+    "passed", "through", "eventually", "be", "goal", "some", "can", "reach", "all",
+    "authority", "owns", "delegates", "require", "satisfied_by",
+    "preservation", "before", "after", "checked_by",
+    "Int", "Bool", "Map", "Set", "Seq", "Option",
+    "true", "false", "none", "is", "and", "or", "not",
+    "stage", "sum", "min", "max", "abs", "old", "unique", "exactlyOne",
+    "add", "remove", "push", "pop", "head", "at", "size", "contains", "then",
+]
 
 
 @dataclass(frozen=True)
@@ -127,6 +189,30 @@ class Location:
 
     path: Optional[str]
     range: Range
+
+
+@dataclass(frozen=True)
+class HoverInfo:
+    markdown: str
+    range: Range
+
+
+@dataclass(frozen=True)
+class SemanticToken:
+    """Absolute-position token; server encodes to LSP relative form."""
+
+    line: int
+    start_char: int
+    length: int
+    token_type: str          # one of SEMANTIC_TOKEN_TYPES
+    modifiers: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CompletionCandidate:
+    label: str
+    role: str                # symbol role or "keyword"; server maps to CompletionItemKind
+    detail: str = ""
 
 
 LoadIndex = Callable[[str], Optional["DocumentIndex"]]
@@ -259,6 +345,169 @@ class DocumentIndex:
             return Location(self.path, sym.selection_range)
         return None
 
+    def references_at(
+        self,
+        line: int,
+        character: int,
+        include_declaration: bool = True,
+        load_index: Optional[LoadIndex] = None,
+        name_resolver: Optional[NameResolver] = None,
+    ) -> List[Range]:
+        """All same-document ranges referring to the symbol at ``line``/``character``."""
+
+        ref = self.reference_at(line, character)
+        if ref is not None:
+            target_loc = self.resolve_reference(ref, load_index, name_resolver)
+            target_name = ref.name
+        else:
+            sym = self.symbol_at(line, character)
+            if sym is None:
+                return []
+            target_loc = Location(self.path, sym.selection_range)
+            target_name = sym.name
+
+        if target_loc is None:
+            return []
+
+        matches: List[Range] = []
+        for candidate in self.references:
+            if candidate.name != target_name:
+                continue
+            loc = self.resolve_reference(candidate, load_index, name_resolver)
+            if loc is not None and _same_location(loc, target_loc):
+                matches.append(candidate.range)
+
+        if include_declaration and _normalize_path(target_loc.path) == self.path:
+            matches.append(target_loc.range)
+
+        unique = list(dict.fromkeys(matches))
+        unique.sort(key=lambda rng: (rng.start.line, rng.start.character))
+        return unique
+
+    def hover_at(
+        self,
+        line: int,
+        character: int,
+        load_index: Optional[LoadIndex] = None,
+        name_resolver: Optional[NameResolver] = None,
+    ) -> Optional[HoverInfo]:
+        """Hover markdown for the reference or symbol at ``line``/``character``."""
+
+        ref = self.reference_at(line, character)
+        if ref is not None:
+            loc = self.resolve_reference(ref, load_index, name_resolver)
+            def_sym: Optional[Symbol] = None
+            def_source = self.source
+            if loc is not None:
+                if loc.path == self.path:
+                    def_sym = next(
+                        (sym for sym in self.symbols if sym.selection_range == loc.range),
+                        None,
+                    )
+                elif loc.path is not None:
+                    target = _load_import_index(loc.path, load_index)
+                    if target is not None:
+                        def_sym = target.symbol_at(loc.range.start.line, loc.range.start.character)
+                        def_source = target.source
+            if def_sym is not None:
+                snippet = _declaration_snippet(def_source, def_sym)
+                markdown = f"```fsl\n{snippet}\n```\n**{def_sym.role}** `{def_sym.name}`"
+            else:
+                markdown = f"**{ref.role}** `{ref.name}`"
+            return HoverInfo(markdown=markdown, range=ref.range)
+
+        sym = self.symbol_at(line, character)
+        if sym is not None:
+            snippet = _declaration_snippet(self.source, sym)
+            markdown = f"```fsl\n{snippet}\n```\n**{sym.role}** `{sym.name}`"
+            return HoverInfo(markdown=markdown, range=sym.selection_range)
+
+        return None
+
+    def semantic_tokens(self) -> List[SemanticToken]:
+        """Absolute-position semantic tokens for every classifiable symbol/reference."""
+
+        tokens: List[SemanticToken] = []
+        for sym in self.symbols:
+            if sym.role in _NON_IDENTIFIER_SYMBOL_ROLES:
+                continue
+            sr = sym.selection_range
+            if sr.start.line != sr.end.line:
+                continue
+            modifiers = ["definition"]
+            if sym.role in _READONLY_SYMBOL_ROLES:
+                modifiers.append("readonly")
+            tokens.append(
+                SemanticToken(
+                    line=sr.start.line,
+                    start_char=sr.start.character,
+                    length=sr.end.character - sr.start.character,
+                    token_type=_token_type_for_role(sym.role),
+                    modifiers=tuple(modifiers),
+                )
+            )
+        for ref in self.references:
+            rr = ref.range
+            if rr.start.line != rr.end.line:
+                continue
+            tokens.append(
+                SemanticToken(
+                    line=rr.start.line,
+                    start_char=rr.start.character,
+                    length=rr.end.character - rr.start.character,
+                    token_type=_token_type_for_role(ref.role),
+                    modifiers=(),
+                )
+            )
+
+        tokens.sort(key=lambda tok: (tok.line, tok.start_char))
+        deduped: List[SemanticToken] = []
+        seen = set()
+        for tok in tokens:
+            key = (tok.line, tok.start_char)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(tok)
+        return deduped
+
+    def completions_at(
+        self,
+        line: int,
+        character: int,
+        load_index: Optional[LoadIndex] = None,
+        name_resolver: Optional[NameResolver] = None,
+    ) -> List[CompletionCandidate]:
+        """Completion candidates for the cursor at ``line``/``character``."""
+
+        lines = self.source.splitlines()
+        prefix = lines[line][:character] if 0 <= line < len(lines) else ""
+        match = re.search(r'([A-Za-z_]\w*)\.\w*$', prefix)
+        if match:
+            binding = self.import_for_alias(match.group(1))
+            if binding is not None:
+                if binding.resolved_path is None:
+                    return []
+                target = _load_import_index(binding.resolved_path, load_index)
+                if target is None:
+                    return []
+                return [
+                    CompletionCandidate(label=sym.name, role=sym.role, detail=sym.detail)
+                    for sym in target.symbols
+                    if sym.exported
+                ]
+
+        candidates: Dict[str, CompletionCandidate] = {}
+        for sym in self.symbols:
+            if sym.outline or sym.exported:
+                candidates.setdefault(
+                    sym.name,
+                    CompletionCandidate(label=sym.name, role=sym.role, detail=sym.detail),
+                )
+        for keyword in FSL_KEYWORDS:
+            candidates.setdefault(keyword, CompletionCandidate(label=keyword, role="keyword"))
+        return list(candidates.values())
+
     def _resolve_local(self, ref: Reference) -> Optional[Symbol]:
         scoped = self._resolve_scoped(ref)
         if scoped is not None:
@@ -335,6 +584,34 @@ def definition_at(
         load_index,
         name_resolver,
     )
+
+
+def encode_semantic_tokens(
+    tokens: Sequence[SemanticToken],
+    token_types: Sequence[str] = SEMANTIC_TOKEN_TYPES,
+    token_modifiers: Sequence[str] = SEMANTIC_TOKEN_MODIFIERS,
+) -> List[int]:
+    """LSP relative encoding: [dLine, dStartChar, length, typeIdx, modBits]* .
+
+    Assumes ``tokens`` sorted by (line, start_char).
+    """
+
+    encoded: List[int] = []
+    prev_line = 0
+    prev_char = 0
+    for tok in tokens:
+        delta_line = tok.line - prev_line
+        delta_char = tok.start_char if delta_line != 0 else tok.start_char - prev_char
+        type_name = tok.token_type if tok.token_type in token_types else "variable"
+        type_idx = token_types.index(type_name)
+        mod_bits = 0
+        for modifier in tok.modifiers:
+            if modifier in token_modifiers:
+                mod_bits |= 1 << token_modifiers.index(modifier)
+        encoded.extend([delta_line, delta_char, tok.length, type_idx, mod_bits])
+        prev_line = tok.line
+        prev_char = tok.start_char
+    return encoded
 
 
 class _IndexBuilder:
@@ -1066,6 +1343,13 @@ class _IndexBuilder:
         for child in node.children:
             self.visit(child, parent, local_scope)
 
+    def _visit_policy_precedence(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        case_name = _name_token_at(node, 0)
+        if case_name is not None:
+            self._add_ref(case_name, "type")
+        for child in node.children:
+            self.visit(child, parent, local_scope)
+
     def _visit_goal_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         self._visit_req_id_symbol(node, parent, "goal")
 
@@ -1169,6 +1453,13 @@ class _IndexBuilder:
             self._add_ref(names[0], "alias")
             self._add_ref(names[1], "type", qualifier=str(names[0]))
 
+    def _visit_struct_fields(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _name_tokens(node):
+            self._add_ref(token, "field")
+        for child in node.children:
+            if isinstance(child, Tree):
+                self.visit(child, parent, local_scope)
+
     def _visit_struct_lit(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
         if token is not None:
@@ -1177,13 +1468,23 @@ class _IndexBuilder:
 
     def _visit_postfix(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         children = list(node.children)
-        if len(children) >= 2 and _tree_data(children[0]) == "var" and _tree_data(children[1]) == "field_suffix":
+        first_is_alias_field = (
+            len(children) >= 2
+            and _tree_data(children[0]) == "var"
+            and _tree_data(children[1]) == "field_suffix"
+        )
+        if first_is_alias_field:
             alias_token = _first_token(children[0])
             field_token = _first_token(children[1])
             if alias_token is not None and field_token is not None:
                 self._add_ref(field_token, "value", qualifier=str(alias_token))
-        for child in children:
+        for i, child in enumerate(children):
             if _tree_data(child) == "field_suffix":
+                if first_is_alias_field and i == 1:
+                    continue  # already recorded as alias.member above
+                field_token = _first_token(child)
+                if field_token is not None:
+                    self._add_ref(field_token, "field")
                 continue
             self.visit(child, parent, local_scope)
 
@@ -1311,6 +1612,22 @@ def _load_import_index(path: str, load_index: Optional[LoadIndex]) -> Optional[D
         if loaded is not None:
             return loaded
     return default_load_index(path)
+
+
+def _same_location(a: Location, b: Location) -> bool:
+    return _normalize_path(a.path) == _normalize_path(b.path) and a.range == b.range
+
+
+def _declaration_snippet(source: str, sym: Symbol) -> str:
+    lines = source.splitlines()
+    line_no = sym.range.start.line
+    if 0 <= line_no < len(lines):
+        return lines[line_no].strip()
+    return sym.name
+
+
+def _token_type_for_role(role: str) -> str:
+    return _ROLE_TO_TOKEN_TYPE.get(role, "variable")
 
 
 def _refinement_spec_names(tree: Tree) -> Tuple[Optional[str], Optional[str]]:

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -11,7 +11,18 @@ from urllib.parse import unquote, urlparse
 
 from lark.exceptions import UnexpectedInput, VisitError
 
-from fslc.lsp.index import DocumentIndex, NameResolver, Range, Symbol, build_index
+from fslc.lsp.index import (
+    SEMANTIC_TOKEN_MODIFIERS,
+    SEMANTIC_TOKEN_TYPES,
+    CompletionCandidate,
+    DocumentIndex,
+    Location,
+    NameResolver,
+    Range,
+    Symbol,
+    build_index,
+    encode_semantic_tokens,
+)
 
 
 SERVER_NAME = "fslc-lsp"
@@ -225,6 +236,65 @@ def _create_server():
         target_uri = _path_to_uri(loc.path) if loc.path else uri
         return types.Location(uri=target_uri, range=_to_lsp_range(types, loc.range))
 
+    @server.feature(types.TEXT_DOCUMENT_HOVER)
+    def hover(ls, params):
+        uri = params.text_document.uri
+        index = _index_for_uri(server, uri)
+        if index is None:
+            return None
+        info = index.hover_at(
+            params.position.line,
+            params.position.character,
+            _loader_for_server(server),
+            _name_resolver_for_server(server, _uri_to_path(uri)),
+        )
+        if info is None:
+            return None
+        return types.Hover(
+            contents=types.MarkupContent(kind=types.MarkupKind.Markdown, value=info.markdown),
+            range=_to_lsp_range(types, info.range),
+        )
+
+    @server.feature(types.TEXT_DOCUMENT_REFERENCES)
+    def references(ls, params):
+        uri = params.text_document.uri
+        include_declaration = True
+        if getattr(params, "context", None) is not None:
+            include_declaration = params.context.include_declaration
+        locations = _workspace_references(
+            server, uri, params.position.line, params.position.character, include_declaration
+        )
+        return locations or None
+
+    @server.feature(types.TEXT_DOCUMENT_COMPLETION, types.CompletionOptions(trigger_characters=["."]))
+    def completion(ls, params):
+        uri = params.text_document.uri
+        index = _index_for_uri(server, uri)
+        if index is None:
+            return None
+        candidates = index.completions_at(
+            params.position.line,
+            params.position.character,
+            _loader_for_server(server),
+            _name_resolver_for_server(server, _uri_to_path(uri)),
+        )
+        items = [_to_completion_item(types, c) for c in candidates]
+        return types.CompletionList(is_incomplete=False, items=items)
+
+    @server.feature(
+        types.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
+        types.SemanticTokensLegend(
+            token_types=list(SEMANTIC_TOKEN_TYPES),
+            token_modifiers=list(SEMANTIC_TOKEN_MODIFIERS),
+        ),
+    )
+    def semantic_tokens_full(ls, params):
+        index = _index_for_uri(server, params.text_document.uri)
+        if index is None:
+            return types.SemanticTokens(data=[])
+        data = encode_semantic_tokens(index.semantic_tokens())
+        return types.SemanticTokens(data=data)
+
     return server
 
 
@@ -387,6 +457,98 @@ def _loader_for_server(server):
     return load
 
 
+def _definition_target(
+    index: DocumentIndex,
+    line: int,
+    character: int,
+    load_index,
+    name_resolver,
+) -> Optional[Tuple[str, Location]]:
+    """The (name, declaration-location) pair for the symbol under the cursor, if any."""
+
+    ref = index.reference_at(line, character)
+    if ref is not None:
+        loc = index.resolve_reference(ref, load_index, name_resolver)
+        if loc is None:
+            return None
+        return ref.name, loc
+    sym = index.symbol_at(line, character)
+    if sym is not None:
+        return sym.name, Location(index.path, sym.selection_range)
+    return None
+
+
+def _loc_equal(a: Location, b: Location) -> bool:
+    def normalize(path: Optional[str]) -> Optional[str]:
+        return str(Path(path).resolve(strict=False)) if path else None
+
+    return normalize(a.path) == normalize(b.path) and a.range == b.range
+
+
+def _dedupe_locations(locations: List[Any]) -> List[Any]:
+    seen = set()
+    deduped: List[Any] = []
+    for loc in locations:
+        key = (
+            loc.uri,
+            loc.range.start.line,
+            loc.range.start.character,
+            loc.range.end.line,
+            loc.range.end.character,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(loc)
+    return deduped
+
+
+def _workspace_references(
+    server, uri: str, line: int, character: int, include_declaration: bool
+) -> List[Any]:
+    """Same-document references plus references from every other workspace ``.fsl`` file."""
+
+    from lsprotocol import types
+
+    index = _index_for_uri(server, uri)
+    if index is None:
+        return []
+    loader = _loader_for_server(server)
+    this_path = _uri_to_path(uri)
+    resolver = _name_resolver_for_server(server, this_path)
+
+    local_ranges = index.references_at(line, character, include_declaration, loader, resolver)
+    results = [types.Location(uri=uri, range=_to_lsp_range(types, r)) for r in local_ranges]
+
+    target = _definition_target(index, line, character, loader, resolver)
+    if target is None:
+        return _dedupe_locations(results)
+    target_name, target_loc = target
+
+    this_norm = str(Path(this_path).resolve(strict=False)) if this_path else None
+    for root in _workspace_roots(server, this_path):
+        for fsl_path in sorted(root.rglob("*.fsl")):
+            if not fsl_path.is_file():
+                continue
+            normalized = str(fsl_path.resolve(strict=False))
+            if this_norm is not None and normalized == this_norm:
+                continue  # already covered by references_at() above
+            other_uri = _path_to_uri(str(fsl_path))
+            other_index = _index_for_uri(server, other_uri)
+            if other_index is None:
+                continue
+            for candidate in other_index.references:
+                if candidate.name != target_name:
+                    continue
+                loc = other_index.resolve_reference(candidate, loader, resolver)
+                if loc is not None and _loc_equal(loc, target_loc):
+                    results.append(
+                        types.Location(uri=other_uri, range=_to_lsp_range(types, candidate.range))
+                    )
+
+    return _dedupe_locations(results)
+
+
 def _result_to_diagnostics(types, source: str, result: Dict[str, Any], index: Optional[DocumentIndex]):
     diagnostics = []
     if result.get("result") == "error":
@@ -503,6 +665,52 @@ def _symbol_kind(types, sym: Symbol):
         "type": types.SymbolKind.Class,
     }
     return by_role.get(sym.role, types.SymbolKind.Variable)
+
+
+def _to_completion_item(types, candidate: CompletionCandidate):
+    by_role = {
+        "spec": types.CompletionItemKind.Module,
+        "compose": types.CompletionItemKind.Module,
+        "requirements": types.CompletionItemKind.Module,
+        "business": types.CompletionItemKind.Module,
+        "governance": types.CompletionItemKind.Module,
+        "refinement": types.CompletionItemKind.Module,
+        "alias": types.CompletionItemKind.Module,
+        "type": types.CompletionItemKind.Class,
+        "entity": types.CompletionItemKind.Class,
+        "struct": types.CompletionItemKind.Struct,
+        "number": types.CompletionItemKind.Class,
+        "enum": types.CompletionItemKind.Enum,
+        "enum_member": types.CompletionItemKind.EnumMember,
+        "action": types.CompletionItemKind.Function,
+        "transition": types.CompletionItemKind.Function,
+        "const": types.CompletionItemKind.Constant,
+        "state_var": types.CompletionItemKind.Variable,
+        "binder": types.CompletionItemKind.Variable,
+        "let": types.CompletionItemKind.Variable,
+        "value": types.CompletionItemKind.Variable,
+        "actor": types.CompletionItemKind.Variable,
+        "kpi": types.CompletionItemKind.Variable,
+        "authority": types.CompletionItemKind.Variable,
+        "parameter": types.CompletionItemKind.Variable,
+        "field": types.CompletionItemKind.Field,
+        "process": types.CompletionItemKind.Class,
+        "stage": types.CompletionItemKind.EnumMember,
+        "property": types.CompletionItemKind.Event,
+        "requirement": types.CompletionItemKind.Event,
+        "acceptance": types.CompletionItemKind.Event,
+        "forbidden": types.CompletionItemKind.Event,
+        "control": types.CompletionItemKind.Event,
+        "policy": types.CompletionItemKind.Event,
+        "goal": types.CompletionItemKind.Event,
+        "keyword": types.CompletionItemKind.Keyword,
+    }
+    kind = by_role.get(candidate.role, types.CompletionItemKind.Variable)
+    return types.CompletionItem(
+        label=candidate.label,
+        kind=kind,
+        detail=candidate.detail or candidate.role,
+    )
 
 
 def _to_lsp_range(types, rng: Range):

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -4,7 +4,17 @@
 """Regression tests for the raw-tree LSP index."""
 from pathlib import Path
 
-from fslc.lsp.index import build_index, default_load_index
+from fslc.lsp.index import (
+    SEMANTIC_TOKEN_MODIFIERS,
+    SEMANTIC_TOKEN_TYPES,
+    CompletionCandidate,
+    HoverInfo,
+    Range,
+    SemanticToken,
+    build_index,
+    default_load_index,
+    encode_semantic_tokens,
+)
 from fslc.lsp.server import check_source
 
 
@@ -268,3 +278,346 @@ def test_refinement_local_binders_still_resolve_in_file():
     )
     assert u_loc.path == str(paths["refinement"].resolve())
     assert _target_text(u_loc) == "u"
+
+
+def test_policy_precedence_case_name_and_stages_are_indexed():
+    # grammar: policy_precedence: "every" NAME "reaching" stage_disjunction
+    #   "must" "have" "passed" "through" stage_disjunction
+    # (business-layer no-bypass control, docs/DESIGN-precedence-policy.md;
+    # source shape mirrors tests/test_precedence_policy.py's BIZ_COMPLIANT_SRC)
+    source = '''business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved, Rejected, Refunded
+    initial Requested
+    transition approve Requested -> Approved by Manager
+    transition reject Requested -> Rejected by Manager
+    transition refund Approved -> Refunded by Manager
+  }
+
+  policy CTRL-APPROVAL "no bypass"
+    every Return reaching Refunded must have passed through Approved
+}
+verify {
+  instances Return = 3
+}
+'''
+    index = build_index(source)
+
+    _reference(index, "Return", "type")
+    _reference(index, "Refunded", "value")
+    _reference(index, "Approved", "value")
+
+
+def test_struct_fields_keys_are_indexed_as_field_references():
+    # grammar: struct_fields: "{" NAME ":" expr ("," NAME ":" expr)* ","? "}"
+    # (also reached via the ref_struct_fields alias inside refinement maps)
+    source = '''spec StructFieldsDemo {
+  type K = 0..1
+
+  struct Point { x: K, y: K }
+
+  state {
+    p: Point
+  }
+
+  init {
+    p = Point { x: 0, y: 0 }
+  }
+}
+'''
+    index = build_index(source)
+
+    _reference(index, "x", "field")
+    _reference(index, "y", "field")
+
+
+def test_postfix_multi_level_field_access_indexes_tail_as_field_reference():
+    # grammar: postfix: atom postfix_suffix*, field_suffix: "." NAME
+    # a.b.c: the first field_suffix after a leading var (b) stays the
+    # existing alias.member "value" reference (compose namespace lookups
+    # depend on it); the second-level field_suffix (c) must now surface as
+    # a "field" reference too.
+    source = '''spec PostfixFieldChain {
+  type K = 0..1
+
+  struct Inner { amount: K }
+  struct Outer { payload: Inner }
+
+  state {
+    outer: Outer
+  }
+
+  invariant TailFieldAccessed {
+    outer.payload.amount == 0
+  }
+}
+'''
+    index = build_index(source)
+
+    _reference(index, "outer", "value")
+    _reference(index, "payload", "value", qualifier="outer")
+    _reference(index, "amount", "field")
+
+
+def test_hover_on_reference_reports_definition_role_and_snippet():
+    source = '''spec HoverDemo {
+  type K = 0..1
+
+  state {
+    counter: K
+  }
+
+  init {
+    counter = 0
+  }
+
+  invariant CounterBounded {
+    counter >= 0
+  }
+}
+'''
+    index = build_index(source)
+    ref = _reference(index, "counter", "value")
+
+    hover = index.hover_at(ref.range.start.line, ref.range.start.character)
+
+    assert isinstance(hover, HoverInfo)
+    assert hover.range == ref.range
+    assert "state_var" in hover.markdown
+    assert "counter" in hover.markdown
+    assert "```fsl" in hover.markdown
+
+
+def test_hover_on_definition_reports_own_role():
+    source = '''spec HoverDefDemo {
+  type K = 0..1
+
+  state {
+    counter: K
+  }
+
+  init {
+    counter = 0
+  }
+
+  action bump() {
+    requires counter < 1
+    counter = counter + 1
+  }
+}
+'''
+    index = build_index(source)
+    action_sym = _symbol(index, "bump", "action")
+
+    hover = index.hover_at(
+        action_sym.selection_range.start.line,
+        action_sym.selection_range.start.character,
+    )
+
+    assert isinstance(hover, HoverInfo)
+    assert hover.range == action_sym.selection_range
+    assert "action" in hover.markdown
+    assert "bump" in hover.markdown
+    assert "```fsl" in hover.markdown
+
+
+def test_references_at_collects_all_uses_and_declaration():
+    source = '''spec ReferencesDemo {
+  type K = 0..2
+
+  state {
+    counter: K
+  }
+
+  init {
+    counter = 0
+  }
+
+  action bump() {
+    requires counter < 2
+    counter = counter + 1
+  }
+
+  invariant CounterBounded {
+    counter >= 0
+  }
+}
+'''
+    index = build_index(source)
+    counter_sym = _symbol(index, "counter", "state_var")
+    value_refs = [r for r in index.references if r.name == "counter" and r.role == "value"]
+    assert len(value_refs) >= 3  # init assignment, guard + body uses, invariant use
+
+    with_decl = index.references_at(
+        counter_sym.selection_range.start.line,
+        counter_sym.selection_range.start.character,
+        include_declaration=True,
+    )
+    without_decl = index.references_at(
+        counter_sym.selection_range.start.line,
+        counter_sym.selection_range.start.character,
+        include_declaration=False,
+    )
+
+    assert all(isinstance(rng, Range) for rng in with_decl)
+    assert len(with_decl) == len(value_refs) + 1
+    assert len(without_decl) == len(value_refs)
+    assert counter_sym.selection_range in with_decl
+    assert counter_sym.selection_range not in without_decl
+    for ref in value_refs:
+        assert ref.range in with_decl
+        assert ref.range in without_decl
+        assert _slice(source, ref.range) == "counter"
+    assert _slice(source, counter_sym.selection_range) == "counter"
+
+    # querying from a usage position aggregates the identical set
+    from_usage = index.references_at(
+        value_refs[0].range.start.line,
+        value_refs[0].range.start.character,
+        include_declaration=True,
+    )
+    assert from_usage == with_decl
+
+
+def test_semantic_tokens_classify_core_roles():
+    source = '''spec SemanticDemo {
+  type K = 0..1
+  enum Status { Active, Done }
+
+  state {
+    counter: K,
+    status: Status
+  }
+
+  init {
+    counter = 0
+    status = Active
+  }
+
+  action bump() {
+    requires counter < 1
+    counter = counter + 1
+  }
+}
+'''
+    index = build_index(source)
+    tokens = index.semantic_tokens()
+
+    assert tokens
+    assert all(isinstance(tok, SemanticToken) for tok in tokens)
+    assert all(tok.token_type in SEMANTIC_TOKEN_TYPES for tok in tokens)
+
+    by_type = {}
+    for tok in tokens:
+        by_type.setdefault(tok.token_type, []).append(tok)
+
+    assert "type" in by_type        # type K
+    assert "function" in by_type    # action bump
+    assert "variable" in by_type    # counter/status state vars and value refs
+    assert "enum" in by_type        # enum Status
+    assert "enumMember" in by_type  # Active, Done
+
+    assert any("definition" in tok.modifiers for tok in by_type["function"])
+    assert any("definition" in tok.modifiers for tok in by_type["enumMember"])
+
+
+def test_encode_semantic_tokens_roundtrip():
+    tokens = [
+        SemanticToken(line=2, start_char=4, length=3, token_type="type", modifiers=("definition",)),
+        SemanticToken(line=2, start_char=10, length=5, token_type="variable", modifiers=()),
+        SemanticToken(
+            line=5, start_char=2, length=6, token_type="function",
+            modifiers=("definition", "readonly"),
+        ),
+    ]
+
+    encoded = encode_semantic_tokens(tokens)
+
+    assert all(isinstance(n, int) for n in encoded)
+    assert len(encoded) == 5 * len(tokens)
+
+    # first token: absolute deltaLine/deltaStartChar (previous position is (0, 0))
+    assert encoded[0:5] == [
+        2,
+        4,
+        3,
+        SEMANTIC_TOKEN_TYPES.index("type"),
+        1 << SEMANTIC_TOKEN_MODIFIERS.index("definition"),
+    ]
+    # second token: same line -> deltaLine 0, deltaStartChar relative to previous start
+    assert encoded[5:10] == [
+        0,
+        10 - 4,
+        5,
+        SEMANTIC_TOKEN_TYPES.index("variable"),
+        0,
+    ]
+    # third token: new line -> deltaLine relative, deltaStartChar absolute again
+    expected_mod = (
+        (1 << SEMANTIC_TOKEN_MODIFIERS.index("definition"))
+        | (1 << SEMANTIC_TOKEN_MODIFIERS.index("readonly"))
+    )
+    assert encoded[10:15] == [
+        5 - 2,
+        2,
+        6,
+        SEMANTIC_TOKEN_TYPES.index("function"),
+        expected_mod,
+    ]
+
+
+def test_completion_includes_symbols_and_keywords():
+    source = '''spec CompletionDemo {
+  type K = 0..1
+
+  state {
+    counter: K
+  }
+
+  init {
+    counter = 0
+  }
+
+  invariant CounterBounded {
+    counter >= 0
+  }
+}
+'''
+    index = build_index(source)
+    completions = index.completions_at(0, 0)
+
+    assert all(isinstance(c, CompletionCandidate) for c in completions)
+    labels = {c.label for c in completions}
+    assert "K" in labels
+    assert "CounterBounded" in labels
+    assert "invariant" in labels
+    assert "forall" in labels
+
+    type_candidates = [c for c in completions if c.label == "K"]
+    assert type_candidates and type_candidates[0].role == "type"
+    keyword_candidates = [c for c in completions if c.label == "invariant"]
+    assert keyword_candidates and keyword_candidates[0].role == "keyword"
+
+
+def test_completion_member_after_alias_dot():
+    path = SPECS / "order_system.fsl"
+    source = path.read_text(encoding="utf-8")
+    index = build_index(source, str(path))
+
+    lines = source.splitlines()
+    line_no = next(i for i, text in enumerate(lines) if "cart." in text)
+    character = lines[line_no].index("cart.") + len("cart.")
+
+    completions = index.completions_at(line_no, character, load_index=default_load_index)
+
+    assert completions
+    assert all(isinstance(c, CompletionCandidate) for c in completions)
+    assert all(c.role != "keyword" for c in completions)
+
+    cart_index = default_load_index(str((SPECS / "cart_v1.fsl").resolve()))
+    exported_names = {sym.name for sym in cart_index.symbols if sym.exported}
+    labels = {c.label for c in completions}
+    assert labels == exported_names

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Regression tests for the pygls adapter layer (`src/fslc/lsp/server.py`).
+
+`fslc.lsp.index` (`DocumentIndex`) is pure and already covered by
+`tests/test_lsp_index.py`; these tests only exercise the thin lsprotocol
+adapter: feature registration, role -> `CompletionItemKind` mapping, and the
+hover/references/completion/semanticTokens handlers wired on top of it.
+"""
+from pathlib import Path
+
+import pytest
+
+pygls = pytest.importorskip("pygls")
+
+from lsprotocol import types  # noqa: E402  (import after the skip guard)
+
+from fslc.lsp.index import (  # noqa: E402
+    CompletionCandidate,
+    build_index,
+    encode_semantic_tokens,
+)
+from fslc.lsp.server import (  # noqa: E402
+    _create_server,
+    _definition_target,
+    _path_to_uri,
+    _to_completion_item,
+    _to_lsp_range,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SPECS = ROOT / "specs"
+CART_V1 = SPECS / "cart_v1.fsl"
+
+# A minimal compose workspace used by the cross-file tests below, kept
+# self-contained (via tmp_path) rather than reusing specs/ directly: several
+# fixtures under specs/ intentionally redeclare `spec ShoppingCart` (buggy
+# variants), so a workspace-wide name-based resolver lookup over the real
+# specs/ directory is not deterministic enough to assert an exact match set
+# against. Path-based `use ... from "..."` resolution (exercised here) does
+# not go through that name map at all.
+LIB_SOURCE = """spec Lib {
+  type Id = 0..1
+
+  state { x: Int }
+
+  init { x = 0 }
+
+  action bump(i: Id) {
+    x = x + 1
+  }
+}
+"""
+
+MAIN_SOURCE = """compose Main {
+  use Lib as lib from "lib.fsl"
+
+  state { y: Int }
+  init { y = 0 }
+
+  action bump_and_log(i: lib.Id) = lib.bump(i) {
+    y = y + 1
+  }
+
+  internal lib.bump
+}
+"""
+
+
+def _symbol(index, name, role):
+    matches = [sym for sym in index.symbols if sym.name == name and sym.role == role]
+    assert matches, f"missing symbol {role}:{name}"
+    return matches[0]
+
+
+def _initialize(server) -> None:
+    """Run the minimal LSP handshake.
+
+    pygls' ``server.workspace`` raises ``RuntimeError`` ("has the server been
+    initialized?") until ``initialize`` has run once -- real clients always
+    send it first, but a handler invoked directly in a test must do the same
+    before touching any code path that calls ``_workspace_roots`` (references,
+    in this file). ``root_uri=None`` leaves workspace folders empty, so
+    ``_workspace_roots`` falls back to the current document's own directory,
+    same as an unconfigured client would get.
+    """
+
+    server.lsp.lsp_initialize(
+        types.InitializeParams(
+            process_id=None,
+            root_uri=None,
+            capabilities=types.ClientCapabilities(),
+        )
+    )
+
+
+def _loc_key(loc):
+    return (
+        loc.uri,
+        loc.range.start.line,
+        loc.range.start.character,
+        loc.range.end.line,
+        loc.range.end.character,
+    )
+
+
+def test_create_server_registers_all_features():
+    server = _create_server()
+    features = set(server.lsp.fm.features.keys())
+    expected = {
+        types.TEXT_DOCUMENT_HOVER,
+        types.TEXT_DOCUMENT_REFERENCES,
+        types.TEXT_DOCUMENT_COMPLETION,
+        types.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
+        types.TEXT_DOCUMENT_DOCUMENT_SYMBOL,
+        types.TEXT_DOCUMENT_DEFINITION,
+    }
+    assert expected <= features
+
+
+def test_to_completion_item_maps_roles_to_kinds():
+    item = _to_completion_item(types, CompletionCandidate("Foo", "type", "type"))
+    assert item.kind == types.CompletionItemKind.Class
+
+    item = _to_completion_item(types, CompletionCandidate("act", "action", "action"))
+    assert item.kind == types.CompletionItemKind.Function
+
+    item = _to_completion_item(types, CompletionCandidate("k", "keyword"))
+    assert item.kind == types.CompletionItemKind.Keyword
+
+    item = _to_completion_item(types, CompletionCandidate("mystery", "no_such_role"))
+    assert item.kind == types.CompletionItemKind.Variable
+
+
+def test_semantic_tokens_full_handler_returns_encoded_data():
+    source = CART_V1.read_text(encoding="utf-8")
+    index = build_index(source, str(CART_V1))
+
+    data = encode_semantic_tokens(index.semantic_tokens())
+
+    assert data
+    assert len(data) % 5 == 0
+
+
+def test_definition_target_finds_symbol_and_reference_targets():
+    source = CART_V1.read_text(encoding="utf-8")
+    index = build_index(source, str(CART_V1))
+    stock = _symbol(index, "stock", "state_var")
+
+    # Cursor directly on the declaration -> falls back to the symbol branch.
+    target = _definition_target(
+        index, stock.selection_range.start.line, stock.selection_range.start.character, None, None
+    )
+    assert target is not None
+    name, loc = target
+    assert name == "stock"
+    assert loc.range == stock.selection_range
+
+    # Cursor on a usage -> reference branch, resolving back to the same declaration.
+    usage = next(ref for ref in index.references if ref.name == "stock" and ref.role == "value")
+    target = _definition_target(
+        index, usage.range.start.line, usage.range.start.character, None, None
+    )
+    assert target is not None
+    name, loc = target
+    assert name == "stock"
+    assert loc.range == stock.selection_range
+
+
+def test_hover_handler_via_index():
+    server = _create_server()
+    uri = _path_to_uri(str(CART_V1))
+    index = build_index(CART_V1.read_text(encoding="utf-8"), str(CART_V1))
+    stock = _symbol(index, "stock", "state_var")
+
+    hover_handler = server.lsp.fm.features[types.TEXT_DOCUMENT_HOVER]
+    result = hover_handler(
+        types.HoverParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(
+                line=stock.selection_range.start.line,
+                character=stock.selection_range.start.character,
+            ),
+        )
+    )
+
+    assert isinstance(result, types.Hover)
+    assert "stock" in result.contents.value
+    assert result.range == _to_lsp_range(types, stock.selection_range)
+
+
+def test_references_handler_via_index():
+    server = _create_server()
+    _initialize(server)
+    uri = _path_to_uri(str(CART_V1))
+    index = build_index(CART_V1.read_text(encoding="utf-8"), str(CART_V1))
+    stock = _symbol(index, "stock", "state_var")
+
+    references_handler = server.lsp.fm.features[types.TEXT_DOCUMENT_REFERENCES]
+    result = references_handler(
+        types.ReferenceParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(
+                line=stock.selection_range.start.line,
+                character=stock.selection_range.start.character,
+            ),
+            context=types.ReferenceContext(include_declaration=True),
+        )
+    )
+
+    assert result
+    assert all(isinstance(loc, types.Location) for loc in result)
+    declaration = types.Location(uri=uri, range=_to_lsp_range(types, stock.selection_range))
+    assert _loc_key(declaration) in {_loc_key(loc) for loc in result}
+
+
+def test_workspace_references_finds_cross_file_alias_reference(tmp_path):
+    lib_path = tmp_path / "lib.fsl"
+    main_path = tmp_path / "main.fsl"
+    lib_path.write_text(LIB_SOURCE, encoding="utf-8")
+    main_path.write_text(MAIN_SOURCE, encoding="utf-8")
+
+    lib_index = build_index(LIB_SOURCE, str(lib_path))
+    bump = _symbol(lib_index, "bump", "action")
+    main_index = build_index(MAIN_SOURCE, str(main_path))
+    main_bump_refs = [ref for ref in main_index.references if ref.name == "bump"]
+    assert len(main_bump_refs) == 2  # the `= lib.bump(i)` sync target and `internal lib.bump`
+
+    server = _create_server()
+    _initialize(server)
+    lib_uri = _path_to_uri(str(lib_path))
+    main_uri = _path_to_uri(str(main_path))
+
+    references_handler = server.lsp.fm.features[types.TEXT_DOCUMENT_REFERENCES]
+    result = references_handler(
+        types.ReferenceParams(
+            text_document=types.TextDocumentIdentifier(uri=lib_uri),
+            position=types.Position(
+                line=bump.selection_range.start.line,
+                character=bump.selection_range.start.character,
+            ),
+            context=types.ReferenceContext(include_declaration=True),
+        )
+    )
+
+    assert result is not None
+    expected = {
+        _loc_key(types.Location(uri=lib_uri, range=_to_lsp_range(types, bump.selection_range)))
+    } | {
+        _loc_key(types.Location(uri=main_uri, range=_to_lsp_range(types, ref.range)))
+        for ref in main_bump_refs
+    }
+    assert {_loc_key(loc) for loc in result} == expected
+
+
+def test_completion_handler_suggests_alias_members(tmp_path):
+    lib_path = tmp_path / "lib.fsl"
+    main_path = tmp_path / "main.fsl"
+    lib_path.write_text(LIB_SOURCE, encoding="utf-8")
+    main_path.write_text(MAIN_SOURCE, encoding="utf-8")
+
+    # Position the cursor right after "lib." on the `internal lib.bump` line.
+    main_lines = MAIN_SOURCE.splitlines()
+    target_line = next(i for i, line in enumerate(main_lines) if "internal lib.bump" in line)
+    target_char = main_lines[target_line].index("lib.bump") + len("lib.")
+
+    server = _create_server()
+    main_uri = _path_to_uri(str(main_path))
+
+    completion_handler = server.lsp.fm.features[types.TEXT_DOCUMENT_COMPLETION]
+    result = completion_handler(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=main_uri),
+            position=types.Position(line=target_line, character=target_char),
+        )
+    )
+
+    assert isinstance(result, types.CompletionList)
+    assert result.is_incomplete is False
+    labels = {item.label: item for item in result.items}
+    assert "bump" in labels
+    assert labels["bump"].kind == types.CompletionItemKind.Function
+    assert "Id" in labels
+    assert labels["Id"].kind == types.CompletionItemKind.Class


### PR DESCRIPTION
## Summary
- The FSL language server (`fslc-lsp`) previously served only diagnostics, a document-symbol outline, and go-to-definition. This adds the four editor features it was missing — **hover**, **find references**, **completion**, and **semantic tokens** — so a spec author gets the full "navigate the graph" experience an LSP client expects.
- It also fixes three parse-tree shapes the raw-tree indexer silently under-indexed, so both the new features and the existing go-to-definition now work on them.

## Changes
- **`src/fslc/lsp/index.py`** — pygls-free core logic (returns lightweight dataclasses, no `lsprotocol` import):
  - `DocumentIndex.hover_at` — declaration snippet + role for the symbol/reference under the cursor
  - `DocumentIndex.references_at` — same-document reference set, honoring `includeDeclaration`
  - `DocumentIndex.semantic_tokens` + `encode_semantic_tokens` — absolute tokens over every symbol/reference role, plus the LSP relative encoding
  - `DocumentIndex.completions_at` — local symbols + FSL keywords, and `alias.`-member completion
  - legend constants, role→token-type map, keyword list
- **`src/fslc/lsp/server.py`** — thin lsprotocol adapters wiring the above into `textDocument/hover`, `textDocument/references` (extended cross-file via `use` aliases + workspace spec-name resolution), `textDocument/completion` (`.` trigger), and `textDocument/semanticTokens/full` (legend registered). Feature count 6 → 10.
- **Indexer fixes**: precedence-policy case name (`type` ref), struct-literal field keys (`field` refs), and every `field_suffix` past the first in a multi-level `a.b.c` chain (`field` refs). The existing `a.b` alias.member `value` reference is unchanged.
- **Tests**: `tests/test_lsp_server.py` (new, pygls `importorskip`); `tests/test_lsp_index.py` extended.

## Verification
- `pytest tests/test_lsp_index.py tests/test_lsp_server.py -q` → **25 passed** (index 17 + server 8)
- `pytest -q` (full suite) → **872 passed, 78 skipped**
- E2E smoke: created the real server, `initialize`d it, and invoked all four feature handlers on `specs/cart_v1.fsl` — hover returns a snippet+role, references returns 9 locations for `stock`, completion returns 140 items (keywords + symbols), `semanticTokens/full` returns 58 encoded tokens (data length a multiple of 5).

## Risk / Review Notes
- **No language/verifier change**: grammar, model, BMC, runtime, and every `.fsl` are untouched, so the corpus snapshot and the JSON/exit-code contract are unaffected. All changes are confined to `src/fslc/lsp/`.
- **pygls stays optional**: it is an `lsp` extra, not a `dev` dependency. Core logic is pygls-free and fully tested without it; server-feature tests `importorskip("pygls")`.
- **Cross-file references** walk the workspace's `.fsl` files; a low-frequency operation that reuses the existing per-URI index cache. No public API / CLI / schema change.

## Follow-Up / Post-Merge Checks
- Exercise the VSCode extension (`editors/vscode`) against a real workspace to confirm the client surfaces hover / references / completion / semantic highlighting as expected (the tests cover server responses, not client rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
