### PR TITLE
feat(lang): spec-level kind tag (metadata classification badge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- Optional **spec-level tag** classifying a whole spec: an intent string right
+  after the spec name, `spec ReturnUI "ui: screen flow" { … }`. Metadata only —
+  it desugars to nothing and is never verified (corpus snapshot unchanged) — and
+  is surfaced by `fslc explain` (`skeleton.spec_kind = {id, text}` + a `Kind:` line
+  in `--readable`) and by `fslc html` (a neutral badge next to the spec title).
+  It carries the machine-readable and at-a-glance "this is a UI spec" classification
+  the fsl-ui spike (issue #9) identified, without the `expand_ui` dialect; see
+  `docs/DESIGN-ui.md`. Touches `grammar.py`, `model.py`, `explain.py`,
+  `html_report.py`. (The surfaced field is `spec_kind`, not `kind`, because the
+  enveloped result tree reserves `kind` for the diagnostic discriminator.)
+
 ### Fixed
 - `fslc html`/`fslc explain` now render a declaration's full logic instead of a
   truncated first source line: action `requires`/`ensures` and property bodies

--- a/docs/DESIGN-ui.md
+++ b/docs/DESIGN-ui.md
@@ -109,6 +109,35 @@ fundamental principle of not expanding into the kernel).
   spike's ReturnUI as a template) delivers enough value for now. **The F-UI-1 fix is
   useful independently of the dialect, so it has already been merged ahead.**
 
+## Shipped increment: the spec-level `kind` tag (Tier 1, not the dialect)
+
+Between "write screen flows in plain fsl" (the ReturnUI template) and a full
+`expand_ui` dialect there is a much cheaper middle purchase, now implemented: an
+**optional spec-level tag** classifying the whole spec.
+
+```fsl
+spec ReturnUI "ui: return-request screen flow (behavioral slice only)" { … }
+```
+
+- **What it buys**: the "this is a UI spec" recognition — for a *human reader* (a
+  leading, typed, in-header cue, and a badge in `fslc explain --readable` / `fslc html`)
+  and for a *machine* (`skeleton.spec_kind = {id, text}` in the explain JSON is a
+  read-off-able ontology classification). This is the spec-unit version of the
+  screen/navigate ontology, without the lossy desugaring.
+- **What it deliberately does not do**: no `screen`/`navigate`/`modal` line-level
+  vocabulary (that is Tier 3, the `expand_ui` dialect, gated on demand — it is where
+  cost jumps discontinuously and the F-UI-2/3/4 expander risk lives).
+- **Cost / faithfulness**: zero kernel semantics (the tag desugars to nothing — the
+  same invariant principle below), so the corpus snapshot is unchanged. The tag text is
+  metadata only and never verified; keep the parenthetical scope note (`behavioral slice
+  only`) so heightened recognition does not outrun what FSL actually models.
+- **Files it moved**: `grammar.py` (optional `meta_tag?` on `spec_def`), `model.py`
+  (`spec["kind"]`), `explain.py` (`skeleton.spec_kind` + readable line), `html_report.py`
+  (title badge), `docs/LANGUAGE.md`, `skills/fsl/reference.md`, this note, and a
+  regression test. One pitfall absorbed: the enveloped result tree reserves the key
+  `kind` for the string diagnostic discriminator scanned by `with_faithfulness` /
+  `trace_type_for`, so the surfaced field is named `spec_kind`, not `kind`.
+
 ## Invariant principle
 
 Do not change the kernel semantics. Dialects are AST expansion only. Things that cannot

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -21,7 +21,7 @@ the implementation design of each feature can be reached from
 ## 1. Structure of a specification
 
 ```fsl
-spec <Name> {
+spec <Name> ["<kind>: <intent>"] {   // optional spec-level tag → metadata badge (explain/html); never verified
   const <NAME> = <constant expr>
   type  <Name> = <lo>..<hi>            // domain type (bounded integer)
   symmetric type <Name> = <lo>..<hi>   // domain whose values are interchangeable identities
@@ -46,6 +46,14 @@ spec <Name> {
   terminal { <expr> }                   // intended terminal states (excluded from deadlock checking)
 }
 ```
+
+The optional string after the spec name is a **spec-level tag**
+(`"<kind>: <intent>"`, e.g. `spec ReturnUI "ui: screen flow" { … }`). Like the
+per-declaration tags, it is **metadata only** — never verified — and is surfaced by
+`fslc explain` / `fslc html` as a classification badge next to the spec name (JSON:
+`skeleton.spec_kind = {id, text}`). Use it to record what kind of thing the whole
+spec is (e.g. `ui` for a screen-flow spec that models only the behavioral slice);
+it carries no kernel semantics and desugars to nothing. See `docs/DESIGN-ui.md`.
 
 Any layer — including a kernel `spec` — may declare identity/number sorts whose
 finite sizes come from a sibling top-level `verify` block instead of an inline

--- a/examples/ui_spike/return_ui.fsl
+++ b/examples/ui_spike/return_ui.fsl
@@ -2,7 +2,7 @@
 // screen=enum / navigate=action / guard=requires / no dead ends=leadsTo /
 // all screens reachable=reachable / no double submit=invariant. No new syntax is used.
 // Note: the screen name Done is renamed so it does not clash with abs's St.Paid (avoiding an enum collision; see F below).
-spec ReturnUI {
+spec ReturnUI "ui: return-request screen flow (behavioral slice only)" {
   type Amount = 0..3
   const AUTO_LIMIT = 1
   enum Screen { Form, Submitting, ReadyToPay, MgrPending, Done, Error }

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -6,7 +6,7 @@ of rules as of v2.x.
 ## 1. Top-level structure
 
 ```fsl
-spec <Name> {
+spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadata badge (explain/html); never verified
   const <NAME> = <const expr>             // integer constant (expressions allowed: CAP - 1, etc.)
   type  <Name> = <lo>..<hi>               // domain type (bounded integer)
   symmetric type <Name> = <lo>..<hi>      // interchangeable entity identities

--- a/src/fslc/explain.py
+++ b/src/fslc/explain.py
@@ -363,6 +363,9 @@ def _skeleton(spec, source_lines):
     properties.extend(_property_skeleton("reachable", reach, spec)
                       for reach in spec.get("reachables", []))
     return {
+        # `spec_kind`, not `kind`: the enveloped result tree reserves `kind` for the
+        # string diagnostic discriminator that with_faithfulness/trace_type_for scan.
+        "spec_kind": spec.get("kind"),
         "state": {
             _public_name(name, spec): _public_type(ty)
             for name, ty in spec.get("state", {}).items()
@@ -746,6 +749,10 @@ def render_readable(explained: dict, spec: dict, display_names: dict) -> str:
     """Render an explain result as deterministic human-readable text."""
     skeleton = explained.get("skeleton") or {}
     lines = [f"Spec: {spec['name']} (depth {explained.get('depth')})"]
+    kind = spec.get("kind")
+    if kind:
+        tag = kind["id"] if kind.get("text") is None else f"{kind['id']}: {kind['text']}"
+        lines.append(f"Kind: {tag}")
 
     def section(title, items):
         if not items:

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -14,7 +14,7 @@ verify_def: "verify" "{" verify_item* "}"
 verify_item: "instances" NAME "=" INT ";"? -> verify_instances
            | "values" NAME "=" expr ".." expr ";"? -> verify_values
 
-spec_def: "spec" NAME "{" item* "}"
+spec_def: "spec" NAME meta_tag? "{" item* "}"
 
 compose_def: "compose" NAME "{" compose_item* "}"
 ?compose_item: use_def | internal_def | compose_state | compose_init
@@ -781,7 +781,13 @@ class Ast(Transformer):
         return child
 
     def spec_def(self, meta, name, *items):
-        return ("spec", name, [i for i in items if i])
+        kept = [i for i in items if i]
+        # An optional leading meta_tag (a dict from _parse_meta) classifies the
+        # whole spec, e.g. `spec ReturnUI "ui: screen flow" { ... }`. It is carried
+        # as a pseudo-item so the ("spec", name, items) shape stays a 3-tuple.
+        if kept and isinstance(kept[0], dict):
+            return ("spec", name, [("__spec_meta", kept[0])] + kept[1:])
+        return ("spec", name, kept)
 
     def refinement_impl(self, meta, name):
         return ("impl", name)

--- a/src/fslc/html_report.py
+++ b/src/fslc/html_report.py
@@ -24,6 +24,7 @@ def render_html_report(file: str, source: str, explained: dict, verification: di
     domains = skeleton.get("domains") or []
     kpis = skeleton.get("kpis") or []
     stage_flows = skeleton.get("stage_flows") or []
+    kind = skeleton.get("spec_kind")
 
     all_actions = skeleton.get("actions") or []
     actions = [a for a in all_actions if not a.get("generated")]
@@ -48,7 +49,7 @@ def render_html_report(file: str, source: str, explained: dict, verification: di
     subtitle = _hero_subtitle(len(state), len(actions), len(properties), domains, kpis)
 
     body = "\n".join([
-        _hero(spec, file, depth, status, len(state), len(actions), len(properties), coverage_label, warnings, subtitle),
+        _hero(spec, file, depth, status, len(state), len(actions), len(properties), coverage_label, warnings, subtitle, kind),
         _model_section(state, actions, enums, domains, kpis, stage_flows),
         _actions_section(actions, coverage),
         _properties_section(properties, auto_checks),
@@ -544,13 +545,13 @@ def _generated_property_check(prop: dict) -> dict:
     }
 
 
-def _hero(spec, file, depth, status, states, actions, properties, coverage, warnings, subtitle) -> str:
+def _hero(spec, file, depth, status, states, actions, properties, coverage, warnings, subtitle, kind=None) -> str:
     status_class = _status_class(status)
     return f"""
       <header class="hero">
         <div>
           <p class="eyebrow">FSL specification report</p>
-          <h1>{escape(spec)}</h1>
+          <h1>{escape(spec)}{_kind_badge(kind)}</h1>
           <p class="sub">{escape(subtitle)}</p>
         </div>
         <div class="meta-grid" aria-label="Report summary">
@@ -567,6 +568,16 @@ def _hero(spec, file, depth, status, states, actions, properties, coverage, warn
         </div>
       </header>
 """
+
+
+def _kind_badge(kind) -> str:
+    """A neutral pill next to the spec title classifying the whole spec (e.g. `ui`)."""
+    if not kind:
+        return ""
+    label = escape(str(kind.get("id", "")))
+    text = kind.get("text")
+    title = f' title="{escape(str(text))}"' if text else ""
+    return f' <span class="badge neutral kind"{title}>{label}</span>'
 
 
 def _metric(label, value) -> str:

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -1025,6 +1025,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
     dialect_controls = None
     dialect_governance = None
     dialect_warnings = []
+    spec_kind = None
     for it in items:
         if it[0] == "__display_names":
             dialect_display_names.update(it[1])
@@ -1048,6 +1049,8 @@ def build_spec(tree, display_names=None, semantic_check=True):
             dialect_governance = it[1]
         elif it[0] == "__warnings":
             dialect_warnings.extend(it[1])
+        elif it[0] == "__spec_meta":
+            spec_kind = it[1]
 
     check_stage_usage(items)
 
@@ -1243,6 +1246,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
         "controls": dialect_controls,
         "governance": dialect_governance,
         "symmetry": symmetry,
+        "kind": spec_kind,
     }
 
 

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -23,6 +23,26 @@ def _counterfactual(out, invariant):
     raise AssertionError(f"missing counterfactual for {invariant}")
 
 
+def test_spec_level_kind_tag_surfaces_in_explain_and_readable():
+    ui = EXAMPLES / "ui_spike" / "return_ui.fsl"
+    out = explain_file(str(ui), depth=3)
+    assert out["skeleton"]["spec_kind"] == {
+        "id": "ui",
+        "text": "return-request screen flow (behavioral slice only)",
+    }
+    # The full CLI envelope path (with_faithfulness / trace_type_for) walks every
+    # nested dict; a `spec_kind` dict under a reserved key would crash it. Guard.
+    enveloped = run_explain(str(ui), depth=3)
+    assert enveloped["result"] == "explained"
+    readable = explain_file(str(ui), depth=3, readable=True)["readable"]
+    assert "Kind: ui: return-request screen flow (behavioral slice only)" in readable
+
+
+def test_spec_without_kind_tag_has_null_spec_kind():
+    out = explain_file(str(SPECS / "cart_v1.fsl"), depth=3)
+    assert out["skeleton"]["spec_kind"] is None
+
+
 def test_cart_v1_skeleton_lists_actions_properties_auto_checks_and_tags():
     out = explain_file(str(SPECS / "cart_v1.fsl"), depth=4)
     assert out["result"] == "explained"

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -10,6 +10,17 @@ ROOT = Path(__file__).resolve().parents[1]
 SPECS = ROOT / "specs"
 
 
+def test_spec_level_kind_tag_renders_title_badge():
+    ui = ROOT / "examples" / "ui_spike" / "return_ui.fsl"
+    result = run_html(str(ui), depth=3, write_file=False)
+
+    assert result["result"] == "generated"
+    html = result["content"]
+    assert '<span class="badge neutral kind"' in html
+    assert 'title="return-request screen flow (behavioral slice only)"' in html
+    assert ">ui</span>" in html
+
+
 def test_run_html_generates_self_contained_report():
     result = run_html(str(SPECS / "cart_v1.fsl"), depth=4, write_file=False)
 


### PR DESCRIPTION
## What

Adds an optional **spec-level tag** classifying a whole spec:

```fsl
spec ReturnUI "ui: return-request screen flow (behavioral slice only)" { … }
```

Metadata only — desugars to nothing, never verified. Surfaced in three places:
- `fslc explain` JSON → `skeleton.spec_kind = {id, text}`
- `fslc explain --readable` → `Kind: …` line
- `fslc html` → neutral badge next to the spec title

## Why

The fsl-ui spike (#9) established that screen flows are expressible in plain FSL. The open question was whether a *dedicated UI syntax* adds value. Conclusion: no formal-semantics gain (a dialect desugars to the same kernel), but a machine-readable + at-a-glance "this is a UI spec" **classification** does. This is the cheap **Tier-1** purchase of that benefit — spec-unit classification without the lossy `expand_ui` dialect (`screen`/`navigate` line-level vocabulary, deferred until demand; that is where cost jumps discontinuously and the F-UI-2/3/4 expander risk lives). See `docs/DESIGN-ui.md`.

## Design note

The surfaced field is `spec_kind`, **not** `kind`: the enveloped result tree reserves `kind` for the string diagnostic discriminator that `with_faithfulness` / `trace_type_for` scan on every nested dict. A `kind` dict there crashes the walker (`unhashable type: 'dict'`); a regression test pins the CLI envelope path.

## Verification

- **corpus snapshot: 152 passed** — the feature is verdict-neutral (metadata only, no kernel semantics).
- example `return_ui.fsl`: still `proved` + `refines`.
- test_explain / test_html_report (3 new) pass; test_v1: 39 pass; **LSP tests: 25 pass**.
- **LSP + VSCode tmLanguage: no change needed** — verified empirically (shared `parse_src`/`build_spec`; `_TOP_LEVEL_NAME` captures the name before the tag; generic string highlighting covers the tag).
- no absolute paths in the tracked diff.

11 files, +116/−8. bmc/runtime untouched (no concrete semantics); no new files (no SPDX); corpus snapshot not regenerated (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
