### PR TITLE
feat(db): implement post-MVP compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `not_null_before_backfill`. Includes golden fixtures in `examples/db/`,
   docs in `docs/DESIGN-db.md`, and updated language/skill references. (#122,
   #123, #124, #125, #126, #127, #128)
+- fsl-db post-MVP compatibility extensions: destructive/irreversible migration
+  annotations, bounded data preservation and rollback-equivalence findings,
+  rename/split/merge transforms, API response and offline payload compatibility,
+  runtime observation evidence via `fslc db observe`, and a minimal SQL DDL
+  importer via `fslc db import`. The new checks stay under explicit assumptions
+  for finite rollout windows, offline TTL ticks, bounded row models, and
+  observability coverage. (#129, #130, #131, #132, #133, #134)
 - Issue #104 follow-ups: typed `relation A -> B` state with relation helpers
   (`.contains/.add/.remove`, `reachable`, `acyclic`, `functional`,
   `injective`, `domain`, `range`); `helpful action(args)` metadata for

--- a/docs/DESIGN-db.md
+++ b/docs/DESIGN-db.md
@@ -1,21 +1,26 @@
-# FSL DB Compatibility Dialect Design
+# FSL DB / Multi-Environment Compatibility Dialect Design
 
-Status: adopted for the MVP behind issues #122-#128.
+Status: adopted. The first slice shipped issues #122-#128; the bounded
+post-MVP compatibility extensions cover issues #129-#134.
 
 ## Decision
 
 `dbsystem` is a frontend dialect, not a new verifier kernel. It parses database
-schema, migration, artifact, and environment declarations into a typed IR, then
-lowers them to the existing kernel state machine:
+schema, migration, artifact, API/offline, observation, importer, and environment
+declarations into a typed IR, then lowers the DB lifecycle portion to the
+existing kernel state machine:
 
 - `schema_version: SchemaVersion`
 - `column_exists: Map<Column, Bool>`
 - `column_backfilled: Map<Column, Bool>`
 - `column_not_null: Map<Column, Bool>`
-- one action per migration
+- one generated action per migration, or a no-op snapshot action when no
+  migration is needed
 - generated invariants for read/write compatibility and not-null/backfill order
 
-This keeps the shared kernel unchanged and avoids unsupported state shapes such as
+The remaining compatibility dimensions are checked in the fsl-db layer and
+reported with the same stable finding envelope. This keeps the shared kernel
+unchanged and avoids unsupported state shapes such as
 `Map<ArtifactVersion, Set<Column>>`. Static artifact capabilities are represented
 by generated invariants and metadata, not by nested runtime state.
 
@@ -27,46 +32,91 @@ A snapshot is `(environment, schema_version)`. An environment declares a finite
 schema range, and each `active` / `supported` / `may_exist` artifact may further
 restrict itself with `when schema lo..hi`.
 
-In the MVP, `environment schema lo..hi` means exactly the set of schema versions in
-that environment that are reachable in the declared migration order. It does not
-mean every Cartesian product of arbitrary schema and artifact versions; artifact
+`environment schema lo..hi` means exactly the set of schema versions in that
+environment that are reachable in the declared migration order. It does not mean
+every Cartesian product of arbitrary schema and artifact versions; artifact
 coexistence is explicit in the artifact windows.
 
 Rules checked in snapshot mode:
 
-- `all_active_reads_exist`: every applicable artifact read targets an existing column.
-- `all_active_writes_exist`: every applicable artifact write targets an existing column.
-- `removed_only_after_unused`: covered by the same read/write compatibility facts.
-- `not_null_after_backfill`: a column can be `not_null` only after it exists and is
-  backfilled.
+- `all_active_reads_exist`: every applicable artifact read targets an existing
+  column.
+- `all_active_writes_exist`: every applicable artifact write targets an existing
+  column.
+- `removed_only_after_unused`: covered by the same read/write compatibility
+  facts.
+- `not_null_after_backfill`: a column can be `not_null` only after it exists and
+  is backfilled.
+- `api_calls_accepted`: an artifact call must be accepted by an active or
+  supported provider in the same environment snapshot.
+- `api_responses_expected`: an expected response field must be produced by an
+  active or supported provider in the same environment snapshot.
+- `offline_payloads_accepted`: an offline payload that may be emitted by a
+  client must still be accepted by an active or supported provider during the
+  declared finite TTL window.
 
 ### 2. Rollout Plan
 
-Migrations are a single declared, monotonic sequence in the MVP. Each migration is
-lowered to one kernel action guarded by `schema_version == from`, then updates the
-column lifecycle maps and moves to `to`.
+Migrations are a single declared, monotonic sequence. Each migration is lowered
+to one kernel action guarded by `schema_version == from`, then updates the column
+lifecycle maps and moves to `to`.
 
-Rollout percentages are not probabilities. A `10% rollout` is modeled as a finite
-coexistence window: both old and new artifacts may be present for the same schema
-snapshot. A kill switch is modeled by widening or reintroducing the old artifact's
-window, then rechecking compatibility.
+Rollout percentages are not probabilities. A `10% rollout` is modeled as a
+finite coexistence window: both old and new artifacts may be present for the same
+schema snapshot. A kill switch is modeled by widening or reintroducing the old
+artifact's window, then rechecking compatibility.
 
-### 3. Runtime Observation
+Destructive operations must be explicit. A `drop` of an existing column requires
+`destructive` or `irreversible`; this annotation is operational approval
+metadata, not a spec weakening. An annotated drop can still fail read/write/API
+compatibility.
 
-Runtime observation is evidence, not proof. Future log adapters may emit
-`observed_mismatch` findings such as declared-unused-but-observed, unsupported
-artifact still observed, or legacy API still called. Absence from logs is not a
-proof of unused; it requires an explicit observability coverage assumption.
+### 3. Preservation and Rollback
 
-### 4. Data Preservation / Rollback
+`data_preserved` and `rollback_equivalent` are bounded abstract checks, not full
+production-data proofs. They model whether the migration preserves observable
+row information in a finite abstract row model and whether a `rollbackable`
+migration has an observationally equivalent `up; down` shape.
 
-Data preservation is outside the MVP. The intended model is refinement/simulation:
-old and new schemas map to a common abstract row model, then preservation checks
-whether observable data is retained. Rollback is `up; down` observational
-equivalence under a bounded row model. Lossy rename/split/merge migrations must be
-marked irreversible instead of silently accepted.
+Supported preservation transforms:
 
-## MVP Syntax
+- `rename old to new`
+- `split source into target_a, target_b, ...`
+- `merge source_a, source_b, ... into target`
+
+`split` and `merge` must declare whether the mapping is `lossless`, `lossy`, or
+`irreversible`. A lossy transform can be operationally intentional, but it still
+violates `data_preserved`; the annotation prevents silent acceptance.
+
+### 4. Runtime Observation
+
+Runtime observation is evidence, not proof. `fslc db observe` compares an
+observation log to a `dbsystem` and emits `observed_mismatch` findings such as:
+
+- `declared_unused_but_observed`
+- `unsupported_artifact_observed`
+- `legacy_api_still_called`
+
+Absence from logs is not proof of unused behavior. Observation results include
+`DB-ASSUME-OBSERVABILITY-COVERAGE` and `formal_result: "not_run"` to keep them
+separate from formal compatibility verification.
+
+### 5. Importer Boundary
+
+`fslc db import` provides a deliberately small SQL DDL importer to establish the
+typed IR boundary. It supports:
+
+- `CREATE TABLE`
+- `ALTER TABLE ... ADD COLUMN`
+- `ALTER TABLE ... DROP COLUMN`
+- `ALTER TABLE ... RENAME COLUMN ... TO ...`
+- `UPDATE ... SET ...` as a backfill signal
+
+Unsupported constructs are reported as `unsupported_sql` warnings and are not
+silently ignored. ORM-specific importers (Prisma, Rails, Drizzle, etc.) are
+extension points built on the same IR, not part of this first importer.
+
+## Syntax
 
 ```fsl
 dbsystem UserDb {
@@ -74,29 +124,38 @@ dbsystem UserDb {
     schema 0
     table users {
       column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
       column display_name: Text absent;
     }
   }
 
-  migration add_display_name from 0 to 1 {
-    add users.display_name nullable;
+  migration rename_legacy_name from 0 to 1 rollbackable {
+    rename users.legacy_name to users.display_name;
   }
-  migration backfill_display_name from 1 to 2 {
-    backfill users.display_name;
+  migration split_full_name from 1 to 2 {
+    split users.display_name into users.first_name, users.last_name lossy;
   }
-  migration require_display_name from 2 to 3 {
-    set_not_null users.display_name;
+  migration drop_legacy_name from 2 to 3 {
+    drop users.legacy_name irreversible;
   }
 
   artifact server_v2 {
     reads users.id, users.display_name;
     writes users.display_name;
+    accepts api.CreateUserV1, api.CreateUserV2;
+    responds response.email;
+  }
+
+  artifact ios_v1 {
+    calls api.CreateUserV1;
+    emits_offline api.CreateUserV1 ttl 2;
+    expects response.email;
   }
 
   environment prod {
     schema 0..3;
     active server_v2 when schema 1..3;
-    supported server_v2 when schema 1..3;
+    may_exist ios_v1 when schema 0..3;
   }
 
   check compatibility {
@@ -104,9 +163,24 @@ dbsystem UserDb {
     rule all_active_writes_exist;
     rule removed_only_after_unused;
     rule not_null_after_backfill;
+    rule destructive_operations_annotated;
+    rule preservation_transforms_annotated;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
+    rule data_preserved;
+    rule rollback_equivalent;
   }
 }
 ```
+
+If `check compatibility` is omitted, the default rule set includes the DB
+read/write lifecycle rules, destructive annotation enforcement, preservation
+annotation enforcement, and API/offline compatibility. `data_preserved` and
+`rollback_equivalent` remain opt-in because they add the bounded row-model
+assumption.
+
+## CLI
 
 `fslc check` and `fslc verify` accept `dbsystem` because it expands to a kernel
 spec. `fslc db check` additionally returns fsl-db findings:
@@ -114,6 +188,8 @@ spec. `fslc db check` additionally returns fsl-db findings:
 ```bash
 fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
+fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql -o /tmp/imported.fsl
 ```
 
 ## Finding Contract
@@ -136,15 +212,30 @@ The stable finding schema is `fsl-db-finding.v0` (see
 - `repair_candidates`
 - `assumptions`
 
-Current violation kinds:
+Violation kinds currently include:
 
 - `column_removed_while_still_read`
 - `column_removed_while_still_written`
 - `not_null_before_backfill`
+- `destructive_migration_unannotated`
+- `preservation_transform_unannotated`
+- `data_preservation_loss`
+- `rollback_not_equivalent`
+- `api_call_not_accepted`
+- `api_response_field_missing`
+- `offline_payload_not_accepted`
+
+Observation-only kinds currently include:
+
+- `declared_unused_but_observed`
+- `unsupported_artifact_observed`
+- `legacy_api_still_called`
 
 `repair_candidates` distinguish compatibility-preserving changes from spec
-weakening with `weakens_spec: true|false`. Findings emit schema identifiers only;
-row values, SQL literals, secrets, and production payloads are not logged.
+weakening with `weakens_spec: true|false`. For destructive operations, adding an
+annotation and adding a compatibility shim are separate candidates. Findings emit
+schema identifiers only; row values, SQL literals, secrets, and production
+payloads are not logged.
 
 Successful formal checks return `verified_under_assumptions`, not bare
 `verified`, because the DB dialect relies on finite rollout windows and complete
@@ -153,32 +244,35 @@ capability declarations. Runtime evidence findings remain separate
 
 ## Discrete Rollout / TTL Modeling
 
-FSL does not prove probability, percentages, wall-clock days, DB optimizer timing,
-lock timing, or full production data coverage.
+FSL does not prove probability, percentages, wall-clock days, DB optimizer
+timing, lock timing, or full production data coverage.
 
 Use finite abstractions:
 
 - percentage rollout -> old/new artifacts coexist over a schema window
 - A/B test -> finite variant artifacts or actions
 - kill switch -> old artifact window remains or returns
-- `days(14)` / offline TTL -> bounded tick or TTL step with an assumption that one
-  tick represents the operational interval
+- offline TTL -> finite logical ticks declared on `emits_offline ... ttl N`
 
-Assumptions reported by `fslc db check` include:
+Assumptions reported by `fslc db check` may include:
 
 - `DB-ASSUME-ROLLING-SNAPSHOT`: schema ranges are finite reachable snapshots;
   percentages are coexistence windows
-- `DB-ASSUME-CAPABILITY-DECLARATIONS`: artifact read/write declarations are
+- `DB-ASSUME-CAPABILITY-DECLARATIONS`: artifact capability declarations are
   complete for the checked window
+- `DB-ASSUME-OFFLINE-TTL-FINITE`: offline TTL values are finite logical ticks
+- `DB-ASSUME-BOUNDED-ROW-MODEL`: preservation and rollback checks use a bounded
+  abstract row model
 
-Future runtime observation should add an observability coverage assumption when it
-uses logs to support unused/unsupported claims.
+`fslc db observe` additionally reports:
 
-## Out Of MVP
+- `DB-ASSUME-OBSERVABILITY-COVERAGE`: logs are evidence only; absence from logs
+  does not prove unused behavior
 
-- SQL, Prisma, Rails, Drizzle, or other importers
+## Remaining Boundaries
+
 - DB-engine-specific locking/optimizer semantics
-- offline-client replay and TTL implementation
-- runtime log adapters
-- data preservation, rollback equivalence, destructive annotation enforcement
-- rename/split/merge information-preservation proofs
+- full production-data preservation proof
+- probability, wall-clock time, and percentile reasoning
+- ORM-specific importers beyond the first minimal SQL DDL importer
+- feature-flag semantics beyond finite artifact/window modeling

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -98,16 +98,24 @@ dbsystem <Name> {
     }
   }
 
-  migration <name> from <v0> to <v1> {
+  migration <name> from <v0> to <v1> [rollbackable] {
     add <table>.<column> nullable;
     backfill <table>.<column>;
     set_not_null <table>.<column>;
-    drop <table>.<column>;
+    rename <table>.<old> to <table>.<new>;
+    split <table>.<source> into <table>.<a>, <table>.<b> lossless|lossy|irreversible;
+    merge <table>.<a>, <table>.<b> into <table>.<target> lossless|lossy|irreversible;
+    drop <table>.<column> destructive|irreversible;
   }
 
   artifact <version> {
     reads <table>.<column>, ...;
     writes <table>.<column>, ...;
+    calls api.<operation>, ...;
+    accepts api.<operation>, ...;
+    expects response.<field>, ...;
+    responds response.<field>, ...;
+    emits_offline api.<operation> ttl <finite_ticks>;
   }
 
   environment <env> {
@@ -122,6 +130,13 @@ dbsystem <Name> {
     rule all_active_writes_exist;
     rule removed_only_after_unused;
     rule not_null_after_backfill;
+    rule destructive_operations_annotated;
+    rule preservation_transforms_annotated;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
+    rule data_preserved;
+    rule rollback_equivalent;
   }
 }
 ```
@@ -131,8 +146,9 @@ column lifecycle maps. It never uses nested `Map<_, Set<_>>` state. `fslc check`
 and `fslc verify` work on it after expansion; `fslc db check` additionally emits
 stable fsl-db findings and returns `verified_under_assumptions` for successful
 formal checks. Environment schema ranges are finite reachable snapshots in the
-declared migration order; rollout percentages and wall-clock TTLs must be modeled
-as finite coexistence windows/ticks. See `docs/DESIGN-db.md`.
+declared migration order; rollout percentages and offline TTLs must be modeled as
+finite coexistence windows/ticks. API/offline and bounded preservation/rollback
+checks are dialect-level compatibility checks. See `docs/DESIGN-db.md`.
 
 `fslc verify` can override a `verify` block's `instances`/`values` bounds from
 the command line, without editing the spec:
@@ -462,6 +478,8 @@ fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|requirement
 fslc html      <file.fsl> [--depth K] [-o report.html] # self-contained review report (§15)
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc db check  <file.fsl> [--depth K] [--engine bmc|induction] # dbsystem compatibility findings (§13.5)
+fslc db observe <file.fsl> --trace events.json                  # runtime observation evidence
+fslc db import <file.sql> [--name Name] [-o out.fsl]            # minimal SQL DDL -> dbsystem
 ```
 
 In addition to `reachable` and action coverage, `scenarios` outputs, for each
@@ -1285,30 +1303,101 @@ requirement NFR-1 "complete within 4 ticks of acceptance" {
 
 ### 13.5 Database compatibility layer: `dbsystem` (fsl-db)
 
-`dbsystem` models schema migration compatibility across application artifacts and
-environments. It is a dialect expansion, not a DB engine model: SQL parsers,
-ORM importers, optimizer behavior, lock timing, and production-data completeness
-are outside the MVP.
+`dbsystem` models migration compatibility across databases, application
+artifacts, API/offline payloads, and environments. It is a dialect expansion, not
+a DB engine model: optimizer behavior, lock timing, wall-clock TTLs,
+probability, and full production-data completeness are outside the formal model.
 
-The MVP checks column lifecycle and read/write capabilities:
+Core shape:
+
+```fsl
+dbsystem <Name> {
+  database <db> {
+    schema <initial_version>
+    table <table> {
+      column <column>: <db_type> present backfilled not_null;
+      column <future_column>: <db_type> absent;
+    }
+  }
+
+  migration <name> from <v0> to <v1> [rollbackable] {
+    add <table>.<column> nullable;
+    backfill <table>.<column>;
+    set_not_null <table>.<column>;
+    rename <table>.<old> to <table>.<new>;
+    split <table>.<source> into <table>.<a>, <table>.<b> lossless|lossy|irreversible;
+    merge <table>.<a>, <table>.<b> into <table>.<target> lossless|lossy|irreversible;
+    drop <table>.<column> destructive|irreversible;
+  }
+
+  artifact <version> {
+    reads <table>.<column>, ...;
+    writes <table>.<column>, ...;
+    calls api.<operation>, ...;
+    accepts api.<operation>, ...;
+    expects response.<field>, ...;
+    responds response.<field>, ...;
+    emits_offline api.<operation> ttl <finite_ticks>;
+  }
+
+  environment <env> {
+    schema <lo>..<hi>;
+    active <version> when schema <lo>..<hi>;
+    supported <version> when schema <lo>..<hi>;
+    may_exist <version> when schema <lo>..<hi>;
+  }
+
+  check compatibility {
+    rule all_active_reads_exist;
+    rule all_active_writes_exist;
+    rule removed_only_after_unused;
+    rule not_null_after_backfill;
+    rule destructive_operations_annotated;
+    rule preservation_transforms_annotated;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
+    rule data_preserved;
+    rule rollback_equivalent;
+  }
+}
+```
+
+If `check compatibility` is omitted, default rules cover read/write lifecycle,
+destructive annotations, preservation-transform annotations, and API/offline
+compatibility. `data_preserved` and `rollback_equivalent` are opt-in bounded
+checks and report `DB-ASSUME-BOUNDED-ROW-MODEL`.
+
+Current formal violation kinds include:
 
 - `column_removed_while_still_read`
 - `column_removed_while_still_written`
 - `not_null_before_backfill`
+- `destructive_migration_unannotated`
+- `preservation_transform_unannotated`
+- `data_preservation_loss`
+- `rollback_not_equivalent`
+- `api_call_not_accepted`
+- `api_response_field_missing`
+- `offline_payload_not_accepted`
 
 Use `fslc db check` when you want fsl-db vocabulary:
 
 ```bash
 fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
+fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql -o /tmp/imported.fsl
 ```
 
 Successful checks return `verified_under_assumptions` with the finite rollout and
 capability-completeness assumptions. Compatibility failures return
 `finding_schema_version: "fsl-db-finding.v0"` plus `findings[]` containing the
 environment, artifact, migration/schema element, minimal conflict set, and repair
-candidates. Use ordinary `fslc verify` when you want to inspect the generated
-kernel counterexample directly.
+candidates. Runtime observation returns `observed_mismatch` with
+`formal_result: "not_run"`; absence from logs is not proof of unused behavior.
+Use ordinary `fslc verify` when you want to inspect the generated kernel
+counterexample directly.
 
 ### 13.6 What is not handled (the boundary of the layers)
 

--- a/docs/intro/db.en.html
+++ b/docs/intro/db.en.html
@@ -85,7 +85,7 @@ environment prod {
       <tr><td><code>when schema lo..hi</code></td><td>The schema window where that artifact may coexist.</td><td>Finite modeling of percentage rollout, kill switches, and staged cutovers.</td></tr>
     </table>
     <div class="callout reveal" style="margin-top:24px">
-      <p style="margin:0">In the MVP, multiple environments are represented by multiple <code>environment</code> blocks. Each <code>schema lo..hi</code> range is the finite set of snapshots reachable through the declared migration plan. It is not an arbitrary Cartesian product of schemas and artifacts; each artifact's <code>when schema</code> window defines coexistence.</p>
+      <p style="margin:0">Multiple environments are represented by multiple <code>environment</code> blocks. Each <code>schema lo..hi</code> range is the finite set of snapshots reachable through the declared migration plan. It is not an arbitrary Cartesian product of schemas and artifacts; each artifact's <code>when schema</code> window defines coexistence.</p>
     </div>
   </div>
 </section>
@@ -93,7 +93,7 @@ environment prod {
 <section>
   <div class="wrap">
     <p class="kicker reveal">Model</p>
-    <h2 class="reveal">The MVP lowers to the existing kernel</h2>
+    <h2 class="reveal"><code>dbsystem</code> lowers to the existing kernel</h2>
     <p class="lead narrow reveal"><code>dbsystem</code> is not a new verifier kernel. It parses DB declarations into a typed IR and lowers them to the existing state-machine kernel.</p>
     <table class="matrix reveal">
       <tr><th>dbsystem element</th><th>Meaning</th><th>Lowered shape</th></tr>
@@ -132,12 +132,21 @@ environment prod {
   artifact server_v2 {
     reads users.id, users.display_name;
     writes users.display_name;
+    accepts api.CreateUserV1, api.CreateUserV2;
+    responds response.email;
+  }
+
+  artifact ios_v1 {
+    calls api.CreateUserV1;
+    emits_offline api.CreateUserV1 ttl 2;
+    expects response.email;
   }
 
   environment prod {
     schema 0..3;
     active server_v2 when schema 1..3;
     supported server_v2 when schema 1..3;
+    may_exist ios_v1 when schema 0..3;
   }
 
   environment staging {
@@ -150,6 +159,9 @@ environment prod {
     rule all_active_writes_exist;
     rule removed_only_after_unused;
     rule not_null_after_backfill;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
   }
 }</code></pre>
     </div>
@@ -164,7 +176,9 @@ environment prod {
       <pre><code>fslc check examples/db/safe_add_nullable_column.fsl
 fslc verify examples/db/safe_add_nullable_column.fsl --depth 8
 fslc db check examples/db/safe_add_nullable_column.fsl
-fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction</code></pre>
+fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
+fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>Result</th><th>How to read it</th></tr>
@@ -172,6 +186,9 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
       <tr><td><code>column_removed_while_still_read</code></td><td>An artifact still reads a column that has been removed in the coexistence window.</td></tr>
       <tr><td><code>column_removed_while_still_written</code></td><td>An artifact still writes a column that has been removed in the coexistence window.</td></tr>
       <tr><td><code>not_null_before_backfill</code></td><td>A column is made NOT NULL before the backfill step that justifies it.</td></tr>
+      <tr><td><code>api_response_field_missing</code></td><td>A coexisting provider no longer returns a response field expected by an old client.</td></tr>
+      <tr><td><code>offline_payload_not_accepted</code></td><td>A coexisting provider no longer accepts an offline payload inside its TTL window.</td></tr>
+      <tr><td><code>observed_mismatch</code></td><td>A runtime log disagrees with the declarations. This is observation evidence, not formal proof.</td></tr>
     </table>
   </div>
 </section>
@@ -179,23 +196,23 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
 <section>
   <div class="wrap">
     <p class="kicker reveal">Boundary</p>
-    <h2 class="reveal">Separate MVP multi-env checks from later phases</h2>
+    <h2 class="reveal">Separate the implemented finite model from remaining boundaries</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>Data preservation and rollback</h3>
-        <p>Row-level preservation and <code>up; down</code> equivalence are outside the MVP. The intended future model is refinement/simulation.</p>
+        <p><code>data_preserved</code> and <code>rollback_equivalent</code> use a finite abstract row model. They are not full production-data proofs.</p>
       </div>
       <div class="syntax-card">
         <h3>API / offline / feature flags</h3>
-        <p>The proposal treats these as important compatibility dimensions, but the MVP formal rules primarily cover DB column read/write compatibility and NOT NULL ordering. API contracts, offline TTL, and feature-flag variants are later phases.</p>
+        <p>API operations, response fields, and offline payload TTLs can be written as finite capabilities/ticks. Feature flags are approximated as artifact/window variants.</p>
       </div>
       <div class="syntax-card">
         <h3>Runtime observation</h3>
-        <p>Logs can provide evidence that old artifacts or undeclared accesses still exist, but log absence is not a formal proof of unused behavior.</p>
+        <p><code>fslc db observe</code> returns <code>observed_mismatch</code> for old artifacts or undeclared accesses found in logs. Log absence is not proof of unused behavior.</p>
       </div>
       <div class="syntax-card">
         <h3>SQL/ORM import</h3>
-        <p>Prisma, Rails, Drizzle, SQL DDL, and other importers are outside the MVP. Today, write <code>dbsystem</code> directly.</p>
+        <p><code>fslc db import</code> converts a minimal SQL DDL subset to <code>dbsystem</code>. Prisma, Rails, Drizzle, and other ORM importers are extension points.</p>
       </div>
       <div class="syntax-card">
         <h3>Time and probability</h3>
@@ -212,12 +229,12 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>Design decisions</h3>
-        <p>The lowering, finding schema, assumptions, and MVP boundary are described in the design document.</p>
+        <p>The lowering, finding schema, assumptions, and remaining boundaries are described in the design document.</p>
         <p><a class="btn" href="../DESIGN-db.md">DESIGN-db.md</a></p>
       </div>
       <div class="syntax-card">
         <h3>Working examples</h3>
-        <p>The fixtures cover safe column addition, unsafe drops, and NOT NULL ordering failures.</p>
+        <p>The fixtures cover safe column addition, unsafe drops, NOT NULL ordering failures, API/offline compatibility, observation, and import.</p>
         <p><a class="btn" href="../../examples/db/README.md">examples/db</a></p>
       </div>
       <div class="syntax-card">

--- a/docs/intro/db.ja.html
+++ b/docs/intro/db.ja.html
@@ -85,7 +85,7 @@ environment prod {
       <tr><td><code>when schema lo..hi</code></td><td>その artifact が同居しうる schema window。</td><td>割合 rollout、kill switch、段階的切替の有限近似。</td></tr>
     </table>
     <div class="callout reveal" style="margin-top:24px">
-      <p style="margin:0">MVPでは、複数環境は <code>environment</code> を複数書くことで表します。各環境の <code>schema lo..hi</code> は、宣言順の migration plan で到達可能な有限 snapshot 群です。任意の schema と artifact の直積ではなく、artifact ごとの <code>when schema</code> window が同居関係を決めます。</p>
+      <p style="margin:0">複数環境は <code>environment</code> を複数書くことで表します。各環境の <code>schema lo..hi</code> は、宣言順の migration plan で到達可能な有限 snapshot 群です。任意の schema と artifact の直積ではなく、artifact ごとの <code>when schema</code> window が同居関係を決めます。</p>
     </div>
   </div>
 </section>
@@ -93,7 +93,7 @@ environment prod {
 <section>
   <div class="wrap">
     <p class="kicker reveal">モデル</p>
-    <h2 class="reveal">MVPは既存カーネルへ展開される</h2>
+    <h2 class="reveal"><code>dbsystem</code> は既存カーネルへ展開される</h2>
     <p class="lead narrow reveal"><code>dbsystem</code> は新しい verifier kernel ではありません。DB向けの宣言を typed IR に読み込み、既存の状態機械へ展開します。</p>
     <table class="matrix reveal">
       <tr><th>dbsystem の要素</th><th>意味</th><th>展開後の考え方</th></tr>
@@ -132,12 +132,21 @@ environment prod {
   artifact server_v2 {
     reads users.id, users.display_name;
     writes users.display_name;
+    accepts api.CreateUserV1, api.CreateUserV2;
+    responds response.email;
+  }
+
+  artifact ios_v1 {
+    calls api.CreateUserV1;
+    emits_offline api.CreateUserV1 ttl 2;
+    expects response.email;
   }
 
   environment prod {
     schema 0..3;
     active server_v2 when schema 1..3;
     supported server_v2 when schema 1..3;
+    may_exist ios_v1 when schema 0..3;
   }
 
   environment staging {
@@ -150,6 +159,9 @@ environment prod {
     rule all_active_writes_exist;
     rule removed_only_after_unused;
     rule not_null_after_backfill;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
   }
 }</code></pre>
     </div>
@@ -164,7 +176,9 @@ environment prod {
       <pre><code>fslc check examples/db/safe_add_nullable_column.fsl
 fslc verify examples/db/safe_add_nullable_column.fsl --depth 8
 fslc db check examples/db/safe_add_nullable_column.fsl
-fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction</code></pre>
+fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
+fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>結果</th><th>読み方</th></tr>
@@ -172,6 +186,9 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
       <tr><td><code>column_removed_while_still_read</code></td><td>同居期間中の成果物が、すでに削除されたカラムを読んでいる。</td></tr>
       <tr><td><code>column_removed_while_still_written</code></td><td>同居期間中の成果物が、すでに削除されたカラムへ書こうとしている。</td></tr>
       <tr><td><code>not_null_before_backfill</code></td><td>backfill 前に NOT NULL 化する順序違反。</td></tr>
+      <tr><td><code>api_response_field_missing</code></td><td>旧クライアントが期待する応答フィールドを、同居中の提供側が返していない。</td></tr>
+      <tr><td><code>offline_payload_not_accepted</code></td><td>TTL window 内に残る offline payload を、同居中の提供側が受け付けない。</td></tr>
+      <tr><td><code>observed_mismatch</code></td><td>runtime log が仕様宣言と食い違った。形式証明ではなく観測証拠。</td></tr>
     </table>
   </div>
 </section>
@@ -179,23 +196,23 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
 <section>
   <div class="wrap">
     <p class="kicker reveal">境界</p>
-    <h2 class="reveal">MVPで書ける複数環境と、後続フェーズを分ける</h2>
+    <h2 class="reveal">実装済みの有限モデルと、残る境界を分ける</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>データ保存性・rollback</h3>
-        <p>行データが観測上保存されるか、<code>up; down</code> が同値かはMVP外です。将来は refinement/simulation として扱います。</p>
+        <p><code>data_preserved</code> と <code>rollback_equivalent</code> は有限の抽象行モデルで確認します。全本番データへの証明ではありません。</p>
       </div>
       <div class="syntax-card">
         <h3>API / offline / feature flag</h3>
-        <p>提案書では重要な対象ですが、MVPの形式 rule は主にDBカラムの read/write と NOT NULL 順序です。API契約、offline TTL、feature flag variant は後続フェーズです。</p>
+        <p>API operation、response field、offline payload TTL は有限の capability/tick として記述できます。feature flag は artifact/window として近似します。</p>
       </div>
       <div class="syntax-card">
         <h3>runtime observation</h3>
-        <p>ログからの「まだ古い成果物がいる」「未宣言の読み書きがある」は証拠であり、形式証明ではありません。</p>
+        <p><code>fslc db observe</code> は「まだ古い成果物がいる」「未宣言の読み書きがある」を <code>observed_mismatch</code> として返します。ログ不在は未使用の証明ではありません。</p>
       </div>
       <div class="syntax-card">
         <h3>SQL/ORM import</h3>
-        <p>Prisma、Rails、Drizzle、SQL DDL などからの自動 import はMVP外です。現時点では <code>dbsystem</code> を直接書きます。</p>
+        <p><code>fslc db import</code> は最小 SQL DDL を <code>dbsystem</code> に変換します。Prisma、Rails、Drizzle などの ORM 専用 importer は拡張点です。</p>
       </div>
       <div class="syntax-card">
         <h3>時間・確率</h3>
@@ -212,12 +229,12 @@ fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --en
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>設計判断</h3>
-        <p>lowering、所見 schema、MVP外の境界は design doc にまとまっています。</p>
+        <p>lowering、所見 schema、仮定、残る境界は design doc にまとまっています。</p>
         <p><a class="btn" href="../DESIGN-db.md">DESIGN-db.md</a></p>
       </div>
       <div class="syntax-card">
         <h3>動く例</h3>
-        <p>安全な追加、危険な drop、NOT NULL 順序違反などの fixture があります。</p>
+        <p>安全な追加、危険な drop、NOT NULL 順序違反、API/offline、観測、importer の fixture があります。</p>
         <p><a class="btn" href="../../examples/db/README.md">examples/db</a></p>
       </div>
       <div class="syntax-card">

--- a/examples/db/README.md
+++ b/examples/db/README.md
@@ -1,4 +1,4 @@
-# fsl-db MVP examples
+# fsl-db examples
 
 These files exercise the `dbsystem` dialect. The dialect lowers database
 schema/artifact/environment compatibility into the existing FSL kernel and
@@ -9,7 +9,20 @@ Run:
 ```bash
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db check examples/db/unsafe_drop_column_with_old_server.fsl
+fslc db check examples/db/unsafe_api_response_field_removed.fsl
+fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql
 ```
 
-The MVP intentionally excludes SQL/ORM importers, rollback equivalence, runtime
-observation, and data-preservation proofs; see `docs/DESIGN-db.md`.
+Coverage highlights:
+
+- safe and unsafe read/write compatibility across environment windows
+- destructive drop annotation enforcement
+- bounded rename/split/merge preservation and rollback checks
+- API response and offline payload compatibility across artifacts
+- runtime observation evidence separated from formal verification
+- minimal SQL DDL import with explicit unsupported-construct warnings
+
+The model is intentionally finite: schema ranges are reachable rollout
+snapshots, offline TTLs are logical ticks, and preservation/rollback checks use a
+bounded abstract row model rather than full production-data proof.

--- a/examples/db/minimal_import.sql
+++ b/examples/db/minimal_import.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+  id INT NOT NULL,
+  legacy_name TEXT,
+  display_name TEXT
+);
+
+ALTER TABLE users ADD COLUMN nickname TEXT;
+UPDATE users SET nickname = display_name;
+ALTER TABLE users RENAME COLUMN nickname TO public_name;

--- a/examples/db/runtime_observation_mismatch.json
+++ b/examples/db/runtime_observation_mismatch.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "fsl-db-observation.v0",
+  "events": [
+    {
+      "environment": "prod",
+      "schema_version": 0,
+      "artifact": "server_v2",
+      "capability": "reads",
+      "target": "users.legacy_name"
+    },
+    {
+      "environment": "prod",
+      "schema_version": 0,
+      "artifact": "old_mobile",
+      "capability": "calls",
+      "target": "api.CreateUserV1"
+    }
+  ]
+}

--- a/examples/db/runtime_observation_target.fsl
+++ b/examples/db/runtime_observation_target.fsl
@@ -1,0 +1,24 @@
+dbsystem RuntimeObservationTarget {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  artifact server_v2 {
+    reads users.id;
+    accepts api.CreateUserV2;
+  }
+
+  artifact old_mobile {
+    calls api.CreateUserV1;
+  }
+
+  environment prod {
+    schema 0..0;
+    active server_v2 when schema 0..0;
+    may_exist old_mobile when schema 0..0;
+  }
+}

--- a/examples/db/safe_api_offline_compat.fsl
+++ b/examples/db/safe_api_offline_compat.fsl
@@ -1,0 +1,25 @@
+dbsystem SafeApiOfflineCompat {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+    }
+  }
+
+  artifact server_v2 {
+    accepts api.CreateUserV1, api.CreateUserV2;
+    responds response.email;
+  }
+
+  artifact ios_v1 {
+    calls api.CreateUserV1;
+    emits_offline api.CreateUserV1 ttl 2;
+    expects response.email;
+  }
+
+  environment prod {
+    schema 0..0;
+    active server_v2 when schema 0..0;
+    may_exist ios_v1 when schema 0..0;
+  }
+}

--- a/examples/db/safe_destructive_drop_with_annotation.fsl
+++ b/examples/db/safe_destructive_drop_with_annotation.fsl
@@ -1,0 +1,28 @@
+dbsystem SafeDestructiveDropWithAnnotation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  migration drop_legacy_name from 0 to 1 {
+    drop users.legacy_name irreversible;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.legacy_name;
+    writes users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+  }
+}

--- a/examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl
+++ b/examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl
@@ -21,7 +21,7 @@ dbsystem SafeDualWriteBackfillSwitchReadDropOld {
   }
 
   migration drop_legacy_name from 3 to 4 {
-    drop users.legacy_name;
+    drop users.legacy_name irreversible;
   }
 
   artifact server_v1 {

--- a/examples/db/safe_rename_preservation.fsl
+++ b/examples/db/safe_rename_preservation.fsl
@@ -1,0 +1,39 @@
+dbsystem SafeRenamePreservation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+      column display_name: Text absent;
+    }
+  }
+
+  migration rename_legacy_name from 0 to 1 rollbackable {
+    rename users.legacy_name to users.display_name;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.display_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+  }
+
+  check compatibility {
+    rule all_active_reads_exist;
+    rule all_active_writes_exist;
+    rule removed_only_after_unused;
+    rule not_null_after_backfill;
+    rule destructive_operations_annotated;
+    rule preservation_transforms_annotated;
+    rule data_preserved;
+    rule rollback_equivalent;
+  }
+}

--- a/examples/db/safe_rollback_equivalence.fsl
+++ b/examples/db/safe_rollback_equivalence.fsl
@@ -1,0 +1,26 @@
+dbsystem SafeRollbackEquivalence {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column display_name: Text absent;
+    }
+  }
+
+  migration add_display_name from 0 to 1 rollbackable {
+    add users.display_name nullable;
+  }
+
+  artifact server_v1 {
+    reads users.id;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..1;
+  }
+
+  check compatibility {
+    rule rollback_equivalent;
+  }
+}

--- a/examples/db/unsafe_annotated_drop_with_old_server.fsl
+++ b/examples/db/unsafe_annotated_drop_with_old_server.fsl
@@ -1,0 +1,27 @@
+dbsystem UnsafeAnnotatedDropWithOldServer {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  migration drop_legacy_name from 0 to 1 {
+    drop users.legacy_name irreversible;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..1;
+    active server_v2 when schema 1..1;
+  }
+}

--- a/examples/db/unsafe_api_response_field_removed.fsl
+++ b/examples/db/unsafe_api_response_field_removed.fsl
@@ -1,0 +1,22 @@
+dbsystem UnsafeApiResponseFieldRemoved {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+    }
+  }
+
+  artifact server_v2 {
+    responds response.email_normalized;
+  }
+
+  artifact ios_v1 {
+    expects response.email;
+  }
+
+  environment prod {
+    schema 0..0;
+    active server_v2 when schema 0..0;
+    may_exist ios_v1 when schema 0..0;
+  }
+}

--- a/examples/db/unsafe_destructive_drop_without_annotation.fsl
+++ b/examples/db/unsafe_destructive_drop_without_annotation.fsl
@@ -1,0 +1,27 @@
+dbsystem UnsafeDestructiveDropWithoutAnnotation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  migration drop_legacy_name from 0 to 1 {
+    drop users.legacy_name;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+  }
+}

