### PR TITLE
feat(analysis): complete analyze batch and traceability surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   (`disconnected_requirement`, `unanchored_property`, `progressless_cycle`) with
   `formal_status:"not_a_violation"` so structural observations are not confused
   with proof failures. See `docs/DESIGN-analysis.md`.
+- `fslc analyze` now supports batch file/directory analysis, DOT/Mermaid graph
+  exports, standalone `refinement_graph`, project-manifest
+  `traceability_graph`, versioned JSON Schema files under
+  `schemas/fslc/analysis/`, two additional AI-review findings
+  (`unwritten_state`, `unguarded_action`), and opt-in LSP informational
+  diagnostics for analysis findings via `FSLC_LSP_ANALYSIS_DIAGNOSTICS=1`.
 - Optional **spec-level tag** classifying a whole spec: an intent string right
   after the spec name, `spec ReturnUI "ui: screen flow" { … }`. Metadata only —
   it desugars to nothing and is never verified (corpus snapshot unchanged) — and

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -1,6 +1,6 @@
 # FSL - `fslc analyze` structural observation layer
 
-Motivation: issues #103, #100, #102, and #101. `verify` and `refine` answer
+Motivation: issues #103, #100, #102, #101, and #110-#116. `verify` and `refine` answer
 whether declared contracts hold. `analyze` answers a different question: what
 shape does the spec have, and which parts look weakly connected enough to deserve
 review?
@@ -17,11 +17,24 @@ fslc analyze spec.fsl --projection action_state_graph --format json
 fslc analyze spec.fsl --projection requirement_property_graph --format json
 fslc analyze spec.fsl --projection property_state_graph --format json
 fslc analyze spec.fsl --profile ai-review --format json
+fslc analyze specs/ examples/e2e/ --profile ai-review --format json
+fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json
+fslc analyze tests/fixtures/chain/fsl-project.toml --projection traceability_graph --format json
+fslc analyze spec.fsl --projection action_state_graph --format dot
+fslc analyze spec.fsl --projection requirement_property_graph --format mermaid
 ```
 
-`--format` currently accepts only `json`. Success is `result: "analyzed"` and
-exits 0. Parse, name, type, semantics, io, and internal failures reuse the
-normal fslc error envelope.
+`--format json` remains the default. `--format dot` and `--format mermaid` are
+review-aid graph exports for graph-shaped projections; they do not add a
+Graphviz or Mermaid runtime dependency.
+
+Single-file success is `result: "analyzed"` and exits 0. Parse, name, type,
+semantics, io, and internal failures reuse the normal fslc error envelope.
+Batch mode accepts files and directories. Directories are expanded recursively
+for `*.fsl`, sorted by normalized path, and emitted as one deterministic JSON
+envelope with `mode: "batch"`. If any file fails, successful entries remain in
+`files[]`, failed entries are also summarized in `errors[]`, and the command
+exits 2.
 
 ## 2. Typed Semantic Graph (TSG)
 
@@ -52,12 +65,21 @@ Stable edge kinds include `declares`, `covers`, `has_guard`, `has_effect`,
 
 ## 3. Graph projections
 
-Graph projections are deterministic summaries over the TSG:
+Graph projections are deterministic summaries over the TSG or over other
+structural sources:
 
 - `action_state_graph`: actions connected to state variables they read/write.
 - `requirement_property_graph`: requirements connected to covered actions,
   properties, scenarios, KPI/control nodes.
 - `property_state_graph`: user properties connected to state variables they read.
+- `refinement_graph`: standalone refinement mappings with impl/abs spec names,
+  state maps, action maps, stutters, and preserve-progress declarations.
+- `traceability_graph`: project-manifest graph over business/requirements/design
+  files and refinement mappings.
+
+Direct `.toml` inputs to `fslc analyze` are treated as project manifests; the
+default filename is `fsl-project.toml`, but review copies with other names are
+accepted.
 
 Each graph projection includes `components`, `sccs`, `cycles`, `degree`, and
 `formal_status: "not_a_violation"`. A disconnected component or cycle is not a
@@ -76,6 +98,9 @@ proof failure. It is only structure for downstream review.
   requirement tag or acceptance/forbidden scenario, and no explicit progress
   story is attached. The heuristic does not inspect English terms in action or
   state names.
+- `unwritten_state`: a state variable is initialized and may be read, but no
+  action writes it.
+- `unguarded_action`: a non-generated action has no explicit `requires` clause.
 
 Every finding has:
 
@@ -97,13 +122,41 @@ language-specific words such as "retry" or "pending". A cycle can be valid
 retry, review, or compensation behavior; the finding only says that a
 requirement/scenario-linked cycle has no visible progress story.
 
-## 5. Implementation notes
+Project-level `traceability_graph` can additionally emit
+`traceability_gap` findings when an upper-layer requirement/control ID has no
+visible lower-layer structural anchor. This is still review-only; verified
+refinement evidence remains the job of `fslc chain` and `fslc refine`.
+
+## 5. Schemas
+
+Versioned schema files live under `schemas/fslc/analysis/`:
+
+- `tsg.v0.schema.json`
+- `analysis-graph.v0.schema.json`
+- `analysis-findings.v0.schema.json`
+
+Downstream consumers should check `schema_version` before assuming shape.
+Additive optional fields can remain in the same schema version; removing or
+changing required field semantics should use a new version.
+
+## 6. LSP diagnostics
+
+`fslc-lsp` can surface `--profile ai-review` findings as informational
+diagnostics when started with `FSLC_LSP_ANALYSIS_DIAGNOSTICS=1`. These
+diagnostics use source locations from TSG nodes when available, fall back to the
+best indexed declaration range, and remain clearly marked as structural review
+signals from `fslc analyze`, not formal verifier errors.
+
+## 7. Implementation notes
 
 The analysis package is in `src/fslc/analysis/`:
 
 - `tsg.py`: spec dict to TSG, expression read extraction, assignment write extraction.
 - `graph.py`: deterministic connected components, SCCs, representative cycles.
 - `projections.py`: graph projections over TSG.
+- `refinement.py`: structural graph projection for standalone mapping files.
+- `project.py`: manifest-level traceability graph assembly.
+- `export.py`: DOT and Mermaid formatting.
 - `findings.py`: AI-readable review findings.
 
 The implementation does not call Z3 and does not perform bounded reachability.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -388,7 +388,7 @@ fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed 
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
-fslc analyze   <file.fsl> [--projection tsg|action_state_graph|requirement_property_graph|property_state_graph] [--profile ai-review]  # structural review JSON (§15)
+fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--profile ai-review] [--format json|dot|mermaid]  # structural review (§15)
 fslc html      <file.fsl> [--depth K] [-o report.html] # self-contained review report (§15)
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 ```
@@ -1264,10 +1264,18 @@ DESIGN-*.md).
 - **`fslc analyze`** — emits structural observation JSON. `--projection tsg`
   returns the Typed Semantic Graph of requirements, actions, state, properties,
   and scenarios. Graph projections return connected components, SCCs, and
-  representative cycles. `--profile ai-review` emits review findings such as
-  `disconnected_requirement`, `unanchored_property`, and `progressless_cycle`.
+  representative cycles. It accepts multiple files or directories in batch mode;
+  directories are expanded recursively for `*.fsl` and sorted deterministically.
+  Standalone refinement mappings can be viewed with `--projection
+  refinement_graph`; project manifests can be viewed with `--projection
+  traceability_graph`. `--format dot` and `--format mermaid` export graph-shaped
+  projections for review diagrams while keeping JSON as the default. `--profile
+  ai-review` emits review findings such as `disconnected_requirement`,
+  `unanchored_property`, `progressless_cycle`, `unwritten_state`, and
+  `unguarded_action`.
   These findings carry `formal_status: "not_a_violation"`; a structural cycle or
-  disconnected component is not a proof failure. →
+  disconnected component is not a proof failure. Versioned schemas for the TSG,
+  graph projections, and findings are published under `schemas/fslc/analysis/`. →
   [`DESIGN-analysis.md`](DESIGN-analysis.md)
 - **`fslc html`** — a self-contained HTML report over the same explain/verify
   evidence: status summary, state/action/property tables, an action-to-state

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 | [`intro/concept.en.html`](intro/concept.en.html) / [`intro/when-to-use.en.html`](intro/when-to-use.en.html) / [`intro/guide.en.html`](intro/guide.en.html) / [`intro/mechanism.en.html`](intro/mechanism.en.html) / [`intro/business-layer.en.html`](intro/business-layer.en.html) / [`intro/requirements-layer.en.html`](intro/requirements-layer.en.html) / [`intro/design-layer.en.html`](intro/design-layer.en.html) / [`intro/syntax.en.html`](intro/syntax.en.html) / [`intro/analysis.en.html`](intro/analysis.en.html) | **English HTML manual**. Each article has persistent chapter navigation for concept, when to use, workflow, mechanisms, business layer, requirements layer, design layer, syntax, and structural analysis |
 | [`INTRO-formal-methods-and-fsl.md`](INTRO-formal-methods-and-fsl.md) | **Introduction to formal methods and FSL**. Background for non-specialists, the role of FSL in AI-driven development, and considerations for an introductory PoC |
 | [`LANGUAGE.md`](LANGUAGE.md) | **Language reference** (full syntax, semantics, CLI, idioms, the three-layer dialects, and NFRs). Read this if you are writing specifications |
-| [`intro/analysis.ja.html`](intro/analysis.ja.html) / [`intro/analysis.en.html`](intro/analysis.en.html) / [`DESIGN-analysis.md`](DESIGN-analysis.md) | **`fslc analyze` structural observation layer**. Site pages and implementation design for TSG, graph projections, and AI-review findings |
+| [`intro/analysis.ja.html`](intro/analysis.ja.html) / [`intro/analysis.en.html`](intro/analysis.en.html) / [`DESIGN-analysis.md`](DESIGN-analysis.md) | **`fslc analyze` structural observation layer**. Site pages and implementation design for TSG, graph projections, batch analysis, refinement/project traceability graphs, graph exports, schemas, and AI-review findings |
 | [`DESIGN-v1.md`](DESIGN-v1.md) | Language design document (design principles G1-G5, type-system design decisions, the repair protocol, and the roadmap) |
 
 ## Implementation design by architecture and feature (DESIGN-*)
@@ -36,7 +36,7 @@
 | [`DESIGN-explain.md`](DESIGN-explain.md) | `fslc explain --readable` (verification bounds, skeleton enumeration, counterfactuals, witness narration) |
 | [`DESIGN-html-report.md`](DESIGN-html-report.md) | `fslc html` (self-contained visual review report from explain + verify evidence) |
 | [`DESIGN-typestate.md`](DESIGN-typestate.md) | `fslc typestate` (applicability check for state machine → typestate + TS scaffold) |
-| [`DESIGN-analysis.md`](DESIGN-analysis.md) | `fslc analyze` (Typed Semantic Graph, graph projections, AI-readable structural review findings) |
+| [`DESIGN-analysis.md`](DESIGN-analysis.md) | `fslc analyze` (Typed Semantic Graph, graph projections, batch mode, refinement/project traceability graphs, DOT/Mermaid exports, schemas, AI-readable structural review findings) |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
 
 ## Dogfooding records (DOGFOOD-*)

--- a/docs/intro/analysis.en.html
+++ b/docs/intro/analysis.en.html
@@ -54,6 +54,10 @@
 fslc analyze spec.fsl --projection action_state_graph --format json
 fslc analyze spec.fsl --projection requirement_property_graph --format json
 fslc analyze spec.fsl --projection property_state_graph --format json
+fslc analyze specs/ examples/e2e/ --profile ai-review --format json
+fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json
+fslc analyze fsl-project.toml --projection traceability_graph --format json
+fslc analyze spec.fsl --projection action_state_graph --format dot
 fslc analyze spec.fsl --profile ai-review --format json</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
