### PR TITLE
docs(analysis): clarify analyze review value in manuals

### DIFF
--- a/docs/intro/analysis.en.html
+++ b/docs/intro/analysis.en.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Structural Analysis with fslc analyze — FSL Manual</title>
-<meta name="description" content="How to use fslc analyze for Typed Semantic Graph output, graph projections, AI-review findings, and review-only structural observations." />
+<meta name="description" content="How to use fslc analyze to shorten FSL review discovery time with impact graphs, requirement traceability, AI-review findings, and graph exports." />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="analysis">
@@ -17,9 +17,52 @@
 <section class="hero">
   <div class="wrap narrow center">
     <p class="kicker reveal">Structural observation</p>
-    <h1 class="reveal">Use <code>fslc analyze</code> to inspect the shape of a spec</h1>
-    <p class="lead reveal">Verification answers whether declared contracts hold. Analysis answers a different question: what is connected to what, and what deserves review?</p>
+    <h1 class="reveal">Use <code>fslc analyze</code> to create a review entry point</h1>
+    <p class="lead reveal"><code>fslc analyze</code> turns an FSL spec into a review map: which requirements, actions, state variables, and properties are connected. Use it before or after verification to find impact scope, weakly anchored declarations, and traceability gaps quickly.</p>
     <p class="reveal dim" style="margin-top:18px">Implementation details live in <a href="../DESIGN-analysis.md">DESIGN-analysis.md</a>.</p>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">What it does</p>
+    <h2 class="reveal">Narrow the review before reading the whole spec</h2>
+    <p class="lead narrow reveal">The slow part of review is often not the final correctness judgment. It is discovering what to read and how an upper requirement maps to lower design. <code>analyze</code> does that discovery mechanically first.</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
+      <div class="syntax-card">
+        <h3>See impact scope</h3>
+        <p><code>action_state_graph</code> lists which state variables each action reads and writes. That makes it easier to see what a changed action can affect without relying only on grep or full manual reading.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Follow requirement links</h3>
+        <p><code>requirement_property_graph</code> and <code>traceability_graph</code> connect requirement IDs, properties, scenarios, and lower-layer design actions. Use them to check where upper intent lands in design.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Surface review candidates</h3>
+        <p><code>--profile ai-review</code> flags review-required structures such as weakly anchored properties, unguarded updating actions, and state that is read but never written. These are prioritization signals, not violation verdicts.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Share the same view</h3>
+        <p>Outputs are available as JSON, DOT, Mermaid, and JSON Schema-backed contracts. The same review view can feed PR descriptions, CI, editor diagnostics, and visualization tools.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Effect</p>
+    <h2 class="reveal">Why it can reduce review time</h2>
+    <table class="matrix reveal">
+      <tr><th>Manual review work</th><th>What <code>analyze</code> emits first</th><th>Effect</th></tr>
+      <tr><td>Find which state a changed action affects</td><td>Action/state read-write graph</td><td>Shortens impact discovery and narrows what to read.</td></tr>
+      <tr><td>Trace whether requirement IDs reach properties or design actions</td><td>Requirement, property, scenario, and refinement graphs</td><td>Makes traceability review reproducible.</td></tr>
+      <tr><td>Read every declaration evenly to find suspicious spots</td><td><code>ai-review</code> findings</td><td>Gives reviewers an ordered starting point.</td></tr>
+      <tr><td>Explain the basis for a PR comment</td><td>JSON with witness, candidate repair, and do-not-assume fields</td><td>Provides shareable evidence and caveats for the comment.</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0"><code>analyze</code> does not replace review. Humans still judge the intended behavior. Its effect comes from shortening the early discovery and evidence-gathering phase.</p>
+    </div>
   </div>
 </section>
 
@@ -48,7 +91,7 @@
 <section style="background:var(--surface-2)">
   <div class="wrap">
     <p class="kicker reveal">Commands</p>
-    <h2 class="reveal">Run projections and findings</h2>
+    <h2 class="reveal">Run outputs by purpose</h2>
     <div class="panel reveal">
       <pre><code>fslc analyze spec.fsl --projection tsg --format json
 fslc analyze spec.fsl --projection action_state_graph --format json