--- a/examples/db/unsafe_lossy_merge_preservation.fsl
+++ b/examples/db/unsafe_lossy_merge_preservation.fsl
@@ -1,0 +1,34 @@
+dbsystem UnsafeLossyMergePreservation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column first_name: Text present backfilled nullable;
+      column last_name: Text present backfilled nullable;
+      column display_name: Text absent;
+    }
+  }
+
+  migration merge_name from 0 to 1 {
+    merge users.first_name, users.last_name into users.display_name lossy;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.first_name, users.last_name;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.display_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+  }
+
+  check compatibility {
+    rule data_preserved;
+    rule preservation_transforms_annotated;
+  }
+}

--- a/examples/db/unsafe_lossy_split_preservation.fsl
+++ b/examples/db/unsafe_lossy_split_preservation.fsl
@@ -1,0 +1,34 @@
+dbsystem UnsafeLossySplitPreservation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+
+  migration split_full_name from 0 to 1 {
+    split users.full_name into users.first_name, users.last_name lossy;
+  }
+
+  artifact server_v1 {
+    reads users.id, users.full_name;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.first_name, users.last_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+  }
+
+  check compatibility {
+    rule data_preserved;
+    rule preservation_transforms_annotated;
+  }
+}

--- a/examples/db/unsafe_offline_payload_rejected.fsl
+++ b/examples/db/unsafe_offline_payload_rejected.fsl
@@ -1,0 +1,22 @@
+dbsystem UnsafeOfflinePayloadRejected {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+    }
+  }
+
+  artifact server_v2 {
+    accepts api.CreateUserV2;
+  }
+
+  artifact ios_v1 {
+    emits_offline api.CreateUserV1 ttl 2;
+  }
+
+  environment prod {
+    schema 0..0;
+    active server_v2 when schema 0..0;
+    may_exist ios_v1 when schema 0..0;
+  }
+}