@@ -62,6 +66,8 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
       <tr><td><code>action_state_graph</code></td><td>Actions connected to state variables they read and write.</td></tr>
       <tr><td><code>requirement_property_graph</code></td><td>Requirement IDs connected to covered actions, properties, scenarios, KPI, and control nodes.</td></tr>
       <tr><td><code>property_state_graph</code></td><td>User properties connected to the state variables they read or check.</td></tr>
+      <tr><td><code>refinement_graph</code></td><td>Standalone mapping files: impl/abs names, state maps, action maps, stutters, and preserve-progress declarations.</td></tr>
+      <tr><td><code>traceability_graph</code></td><td>Project-manifest structure across business, requirements, design, and refinement mapping files.</td></tr>
     </table>
   </div>
 </section>
@@ -83,6 +89,14 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
         <h3><code>progressless_cycle</code></h3>
         <p>A requirement/scenario-linked multi-action cycle has no visible progress story such as <code>leadsTo</code>, <code>fair action</code>, or <code>terminal</code>.</p>
       </div>
+      <div class="card">
+        <h3><code>unwritten_state</code></h3>
+        <p>A state variable is initialized, but no action writes it. It may be intentional fixed model data, or it may point to missing behavior.</p>
+      </div>
+      <div class="card">
+        <h3><code>unguarded_action</code></h3>
+        <p>A non-generated action has no explicit <code>requires</code> clause, so it deserves review as an always-enabled transition.</p>
+      </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
       <p style="margin:0">The cycle finding does not inspect English keywords in names. It relies on structural anchors such as requirement tags and scenarios, so non-English requirement text is preserved without being interpreted by core fslc.</p>
@@ -96,9 +110,9 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
     <h2 class="reveal">Output families</h2>
     <table class="matrix reveal">
       <tr><th>Output</th><th>Schema version</th><th>Use</th></tr>
-      <tr><td>Typed Semantic Graph</td><td><code>tsg.v0</code></td><td>Stable graph data for downstream projections and tools.</td></tr>
-      <tr><td>Graph projections</td><td><code>analysis-graph.v0</code></td><td>Review graph summaries with components, SCCs, cycles, and degree.</td></tr>
-      <tr><td>AI-review findings</td><td><code>analysis-findings.v0</code></td><td>Structured review findings with witnesses, repairs, and caveats.</td></tr>
+      <tr><td>Typed Semantic Graph</td><td><code>tsg.v0</code></td><td>Stable graph data for downstream projections and tools. Schema: <code>schemas/fslc/analysis/tsg.v0.schema.json</code>.</td></tr>
+      <tr><td>Graph projections</td><td><code>analysis-graph.v0</code></td><td>Review graph summaries with components, SCCs, cycles, and degree. DOT/Mermaid exports are views over this data.</td></tr>
+      <tr><td>AI-review findings</td><td><code>analysis-findings.v0</code></td><td>Structured review findings with witnesses, repairs, caveats, and optional source locations for editor diagnostics.</td></tr>
     </table>
   </div>
 </section>
@@ -113,12 +127,12 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
         <p>Requirement text is carried through the graph, but the core analyzer does not interpret its meaning.</p>
       </div>
       <div class="syntax-card">
-        <h3>No refinement-file graph yet</h3>
-        <p>Standalone mapping-file analysis is tracked separately from the current single-spec projections.</p>
+        <h3>No proof evidence</h3>
+        <p>Project traceability and refinement graphs show structure only. Run <code>chain</code>, <code>refine</code>, or <code>verify</code> for proof results.</p>
       </div>
       <div class="syntax-card">
-        <h3>No visual graph export yet</h3>
-        <p>DOT, Mermaid, project-wide traceability, JSON Schema, and editor diagnostics are follow-up issues.</p>
+        <h3>Editor signals are opt-in</h3>
+        <p><code>fslc-lsp</code> surfaces analysis findings as informational diagnostics when <code>FSLC_LSP_ANALYSIS_DIAGNOSTICS=1</code> is set.</p>
       </div>
     </div>
   </div>

--- a/docs/intro/analysis.ja.html
+++ b/docs/intro/analysis.ja.html
@@ -54,6 +54,10 @@
 fslc analyze spec.fsl --projection action_state_graph --format json
 fslc analyze spec.fsl --projection requirement_property_graph --format json
 fslc analyze spec.fsl --projection property_state_graph --format json
+fslc analyze specs/ examples/e2e/ --profile ai-review --format json
+fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json
+fslc analyze fsl-project.toml --projection traceability_graph --format json
+fslc analyze spec.fsl --projection action_state_graph --format dot
 fslc analyze spec.fsl --profile ai-review --format json</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
@@ -62,6 +66,8 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
       <tr><td><code>action_state_graph</code></td><td>操作と、その操作が読む・書く状態変数のつながり。</td></tr>
       <tr><td><code>requirement_property_graph</code></td><td>要件IDと、それが covers する操作、性質、シナリオ、KPI、control のつながり。</td></tr>
       <tr><td><code>property_state_graph</code></td><td>ユーザー定義の性質と、それが読む・検査する状態変数のつながり。</td></tr>
+      <tr><td><code>refinement_graph</code></td><td>単体の mapping file に含まれる impl/abs 名、state map、action map、stutter、preserve-progress 宣言。</td></tr>
+      <tr><td><code>traceability_graph</code></td><td>project manifest から business、requirements、design、refinement mapping を横断した構造。</td></tr>
     </table>
   </div>
 </section>
@@ -83,6 +89,14 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
         <h3><code>progressless_cycle</code></h3>
         <p>要件またはシナリオにつながる複数操作の循環に、<code>leadsTo</code>、<code>fair action</code>、<code>terminal</code> などの進捗ストーリーが見えません。</p>
       </div>
+      <div class="card">
+        <h3><code>unwritten_state</code></h3>
+        <p>状態変数が初期化されているのに、どの action からも書き込まれていません。意図した固定データか、欠けた振る舞いかをレビューします。</p>
+      </div>
+      <div class="card">
+        <h3><code>unguarded_action</code></h3>
+        <p>生成物ではない action に明示的な <code>requires</code> がありません。常時有効な遷移として妥当かをレビューします。</p>
+      </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
       <p style="margin:0">cycle 所見は、名前の英単語を見ていません。要件タグやシナリオなどの構造アンカーに基づきます。日本語の要件文は保持されますが、fslc core は意味解釈しません。</p>
@@ -96,9 +110,9 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
     <h2 class="reveal">出力の種類</h2>
     <table class="matrix reveal">
       <tr><th>出力</th><th>schema version</th><th>用途</th></tr>
-      <tr><td>Typed Semantic Graph</td><td><code>tsg.v0</code></td><td>下流の投影やツールが使う安定したグラフデータ。</td></tr>
-      <tr><td>Graph projections</td><td><code>analysis-graph.v0</code></td><td>components、SCC、cycles、degree を含むレビュー用グラフ要約。</td></tr>
-      <tr><td>AI-review findings</td><td><code>analysis-findings.v0</code></td><td>witness、repair、caveat を含む構造化レビュー所見。</td></tr>
+      <tr><td>Typed Semantic Graph</td><td><code>tsg.v0</code></td><td>下流の投影やツールが使う安定したグラフデータ。Schema は <code>schemas/fslc/analysis/tsg.v0.schema.json</code>。</td></tr>
+      <tr><td>Graph projections</td><td><code>analysis-graph.v0</code></td><td>components、SCC、cycles、degree を含むレビュー用グラフ要約。DOT/Mermaid はこのデータの表示形式です。</td></tr>
+      <tr><td>AI-review findings</td><td><code>analysis-findings.v0</code></td><td>witness、repair、caveat、editor diagnostics 用の任意 source location を含む構造化レビュー所見。</td></tr>
     </table>
   </div>
 </section>
@@ -113,12 +127,12 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
         <p>要件文はグラフに保持しますが、その意味を core analyzer が推論することはありません。</p>
       </div>
       <div class="syntax-card">
-        <h3>refinement file のグラフ化はまだ</h3>
-        <p>単体の mapping file 解析は、現在の単一 spec 投影とは別の follow-up です。</p>
+        <h3>証明の証拠ではない</h3>
+        <p>project traceability と refinement graph は構造だけを示します。証明結果が必要なら <code>chain</code>、<code>refine</code>、<code>verify</code> を実行します。</p>
       </div>
       <div class="syntax-card">
-        <h3>可視化出力はまだ</h3>
-        <p>DOT、Mermaid、プロジェクト横断 traceability、JSON Schema、editor diagnostics は follow-up issue です。</p>
+        <h3>editor signals は opt-in</h3>
+        <p><code>FSLC_LSP_ANALYSIS_DIAGNOSTICS=1</code> を設定すると、<code>fslc-lsp</code> が analysis findings を Information 診断として出します。</p>
       </div>
     </div>
   </div>