@@ -58,16 +101,17 @@ fslc analyze specs/ examples/e2e/ --profile ai-review --format json
 fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json
 fslc analyze fsl-project.toml --projection traceability_graph --format json
 fslc analyze spec.fsl --projection action_state_graph --format dot
-fslc analyze spec.fsl --profile ai-review --format json</code></pre>
+fslc analyze spec.fsl --projection action_state_graph --format mermaid</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
-      <tr><th>Projection</th><th>What it shows</th></tr>
-      <tr><td><code>tsg</code></td><td>The full Typed Semantic Graph over specs, state, actions, guards, effects, properties, requirements, and scenarios.</td></tr>
-      <tr><td><code>action_state_graph</code></td><td>Actions connected to state variables they read and write.</td></tr>
-      <tr><td><code>requirement_property_graph</code></td><td>Requirement IDs connected to covered actions, properties, scenarios, KPI, and control nodes.</td></tr>
-      <tr><td><code>property_state_graph</code></td><td>User properties connected to the state variables they read or check.</td></tr>
-      <tr><td><code>refinement_graph</code></td><td>Standalone mapping files: impl/abs names, state maps, action maps, stutters, and preserve-progress declarations.</td></tr>
-      <tr><td><code>traceability_graph</code></td><td>Project-manifest structure across business, requirements, design, and refinement mapping files.</td></tr>
+      <tr><th>Output</th><th>What it shows</th><th>Main use</th></tr>
+      <tr><td><code>tsg</code></td><td>The full Typed Semantic Graph over specs, state, actions, guards, effects, properties, requirements, and scenarios.</td><td>Get source graph data for custom tools or downstream projections.</td></tr>
+      <tr><td><code>action_state_graph</code></td><td>Actions connected to state variables they read and write.</td><td>Review impact scope.</td></tr>
+      <tr><td><code>requirement_property_graph</code></td><td>Requirement IDs connected to covered actions, properties, scenarios, KPI, and control nodes.</td><td>Review requirement anchoring and isolation.</td></tr>
+      <tr><td><code>property_state_graph</code></td><td>User properties connected to the state variables they read or check.</td><td>Review what each property observes.</td></tr>
+      <tr><td><code>refinement_graph</code></td><td>Standalone mapping files: impl/abs names, state maps, action maps, stutters, and preserve-progress declarations.</td><td>Review refinement correspondences.</td></tr>
+      <tr><td><code>traceability_graph</code></td><td>Project-manifest structure across business, requirements, design, and refinement mapping files.</td><td>Check whether upper requirements land in lower design.</td></tr>
+      <tr><td><code>--profile ai-review</code></td><td>Structural review candidates with witnesses, repair candidates, and do-not-assume caveats.</td><td>Choose the first places to inspect.</td></tr>
     </table>
   </div>
 </section>
@@ -91,11 +135,11 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
       </div>
       <div class="card">
         <h3><code>unwritten_state</code></h3>
-        <p>A state variable is initialized, but no action writes it. It may be intentional fixed model data, or it may point to missing behavior.</p>
+        <p>A state variable is initialized and read, but no action writes it. If it is fixed data, consider making that explicit; otherwise suspect missing behavior.</p>
       </div>
       <div class="card">
         <h3><code>unguarded_action</code></h3>
-        <p>A non-generated action has no explicit <code>requires</code> clause, so it deserves review as an always-enabled transition.</p>
+        <p>An action that writes state has no <code>requires</code> clause. Review whether it should really be always enabled or whether a guard was omitted.</p>
       </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
@@ -120,7 +164,7 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
 <section>
   <div class="wrap">
     <p class="kicker reveal">Limits</p>
-    <h2 class="reveal">What it does not do yet</h2>
+    <h2 class="reveal">Make the boundaries explicit</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>No natural-language inference</h3>
@@ -128,7 +172,11 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
       </div>
       <div class="syntax-card">
         <h3>No proof evidence</h3>