--- a/examples/db/unsafe_rollback_drop.fsl
+++ b/examples/db/unsafe_rollback_drop.fsl
@@ -1,0 +1,27 @@
+dbsystem UnsafeRollbackDrop {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  migration drop_legacy_name from 0 to 1 rollbackable {
+    drop users.legacy_name irreversible;
+  }
+
+  artifact server_v1 {
+    reads users.id;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 1..1;
+  }
+
+  check compatibility {
+    rule rollback_equivalent;
+    rule destructive_operations_annotated;
+  }
+}

--- a/examples/db/unsafe_split_without_annotation.fsl
+++ b/examples/db/unsafe_split_without_annotation.fsl
@@ -1,0 +1,24 @@
+dbsystem UnsafeSplitWithoutAnnotation {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+
+  migration split_full_name from 0 to 1 {
+    split users.full_name into users.first_name, users.last_name;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.first_name, users.last_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v2 when schema 1..1;
+  }
+}

--- a/examples/db/unsupported_import.sql
+++ b/examples/db/unsupported_import.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (
+  id INT NOT NULL
+);
+
+CREATE INDEX users_id_idx ON users(id);

--- a/schemas/fslc/db/finding.v0.schema.json
+++ b/schemas/fslc/db/finding.v0.schema.json
@@ -36,6 +36,13 @@
         "column_removed_while_still_read",
         "column_removed_while_still_written",
         "not_null_before_backfill",