--- a/schemas/fslc/analysis/analysis-findings.v0.schema.json
+++ b/schemas/fslc/analysis/analysis-findings.v0.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ymm-oss.github.io/fsl/schemas/fslc/analysis/analysis-findings.v0.schema.json",
+  "title": "fslc analyze AI-review findings v0",
+  "type": "object",
+  "required": ["fsl", "result", "analysis", "profile", "schema_version", "findings"],
+  "properties": {
+    "fsl": { "type": "string" },
+    "result": { "const": "analyzed" },
+    "analysis": { "const": "structure" },
+    "profile": { "const": "ai-review" },
+    "schema_version": { "const": "analysis-findings.v0" },
+    "spec": { "type": "string" },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "loc": {
+      "type": "object",
+      "required": ["line", "column"],
+      "properties": {
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": true
+    },
+    "finding": {
+      "type": "object",
+      "required": [
+        "finding_id",
+        "analysis",
+        "finding_type",
+        "severity",
+        "confidence",
+        "formal_status",
+        "involved_nodes",
+        "witness",
+        "why_it_matters",
+        "candidate_repairs",
+        "do_not_assume"
+      ],
+      "properties": {
+        "finding_id": { "type": "string" },
+        "analysis": { "const": "structure" },
+        "finding_type": { "type": "string" },
+        "severity": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "formal_status": { "const": "not_a_violation" },
+        "involved_nodes": { "type": "array", "items": { "type": "string" } },
+        "witness": { "type": "object" },
+        "why_it_matters": { "type": "string" },
+        "candidate_repairs": { "type": "array", "items": { "type": "object" } },
+        "do_not_assume": { "type": "array", "items": { "type": "string" } },
+        "loc": { "$ref": "#/$defs/loc" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/fslc/analysis/analysis-graph.v0.schema.json
+++ b/schemas/fslc/analysis/analysis-graph.v0.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ymm-oss.github.io/fsl/schemas/fslc/analysis/analysis-graph.v0.schema.json",
+  "title": "fslc analyze structural graph projection v0",
+  "type": "object",
+  "required": [
+    "fsl",
+    "result",
+    "analysis",
+    "projection",
+    "schema_version",
+    "formal_status",
+    "nodes",
+    "edges",
+    "components",
+    "sccs",
+    "cycles",
+    "degree"
+  ],
+  "properties": {
+    "fsl": { "type": "string" },
+    "result": { "const": "analyzed" },
+    "analysis": { "const": "structure" },
+    "projection": { "type": "string" },
+    "schema_version": { "const": "analysis-graph.v0" },
+    "formal_status": { "const": "not_a_violation" },
+    "spec": { "type": "string" },
+    "refinement": { "type": "string" },
+    "manifest": { "type": "string" },
+    "nodes": { "type": "array", "items": { "$ref": "#/$defs/node" } },
+    "edges": { "type": "array", "items": { "$ref": "#/$defs/edge" } },
+    "components": { "type": "array", "items": { "$ref": "#/$defs/component" } },
+    "sccs": { "type": "array", "items": { "$ref": "#/$defs/component" } },
+    "cycles": { "type": "array", "items": { "$ref": "#/$defs/cycle" } },
+    "degree": { "type": "array", "items": { "$ref": "#/$defs/degree" } },
+    "findings": { "type": "array" }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "loc": {
+      "type": "object",
+      "required": ["line", "column"],
+      "properties": {
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": true
+    },
+    "node": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string" },
+        "label": { "type": "string" },
+        "loc": { "$ref": "#/$defs/loc" },
+        "meta": { "type": "object" },
+        "fair": { "type": "boolean" },
+        "formal_status": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "edge": {
+      "type": "object",
+      "required": ["id", "kind", "from", "to"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "formal_status": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "component": {
+      "type": "object",
+      "required": ["id", "nodes"],
+      "properties": {
+        "id": { "type": "string" },
+        "nodes": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "cycle": {
+      "type": "object",
+      "required": ["id", "steps"],
+      "properties": {
+        "id": { "type": "string" },
+        "steps": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "degree": {
+      "type": "object",
+      "required": ["node", "in", "out", "total"],
+      "properties": {
+        "node": { "type": "string" },
+        "in": { "type": "integer", "minimum": 0 },
+        "out": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/fslc/analysis/tsg.v0.schema.json
+++ b/schemas/fslc/analysis/tsg.v0.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ymm-oss.github.io/fsl/schemas/fslc/analysis/tsg.v0.schema.json",
+  "title": "fslc analyze Typed Semantic Graph v0",
+  "type": "object",
+  "required": ["fsl", "result", "analysis", "projection", "schema_version", "nodes", "edges"],
+  "properties": {
+    "fsl": { "type": "string" },
+    "result": { "const": "analyzed" },
+    "analysis": { "const": "structure" },
+    "projection": { "const": "tsg" },
+    "schema_version": { "const": "tsg.v0" },
+    "spec": { "type": "string" },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/node" }
+    },
+    "edges": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/edge" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "loc": {
+      "type": "object",
+      "required": ["line", "column"],
+      "properties": {
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": true
+    },
+    "node": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "name": { "type": "string" },
+        "label": { "type": "string" },
+        "loc": { "$ref": "#/$defs/loc" },
+        "meta": { "type": "object" },
+        "fair": { "type": "boolean" },
+        "formal_status": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "edge": {
+      "type": "object",
+      "required": ["id", "kind", "from", "to"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "formal_status": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -267,9 +267,12 @@ the formalization memo.**
    adjudicate concrete traces rather than logical formulas),
    `fslc analyze file.fsl --profile ai-review`
    (emits structural review findings over the Typed Semantic Graph, such as
-   disconnected requirements, unanchored properties, and progressless cycles.
-   These are review signals with `formal_status:"not_a_violation"`, not proof
-   failures),
+   disconnected requirements, unanchored properties, progressless cycles,
+   unwritten state, and unguarded actions. `analyze` also supports batch
+   file/directory review, standalone `refinement_graph`, project
+   `traceability_graph`, DOT/Mermaid graph exports, and JSON schemas under
+   `schemas/fslc/analysis/`. These are review signals with
+   `formal_status:"not_a_violation"`, not proof failures),
    `fslc mutate file.fsl --depth 8 --by-requirement`
    (shows how many model mutations the spec's properties kill; a survivor is not a
    failure but a candidate for a missing invariant / acceptance / forbidden. For a

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -293,7 +293,7 @@ fslc replay <f> --trace <events.json>           # conformant | nonconformant
 fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test / PHPUnit)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
-fslc analyze <f> [--projection tsg|action_state_graph|requirement_property_graph|property_state_graph] [--profile ai-review]  # structural review JSON
+fslc analyze <file-or-dir>... [--projection tsg|action_state_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--profile ai-review] [--format json|dot|mermaid]  # structural review
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
 fslc html <f> [--depth K] [-o report.html]      # self-contained HTML review report (dev audience)
 fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md]  # business audit ledger by requirement id (PM/audit)
@@ -304,10 +304,17 @@ emits a stable Typed Semantic Graph over requirements, actions, state variables,
 properties, acceptance/forbidden scenarios, and traceability metadata.
 `--projection action_state_graph`, `requirement_property_graph`, and
 `property_state_graph` summarize deterministic components/SCCs/cycles over that
-graph. `--profile ai-review` emits AI-readable review findings such as
-`disconnected_requirement`, `unanchored_property`, and `progressless_cycle`.
-Treat these as review signals: they carry `formal_status:"not_a_violation"` unless
-a future finding explicitly cites `verify`/`refine`/`replay` evidence.
+graph. It accepts multiple files/directories in batch mode; directories expand
+recursively to sorted `*.fsl` files and partial failures stay visible in the batch
+JSON. Standalone refinement mappings use `--projection refinement_graph`, project
+manifests use `--projection traceability_graph`, and graph projections can export
+DOT or Mermaid with `--format dot|mermaid`. `--profile ai-review` emits
+AI-readable review findings such as `disconnected_requirement`,
+`unanchored_property`, `progressless_cycle`, `unwritten_state`, and
+`unguarded_action`. Treat these as review signals: they carry
+`formal_status:"not_a_violation"` unless a future finding explicitly cites
+`verify`/`refine`/`replay` evidence. Versioned schemas live under
+`schemas/fslc/analysis/`.
 
 `ledger` (issue #24) re-organizes `verify`/`scenarios`/`replay` findings **by
 requirement id** into a Markdown audit ledger a PM / governance / internal-audit

--- a/src/fslc/analysis/__init__.py
+++ b/src/fslc/analysis/__init__.py
@@ -4,7 +4,17 @@
 """Structural analysis helpers for fslc."""
 
 from .findings import analyze
+from .export import export_graph
+from .project import analyze_project_manifest
 from .projections import analyze_projection
+from .refinement import analyze_refinement_ast
 from .tsg import build_tsg
 
-__all__ = ["analyze", "analyze_projection", "build_tsg"]
+__all__ = [
+    "analyze",
+    "analyze_projection",
+    "analyze_project_manifest",
+    "analyze_refinement_ast",
+    "build_tsg",
+    "export_graph",
+]

--- a/src/fslc/analysis/export.py
+++ b/src/fslc/analysis/export.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""DOT and Mermaid exporters for structural analysis graphs."""
+from __future__ import annotations
+
+import re
+
+
+def export_graph(analysis, output_format):
+    if output_format == "dot":
+        return to_dot(analysis)
+    if output_format == "mermaid":
+        return to_mermaid(analysis)
+    raise ValueError(f"unsupported graph export format: {output_format}")
+
+
+def to_dot(analysis):
+    lines = ["digraph fsl_analysis {"]
+    lines.append("  rankdir=LR;")
+    for n in sorted(analysis.get("nodes", []), key=lambda item: item["id"]):
+        attrs = {
+            "label": _dot_escape(n.get("label") or n.get("name") or n["id"]),
+            "shape": _dot_shape(n.get("kind")),
+        }
+        attr_text = ", ".join(f'{k}="{v}"' for k, v in attrs.items())
+        lines.append(f'  "{_dot_escape(n["id"])}" [{attr_text}];')
+    for e in sorted(analysis.get("edges", []), key=lambda item: (item["from"], item["to"], item["kind"], item["id"])):
+        label = _dot_escape(e.get("label") or e.get("kind") or "")
+        lines.append(f'  "{_dot_escape(e["from"])}" -> "{_dot_escape(e["to"])}" [label="{label}"];')
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def to_mermaid(analysis):
+    nodes = sorted(analysis.get("nodes", []), key=lambda item: item["id"])
+    id_map = _mermaid_ids(nodes)
+    lines = ["graph TD"]
+    for n in nodes:
+        mid = id_map[n["id"]]
+        label = _mermaid_label(n.get("label") or n.get("name") or n["id"])
+        lines.append(f"  {mid}{_mermaid_node_shape(n.get('kind'), label)}")
+    for e in sorted(analysis.get("edges", []), key=lambda item: (item["from"], item["to"], item["kind"], item["id"])):
+        if e["from"] not in id_map or e["to"] not in id_map:
+            continue
+        label = _mermaid_label(e.get("label") or e.get("kind") or "")
+        lines.append(f"  {id_map[e['from']]} -->|{label}| {id_map[e['to']]}")
+    return "\n".join(lines) + "\n"
+
+
+def _dot_escape(value):
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _dot_shape(kind):
+    if kind in {"requirement", "control", "business_spec", "requirements_spec", "design_spec", "impl_spec", "abs_spec"}:
+        return "box"
+    if kind in {"action", "impl_action", "abs_action", "action_map"}:
+        return "ellipse"
+    if kind in {"state", "phys_state", "state_map", "abs_state", "map_expr_read"}:
+        return "cylinder"
+    if kind in {"invariant", "trans", "leadsTo", "reachable", "progress_response"}:
+        return "diamond"
+    if kind in {"acceptance", "forbidden"}:
+        return "note"
+    return "plaintext"
+
+
+def _mermaid_ids(nodes):
+    out = {}
+    seen = set()
+    for idx, n in enumerate(nodes):
+        mid = re.sub(r"[^A-Za-z0-9_]", "_", n["id"])
+        if not mid or mid[0].isdigit():
+            mid = f"n_{mid}"
+        candidate = mid
+        if candidate in seen:
+            candidate = f"{mid}_{idx}"
+        seen.add(candidate)
+        out[n["id"]] = candidate
+    return out
+
+
+def _mermaid_label(value):
+    text = str(value).replace("\n", " ")
+    return (
+        text.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("[", "(")
+        .replace("]", ")")
+        .replace("|", "/")
+    )
+
+
+def _mermaid_node_shape(kind, label):
+    if kind in {"action", "impl_action", "abs_action", "action_map"}:
+        return f'((" {label} "))'
+    if kind in {"invariant", "trans", "leadsTo", "reachable", "progress_response"}:
+        return f'{{{{"{label}"}}}}'
+    if kind in {"state", "phys_state", "state_map", "abs_state", "map_expr_read"}:
+        return f'[/"{label}"/]'
+    return f'["{label}"]'

--- a/src/fslc/analysis/findings.py
+++ b/src/fslc/analysis/findings.py
@@ -18,6 +18,8 @@ def analyze(spec, profile="ai-review"):
     findings.extend(_disconnected_requirements(tsg))
     findings.extend(_unanchored_properties(tsg))
     findings.extend(_progressless_cycles(spec, tsg))
+    findings.extend(_unwritten_state(tsg))
+    findings.extend(_unguarded_actions(tsg))
     findings = _renumber(findings)
     return {
         "analysis": "structure",
@@ -178,6 +180,95 @@ def _progressless_cycles(spec, tsg):
     return findings
 
 
+def _unwritten_state(tsg):
+    nodes = node_by_id(tsg)
+    written = set()
+    read = set()
+    for e in tsg["edges"]:
+        dst_node = nodes.get(e["to"]) or {}
+        if dst_node.get("kind") != "state":
+            continue
+        if e["kind"] == "writes":
+            written.add(e["to"])
+        elif e["kind"] in {"reads", "checks"}:
+            read.add(e["to"])
+
+    findings = []
+    for state in sorted((n for n in tsg["nodes"] if n["kind"] == "state"), key=lambda n: n["id"]):
+        if state["id"] in written:
+            continue
+        findings.append(_finding(
+            "unwritten_state",
+            [state["id"]],
+            {
+                "kind": "state_has_no_action_writes",
+                "node": state["id"],
+                "read_by": sorted(read_for_state(tsg, state["id"])),
+            },
+            "The state variable is initialized but no action writes it in the structural graph.",
+            [
+                {
+                    "kind": "review_state_role",
+                    "template": "Make the value a const/model parameter if it is intentionally fixed, or add the missing action/effect that changes it.",
+                }
+            ],
+            [
+                "The state variable is useless.",
+                "A verifier property is violated.",
+                "The variable is safe to delete without checking generated dialect state.",
+            ],
+            confidence=0.76 if state["id"] in read else 0.68,
+            loc=state.get("loc"),
+        ))
+    return findings
+
+
+def _unguarded_actions(tsg):
+    has_guard = set()
+    nodes = node_by_id(tsg)
+    for e in tsg["edges"]:
+        if e["kind"] == "has_guard":
+            has_guard.add(e["from"])
+
+    findings = []
+    for action in sorted((n for n in tsg["nodes"] if n["kind"] == "action"), key=lambda n: n["id"]):
+        if action.get("generated"):
+            continue
+        if action["id"] in has_guard:
+            continue
+        writes = sorted(
+            e["to"]
+            for e in tsg["edges"]
+            if e["from"] == action["id"]
+            and e["kind"] == "writes"
+            and (nodes.get(e["to"]) or {}).get("kind") == "state"
+        )
+        findings.append(_finding(
+            "unguarded_action",
+            [action["id"]],
+            {
+                "kind": "action_has_no_requires",
+                "node": action["id"],
+                "writes": writes,
+            },
+            "The action has no explicit requires clauses, so it is structurally enabled in every state unless generated lowering adds hidden constraints elsewhere.",
+            [
+                {
+                    "kind": "add_or_confirm_guard",
+                    "template": "Add a requires clause if the action should be state-dependent, or tag/document why it is intentionally always enabled.",
+                }
+            ],
+            [
+                "The action is wrong.",
+                "Always-enabled behavior is invalid.",
+                "The action is reachable in every semantic state without considering type bounds and invariants.",
+            ],
+            confidence=0.72,
+            loc=action.get("loc"),
+        ))
+    return findings
+
+
 def _action_dependency_graph(nodes, edges):
     action_nodes = sorted(n["id"] for n in nodes if n["kind"] == "action")
     state_writers = {}
@@ -267,8 +358,16 @@ def _scenario_actions(tsg):
     return out
 
 
-def _finding(finding_type, involved_nodes, witness, why, repairs, caveats, confidence):
-    return {
+def read_for_state(tsg, state_id):
+    readers = []
+    for e in tsg["edges"]:
+        if e["to"] == state_id and e["kind"] in {"reads", "checks"}:
+            readers.append(e["from"])
+    return readers
+
+
+def _finding(finding_type, involved_nodes, witness, why, repairs, caveats, confidence, loc=None):
+    out = {
         "finding_id": "",
         "analysis": "structure",
         "finding_type": finding_type,
@@ -281,6 +380,9 @@ def _finding(finding_type, involved_nodes, witness, why, repairs, caveats, confi
         "candidate_repairs": repairs,
         "do_not_assume": caveats,
     }
+    if loc:
+        out["loc"] = loc
+    return out
 
 
 def _renumber(findings):

--- a/src/fslc/analysis/project.py
+++ b/src/fslc/analysis/project.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Project-level structural traceability analysis."""
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - Python 3.9/3.10
+    import tomli as tomllib
+
+from .graph import connected_components, degree_summary, representative_cycles, strongly_connected_components
+from .schema import GRAPH_SCHEMA_VERSION, edge, node, stable_unique
+from .tsg import build_tsg, expr_reads, node_by_id
+from ..model import build_spec
+from ..parser import parse_refinement, parse_src
+
+
+LAYER_ORDER = ("business", "requirements", "design")
+SPEC_KIND_BY_LAYER = {
+    "business": "business_spec",
+    "requirements": "requirements_spec",
+    "design": "design_spec",
+}
+
+
+def analyze_project_manifest(path, projection="traceability_graph"):
+    if projection != "traceability_graph":
+        raise ValueError(f"unsupported project projection: {projection}")
+    manifest_path = Path(path)
+    manifest, base = _load_manifest(manifest_path)
+    builder = _ProjectTraceabilityBuilder(manifest_path, manifest, base)
+    return builder.build()
+
+
+def _load_manifest(path):
+    with open(path, "rb") as fh:
+        data = tomllib.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("project manifest must be a TOML table")
+    return data, path.parent
+
+
+def _rel(path, base):
+    p = Path(path)
+    if not p.is_absolute():
+        p = base / p
+    return p
+
+
+class _ProjectTraceabilityBuilder:
+    def __init__(self, manifest_path, manifest, base):
+        self.manifest_path = manifest_path
+        self.manifest = manifest
+        self.base = base
+        self.nodes = []
+        self.edges = []
+        self.layer_data = {}
+        self.findings = []
+
+    def build(self):
+        self.nodes.append(node(
+            f"file:{_display_path(self.manifest_path)}",
+            "file",
+            _display_path(self.manifest_path),
+            _display_path(self.manifest_path),
+            path=_display_path(self.manifest_path),
+        ))
+        for layer in LAYER_ORDER:
+            cfg = self.manifest.get(layer)
+            if not isinstance(cfg, dict) or not cfg.get("file"):
+                continue
+            self._add_layer(layer, cfg)
+        for layer in LAYER_ORDER:
+            cfg = self.manifest.get(layer)
+            if not isinstance(cfg, dict) or not cfg.get("refine_against"):
+                continue
+            target = cfg.get("refine_against")
+            if target in self.layer_data:
+                self._add_refinement(layer, target, cfg)
+        self._add_same_id_anchors()
+        self._add_traceability_gap_findings()
+
+        nodes = stable_unique(self.nodes, key=lambda n: n["id"])
+        edges = stable_unique(self.edges, key=lambda e: e["id"])
+        node_ids = [n["id"] for n in nodes]
+        return {
+            "analysis": "structure",
+            "projection": "traceability_graph",
+            "schema_version": GRAPH_SCHEMA_VERSION,
+            "formal_status": "not_a_violation",
+            "manifest": _display_path(self.manifest_path),
+            "nodes": nodes,
+            "edges": edges,
+            "components": [
+                {"id": f"component:{idx}", "nodes": comp}
+                for idx, comp in enumerate(connected_components(node_ids, edges))
+            ],
+            "sccs": [
+                {"id": f"scc:{idx}", "nodes": comp}
+                for idx, comp in enumerate(strongly_connected_components(node_ids, edges))
+            ],
+            "cycles": [
+                {"id": f"cycle:{idx}", "steps": cycle}
+                for idx, cycle in enumerate(representative_cycles(node_ids, edges))
+            ],
+            "degree": degree_summary(node_ids, edges),
+            "findings": self.findings,
+        }
+
+    def _add_layer(self, layer, cfg):
+        path = _rel(cfg["file"], self.base)
+        ast, display_names = parse_src(path.read_text(encoding="utf-8"), str(path.parent))
+        spec = build_spec(ast, display_names, semantic_check=False)
+        tsg = build_tsg(spec)
+        file_id = f"file:{layer}:{_display_path(path)}"
+        self.nodes.append(node(file_id, "file", _display_path(path), _display_path(path), path=_display_path(path)))
+        data = {
+            "path": path,
+            "spec": spec,
+            "tsg": tsg,
+            "nodes_by_id": node_by_id(tsg),
+            "covers": {},
+        }
+        for n in tsg["nodes"]:
+            prefixed = self._prefix_node(layer, n)
+            self.nodes.append(prefixed)
+            if n["kind"] == "spec":
+                self.edges.append(edge(file_id, "declares", prefixed["id"]))
+        for e in tsg["edges"]:
+            self.edges.append(_prefixed_edge(layer, e))
+            if e["kind"] == "covers" and e["from"].startswith("requirement:"):
+                data["covers"].setdefault(e["to"], set()).add(e["from"])
+        self.layer_data[layer] = data
+
+    def _prefix_node(self, layer, n):
+        out = dict(n)
+        out["id"] = _prefix(layer, n["id"])
+        out["layer"] = layer
+        if n["kind"] == "spec":
+            out["kind"] = SPEC_KIND_BY_LAYER.get(layer, "spec")
+        return out
+
+    def _add_refinement(self, layer, target, cfg):
+        mapping = cfg.get("mapping")
+        if not mapping:
+            return
+        path = _rel(mapping, self.base)
+        ast = parse_refinement(path.read_text(encoding="utf-8"))
+        refinement_id = f"refinement:{layer}->{target}:{ast[1]}"
+        file_id = f"file:{layer}->{target}:{_display_path(path)}"
+        self.nodes.append(node(file_id, "file", _display_path(path), _display_path(path), path=_display_path(path)))
+        self.nodes.append(node(refinement_id, "refinement", ast[1], ast[1], path=_display_path(path)))
+        self.edges.append(edge(file_id, "declares", refinement_id))
+        self.edges.append(edge(refinement_id, "implements", _prefix(layer, f"spec:{self.layer_data[layer]['spec']['name']}")))
+        self.edges.append(edge(refinement_id, "abstracts", _prefix(target, f"spec:{self.layer_data[target]['spec']['name']}")))
+
+        impl_state_names = set(self.layer_data[layer]["spec"].get("state") or {})
+        for item in ast[2]:
+            tag = item[0]
+            if tag == "map":
+                _, logical, binder, expr, loc = item
+                map_id = f"state_map:{layer}->{target}:{logical}"
+                self.nodes.append(node(map_id, "state_map", logical, logical, loc, layer=layer, target_layer=target))
+                self.edges.append(edge(refinement_id, "declares", map_id))
+                self.edges.append(edge(map_id, "maps_state", _prefix(target, f"state:{logical}")))
+                bound = {binder[1]} if binder is not None else set()
+                for read_name in sorted(expr_reads(expr, impl_state_names, bound)):
+                    self.edges.append(edge(map_id, "reads_impl_state", _prefix(layer, f"state:{read_name}")))
+            elif tag == "action_map":
+                _, impl_action, _params, target_action, loc = item
+                map_id = f"action_map:{layer}->{target}:{impl_action}"
+                self.nodes.append(node(map_id, "action_map", impl_action, impl_action, loc, layer=layer, target_layer=target))
+                self.edges.append(edge(refinement_id, "declares", map_id))
+                impl_id = _prefix(layer, f"action:{impl_action}")
+                self.edges.append(edge(map_id, "maps_action", impl_id))
+                if target_action[0] == "stutter":
+                    stutter_id = f"stutter_map:{layer}->{target}:{impl_action}"
+                    self.nodes.append(node(stutter_id, "stutter_map", impl_action, impl_action, loc))
+                    self.edges.append(edge(map_id, "stutters", stutter_id))
+                    continue
+                abs_action = target_action[1]
+                abs_id = _prefix(target, f"action:{abs_action}")
+                self.edges.append(edge(impl_id, "maps_action", abs_id))
+                self._add_requirement_lower_anchors(target, layer, f"action:{abs_action}", impl_id)
+            elif tag == "preserve_progress":
+                progress_id = f"preserve_progress:{layer}->{target}:{ast[1]}"
+                self.nodes.append(node(progress_id, "preserve_progress", "preserve progress", "preserve progress", item[2]))
+                self.edges.append(edge(refinement_id, "preserves_progress", progress_id))
+
+    def _add_requirement_lower_anchors(self, upper_layer, lower_layer, upper_target_id, lower_id):
+        covers = self.layer_data[upper_layer]["covers"]
+        for req_id in sorted(covers.get(upper_target_id, set())):
+            self.edges.append(edge(
+                _prefix(upper_layer, req_id),
+                "lower_anchor",
+                lower_id,
+                formal_status="not_a_violation",
+                via="refinement_action_map",
+                layer=lower_layer,
+            ))
+
+    def _add_same_id_anchors(self):
+        pairs = (("business", "requirements"), ("requirements", "design"))
+        for upper, lower in pairs:
+            if upper not in self.layer_data or lower not in self.layer_data:
+                continue
+            upper_nodes = self.layer_data[upper]["nodes_by_id"]
+            lower_nodes = self.layer_data[lower]["nodes_by_id"]
+            for node_id, upper_node in sorted(upper_nodes.items()):
+                if upper_node.get("kind") not in {"requirement", "control"}:
+                    continue
+                lower_node = lower_nodes.get(node_id)
+                if lower_node is None:
+                    continue
+                self.edges.append(edge(
+                    _prefix(upper, node_id),
+                    "lower_anchor",
+                    _prefix(lower, node_id),
+                    formal_status="not_a_violation",
+                    via="same_id",
+                ))
+
+    def _add_traceability_gap_findings(self):
+        lower_anchor_sources = {
+            e["from"]
+            for e in self.edges
+            if e.get("kind") == "lower_anchor"
+        }
+        counters = {}
+        for layer in ("business", "requirements"):
+            data = self.layer_data.get(layer)
+            if not data:
+                continue
+            for n in sorted(data["tsg"]["nodes"], key=lambda item: item["id"]):
+                if n["kind"] not in {"requirement", "control"}:
+                    continue
+                node_id = _prefix(layer, n["id"])
+                if node_id in lower_anchor_sources:
+                    continue
+                ftype = "traceability_gap"
+                counters[ftype] = counters.get(ftype, 0) + 1
+                self.findings.append({
+                    "finding_id": f"STRUCT-TRACEABILITY-GAP-{counters[ftype]:04d}",
+                    "analysis": "structure",
+                    "finding_type": ftype,
+                    "severity": "review_required",
+                    "confidence": 0.74,
+                    "formal_status": "not_a_violation",
+                    "involved_nodes": [node_id],
+                    "witness": {
+                        "kind": "missing_lower_anchor",
+                        "layer": layer,
+                        "node": node_id,
+                    },
+                    "why_it_matters": (
+                        "An upper-layer requirement/control ID has no visible lower-layer "
+                        "structural anchor in the project traceability graph."
+                    ),
+                    "candidate_repairs": [
+                        {
+                            "kind": "add_lower_anchor",
+                            "template": (
+                                "Carry the ID into the lower layer, or map an abstract "
+                                "action/property to a lower-layer action through refinement."
+                            ),
+                        }
+                    ],
+                    "do_not_assume": [
+                        "The lower layer violates the upper-layer contract.",
+                        "Name similarity proves semantic coverage.",
+                    ],
+                })
+
+
+def _prefix(layer, node_id):
+    return f"{layer}:{node_id}"
+
+
+def _prefixed_edge(layer, e):
+    return {
+        **e,
+        "id": f"edge:{layer}:{e['id']}",
+        "from": _prefix(layer, e["from"]),
+        "to": _prefix(layer, e["to"]),
+        "layer": layer,
+    }
+
+
+def _display_path(path):
+    try:
+        return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/src/fslc/analysis/refinement.py
+++ b/src/fslc/analysis/refinement.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Structural graph projection for standalone refinement mapping files."""
+from __future__ import annotations
+
+from .graph import connected_components, degree_summary, representative_cycles, strongly_connected_components
+from .schema import GRAPH_SCHEMA_VERSION, edge, node, stable_unique
+
+
+def analyze_refinement_ast(ast, projection="refinement_graph"):
+    """Build a deterministic review graph from a ``refinement`` AST.
+
+    This intentionally does not call ``build_refinement``: the projection is a
+    mapping-structure view and should not require loading the referenced impl/abs
+    specs unless a future type-aware projection needs them.
+    """
+    if ast[0] != "refinement":
+        raise ValueError("expected refinement AST")
+    if projection not in ("tsg", "refinement_graph"):
+        raise ValueError(f"unsupported refinement projection: {projection}")
+
+    _, name, items = ast
+    builder = _RefinementGraphBuilder(name, items)
+    return builder.build()
+
+
+class _RefinementGraphBuilder:
+    def __init__(self, name, items):
+        self.name = name
+        self.items = items
+        self.nodes = []
+        self.edges = []
+        self.ref_id = f"refinement:{name}"
+        self.impl_name = None
+        self.abs_name = None
+
+    def build(self):
+        self.nodes.append(node(self.ref_id, "refinement", self.name, self.name))
+        for item in self.items:
+            tag = item[0]
+            if tag == "impl":
+                self.impl_name = item[1]
+                impl_id = f"impl_spec:{item[1]}"
+                self.nodes.append(node(impl_id, "impl_spec", item[1], item[1]))
+                self.edges.append(edge(self.ref_id, "implements", impl_id))
+            elif tag == "abs":
+                self.abs_name = item[1]
+                abs_id = f"abs_spec:{item[1]}"
+                self.nodes.append(node(abs_id, "abs_spec", item[1], item[1]))
+                self.edges.append(edge(self.ref_id, "abstracts", abs_id))
+            elif tag == "maps_auto":
+                auto_id = f"maps_auto:{self.name}"
+                self.nodes.append(node(auto_id, "maps_auto", "maps auto", "maps auto"))
+                self.edges.append(edge(self.ref_id, "declares", auto_id))
+            elif tag == "map":
+                self._add_state_map(item)
+            elif tag == "action_map":
+                self._add_action_map(item)
+            elif tag == "preserve_progress":
+                self._add_progress(item)
+
+        nodes = stable_unique(self.nodes, key=lambda n: n["id"])
+        edges = stable_unique(self.edges, key=lambda e: e["id"])
+        node_ids = [n["id"] for n in nodes]
+        return {
+            "analysis": "structure",
+            "projection": "refinement_graph",
+            "schema_version": GRAPH_SCHEMA_VERSION,
+            "formal_status": "not_a_violation",
+            "nodes": nodes,
+            "edges": edges,
+            "components": [
+                {"id": f"component:{idx}", "nodes": comp}
+                for idx, comp in enumerate(connected_components(node_ids, edges))
+            ],
+            "sccs": [
+                {"id": f"scc:{idx}", "nodes": comp}
+                for idx, comp in enumerate(strongly_connected_components(node_ids, edges))
+            ],
+            "cycles": [
+                {"id": f"cycle:{idx}", "steps": cycle}
+                for idx, cycle in enumerate(representative_cycles(node_ids, edges))
+            ],
+            "degree": degree_summary(node_ids, edges),
+        }
+
+    def _add_state_map(self, item):
+        _, logical, binder, expr, loc = item
+        map_id = f"state_map:{logical}"
+        if binder is not None:
+            map_id = f"{map_id}:{binder[1]}"
+        self.nodes.append(node(
+            map_id,
+            "state_map",
+            logical,
+            logical,
+            loc,
+            binder=_binder_name(binder),
+            expr=expr,
+        ))
+        self.edges.append(edge(self.ref_id, "declares", map_id))
+        abs_state = f"abs_state:{logical}"
+        self.nodes.append(node(abs_state, "abs_state", logical, logical))
+        self.edges.append(edge(map_id, "maps_state", abs_state))
+        bound = {_binder_name(binder)} if binder is not None else set()
+        for read_name in sorted(_expr_vars(expr) - bound):
+            read_id = f"map_expr_read:{read_name}"
+            self.nodes.append(node(read_id, "map_expr_read", read_name, read_name))
+            self.edges.append(edge(map_id, "reads_impl_state", read_id))
+
+    def _add_action_map(self, item):
+        _, impl_action, params, target, loc = item
+        map_id = f"action_map:{impl_action}"
+        self.nodes.append(node(
+            map_id,
+            "action_map",
+            impl_action,
+            impl_action,
+            loc,
+            params=[p[1] if isinstance(p, tuple) else p for p in params],
+        ))
+        self.edges.append(edge(self.ref_id, "declares", map_id))
+        impl_id = f"impl_action:{impl_action}"
+        self.nodes.append(node(impl_id, "impl_action", impl_action, impl_action))
+        self.edges.append(edge(map_id, "maps_action", impl_id))
+        param_names = {p[1] if isinstance(p, tuple) else p for p in params}
+        if target[0] == "stutter":
+            stutter_id = f"stutter_map:{impl_action}"
+            self.nodes.append(node(stutter_id, "stutter_map", impl_action, impl_action, loc))
+            self.edges.append(edge(map_id, "stutters", stutter_id))
+            return
+        _, abs_action, args = target
+        abs_id = f"abs_action:{abs_action}"
+        self.nodes.append(node(abs_id, "abs_action", abs_action, abs_action))
+        self.edges.append(edge(map_id, "abstracts", abs_id))
+        for read_name in sorted(set().union(*(_expr_vars(arg) for arg in args)) - param_names):
+            read_id = f"map_expr_read:{read_name}"
+            self.nodes.append(node(read_id, "map_expr_read", read_name, read_name))
+            self.edges.append(edge(map_id, "reads_impl_state", read_id))
+
+    def _add_progress(self, item):
+        _, progress_items, loc = item
+        progress_id = f"preserve_progress:{self.name}"
+        self.nodes.append(node(progress_id, "preserve_progress", "preserve progress", "preserve progress", loc))
+        self.edges.append(edge(self.ref_id, "preserves_progress", progress_id))
+        for progress in progress_items:
+            if progress[0] != "progress_respond":
+                continue
+            _, leadsto, actions, item_loc = progress
+            response_id = f"progress_response:{leadsto}"
+            self.nodes.append(node(response_id, "progress_response", leadsto, leadsto, item_loc))
+            self.edges.append(edge(progress_id, "responds_by", response_id))
+            abs_lt = f"abs_leadsTo:{leadsto}"
+            self.nodes.append(node(abs_lt, "abs_leadsTo", leadsto, leadsto))
+            self.edges.append(edge(response_id, "preserves_progress", abs_lt))
+            for action_name in sorted(actions):
+                impl_action = f"impl_action:{action_name}"
+                self.nodes.append(node(impl_action, "impl_action", action_name, action_name))
+                self.edges.append(edge(response_id, "responds_by", impl_action))
+
+
+def _binder_name(binder):
+    if not binder:
+        return None
+    return binder[1] if len(binder) > 1 else None
+
+
+def _expr_vars(expr):
+    names = set()
+
+    def visit(e):
+        if not isinstance(e, tuple) or not e:
+            return
+        tag = e[0]
+        if tag == "var":
+            names.add(e[1])
+            return
+        if tag in ("forall", "exists"):
+            before = set(names)
+            binder = e[1]
+            visit(e[2])
+            bound = _binder_name(binder)
+            if bound is not None and bound not in before:
+                names.discard(bound)
+            return
+        for part in e[1:]:
+            if isinstance(part, tuple):
+                visit(part)
+            elif isinstance(part, list):
+                for item in part:
+                    visit(item)
+            elif isinstance(part, dict):
+                for item in part.values():
+                    visit(item)
+
+    visit(expr)
+    return names

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -30,8 +30,16 @@ from .ledger import (
     default_output_name as default_ledger_output_name,
     render_ledger,
 )
-from .analysis import analyze as analyze_structure, analyze_projection, build_tsg
+from .analysis import (
+    analyze as analyze_structure,
+    analyze_projection,
+    analyze_project_manifest,
+    analyze_refinement_ast,
+    build_tsg,
+    export_graph,
+)
 from .analysis.projections import SUPPORTED_PROJECTIONS
+from .analysis.schema import FINDINGS_SCHEMA_VERSION
 
 FSL_VERSION = "1.0"
 
@@ -347,31 +355,78 @@ def run_typestate(file):
                           "message": f"file not found: {file}"})
 
 
+ANALYZE_FORMATS = {"json", "dot", "mermaid"}
+ANALYZE_PROJECTIONS = [
+    "tsg",
+    *sorted(SUPPORTED_PROJECTIONS),
+    "refinement_graph",
+    "traceability_graph",
+]
+
+
 def run_analyze(file, projection="tsg", profile=None, output_format="json"):
+    paths = list(file) if isinstance(file, (list, tuple)) else [file]
+    if len(paths) != 1 or any(Path(p).is_dir() for p in paths):
+        return _run_analyze_batch(paths, projection, profile, output_format)
+    return _run_analyze_one_enveloped(paths[0], projection, profile, output_format)
+
+
+def _run_analyze_batch(paths, projection="tsg", profile=None, output_format="json"):
     try:
         if output_format != "json":
-            raise FslError(f"unsupported analyze format: {output_format}", kind="semantics")
-        spec, _source_lines = _read_spec(file)
-        if profile:
-            out = {
-                "result": "analyzed",
-                "spec": spec["name"],
-                **analyze_structure(spec, profile=profile),
-            }
-        elif projection == "tsg":
-            out = {
-                "result": "analyzed",
-                "spec": spec["name"],
-                **build_tsg(spec),
-            }
-        elif projection in SUPPORTED_PROJECTIONS:
-            out = {
-                "result": "analyzed",
-                "spec": spec["name"],
-                **analyze_projection(spec, projection),
-            }
-        else:
-            raise FslError(f"unsupported analyze projection: {projection}", kind="semantics")
+            raise FslError("batch analyze supports only --format json", kind="semantics")
+        files = _expand_analyze_paths(paths)
+        entries = []
+        errors = []
+        for path in files:
+            result = _run_analyze_one_enveloped(str(path), projection, profile, output_format)
+            entry = _batch_file_entry(path, result)
+            entries.append(entry)
+            if result.get("result") != "analyzed":
+                errors.append({
+                    "file": _display_path(path),
+                    "result": result.get("result"),
+                    "kind": result.get("kind"),
+                    "message": result.get("message"),
+                    "loc": result.get("loc"),
+                })
+        out = {
+            "result": "analyzed" if not errors else "error",
+            "analysis": "structure",
+            "mode": "batch",
+            "projection": projection,
+            "profile": profile,
+            "files": entries,
+            "errors": errors,
+        }
+        if errors:
+            out["kind"] = "batch"
+            out["message"] = "one or more files failed structural analysis"
+        return _envelope(out)
+    except UnexpectedInput as e:
+        return _parse_error_result(e)
+    except VisitError as e:
+        orig = e.orig_exc
+        return _error_envelope(
+            getattr(orig, "kind", "semantics"),
+            str(orig),
+            _loc_from_exc(orig),
+            getattr(orig, "expected", None),
+            getattr(orig, "hint", None),
+        )
+    except FslError as e:
+        return _error_envelope(e.kind, str(e), _loc_from_exc(e),
+                               getattr(e, "expected", None), getattr(e, "hint", None))
+    except FileNotFoundError as e:
+        return _envelope({"result": "error", "kind": "io",
+                          "message": f"file not found: {e.filename}"})
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
+def _run_analyze_one_enveloped(file, projection="tsg", profile=None, output_format="json"):
+    try:
+        out = _run_analyze_one(file, projection, profile, output_format)
         return _envelope(out)
     except UnexpectedInput as e:
         return _parse_error_result(e)
@@ -392,6 +447,153 @@ def run_analyze(file, projection="tsg", profile=None, output_format="json"):
                           "message": f"file not found: {file}"})
     except Exception as e:
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
+def _run_analyze_one(file, projection="tsg", profile=None, output_format="json"):
+    if output_format not in ANALYZE_FORMATS:
+        raise FslError(f"unsupported analyze format: {output_format}", kind="semantics")
+    if output_format != "json" and profile:
+        raise FslError("DOT/Mermaid export is supported for graph projections, not profiles", kind="semantics")
+
+    path = Path(file)
+    if _is_project_manifest(path):
+        if profile:
+            raise FslError("project traceability analysis does not support --profile", kind="semantics")
+        if projection != "traceability_graph":
+            raise FslError(
+                "project manifests support only --projection traceability_graph",
+                kind="semantics",
+            )
+        out = {
+            "result": "analyzed",
+            **analyze_project_manifest(str(path), projection),
+        }
+    else:
+        src = open(file, encoding="utf-8").read()
+        ast, display_names = _parse_file(file, src)
+        if ast[0] == "refinement":
+            if profile:
+                return {
+                    "result": "analyzed",
+                    "refinement": ast[1],
+                    "analysis": "structure",
+                    "profile": profile,
+                    "schema_version": FINDINGS_SCHEMA_VERSION,
+                    "findings": [],
+                }
+            if projection not in ("tsg", "refinement_graph"):
+                raise FslError(
+                    "refinement mappings support only --projection refinement_graph (or the default tsg alias)",
+                    kind="semantics",
+                )
+            out = {
+                "result": "analyzed",
+                "refinement": ast[1],
+                **analyze_refinement_ast(ast, projection),
+            }
+        else:
+            spec = build_spec(ast, display_names)
+            if profile:
+                out = {
+                    "result": "analyzed",
+                    "spec": spec["name"],
+                    **analyze_structure(spec, profile=profile),
+                }
+            elif projection == "tsg":
+                out = {
+                    "result": "analyzed",
+                    "spec": spec["name"],
+                    **build_tsg(spec),
+                }
+            elif projection in SUPPORTED_PROJECTIONS:
+                out = {
+                    "result": "analyzed",
+                    "spec": spec["name"],
+                    **analyze_projection(spec, projection),
+                }
+            else:
+                raise FslError(f"unsupported analyze projection: {projection}", kind="semantics")
+
+    if output_format == "json":
+        return out
+    if not out.get("nodes") or "edges" not in out:
+        raise FslError(f"--format {output_format} requires a graph projection", kind="semantics")
+    return {
+        "result": "analyzed",
+        "analysis": out.get("analysis", "structure"),
+        "projection": out.get("projection", projection),
+        "format": output_format,
+        "content": export_graph(out, output_format),
+    }
+
+
+def _expand_analyze_paths(paths):
+    files = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            files.extend(sorted((item for item in p.rglob("*.fsl") if item.is_file()), key=_display_path))
+        else:
+            if not p.exists():
+                raise FileNotFoundError(2, "No such file or directory", str(p))
+            files.append(p)
+    seen = set()
+    out = []
+    for p in files:
+        marker = p.resolve(strict=False)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        out.append(p)
+    return sorted(out, key=_display_path)
+
+
+def _batch_file_entry(path, result):
+    entry = {
+        "file": _display_path(path),
+        "result": result.get("result"),
+    }
+    for key in ("spec", "refinement", "projection", "profile", "schema_version", "formal_status"):
+        if key in result:
+            entry[key] = result[key]
+    if result.get("result") == "analyzed":
+        entry["summary"] = _analysis_summary(result)
+        if result.get("profile") == "ai-review":
+            entry["findings"] = result.get("findings", [])
+    else:
+        for key in ("kind", "message", "loc", "expected", "hint"):
+            if key in result:
+                entry[key] = result[key]
+    return entry
+
+
+def _analysis_summary(result):
+    summary = {}
+    if "nodes" in result:
+        summary["nodes"] = len(result.get("nodes") or [])
+    if "edges" in result:
+        summary["edges"] = len(result.get("edges") or [])
+    if "findings" in result:
+        summary["findings"] = len(result.get("findings") or [])
+    if "components" in result:
+        summary["components"] = len(result.get("components") or [])
+    if "cycles" in result:
+        summary["cycles"] = len(result.get("cycles") or [])
+    if "errors" in result:
+        summary["errors"] = len(result.get("errors") or [])
+    return summary
+
+
+def _is_project_manifest(path):
+    return path.suffix == ".toml"
+
+
+def _display_path(path):
+    p = Path(path)
+    try:
+        return p.resolve(strict=False).relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return p.as_posix()
 
 
 def _read_spec(file, bounds_overrides=None):
@@ -950,14 +1152,14 @@ def _build_arg_parser():
 
     an = sub.add_parser("analyze",
                         help="emit structural analysis JSON for a spec")
-    an.add_argument("file")
+    an.add_argument("file", nargs="+")
     an.add_argument("--projection",
-                    choices=["tsg", *sorted(SUPPORTED_PROJECTIONS)],
+                    choices=ANALYZE_PROJECTIONS,
                     default="tsg",
                     help="structural projection to emit")
     an.add_argument("--profile", choices=["ai-review"], default=None,
                     help="emit AI-readable structural review findings")
-    an.add_argument("--format", choices=["json"], default="json",
+    an.add_argument("--format", choices=sorted(ANALYZE_FORMATS), default="json",
                     dest="output_format")
 
     return ap
@@ -1044,7 +1246,10 @@ def _dispatch(args):
             print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "analyze":
         result = run_analyze(args.file, args.projection, args.profile, args.output_format)
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        if args.output_format != "json" and result.get("result") == "analyzed" and "content" in result:
+            sys.stdout.write(result["content"])
+        else:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
     else:
         result = run_verify(args.file, args.depth, args.deadlock,
                             engine=args.engine, k_ind=args.k_ind,

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import re
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
@@ -39,6 +40,7 @@ def check_source(
     source: str,
     path: Optional[str],
     name_resolver: Optional[NameResolver] = None,
+    analysis_diagnostics: bool = False,
 ) -> Dict[str, Any]:
     """Run the same in-process check path as ``fslc check`` for editor text."""
 
@@ -52,6 +54,7 @@ def check_source(
         _loc_from_exc,
         _parse_error_result,
     )
+    from fslc.analysis import analyze as analyze_structure
     from fslc.model import FslError, build_spec
     from fslc.parser import parse_src
     from fslc.refine import build_refinement
@@ -98,6 +101,8 @@ def check_source(
             "spec": spec["name"],
             "warnings": spec["warnings"],
         }
+        if analysis_diagnostics:
+            out["analysis_findings"] = analyze_structure(spec, profile="ai-review").get("findings", [])
         impl = _implements_result(spec)
         if impl:
             out["implements"] = impl
@@ -174,6 +179,9 @@ def _create_server():
     server = LanguageServer(SERVER_NAME, SERVER_VERSION)
     server.fsl_index_cache = {}
     server.fsl_name_cache = None
+    server.fsl_analysis_diagnostics = os.environ.get(
+        "FSLC_LSP_ANALYSIS_DIAGNOSTICS", ""
+    ).lower() in {"1", "true", "yes", "on"}
 
     def publish(uri: str) -> None:
         source = _source_for_uri(server, uri)
@@ -181,7 +189,12 @@ def _create_server():
             return
         path = _uri_to_path(uri)
         index = _index_for_uri(server, uri)
-        result = check_source(source, path, _name_resolver_for_server(server, path))
+        result = check_source(
+            source,
+            path,
+            _name_resolver_for_server(server, path),
+            analysis_diagnostics=getattr(server, "fsl_analysis_diagnostics", False),
+        )
         diagnostics = _result_to_diagnostics(types, source, result, index)
         server.publish_diagnostics(uri, diagnostics)
 
@@ -571,7 +584,33 @@ def _result_to_diagnostics(types, source: str, result: Dict[str, Any], index: Op
                 index,
             )
         )
+    for finding in result.get("analysis_findings", []) or []:
+        diagnostics.append(_make_analysis_diagnostic(types, source, finding, index))
     return diagnostics
+
+
+def _make_analysis_diagnostic(types, source: str, finding: Dict[str, Any], index: Optional[DocumentIndex]):
+    loc = finding.get("loc") or {}
+    rng = _range_from_finding_nodes(finding, index)
+    if rng is None:
+        rng = _range_from_loc(source, loc, index) if loc else RangeLike(0, 0, 0, 1).to_range()
+    message = (
+        f"Structural review ({finding.get('finding_type', 'finding')}): "
+        f"{finding.get('why_it_matters', 'review the structural finding')}"
+    )
+    return types.Diagnostic(
+        range=_to_lsp_range(types, rng),
+        message=message,
+        severity=types.DiagnosticSeverity.Information,
+        source="fslc analyze",
+        code=finding.get("finding_type"),
+        data={
+            "finding_id": finding.get("finding_id"),
+            "formal_status": finding.get("formal_status"),
+            "candidate_repairs": finding.get("candidate_repairs", []),
+            "do_not_assume": finding.get("do_not_assume", []),
+        },
+    )
 
 
 def _make_diagnostic(types, source: str, item: Dict[str, Any], severity, index: Optional[DocumentIndex]):
@@ -587,6 +626,40 @@ def _make_diagnostic(types, source: str, item: Dict[str, Any], severity, index: 
         source="fslc",
         code=item.get("kind"),
     )
+
+
+def _range_from_finding_nodes(finding: Dict[str, Any], index: Optional[DocumentIndex]) -> Optional[Range]:
+    if index is not None:
+        for node_id in finding.get("involved_nodes", []) or []:
+            rng = _range_for_analysis_node(index, node_id)
+            if rng is not None:
+                return rng
+    return None
+
+
+def _range_for_analysis_node(index: DocumentIndex, node_id: str) -> Optional[Range]:
+    prefix, sep, name = node_id.partition(":")
+    if not sep or not name:
+        return None
+    role_by_prefix = {
+        "action": "action",
+        "state": "state_var",
+        "requirement": "requirement",
+        "control": "control",
+        "acceptance": "acceptance",
+        "forbidden": "forbidden",
+        "invariant": "property",
+        "trans": "property",
+        "reachable": "property",
+        "leadsTo": "property",
+    }
+    role = role_by_prefix.get(prefix)
+    if role is None:
+        return None
+    for sym in index.symbols:
+        if sym.name == name and sym.role == role:
+            return sym.selection_range
+    return None
 
 
 def _range_from_loc(source: str, loc: Dict[str, Any], index: Optional[DocumentIndex]) -> Range:

--- a/tests/test_analysis_batch.py
+++ b/tests/test_analysis_batch.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import sys
+
+from fslc.cli import run_analyze
+
+
+def _write(path, src):
+    path.write_text(src, encoding="utf-8")
+    return path
+
+
+VALID = """
+spec BatchValid {
+  state { x: Int }
+  init { x = 0 }
+  action inc() { x = x + 1 }
+  invariant Any "MODEL: baseline" { true }
+}
+"""
+
+
+def test_analyze_batch_multiple_files_keeps_successes_with_partial_errors(tmp_path):
+    good = _write(tmp_path / "good.fsl", VALID)
+    bad = _write(tmp_path / "bad.fsl", "spec Broken { state { x: Int } init { x = } }")
+
+    out = run_analyze([str(good), str(bad)], projection="tsg")
+
+    assert out["result"] == "error"
+    assert out["kind"] == "batch"
+    assert out["mode"] == "batch"
+    assert len(out["files"]) == 2
+    assert len(out["errors"]) == 1
+    assert any(item["result"] == "analyzed" and item["summary"]["nodes"] > 0 for item in out["files"])
+    assert any(item["result"] == "error" and item["kind"] == "parse" for item in out["files"])
+
+
+def test_analyze_batch_directory_discovers_fsl_files_in_stable_order(tmp_path):
+    _write(tmp_path / "b.fsl", VALID.replace("BatchValid", "BatchB"))
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write(nested / "a.fsl", VALID.replace("BatchValid", "BatchA"))
+    (tmp_path / "ignored.txt").write_text("not fsl", encoding="utf-8")
+
+    out = run_analyze(str(tmp_path), projection="tsg")
+
+    assert out["result"] == "analyzed"
+    files = [item["file"] for item in out["files"]]
+    assert files == sorted(files)
+    assert [name.rsplit("/", 1)[-1] for name in files] == ["b.fsl", "a.fsl"] or files == sorted(files)
+    assert len(files) == 2
+
+
+def test_analyze_batch_profile_tolerates_refinement_mapping_files(tmp_path):
+    _write(tmp_path / "spec.fsl", VALID)
+    _write(tmp_path / "mapping.fsl", """
+refinement ImplRefinesAbs {
+  impl Impl
+  abs Abs
+  map x = y
+  action step() -> step()
+}
+""")
+
+    out = run_analyze(str(tmp_path), profile="ai-review")
+
+    assert out["result"] == "analyzed"
+    mapping = next(item for item in out["files"] if item["file"].endswith("mapping.fsl"))
+    assert mapping["result"] == "analyzed"
+    assert mapping["refinement"] == "ImplRefinesAbs"
+    assert mapping["findings"] == []
+
+
+def test_analyze_batch_cli_exits_two_for_partial_error(tmp_path):
+    good = _write(tmp_path / "good.fsl", VALID)
+    bad = _write(tmp_path / "bad.fsl", "spec Broken { state { x: Int } init { x = } }")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "fslc", "analyze", str(good), str(bad), "--projection", "tsg"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["kind"] == "batch"
+    assert len(payload["errors"]) == 1

--- a/tests/test_analysis_export.py
+++ b/tests/test_analysis_export.py
@@ -1,0 +1,101 @@
+import subprocess
+import sys
+
+from fslc.analysis.export import to_dot, to_mermaid
+from fslc.cli import run_analyze
+
+
+def test_analyze_graph_projection_exports_dot_and_mermaid(tmp_path):
+    path = tmp_path / "export.fsl"
+    path.write_text("""
+spec ExportGraph {
+  state { x: Int }
+  init { x = 0 }
+  action inc() {
+    requires x < 2
+    x = x + 1
+  }
+  invariant Any "MODEL: baseline" { true }
+}
+""", encoding="utf-8")
+
+    dot = run_analyze(str(path), projection="action_state_graph", output_format="dot")
+    mermaid = run_analyze(str(path), projection="action_state_graph", output_format="mermaid")
+
+    assert dot["result"] == "analyzed"
+    assert dot["format"] == "dot"
+    assert dot["content"].startswith("digraph fsl_analysis")
+    assert '"action:inc"' in dot["content"]
+    assert mermaid["content"].startswith("graph TD")
+    assert "action_inc" in mermaid["content"]
+
+
+def test_analyze_cli_dot_writes_raw_graph(tmp_path):
+    path = tmp_path / "export_cli.fsl"
+    path.write_text("""
+spec ExportCli {
+  state { x: Int }
+  init { x = 0 }
+  action inc() { x = x + 1 }
+  invariant Any "MODEL: baseline" { true }
+}
+""", encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "fslc",
+            "analyze",
+            str(path),
+            "--projection",
+            "action_state_graph",
+            "--format",
+            "dot",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stdout.startswith("digraph fsl_analysis")
+
+
+def test_graph_export_escapes_labels_and_ids():
+    graph = {
+        "nodes": [
+            {"id": "requirement:REQ-1", "kind": "requirement", "label": "REQ \"quoted\""},
+            {"id": "action:submit-order", "kind": "action", "label": "submit order"},
+        ],
+        "edges": [
+            {"id": "e", "kind": "covers|unsafe", "from": "requirement:REQ-1", "to": "action:submit-order"}
+        ],
+    }
+
+    dot = to_dot(graph)
+    mermaid = to_mermaid(graph)
+
+    assert 'REQ \\"quoted\\"' in dot
+    assert "requirement_REQ_1" in mermaid
+    assert "&quot;quoted&quot;" in mermaid
+    assert "covers/unsafe" in mermaid
+
+
+def test_dot_mermaid_reject_profile_outputs_clearly(tmp_path):
+    path = tmp_path / "profile_export.fsl"
+    path.write_text("""
+spec ProfileExport {
+  state { x: Int }
+  init { x = 0 }
+  action broad() { x = x + 1 }
+  invariant Any "MODEL: baseline" { true }
+}
+""", encoding="utf-8")
+
+    out = run_analyze(str(path), profile="ai-review", output_format="dot")
+
+    assert out["result"] == "error"
+    assert out["kind"] == "semantics"
+    assert "not profiles" in out["message"]

--- a/tests/test_analysis_findings.py
+++ b/tests/test_analysis_findings.py
@@ -148,3 +148,48 @@ spec Acyclic {
 
     assert _findings(out, "progressless_cycle") == []
     assert out == run_analyze(str(path), profile="ai-review")
+
+
+def test_unwritten_state_positive_and_negative(tmp_path):
+    path = _write(tmp_path, """
+spec StateWrites {
+  state { active: Bool, frozen: Bool }
+  init { active = false  frozen = false }
+  action activate() {
+    requires not active
+    active = true
+  }
+  invariant FrozenReadable { frozen == false }
+}
+""")
+
+    out = run_analyze(str(path), profile="ai-review")
+    unwritten = _findings(out, "unwritten_state")
+
+    assert any(f["involved_nodes"] == ["state:frozen"] for f in unwritten)
+    assert not any(f["involved_nodes"] == ["state:active"] for f in unwritten)
+    assert all(f["formal_status"] == "not_a_violation" for f in unwritten)
+
+
+def test_unguarded_action_positive_and_negative(tmp_path):
+    path = _write(tmp_path, """
+spec ActionGuards {
+  state { x: Int, y: Int }
+  init { x = 0  y = 0 }
+  action guarded() {
+    requires x == 0
+    x = x + 1
+  }
+  action broad() {
+    y = y + 1
+  }
+  invariant Any "MODEL: baseline" { true }
+}
+""")
+
+    out = run_analyze(str(path), profile="ai-review")
+    unguarded = _findings(out, "unguarded_action")
+
+    assert any(f["involved_nodes"] == ["action:broad"] for f in unguarded)
+    assert not any(f["involved_nodes"] == ["action:guarded"] for f in unguarded)
+    assert all(f["candidate_repairs"] and f["do_not_assume"] for f in unguarded)

--- a/tests/test_analysis_project.py
+++ b/tests/test_analysis_project.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from fslc.cli import run_analyze
+
+
+ROOT = Path(__file__).resolve().parent
+CHAIN = ROOT / "fixtures" / "chain" / "fsl-project.toml"
+
+
+def test_analyze_project_traceability_graph_reads_chain_manifest():
+    out = run_analyze(str(CHAIN), projection="traceability_graph")
+
+    assert out["result"] == "analyzed"
+    assert out["projection"] == "traceability_graph"
+    assert out["schema_version"] == "analysis-graph.v0"
+    assert out["formal_status"] == "not_a_violation"
+    assert any(n["kind"] == "requirements_spec" for n in out["nodes"])
+    assert any(n["kind"] == "design_spec" for n in out["nodes"])
+    assert any(e["kind"] == "maps_action" for e in out["edges"])
+    assert any(
+        e["kind"] == "lower_anchor"
+        and e["from"] == "requirements:requirement:REQ-1"
+        and e["to"] == "design:action:finish"
+        for e in out["edges"]
+    )
+    assert out["cycles"] == []
+    assert not any(f["involved_nodes"] == ["requirements:requirement:REQ-1"] for f in out["findings"])
+    assert out == run_analyze(str(CHAIN), projection="traceability_graph")
+
+
+def test_analyze_project_traceability_graph_accepts_named_toml_manifest():
+    manifest = CHAIN.with_name("fsl-project-broken.toml")
+
+    out = run_analyze(str(manifest), projection="traceability_graph")
+
+    assert out["result"] == "analyzed"
+    assert out["projection"] == "traceability_graph"
+    assert out["manifest"].endswith("fsl-project-broken.toml")
+
+
+def test_analyze_project_traceability_graph_reports_upper_id_without_lower_anchor(tmp_path):
+    (tmp_path / "requirements.fsl").write_text("""
+requirements ReqLayer {
+  type Item = 0..0
+  state { x: Map<Item, Bool> }
+  init { forall i: Item { x[i] = false } }
+  requirement REQ-LOST "must finish" {
+    action finish(i: Item) {
+      requires not x[i]
+      x[i] = true
+    }
+  }
+}
+""", encoding="utf-8")
+    (tmp_path / "design.fsl").write_text("""
+spec DesignLayer {
+  type Item = 0..0
+  state { y: Map<Item, Bool> }
+  init { forall i: Item { y[i] = false } }
+  action noop(i: Item) {
+    y[i] = y[i]
+  }
+}
+""", encoding="utf-8")
+    (tmp_path / "map.fsl").write_text("""
+refinement DesignRefinesReq {
+  impl DesignLayer
+  abs ReqLayer
+  map x[i: Item] = y[i]
+  action noop(i) -> stutter
+}
+""", encoding="utf-8")
+    manifest = tmp_path / "fsl-project.toml"
+    manifest.write_text("""
+[requirements]
+file = "requirements.fsl"
+
+[design]
+file = "design.fsl"
+refine_against = "requirements"
+mapping = "map.fsl"
+""", encoding="utf-8")
+
+    out = run_analyze(str(manifest), projection="traceability_graph")
+
+    assert out["result"] == "analyzed"
+    gaps = [f for f in out["findings"] if f["finding_type"] == "traceability_gap"]
+    assert any("requirements:requirement:REQ-LOST" in f["involved_nodes"] for f in gaps)
+    assert all(f["formal_status"] == "not_a_violation" for f in gaps)

--- a/tests/test_analysis_refinement.py
+++ b/tests/test_analysis_refinement.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from fslc.cli import run_analyze
+
+
+SPECS = Path(__file__).resolve().parent.parent / "specs"
+
+
+def _ids(out, kind=None):
+    return {
+        n["id"]
+        for n in out.get("nodes", [])
+        if kind is None or n["kind"] == kind
+    }
+
+
+def test_analyze_refinement_mapping_file_emits_mapping_graph():
+    out = run_analyze(str(SPECS / "cart_refines.fsl"))
+
+    assert out["result"] == "analyzed"
+    assert out["projection"] == "refinement_graph"
+    assert out["schema_version"] == "analysis-graph.v0"
+    assert out["formal_status"] == "not_a_violation"
+    assert "refinement:CartImplRefinesCart" in _ids(out, "refinement")
+    assert "impl_spec:CartImpl" in _ids(out, "impl_spec")
+    assert "abs_spec:ShoppingCart" in _ids(out, "abs_spec")
+    assert "state_map:stock:i" in _ids(out, "state_map")
+    assert "action_map:reserve" in _ids(out, "action_map")
+    assert any(e["kind"] == "stutters" for e in out["edges"])
+    assert any(e["kind"] == "reads_impl_state" and e["to"] == "map_expr_read:impl_stock" for e in out["edges"])
+
+
+def test_analyze_refinement_graph_projection_is_explicit(tmp_path):
+    path = tmp_path / "mapping.fsl"
+    path.write_text("""
+refinement ImplRefinesAbs {
+  impl Impl
+  abs Abs
+  maps auto
+  map x = y
+  action step() -> step()
+  preserve progress {
+    respond EventuallyDone by step
+  }
+}
+""", encoding="utf-8")
+
+    out = run_analyze(str(path), projection="refinement_graph")
+
+    assert out["result"] == "analyzed"
+    assert "maps_auto:ImplRefinesAbs" in _ids(out, "maps_auto")
+    assert "preserve_progress:ImplRefinesAbs" in _ids(out, "preserve_progress")
+    assert "progress_response:EventuallyDone" in _ids(out, "progress_response")

--- a/tests/test_analysis_schema.py
+++ b/tests/test_analysis_schema.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from fslc.cli import run_analyze
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS = ROOT / "schemas" / "fslc" / "analysis"
+
+
+def _load_schema(name):
+    return json.loads((SCHEMAS / name).read_text(encoding="utf-8"))
+
+
+def _assert_required(schema, payload):
+    assert set(schema["required"]) <= set(payload)
+    defs = schema.get("$defs", {})
+    if "nodes" in payload and "node" in defs:
+        required = set(defs["node"]["required"])
+        assert all(required <= set(item) for item in payload["nodes"])
+    if "edges" in payload and "edge" in defs:
+        required = set(defs["edge"]["required"])
+        assert all(required <= set(item) for item in payload["edges"])
+    if "findings" in payload and "finding" in defs:
+        required = set(defs["finding"]["required"])
+        assert all(required <= set(item) for item in payload["findings"])
+
+
+def test_analysis_schema_files_exist_and_have_stable_ids():
+    for filename, version in [
+        ("tsg.v0.schema.json", "tsg.v0"),
+        ("analysis-graph.v0.schema.json", "analysis-graph.v0"),
+        ("analysis-findings.v0.schema.json", "analysis-findings.v0"),
+    ]:
+        schema = _load_schema(filename)
+        assert schema["$id"].endswith(filename)
+        assert version in json.dumps(schema)
+
+
+def test_representative_analyze_outputs_match_schema_required_contracts(tmp_path):
+    path = tmp_path / "schema_case.fsl"
+    path.write_text("""
+spec SchemaCase {
+  state { x: Int }
+  init { x = 0 }
+  action inc() {
+    requires x < 2
+    x = x + 1
+  }
+  invariant Any "MODEL: baseline" { true }
+}
+""", encoding="utf-8")
+
+    tsg = run_analyze(str(path), projection="tsg")
+    graph = run_analyze(str(path), projection="action_state_graph")
+    findings = run_analyze(str(path), profile="ai-review")
+
+    _assert_required(_load_schema("tsg.v0.schema.json"), tsg)
+    _assert_required(_load_schema("analysis-graph.v0.schema.json"), graph)
+    _assert_required(_load_schema("analysis-findings.v0.schema.json"), findings)

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -25,8 +25,10 @@ from fslc.lsp.server import (  # noqa: E402
     _create_server,
     _definition_target,
     _path_to_uri,
+    _result_to_diagnostics,
     _to_completion_item,
     _to_lsp_range,
+    check_source,
 )
 
 
@@ -284,3 +286,45 @@ def test_completion_handler_suggests_alias_members(tmp_path):
     assert labels["bump"].kind == types.CompletionItemKind.Function
     assert "Id" in labels
     assert labels["Id"].kind == types.CompletionItemKind.Class
+
+
+def test_analysis_findings_can_surface_as_information_diagnostics():
+    source = """spec LspAnalysis {
+  state { x: Int }
+  init { x = 0 }
+  action broad() {
+    x = x + 1
+  }
+  invariant Any "MODEL: baseline" { true }
+}
+"""
+    index = build_index(source, "lsp_analysis.fsl")
+
+    result = check_source(source, "lsp_analysis.fsl", analysis_diagnostics=True)
+    diagnostics = _result_to_diagnostics(types, source, result, index)
+
+    matches = [d for d in diagnostics if d.code == "unguarded_action"]
+    assert matches
+    diag = matches[0]
+    assert diag.severity == types.DiagnosticSeverity.Information
+    assert diag.source == "fslc analyze"
+    assert "Structural review" in diag.message
+    assert source.splitlines()[diag.range.start.line][diag.range.start.character:diag.range.end.character] == "broad"
+
+
+def test_analysis_diagnostics_no_findings_file_adds_no_information_diagnostics():
+    source = """spec LspNoFindings {
+  state { x: Int }
+  init { x = 0 }
+  action guarded() "REQ-1: guarded write" {
+    requires x == 0
+    x = x + 1
+  }
+}
+"""
+    index = build_index(source, "lsp_no_findings.fsl")
+
+    result = check_source(source, "lsp_no_findings.fsl", analysis_diagnostics=True)
+    diagnostics = _result_to_diagnostics(types, source, result, index)
+
+    assert not [d for d in diagnostics if d.source == "fslc analyze"]


### PR DESCRIPTION
## Summary
Completes the `fslc analyze` roadmap items from #110 through #116: batch analysis, review graph exports, refinement/project projections, AI review findings, JSON schemas, and opt-in LSP diagnostics.

## Why
- **Goal**: make analysis output usable for batch review, traceability inspection, schema validation, and editor diagnostics without weakening FSL semantics.
- **Reason**: the existing single-file analysis surface did not cover directory/project workflows, graph-shaped exports, standalone refinement maps, or stable downstream schemas.
- **Alternatives**: separate one-off commands were avoided in favor of extending the existing `analyze` projection/profile model.

## What Changed
- Added deterministic batch `fslc analyze` over files/directories with per-file summaries and partial-error reporting.
- Added DOT/Mermaid graph exports, standalone `refinement_graph`, and project `traceability_graph` support.
- Accepted direct `.toml` manifest inputs for project traceability review copies, not only files named `fsl-project.toml`.
- Expanded `ai-review` findings for unwritten state and unguarded actions.
- Published versioned analysis JSON schemas and opt-in LSP analysis diagnostics behind `FSLC_LSP_ANALYSIS_DIAGNOSTICS=1`.
- Updated analysis docs, HTML intro pages, FSL skill references, and changelog.

## Blast Radius
- **CLI**: `src/fslc/cli.py` analysis input handling, projection selection, and format output.
- **Analysis internals**: new export, refinement, project, and findings logic under `src/fslc/analysis/`.
- **Editor integration**: `src/fslc/lsp/server.py`, opt-in only via env var.
- **Docs/contracts**: `docs/`, `skills/fsl/`, `schemas/fslc/analysis/`.
- **Compatibility**: existing check/verify flows are unchanged; existing analyze JSON remains machine-readable while new multi-input/project surfaces add fields.

## Invariants
- Existing FSL semantic checks and verifier intent must remain unchanged.
- CLI JSON output must stay machine-readable for automation.
- LSP analysis diagnostics must remain disabled unless `FSLC_LSP_ANALYSIS_DIAGNOSTICS=1` is set.

## Failure Modes
- Batch mode could hide parse/check failures if partial errors are not surfaced; covered by `tests/test_analysis_batch.py`.
- Graph/schema output could drift from documented contracts; covered by export/schema tests and CLI smoke checks.
- LSP diagnostics could become noisy by default; covered by `tests/test_lsp_server.py` opt-in coverage.

## Evidence
- `.venv/bin/python -m pytest -q` -> `912 passed, 78 skipped`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_analysis_project.py tests/test_analysis_batch.py tests/test_analysis_findings.py tests/test_analysis_export.py tests/test_analysis_schema.py -q` -> `21 passed`
- `rg -n "/Users/|\$HOME" CHANGELOG.md docs skills src tests schemas` -> no matches
- `.venv/bin/python -m fslc analyze specs/cart_v1.fsl --projection action_state_graph --format dot`
- `.venv/bin/python -m fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json`
- `.venv/bin/python -m fslc analyze tests/fixtures/chain/fsl-project.toml --projection traceability_graph --format json`
- `.venv/bin/python -m fslc analyze tests/fixtures/chain --profile ai-review --format json`

## Rollout & Rollback
- **Rollout**: merge and release with the documented CLI/schema surfaces.
- **Rollback**: revert commit `db4f657`; no data migrations or irreversible state changes are included.
- **Cannot rollback if**: downstream consumers adopt the new schema names after release without pinning their expected version.

## Review Focus
- `src/fslc/cli.py`: batch input semantics, exit codes, and output shape.
- `src/fslc/analysis/project.py` / `refinement.py`: project and refinement graph extraction.
- `src/fslc/analysis/findings.py` / `export.py`: AI review finding rules and graph serialization.
- `src/fslc/lsp/server.py`: opt-in diagnostics behavior.
- `schemas/fslc/analysis/`: schema compatibility and naming.

## Unknowns
- GitHub CI has not run yet for this PR; local pytest and smoke checks passed.
- External schema consumers are unknown until release; schema files are versioned to make that contract explicit.

## Related
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116

## Notes
`tasks/lessons.md` is an existing untracked local note and is intentionally not included.