-        <p>Project traceability and refinement graphs show structure only. Run <code>chain</code>, <code>refine</code>, or <code>verify</code> for proof results.</p>
+        <p>Findings, project traceability, and refinement graphs show structure only. Run <code>verify</code>, <code>refine</code>, or <code>chain</code> for counterexamples, reachability, or refinement results.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>No automatic fixes</h3>
+        <p>Candidate repairs are options. Add a guard, make a value constant, or add a requirement tag only after confirming the intended behavior.</p>
       </div>
       <div class="syntax-card">
         <h3>Editor signals are opt-in</h3>

--- a/docs/intro/analysis.ja.html
+++ b/docs/intro/analysis.ja.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>fslc analyze による構造分析 — FSL 日本語マニュアル</title>
-<meta name="description" content="fslc analyze で Typed Semantic Graph、グラフ投影、AIレビュー向け所見、レビュー専用の構造観測を使う方法。" />
+<meta name="description" content="fslc analyze で影響範囲、要件とのつながり、AIレビュー所見、グラフ出力を使い、FSL仕様レビューの探索時間を短くする方法。" />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="analysis">
@@ -17,9 +17,52 @@
 <section class="hero">
   <div class="wrap narrow center">
     <p class="kicker reveal">構造の観測</p>
-    <h1 class="reveal"><code>fslc analyze</code> で仕様の形を見る</h1>
-    <p class="lead reveal">検証は「書かれた契約が成り立つか」を答えます。分析は別の問い、つまり「何が何につながっていて、どこをレビューすべきか」を答えます。</p>
+    <h1 class="reveal"><code>fslc analyze</code> でレビューの入口を作る</h1>
+    <p class="lead reveal"><code>fslc analyze</code> は、FSL 仕様を「どの要件・操作・状態・性質がつながっているか」というレビュー用の地図にします。検証の前後で、影響範囲、根拠の薄い宣言、トレーサビリティの穴を短時間で見つけるためのコマンドです。</p>
     <p class="reveal dim" style="margin-top:18px">実装設計の詳細は <a href="../DESIGN-analysis.md">DESIGN-analysis.md</a> にあります。</p>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">何ができるか</p>
+    <h2 class="reveal">仕様を読む前に、見るべき場所を絞る</h2>
+    <p class="lead narrow reveal">レビューで時間がかかるのは、正誤判断そのものよりも「どこを読むべきか」「この要件は下位設計の何に対応するか」を探す時間です。<code>analyze</code> はその探索を機械的に先に済ませます。</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
+      <div class="syntax-card">
+        <h3>影響範囲をつかむ</h3>
+        <p><code>action_state_graph</code> で、各操作が読む・書く状態変数を一覧化します。変更した操作がどの状態に効くかを、全文読解や grep だけに頼らず確認できます。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>要件とのつながりを追う</h3>
+        <p><code>requirement_property_graph</code> と <code>traceability_graph</code> で、要件ID、性質、シナリオ、下位設計の操作の対応を見ます。上位要求が設計側でどこに落ちているかを確認できます。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>レビュー候補を出す</h3>
+        <p><code>--profile ai-review</code> は、根拠の薄い性質、guard のない更新操作、一度も書かれない状態などを「要確認」として出します。これは違反判定ではなく、レビューの優先順位付けです。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>共有できる形にする</h3>
+        <p>JSON、DOT、Mermaid、JSON Schema で出力できます。PR説明、CI、エディタ診断、外部可視化ツールに同じ観点を渡せます。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">効果</p>
+    <h2 class="reveal">レビュー時間が減る理由</h2>
+    <table class="matrix reveal">
+      <tr><th>手作業で時間がかかること</th><th><code>analyze</code> で先に出せるもの</th><th>効果</th></tr>
+      <tr><td>変更した操作がどの状態に影響するか探す</td><td>操作と状態の read/write グラフ</td><td>影響範囲の探索を短縮し、読む対象を絞れる。</td></tr>
+      <tr><td>要件IDが実際の性質や設計操作に結びついているか追う</td><td>要件・性質・シナリオ・refinement のグラフ</td><td>トレーサビリティ確認を再現可能にできる。</td></tr>
+      <tr><td>全宣言を均等に読んで怪しい箇所を探す</td><td><code>ai-review</code> findings</td><td>最初に見るべき候補を並べ、レビューの順序を決めやすくする。</td></tr>
+      <tr><td>PRコメント用に根拠を説明する</td><td>witness、candidate repair、do-not-assume 付き JSON</td><td>指摘の根拠と注意点をそのまま共有できる。</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0"><code>analyze</code> はレビューを置き換えるものではありません。仕様判断は人間が行います。効果が出るのは、レビュー前半の「探索」と「根拠集め」を短くできるからです。</p>
+    </div>
   </div>
 </section>
 