+        "destructive_migration_unannotated",
+        "preservation_transform_unannotated",
+        "data_preservation_loss",
+        "rollback_not_equivalent",
+        "api_call_not_accepted",
+        "api_response_field_missing",
+        "offline_payload_not_accepted",
         "declared_unused_but_observed",
         "unsupported_artifact_observed",
         "legacy_api_still_called"

--- a/schemas/fslc/db/observation.v0.schema.json
+++ b/schemas/fslc/db/observation.v0.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ymm-oss/fsl/schemas/fslc/db/observation.v0.schema.json",
+  "title": "fsl-db runtime observation v0",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["events"],
+      "properties": {
+        "schema_version": {
+          "const": "fsl-db-observation.v0"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/event"
+          }
+        }
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/event"
+      }
+    }
+  ],
+  "$defs": {
+    "event": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["environment", "schema_version", "artifact", "capability", "target"],
+      "properties": {
+        "environment": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "integer"
+        },
+        "artifact": {
+          "type": "string"
+        },
+        "capability": {
+          "enum": ["reads", "writes", "calls"]
+        },
+        "target": {
+          "type": "string",
+          "description": "Schema identifier only, e.g. users.email or api.CreateUserV1"
+        }
+      }
+    }
+  }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -84,7 +84,8 @@ governance <Name> {
 }
 ```
 
-Database compatibility dialect (MVP; expands to the same kernel):
+Database / multi-environment compatibility dialect (expands to the same kernel
+for DB lifecycle checks and reports stable fsl-db findings for the dialect layer):
 
 ```fsl
 dbsystem <Name> {
@@ -95,15 +96,23 @@ dbsystem <Name> {
       column <future_column>: <db_type> absent;
     }
   }
