### PR TITLE
[codex] Complete issue 104 implementation followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Issue #104 follow-ups: typed `relation A -> B` state with relation helpers
+  (`.contains/.add/.remove`, `reachable`, `acyclic`, `functional`,
+  `injective`, `domain`, `range`); `helpful action(args)` metadata for
+  per-binding ranked `leadsTo` induction under interleaving; opt-in
+  `fslc sweep` with `sweep.results` and `sweep.minimal_counterexample`; richer
+  `preserve progress` diagnostics (`progress_failure` classification and
+  lower-layer `fair action` repair hints); and `fslc html` relation/refinement
+  visual evidence.
 - `fslc analyze` structural observation JSON. `--projection tsg` emits a stable
   Typed Semantic Graph over requirements, actions, state variables, properties,
   acceptance/forbidden scenarios, and traceability metadata. Graph projections

--- a/docs/DESIGN-html-report.md
+++ b/docs/DESIGN-html-report.md
@@ -60,7 +60,11 @@ the verifier's verdict on it:
   dialect-generated (type-bound checks, partial-op checks, generated actions,
   deadline invariants)
 - verification status and warnings
-- counterexample or reachable trace timeline
+- counterexample or reachable trace timeline, including relation edge summaries
+  when trace state contains `relation A -> B` values
+- refinement evidence when `verify` reports an inline `implements` failure:
+  implementation-side action/state/trace next to the abstract-side mapped state
+  and mismatch payload
 - witness examples with state snapshots
 - counterfactual table
 - escaped source with line numbers
@@ -79,6 +83,11 @@ The report is a dense product-review surface rather than a marketing page. It
 uses restrained surfaces, fixed-radius panels, semantic status colors, tables for
 scanability, and SVG only for the model relationship view. All source, formulas,
 JSON, and requirement text are HTML-escaped before rendering.