@@ -48,7 +91,7 @@
 <section style="background:var(--surface-2)">
   <div class="wrap">
     <p class="kicker reveal">コマンド</p>
-    <h2 class="reveal">投影と所見を出す</h2>
+    <h2 class="reveal">目的別に出力する</h2>
     <div class="panel reveal">
       <pre><code>fslc analyze spec.fsl --projection tsg --format json
 fslc analyze spec.fsl --projection action_state_graph --format json
@@ -58,16 +101,17 @@ fslc analyze specs/ examples/e2e/ --profile ai-review --format json
 fslc analyze specs/cart_refines.fsl --projection refinement_graph --format json
 fslc analyze fsl-project.toml --projection traceability_graph --format json
 fslc analyze spec.fsl --projection action_state_graph --format dot
-fslc analyze spec.fsl --profile ai-review --format json</code></pre>
+fslc analyze spec.fsl --projection action_state_graph --format mermaid</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
-      <tr><th>投影</th><th>見えるもの</th></tr>
-      <tr><td><code>tsg</code></td><td>spec、状態、操作、ガード、効果、性質、要件、シナリオを含む Typed Semantic Graph 全体。</td></tr>
-      <tr><td><code>action_state_graph</code></td><td>操作と、その操作が読む・書く状態変数のつながり。</td></tr>
-      <tr><td><code>requirement_property_graph</code></td><td>要件IDと、それが covers する操作、性質、シナリオ、KPI、control のつながり。</td></tr>
-      <tr><td><code>property_state_graph</code></td><td>ユーザー定義の性質と、それが読む・検査する状態変数のつながり。</td></tr>
-      <tr><td><code>refinement_graph</code></td><td>単体の mapping file に含まれる impl/abs 名、state map、action map、stutter、preserve-progress 宣言。</td></tr>
-      <tr><td><code>traceability_graph</code></td><td>project manifest から business、requirements、design、refinement mapping を横断した構造。</td></tr>
+      <tr><th>出力</th><th>見えるもの</th><th>主な使いどころ</th></tr>
+      <tr><td><code>tsg</code></td><td>spec、状態、操作、ガード、効果、性質、要件、シナリオを含む Typed Semantic Graph 全体。</td><td>独自ツールや下流の投影で使う元データを得る。</td></tr>
+      <tr><td><code>action_state_graph</code></td><td>操作と、その操作が読む・書く状態変数のつながり。</td><td>変更の影響範囲を確認する。</td></tr>
+      <tr><td><code>requirement_property_graph</code></td><td>要件IDと、それが covers する操作、性質、シナリオ、KPI、control のつながり。</td><td>要件の根拠や孤立を確認する。</td></tr>
+      <tr><td><code>property_state_graph</code></td><td>ユーザー定義の性質と、それが読む・検査する状態変数のつながり。</td><td>性質が何を監視しているか確認する。</td></tr>
+      <tr><td><code>refinement_graph</code></td><td>単体の mapping file に含まれる impl/abs 名、state map、action map、stutter、preserve-progress 宣言。</td><td>詳細化の対応関係をレビューする。</td></tr>
+      <tr><td><code>traceability_graph</code></td><td>project manifest から business、requirements、design、refinement mapping を横断した構造。</td><td>上位要件が下位設計へ落ちているか確認する。</td></tr>
+      <tr><td><code>--profile ai-review</code></td><td>構造上のレビュー候補と、その witness、修正候補、早合点してはいけないこと。</td><td>レビューの初動で見る順序を決める。</td></tr>
     </table>
   </div>
 </section>