-  migration <name> from <v0> to <v1> {
+  migration <name> from <v0> to <v1> [rollbackable] {
     add <table>.<column> nullable;
     backfill <table>.<column>;
     set_not_null <table>.<column>;
-    drop <table>.<column>;
+    rename <table>.<old> to <table>.<new>;
+    split <table>.<source> into <table>.<a>, <table>.<b> lossless|lossy|irreversible;
+    merge <table>.<a>, <table>.<b> into <table>.<target> lossless|lossy|irreversible;
+    drop <table>.<column> destructive|irreversible;
   }
   artifact <version> {
     reads <table>.<column>, ...;
     writes <table>.<column>, ...;
+    calls api.<operation>, ...;
+    accepts api.<operation>, ...;
+    expects response.<field>, ...;
+    responds response.<field>, ...;
+    emits_offline api.<operation> ttl <finite_ticks>;
   }
   environment <env> {
     schema <lo>..<hi>;
@@ -116,14 +125,25 @@ dbsystem <Name> {
     rule all_active_writes_exist;
     rule removed_only_after_unused;
     rule not_null_after_backfill;
+    rule destructive_operations_annotated;
+    rule preservation_transforms_annotated;
+    rule api_calls_accepted;
+    rule api_responses_expected;
+    rule offline_payloads_accepted;
+    rule data_preserved;
+    rule rollback_equivalent;
   }
 }
 ```
 
-`dbsystem` checks database migration compatibility, not DB-engine behavior. Schema
-ranges are finite reachable rollout snapshots; percentages and wall-clock TTLs
-must be modeled as finite coexistence windows/ticks. Use `fslc db check` for
-stable fsl-db findings (`verified_under_assumptions` on success).
+`dbsystem` checks migration compatibility across DB schema, artifacts, API/offline
+payloads, and environments. It does not model DB-engine locks/optimizers,
+probability, wall-clock TTL, or full production-data completeness. Schema ranges
+are finite reachable rollout snapshots; percentages and offline TTLs must be
+modeled as finite coexistence windows/ticks. Use `fslc db check` for stable
+fsl-db findings (`verified_under_assumptions` on success). Use
+`fslc db observe` for runtime evidence only (`observed_mismatch`, not formal
+violation) and `fslc db import` for the minimal SQL DDL importer boundary.
 
 Composite spec (a separate top-level form):
 
@@ -351,6 +371,8 @@ fslc typestate <f> [--ts]                       # state machine -> ghost-type ap
 fslc html <f> [--depth K] [-o report.html]      # self-contained HTML review report (dev audience)
 fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md]  # business audit ledger by requirement id (PM/audit)
 fslc db check <f> [--depth K] [--engine bmc|induction]  # dbsystem compatibility findings
+fslc db observe <f> --trace events.json                 # runtime observation evidence
+fslc db import <sql> [--name Name] [-o out.fsl]         # minimal SQL DDL -> dbsystem
 ```
 
 `analyze` is a structural observation layer, not a verifier. `--projection tsg`

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -4104,6 +4104,7 @@ def _requires_clause_locally_implied(inst, req_idx, spec):
 def _requires_vacuity_candidates(instances, spec):
     pending = {}
     suppress = {}
+    generated = set(spec.get("generated_names") or [])
     for idx, inst in enumerate(instances):
         if inst["action_def"].get("sync"):
             # Synchronized compose actions are excluded: their clauses are
@@ -4115,6 +4116,8 @@ def _requires_vacuity_candidates(instances, spec):
             # by verifying the component spec on its own (no loss of detection).
             continue
         aname = inst["action"]
+        if aname in generated:
+            continue
         action_pending = pending.setdefault(aname, {})
         action_suppress = suppress.setdefault(aname, set())
         for req_idx, req in enumerate(inst["requires"]):

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -41,7 +41,8 @@ from .analysis import (
 )
 from .analysis.projections import SUPPORTED_PROJECTIONS
 from .analysis.schema import FINDINGS_SCHEMA_VERSION
-from .db_check import check_dbsystem, load_dbsystem
+from .db_check import check_dbsystem, load_dbsystem, observe_dbsystem
+from .db_import import import_sql_file
 
 FSL_VERSION = "1.0"
 
@@ -1223,6 +1224,52 @@ def run_db_check(file, depth=8, engine="bmc", deadlock_mode="warn"):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
+def run_db_observe(file, trace):
+    try:
+        system = load_dbsystem(file)
+        return _envelope(observe_dbsystem(system, trace))
+    except UnexpectedInput as e:
+        return _parse_error_result(e)
+    except VisitError as e:
+        orig = e.orig_exc
+        return _error_envelope(
+            getattr(orig, "kind", "semantics"),
+            str(orig),
+            _loc_from_exc(orig),
+            getattr(orig, "expected", None),
+            getattr(orig, "hint", None),
+        )
+    except FslError as e:
+        return _error_envelope(e.kind, str(e), _loc_from_exc(e),
+                               getattr(e, "expected", None), getattr(e, "hint", None))
+    except FileNotFoundError as e:
+        return _envelope({"result": "error", "kind": "io", "message": str(e)})
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
+def run_db_import(file, name="ImportedDb", output=None):
+    try:
+        imported = import_sql_file(file, name=name)
+        result = {
+            "result": "imported_with_warnings" if imported.warnings else "imported",
+            "dialect": "fsl-db-mvp.v0",
+            "source_format": "sql-ddl-minimal.v0",
+            "dbsystem": imported.system.name,
+            "warnings": imported.warnings,
+            "dbsystem_source": imported.source,
+        }
+        if output:
+            Path(output).write_text(imported.source, encoding="utf-8")
+            result["output"] = output
+            result.pop("dbsystem_source", None)
+        return _envelope(result)
+    except FileNotFoundError as e:
+        return _envelope({"result": "error", "kind": "io", "message": str(e)})
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
 def exit_code(result):
     r = result.get("result")
     if r in ("verified", "proved", "scenarios", "conformant", "generated",
@@ -1382,6 +1429,13 @@ def _build_arg_parser():
     dbc.add_argument("--depth", type=int, default=8)
     dbc.add_argument("--engine", choices=["bmc", "induction"], default="bmc")
     dbc.add_argument("--deadlock", choices=["warn", "error", "ignore"], default="warn")
+    dbo = db_sub.add_parser("observe", help="compare runtime observation logs to dbsystem declarations")
+    dbo.add_argument("file")
+    dbo.add_argument("--trace", required=True)
+    dbi = db_sub.add_parser("import", help="import a minimal SQL DDL subset into dbsystem")
+    dbi.add_argument("file")
+    dbi.add_argument("--name", default="ImportedDb")
+    dbi.add_argument("-o", "--output")
 
     return ap
 
@@ -1484,6 +1538,15 @@ def _dispatch(args):
     elif args.cmd == "db":
         if args.db_cmd == "check":
             result = run_db_check(args.file, args.depth, args.engine, args.deadlock)
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif args.db_cmd == "observe":
+            result = run_db_observe(args.file, args.trace)
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif args.db_cmd == "import":
+            result = run_db_import(args.file, name=args.name, output=args.output)
+            if result.get("result") == "imported" and not args.output:
+                sys.stdout.write(result["dbsystem_source"])
+                sys.exit(0)
             print(json.dumps(result, indent=2, ensure_ascii=False))
         else:
             result = _envelope({

--- a/src/fslc/db_check.py
+++ b/src/fslc/db_check.py
@@ -4,15 +4,24 @@
 """AI-readable fsl-db compatibility checks and finding translation."""
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from .bmc import prove, verify
-from .db_expand import DB_DIALECT_VERSION, DB_FINDING_SCHEMA_VERSION, expand_dbsystem
+from .db_expand import (
+    DB_DIALECT_VERSION,
+    DB_FINDING_SCHEMA_VERSION,
+    DEFAULT_RULES,
+    expand_dbsystem,
+)
 from .db_ir import ColumnKey, DbMigration, DbMigrationOp, DbSystem, column_label
 from .db_parser import parse_dbsystem
-from .model import build_spec
+from .model import FslError, build_spec
+
+
+DB_OBSERVATION_SCHEMA_VERSION = "fsl-db-observation.v0"
 
 
 def load_dbsystem(path):
@@ -63,6 +72,30 @@ def check_dbsystem(system, depth=8, engine="bmc", deadlock_mode="warn"):
     )
 
 
+def observe_dbsystem(system, trace_path):
+    expansion = expand_dbsystem(system)
+    events = _load_observation_events(trace_path)
+    assumptions = list(expansion.assumptions) + [{
+        "id": "DB-ASSUME-OBSERVABILITY-COVERAGE",
+        "text": (
+            "runtime observation is evidence only; absence from logs is not a proof "
+            "that a capability is unused or unsupported"
+        ),
+    }]
+    findings = _observation_findings(system, events, assumptions)
+    return {
+        "result": "observed_mismatch" if findings else "observed_conformant",
+        "dialect": DB_DIALECT_VERSION,
+        "finding_schema_version": DB_FINDING_SCHEMA_VERSION,
+        "observation_schema_version": DB_OBSERVATION_SCHEMA_VERSION,
+        "dbsystem": system.name,
+        "assumptions": assumptions,
+        "findings": findings,
+        "formal_result": "not_run",
+        "note": "runtime observation is separate from fsl-db formal compatibility verification",
+    }
+
+
 def _db_result(result, system, assumptions, findings, kernel):
     out = {
         "result": result,
@@ -100,7 +133,12 @@ def _initial_state(system):
     }
 
 
+def _active_rules(system):
+    return set(system.check.rules or DEFAULT_RULES)
+
+
 def _static_findings(system, assumptions):
+    rules = _active_rules(system)
     states = {system.database.initial_schema: _initial_state(system)}
     sources = {system.database.initial_schema: None}
     findings = []
@@ -110,8 +148,17 @@ def _static_findings(system, assumptions):
     for migration in system.migrations:
         next_state = deepcopy(current_state)
         for op in migration.ops:
+            before_op_state = deepcopy(next_state)
             _apply_op(next_state, op)
-            findings.extend(_op_findings(system, migration, op, next_state, assumptions))
+            findings.extend(_op_findings(
+                system,
+                migration,
+                op,
+                before_op_state,
+                next_state,
+                assumptions,
+                rules,
+            ))
         states[migration.to_schema] = deepcopy(next_state)
         sources[migration.to_schema] = migration
         current_state = next_state
@@ -176,6 +223,15 @@ def _static_findings(system, assumptions):
                             repair_candidates=_compat_repairs("writes", entry.artifact, column, env.name),
                             assumptions=assumptions,
                         ))
+                findings.extend(_api_offline_findings(
+                    system,
+                    env,
+                    entry,
+                    artifact,
+                    schema_version,
+                    rules,
+                    assumptions,
+                ))
     return findings
 
 
@@ -195,9 +251,42 @@ def _apply_op(state: Dict[ColumnKey, dict], op: DbMigrationOp):
         cell["exists"] = False
         cell["backfilled"] = False
         cell["not_null"] = False
+    elif op.op == "rename":
+        target = state[op.columns[0]]
+        target["exists"] = True
+        target["backfilled"] = cell["backfilled"]
+        target["not_null"] = cell["not_null"]
+        cell["exists"] = False
+        cell["backfilled"] = False
+        cell["not_null"] = False
+    elif op.op == "split":
+        cell["exists"] = False
+        cell["backfilled"] = False
+        cell["not_null"] = False
+        for target_key in op.columns:
+            target = state[target_key]
+            target["exists"] = True
+            target["backfilled"] = True
+            target["not_null"] = False
+    elif op.op == "merge":
+        for source_key in op.columns:
+            source = state[source_key]
+            source["exists"] = False
+            source["backfilled"] = False
+            source["not_null"] = False
+        cell["exists"] = True
+        cell["backfilled"] = True
+        cell["not_null"] = False
 
 
-def _op_findings(system, migration: DbMigration, op: DbMigrationOp, state, assumptions):
+def _op_findings(
+        system,
+        migration: DbMigration,
+        op: DbMigrationOp,
+        before_state,
+        state,
+        assumptions,
+        rules):
     findings = []
     if op.op in ("add", "set_not_null") and state[op.column]["not_null"] and not state[op.column]["backfilled"]:
         findings.append(_finding(
@@ -243,7 +332,344 @@ def _op_findings(system, migration: DbMigration, op: DbMigrationOp, state, assum
             ],
             assumptions=assumptions,
         ))
+    annotations = _annotations(migration, op)
+    if (
+            "destructive_operations_annotated" in rules
+            and op.op == "drop"
+            and before_state[op.column]["exists"]
+            and not annotations.intersection({"destructive", "irreversible"})):
+        findings.append(_finding(
+            kind="destructive_migration_unannotated",
+            severity="error",
+            environment=None,
+            migration=migration.name,
+            schema_element=column_label(op.column),
+            artifact=None,
+            artifact_version=None,
+            failed_rule="destructive_operations_annotated",
+            witness={
+                "schema_version": migration.to_schema,
+                "operation": op.op,
+                "column": column_label(op.column),
+                "annotations": sorted(annotations),
+            },
+            minimal_conflict_set={
+                "migration": migration.name,
+                "schema_element": column_label(op.column),
+            },
+            repair_candidates=_destructive_repairs(op.column),
+            assumptions=assumptions,
+        ))
+    if (
+            "preservation_transforms_annotated" in rules
+            and op.op in ("split", "merge")
+            and not annotations.intersection({"lossless", "lossy", "irreversible"})):
+        findings.append(_finding(
+            kind="preservation_transform_unannotated",
+            severity="error",
+            environment=None,
+            migration=migration.name,
+            schema_element=_transform_label(op),
+            artifact=None,
+            artifact_version=None,
+            failed_rule="preservation_transforms_annotated",
+            witness={
+                "schema_version": migration.to_schema,
+                "operation": op.op,
+                "annotations": sorted(annotations),
+            },
+            minimal_conflict_set={
+                "migration": migration.name,
+                "schema_element": _transform_label(op),
+            },
+            repair_candidates=_preservation_repairs(op),
+            assumptions=assumptions,
+        ))
+    if "data_preserved" in rules and _is_preservation_loss(op, annotations, before_state):
+        findings.append(_finding(
+            kind="data_preservation_loss",
+            severity="error",
+            environment=None,
+            migration=migration.name,
+            schema_element=_transform_label(op),
+            artifact=None,
+            artifact_version=None,
+            failed_rule="data_preserved",
+            witness={
+                "schema_version": migration.to_schema,
+                "operation": op.op,
+                "annotations": sorted(annotations),
+                "bounded_row_model": True,
+            },
+            minimal_conflict_set={
+                "migration": migration.name,
+                "schema_element": _transform_label(op),
+            },
+            repair_candidates=_preservation_repairs(op),
+            assumptions=assumptions,
+        ))
+    if (
+            "rollback_equivalent" in rules
+            and "rollbackable" in set(migration.annotations)
+            and _breaks_rollback_equivalence(op, annotations, before_state)):
+        findings.append(_finding(
+            kind="rollback_not_equivalent",
+            severity="error",
+            environment=None,
+            migration=migration.name,
+            schema_element=_transform_label(op),
+            artifact=None,
+            artifact_version=None,
+            failed_rule="rollback_equivalent",
+            witness={
+                "schema_version": migration.to_schema,
+                "operation": op.op,
+                "annotations": sorted(annotations),
+                "check": "up_down_observable_equivalence",
+            },
+            minimal_conflict_set={
+                "migration": migration.name,
+                "schema_element": _transform_label(op),
+            },
+            repair_candidates=_rollback_repairs(op),
+            assumptions=assumptions,
+        ))
     return findings
+
+
+def _annotations(migration: DbMigration, op: DbMigrationOp):
+    return set(migration.annotations) | set(op.annotations)
+
+
+def _transform_label(op: DbMigrationOp):
+    if op.op == "rename":
+        return f"{column_label(op.column)}->{column_label(op.columns[0])}"
+    if op.op == "split":
+        return f"{column_label(op.column)}->{','.join(column_label(c) for c in op.columns)}"
+    if op.op == "merge":
+        return f"{','.join(column_label(c) for c in op.columns)}->{column_label(op.column)}"
+    return column_label(op.column)
+
+
+def _is_preservation_loss(op: DbMigrationOp, annotations, before_state):
+    if op.op == "drop":
+        return before_state[op.column]["exists"]
+    if op.op in ("split", "merge"):
+        return "lossless" not in annotations
+    return False
+
+
+def _breaks_rollback_equivalence(op: DbMigrationOp, annotations, before_state):
+    if op.op == "drop":
+        return before_state[op.column]["exists"]
+    if op.op in ("split", "merge"):
+        return "lossless" not in annotations
+    return False
+
+
+def _entry_active_at(env, entry, schema_version):
+    window = entry.schema_window or env.schema_window
+    return window[0] <= schema_version <= window[1]
+
+
+def _providers_for(system, env, schema_version, capability, target):
+    providers = []
+    artifacts = system.artifact_map()
+    for entry in env.artifacts:
+        if entry.role == "may_exist" or not _entry_active_at(env, entry, schema_version):
+            continue
+        artifact = artifacts[entry.artifact]
+        if target in getattr(artifact, capability):
+            providers.append(entry.artifact)
+    return providers
+
+
+def _api_offline_findings(system, env, entry, artifact, schema_version, rules, assumptions):
+    findings = []
+    if "api_calls_accepted" in rules:
+        for target in artifact.calls:
+            if not _providers_for(system, env, schema_version, "accepts", target):
+                findings.append(_capability_finding(
+                    "api_call_not_accepted",
+                    "api_calls_accepted",
+                    env.name,
+                    entry,
+                    schema_version,
+                    "calls",
+                    target,
+                    assumptions,
+                ))
+    if "api_responses_expected" in rules:
+        for target in artifact.expects:
+            if not _providers_for(system, env, schema_version, "responds", target):
+                findings.append(_capability_finding(
+                    "api_response_field_missing",
+                    "api_responses_expected",
+                    env.name,
+                    entry,
+                    schema_version,
+                    "expects",
+                    target,
+                    assumptions,
+                ))
+    if "offline_payloads_accepted" in rules:
+        for target in artifact.emits_offline:
+            if not _providers_for(system, env, schema_version, "accepts", target):
+                ttl = artifact.offline_ttls.get(target)
+                findings.append(_capability_finding(
+                    "offline_payload_not_accepted",
+                    "offline_payloads_accepted",
+                    env.name,
+                    entry,
+                    schema_version,
+                    "emits_offline",
+                    target,
+                    assumptions,
+                    extra_witness={"ttl_ticks": ttl} if ttl is not None else None,
+                ))
+    return findings
+
+
+def _capability_finding(
+        kind,
+        failed_rule,
+        env_name,
+        entry,
+        schema_version,
+        capability,
+        target,
+        assumptions,
+        extra_witness=None):
+    witness = {
+        "schema_version": schema_version,
+        "environment_role": entry.role,
+        "declared_capability": capability,
+        "target": column_label(target),
+    }
+    if extra_witness:
+        witness.update(extra_witness)
+    return _finding(
+        kind=kind,
+        severity="error",
+        environment=env_name,
+        migration=None,
+        schema_element=column_label(target),
+        artifact=entry.artifact,
+        artifact_version=entry.artifact,
+        failed_rule=failed_rule,
+        witness=witness,
+        minimal_conflict_set={
+            "environment": env_name,
+            "artifact": entry.artifact,
+            "schema_element": column_label(target),
+        },
+        repair_candidates=_capability_repairs(capability, entry.artifact, target, env_name),
+        assumptions=assumptions,
+    )
+
+
+def _load_observation_events(trace_path):
+    try:
+        data = json.loads(Path(trace_path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise FslError(f"invalid observation JSON: {exc.msg}", kind="parse") from exc
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("events"), list):
+        return data["events"]
+    raise FslError("observation JSON must be an array or {\"events\": [...]}", kind="semantics")
+
+
+def _target_key(raw):
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        return (str(raw[0]), str(raw[1]))
+    text = str(raw)
+    left, sep, right = text.partition(".")
+    if not sep:
+        return ("unknown", text)
+    return (left, right)
+
+
+def _observation_findings(system, events, assumptions):
+    findings = []
+    artifacts = system.artifact_map()
+    envs = {env.name: env for env in system.environments}
+    for idx, event in enumerate(events):
+        env = envs.get(event.get("environment"))
+        artifact_name = event.get("artifact")
+        capability = event.get("capability")
+        target = _target_key(event.get("target"))
+        schema_version = event.get("schema_version")
+        if env is None or artifact_name not in artifacts or not _artifact_declared_in_env(env, artifact_name, schema_version):
+            findings.append(_observation_finding(
+                "unsupported_artifact_observed",
+                event,
+                idx,
+                target,
+                assumptions,
+                "observed artifact is not declared in the environment/schema window",
+            ))
+            continue
+        artifact = artifacts[artifact_name]
+        declared = getattr(artifact, capability, []) if isinstance(capability, str) else []
+        if capability in ("reads", "writes") and target not in declared:
+            findings.append(_observation_finding(
+                "declared_unused_but_observed",
+                event,
+                idx,
+                target,
+                assumptions,
+                "observed DB access is not declared as an artifact capability",
+            ))
+        elif capability == "calls" and not _providers_for(system, env, int(schema_version), "accepts", target):
+            findings.append(_observation_finding(
+                "legacy_api_still_called",
+                event,
+                idx,
+                target,
+                assumptions,
+                "observed API call is not accepted by an active/supported artifact",
+            ))
+    return findings
+
+
+def _artifact_declared_in_env(env, artifact_name, schema_version):
+    try:
+        version = int(schema_version)
+    except (TypeError, ValueError):
+        return False
+    return any(
+        entry.artifact == artifact_name and _entry_active_at(env, entry, version)
+        for entry in env.artifacts
+    )
+
+
+def _observation_finding(kind, event, index, target, assumptions, reason):
+    return _finding(
+        kind=kind,
+        severity="error",
+        environment=event.get("environment"),
+        migration=None,
+        schema_element=column_label(target),
+        artifact=event.get("artifact"),
+        artifact_version=event.get("artifact"),
+        failed_rule="runtime_observation",
+        witness={
+            "event_index": index,
+            "schema_version": event.get("schema_version"),
+            "capability": event.get("capability"),
+            "target": column_label(target),
+            "reason": reason,
+        },
+        minimal_conflict_set={
+            "environment": event.get("environment"),
+            "artifact": event.get("artifact"),
+            "schema_element": column_label(target),
+        },
+        repair_candidates=_observation_repairs(event, target),
+        assumptions=assumptions,
+        result="observed_mismatch",
+    )
 
 
 def _finding(
@@ -258,11 +684,12 @@ def _finding(
         witness,
         minimal_conflict_set,
         repair_candidates,
-        assumptions):
+        assumptions,
+        result="violated"):
     return {
         "schema_version": DB_FINDING_SCHEMA_VERSION,
         "fsl": DB_DIALECT_VERSION,
-        "result": "violated",
+        "result": result,
         "kind": kind,
         "severity": severity,
         "environment": environment,
@@ -300,6 +727,102 @@ def _compat_repairs(capability, artifact, column, env_name):
             "description": (
                 f"remove the declared {capability} capability only if {artifact} truly no longer uses {label}"
             ),
+        },
+    ]
+
+
+def _destructive_repairs(column):
+    label = column_label(column)
+    return [
+        {
+            "kind": "annotation_change",
+            "weakens_spec": False,
+            "description": f"mark the operation as irreversible/destructive if {label} loss is intended",
+        },
+        {
+            "kind": "compat_shim",
+            "weakens_spec": False,
+            "description": f"keep {label} or replace it with a compatibility shim before dropping it",
+        },
+    ]
+
+
+def _preservation_repairs(op):
+    label = _transform_label(op)
+    return [
+        {
+            "kind": "preservation_mapping",
+            "weakens_spec": False,
+            "description": f"provide a lossless preservation transform for {label}",
+        },
+        {
+            "kind": "annotation_change",
+            "weakens_spec": False,
+            "description": f"mark {label} as lossy/irreversible when information loss is intended",
+        },
+        {
+            "kind": "migration_change",
+            "weakens_spec": False,
+            "description": f"split the migration so old and new representations coexist during backfill for {label}",
+        },
+    ]
+
+
+def _rollback_repairs(op):
+    label = _transform_label(op)
+    return [
+        {
+            "kind": "rollback_contract_change",
+            "weakens_spec": False,
+            "description": f"remove rollbackable from the migration unless {label} has an inverse",
+        },
+        {
+            "kind": "preservation_mapping",
+            "weakens_spec": False,
+            "description": f"add a lossless inverse transform for {label}",
+        },
+    ]
+
+
+def _capability_repairs(capability, artifact, target, env_name):
+    label = column_label(target)
+    return [
+        {
+            "kind": "compat_shim",
+            "weakens_spec": False,
+            "description": f"keep an active provider for {label} while {artifact} is in {env_name}",
+        },
+        {
+            "kind": "rollout_window_change",
+            "weakens_spec": False,
+            "description": f"narrow the {artifact} environment window until {label} is supported",
+        },
+        {
+            "kind": "declaration_change",
+            "weakens_spec": True,
+            "description": f"remove the declared {capability} capability only if {artifact} truly no longer uses {label}",
+        },
+    ]
+
+
+def _observation_repairs(event, target):
+    label = column_label(target)
+    artifact = event.get("artifact")
+    return [
+        {
+            "kind": "declaration_change",
+            "weakens_spec": False,
+            "description": f"declare the observed {event.get('capability')} capability for {artifact} on {label}",
+        },
+        {
+            "kind": "rollout_window_change",
+            "weakens_spec": False,
+            "description": f"keep {artifact} in the environment window until observations stop",
+        },
+        {
+            "kind": "compat_shim",
+            "weakens_spec": False,
+            "description": f"restore compatibility for observed use of {label}",
         },
     ]
 

--- a/src/fslc/db_expand.py
+++ b/src/fslc/db_expand.py
@@ -28,8 +28,16 @@ DEFAULT_RULES = (
     "all_active_writes_exist",
     "removed_only_after_unused",
     "not_null_after_backfill",
+    "destructive_operations_annotated",
+    "preservation_transforms_annotated",
+    "api_calls_accepted",
+    "api_responses_expected",
+    "offline_payloads_accepted",
 )
-ALLOWED_RULES = frozenset(DEFAULT_RULES)
+ALLOWED_RULES = frozenset(DEFAULT_RULES + (
+    "data_preserved",
+    "rollback_equivalent",
+))
 
 
 @dataclass(frozen=True)
@@ -179,8 +187,10 @@ def validate_dbsystem(system):
                 hint="MVP dbsystem migrations are a single declared rollout sequence",
             )
         for op in migration.ops:
-            if op.column not in columns:
-                _err(f"unknown column '{op.column_label}'", loc=op.loc)
+            refs = [op.column] + list(op.columns)
+            for ref in refs:
+                if ref not in columns:
+                    _err(f"unknown column '{column_label(ref)}'", loc=op.loc)
         current = migration.to_schema
         reached_versions.add(current)
 
@@ -188,7 +198,7 @@ def validate_dbsystem(system):
     for artifact in system.artifacts:
         if artifact.name in artifacts:
             _err(f"duplicate artifact '{artifact.name}'", loc=artifact.loc)
-        for ref in _artifact_columns(artifact):
+        for ref in _artifact_db_columns(artifact):
             if ref not in columns:
                 _err(f"unknown column '{column_label(ref)}'", loc=artifact.loc)
         artifacts[artifact.name] = artifact
@@ -233,15 +243,8 @@ def _validate_window(window, label, loc=None):
         _err(f"{label} has an empty range {window[0]}..{window[1]}", loc=loc)
 
 
-def _artifact_columns(artifact: DbArtifact):
-    return (
-        list(artifact.reads)
-        + list(artifact.writes)
-        + list(artifact.calls)
-        + list(artifact.accepts)
-        + list(artifact.expects)
-        + list(artifact.emits_offline)
-    )
+def _artifact_db_columns(artifact: DbArtifact):
+    return list(artifact.reads) + list(artifact.writes)
 
 
 def _effective_window(env: DbEnvironment, entry: DbEnvironmentArtifact):
@@ -360,10 +363,51 @@ def expand_dbsystem(system):
                 body.append(_assign_index("column_exists", member, _bool(False), op.loc))
                 body.append(_assign_index("column_backfilled", member, _bool(False), op.loc))
                 body.append(_assign_index("column_not_null", member, _bool(False), op.loc))
+            elif op.op == "rename":
+                target = _var(col_member[op.columns[0]])
+                body.append(("requires", _idx("column_exists", member), op.loc))
+                body.append(_assign_index("column_exists", member, _bool(False), op.loc))
+                body.append(_assign_index("column_backfilled", member, _bool(False), op.loc))
+                body.append(_assign_index("column_not_null", member, _bool(False), op.loc))
+                body.append(_assign_index("column_exists", target, _bool(True), op.loc))
+                body.append(_assign_index("column_backfilled", target, _bool(True), op.loc))
+                body.append(_assign_index("column_not_null", target, _idx("column_not_null", member), op.loc))
+            elif op.op == "split":
+                body.append(("requires", _idx("column_exists", member), op.loc))
+                body.append(_assign_index("column_exists", member, _bool(False), op.loc))
+                body.append(_assign_index("column_backfilled", member, _bool(False), op.loc))
+                body.append(_assign_index("column_not_null", member, _bool(False), op.loc))
+                for target_key in op.columns:
+                    target = _var(col_member[target_key])
+                    body.append(_assign_index("column_exists", target, _bool(True), op.loc))
+                    body.append(_assign_index("column_backfilled", target, _bool(True), op.loc))
+                    body.append(_assign_index("column_not_null", target, _bool(False), op.loc))
+            elif op.op == "merge":
+                target = member
+                for source_key in op.columns:
+                    source = _var(col_member[source_key])
+                    body.append(("requires", _idx("column_exists", source), op.loc))
+                    body.append(_assign_index("column_exists", source, _bool(False), op.loc))
+                    body.append(_assign_index("column_backfilled", source, _bool(False), op.loc))
+                    body.append(_assign_index("column_not_null", source, _bool(False), op.loc))
+                body.append(_assign_index("column_exists", target, _bool(True), op.loc))
+                body.append(_assign_index("column_backfilled", target, _bool(True), op.loc))
+                body.append(_assign_index("column_not_null", target, _bool(False), op.loc))
         body.append(("assign", ("var", "schema_version"), _num(migration.to_schema), migration.loc))
         items.append(("action", action_name, [], body, migration.loc, False, _meta(
             "DB-MIGRATION",
             f"{migration.name}: schema {migration.from_schema} -> {migration.to_schema}",
+        )))
+
+    if not system.migrations:
+        action_name = "observe_schema_" + _safe(str(system.database.initial_schema))
+        generated_names.append(action_name)
+        items.append(("action", action_name, [], [
+            ("requires", _bin("==", _var("schema_version"), _num(system.database.initial_schema)), system.database.loc),
+            ("assign", ("var", "schema_version"), _num(system.database.initial_schema), system.database.loc),
+        ], system.database.loc, False, _meta(
+            "DB-SNAPSHOT",
+            f"{system.database.name}: schema {system.database.initial_schema} static compatibility snapshot",
         )))
 
     invariant_metadata = {}
@@ -432,9 +476,22 @@ def expand_dbsystem(system):
         },
         {
             "id": "DB-ASSUME-CAPABILITY-DECLARATIONS",
-            "text": "artifact reads/writes declarations are complete for the checked compatibility window",
+            "text": "artifact capability declarations are complete for the checked compatibility window",
         },
     ]