+
+Relation and refinement evidence are display-only views over existing verifier
+JSON. `fslc html` does not invent graph semantics: relation graphs render the
+pair lists already emitted in traces, and refinement panels render
+`implements.violation` / `refinement_failed` payloads side by side.
 
 ## Non-goals
 

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -63,8 +63,12 @@ refinement CartImplRefinesCart {
   safety refinement. When present, fslc pulls the named abstract `leadsTo` P/Q
   through the state mapping and runs the same bounded lasso/stall search on impl
   executions. The `by` actions are validated impl action names and are returned
-  in JSON as review context; fairness still comes from the impl actions marked
-  `fair`.
+  in JSON as review context; they do not create fairness or implementation
+  conformance by themselves. Fairness still comes from the impl actions marked
+  `fair`. Failures report `kind:"progress_lost"` plus
+  `progress_failure:"lasso_blocks_progress"` or
+  `"deadlock_or_stall_blocks_progress"`, pending bindings, `impl_trace`, and
+  `progress:{leadsTo, actions}` so repair can target the lower-layer action.
 - The grammar does not coexist with existing `.fsl` files (an **independent
   file** with `refinement` at the top level. Parsing adds `refinement_def` to
   the same Lark grammar).

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -149,6 +149,7 @@ leadsTo <Name> {
   <expr> ~> <expr>                      // once P holds (including the same instant), Q eventually holds
   <expr> ~> within K <expr>             // Q must hold within K steps after P
   forall x: T { <expr> ~> <expr> }      // checked independently per binding (only an outer forall may nest)
+  helpful <action>(<binding expr>, ...)  // optional; per-binding progress action for ranked induction
   decreases <int expr>                  // optional; induction-only ranking measure
 }
 ```
@@ -159,10 +160,17 @@ constant expression. It is checked by BMC, not by the ranked induction proof.
 `decreases` is optional and must be an integer-valued expression. Under
 `fslc verify --engine induction`, the verifier proves the ranked response by
 checking, under the proved invariants, that whenever `P` is pending and `Q` is
-false: the measure is non-negative; some action is enabled; and every enabled
-action either makes `Q` true or keeps `P` true while strictly decreasing the
-measure. Ranked proof success is independent of `--depth`; `--depth` is still
-used for the base BMC check and reachable/coverage evidence.
+false: the measure is non-negative; progress is possible; and the enabled-action
+discipline is satisfied. Without `helpful`, every enabled action must either make
+`Q` true or keep `P` true while strictly decreasing the measure. With one or more
+`helpful action(args...)` lines, only the matching helpful action instance must
+strictly decrease the measure when it fires; unrelated action instances only need
+to keep the pending obligation true unless they make `Q` true. The matching
+helpful action must be a lower-layer `fair action` and must be enabled whenever
+the obligation is pending. `helpful` is metadata for the ranked proof: it does
+not create a fairness assumption. Ranked proof success is independent of
+`--depth`; `--depth` is still used for the base BMC check and
+reachable/coverage evidence.
 
 **Placement.** `decreases` is a sibling of the response body inside the
 `leadsTo` block, *outside* any `forall` wrapper — never nested inside the
@@ -182,19 +190,26 @@ leadsTo Responds {
 }
 ```
 
-**Per-entity measures fail under interleaving.** The ranking discipline
-above applies to *every* enabled action, not just the one that resolves the
-pending binding. A measure that mentions only the bound entity, e.g.
-`decreases level[c]` inside `forall c: Case { level[c] > 0 ~> level[c] == 0 }`,
-therefore always fails: an action that advances a *different* entity (say
-`step(c=1)` while the pending binding is `c=0`) leaves `level[c=0]`
-unchanged, and the discipline requires every enabled action to strictly
-decrease the measure. The verifier reports this as
-`rank_failure: "non_decreasing_action"`, with the CTI's `last_action`
-showing the other entity's binding — this is by design, not a bug. Proving
-per-entity liveness under interleaving needs a fairness-aware discipline
-(only the binding's own "helpful" action must decrease); that is not
-implemented and is tracked separately (issue #72).
+**Per-entity measures under interleaving need `helpful`.** A measure that
+mentions only the bound entity, e.g. `decreases level[c]` inside
+`forall c: Case { level[c] > 0 ~> level[c] == 0 }`, is not enough by itself:
+an action that advances a different entity can leave `level[c]` unchanged. Add
+the per-binding progress action:
+
+```fsl
+leadsTo Responds {
+  forall c: Case { level[c] > 0 ~> level[c] == 0 }
+  helpful step(c)
+  decreases level[c]
+}
+```
+
+With this form, `step(c)` must be declared `fair action`, must be enabled in
+every pending state for that binding, and must strictly decrease `level[c]`
+when it fires. Other interleavings may preserve the pending obligation without
+decreasing this per-entity measure. Diagnostics distinguish
+`progress_action_not_fair`, `helpful_action_not_enabled`,
+`non_decreasing_helpful_action`, and `pending_not_preserved`.
 
 **Working idiom: a global sum measure.** Sum the tracked quantity across the
 domain with the built-in `sum()` aggregate (§3): `decreases sum(k: Case of
@@ -204,11 +219,10 @@ unchanged whether `Case` is sized via `verify { instances Case = N }` or
 shrunk with a CLI `--instances` override. Because every fair `step` decrements
 exactly one `level[k]`, every enabled action strictly decreases the total, so
 induction returns `"proved"` with `"completeness": "unbounded"`. This idiom
-only covers designs where *every* enabled action decreases the total; a
-design where some enabled action advances the domain without shrinking the
-sum is still an open case, needing the fairness-aware "helpful action"
-discipline from issue #72 above. (Conditional expressions can't substitute
-for a per-branch measure either: `if/then/else` is legal only in
+only covers designs where *every* enabled action decreases the total. For
+per-entity progress under interleaving, prefer the `helpful` form above.
+(Conditional expressions can't substitute for a per-branch measure either:
+`if/then/else` is legal only in
 refinement-mapping expressions (§10), not in the general expression grammar
 that `decreases` draws from.)
 
@@ -227,6 +241,7 @@ that `decreases` draws from.)
 | `Map<K, V>` | `stock: Map<ItemId, Qty>` | K is recommended to be a bounded scalar (domain type / enum / Bool) |
 | `Set<T>` | `shipped: Set<OrderId>` | T is a bounded scalar |
 | `Seq<T, N>` | `queue: Seq<JobId, 3>` | A sequence (FIFO) of capacity N. T is a scalar, N is a constant |
+| `relation A -> B` | `delegates: relation User -> User` | A bounded binary relation over bounded scalar endpoints |
 
 **Scalar** = Int / Bool / domain type / enum. In a `state` declaration,
 `x: lo..hi` is accepted as an anonymous domain type and is equivalent to
@@ -235,7 +250,7 @@ declaring `type X = lo..hi` and writing `x: X`.
 **Types legal as state variables** (anything else is rejected by `check` as a type error):
 scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
 | `Map<bounded scalar, scalar | Option<scalar> | struct>`
-| `Set<bounded scalar>` | `Seq<scalar, N>`
+| `Set<bounded scalar>` | `Seq<scalar, N>` | `relation bounded-scalar -> bounded-scalar`
 
 - Nesting structs, Set/Map/Seq inside a struct field,
   `Option<Option<...>>`, and `Option<Set/Map/Seq/struct>` are not allowed
@@ -271,6 +286,10 @@ scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
 - Set: `Set {}` / `Set { 1, 2 }`, `.add(e)` `.remove(e)` `.contains(e)` `.size()`
 - Seq: `Seq {}` / `Seq { 1, 2 }`, `.push(e)` `.pop()` `.head()` `.at(i)`
   `.contains(e)` `.size()`, `==` is equality of length and all elements
+- Relation: `r.contains(a, b)`, `r.add(a, b)`, `r.remove(a, b)`,
+  `reachable(r, a, b)`, `acyclic(r)`, `functional(r)`, `injective(r)`,
+  `domain(r)`, `range(r)`. `reachable` and `acyclic` require a self-relation
+  (`relation T -> T`); endpoint type/arity errors include repair hints.
 - Inside ensures / trans only: read the pre-transition state with `old(expr)`
 - Inside a leadsTo block only: `P ~> Q` (response property. not part of the operator hierarchy of general expressions);
   optional `within K` before Q for a bounded deadline, and optional
@@ -290,7 +309,8 @@ variable.
 ## 4. Statements (init / action bodies)
 
 - Assignment: `x = expr`, `m[k] = expr`, `m[k].field = expr`, `o.field = expr`
-- Updating a Set/Seq uses the **reassignment idiom**: `s = s.add(x)`, `q = q.pop()`
+- Updating a Set/Seq/relation uses the **reassignment idiom**:
+  `s = s.add(x)`, `q = q.pop()`, `r = r.add(a, b)`
 - `if expr { stmt... } else { stmt... }` is allowed in both `init` and action bodies
   (can be nested with an if inside the else)
 - `forall x: T { stmt... }` (bulk initialization / bulk update)
@@ -381,6 +401,8 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                                                  #   invariant / trans / leadsTo / reachable (for probing)
                [--exclude-property <Name>]...    # skip named invariant/trans/leadsTo/reachable
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
+fslc sweep     <file.fsl> --instances E=lo..hi --depth lo..hi [--property Name]
+                                                 # opt-in scope sweep over bounded verification
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
 fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
@@ -408,9 +430,17 @@ from the run and from checked-property outputs (`invariants_checked`,
 `transitions_checked`, `leads_to`, and `reachables`). When `--property` and
 `--exclude-property` name the same property, exclusion wins.
 
+`sweep` is an opt-in wrapper around `verify`; it does not change normal
+verification. It evaluates a deterministic grid of `--instances NAME=lo..hi`,
+`--values NAME=lo..hi`, and `--depth lo..hi` overrides, records each underlying
+verification result under `sweep.results`, and returns the first failing scope
+under `sweep.minimal_counterexample`. For `--values`, the sweep fixes the lower
+bound and expands the upper bound (`lo..lo`, `lo..lo+1`, ..., `lo..hi`). A
+passing sweep means "no counterexample in this grid", not an unbounded proof.
+
 Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant / refines /
-mutated / explained / analyzed / typestate,
-`1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed,
+mutated / explained / analyzed / typestate / sweep_passed,
+`1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed / sweep_failed,
 `2` = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 `--vacuity error`), `3` = internal error.
 
@@ -748,8 +778,11 @@ This pulls the named abstract `leadsTo` through the state mapping and checks
 `P(α(impl_state)) ~> Q(α(impl_state))` on impl executions. If the lower layer can
 spin forever or deadlock while the abstract response remains pending, the result
 is `refinement_failed` with `kind:"progress_lost"` and
-`violation_kind:"leadsTo"`. The `by` actions are review metadata and must name
-impl actions; fairness still comes from lower-layer `fair action` declarations.
+`violation_kind:"leadsTo"`. `progress_failure` distinguishes
+`lasso_blocks_progress` from `deadlock_or_stall_blocks_progress`. The `by`
+actions are review metadata and must name impl actions; they do not create
+fairness or prove implementation conformance. Fairness still comes from
+lower-layer `fair action` declarations.
 For unbounded proof, keep using a lower-layer `leadsTo ... decreases ...` and
 `verify --engine induction`.
 

--- a/docs/intro/syntax.en.html
+++ b/docs/intro/syntax.en.html
@@ -185,18 +185,20 @@ verify { instances Claim = 3 values Amount = 0..3 }</code></pre>
       <tr><td>Map</td><td><code>Map&lt;ItemId, Qty&gt;</code></td><td>Bounded key to scalar, Option, or struct value.</td></tr>
       <tr><td>Set</td><td><code>Set&lt;UserId&gt;</code></td><td>A set of bounded scalar values.</td></tr>
       <tr><td>Seq</td><td><code>Seq&lt;JobId, CAP&gt;</code></td><td>Capacity-bounded queue or log.</td></tr>
+      <tr><td>Relation</td><td><code>relation User -&gt; Role</code></td><td>Bounded binary link graph.</td></tr>
       <tr><td>Dialect kinds</td><td><code>entity Claim</code>, <code>number Amount</code></td><td>Business/requirements kinds bounded by <code>verify</code>.</td></tr>
     </table>
 
     <div class="panel reveal">
       <h3>Allowed state-variable shapes</h3>
-      <p>Use scalar, <code>Option&lt;scalar&gt;</code>, struct, map, set, or sequence. Avoid nested maps and containers inside containers.</p>
+      <p>Use scalar, <code>Option&lt;scalar&gt;</code>, struct, map, set, sequence, or relation. Avoid nested maps and containers inside containers.</p>
       <pre><code>state {
   status: St,
   cart: Option&lt;ItemId&gt;,
   orders: Map&lt;OrderId, Order&gt;,
   locked: Set&lt;UserId&gt;,
-  queue: Seq&lt;JobId, CAP&gt;
+  queue: Seq&lt;JobId, CAP&gt;,
+  delegates: relation User -&gt; User
 }</code></pre>
     </div>
   </div>
@@ -286,6 +288,7 @@ init {
       <tr><td>Option</td><td><code>none</code>, <code>some(e)</code>, <code>x is some(v)</code></td><td><code>cart[u] is some(i) and stock[i] &gt; 0</code></td></tr>
       <tr><td>Set</td><td><code>Set {}</code>, <code>.add</code>, <code>.remove</code>, <code>.contains</code>, <code>.size()</code></td><td><code>active.contains(u)</code></td></tr>
       <tr><td>Seq</td><td><code>Seq {}</code>, <code>.push</code>, <code>.pop</code>, <code>.head</code>, <code>.at</code>, <code>.size()</code></td><td><code>i &lt; q.size() =&gt; q.at(i) == j</code></td></tr>
+      <tr><td>Relation</td><td><code>relation A -&gt; B</code>, <code>.add</code>, <code>.remove</code>, <code>.contains</code>, <code>reachable</code>, <code>acyclic</code></td><td><code>acyclic(delegates)</code></td></tr>
       <tr><td>Special</td><td><code>old(expr)</code>, <code>stage(x)</code></td><td><code>total == old(total) + 1</code></td></tr>
     </table>
 
@@ -324,6 +327,7 @@ requires stock[i] &gt; 0</code></pre>
       <tr><td><code>reachable Name { P }</code></td><td>P can be reached.</td><td><code>stock[0] == 0</code></td></tr>
       <tr><td><code>leadsTo Name { P ~&gt; Q }</code></td><td>When P happens, Q eventually happens.</td><td><code>pending ~&gt; done</code></td></tr>
       <tr><td><code>leadsTo ... within K</code></td><td>Q within K steps.</td><td><code>pending ~&gt; within 3 done</code></td></tr>
+      <tr><td><code>helpful action(args)</code></td><td>Per-binding progress action for ranked induction.</td><td><code>helpful step(c)</code></td></tr>
       <tr><td><code>leadsTo ... decreases M</code></td><td>Ranking for induction proof of progress.</td><td><code>decreases remaining</code></td></tr>
       <tr><td><code>unless Name { P unless Q }</code></td><td>Safety: P holds until Q.</td><td>Safety of a held state.</td></tr>
       <tr><td><code>until Name { P until Q }</code></td><td>Combines <code>unless</code> safety with <code>leadsTo</code> liveness.</td><td>Hold the state, yet eventually complete.</td></tr>
@@ -336,9 +340,10 @@ requires stock[i] &gt; 0</code></pre>
   forall c: Claim {
     claims[c].st == Approved ~&gt; claims[c].st == Paid
   }
+  helpful pay(c)
   decreases unpaid_count
 }</code></pre>
-      <p style="margin-top:16px">The outer <code>forall</code> checks responsiveness per target. Add <code>fair</code> to the actions that drive progress, <code>within K</code> to bound the response in steps, and <code>decreases M</code> to supply a ranking for the induction proof. The <code>~&gt;</code> arrow is only valid inside <code>leadsTo</code>.</p>
+      <p style="margin-top:16px">The outer <code>forall</code> checks responsiveness per target. Add <code>fair</code> to the actions that drive progress, <code>within K</code> to bound the response in steps, <code>helpful action(args)</code> to identify the per-binding progress action, and <code>decreases M</code> to supply a ranking for the induction proof. <code>helpful</code> does not create fairness; the action still needs <code>fair action</code>. The <code>~&gt;</code> arrow is only valid inside <code>leadsTo</code>.</p>
     </div>
   </div>
 </section>
@@ -476,6 +481,14 @@ type Cell = 0..ROOMS*SLOTS-1
       <div class="syntax-card">
         <h3>Use <code>terminal</code> for intended stops</h3>
         <pre><code>terminal { status == Done or status == Failed }</code></pre>
+      </div>
+      <div class="syntax-card">
+        <h3>Sweep bounded scope</h3>
+        <pre><code>fslc sweep spec.fsl \
+  --instances Case=1..3 \
+  --depth 1..8 \
+  --property AtMostOne</code></pre>
+        <p><code>sweep.results</code> records each run; <code>sweep.minimal_counterexample</code> points at the first failing scope.</p>
       </div>
     </div>
   </div>

--- a/docs/intro/syntax.ja.html
+++ b/docs/intro/syntax.ja.html
@@ -175,6 +175,9 @@ verify { instances Return = 3 }</code></pre>
     <div class="callout reveal" style="margin-top:24px">
       <p style="margin:0"><b><code>verify { ... }</code> の配置:</b> 業務層・要件層の有限範囲は、同じファイルのトップレベルに置く別ブロックです。<code>spec</code> の中には置きません。</p>
     </div>
+    <div class="callout reveal" style="margin-top:16px">
+      <p style="margin:0"><b>範囲を掃引する:</b> <code>fslc sweep spec.fsl --instances Case=1..3 --depth 1..8 --property AtMostOne</code> は、各検証結果を <code>sweep.results</code> に、最初に失敗した範囲を <code>sweep.minimal_counterexample</code> に出します。</p>
+    </div>
   </div>
 </section>
 
@@ -196,19 +199,21 @@ verify { instances Return = 3 }</code></pre>
       <tr><td>対応表</td><td><code>Map&lt;ItemId, Qty&gt;</code></td><td>範囲つきキーから値へ。値は単純値、値がない/ある型、構造体。</td></tr>
       <tr><td>集合</td><td><code>Set&lt;UserId&gt;</code></td><td>範囲つき値の集合。</td></tr>
       <tr><td>列</td><td><code>Seq&lt;JobId, CAP&gt;</code></td><td>容量つき列。FIFOやログ。</td></tr>
+      <tr><td>関係</td><td><code>relation User -&gt; Role</code></td><td>有限範囲の2項リンク。</td></tr>
       <tr><td>業務対象・数値種別</td><td><code>entity Claim</code>, <code>number Amount</code></td><td>業務層・要件層の型種別。範囲は <code>verify</code> ブロックで指定します。</td></tr>
     </table>
 
     <div class="panel reveal">
       <h3>状態 <code>state</code> 変数に置ける型</h3>
-      <p>許可されるのは、単純値、値がない/ある型、構造体、対応表、集合、列です。対応表や集合のキーには、基本的に有限範囲の値を使います。</p>
+      <p>許可されるのは、単純値、値がない/ある型、構造体、対応表、集合、列、関係です。対応表・集合・関係の端点には、基本的に有限範囲の値を使います。</p>
       <pre><code>// OK
 state {
   status: St,
   cart: Option&lt;ItemId&gt;,
   orders: Map&lt;OrderId, Order&gt;,
   locked: Set&lt;UserId&gt;,
-  queue: Seq&lt;JobId, CAP&gt;
+  queue: Seq&lt;JobId, CAP&gt;,
+  delegates: relation User -&gt; User
 }
 
 // NG の代表: 対応表の入れ子 / 構造体そのものの Option / 構造体内の集合 など</code></pre>
@@ -294,7 +299,8 @@ m[k] = expr
 m[k].field = expr
 o.field = expr
 s = s.add(x)
-q = q.pop().push(y)</code></pre>
+q = q.pop().push(y)
+r = r.add(a, b)</code></pre>
       </div>
       <div class="panel" style="margin-top:0">
         <h3>同時代入の意味</h3>
@@ -326,6 +332,7 @@ action bad() {
       <tr><td>値がない/ある型</td><td><code>none</code>, <code>some(e)</code>, <code>x is some(v)</code></td><td><code>cart[u] is some(i) and stock[i] &gt; 0</code></td></tr>
       <tr><td>集合</td><td><code>Set {}</code>, <code>.add</code>, <code>.remove</code>, <code>.contains</code>, <code>.size()</code></td><td><code>active.contains(u)</code></td></tr>
       <tr><td>列</td><td><code>Seq {}</code>, <code>.push</code>, <code>.pop</code>, <code>.head</code>, <code>.at</code>, <code>.contains</code>, <code>.size</code></td><td><code>q.size() &gt; 0 =&gt; q.head() == j</code></td></tr>
+      <tr><td>関係</td><td><code>relation A -&gt; B</code>, <code>.add</code>, <code>.remove</code>, <code>.contains</code>, <code>reachable</code>, <code>acyclic</code></td><td><code>acyclic(delegates)</code></td></tr>
       <tr><td>構造体</td><td><code>S { f: e }</code>, <code>x.field</code></td><td><code>orders[o].st == Paid</code></td></tr>
       <tr><td>特殊</td><td><code>old(expr)</code>, <code>stage(x)</code></td><td><code>total == old(total) + 1</code></td></tr>
     </table>
@@ -371,6 +378,7 @@ requires stock[i] &gt; 0
       <tr><td><code>reachable Name { P }</code></td><td>P に到達できること。</td><td><code>stock[0] == 0</code></td></tr>
       <tr><td><code>leadsTo Name { P ~&gt; Q }</code></td><td>P になったらいつか Q。</td><td><code>pending ~&gt; done</code></td></tr>
       <tr><td><code>leadsTo ... within K</code></td><td>K手以内の応答。</td><td><code>pending ~&gt; within 3 done</code></td></tr>
+      <tr><td><code>helpful action(args)</code></td><td>対象ごとの進捗操作を指定。</td><td><code>helpful step(c)</code></td></tr>
       <tr><td><code>leadsTo ... decreases M</code></td><td>帰納法で使う減少量。</td><td><code>decreases remaining</code></td></tr>
       <tr><td><code>unless Name { P unless Q }</code></td><td>Q まで P を保つ安全性。</td><td>保持状態の安全性。</td></tr>
       <tr><td><code>until Name { P until Q }</code></td><td>安全性 <code>unless</code> と応答性 <code>leadsTo</code> の組み合わせ。</td><td>保ちながらいつか完了。</td></tr>
@@ -383,9 +391,10 @@ requires stock[i] &gt; 0
   forall c: Claim {
     claims[c].st == Approved ~&gt; claims[c].st == Paid
   }
+  helpful pay(c)
   decreases unpaid_count
 }</code></pre>
-      <p style="margin-top:16px">外側の <code>forall</code> は、対象ごとに応答性を分けて検査します。<code>~&gt;</code> は <code>leadsTo</code> の中だけで使えます。</p>
+      <p style="margin-top:16px">外側の <code>forall</code> は、対象ごとに応答性を分けて検査します。<code>helpful action(args)</code> はその対象の進捗を担う操作を指定し、<code>decreases</code> の帰納証明で使います。ただし <code>helpful</code> は公平性を作りません。実際の進捗操作には下位層の <code>fair action</code> が必要です。<code>~&gt;</code> は <code>leadsTo</code> の中だけで使えます。</p>
     </div>
   </div>
 </section>

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -239,6 +239,7 @@ the formalization memo.**
 | business-flow reachability / completion goal | `goal G "..." some Case can reach Target` or `goal G "..." all Case can be Target [or Target ...]` |
 | "once X has happened, it can never happen again" (history dependence) | ghost variable (`ever_*`) + invariant |
 | "X can be reached / X can end up being reached" (possibility) | `reachable` (witness, or detection of over-constraint) |
+| "A is linked to B" / graph reachability / acyclicity / functional relation | `state { r: relation A -> B }` plus `.contains/.add/.remove`, `reachable`, `acyclic`, `functional`, `injective`, `domain`, `range` |
 | "within K times / K ticks" (deadline) | kernel `leadsTo ... within K` for step deadlines, or requirements `time` + `deadline` for SLA/tick semantics (reference §11) |
 | upper/lower bound or non-negativity of a number | kernel: `type T = lo..hi`; business/requirements dialects: `number T` plus `verify { values T = lo..hi }` (do not hand-write boundary invariants) |
 | "at most / less than / at least / greater than" "before / after" | `<= / < / >= / >`. **Make boundary implications explicit in the memo** (the most frequent misreading) |
@@ -284,6 +285,9 @@ the formalization memo.**
    contract**. If implementation conformance is also required, anchor to the
    implementation with `testgen` (pytest via an Adapter) / `replay` (matching
    against execution logs).
+   For scope-sensitive failures, use `fslc sweep file.fsl --instances Case=1..3
+   --depth 1..8 [--property Name]`; it reports each run under `sweep.results` and
+   the first failing scope under `sweep.minimal_counterexample`.
 
 ## Connected workflow (across layers — when alignment is the deliverable)
 
@@ -352,6 +356,7 @@ existing result/kind fields:
 | `violated` / `partial_op` | pop/head on an empty Seq, index out of range, or divisor 0 | Guard with `requires q.size() > 0` / `requires d != 0` or an `if` |
 | `violated` / `ensures` | Postcondition not satisfied | Decide whether the body or the ensures is correct, and fix accordingly |
 | `violated` / `leadsTo` | Response-property counterexample (lasso / stall) | Check the trace's `loop_start`. Either add `fair` to the action that drives progress, or fix the spec |
+| `unknown_cti` / `leadsTo_rank` | Ranked response proof failed | Read `rank_failure`: `progress_action_not_fair` means `helpful` named a non-fair action; `helpful_action_not_enabled` means the matching progress action is blocked while P is pending; `non_decreasing_helpful_action` means the helpful action fires without lowering the measure; otherwise repair the rank or pending preservation |
 | `reachable_failed` | A state you want to reach is unreachable | Read `action_coverage`'s `blocking_requires` (unsat core). Loosen a guard / add an action / increase `--depth` |
 | `unknown_cti` | The invariant is true but not inductive | **The CTI's starting state = a phantom state satisfying all invariants. Add an auxiliary invariant (one that is a domain truth) that excludes it, then re-run.** Check `suggested_invariants` first — for the monotone-counter idiom the result carries ready-made candidate expressions. Track record: converges in one round (e.g. "no duplicates in the queue," "refunds only from Captured") |
 | warning / `vacuous_implication` | The antecedent of an implication invariant is never reached within depth | Check whether an action / reachable witness that makes the antecedent hold is missing, or whether the antecedent expression is reversed or too strong relative to intent. Do not simply weaken the consequent |
@@ -364,7 +369,7 @@ existing result/kind fields:
 | `error` / `vacuous` | init is unsatisfiable (contradictory assignments, etc.) | Review init. Check that you are not giving one state variable contradictory values. A violation from an out-of-range value is different and becomes `violated`/`type_bound` |
 | `refinement_failed` / `abs_requires_failed` | A detailed-layer transition breaks an upper-layer guard (e.g. a shortcut skipping approval) | Read `impl_action` and `impl_trace`. Add a guard to the detailed layer, or review the interpretation of the correspondence (`maps` / mapping) |
 | `refinement_failed` / `abs_state_mismatch` / `stutter_changed_abs` / `map_out_of_bounds` | Mapping inconsistency (an update has no correspondence / a stutter nonetheless changes upper-layer state / a mapped value is out of the type's range) | Compare the `mismatch` path with `abs_before/after`. Fix the mapping expression or the action correspondence |
-| `refinement_failed` / `progress_lost` | A `preserve progress` mapping pulled an upper `leadsTo` into the lower layer and found a lasso/stall | Read `impl_trace`, `pending_since`, `loop_start`/`stutter`, and the `progress.actions`. Add/restore `fair` on the lower progress action, add a lower-layer ranked `leadsTo`, or revise the progress mapping |
+| `refinement_failed` / `progress_lost` | A `preserve progress` mapping pulled an upper `leadsTo` into the lower layer and found a lasso/stall | Read `progress_failure`, `impl_trace`, `pending_since`, `loop_start`/`stutter`, and the `progress.actions`. Add/restore lower-layer `fair action` on the progress action, add a lower-layer ranked `leadsTo`, or revise the progress mapping |
 | `implements.result: violated` within verify | The requirements layer deviates from the upper (business) layer | The contents of `implements.violation` have the same shape as refinement_failed. Same procedure as above + check the `requirement` on the requirements side |
 | `error` / `acceptance` | Replay of an acceptance criterion failed | The ID and step of the failed AC are returned. Decide whether the procedure's precondition (state) or the expect is correct, and fix accordingly |
 | `error` / `forbidden` | An operation sequence that should be rejected was accepted (under-constraint; the kind that a safety invariant stays silent about) | `accepted_trace` is the accepting path. The requires enabling the last operation is too loose → add a guard or review the spec |
@@ -388,8 +393,9 @@ preserve progress {
 
 This checks the upper `leadsTo` after pulling it through the state mapping. A
 failure is `refinement_failed / progress_lost`. The `by` actions are validated
-impl action names and review metadata; the actual lasso exclusion still comes
-from lower-layer `fair action` declarations.
+impl action names and review metadata; they do not create fairness or prove
+implementation conformance. The actual lasso exclusion still comes from
+lower-layer `fair action` declarations.
 
 When a counterexample makes you **change an interpretation** (added a guard,
 loosened an invariant, decided how to handle an exception), record that judgment in

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -27,7 +27,7 @@ spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadat
   invariant <Name> { <expr> }
   trans     <Name> { <expr> }            // two-state safety. old(expr) for the old state
   reachable <Name> { <expr> }
-  leadsTo   <Name> { <expr> ~> [within K] <expr> [decreases <int expr>] } // outer forall x: T { … } may wrap the response
+  leadsTo   <Name> { <expr> ~> [within K] <expr> [helpful act(args)] [decreases <int expr>] } // outer forall x: T { … } may wrap the response
   unless    <Name> { <expr> unless <expr> } // safety: preserve P until Q
   until     <Name> { <expr> until <expr> }  // unless safety + progress P ~> Q
   terminal  { <expr> }                     // intended terminal state (excluded from the deadlock check)
@@ -153,12 +153,14 @@ refinement <Name> {
 | Map<K, V> | `m: Map<ItemId, Qty>` | K is a bounded scalar (Int keys give a deprecation warning) |
 | Set<T> | `s: Set<OrderId>` | T is a bounded scalar |
 | Seq<T, N> | `q: Seq<JobId, CAP>` | T is a scalar, N is a positive constant. FIFO |
+| relation A -> B | `r: relation User -> Role` | Binary relation over bounded scalar endpoints |
 
 Scalar = Int / Bool / domain type / enum. In a `state` declaration,
 `x: lo..hi` is an anonymous domain type and is equivalent to declaring
 `type X = lo..hi` and writing `x: X`.
 **State-variable whitelist**: scalar | Option<scalar> | struct |
-Map<bounded scalar, scalar|Option|struct> | Set<bounded scalar> | Seq<scalar, N>.
+Map<bounded scalar, scalar|Option|struct> | Set<bounded scalar> | Seq<scalar, N> |
+relation bounded-scalar -> bounded-scalar.
 Anything else (nested structs, Set/Map/Seq as a Map value, etc.) is rejected by
 check as a type error.
 
@@ -183,6 +185,9 @@ check as a type error.
 - Set: `Set {}` `Set { 1, 2 }`, `.add(e) .remove(e) .contains(e) .size()`
 - Seq: `Seq {}` `Seq { 1, 2 }` (element count ≤ N), `.push(e) .pop() .head() .at(i)
   .contains(e) .size()`, `==` (length + all elements)
+- Relation: `.contains(a,b) .add(a,b) .remove(a,b)`,
+  `reachable(r,a,b) acyclic(r) functional(r) injective(r) domain(r) range(r)`.
+  `reachable`/`acyclic` require a self-relation (`relation T -> T`).
 - ensures/trans only: `old(expr)` / leadsTo only: `P ~> Q`,
   `P ~> within K Q`, plus optional `decreases <int expr>` for induction ranking /
   mapping-expression only:
@@ -191,7 +196,8 @@ check as a type error.
 ## 4. Statements (init / action body)
 
 - Assignment: `x = e`, `m[k] = e`, `m[k].f = e`, `o.f = e`, `o.f = some(e)`
-- Set/Seq are re-assigned: `s = s.add(x)`, `q = q.pop().push(y)` (chaining allowed)
+- Set/Seq/relation are re-assigned: `s = s.add(x)`, `q = q.pop().push(y)`,
+  `r = r.add(a,b)` (chaining allowed)
 - `if expr { stmt... } [else { stmt... }]` is allowed in both `init` and action
   bodies (may nest with an if inside else)
 - `forall x: T { stmt... }` (bulk assignment)
@@ -226,24 +232,28 @@ check as a type error.
    counterexamples.
 7. `leadsTo ... decreases M` under `verify --engine induction` proves an
    unbounded response when, under the proved invariants and while P holds and Q is
-   false, M is non-negative, some action is enabled, and every enabled action
-   either makes Q true or keeps P true while strictly decreasing M. Without
+   false, M is non-negative and the ranked progress discipline holds. Without
+   `helpful`, every enabled action must either make Q true or keep P true while
+   strictly decreasing M. With `helpful act(args...)`, only the matching helpful
+   action instance must strictly decrease M when it fires; unrelated actions only
+   need to preserve the pending obligation unless they make Q true. `helpful`
+   does **not** create fairness: the matching action must still be declared
+   `fair action` and be enabled whenever the obligation is pending. Without
    `decreases`, leadsTo remains bounded to `--depth`.
    - **Placement**: `decreases` is a sibling of the forall wrapper, *outside*
      its braces — `leadsTo L { forall c: Case { P ~> Q } decreases M }`.
      Nesting it inside the forall body is a **parse error**
      (`fslc` reports `unexpected 'decreases' here` with a placement hint),
      not "ranking doesn't work under forall".
-   - **Per-entity measure trap**: `decreases level[c]` inside
-     `forall c: Case { level[c] > 0 ~> level[c] == 0 }` always fails —
-     every enabled action must decrease M, so an action advancing a
-     *different* entity (`step(c=1)` while `c=0` is pending) violates it.
-     Reported as `rank_failure: "non_decreasing_action"`. Working idiom:
-     a **global sum measure** with the built-in `sum()` aggregate, e.g.
-     `decreases sum(k: Case of level[k])` — instances-count independent,
-     works with `--instances` overrides too. Only covers designs where every
-     enabled action decreases the total; fairness-aware per-entity ranking
-     is future work (#72).
+   - **Per-entity measure under interleaving**: use
+     `helpful step(c) decreases level[c]`. Without `helpful`, an action advancing
+     a different entity still reports `rank_failure:"non_decreasing_action"`.
+     With `helpful`, diagnostics include `progress_action_not_fair`,
+     `helpful_action_not_enabled`, `non_decreasing_helpful_action`, and
+     `pending_not_preserved`.
+   - **Global sum idiom**: `decreases sum(k: Case of level[k])` is still the
+     simplest instances-count-independent measure when every enabled action
+     decreases the total; works with `--instances` overrides too.
 8. `symmetric type` / `symmetric enum` means those values are interchangeable
    entity identities. For leadsTo lasso/stall search, fslc symmetry-breaks the
    representative state using canonical rows from `Map<SymmetricType, V>` and
@@ -286,6 +296,8 @@ fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--instances NAME=N]...              # override verify-block `instances NAME = N`
                [--values NAME=LO..HI]...            # override verify-block `values NAME = LO..HI`
                [--strict-tags] [--requirements ids.txt]
+fslc sweep <f> --instances NAME=LO..HI --depth LO..HI [--property Name]
+                                                     # grid of verify runs; JSON sweep.results/minimal_counterexample
 fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emits a text review view
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
@@ -362,6 +374,12 @@ first failed layer and later layers are marked `skipped`.
   same world size on both sides — otherwise a shrunken impl vs a full-size
   abstract fails `map_out_of_bounds`; an impl-only carried number applies to
   the impl only.
+- `sweep` is opt-in bounded honesty for scope exploration. It calls normal
+  `verify` repeatedly over instance/value/depth ranges and returns
+  `result:"sweep_passed"` or `"sweep_failed"`, with every run under
+  `sweep.results` and the first failing scope under
+  `sweep.minimal_counterexample`. For `--values NAME=LO..HI`, it fixes `LO` and
+  expands `LO..LO`, `LO..LO+1`, ..., `LO..HI`.
 - `explain` is deterministic formatting with no LLM. JSON mode enumerates
   state/action/requires/writes/properties/implicit checks by source loc and
   structural traversal, and attaches to each user invariant the shortest
@@ -429,10 +447,12 @@ first failed layer and later layers are marked `skipped`.
 - leadsTo violation: `pending_since` + `loop_start` (lasso) or `stutter: true`.
 - progress-preserving refinement failure: `refinement_failed`,
   `kind:"progress_lost"`, `violation_kind:"leadsTo"`, `impl_trace`,
+  `progress_failure:"lasso_blocks_progress"|"deadlock_or_stall_blocks_progress"`,
   `progress:{leadsTo, actions}`, and `faithfulness_class:"liveness_not_refined"`.
 - leadsTo ranking failure: `unknown_cti` / `violation_kind:"leadsTo_rank"` with
   `rank_failure` (`unbounded_below`, `deadlock`, `non_decreasing_action`, or
-  `pending_not_preserved`).
+  `pending_not_preserved`; with `helpful`, also `progress_action_not_fair`,
+  `helpful_action_not_enabled`, and `non_decreasing_helpful_action`).
 
 ### ⚠ Liveness scales differently from safety — verify it on a reduced model
 

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -691,6 +691,8 @@ def _eval_expr_uncached(e, state, binds, spec, old_state=None, in_ensures=False)
                 return ("set_val", state[n], ty[1])
             if ty[0] == "seq":
                 return ("seq_val", state[f"{n}__data"], state[f"{n}__len"], ty[1], ty[2])
+            if ty[0] == "relation":
+                return ("relation_val", state[n], ty[1], ty[2])
         if n in state:
             return state[n]
         _err(f"unknown identifier '{n}'")
@@ -770,6 +772,81 @@ def _eval_expr_uncached(e, state, binds, spec, old_state=None, in_ensures=False)
         return _eval_count(e, state, binds, spec, old_state, in_ensures)
     if tag == "sum":
         return _eval_sum(e, state, binds, spec, old_state, in_ensures)
+    if tag == "rel_reachable":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("reachable() expects a relation as its first argument")
+        rel, src_ty, dst_ty = parts
+        if not _same_relation_endpoint_type(src_ty, dst_ty):
+            _relation_type_error(
+                f"reachable() requires a self-relation, got relation {src_ty} -> {dst_ty}"
+            )
+        src = eval_expr(e[2], state, binds, spec, old_state, in_ensures)
+        dst = eval_expr(e[3], state, binds, spec, old_state, in_ensures)
+        return _relation_reachable_expr(rel, src_ty, src, dst, spec)
+    if tag == "rel_acyclic":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("acyclic() expects a relation")
+        rel, src_ty, dst_ty = parts
+        if not _same_relation_endpoint_type(src_ty, dst_ty):
+            _relation_type_error(
+                f"acyclic() requires a binary self-relation, got relation {src_ty} -> {dst_ty}"
+            )
+        checks = [
+            z3.Not(_relation_reachable_expr(rel, src_ty, _z3_domain_value(src_ty, v),
+                                            _z3_domain_value(src_ty, v), spec))
+            for v in _relation_endpoint_values(src_ty, spec)
+        ]
+        return z3.And(*checks) if checks else z3.BoolVal(True)
+    if tag == "rel_functional":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("functional() expects a relation")
+        rel, src_ty, dst_ty = parts
+        checks = []
+        dst_values = _relation_endpoint_values(dst_ty, spec)
+        for src in _relation_endpoint_values(src_ty, spec):
+            zsrc = _z3_domain_value(src_ty, src)
+            for i, left in enumerate(dst_values):
+                for right in dst_values[i + 1:]:
+                    checks.append(z3.Not(z3.And(
+                        _relation_contains(rel, src_ty, dst_ty, zsrc, _z3_domain_value(dst_ty, left), spec),
+                        _relation_contains(rel, src_ty, dst_ty, zsrc, _z3_domain_value(dst_ty, right), spec),
+                    )))
+        return z3.And(*checks) if checks else z3.BoolVal(True)
+    if tag == "rel_injective":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("injective() expects a relation")
+        rel, src_ty, dst_ty = parts
+        checks = []
+        src_values = _relation_endpoint_values(src_ty, spec)
+        for dst in _relation_endpoint_values(dst_ty, spec):
+            zdst = _z3_domain_value(dst_ty, dst)
+            for i, left in enumerate(src_values):
+                for right in src_values[i + 1:]:
+                    checks.append(z3.Not(z3.And(
+                        _relation_contains(rel, src_ty, dst_ty, _z3_domain_value(src_ty, left), zdst, spec),
+                        _relation_contains(rel, src_ty, dst_ty, _z3_domain_value(src_ty, right), zdst, spec),
+                    )))
+        return z3.And(*checks) if checks else z3.BoolVal(True)
+    if tag == "rel_domain":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("domain() expects a relation")
+        return _relation_set_from_projection(parts[0], parts[1], parts[2], spec, "domain")
+    if tag == "rel_range":
+        rel_val = eval_expr(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("range() expects a relation")
+        return _relation_set_from_projection(parts[0], parts[1], parts[2], spec, "range")
     if tag == "min":
         a, b = eval_expr(e[1], state, binds, spec, old_state, in_ensures), \
                eval_expr(e[2], state, binds, spec, old_state, in_ensures)
@@ -1005,7 +1082,36 @@ def _eval_seq_method(data, length, elem_ty, cap, method, args, state, binds, spe
     return None
 
 
+def _eval_relation_method(rel, src_ty, dst_ty, method, args, state, binds, spec,
+                          old_state, in_ensures):
+    if method == "contains":
+        if len(args) != 2:
+            _err("relation.contains expects 2 arguments", kind="type")
+        src = eval_expr(args[0], state, binds, spec, old_state, in_ensures)
+        dst = eval_expr(args[1], state, binds, spec, old_state, in_ensures)
+        return _relation_contains(rel, src_ty, dst_ty, src, dst, spec)
+    if method in ("add", "remove"):
+        if len(args) != 2:
+            _err(f"relation.{method} expects 2 arguments", kind="type")
+        src = eval_expr(args[0], state, binds, spec, old_state, in_ensures)
+        dst = eval_expr(args[1], state, binds, spec, old_state, in_ensures)
+        key = _relation_key(src_ty, dst_ty, src, dst, spec)
+        val = z3.BoolVal(method == "add")
+        return ("relation_val", z3.Store(rel, key, val), src_ty, dst_ty)
+    return None
+
+
 def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures):
+    relation_parts = _relation_parts(base)
+    if relation_parts is not None:
+        res = _eval_relation_method(
+            relation_parts[0], relation_parts[1], relation_parts[2], method, args,
+            state, binds, spec, old_state, in_ensures,
+        )
+        if res is not None:
+            return res
+        _err(f"unknown method '{method}' on relation", kind="type")
+
     set_parts = _set_elem_ty(base, state, spec)
     if set_parts is not None:
         res = _eval_set_method(
@@ -1027,7 +1133,7 @@ def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures):
             return res
         _err(f"unknown method '{method}' on Seq")
 
-    _err("method call on value that is neither Set nor Seq")
+    _err("method call on value that is neither relation, Set, nor Seq")
 
 
 def _eval_is(inner, pat, state, binds, spec, old_state, in_ensures):
@@ -1067,6 +1173,15 @@ def _apply_assign(lv, rhs, pend, state, binds, spec):
                 m = z3.Store(m, idx, z3.BoolVal(True))
             pend[n] = m
             return ("scalar", n)
+        if ty[0] == "relation" and rhs[0] == "set_lit":
+            if rhs[1]:
+                _err(
+                    "relation literals only support the empty initializer Set {}; "
+                    "use r = r.add(a, b) to add pairs",
+                    kind="type",
+                )
+            pend[n] = z3.K(z3.IntSort(), z3.BoolVal(False))
+            return ("scalar", n)
         if ty[0] == "seq" and rhs[0] == "seq_lit":
             elem_ty, cap = ty[1], ty[2]
             if len(rhs[1]) > cap:
@@ -1095,6 +1210,11 @@ def _apply_assign(lv, rhs, pend, state, binds, spec):
                 pend[n] = val[1]
             else:
                 pend[n] = val
+        elif ty[0] == "relation":
+            if isinstance(val, tuple) and val[0] == "relation_val":
+                pend[n] = val[1]
+            else:
+                _err("relation assignment requires Set {} or a relation operation expression")
         elif ty[0] == "seq":
             if isinstance(val, tuple) and val[0] == "seq_val":
                 pend[f"{n}__data"] = val[1]
@@ -1513,6 +1633,109 @@ def _z3_domain_value(kty, value):
     return z3.IntVal(value)
 
 
+def _relation_endpoint_values(ty, spec):
+    return list(_map_domain(ty, spec))
+
+
+def _relation_endpoint_size(ty, spec):
+    return len(_relation_endpoint_values(ty, spec))
+
+
+def _relation_endpoint_index(ty, value, spec):
+    if ty[0] == "bool":
+        if isinstance(value, bool):
+            return z3.IntVal(1 if value else 0)
+        if isinstance(value, z3.ExprRef) and value.sort().kind() == z3.Z3_BOOL_SORT:
+            return z3.If(value, z3.IntVal(1), z3.IntVal(0))
+        _err("relation Bool endpoint expects a Bool expression", kind="type")
+    lo, _hi = domain_range(ty, spec["types"])
+    if isinstance(value, bool):
+        value = z3.IntVal(1 if value else 0)
+    elif isinstance(value, int):
+        value = z3.IntVal(value)
+    return value - z3.IntVal(lo)
+
+
+def _relation_key(src_ty, dst_ty, src, dst, spec):
+    dst_size = _relation_endpoint_size(dst_ty, spec)
+    return _relation_endpoint_index(src_ty, src, spec) * z3.IntVal(dst_size) + \
+        _relation_endpoint_index(dst_ty, dst, spec)
+
+
+def _relation_contains(rel, src_ty, dst_ty, src, dst, spec):
+    return z3.Select(rel, _relation_key(src_ty, dst_ty, src, dst, spec))
+
+
+def _same_relation_endpoint_type(src_ty, dst_ty):
+    return src_ty == dst_ty
+
+
+def _relation_type_error(message):
+    _err(
+        message,
+        kind="type",
+        hint=(
+            "relation helpers operate on binary relation state. Use .contains(a, b), "
+            ".add(a, b), .remove(a, b), reachable(r, a, b), acyclic(r), "
+            "functional(r), injective(r), domain(r), or range(r)."
+        ),
+    )
+
+
+def _relation_parts(base):
+    if isinstance(base, tuple) and base[0] == "relation_val":
+        return base[1], base[2], base[3]
+    return None
+
+
+def _relation_reachable_expr(rel, ty, src, dst, spec):
+    values = _relation_endpoint_values(ty, spec)
+    if not values:
+        return z3.BoolVal(False)
+
+    def const(v):
+        return _z3_domain_value(ty, v)
+
+    def path_at_most(k, a, b):
+        direct = _relation_contains(rel, ty, ty, a, b, spec)
+        if k <= 1:
+            return direct
+        via = [
+            z3.And(
+                _relation_contains(rel, ty, ty, a, const(mid), spec),
+                path_at_most(k - 1, const(mid), b),
+            )
+            for mid in values
+        ]
+        return z3.Or(direct, *via)
+
+    return path_at_most(len(values), src, dst)
+
+
+def _relation_set_from_projection(rel, src_ty, dst_ty, spec, side):
+    elem_ty = src_ty if side == "domain" else dst_ty
+    arr = z3.K(z3_sort(elem_ty, spec["types"]), z3.BoolVal(False))
+    src_values = _relation_endpoint_values(src_ty, spec)
+    dst_values = _relation_endpoint_values(dst_ty, spec)
+    for src in src_values:
+        zsrc = _z3_domain_value(src_ty, src)
+        present = z3.Or(*[
+            _relation_contains(rel, src_ty, dst_ty, zsrc, _z3_domain_value(dst_ty, dst), spec)
+            for dst in dst_values
+        ]) if dst_values else z3.BoolVal(False)
+        if side == "domain":
+            arr = z3.Store(arr, zsrc, present)
+    if side == "range":
+        for dst in dst_values:
+            zdst = _z3_domain_value(dst_ty, dst)
+            present = z3.Or(*[
+                _relation_contains(rel, src_ty, dst_ty, _z3_domain_value(src_ty, src), zdst, spec)
+                for src in src_values
+            ]) if src_values else z3.BoolVal(False)
+            arr = z3.Store(arr, zdst, present)
+    return ("set_val", arr, elem_ty)
+
+
 def _symmetric_type_names(spec):
     symmetry = spec.get("symmetry") or {}
     return [name for name in symmetry if spec["types"].get(name, {}).get("symmetric")]
@@ -1712,6 +1935,21 @@ def _logical_val(model, state, name, ty, spec):
             else:
                 obj[fn] = _display_value(fty, _py_val(model, state[f"{name}__{fn}"]), spec)
         return obj
+    if ty[0] == "relation":
+        src_ty, dst_ty = ty[1], ty[2]
+        pairs = []
+        for src in _relation_endpoint_values(src_ty, spec):
+            for dst in _relation_endpoint_values(dst_ty, spec):
+                key = _relation_key(
+                    src_ty, dst_ty, _z3_domain_value(src_ty, src),
+                    _z3_domain_value(dst_ty, dst), spec,
+                )
+                if _py_val(model, z3.Select(state[name], key)):
+                    pairs.append([
+                        _display_value(src_ty, src, spec),
+                        _display_value(dst_ty, dst, spec),
+                    ])
+        return pairs
     if ty[0] == "map":
         kty, vty = ty[1], ty[2]
         mout = {}
@@ -1849,6 +2087,12 @@ def _expr_static_type(e, spec, env):
     if tag == "method":
         method = e[2]
         base_ty = _expr_static_type(e[1], spec, env)
+        if base_ty and base_ty[0] == "relation":
+            if method == "contains":
+                return ("bool",)
+            if method in ("add", "remove"):
+                return base_ty
+            _err(f"unknown method '{method}' on relation", kind="type")
         if method in ("contains",):
             return ("bool",)
         if method == "size":
@@ -1877,6 +2121,13 @@ def _expr_static_type(e, spec, env):
         return _merge_ite_static_types(a_ty, b_ty)
     if tag in ("not", "is", "forall", "exists", "unique", "exactly_one"):
         return ("bool",)
+    if tag in ("rel_reachable", "rel_acyclic", "rel_functional", "rel_injective"):
+        return ("bool",)
+    if tag in ("rel_domain", "rel_range"):
+        rel_ty = _expr_static_type(e[1], spec, env)
+        if not rel_ty or rel_ty[0] != "relation":
+            _relation_type_error(f"{'domain' if tag == 'rel_domain' else 'range'}() expects a relation")
+        return ("set", rel_ty[1] if tag == "rel_domain" else rel_ty[2])
     if tag in ("count", "sum", "min", "max", "abs"):
         return ("int",)
     return None
@@ -2080,6 +2331,17 @@ def _logical_eq_var(spec, s1, s2, name, ty):
         for i in _map_domain(elem_ty, spec):
             key = _z3_domain_value(elem_ty, i)
             parts.append(z3.Select(m1, key) == z3.Select(m2, key))
+        return z3.And(*parts) if parts else z3.BoolVal(True)
+    if ty[0] == "relation":
+        src_ty, dst_ty = ty[1], ty[2]
+        parts = []
+        for src in _relation_endpoint_values(src_ty, spec):
+            for dst in _relation_endpoint_values(dst_ty, spec):
+                key = _relation_key(
+                    src_ty, dst_ty, _z3_domain_value(src_ty, src),
+                    _z3_domain_value(dst_ty, dst), spec,
+                )
+                parts.append(z3.Select(s1[name], key) == z3.Select(s2[name], key))
         return z3.And(*parts) if parts else z3.BoolVal(True)
     if ty[0] == "map":
         kty, vty = ty[1], ty[2]
@@ -2870,6 +3132,94 @@ _LEADSTO_RANK_PROGRESS_HINT = (
     "from every state where P holds and Q is false, each enabled action must "
     "either make Q true, or keep P true and strictly decrease the measure"
 )
+_LEADSTO_HELPFUL_PROGRESS_HINT = (
+    "helpful marks which action instance is responsible for progress. The "
+    "matching action must be declared `fair action`, must be enabled whenever "
+    "the obligation is pending, and must strictly decrease the rank when it fires; "
+    "other actions only need to keep the pending obligation true unless they make Q true"
+)
+
+
+def _model_bool(model, expr):
+    return z3.is_true(model.eval(expr, model_completion=True))
+
+
+def _helpful_arg_value(expr, extra_binds, spec, loc=None):
+    try:
+        val = eval_expr(expr, {}, extra_binds, spec)
+    except Exception as ex:
+        _err(
+            "helpful action arguments must be state-independent leadsto binders, "
+            "constants, enum members, or arithmetic over those values",
+            kind="type",
+            loc=loc,
+            hint="use `helpful actionName(c)` to bind the helpful action to the pending forall entity",
+        )
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, int):
+        return val
+    if isinstance(val, z3.ExprRef):
+        simplified = z3.simplify(val)
+        if z3.is_int_value(simplified):
+            return simplified.as_long()
+        if z3.is_true(simplified):
+            return True
+        if z3.is_false(simplified):
+            return False
+    _err(
+        "helpful action arguments must resolve to concrete bounded values",
+        kind="type",
+        loc=loc,
+        hint="helpful metadata is a per-binding action selector, not a state predicate",
+    )
+
+
+def _helpful_matches(leadsto, extra_binds, instances, spec):
+    out = []
+    for helper in leadsto.get("helpful") or []:
+        name = helper["action"]
+        action_def = next((a for a in spec["actions"] if a["name"] == name), None)
+        if action_def is None:
+            continue
+        params = [p[0] for p in action_def["params"]]
+        expected = [
+            _helpful_arg_value(arg, extra_binds, spec, helper.get("loc"))
+            for arg in helper.get("args") or []
+        ]
+        for idx, inst in enumerate(instances):
+            if inst["action"] != name:
+                continue
+            if all(inst["binds"].get(param) == value for param, value in zip(params, expected)):
+                out.append((idx, helper))
+    return out
+
+
+def _display_instance(inst, spec):
+    act = inst["action_def"]
+    return annotate_display_name({
+        "name": display_label(inst["action"], spec),
+        "params": {pk: _display_param(pk, pv, act, spec) for pk, pv in inst["binds"].items()},
+    }, inst["action"], spec)
+
+
+def _display_helpful_instances(matches, instances, spec):
+    seen = set()
+    out = []
+    for idx, _helper in matches:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        out.append(_display_instance(instances[idx], spec))
+    return out
+
+
+def _helpful_labels(leadsto):
+    labels = []
+    for helper in leadsto.get("helpful") or []:
+        args = ", ".join(_leadsto_measure_label(arg) for arg in helper.get("args") or [])
+        labels.append(f"{helper['action']}({args})")
+    return labels
 
 
 def _rank_failure_common(spec, leadsto, model, state, extra_binds, binding_types, detail):
@@ -2924,20 +3274,85 @@ def _prove_leadsto_rank_no_deadlock(spec, leadsto, extra_binds, binding_types, i
         solver.add(_inv_constraint(inv, state, spec, expr_cache))
     p = _eval_at_state(leadsto["P"], state, extra_binds, spec, expr_cache)
     q = _eval_at_state(leadsto["Q"], state, extra_binds, spec, expr_cache)
-    enabled = _action_enabled_exprs(state, instances, spec, expr_cache)
-    solver.add(p, z3.Not(q), _deadlock_from_enabled(enabled))
+    helpful_matches = _helpful_matches(leadsto, extra_binds, instances, spec)
+    if leadsto.get("helpful"):
+        enabled = [
+            _enabled_instance(instances[idx], state, spec, extra_binds, expr_cache)
+            for idx, _helper in helpful_matches
+        ]
+        no_helpful_enabled = z3.Not(z3.Or(*enabled)) if enabled else z3.BoolVal(True)
+        solver.add(p, z3.Not(q), no_helpful_enabled)
+        failure_kind = "helpful_action_not_enabled"
+        blocked_actions = _display_helpful_instances(helpful_matches, instances, spec)
+        message = (
+            f"leadsTo '{display_label(leadsto['name'], spec)}' can be pending "
+            "while no matching helpful action instance is enabled"
+        )
+        hint = _LEADSTO_HELPFUL_PROGRESS_HINT
+    else:
+        enabled = _action_enabled_exprs(state, instances, spec, expr_cache)
+        solver.add(p, z3.Not(q), _deadlock_from_enabled(enabled))
+        failure_kind = "deadlock"
+        blocked_actions = None
+        message = (
+            f"leadsTo '{display_label(leadsto['name'], spec)}' can be pending "
+            "in a state with no enabled action"
+        )
+        hint = _LEADSTO_RANK_DEADLOCK_HINT
     if solver.check() != z3.sat:
         return None
     model = solver.model()
     measure = _eval_int_measure(leadsto, state, extra_binds, spec, expr_cache)
-    return _rank_failure_common(spec, leadsto, model, state, extra_binds, binding_types, {
-        "rank_failure": "deadlock",
+    detail = {
+        "rank_failure": failure_kind,
         "measure_value": _model_int(model, measure),
+        "message": message,
+        "hint": hint,
+    }
+    if blocked_actions is not None:
+        detail["helpful_actions"] = blocked_actions
+        detail["helpful"] = _helpful_labels(leadsto)
+    return _rank_failure_common(spec, leadsto, model, state, extra_binds, binding_types, detail)
+
+
+def _prove_leadsto_rank_helpful_fairness(spec, leadsto, extra_binds, binding_types, invariants, instances):
+    helpful_matches = _helpful_matches(leadsto, extra_binds, instances, spec)
+    if not helpful_matches:
+        return None
+    nonfair = [
+        (idx, helper) for idx, helper in helpful_matches
+        if not instances[idx]["action_def"].get("fair")
+    ]
+    if not nonfair:
+        return None
+
+    expr_cache = {}
+    state = make_ind_state(spec, f"rank_{leadsto['name']}_fair")
+    solver = z3.Solver()
+    solver.add(*_enum_phys_constraints(spec, state))
+    for inv in invariants:
+        solver.add(_inv_constraint(inv, state, spec, expr_cache))
+    p = _eval_at_state(leadsto["P"], state, extra_binds, spec, expr_cache)
+    q = _eval_at_state(leadsto["Q"], state, extra_binds, spec, expr_cache)
+    solver.add(p, z3.Not(q))
+    if solver.check() != z3.sat:
+        return None
+
+    model = solver.model()
+    measure = _eval_int_measure(leadsto, state, extra_binds, spec, expr_cache)
+    return _rank_failure_common(spec, leadsto, model, state, extra_binds, binding_types, {
+        "rank_failure": "progress_action_not_fair",
+        "measure_value": _model_int(model, measure),
+        "helpful_actions": _display_helpful_instances(nonfair, instances, spec),
         "message": (
-            f"leadsTo '{display_label(leadsto['name'], spec)}' can be pending "
-            "in a state with no enabled action"
+            f"leadsTo '{display_label(leadsto['name'], spec)}' uses helpful action "
+            "metadata, but a matching progress action is not declared fair"
         ),
-        "hint": _LEADSTO_RANK_DEADLOCK_HINT,
+        "hint": (
+            "helpful only identifies the per-binding progress action. Add `fair` "
+            "to the lower-layer action instance that must eventually run; helpful "
+            "does not create a fairness assumption."
+        ),
     })
 
 
@@ -2961,19 +3376,35 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
     measure = _eval_int_measure(leadsto, cur, extra_binds, spec, expr_cache)
     measure_next = _eval_int_measure(leadsto, nxt, extra_binds, spec, expr_cache)
     progress = z3.Or(q_next, z3.And(p_next, measure_next < measure))
-    solver.add(p, z3.Not(q), z3.Not(progress))
+    helpful_matches = _helpful_matches(leadsto, extra_binds, instances, spec)
+    if helpful_matches:
+        helpful_choice = z3.Or(*[choice == idx for idx, _helper in helpful_matches])
+        pending_preserved = z3.Or(q_next, p_next)
+        allowed = z3.Or(
+            z3.And(helpful_choice, progress),
+            z3.And(z3.Not(helpful_choice), pending_preserved),
+        )
+        hint = _LEADSTO_HELPFUL_PROGRESS_HINT
+    else:
+        allowed = progress
+        hint = _LEADSTO_RANK_PROGRESS_HINT
+    solver.add(p, z3.Not(q), z3.Not(allowed))
     if solver.check() != z3.sat:
         return None
 
     model = solver.model()
     trace = _build_trace(model, [cur, nxt], [choice], instances, spec, 1)
-    q_next_holds = z3.is_true(model.eval(q_next, model_completion=True))
-    p_next_holds = z3.is_true(model.eval(p_next, model_completion=True))
-    decreases = z3.is_true(model.eval(measure_next < measure, model_completion=True))
+    q_next_holds = _model_bool(model, q_next)
+    p_next_holds = _model_bool(model, p_next)
+    decreases = _model_bool(model, measure_next < measure)
+    choice_idx = model.eval(choice, model_completion=True).as_long()
+    helpful_idx_set = {idx for idx, _helper in helpful_matches}
     rank_failure = "non_decreasing_action"
     if not q_next_holds and not p_next_holds:
         rank_failure = "pending_not_preserved"
-    return _attach_requirement({
+    elif helpful_matches and choice_idx in helpful_idx_set and not decreases:
+        rank_failure = "non_decreasing_helpful_action"
+    detail = {
         "result": "unknown_cti",
         "spec": spec["name"],
         "violation_kind": "leadsTo_rank",
@@ -2989,12 +3420,30 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
             "states": trace,
             "violated_at": 1,
         },
-        "message": (
+        "hint": hint,
+    }
+    if helpful_matches:
+        detail["helpful_actions"] = _display_helpful_instances(helpful_matches, instances, spec)
+    if rank_failure == "pending_not_preserved":
+        detail["message"] = (
+            f"enabled action '{trace[1]['action']['name']}' can make "
+            f"leadsTo '{display_label(leadsto['name'], spec)}' no longer pending "
+            "without making Q true"
+        )
+    elif rank_failure == "non_decreasing_helpful_action":
+        detail["message"] = (
+            f"helpful action '{trace[1]['action']['name']}' can leave "
+            f"leadsTo '{display_label(leadsto['name'], spec)}' pending without "
+            "strictly decreasing the measure"
+        )
+    else:
+        detail["message"] = (
             f"enabled action '{trace[1]['action']['name']}' can leave "
             f"leadsTo '{display_label(leadsto['name'], spec)}' pending without "
             "strictly decreasing the measure"
-        ),
-        "hint": _LEADSTO_RANK_PROGRESS_HINT,
+        )
+    return _attach_requirement({
+        **detail,
     }, leadsto)
 
 
@@ -3008,6 +3457,10 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
             for extra_binds in expand_leadsto_bindings(leadsto, spec):
                 failure = _prove_leadsto_rank_lower_bound(
                     spec, leadsto, extra_binds, binding_types, invariants)
+                if failure is not None:
+                    return failure, None
+                failure = _prove_leadsto_rank_helpful_fairness(
+                    spec, leadsto, extra_binds, binding_types, invariants, instances)
                 if failure is not None:
                     return failure, None
                 failure = _prove_leadsto_rank_no_deadlock(
@@ -3024,6 +3477,8 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
                 "proof": "ranking",
                 "decreases": _leadsto_measure_label(leadsto.get("decreases")),
             }
+            if leadsto.get("helpful"):
+                proved[leadsto["name"]]["helpful"] = _helpful_labels(leadsto)
             continue
 
         try:
@@ -3038,6 +3493,11 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
                 for extra_binds in expand_leadsto_bindings(candidate_leadsto, spec):
                     failure = _prove_leadsto_rank_lower_bound(
                         spec, candidate_leadsto, extra_binds, binding_types, invariants)
+                    if failure is not None:
+                        candidate_failed = True
+                        break
+                    failure = _prove_leadsto_rank_helpful_fairness(
+                        spec, candidate_leadsto, extra_binds, binding_types, invariants, instances)
                     if failure is not None:
                         candidate_failed = True
                         break
@@ -3062,6 +3522,8 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
                 "decreases": _leadsto_measure_label(candidate),
                 "synthesized": True,
             }
+            if leadsto.get("helpful"):
+                proved[leadsto["name"]]["helpful"] = _helpful_labels(leadsto)
             break
     return None, proved
 
@@ -4749,6 +5211,15 @@ def prove(
         vacuity_mode=vacuity_mode,
     )
     if base["result"] in ("violated", "reachable_failed", "error"):
+        if base.get("result") == "violated" and base.get("violation_kind") == "leadsTo":
+            instances = build_instances(spec)
+            rank_failure, _ranked_leadstos = _prove_ranked_leadstos(
+                spec, leadstos, invariants, instances)
+            if rank_failure is not None:
+                rank_failure.setdefault("checked_to_depth", base_depth)
+                rank_failure.setdefault("completeness", "bounded")
+                return _finish_result(
+                    rank_failure, spec, base_depth, started, completeness="bounded")
         return _add_result_metadata(
             base,
             base.get("checked_to_depth", base_depth),

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -6,6 +6,7 @@ import sys
 import json
 import argparse
 import re
+import itertools
 
 from lark.exceptions import UnexpectedInput, VisitError
 
@@ -430,6 +431,40 @@ def _parse_values_override(raw):
     return name, (lo, hi)
 
 
+def _parse_sweep_int_range(raw, flag):
+    name, sep, rng = raw.partition("=")
+    name = name.strip()
+    lo_s, dots, hi_s = rng.partition("..")
+    if not sep or not name or not dots:
+        raise FslError(
+            f"invalid {flag} value '{raw}': expected NAME=LO..HI", kind="semantics")
+    try:
+        lo, hi = int(lo_s.strip()), int(hi_s.strip())
+    except ValueError:
+        raise FslError(
+            f"invalid {flag} value '{raw}': bounds must be integers", kind="semantics")
+    if lo > hi:
+        raise FslError(
+            f"invalid {flag} value '{raw}': lower bound must be <= upper bound",
+            kind="semantics",
+        )
+    return name, (lo, hi)
+
+
+def _parse_sweep_depth(raw):
+    lo_s, dots, hi_s = raw.partition("..")
+    if not dots:
+        raise FslError(f"invalid --depth value '{raw}': expected LO..HI", kind="semantics")
+    try:
+        lo, hi = int(lo_s.strip()), int(hi_s.strip())
+    except ValueError:
+        raise FslError("invalid --depth value: bounds must be integers", kind="semantics")
+    if lo < 0 or lo > hi:
+        raise FslError(
+            f"invalid --depth value '{raw}': expected 0 <= LO <= HI", kind="semantics")
+    return lo, hi
+
+
 def _build_bounds_overrides(instances, values):
     overrides = {"instances": {}, "values": {}}
     for raw in instances or []:
@@ -439,6 +474,131 @@ def _build_bounds_overrides(instances, values):
         name, bounds = _parse_values_override(raw)
         overrides["values"][name] = bounds
     return overrides
+
+
+def _build_sweep_ranges(instances, values):
+    instance_ranges = {}
+    for raw in instances or []:
+        name, bounds = _parse_sweep_int_range(raw, "--instances")
+        if bounds[0] < 1:
+            raise FslError(
+                f"invalid --instances value '{raw}': instance lower bound must be >= 1",
+                kind="semantics",
+            )
+        instance_ranges[name] = bounds
+    value_ranges = {}
+    for raw in values or []:
+        name, bounds = _parse_sweep_int_range(raw, "--values")
+        value_ranges[name] = bounds
+    return instance_ranges, value_ranges
+
+
+def _sweep_counterexample(result):
+    return result.get("result") in {
+        "violated",
+        "reachable_failed",
+        "unknown_cti",
+        "nonconformant",
+        "refinement_failed",
+    }
+
+
+def _sweep_summary(result):
+    out = {
+        "result": result.get("result"),
+        "checked_to_depth": result.get("checked_to_depth"),
+    }
+    for key in ("invariant", "trans", "violation_kind", "violated_at_step", "rank_failure"):
+        if key in result:
+            out[key] = result[key]
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def run_sweep(
+        file, depth_range, deadlock_mode, engine="bmc", k_ind=1,
+        vacuity_mode="warn", strict_tags=False, requirements=None,
+        property_name=None, instances=None, values=None):
+    try:
+        depth_lo, depth_hi = _parse_sweep_depth(depth_range)
+        instance_ranges, value_ranges = _build_sweep_ranges(instances, values)
+        instance_names = sorted(instance_ranges)
+        value_names = sorted(value_ranges)
+        instance_options = [
+            range(instance_ranges[name][0], instance_ranges[name][1] + 1)
+            for name in instance_names
+        ]
+        value_options = [
+            [(value_ranges[name][0], hi)
+             for hi in range(value_ranges[name][0], value_ranges[name][1] + 1)]
+            for name in value_names
+        ]
+
+        results = []
+        minimal = None
+        spec_name = None
+        instance_product = itertools.product(*instance_options) if instance_names else [()]
+        value_product_template = list(itertools.product(*value_options)) if value_names else [()]
+        for instance_combo in instance_product:
+            instance_scope = dict(zip(instance_names, instance_combo))
+            instance_args = [f"{name}={value}" for name, value in instance_scope.items()]
+            for value_combo in value_product_template:
+                value_scope = dict(zip(value_names, value_combo))
+                value_args = [f"{name}={lo}..{hi}" for name, (lo, hi) in value_scope.items()]
+                for depth in range(depth_lo, depth_hi + 1):
+                    verification = run_verify(
+                        file,
+                        depth,
+                        deadlock_mode,
+                        engine=engine,
+                        k_ind=k_ind,
+                        vacuity_mode=vacuity_mode,
+                        strict_tags=strict_tags,
+                        requirements=requirements,
+                        property_name=property_name,
+                        instances=instance_args,
+                        values=value_args,
+                    )
+                    spec_name = spec_name or verification.get("spec")
+                    entry = {
+                        "scope": {
+                            "instances": instance_scope,
+                            "values": {
+                                name: [bounds[0], bounds[1]]
+                                for name, bounds in value_scope.items()
+                            },
+                            "depth": depth,
+                        },
+                        "summary": _sweep_summary(verification),
+                        "verification": verification,
+                    }
+                    results.append(entry)
+                    if minimal is None and _sweep_counterexample(verification):
+                        minimal = entry
+
+        out = {
+            "result": "sweep_failed" if minimal else "sweep_passed",
+            "spec": spec_name,
+            "sweep": {
+                "minimality_order": ["instances", "values", "depth"],
+                "ranges": {
+                    "instances": {
+                        name: [lo, hi] for name, (lo, hi) in instance_ranges.items()
+                    },
+                    "values": {
+                        name: [lo, hi] for name, (lo, hi) in value_ranges.items()
+                    },
+                    "depth": [depth_lo, depth_hi],
+                },
+                "results": results,
+                "minimal_counterexample": minimal,
+            },
+        }
+        return _envelope(out)
+    except FslError as e:
+        return _error_envelope(e.kind, str(e), _loc_from_exc(e),
+                               getattr(e, "expected", None), getattr(e, "hint", None))
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
 def run_verify(
@@ -835,7 +995,10 @@ def exit_code(result):
     if r in ("verified", "proved", "scenarios", "conformant", "generated",
              "refines", "typestate", "mutated", "explained", "analyzed"):
         return 0
-    if r in ("violated", "reachable_failed", "unknown_cti", "nonconformant", "refinement_failed"):
+    if r == "sweep_passed":
+        return 0
+    if r in ("violated", "reachable_failed", "unknown_cti", "nonconformant",
+             "refinement_failed", "sweep_failed"):
         return 1
     if r == "error":
         kind = result.get("kind")
@@ -884,6 +1047,24 @@ def _build_arg_parser():
                         "(NAME=LO..HI; repeatable)")
     v.add_argument("--strict-tags", action="store_true")
     v.add_argument("--requirements", default=None)
+
+    sw = sub.add_parser("sweep", help="run bounded verification across a scope grid")
+    sw.add_argument("file")
+    sw.add_argument("--depth", default="0..8",
+                    help="depth range LO..HI to sweep (default: 0..8)")
+    sw.add_argument("--engine", choices=["bmc", "induction"], default="bmc")
+    sw.add_argument("--k", type=int, default=1, dest="k_ind",
+                    help="max induction depth (induction engine only)")
+    sw.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
+    sw.add_argument("--vacuity", choices=["warn", "error", "ignore"], default="warn")
+    sw.add_argument("--property", dest="property_name", default=None,
+                    help="check a single named property in isolation")
+    sw.add_argument("--instances", action="append", default=None,
+                    help="sweep an entity bound (NAME=LO..HI; repeatable)")
+    sw.add_argument("--values", action="append", default=None,
+                    help="sweep a number upper bound as LO..LO through LO..HI")
+    sw.add_argument("--strict-tags", action="store_true")
+    sw.add_argument("--requirements", default=None)
 
     sc = sub.add_parser("scenarios")
     sc.add_argument("file")
@@ -981,6 +1162,16 @@ def _dispatch(args):
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "scenarios":
         result = run_scenarios(args.file, args.depth, args.deadlock)
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif args.cmd == "sweep":
+        result = run_sweep(args.file, args.depth, args.deadlock,
+                           engine=args.engine, k_ind=args.k_ind,
+                           vacuity_mode=args.vacuity,
+                           strict_tags=args.strict_tags,
+                           requirements=args.requirements,
+                           property_name=args.property_name,
+                           instances=args.instances,
+                           values=args.values)
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "replay":
         result = run_replay(args.file, args.trace)

--- a/src/fslc/explain.py
+++ b/src/fslc/explain.py
@@ -175,6 +175,15 @@ def _leadsto_body_text(item, display_names):
     )
     if item.get("within") is not None:
         text += f" within {item['within']}"
+    helpful = item.get("helpful") or []
+    if helpful:
+        helper_text = []
+        for helper in helpful:
+            args = ", ".join(_expr_to_text(arg, display_names) for arg in helper.get("args") or [])
+            helper_text.append(f"helpful {helper['action']}({args})")
+        text += "; " + "; ".join(helper_text)
+    if item.get("decreases") is not None:
+        text += f"; decreases {_expr_to_text(item['decreases'], display_names)}"
     return text
 
 
@@ -643,6 +652,21 @@ def _expr_to_text(expr, display_names=None):
         return f"{_type_ref_to_text(('name', expr[1]))} {{ {fields} }}"
     if tag in ("old", "abs"):
         return f"{tag}({_expr_to_text(expr[1], display_names)})"
+    if tag == "rel_reachable":
+        return (
+            f"reachable({_expr_to_text(expr[1], display_names)}, "
+            f"{_expr_to_text(expr[2], display_names)}, "
+            f"{_expr_to_text(expr[3], display_names)})"
+        )
+    if tag in ("rel_acyclic", "rel_functional", "rel_injective", "rel_domain", "rel_range"):
+        name = {
+            "rel_acyclic": "acyclic",
+            "rel_functional": "functional",
+            "rel_injective": "injective",
+            "rel_domain": "domain",
+            "rel_range": "range",
+        }[tag]
+        return f"{name}({_expr_to_text(expr[1], display_names)})"
     if tag in ("min", "max"):
         return (
             f"{tag}({_expr_to_text(expr[1], display_names)}, "

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -69,6 +69,7 @@ state_def: "state" "{" var_decl ("," var_decl)* ","? "}"
 var_decl: NAME ":" type
 ?type: "Int"  -> t_int
      | "Bool" -> t_bool
+     | "relation" type "->" type -> t_relation
      | expr ".." expr -> t_range
      | "Map" "<" type "," type ">" -> t_map
      | "Set" "<" type ">" -> t_set
@@ -112,8 +113,10 @@ terminal_def: "terminal" "{" expr "}"
 until_def: "until" NAME meta_tag? "{" expr _UNTIL expr "}"
 unless_def: "unless" NAME meta_tag? "{" expr _UNLESS expr "}"
 
-leadsto_def: "leadsTo" NAME meta_tag? "{" lt_body leadsto_decreases? "}"
+leadsto_def: "leadsTo" NAME meta_tag? "{" lt_body leadsto_item* "}"
+?leadsto_item: leadsto_helpful | leadsto_decreases
 leadsto_decreases: "decreases" expr
+leadsto_helpful: "helpful" NAME "(" [expr_list] ")"
 meta_tag: STRING
 ?lt_body: lt_forall | lt_implies
 lt_forall: "forall" binder [":"] "{" lt_body "}"
@@ -160,6 +163,12 @@ postfix_suffix: "[" expr "]" -> idx_suffix
      | "stage" "(" expr ")" -> stage_e
      | "count" "(" NAME ":" qname "where" expr ")" -> count_e
      | "sum" "(" NAME ":" qname "of" expr ["where" expr] ")" -> sum_e
+     | "reachable" "(" expr "," expr "," expr ")" -> rel_reachable_e
+     | "acyclic" "(" expr ")" -> rel_acyclic_e
+     | "functional" "(" expr ")" -> rel_functional_e
+     | "injective" "(" expr ")" -> rel_injective_e
+     | "domain" "(" expr ")" -> rel_domain_e
+     | "range" "(" expr ")" -> rel_range_e
      | "min" "(" expr "," expr ")" -> min_e
      | "max" "(" expr "," expr ")" -> max_e
      | "abs" "(" expr ")" -> abs_e
@@ -458,6 +467,24 @@ class Ast(Transformer):
     def sum_e(self, meta, v, ty, body, cond=None):
         return ("sum", v, ty, body, cond)
 
+    def rel_reachable_e(self, meta, rel, src, dst):
+        return ("rel_reachable", rel, src, dst)
+
+    def rel_acyclic_e(self, meta, rel):
+        return ("rel_acyclic", rel)
+
+    def rel_functional_e(self, meta, rel):
+        return ("rel_functional", rel)
+
+    def rel_injective_e(self, meta, rel):
+        return ("rel_injective", rel)
+
+    def rel_domain_e(self, meta, rel):
+        return ("rel_domain", rel)
+
+    def rel_range_e(self, meta, rel):
+        return ("rel_range", rel)
+
     def min_e(self, meta, a, b):
         return ("min", a, b)
 
@@ -553,6 +580,9 @@ class Ast(Transformer):
 
     def t_map(self, meta, k, v):
         return ("map", k, v)
+
+    def t_relation(self, meta, src, dst):
+        return ("relation", src, dst)
 
     def t_set(self, meta, elem):
         return ("set", elem)
@@ -750,17 +780,22 @@ class Ast(Transformer):
     def leadsto_decreases(self, meta, measure):
         return ("decreases", measure)
 
+    def leadsto_helpful(self, meta, name, args=None):
+        return ("helpful", name, list(args or []), _loc(meta))
+
     def leadsto_def(self, meta, name, *rest):
-        req_meta, body, measure = None, None, None
+        req_meta, body, measure, helpful = None, None, None, []
         for r in rest:
             if isinstance(r, dict):
                 req_meta = r
             elif isinstance(r, tuple) and r[0] == "decreases":
                 measure = r[1]
+            elif isinstance(r, tuple) and r[0] == "helpful":
+                helpful.append({"action": r[1], "args": r[2], "loc": r[3]})
             else:
                 body = r
         binders, p, q, within = _flatten_leadsto(body)
-        return ("leadsto", name, binders, p, q, _loc(meta), req_meta, measure, within)
+        return ("leadsto", name, binders, p, q, _loc(meta), req_meta, measure, within, helpful)
 
     def top_def(self, meta, child):
         return child

--- a/src/fslc/html_report.py
+++ b/src/fslc/html_report.py
@@ -54,6 +54,7 @@ def render_html_report(file: str, source: str, explained: dict, verification: di
         _actions_section(actions, coverage),
         _properties_section(properties, auto_checks),
         _status_section(verification),
+        _refinement_section(verification),
         _trace_section(verification),
         _witness_section(witnesses),
         _counterfactual_section(counterfactuals),
@@ -394,6 +395,27 @@ pre {
   color: var(--muted);
   font: 12px/1.45 var(--mono);
 }
+.relation-graphs {
+  margin-top: 14px;
+  display: grid;
+  gap: 12px;
+}
+.edge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+.edge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 8px;
+  border-radius: 7px;
+  background: var(--teal-2);
+  color: var(--teal);
+  font: 700 12px/1.2 var(--mono);
+}
 .callout {
   margin-bottom: 16px;
   padding: 12px 14px;
@@ -613,6 +635,69 @@ def _status_section(verification: dict) -> str:
             </table>
           </div>
           {warning_html}
+        </div>
+      </section>
+"""
+
+
+def _refinement_violation(verification: dict):
+    if verification.get("result") == "refinement_failed":
+        return verification
+    impl = verification.get("implements")
+    if isinstance(impl, dict) and impl.get("result") == "refinement_failed":
+        return impl.get("violation") or impl
+    return None
+
+
+def _refinement_section(verification: dict) -> str:
+    violation = _refinement_violation(verification)
+    if not violation:
+        return ""
+    impl_action = violation.get("impl_action") or violation.get("action") or {}
+    abs_action = violation.get("abs_action") or violation.get("abstract_action") or {}
+    edge = ""
+    if impl_action or abs_action:
+        impl_name = impl_action.get("name") if isinstance(impl_action, dict) else impl_action
+        abs_name = abs_action.get("name") if isinstance(abs_action, dict) else abs_action
+        edge = (
+            '<div class="callout bad">'
+            f"<strong>Action correspondence</strong> "
+            f"<code>{escape(str(impl_name or 'impl step'))}</code> -&gt; "
+            f"<code>{escape(str(abs_name or 'abstract step'))}</code>"
+            "</div>"
+        )
+    impl_payload = _drop_empty({
+        "impl": violation.get("impl"),
+        "action": impl_action,
+        "state": violation.get("impl_state"),
+        "trace": violation.get("impl_trace"),
+    })
+    abs_payload = _drop_empty({
+        "abs": violation.get("abs"),
+        "action": abs_action,
+        "alpha_before": violation.get("alpha_before"),
+        "alpha_after_expected": violation.get("alpha_after_expected"),
+        "alpha_after_actual": violation.get("alpha_after_actual"),
+        "mismatch": violation.get("mismatch"),
+    })
+    return f"""
+      <section class="section" id="refinement">
+        <div class="section-head">
+          <div>
+            <h2>Refinement Evidence</h2>
+            <p>Side-by-side implementation and abstract states for the refinement failure.</p>
+          </div>
+        </div>
+        {edge}
+        <div class="grid-2">
+          <div class="panel panel-pad">
+            <h3>Implementation Side</h3>
+            {_json_pre(impl_payload)}
+          </div>
+          <div class="panel panel-pad">
+            <h3>Abstract Side</h3>
+            {_json_pre(abs_payload)}
+          </div>
         </div>
       </section>
 """
@@ -901,7 +986,7 @@ def _trace_section(verification: dict) -> str:
         content = '<p class="empty">No counterexample trace was emitted. Reachable witnesses may still appear below.</p>'
     else:
         violated_step = verification.get("violated_at_step") if is_counterexample else None
-        content = _trace_timeline(trace, violated_step)
+        content = _trace_timeline(trace, violated_step) + _relation_graphs(trace)
     return f"""
       <section class="section" id="traces">
         <div class="section-head">
@@ -1158,6 +1243,42 @@ def _trace_timeline(trace: list, violated_step=None) -> str:
     return f'<div class="timeline">{"".join(steps)}</div>'
 
 
+def _relation_graphs(trace: list) -> str:
+    panels = []
+    for entry in trace:
+        step = entry.get("step")
+        state = entry.get("state") or {}
+        for name, value in state.items():
+            if not _looks_like_relation(value):
+                continue
+            edges = "".join(
+                f'<span class="edge">{escape(str(src))} -&gt; {escape(str(dst))}</span>'
+                for src, dst in value
+            )
+            panels.append(
+                '<div class="mini-card">'
+                f'<h3><span>{escape(str(name))}</span><span class="badge info">step {escape(str(step))}</span></h3>'
+                f'<div class="edge-list">{edges}</div>'
+                '</div>'
+            )
+    if not panels:
+        return ""
+    return f"""
+      <div class="relation-graphs">
+        <h3>Relation Graphs</h3>
+        <div class="cards">{''.join(panels)}</div>
+      </div>
+"""
+
+
+def _looks_like_relation(value) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, list) and len(item) == 2 for item in value)
+    )
+
+
 def _first_reachable_witness(verification: dict):
     reachables = verification.get("reachables") or {}
     for item in reachables.values():
@@ -1186,6 +1307,8 @@ def _type_text(ty, enums=None) -> str:
         return f"Set<{_type_text(ty[1], enums)}>"
     if tag == "seq":
         return f"Seq<{_type_text(ty[1], enums)}, {ty[2]}>"
+    if tag == "relation":
+        return f"relation {_type_text(ty[1], enums)} -> {_type_text(ty[2], enums)}"
     if tag == "enum":
         name = str(ty[1])
         members = (enums or {}).get(name)
@@ -1257,6 +1380,10 @@ def _json_pre(data) -> str:
 
 def _json_code(data) -> str:
     return f"<code>{escape(json.dumps(data, ensure_ascii=False, sort_keys=True))}</code>"
+
+
+def _drop_empty(data: dict) -> dict:
+    return {k: v for k, v in data.items() if v is not None and v != {} and v != []}
 
 
 def _badge(value) -> str:

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -73,7 +73,8 @@ _STATE_TYPE_HINT = (
     "v1 state variables may use: scalar (Int, Bool, domain, enum), "
     "Option<scalar>, struct (scalar or Option<scalar> fields only), "
     "Map<bounded-scalar (Bool/domain/enum), scalar | Option<scalar> | struct>, "
-    "Set<bounded-scalar (Bool/domain/enum)>, or Seq<scalar, N>"
+    "Set<bounded-scalar (Bool/domain/enum)>, Seq<scalar, N>, or "
+    "relation bounded-scalar -> bounded-scalar"
 )
 
 
@@ -120,6 +121,12 @@ def resolve_type(ty, types, consts=None):
         return _resolve_inline_range(ty, consts)
     if ty[0] == "map":
         return ("map", resolve_type(ty[1], types, consts), resolve_type(ty[2], types, consts))
+    if ty[0] == "relation":
+        return (
+            "relation",
+            resolve_type(ty[1], types, consts),
+            resolve_type(ty[2], types, consts),
+        )
     if ty[0] == "set":
         return ("set", resolve_type(ty[1], types, consts))
     if ty[0] == "seq":
@@ -141,6 +148,8 @@ def is_bounded(ty, types_meta):
         return True
     if ty[0] == "map":
         return is_bounded(ty[1], types_meta)
+    if ty[0] == "relation":
+        return is_bounded(ty[1], types_meta) and is_bounded(ty[2], types_meta)
     if ty[0] == "set":
         return is_bounded(ty[1], types_meta)
     return False
@@ -185,6 +194,12 @@ def resolve_type_ref(ty, types, consts=None):
     if ty[0] == "map":
         return (
             "map",
+            resolve_type_ref(ty[1], types, consts),
+            resolve_type_ref(ty[2], types, consts),
+        )
+    if ty[0] == "relation":
+        return (
+            "relation",
             resolve_type_ref(ty[1], types, consts),
             resolve_type_ref(ty[2], types, consts),
         )
@@ -292,6 +307,15 @@ def expand_phys_var(logical_name, ty, types_meta, out):
             "logical": logical_name,
             "ty": ("set", elem),
             "elem_ty": elem,
+        })
+        return
+    if ty[0] == "relation":
+        out.append({
+            "phys": logical_name,
+            "logical": logical_name,
+            "ty": ty,
+            "source_ty": ty[1],
+            "target_ty": ty[2],
         })
         return
     if ty[0] == "seq":
@@ -418,6 +442,8 @@ def z3_sort(ty, types_meta):
         return z3.BoolSort()
     if ty[0] == "map":
         return z3.ArraySort(z3_sort(ty[1], types_meta), z3_sort(ty[2], types_meta))
+    if ty[0] == "relation":
+        return z3.ArraySort(z3.IntSort(), z3.BoolSort())
     if ty[0] == "set":
         return z3.ArraySort(z3_sort(ty[1], types_meta), z3.BoolSort())
     if ty[0] == "option":
@@ -794,6 +820,35 @@ def check_seq_literal_sizes(state, init, actions, types_meta):
         _check_seq_literals_in_stmts(act["stmts"], state, types_meta)
 
 
+def validate_leadsto_helpful_actions(leadstos, actions):
+    """Check leadsTo-local helpful metadata names real action instances.
+
+    Full semantic obligations (fairness/enabledness/rank decrease) are verifier
+    facts. The model layer only rejects misspelled action names and arity
+    mismatches so authors get fast feedback from `fslc check`.
+    """
+    by_name = {act["name"]: act for act in actions}
+    for leadsto in leadstos:
+        for helper in leadsto.get("helpful") or []:
+            aname = helper["action"]
+            if aname not in by_name:
+                _err(
+                    f"leadsTo '{leadsto['name']}' helpful action '{aname}' is not declared",
+                    kind="type",
+                    loc=helper.get("loc"),
+                    hint="helpful metadata must name an existing action; it does not infer action names",
+                )
+            expected = len(by_name[aname].get("params") or [])
+            got = len(helper.get("args") or [])
+            if got != expected:
+                _err(
+                    f"leadsTo '{leadsto['name']}' helpful action '{aname}' expects "
+                    f"{expected} argument(s), got {got}",
+                    kind="type",
+                    loc=helper.get("loc"),
+                )
+
+
 def validate_state_var_type(ty, types_meta, path):
     """Whitelist validation for state variable types (DESIGN-seq §7)."""
     if is_scalar_type(ty):
@@ -829,6 +884,15 @@ def validate_state_var_type(ty, types_meta, path):
         if not is_bounded_scalar_type(ty[1]):
             _err(
                 f"{path}: Set element must be a bounded scalar (Bool, domain, or enum)",
+                kind="type",
+                hint=_STATE_TYPE_HINT,
+            )
+        return
+    if ty[0] == "relation":
+        src_ty, dst_ty = ty[1], ty[2]
+        if not is_bounded_scalar_type(src_ty) or not is_bounded_scalar_type(dst_ty):
+            _err(
+                f"{path}: relation endpoints must be bounded scalars (Bool, domain, or enum)",
                 kind="type",
                 hint=_STATE_TYPE_HINT,
             )
@@ -1120,6 +1184,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
                 "loc": it[5],
                 "decreases": it[7] if len(it) > 7 else None,
                 "within": within,
+                "helpful": it[9] if len(it) > 9 else [],
             }, it[6] if len(it) > 6 else None))
         elif tag == "until":
             transitions.append(_with_meta({
@@ -1135,6 +1200,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
                 "loc": it[4],
                 "decreases": None,
                 "within": None,
+                "helpful": [],
             }, it[5] if len(it) > 5 else None))
         elif tag == "unless":
             transitions.append(_with_meta({
@@ -1204,6 +1270,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
         _err("spec has no actions", kind="semantics")
 
     check_seq_literal_sizes(state, init, actions, types_meta)
+    validate_leadsto_helpful_actions(leadstos, actions)
 
     all_display_names = dict(display_names or {})
     all_display_names.update(dialect_display_names)

--- a/src/fslc/refine.py
+++ b/src/fslc/refine.py
@@ -58,8 +58,10 @@ _ENSURES_NOTE = (
 
 _PROGRESS_HINT = (
     "the impl refines the abstract safety contract, but admits an execution where "
-    "the pulled-back abstract leadsTo remains pending forever; add fairness/progress "
-    "to the lower layer or review the progress mapping"
+    "the pulled-back abstract leadsTo remains pending. Fairness must come from "
+    "lower-layer `fair action` declarations for the implementation actions named "
+    "by preserve progress; action mappings do not create fairness or prove "
+    "implementation conformance by themselves"
 )
 
 
@@ -89,6 +91,11 @@ def _types_compatible(abs_ty, impl_ty):
             return (
                 _types_compatible(abs_ty[1], impl_ty[1])
                 and abs_ty[2] == impl_ty[2]
+            )
+        if abs_ty[0] == "relation":
+            return (
+                _types_compatible(abs_ty[1], impl_ty[1])
+                and _types_compatible(abs_ty[2], impl_ty[2])
             )
     if abs_ty[0] == "domain" and impl_ty[0] == "int":
         return True
@@ -147,6 +154,10 @@ def _subst_binder(expr, binder_var, key_val):
             return (tag, b, walk(e[2]))
         if tag == "method":
             return ("method", walk(e[1]), e[2], [walk(a) for a in e[3]])
+        if tag in ("rel_reachable",):
+            return (tag, walk(e[1]), walk(e[2]), walk(e[3]))
+        if tag in ("rel_acyclic", "rel_functional", "rel_injective", "rel_domain", "rel_range"):
+            return (tag, walk(e[1]))
         return e
 
     return walk(expr)
@@ -220,6 +231,12 @@ def _expand_alpha_scalar(logical, ty, z3_val, out, types_meta):
             out[f"{logical}__len"] = z3_val[2]
         else:
             _err(f"map for Seq '{logical}' must produce a Seq expression", kind="type")
+        return
+    if ty[0] == "relation":
+        if isinstance(z3_val, tuple) and z3_val[0] == "relation_val":
+            out[logical] = z3_val[1]
+        else:
+            out[logical] = z3_val
         return
     _err(f"unsupported abstraction type {ty} for '{logical}'", kind="type")
 
@@ -789,11 +806,13 @@ def _progress_action_summary(decl):
 def _progress_failure(
         impl_spec, abs_spec, ctx, model, leadsto, decl, binding_types,
         extra_binds, step, pending_since, loop_start=None, stutter=False):
+    progress_failure = "deadlock_or_stall_blocks_progress" if stutter else "lasso_blocks_progress"
     out = {
         "result": "refinement_failed",
         "impl": impl_spec["name"],
         "abs": abs_spec["name"],
         "kind": "progress_lost",
+        "progress_failure": progress_failure,
         "violation_kind": "leadsTo",
         "invariant": leadsto["name"],
         "bindings": _display_leadsto_bindings(model, extra_binds, abs_spec, binding_types),

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -258,6 +258,8 @@ def _default_phys_value(entry, spec):
         return 0
     if ty[0] == "bool":
         return False
+    if ty[0] == "relation":
+        return {}
     if ty[0] == "set":
         elem_ty = ty[1]
         return {i: False for i in _map_domain(elem_ty, spec)}
@@ -331,6 +333,13 @@ def _empty_phys_state(spec):
         elif ty[0] == "set":
             elem_ty = ty[1]
             state[phys] = {i: False for i in _map_domain(elem_ty, spec)}
+        elif ty[0] == "relation":
+            src_ty, dst_ty = ty[1], ty[2]
+            state[phys] = {
+                _relation_key(src_ty, dst_ty, src, dst, spec): False
+                for src in _map_domain(src_ty, spec)
+                for dst in _map_domain(dst_ty, spec)
+            }
         elif ty[0] == "struct":
             if entry.get("option_part") == "present":
                 state[phys] = False
@@ -347,6 +356,84 @@ def _as_bool(v):
     if isinstance(v, bool):
         return v
     raise _EvalError(f"expected bool, got {v!r}")
+
+
+def _relation_endpoint_index(ty, value, spec):
+    if ty[0] == "bool":
+        if not isinstance(value, bool):
+            _err("relation Bool endpoint expects a Bool value", kind="type")
+        return 1 if value else 0
+    lo, _hi = domain_range(ty, spec["types"])
+    return int(value) - lo
+
+
+def _relation_key(src_ty, dst_ty, src, dst, spec):
+    dst_size = len(list(_map_domain(dst_ty, spec)))
+    return _relation_endpoint_index(src_ty, src, spec) * dst_size + \
+        _relation_endpoint_index(dst_ty, dst, spec)
+
+
+def _same_relation_endpoint_type(src_ty, dst_ty):
+    return src_ty == dst_ty
+
+
+def _relation_type_error(message):
+    _err(
+        message,
+        kind="type",
+        hint=(
+            "relation helpers operate on binary relation state. Use .contains(a, b), "
+            ".add(a, b), .remove(a, b), reachable(r, a, b), acyclic(r), "
+            "functional(r), injective(r), domain(r), or range(r)."
+        ),
+    )
+
+
+def _relation_parts(base):
+    if isinstance(base, tuple) and base[0] == "relation_val":
+        return base[1], base[2], base[3]
+    return None
+
+
+def _relation_contains(rel, src_ty, dst_ty, src, dst, spec):
+    return bool(rel.get(_relation_key(src_ty, dst_ty, src, dst, spec), False))
+
+
+def _relation_reachable(rel, ty, src, dst, spec):
+    values = list(_map_domain(ty, spec))
+    frontier = [
+        nxt for nxt in values
+        if _relation_contains(rel, ty, ty, src, nxt, spec)
+    ]
+    seen = set()
+    while frontier:
+        node = frontier.pop(0)
+        if node == dst:
+            return True
+        if node in seen:
+            continue
+        seen.add(node)
+        frontier.extend(
+            nxt for nxt in values
+            if nxt not in seen and _relation_contains(rel, ty, ty, node, nxt, spec)
+        )
+    return False
+
+
+def _relation_projection(rel, src_ty, dst_ty, spec, side):
+    elem_ty = src_ty if side == "domain" else dst_ty
+    out = {i: False for i in _map_domain(elem_ty, spec)}
+    src_values = list(_map_domain(src_ty, spec))
+    dst_values = list(_map_domain(dst_ty, spec))
+    for src in src_values:
+        for dst in dst_values:
+            if not _relation_contains(rel, src_ty, dst_ty, src, dst, spec):
+                continue
+            if side == "domain":
+                out[src] = True
+            else:
+                out[dst] = True
+    return ("set_val", out, elem_ty)
 
 
 def eval_concrete(e, state, binds, spec, old_state=None, in_ensures=False):
@@ -436,6 +523,71 @@ def _eval_concrete_impl(e, state, binds, spec, old_state=None, in_ensures=False)
     if tag == "method":
         base = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
         return _eval_method(base, e[2], e[3], state, binds, spec, old_state, in_ensures)
+    if tag == "rel_reachable":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("reachable() expects a relation as its first argument")
+        rel, src_ty, dst_ty = parts
+        if not _same_relation_endpoint_type(src_ty, dst_ty):
+            _relation_type_error(
+                f"reachable() requires a self-relation, got relation {src_ty} -> {dst_ty}"
+            )
+        src = eval_concrete(e[2], state, binds, spec, old_state, in_ensures)
+        dst = eval_concrete(e[3], state, binds, spec, old_state, in_ensures)
+        return _relation_reachable(rel, src_ty, src, dst, spec)
+    if tag == "rel_acyclic":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("acyclic() expects a relation")
+        rel, src_ty, dst_ty = parts
+        if not _same_relation_endpoint_type(src_ty, dst_ty):
+            _relation_type_error(
+                f"acyclic() requires a binary self-relation, got relation {src_ty} -> {dst_ty}"
+            )
+        return all(not _relation_reachable(rel, src_ty, v, v, spec)
+                   for v in _map_domain(src_ty, spec))
+    if tag == "rel_functional":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("functional() expects a relation")
+        rel, src_ty, dst_ty = parts
+        for src in _map_domain(src_ty, spec):
+            count = sum(
+                1 for dst in _map_domain(dst_ty, spec)
+                if _relation_contains(rel, src_ty, dst_ty, src, dst, spec)
+            )
+            if count > 1:
+                return False
+        return True
+    if tag == "rel_injective":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("injective() expects a relation")
+        rel, src_ty, dst_ty = parts
+        for dst in _map_domain(dst_ty, spec):
+            count = sum(
+                1 for src in _map_domain(src_ty, spec)
+                if _relation_contains(rel, src_ty, dst_ty, src, dst, spec)
+            )
+            if count > 1:
+                return False
+        return True
+    if tag == "rel_domain":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("domain() expects a relation")
+        return _relation_projection(parts[0], parts[1], parts[2], spec, "domain")
+    if tag == "rel_range":
+        rel_val = eval_concrete(e[1], state, binds, spec, old_state, in_ensures)
+        parts = _relation_parts(rel_val)
+        if parts is None:
+            _relation_type_error("range() expects a relation")
+        return _relation_projection(parts[0], parts[1], parts[2], spec, "range")
     if tag == "is":
         return _eval_is(e[1], e[2], state, binds, spec, old_state, in_ensures)
     if tag == "not":
@@ -545,6 +697,8 @@ def _read_logical(name, ty, state, spec):
         return ("set_val", m, ty[1])
     if ty[0] == "seq":
         return ("seq_val", state[f"{name}__data"], state[f"{name}__len"], ty[1], ty[2])
+    if ty[0] == "relation":
+        return ("relation_val", state[name], ty[1], ty[2])
     return state[name]
 
 
@@ -588,6 +742,25 @@ def _eval_set_method(m, elem_ty, method, args, state, binds, spec, old_state, in
     return None
 
 
+def _eval_relation_method(rel, src_ty, dst_ty, method, args, state, binds, spec,
+                          old_state, in_ensures):
+    if method == "contains":
+        if len(args) != 2:
+            _err("relation.contains expects 2 arguments", kind="type")
+        src = eval_concrete(args[0], state, binds, spec, old_state, in_ensures)
+        dst = eval_concrete(args[1], state, binds, spec, old_state, in_ensures)
+        return _relation_contains(rel, src_ty, dst_ty, src, dst, spec)
+    if method in ("add", "remove"):
+        if len(args) != 2:
+            _err(f"relation.{method} expects 2 arguments", kind="type")
+        src = eval_concrete(args[0], state, binds, spec, old_state, in_ensures)
+        dst = eval_concrete(args[1], state, binds, spec, old_state, in_ensures)
+        nm = dict(rel)
+        nm[_relation_key(src_ty, dst_ty, src, dst, spec)] = method == "add"
+        return ("relation_val", nm, src_ty, dst_ty)
+    return None
+
+
 def _eval_seq_method(data, length, elem_ty, cap, method, args, state, binds, spec,
                        old_state, in_ensures, loc=None):
     if method == "push":
@@ -626,6 +799,16 @@ def _eval_seq_method(data, length, elem_ty, cap, method, args, state, binds, spe
 
 
 def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures, loc=None):
+    relation_parts = _relation_parts(base)
+    if relation_parts is not None:
+        res = _eval_relation_method(
+            relation_parts[0], relation_parts[1], relation_parts[2], method, args,
+            state, binds, spec, old_state, in_ensures,
+        )
+        if res is not None:
+            return res
+        _err(f"unknown method '{method}' on relation", kind="type")
+
     set_parts = _set_elem_ty(base)
     if set_parts is not None:
         res = _eval_set_method(set_parts[0], set_parts[1], method, args, state, binds, spec,
@@ -641,7 +824,7 @@ def _eval_method(base, method, args, state, binds, spec, old_state, in_ensures, 
         if res is not None:
             return res
         _err(f"unknown method '{method}' on Seq")
-    _err("method call on value that is neither Set nor Seq")
+    _err("method call on value that is neither relation, Set, nor Seq")
 
 
 def _eval_is(inner, pat, state, binds, spec, old_state, in_ensures):
@@ -799,6 +982,20 @@ def _apply_assign(lv, rhs, pend, state, binds, spec, loc=None):
                 m[idx] = True
             pend[n] = m
             return ("scalar", n)
+        if ty[0] == "relation" and rhs[0] == "set_lit":
+            if rhs[1]:
+                _err(
+                    "relation literals only support the empty initializer Set {}; "
+                    "use r = r.add(a, b) to add pairs",
+                    kind="type",
+                )
+            src_ty, dst_ty = ty[1], ty[2]
+            pend[n] = {
+                _relation_key(src_ty, dst_ty, src, dst, spec): False
+                for src in _map_domain(src_ty, spec)
+                for dst in _map_domain(dst_ty, spec)
+            }
+            return ("scalar", n)
         if ty[0] == "seq" and rhs[0] == "seq_lit":
             elem_ty, cap = ty[1], ty[2]
             if len(rhs[1]) > cap:
@@ -820,6 +1017,11 @@ def _apply_assign(lv, rhs, pend, state, binds, spec, loc=None):
                 pend[n] = val[1]
             else:
                 pend[n] = val
+        elif ty[0] == "relation":
+            if isinstance(val, tuple) and val[0] == "relation_val":
+                pend[n] = val[1]
+            else:
+                _err("relation assignment requires Set {} or a relation operation expression")
         elif ty[0] == "seq":
             if isinstance(val, tuple) and val[0] == "seq_val":
                 pend[f"{n}__data"] = val[1]
@@ -1015,6 +1217,18 @@ def _logical_val(state, name, ty, spec):
         m = state[name]
         elems = [_display_value(elem_ty, i, spec) for i in _map_domain(elem_ty, spec) if m.get(i)]
         return sorted(elems, key=str)
+    if ty[0] == "relation":
+        src_ty, dst_ty = ty[1], ty[2]
+        rel = state[name]
+        pairs = []
+        for src in _map_domain(src_ty, spec):
+            for dst in _map_domain(dst_ty, spec):
+                if rel.get(_relation_key(src_ty, dst_ty, src, dst, spec)):
+                    pairs.append([
+                        _display_value(src_ty, src, spec),
+                        _display_value(dst_ty, dst, spec),
+                    ])
+        return pairs
     if ty[0] == "seq":
         elem_ty, cap = ty[1], ty[2]
         data = state[f"{name}__data"]

--- a/tests/test_helpful_leadsto.py
+++ b/tests/test_helpful_leadsto.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Helpful-action ranking coverage for per-entity leadsTo (#106)."""
+
+from fslc.cli import run_verify
+
+
+HELPFUL_SRC = r'''spec HelpfulPerEntity {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+'''
+
+
+NONFAIR_HELPFUL_SRC = HELPFUL_SRC.replace("fair action step", "action step")
+
+
+BLOCKED_HELPFUL_SRC = r'''spec BlockedHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state {
+    level: Map<Case, Level>,
+    gate: Map<Case, Bool>
+  }
+  init {
+    forall c: Case {
+      level[c] = 2
+      gate[c] = false
+    }
+  }
+
+  fair action step(c: Case) {
+    requires gate[c]
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+'''
+
+
+def _write(tmp_path, src, name):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_helpful_per_entity_measure_proves_under_interleaving(tmp_path):
+    spec = _write(tmp_path, HELPFUL_SRC, "helpful.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "proved"
+    proof = out["leads_to"]["Responds"]
+    assert proof["proof"] == "ranking"
+    assert proof["decreases"] == "level[c]"
+    assert proof["helpful"] == ["step(c)"]
+
+
+def test_helpful_does_not_create_fairness(tmp_path):
+    spec = _write(tmp_path, NONFAIR_HELPFUL_SRC, "nonfair_helpful.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "unknown_cti"
+    assert out["rank_failure"] == "progress_action_not_fair"
+    assert out["helpful_actions"][0]["name"] == "step"
+    assert "helpful only identifies" in out["hint"]
+
+
+def test_blocked_helpful_action_is_reported(tmp_path):
+    spec = _write(tmp_path, BLOCKED_HELPFUL_SRC, "blocked_helpful.fsl")
+    out = run_verify(str(spec), 1, "warn", engine="induction", k_ind=1)
+    assert out["result"] == "unknown_cti"
+    assert out["rank_failure"] == "helpful_action_not_enabled"
+    assert out["helpful"] == ["step(c)"]
+    assert out["bindings"] == {"c": 0}

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 from fslc.cli import exit_code, run_html
+from fslc.html_report import render_html_report
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -110,6 +111,68 @@ spec TemporalSugar {
     assert "trans" in html
     assert "unless HeldUnlessReleased" in html
     assert "until HeldUntilReleased" in html
+
+
+def test_html_report_renders_relation_graph_from_trace(tmp_path):
+    path = tmp_path / "relation_html.fsl"
+    path.write_text(
+        r'''spec RelationHtml {
+  type User = 0..1
+  state { delegates: relation User -> User }
+  init { delegates = Set {} }
+  action delegate(a: User, b: User) {
+    requires a != b
+    delegates = delegates.add(a, b)
+  }
+  reachable CanDelegate { delegates.contains(0, 1) }
+}
+''',
+        encoding="utf-8",
+    )
+
+    result = run_html(str(path), depth=1, write_file=False)
+    assert result["result"] == "generated"
+    html = result["content"]
+    assert "relation 0..1 -&gt; 0..1" in html
+    assert "Relation Graphs" in html
+    assert "delegates" in html
+    assert "0 -&gt; 1" in html
+
+
+def test_html_report_renders_refinement_failure_side_by_side():
+    html = render_html_report(
+        "impl.fsl",
+        "spec Impl {}",
+        {"result": "explained", "spec": "Impl", "skeleton": {"state": {}, "actions": [], "properties": []}},
+        {
+            "result": "verified",
+            "spec": "Impl",
+            "implements": {
+                "abs": "Abs",
+                "result": "refinement_failed",
+                "violation": {
+                    "result": "refinement_failed",
+                    "impl": "Impl",
+                    "abs": "Abs",
+                    "kind": "abs_requires_failed",
+                    "impl_action": {"name": "fast_pay"},
+                    "abs_action": {"name": "pay"},
+                    "impl_state": {"paid": True},
+                    "alpha_before": {"done": False},
+                    "alpha_after_expected": {"done": True},
+                    "alpha_after_actual": {"done": False},
+                    "mismatch": [{"path": "done"}],
+                },
+            },
+        },
+    )
+
+    assert "Refinement Evidence" in html
+    assert "Implementation Side" in html
+    assert "Abstract Side" in html
+    assert "fast_pay" in html
+    assert "fast_pay -&gt;" not in html  # rendered inside escaped JSON, not as raw HTML
+    assert "<script" not in html
 
 
 def test_html_cli_stdout_and_output_file(tmp_path):

--- a/tests/test_refinement_liveness_example.py
+++ b/tests/test_refinement_liveness_example.py
@@ -45,6 +45,8 @@ def test_preserve_progress_catches_liveness_drop():
     assert refine["kind"] == "progress_lost"
     assert refine["violation_kind"] == "leadsTo"
     assert refine["invariant"] == "EveryClaimDecided"
+    assert refine["progress_failure"] == "lasso_blocks_progress"
+    assert "lower-layer `fair action`" in refine["hint"]
     assert refine["progress"] == {
         "leadsTo": "EveryClaimDecided",
         "actions": ["approve", "reject"],

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Typed relation layer coverage (#108)."""
+
+from fslc.cli import run_verify
+from fslc.runtime import Monitor
+
+
+RELATION_SRC = r'''spec RelationDemo {
+  type User = 0..1
+  enum Role { Manager, Staff }
+
+  state {
+    delegates: relation User -> User,
+    roles: relation User -> Role
+  }
+
+  init {
+    delegates = Set {}
+    roles = Set {}
+  }
+
+  action delegate(a: User, b: User) {
+    requires a != b
+    requires not reachable(delegates, b, a)
+    delegates = delegates.add(a, b)
+  }
+
+  action revoke(a: User, b: User) {
+    delegates = delegates.remove(a, b)
+  }
+
+  action grant(u: User, r: Role) {
+    roles = roles.add(u, r)
+  }
+
+  invariant DelegatesAcyclic { acyclic(delegates) }
+  invariant DelegatesFunctional { functional(delegates) }
+  invariant RoleRangeBounded { range(roles).size() <= 2 }
+  invariant DelegateDomainBounded { domain(delegates).size() <= 2 }
+  reachable CanDelegate { delegates.contains(0, 1) }
+}
+'''
+
+
+BAD_SELF_RELATION_SRC = r'''spec BadSelfRelation {
+  type User = 0..1
+  enum Role { Manager, Staff }
+  state { assignments: relation User -> Role }
+  init { assignments = Set {} }
+  action grant(u: User, r: Role) { assignments = assignments.add(u, r) }
+  invariant BadAcyclic { acyclic(assignments) }
+}
+'''
+
+
+CYCLIC_SRC = r'''spec CyclicRelation {
+  type User = 0..1
+  state { delegates: relation User -> User }
+  init { delegates = Set {} }
+  action delegate(a: User, b: User) {
+    requires a != b
+    delegates = delegates.add(a, b)
+  }
+  invariant DelegatesAcyclic { acyclic(delegates) }
+}
+'''
+
+
+def _write(tmp_path, src, name):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_relation_helpers_verify_and_reachability(tmp_path):
+    spec = _write(tmp_path, RELATION_SRC, "relation_demo.fsl")
+    out = run_verify(str(spec), 2, "warn")
+    assert out["result"] == "verified"
+    assert out["reachables"]["CanDelegate"]["witnessed_at_step"] == 1
+
+
+def test_relation_runtime_add_remove_contains_and_enum_display(tmp_path):
+    spec = _write(tmp_path, RELATION_SRC, "relation_demo.fsl")
+    mon = Monitor(str(spec))
+    assert mon.reset()["delegates"] == []
+
+    first = mon.step("delegate", {"a": 0, "b": 1})
+    assert first["ok"] is True
+    assert first["state"]["delegates"] == [[0, 1]]
+
+    blocked_cycle = mon.step("delegate", {"a": 1, "b": 0})
+    assert blocked_cycle["ok"] is False
+    assert blocked_cycle["kind"] == "requires_failed"
+
+    grant = mon.step("grant", {"u": 0, "r": "Manager"})
+    assert grant["ok"] is True
+    assert grant["state"]["roles"] == [[0, "Manager"]]
+
+    revoked = mon.step("revoke", {"a": 0, "b": 1})
+    assert revoked["ok"] is True
+    assert revoked["state"]["delegates"] == []
+
+
+def test_relation_self_helpers_reject_non_self_relation(tmp_path):
+    spec = _write(tmp_path, BAD_SELF_RELATION_SRC, "bad_relation.fsl")
+    out = run_verify(str(spec), 1, "warn")
+    assert out["result"] == "error"
+    assert out["kind"] == "type"
+    assert "self-relation" in out["message"]
+    assert ".contains(a, b)" in out["hint"]
+
+
+def test_relation_trace_displays_counterexample_pairs(tmp_path):
+    spec = _write(tmp_path, CYCLIC_SRC, "cyclic_relation.fsl")
+    out = run_verify(str(spec), 2, "warn")
+    assert out["result"] == "violated"
+    assert out["invariant"] == "DelegatesAcyclic"
+    states = out["trace"]
+    assert states[-1]["state"]["delegates"] == [[0, 1], [1, 0]]

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Scope sweep coverage (#107)."""
+
+from fslc.cli import exit_code, run_sweep, run_verify
+
+
+SWEEP_SRC = r'''requirements SweepCounterexample {
+  entity Case
+
+  state { selected: Map<Case, Bool> }
+
+  init {
+    forall c: Case { selected[c] = false }
+  }
+
+  action select(c: Case) {
+    requires not selected[c]
+    selected[c] = true
+  }
+
+  invariant AtMostOne {
+    count(c: Case where selected[c]) <= 1
+  }
+}
+verify {
+  instances Case = 2
+}
+'''
+
+
+def _write(tmp_path, src, name):
+    path = tmp_path / name
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+def test_sweep_reports_minimal_counterexample_without_changing_verify(tmp_path):
+    spec = _write(tmp_path, SWEEP_SRC, "sweep_counterexample.fsl")
+
+    unchanged = run_verify(str(spec), 1, "warn", property_name="AtMostOne")
+    assert unchanged["result"] == "verified"
+    assert "sweep" not in unchanged
+
+    out = run_sweep(
+        str(spec),
+        "1..2",
+        "warn",
+        property_name="AtMostOne",
+        instances=["Case=1..2"],
+    )
+    assert out["result"] == "sweep_failed"
+    assert exit_code(out) == 1
+    assert "results" in out["sweep"]
+    assert "minimal_counterexample" in out["sweep"]
+
+    minimal = out["sweep"]["minimal_counterexample"]
+    assert minimal["scope"] == {
+        "instances": {"Case": 2},
+        "values": {},
+        "depth": 2,
+    }
+    assert minimal["summary"]["result"] == "violated"
+    assert minimal["summary"]["invariant"] == "AtMostOne"
+    assert minimal["verification"]["trace"][-1]["state"]["selected"] == {
+        "0": True,
+        "1": True,
+    }


### PR DESCRIPTION
## Summary
Implements the issue #104 follow-up set across FSL language support, verification diagnostics, CLI scope sweeping, runtime/html evidence, docs, skills, and intro website pages.

## Why
- **Goal**: Replace the Alloy/TLA+ proposal follow-up with concrete fslc behavior and reviewer-facing documentation.
- **Reason**: The related issues require executable semantics, diagnostics, and user-facing guidance rather than only design notes.
- **Alternatives**: Keeping relation/helpful/sweep behavior as documentation-only was rejected because the issues call for verifier/runtime/CLI support and regression coverage.

## What Changed
- Adds typed `relation A -> B` state support with relation helpers, symbolic verification, runtime monitoring, and trace/html relation evidence.
- Adds `helpful action(...)` hints for ranked `leadsTo` proofs, including fairness and enabledness diagnostics.
- Adds `fslc sweep` for deterministic scope/depth sweeps with minimal counterexample reporting.
- Improves refinement progress diagnostics and html refinement evidence.
- Updates `docs/`, `skills/fsl/`, intro syntax pages, changelog, and regression tests.

## Blast Radius
- **Affected**: parser/grammar, model validation, BMC/proof logic, runtime monitor, refinement mapping, CLI, explain/html report output, FSL docs/skills/site pages.
- **Compatibility**: Existing syntax remains valid; new syntax is additive. HTML/explain output gains extra sections/fields when relation/refinement/helpful data is present.
- **Operational**: No external service or data migration changes.

## Invariants
| Condition | Evidence | Symptom if broken |
|---|---|---|
| Existing FSL specs continue to verify/check | full pytest suite | regressions in parser/verifier/runtime tests |
| `helpful` does not create fairness by itself | `tests/test_helpful_leadsto.py` | false liveness proof under unfair helper action |
| Relation values stay typed and finite-bounded | `tests/test_relation.py` | unsound relation helpers or invalid BMC/runtime traces |

## Failure Modes
| Pattern | Detection |
|---|---|
| Relation helper semantics diverge between runtime and BMC | relation runtime + verifier regression tests |
| Ranked `leadsTo` reports a generic result instead of actionable helper diagnostics | helpful leadsto diagnostic tests |
| Sweep minimality order changes unexpectedly | sweep regression test |

## Evidence
- [x] Focused tests: `PYTHONPYCACHEPREFIX=/private/tmp/fsl-pycache PYTHONPATH=src /Users/rizumita/Workspace/fsl/.venv/bin/pytest -p no:cacheprovider tests/test_relation.py tests/test_helpful_leadsto.py tests/test_sweep.py tests/test_html_report.py tests/test_refinement_liveness_example.py tests/test_sum_decreases.py tests/test_explain.py tests/test_refine.py -q` -> `66 passed`
- [x] Full suite: `PYTHONPYCACHEPREFIX=/private/tmp/fsl-pycache PYTHONPATH=src /Users/rizumita/Workspace/fsl/.venv/bin/pytest -p no:cacheprovider -q` -> `901 passed, 80 skipped`
- [x] Whitespace: `git diff --check`

## Rollout & Rollback
- **Rollout**: merge normally; the changes are additive language/CLI/reporting features plus diagnostics.
- **Rollback**: revert commit `1283bc1` if verifier/runtime regressions appear.
- **Cannot rollback if**: users start relying on the new relation/helpful/sweep syntax in downstream specs without pinning fslc.

## Review Focus
- `src/fslc/bmc.py`: relation symbolic encoding and helpful-ranked `leadsTo` proof rules.
- `src/fslc/runtime.py`: concrete relation semantics matching verifier behavior.
- `src/fslc/cli.py`: sweep result contract and minimal counterexample ordering.
- `docs/LANGUAGE.md` and `skills/fsl/reference.md`: language contract alignment with implementation.

## Unknowns
- GitHub Actions results were not available before PR creation; local full suite passed.

## Related
Closes #104
Closes #105
Closes #106
Closes #107
Closes #108
Closes #109