@@ -90,12 +134,12 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
         <p>要件またはシナリオにつながる複数操作の循環に、<code>leadsTo</code>、<code>fair action</code>、<code>terminal</code> などの進捗ストーリーが見えません。</p>
       </div>
       <div class="card">
-        <h3><code>unwritten_state</code></h3>
-        <p>状態変数が初期化されているのに、どの action からも書き込まれていません。意図した固定データか、欠けた振る舞いかをレビューします。</p>
+        <h3><code>unguarded_action</code></h3>
+        <p>状態を書き換える操作に <code>requires</code> がありません。常に実行可能でよい操作なのか、guard を書き忘れていないかを確認します。</p>
       </div>
       <div class="card">
-        <h3><code>unguarded_action</code></h3>
-        <p>生成物ではない action に明示的な <code>requires</code> がありません。常時有効な遷移として妥当かをレビューします。</p>
+        <h3><code>unwritten_state</code></h3>
+        <p>初期化され、読まれている状態変数を、どの操作も書き換えていません。固定値なら const 化、そうでなければ更新操作の抜けを疑います。</p>
       </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
@@ -120,7 +164,7 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
 <section>
   <div class="wrap">
     <p class="kicker reveal">限界</p>
-    <h2 class="reveal">まだしないこと</h2>
+    <h2 class="reveal">できないことも明確に分ける</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>自然言語の推論はしない</h3>
@@ -128,7 +172,11 @@ fslc analyze spec.fsl --profile ai-review --format json</code></pre>
       </div>
       <div class="syntax-card">
         <h3>証明の証拠ではない</h3>
-        <p>project traceability と refinement graph は構造だけを示します。証明結果が必要なら <code>chain</code>、<code>refine</code>、<code>verify</code> を実行します。</p>
+        <p>所見、project traceability、refinement graph は構造だけを示します。反例、到達可能性、詳細化の成否が必要な場合は <code>verify</code>、<code>refine</code>、<code>chain</code> を使います。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>自動修正しない</h3>
+        <p>candidate repair は選択肢です。guard を足す、const にする、要件タグを追加する、といった判断は仕様の意図を確認してから行います。</p>
       </div>
       <div class="syntax-card">
         <h3>editor signals は opt-in</h3>


### PR DESCRIPTION
## Summary
Clarifies the English and Japanese `fslc analyze` manual pages so readers can quickly understand what the command does and why it reduces review setup time.

## Why
- **Goal**: make both manual pages answer "what can I do with this?" and "what effect should I expect?" before diving into projection details.
- **Reason**: the previous pages emphasized the boundary with `verify`, but did not foreground the user-facing value of impact scanning, traceability review, and review candidate extraction.
- **Alternatives**: a separate concept page was not added; this keeps the explanation close to the existing `analysis.ja.html` command reference.

## What Changed
- Reworked the hero and first sections in both languages around review entry points, expected effects, and concrete review tasks.
- Added a table mapping manual review work to `analyze` outputs.
- Expanded command examples for batch review, refinement graphs, traceability graphs, DOT, and Mermaid output.
- Updated findings and limits text to explain `unguarded_action`, `unwritten_state`, proof boundaries, auto-fix boundaries, and opt-in LSP diagnostics.

## Blast Radius
- **Affected**: `docs/intro/analysis.en.html` and `docs/intro/analysis.ja.html`.
- **Compatibility**: documentation-only change; no CLI, schema, or runtime behavior changes.

## Invariants
- The page must continue to distinguish structural review signals from proof results.
- Existing documented command names and projection names must stay accurate.

## Failure Modes
- Documentation could overpromise by implying `analyze` proves correctness; the limits section explicitly states it does not.
- Command examples could drift from current CLI behavior; examples are aligned with the merged analyze features.

## Evidence
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Rollout & Rollback
- **Rollout**: merge the docs update.
- **Rollback**: revert commit `d9d9f86`; no data or behavior migration involved.

## Review Focus
- `docs/intro/analysis.en.html`: whether the English explanation matches the clarified value proposition.
- `docs/intro/analysis.ja.html`: whether the Japanese explanation makes the user value and expected effect clear.

## Unknowns
- No browser screenshot was captured in this turn; this is a content-only HTML edit using the existing page structure.