+    if any(artifact.emits_offline for artifact in system.artifacts):
+        assumptions.append({
+            "id": "DB-ASSUME-OFFLINE-TTL-FINITE",
+            "text": "offline TTL values are finite logical ticks, not wall-clock time or probability",
+        })
+    if "data_preserved" in rules or "rollback_equivalent" in rules:
+        assumptions.append({
+            "id": "DB-ASSUME-BOUNDED-ROW-MODEL",
+            "text": (
+                "preservation and rollback checks use a bounded abstract row model; "
+                "they are not a proof over all production rows"
+            ),
+        })
 
     display_names = {
         "schema_version": "schema.version",

--- a/src/fslc/db_import.py
+++ b/src/fslc/db_import.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Minimal SQL DDL importer for the fsl-db typed IR boundary."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .db_ir import (
+    ColumnKey,
+    DbArtifact,
+    DbCheck,
+    DbColumn,
+    DbDatabase,
+    DbEnvironment,
+    DbEnvironmentArtifact,
+    DbMigration,
+    DbMigrationOp,
+    DbSystem,
+    DbTable,
+)
+
+
+@dataclass
+class DbImportResult:
+    system: DbSystem
+    source: str
+    warnings: List[dict] = field(default_factory=list)
+
+
+def import_sql_file(path, name="ImportedDb"):
+    return import_sql(Path(path).read_text(encoding="utf-8"), name=name)
+
+
+def import_sql(sql, name="ImportedDb"):
+    warnings: List[dict] = []
+    columns: Dict[ColumnKey, DbColumn] = {}
+    migrations: List[DbMigration] = []
+    current_schema = 0
+
+    for raw in _statements(sql):
+        parsed = _parse_statement(raw)
+        if parsed is None:
+            warnings.append({
+                "kind": "unsupported_sql",
+                "statement": raw,
+                "message": "SQL importer supports CREATE TABLE, ALTER TABLE ADD/DROP/RENAME COLUMN, and UPDATE ... SET for backfill",
+            })
+            continue
+        kind = parsed[0]
+        if kind == "create_table":
+            _, table, defs = parsed
+            for column_name, db_type, not_null in defs:
+                columns[(table, column_name)] = DbColumn(
+                    table=table,
+                    name=column_name,
+                    db_type=db_type,
+                    present=True,
+                    backfilled=True,
+                    not_null=not_null,
+                )
+        else:
+            current_schema += 1
+            migration = _migration_from_sql(parsed, current_schema - 1, current_schema, columns)
+            migrations.append(migration)
+
+    if not columns:
+        columns[("imported", "id")] = DbColumn(
+            table="imported",
+            name="id",
+            db_type="Int",
+            present=True,
+            backfilled=True,
+            not_null=True,
+        )
+        warnings.append({
+            "kind": "empty_import",
+            "message": "no supported table definition was found; emitted a placeholder schema",
+        })
+
+    tables = []
+    for table in sorted({key[0] for key in columns}):
+        tables.append(DbTable(
+            name=table,
+            columns=[columns[key] for key in sorted(columns) if key[0] == table],
+        ))
+
+    final_columns = _final_existing_columns(columns, migrations)
+    artifact = DbArtifact(
+        name="imported_artifact",
+        reads=final_columns,
+        writes=final_columns,
+    )
+    final_schema = current_schema
+    environment = DbEnvironment(
+        name="imported",
+        schema_window=(0, final_schema),
+        artifacts=[
+            DbEnvironmentArtifact("active", artifact.name, (final_schema, final_schema)),
+            DbEnvironmentArtifact("supported", artifact.name, (final_schema, final_schema)),
+        ],
+    )
+    system = DbSystem(
+        name=name,
+        database=DbDatabase(
+            name="imported",
+            initial_schema=0,
+            tables=tables,
+        ),
+        migrations=migrations,
+        artifacts=[artifact],
+        environments=[environment],
+        check=DbCheck(),
+    )
+    return DbImportResult(system=system, source=dbsystem_to_source(system), warnings=warnings)
+
+def _statements(sql):
+    cleaned = re.sub(r"--[^\n]*", "", sql)
+    return [stmt.strip() for stmt in cleaned.split(";") if stmt.strip()]
+
+
+def _parse_statement(stmt):
+    create = re.match(r"create\s+table\s+(\w+)\s*\((.*)\)\s*$", stmt, re.I | re.S)
+    if create:
+        table = create.group(1)
+        defs = []
+        for raw_col in _split_columns(create.group(2)):
+            parts = raw_col.strip().split()
+            if len(parts) < 2:
+                continue
+            column = parts[0].strip('"')
+            db_type = parts[1]
+            lowered = " ".join(parts[2:]).lower()
+            defs.append((column, db_type, "not null" in lowered or "primary key" in lowered))
+        return ("create_table", table, defs)
+
+    add = re.match(r"alter\s+table\s+(\w+)\s+add\s+column\s+(\w+)\s+(\w+)(.*)$", stmt, re.I | re.S)
+    if add:
+        return ("add_column", add.group(1), add.group(2), add.group(3), "not null" in add.group(4).lower())
+
+    drop = re.match(r"alter\s+table\s+(\w+)\s+drop\s+column\s+(\w+)\s*$", stmt, re.I)
+    if drop:
+        return ("drop_column", drop.group(1), drop.group(2))
+
+    rename = re.match(r"alter\s+table\s+(\w+)\s+rename\s+column\s+(\w+)\s+to\s+(\w+)\s*$", stmt, re.I)
+    if rename:
+        return ("rename_column", rename.group(1), rename.group(2), rename.group(3))
+
+    backfill = re.match(r"update\s+(\w+)\s+set\s+(\w+)\s*=", stmt, re.I | re.S)
+    if backfill:
+        return ("backfill", backfill.group(1), backfill.group(2))
+
+    return None
+
+
+def _split_columns(body):
+    out = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(body):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            out.append(body[start:i])
+            start = i + 1
+    out.append(body[start:])
+    return out
+
+
+def _migration_from_sql(parsed, from_schema, to_schema, columns):
+    kind = parsed[0]
+    name = f"m{to_schema}_{kind}"
+    if kind == "add_column":
+        _, table, column, db_type, not_null = parsed
+        columns.setdefault((table, column), DbColumn(
+            table=table,
+            name=column,
+            db_type=db_type,
+            present=False,
+            backfilled=False,
+            not_null=False,
+        ))
+        op = DbMigrationOp("add", (table, column), "not_null" if not_null else "nullable")
+    elif kind == "drop_column":
+        _, table, column = parsed
+        op = DbMigrationOp("drop", (table, column), annotations=("irreversible",))
+    elif kind == "rename_column":
+        _, table, old, new = parsed
+        old_column = columns.get((table, old), DbColumn(table=table, name=old))
+        columns.setdefault((table, old), old_column)
+        columns.setdefault((table, new), DbColumn(
+            table=table,
+            name=new,
+            db_type=old_column.db_type,
+            present=False,
+            backfilled=False,
+            not_null=False,
+        ))
+        op = DbMigrationOp("rename", (table, old), columns=((table, new),))
+    elif kind == "backfill":
+        _, table, column = parsed
+        op = DbMigrationOp("backfill", (table, column))
+    else:
+        raise AssertionError(kind)
+    return DbMigration(name, from_schema, to_schema, [op])
+
+
+def _final_existing_columns(columns, migrations):
+    state = {key: column.present for key, column in columns.items()}
+    for migration in migrations:
+        for op in migration.ops:
+            if op.op == "add":
+                state[op.column] = True
+            elif op.op == "drop":
+                state[op.column] = False
+            elif op.op == "rename":
+                state[op.column] = False
+                state[op.columns[0]] = True
+    return [key for key, present in sorted(state.items()) if present]
+
+
+def dbsystem_to_source(system: DbSystem):
+    lines = [f"dbsystem {system.name} {{", f"  database {system.database.name} {{"]
+    lines.append(f"    schema {system.database.initial_schema}")
+    for table in system.database.tables:
+        lines.append(f"    table {table.name} {{")
+        for column in table.columns:
+            attrs = ["present" if column.present else "absent"]
+            if column.backfilled:
+                attrs.append("backfilled")
+            attrs.append("not_null" if column.not_null else "nullable")
+            lines.append(f"      column {column.name}: {column.db_type} {' '.join(attrs)};")
+        lines.append("    }")
+    lines.append("  }")
+    lines.append("")
+    for migration in system.migrations:
+        annotations = (" " + " ".join(migration.annotations)) if migration.annotations else ""
+        lines.append(f"  migration {migration.name} from {migration.from_schema} to {migration.to_schema}{annotations} {{")
+        for op in migration.ops:
+            op_annotations = (" " + " ".join(op.annotations)) if op.annotations else ""
+            if op.op == "add":
+                lines.append(f"    add {column_label(op.column)} {op.nullability or 'nullable'};")
+            elif op.op == "drop":
+                lines.append(f"    drop {column_label(op.column)}{op_annotations};")
+            elif op.op == "backfill":
+                lines.append(f"    backfill {column_label(op.column)};")
+            elif op.op == "rename":
+                lines.append(f"    rename {column_label(op.column)} to {column_label(op.columns[0])}{op_annotations};")
+        lines.append("  }")
+        lines.append("")
+    for artifact in system.artifacts:
+        lines.append(f"  artifact {artifact.name} {{")
+        if artifact.reads:
+            lines.append(f"    reads {', '.join(column_label(c) for c in artifact.reads)};")
+        if artifact.writes:
+            lines.append(f"    writes {', '.join(column_label(c) for c in artifact.writes)};")
+        lines.append("  }")
+        lines.append("")
+    for env in system.environments:
+        lines.append(f"  environment {env.name} {{")
+        lines.append(f"    schema {env.schema_window[0]}..{env.schema_window[1]};")
+        for entry in env.artifacts:
+            if entry.schema_window:
+                lines.append(
+                    f"    {entry.role} {entry.artifact} when schema {entry.schema_window[0]}..{entry.schema_window[1]};"
+                )
+            else:
+                lines.append(f"    {entry.role} {entry.artifact};")
+        lines.append("  }")
+        lines.append("")
+    lines.append("  check compatibility {")
+    lines.append("    rule all_active_reads_exist;")
+    lines.append("    rule all_active_writes_exist;")
+    lines.append("    rule removed_only_after_unused;")
+    lines.append("    rule not_null_after_backfill;")
+    lines.append("  }")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def column_label(column: ColumnKey) -> str:
+    return f"{column[0]}.{column[1]}"

--- a/src/fslc/db_ir.py
+++ b/src/fslc/db_ir.py
@@ -51,6 +51,8 @@ class DbMigrationOp:
     op: str
     column: ColumnKey
     nullability: Optional[str] = None
+    columns: Tuple[ColumnKey, ...] = ()
+    annotations: Tuple[str, ...] = ()
     loc: Optional[dict] = None
 
     @property
@@ -64,6 +66,7 @@ class DbMigration:
     from_schema: int
     to_schema: int
     ops: List[DbMigrationOp] = field(default_factory=list)
+    annotations: Tuple[str, ...] = ()
     loc: Optional[dict] = None
 
 
@@ -75,7 +78,9 @@ class DbArtifact:
     calls: List[ColumnKey] = field(default_factory=list)
     accepts: List[ColumnKey] = field(default_factory=list)
     expects: List[ColumnKey] = field(default_factory=list)
+    responds: List[ColumnKey] = field(default_factory=list)
     emits_offline: List[ColumnKey] = field(default_factory=list)
+    offline_ttls: Dict[ColumnKey, int] = field(default_factory=dict)
     loc: Optional[dict] = None
 
 

--- a/src/fslc/db_parser.py
+++ b/src/fslc/db_parser.py
@@ -43,23 +43,33 @@ column_type: ":" NAME
             | "not_null" -> col_not_null
             | "nullable" -> col_nullable
 
-migration_def: "migration" NAME "from" INT "to" INT "{" migration_op* "}"
-?migration_op: add_op | drop_op | backfill_op | set_not_null_op
+migration_def: "migration" NAME "from" INT "to" INT annotation* "{" migration_op* "}"
+?migration_op: add_op | drop_op | backfill_op | set_not_null_op | rename_op | split_op | merge_op
 add_op: "add" col_ref add_nullability? ";"?
 add_nullability: "nullable" -> op_nullable
                | "not_null" -> op_not_null
-drop_op: "drop" col_ref ";"?
+drop_op: "drop" col_ref annotation* ";"?
 backfill_op: "backfill" col_ref ";"?
 set_not_null_op: ("set_not_null" | "not_null") col_ref ";"?
+rename_op: "rename" col_ref "to" col_ref annotation* ";"?
+split_op: "split" col_ref "into" col_ref_list annotation* ";"?
+merge_op: "merge" col_ref_list "into" col_ref annotation* ";"?
+annotation: "destructive" -> ann_destructive
+          | "irreversible" -> ann_irreversible
+          | "rollbackable" -> ann_rollbackable
+          | "lossy" -> ann_lossy
+          | "lossless" -> ann_lossless
 
 artifact_def: "artifact" NAME "{" artifact_item* "}"
