### PR TITLE
fix(lsp): include cross-file declaration in textDocument/references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `<actionname>: by <actor>` requirement caption on actions now that a
   business-dialect transition's actor has its own Actor column (real
   `REQ-n`/`POL-n` prose captions are unaffected).
+- (LSP) `textDocument/references` with `includeDeclaration=true` now returns the
+  declaration even when the cursor is on a *cross-file* reference (e.g. a
+  `use`-imported `alias.member` in another spec). Previously the declaration was
+  dropped in that case: `references_at()` only emits the declaration when it lives
+  in the current document, and the workspace loop in `_workspace_references`
+  (`src/fslc/lsp/server.py`) scans other files' references, never their
+  declaration symbol, so a symbol declared in a different workspace file was
+  omitted from the results. `go-to-definition` was unaffected.
 
 ### Changed
 - `skills/` reframed around the doc-substitution philosophy: a `.fsl` spec

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -539,6 +539,21 @@ def _workspace_references(
     target_name, target_loc = target
 
     this_norm = str(Path(this_path).resolve(strict=False)) if this_path else None
+
+    # LSP includeDeclaration: references_at() emits the declaration only when it
+    # lives in the current document (see index.py); the cross-file loop below scans
+    # other files' references, never their declaration symbol. So when the cursor is
+    # on a cross-file reference and the symbol is declared in a different workspace
+    # file, that declaration would be dropped -- add it explicitly here.
+    if include_declaration and target_loc.path is not None:
+        if str(Path(target_loc.path).resolve(strict=False)) != this_norm:
+            results.append(
+                types.Location(
+                    uri=_path_to_uri(target_loc.path),
+                    range=_to_lsp_range(types, target_loc.range),
+                )
+            )
+
     for root in _workspace_roots(server, this_path):
         for fsl_path in sorted(root.rglob("*.fsl")):
             if not fsl_path.is_file():

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -257,6 +257,54 @@ def test_workspace_references_finds_cross_file_alias_reference(tmp_path):
     assert {_loc_key(loc) for loc in result} == expected
 
 
+def test_workspace_references_includes_cross_file_declaration(tmp_path):
+    # Regression: cursor on a cross-file *reference* (main.fsl `lib.bump`) with
+    # include_declaration=True must still return the declaration in lib.fsl.
+    # references_at() only emits the declaration when it lives in the current
+    # document, and the workspace loop scans other files' references (never their
+    # declaration symbol), so the declaration used to be dropped for this case.
+    lib_path = tmp_path / "lib.fsl"
+    main_path = tmp_path / "main.fsl"
+    lib_path.write_text(LIB_SOURCE, encoding="utf-8")
+    main_path.write_text(MAIN_SOURCE, encoding="utf-8")
+
+    lib_index = build_index(LIB_SOURCE, str(lib_path))
+    bump = _symbol(lib_index, "bump", "action")
+    main_index = build_index(MAIN_SOURCE, str(main_path))
+    main_bump_refs = [ref for ref in main_index.references if ref.name == "bump"]
+    assert len(main_bump_refs) == 2
+
+    server = _create_server()
+    _initialize(server)
+    lib_uri = _path_to_uri(str(lib_path))
+    main_uri = _path_to_uri(str(main_path))
+
+    # Cursor on the first cross-file reference in main.fsl (the `= lib.bump(i)` target).
+    cursor = main_bump_refs[0]
+    references_handler = server.lsp.fm.features[types.TEXT_DOCUMENT_REFERENCES]
+    result = references_handler(
+        types.ReferenceParams(
+            text_document=types.TextDocumentIdentifier(uri=main_uri),
+            position=types.Position(
+                line=cursor.range.start.line,
+                character=cursor.range.start.character,
+            ),
+            context=types.ReferenceContext(include_declaration=True),
+        )
+    )
+
+    assert result is not None
+    declaration = types.Location(
+        uri=lib_uri, range=_to_lsp_range(types, bump.selection_range)
+    )
+    got = {_loc_key(loc) for loc in result}
+    assert _loc_key(declaration) in got  # the cross-file declaration must be present
+    for ref in main_bump_refs:
+        assert _loc_key(
+            types.Location(uri=main_uri, range=_to_lsp_range(types, ref.range))
+        ) in got
+
+
 def test_completion_handler_suggests_alias_members(tmp_path):
     lib_path = tmp_path / "lib.fsl"
     main_path = tmp_path / "main.fsl"


### PR DESCRIPTION
## Summary
- `textDocument/references` with `includeDeclaration=true` dropped the declaration when the cursor sat on a *cross-file* reference (e.g. a `use`-imported `alias.member` resolved in another spec).
- Root cause: `references_at()` (`index.py`) only emits the declaration when it lives in the current document, and the workspace loop in `_workspace_references` (`server.py`) scans other files' *references* but never their declaration symbol — so a symbol declared in a different workspace file fell through both paths.
- Fix: when `include_declaration` is set and the resolved declaration's path differs from the current document, add it explicitly.
- `go-to-definition` was unaffected; this only affected the `references` response.

## Test plan
- [x] Added regression test `test_workspace_references_includes_cross_file_declaration` (cursor on a cross-file reference in `main.fsl`, asserts the `lib.fsl` declaration and both `main.fsl` references are all present).
- [x] `pytest tests/test_lsp_server.py -q` — 11 passed (includes upstream's newly-merged analysis-diagnostics tests).
- [x] Rebased onto `origin/main` (16 commits ahead); resolved a `CHANGELOG.md` conflict by folding this entry into the `### Fixed` section upstream had already opened. No overlap with upstream's `server.py`/test changes (different regions of the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)