-artifact_item: artifact_capability col_ref_list ";"?
+artifact_item: artifact_capability col_ref_list ttl_clause? ";"?
 artifact_capability: "reads" -> cap_reads
                    | "writes" -> cap_writes
                    | "calls" -> cap_calls
                    | "accepts" -> cap_accepts
                    | "expects" -> cap_expects
+                   | "responds" -> cap_responds
                    | "emits_offline" -> cap_emits_offline
+ttl_clause: "ttl" INT
 col_ref_list: col_ref ("," col_ref)*
 col_ref: NAME "." NAME
 
@@ -179,19 +189,50 @@ class DbAst(Transformer):
         return "not_null"
 
     def add_op(self, meta, column, nullability=None):
-        return DbMigrationOp("add", column, nullability or "nullable", _loc(meta))
+        return DbMigrationOp("add", column, nullability or "nullable", loc=_loc(meta))
 
-    def drop_op(self, meta, column):
-        return DbMigrationOp("drop", column, None, _loc(meta))
+    def drop_op(self, meta, column, *annotations):
+        return DbMigrationOp("drop", column, None, (), tuple(annotations), _loc(meta))
 
     def backfill_op(self, meta, column):
-        return DbMigrationOp("backfill", column, None, _loc(meta))
+        return DbMigrationOp("backfill", column, loc=_loc(meta))
 
     def set_not_null_op(self, meta, column):
-        return DbMigrationOp("set_not_null", column, None, _loc(meta))
+        return DbMigrationOp("set_not_null", column, loc=_loc(meta))
 
-    def migration_def(self, meta, name, from_schema, to_schema, *ops):
-        return DbMigration(name, from_schema, to_schema, list(ops), _loc(meta))
+    def ann_destructive(self, meta):
+        return "destructive"
+
+    def ann_irreversible(self, meta):
+        return "irreversible"
+
+    def ann_rollbackable(self, meta):
+        return "rollbackable"
+
+    def ann_lossy(self, meta):
+        return "lossy"
+
+    def ann_lossless(self, meta):
+        return "lossless"
+
+    def rename_op(self, meta, source, target, *annotations):
+        return DbMigrationOp("rename", source, None, (target,), tuple(annotations), _loc(meta))
+
+    def split_op(self, meta, source, targets, *annotations):
+        return DbMigrationOp("split", source, None, tuple(targets), tuple(annotations), _loc(meta))
+
+    def merge_op(self, meta, sources, target, *annotations):
+        return DbMigrationOp("merge", target, None, tuple(sources), tuple(annotations), _loc(meta))
+
+    def migration_def(self, meta, name, from_schema, to_schema, *parts):
+        annotations = []
+        ops = []
+        for part in parts:
+            if isinstance(part, DbMigrationOp):
+                ops.append(part)
+            else:
+                annotations.append(part)
+        return DbMigration(name, from_schema, to_schema, ops, tuple(annotations), _loc(meta))
 
     def cap_reads(self, meta):
         return "reads"
@@ -208,19 +249,29 @@ class DbAst(Transformer):
     def cap_expects(self, meta):
         return "expects"
 
+    def cap_responds(self, meta):
+        return "responds"
+
     def cap_emits_offline(self, meta):
         return "emits_offline"
+
+    def ttl_clause(self, meta, ttl):
+        return ttl
 
     def col_ref_list(self, meta, *refs):
         return list(refs)
 
-    def artifact_item(self, meta, capability, refs):
-        return capability, refs
+    def artifact_item(self, meta, capability, refs, ttl=None):
+        return capability, refs, ttl
 
     def artifact_def(self, meta, name, *items):
         caps = defaultdict(list)
-        for capability, refs in items:
+        offline_ttls = {}
+        for capability, refs, ttl in items:
             caps[capability].extend(refs)
+            if capability == "emits_offline" and ttl is not None:
+                for ref in refs:
+                    offline_ttls[ref] = ttl
         return DbArtifact(
             name=name,
             reads=caps["reads"],
@@ -228,7 +279,9 @@ class DbAst(Transformer):
             calls=caps["calls"],
             accepts=caps["accepts"],
             expects=caps["expects"],
+            responds=caps["responds"],
             emits_offline=caps["emits_offline"],
+            offline_ttls=offline_ttls,
             loc=_loc(meta),
         )
 

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -125,13 +125,63 @@
       "result": "error"
     }
   },
+  "examples/db/runtime_observation_target.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/db/safe_add_nullable_column.fsl": {
     "check": {
       "result": "ok",
       "warnings": []
     }
   },
+  "examples/db/safe_api_offline_compat.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/safe_destructive_drop_with_annotation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/safe_rename_preservation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/safe_rollback_equivalence.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/db/unsafe_annotated_drop_with_old_server.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/unsafe_api_response_field_removed.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/unsafe_destructive_drop_without_annotation.fsl": {
     "check": {
       "result": "ok",
       "warnings": []
@@ -149,7 +199,43 @@
       "warnings": []
     }
   },
+  "examples/db/unsafe_lossy_merge_preservation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/db/unsafe_lossy_split_preservation.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
   "examples/db/unsafe_not_null_before_backfill.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/unsafe_offline_payload_rejected.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/unsafe_rollback_drop.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": [
+        "none"
+      ]
+    }
+  },
+  "examples/db/unsafe_split_without_annotation.fsl": {
     "check": {
       "result": "ok",
       "warnings": []

--- a/tests/test_db_dialect.py
+++ b/tests/test_db_dialect.py
@@ -5,7 +5,7 @@
 
 from pathlib import Path
 
-from fslc.cli import run_check, run_db_check, run_verify
+from fslc.cli import run_check, run_db_check, run_db_import, run_db_observe, run_verify
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +14,14 @@ EXAMPLES = ROOT / "examples" / "db"
 
 def _example(name):
     return str(EXAMPLES / name)
+
+
+def _finding_kinds(out):
+    return {finding["kind"] for finding in out["findings"]}
+
+
+def _assumption_ids(out):
+    return {assumption["id"] for assumption in out["assumptions"]}
 
 
 def test_db_system_check_accepts_mvp_syntax():
@@ -117,3 +125,114 @@ def test_db_reference_errors_are_json_errors(tmp_path):
     assert out["result"] == "error"
     assert out["kind"] == "semantics"
     assert "unknown column 'users.missing'" in out["message"]
+
+
+def test_db_destructive_drop_requires_annotation():
+    out = run_db_check(_example("unsafe_destructive_drop_without_annotation.fsl"))
+
+    assert out["result"] == "violated"
+    finding = out["findings"][0]
+    assert finding["kind"] == "destructive_migration_unannotated"
+    assert finding["failed_rule"] == "destructive_operations_annotated"
+    assert finding["schema_element"] == "users.legacy_name"
+    assert {candidate["kind"] for candidate in finding["repair_candidates"]} == {
+        "annotation_change",
+        "compat_shim",
+    }
+
+
+def test_db_destructive_annotation_does_not_weaken_compatibility():
+    safe = run_db_check(_example("safe_destructive_drop_with_annotation.fsl"))
+    assert safe["result"] == "verified_under_assumptions"
+
+    unsafe = run_db_check(_example("unsafe_annotated_drop_with_old_server.fsl"))
+    assert unsafe["result"] == "violated"
+    assert "column_removed_while_still_read" in _finding_kinds(unsafe)
+    assert "destructive_migration_unannotated" not in _finding_kinds(unsafe)
+
+
+def test_db_preservation_and_rollback_rules_report_bounded_findings():
+    safe_rename = run_db_check(_example("safe_rename_preservation.fsl"))
+    assert safe_rename["result"] == "verified_under_assumptions"
+    assert "DB-ASSUME-BOUNDED-ROW-MODEL" in _assumption_ids(safe_rename)
+
+    lossy_split = run_db_check(_example("unsafe_lossy_split_preservation.fsl"))
+    assert lossy_split["result"] == "violated"
+    assert lossy_split["findings"][0]["kind"] == "data_preservation_loss"
+    assert lossy_split["findings"][0]["failed_rule"] == "data_preserved"
+    assert "DB-ASSUME-BOUNDED-ROW-MODEL" in _assumption_ids(lossy_split)
+
+    lossy_merge = run_db_check(_example("unsafe_lossy_merge_preservation.fsl"))
+    assert lossy_merge["result"] == "violated"
+    assert lossy_merge["findings"][0]["kind"] == "data_preservation_loss"
+    assert lossy_merge["findings"][0]["failed_rule"] == "data_preserved"
+
+    unannotated_split = run_db_check(_example("unsafe_split_without_annotation.fsl"))
+    assert unannotated_split["result"] == "violated"
+    assert unannotated_split["findings"][0]["kind"] == "preservation_transform_unannotated"
+
+    safe_rollback = run_db_check(_example("safe_rollback_equivalence.fsl"))
+    assert safe_rollback["result"] == "verified_under_assumptions"
+    assert "DB-ASSUME-BOUNDED-ROW-MODEL" in _assumption_ids(safe_rollback)
+
+    rollback_drop = run_db_check(_example("unsafe_rollback_drop.fsl"))
+    assert rollback_drop["result"] == "violated"
+    assert rollback_drop["findings"][0]["kind"] == "rollback_not_equivalent"
+    assert rollback_drop["findings"][0]["failed_rule"] == "rollback_equivalent"
+
+
+def test_db_api_and_offline_compatibility_are_environment_scoped():
+    safe = run_db_check(_example("safe_api_offline_compat.fsl"))
+    assert safe["result"] == "verified_under_assumptions"
+    assert "DB-ASSUME-OFFLINE-TTL-FINITE" in _assumption_ids(safe)
+
+    missing_response = run_db_check(_example("unsafe_api_response_field_removed.fsl"))
+    assert missing_response["result"] == "violated"
+    assert missing_response["findings"][0]["kind"] == "api_response_field_missing"
+    assert missing_response["findings"][0]["result"] == "violated"
+
+    rejected_offline = run_db_check(_example("unsafe_offline_payload_rejected.fsl"))
+    assert rejected_offline["result"] == "violated"
+    finding = rejected_offline["findings"][0]
+    assert finding["kind"] == "offline_payload_not_accepted"
+    assert finding["witness"]["ttl_ticks"] == 2
+    assert "DB-ASSUME-OFFLINE-TTL-FINITE" in _assumption_ids(rejected_offline)
+
+
+def test_db_runtime_observation_reports_observed_mismatch_not_formal_violation():
+    out = run_db_observe(
+        _example("runtime_observation_target.fsl"),
+        _example("runtime_observation_mismatch.json"),
+    )
+
+    assert out["result"] == "observed_mismatch"
+    assert out["formal_result"] == "not_run"
+    assert out["observation_schema_version"] == "fsl-db-observation.v0"
+    assert _finding_kinds(out) == {
+        "declared_unused_but_observed",
+        "legacy_api_still_called",
+    }
+    assert {finding["result"] for finding in out["findings"]} == {"observed_mismatch"}
+    assert "DB-ASSUME-OBSERVABILITY-COVERAGE" in _assumption_ids(out)
+
+
+def test_db_sql_importer_emits_checkable_dbsystem(tmp_path):
+    output = tmp_path / "imported.fsl"
+    imported = run_db_import(
+        _example("minimal_import.sql"),
+        name="ImportedFromSql",
+        output=str(output),
+    )
+
+    assert imported["result"] == "imported"
+    assert imported["output"] == str(output)
+    checked = run_db_check(str(output))
+    assert checked["result"] == "verified_under_assumptions"
+
+
+def test_db_sql_importer_reports_unsupported_constructs():
+    imported = run_db_import(_example("unsupported_import.sql"), name="ImportedFromSql")
+
+    assert imported["result"] == "imported_with_warnings"
+    assert imported["warnings"][0]["kind"] == "unsupported_sql"
+    assert "CREATE INDEX" in imported["warnings"][0]["statement"]


### PR DESCRIPTION
## Summary
- Extend fsl-db beyond DB column lifecycle into multi-environment API/offline compatibility, destructive annotations, bounded preservation/rollback checks, runtime observation, and minimal SQL DDL import.
- Add DB finding and observation schemas, CLI subcommands, examples, corpus snapshot updates, and docs/skill references.
- Keep runtime observation separate from formal verification with observed_mismatch and explicit observability assumptions.

## Verification
- .venv/bin/python -m compileall -q src/fslc
- .venv/bin/python -m pytest tests/test_db_dialect.py -q
- .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q
- .venv/bin/python -m pytest tests/test_vacuity.py::test_verified_sample_corpus_has_no_vacuity_false_positives -q
- .venv/bin/python -m pytest -q (954 passed, 78 skipped)

Closes #129
Closes #130
Closes #131
Closes #132
Closes #133
Closes #134