### PR TITLE
feat(db): complete multi-environment follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   importer via `fslc db import`. The new checks stay under explicit assumptions
   for finite rollout windows, offline TTL ticks, bounded row models, and
   observability coverage. (#129, #130, #131, #132, #133, #134)
+- fsl-db DB/multi-environment follow-ups: finite feature-flag variants in
+  `environment` blocks with `when flag name=value` artifact windows and
+  `DB-ASSUME-FINITE-FLAG-STATE`, a minimal Prisma schema importer
+  (`prisma-schema-minimal.v0`) alongside SQL DDL import, and external
+  preservation/engine evidence JSON schemas plus fixtures that keep sampled,
+  audited, and dry-run evidence separate from formal proof
+  (`formal_result:"not_run"`). (#144, #145, #146, #147)
 - Issue #104 follow-ups: typed `relation A -> B` state with relation helpers
   (`.contains/.add/.remove`, `reachable`, `acyclic`, `functional`,
   `injective`, `domain`, `range`); `helpful action(args)` metadata for

--- a/docs/DESIGN-db.md
+++ b/docs/DESIGN-db.md
@@ -1,7 +1,8 @@
 # FSL DB / Multi-Environment Compatibility Dialect Design
 
-Status: adopted. The first slice shipped issues #122-#128; the bounded
-post-MVP compatibility extensions cover issues #129-#134.
+Status: adopted. The first slice shipped issues #122-#128; bounded
+compatibility extensions cover issues #129-#134, and DB/multi-environment
+follow-ups cover issues #144-#147.
 
 ## Decision
 
@@ -71,7 +72,32 @@ Destructive operations must be explicit. A `drop` of an existing column requires
 metadata, not a spec weakening. An annotated drop can still fail read/write/API
 compatibility.
 
-### 3. Preservation and Rollback
+### 3. Feature-Flag Snapshots
+
+Feature flags are first-class finite environment dimensions. They are not
+probabilities, percentage-rollout proofs, or experimentation population models.
+An environment may declare finite variants:
+
+```fsl
+environment prod {
+  schema 0..1;
+  flag email_v2 { off, on } default off;
+  active server_legacy when schema 0..1 when flag email_v2=off;
+  active server_new when schema 1..1 when flag email_v2=on;
+  may_exist ios_new when schema 1..1 when flag email_v2=on;
+}
+```
+
+`fslc db check` enumerates `(environment, schema_version, flag variants)` and
+applies the same DB/API/offline compatibility rules inside each finite snapshot.
+Existing artifact/window modeling remains the simple form: omit `flag` and
+`when flag` when rollout variants are irrelevant.
+
+A kill switch is checkable by keeping or reintroducing the old artifact's
+`when flag ...=off` window. The result includes
+`DB-ASSUME-FINITE-FLAG-STATE` whenever any environment declares flags.
+
+### 4. Preservation and Rollback
 
 `data_preserved` and `rollback_equivalent` are bounded abstract checks, not full
 production-data proofs. They model whether the migration preserves observable
@@ -88,7 +114,19 @@ Supported preservation transforms:
 `irreversible`. A lossy transform can be operationally intentional, but it still
 violates `data_preserved`; the annotation prevents silent acceptance.
 
-### 4. Runtime Observation
+Production-data preservation evidence can be attached outside the formal result
+using `schemas/fslc/db/preservation-evidence.v0.schema.json`. Supported evidence
+families include sampled/offline diff jobs, shadow reads, dual-read comparisons,
+and post-migration audits. These results use `formal_result: "not_run"` and
+statuses such as `evidence_supported` or `evidence_failed`; they must not be
+reported as `verified` or `proved`.
+
+Evidence payloads must identify schemas, tables, columns, migration IDs, sample
+counts, and aggregate mismatch counts only. Row values, SQL literals, secrets,
+payload bodies, and raw production records are outside the schema and must be
+redacted before storage.
+
+### 5. Runtime Observation
 
 Runtime observation is evidence, not proof. `fslc db observe` compares an
 observation log to a `dbsystem` and emits `observed_mismatch` findings such as:
@@ -101,7 +139,7 @@ Absence from logs is not proof of unused behavior. Observation results include
 `DB-ASSUME-OBSERVABILITY-COVERAGE` and `formal_result: "not_run"` to keep them
 separate from formal compatibility verification.
 
-### 5. Importer Boundary
+### 6. Importer Boundary
 
 `fslc db import` provides a deliberately small SQL DDL importer to establish the
 typed IR boundary. It supports:
@@ -113,8 +151,48 @@ typed IR boundary. It supports:
 - `UPDATE ... SET ...` as a backfill signal
 
 Unsupported constructs are reported as `unsupported_sql` warnings and are not
-silently ignored. ORM-specific importers (Prisma, Rails, Drizzle, etc.) are
-extension points built on the same IR, not part of this first importer.
+silently ignored.
+
+The first ORM-specific importer is `prisma-schema-minimal.v0`. It imports
+Prisma `model` scalar fields into the same typed IR and reports relation/list or
+model-level constructs as `unsupported_prisma` warnings. Additional importers
+(Rails, Drizzle, Django, Alembic, vendor DSLs) must follow the same rule:
+source-specific constructs either become fsl-db IR or explicit warnings; no DB
+engine runtime semantics are inferred without a separate evidence artifact.
+
+### 7. DB-Engine Evidence Boundary
+
+fsl-db formal compatibility is engine-agnostic by default. It does not model:
+
+- lock acquisition order, lock wait timing, or online DDL blocking behavior
+- optimizer plans, index selection, query latency, or vacuum/analyze effects
+- transaction isolation anomalies or vendor-specific migration executor details
+- cloud-provider maintenance windows or wall-clock migration duration
+
+Operational engine evidence is represented separately with
+`schemas/fslc/db/engine-evidence.v0.schema.json`. A concrete adapter shape is:
+
+```json
+{
+  "schema_version": "fsl-db-engine-evidence.v0",
+  "formal_result": "not_run",
+  "engine": {"vendor": "postgresql", "version": "16"},
+  "adapter": {"kind": "migration_dry_run", "tool": "vendor-online-ddl-checker"},
+  "migration": "add_email_normalized",
+  "checks": [
+    {"kind": "lock_timeout", "status": "passed", "max_wait_ms": 5000},
+    {"kind": "online_ddl_validator", "status": "passed"}
+  ],
+  "assumptions": [
+    {"id": "DB-ENGINE-ASSUME-STAGING-LIKE-PROD", "text": "dry-run environment matches production engine settings relevant to this check"}
+  ],
+  "redaction": {"policy": "engine evidence contains identifiers and aggregate timings only"}
+}
+```
+
+Engine evidence may support or reject an operational rollout plan, but it is not
+a kernel proof and must not change `fslc db check` from
+`verified_under_assumptions` to `verified`/`proved`.
 
 ## Syntax
 
@@ -154,7 +232,8 @@ dbsystem UserDb {
 
   environment prod {
     schema 0..3;
-    active server_v2 when schema 1..3;
+    flag email_v2 { off, on } default off;
+    active server_v2 when schema 1..3 when flag email_v2=on;
     may_exist ios_v1 when schema 0..3;
   }
 
@@ -190,6 +269,7 @@ fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
 fslc db import examples/db/minimal_import.sql --name ImportedFromSql -o /tmp/imported.fsl
+fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrisma
 ```
 
 ## Finding Contract
@@ -263,6 +343,8 @@ Assumptions reported by `fslc db check` may include:
 - `DB-ASSUME-OFFLINE-TTL-FINITE`: offline TTL values are finite logical ticks
 - `DB-ASSUME-BOUNDED-ROW-MODEL`: preservation and rollback checks use a bounded
   abstract row model
+- `DB-ASSUME-FINITE-FLAG-STATE`: feature flags are finite declared variants,
+  not percentage/probability proofs
 
 `fslc db observe` additionally reports:
 
@@ -271,8 +353,7 @@ Assumptions reported by `fslc db check` may include:
 
 ## Remaining Boundaries
 
-- DB-engine-specific locking/optimizer semantics
-- full production-data preservation proof
 - probability, wall-clock time, and percentile reasoning
-- ORM-specific importers beyond the first minimal SQL DDL importer
-- feature-flag semantics beyond finite artifact/window modeling
+- production-data evidence beyond aggregate/sample/audit artifacts
+- DB-engine behavior beyond explicit external evidence adapters
+- ORM/vendor importers beyond SQL and the first minimal Prisma schema importer

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -120,7 +120,8 @@ dbsystem <Name> {
 
   environment <env> {
     schema <lo>..<hi>;
-    active <version> when schema <lo>..<hi>;
+    flag <flag_name> { <variant>, ... } default <variant>;
+    active <version> when schema <lo>..<hi> when flag <flag_name>=<variant>;
     supported <version> when schema <lo>..<hi>;
     may_exist <version> when schema <lo>..<hi>;
   }
@@ -148,7 +149,9 @@ stable fsl-db findings and returns `verified_under_assumptions` for successful
 formal checks. Environment schema ranges are finite reachable snapshots in the
 declared migration order; rollout percentages and offline TTLs must be modeled as
 finite coexistence windows/ticks. API/offline and bounded preservation/rollback
-checks are dialect-level compatibility checks. See `docs/DESIGN-db.md`.
+checks are dialect-level compatibility checks. Feature flags are finite declared
+variants inside an environment and add `DB-ASSUME-FINITE-FLAG-STATE`; they do
+not prove rollout percentages. See `docs/DESIGN-db.md`.
 
 `fslc verify` can override a `verify` block's `instances`/`values` bounds from
 the command line, without editing the spec:
@@ -1406,6 +1409,12 @@ destructive annotations, preservation-transform annotations, and API/offline
 compatibility. `data_preserved` and `rollback_equivalent` are opt-in bounded
 checks and report `DB-ASSUME-BOUNDED-ROW-MODEL`.
 
+Feature flags are finite environment dimensions. `fslc db check` enumerates the
+declared variants with schema snapshots and reports
+`DB-ASSUME-FINITE-FLAG-STATE`; this is a rollout/kill-switch compatibility
+check, not a percentage or probability proof. Omit `flag` / `when flag` to keep
+the existing artifact/window-only model.
+
 Current formal violation kinds include:
 
 - `column_removed_while_still_read`
@@ -1426,6 +1435,7 @@ fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
 fslc db import examples/db/minimal_import.sql --name ImportedFromSql -o /tmp/imported.fsl
+fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrisma
 ```
 
 Successful checks return `verified_under_assumptions` with the finite rollout and
@@ -1436,6 +1446,14 @@ candidates. Runtime observation returns `observed_mismatch` with
 `formal_result: "not_run"`; absence from logs is not proof of unused behavior.
 Use ordinary `fslc verify` when you want to inspect the generated kernel
 counterexample directly.
+
+Importer boundary: SQL DDL import is `sql-ddl-minimal.v0`. The first
+source-specific ORM importer is `prisma-schema-minimal.v0`, which imports Prisma
+`model` scalar fields and reports relation/list/model attributes as
+`unsupported_prisma` warnings. Production-data preservation evidence and
+DB-engine evidence live in separate JSON schemas under `schemas/fslc/db/` and
+use `formal_result: "not_run"`; they never upgrade sampled/audited evidence into
+`verified` or `proved`.
 
 ### 13.6 AI hard-contract layer: `ai_component` (fsl-ai)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@
 | [`DESIGN-typestate.md`](DESIGN-typestate.md) | `fslc typestate` (applicability check for state machine → typestate + TS scaffold) |
 | [`DESIGN-analysis.md`](DESIGN-analysis.md) | `fslc analyze` (Typed Semantic Graph, graph projections, focus impact slices, action dependency/conflict graphs, structural metrics, batch mode, refinement/project traceability graphs, DOT/Mermaid exports, schemas, AI-readable structural review findings/candidates) |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
-| [`DESIGN-db.md`](DESIGN-db.md) | fsl-db (`dbsystem`) database compatibility dialect: multi-environment schema/artifact checks, finding schema, rollout assumptions, and post-MVP preservation/runtime boundaries |
+| [`DESIGN-db.md`](DESIGN-db.md) | fsl-db (`dbsystem`) database compatibility dialect: multi-environment schema/artifact/feature-flag checks, finding schema, rollout assumptions, SQL/Prisma importers, and external preservation/engine evidence boundaries |
 | [`DESIGN-ai-hard.md`](DESIGN-ai-hard.md) | fsl-ai (`ai_component`) hard-contract dialect: tool authority, human approval, forbidden tools, fallback, event replay, finding schema, and guarantee boundaries |
 
 ## Dogfooding records (DOGFOOD-*)

--- a/docs/intro/db.en.html
+++ b/docs/intro/db.en.html
@@ -144,7 +144,8 @@ environment prod {
 
   environment prod {
     schema 0..3;
-    active server_v2 when schema 1..3;
+    flag email_v2 { off, on } default off;
+    active server_v2 when schema 1..3 when flag email_v2=on;
     supported server_v2 when schema 1..3;
     may_exist ios_v1 when schema 0..3;
   }
@@ -178,7 +179,8 @@ fslc verify examples/db/safe_add_nullable_column.fsl --depth 8
 fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
-fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre>
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql
+fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrisma</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>Result</th><th>How to read it</th></tr>
@@ -204,7 +206,7 @@ fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre
       </div>
       <div class="syntax-card">
         <h3>API / offline / feature flags</h3>
-        <p>API operations, response fields, and offline payload TTLs can be written as finite capabilities/ticks. Feature flags are approximated as artifact/window variants.</p>
+        <p>API operations, response fields, offline payload TTLs, and feature flags are finite capabilities, ticks, and declared variants. They remain rollout snapshots, not probability proofs.</p>
       </div>
       <div class="syntax-card">
         <h3>Runtime observation</h3>
@@ -212,7 +214,11 @@ fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre
       </div>
       <div class="syntax-card">
         <h3>SQL/ORM import</h3>
-        <p><code>fslc db import</code> converts a minimal SQL DDL subset to <code>dbsystem</code>. Prisma, Rails, Drizzle, and other ORM importers are extension points.</p>
+        <p><code>fslc db import</code> converts minimal SQL DDL and Prisma schema scalar fields to <code>dbsystem</code>. Unsupported constructs are explicit warnings.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>External evidence</h3>
+        <p>Production-data diff/audit evidence and DB-engine dry-run evidence use separate JSON schemas with <code>formal_result: "not_run"</code>.</p>
       </div>
       <div class="syntax-card">
         <h3>Time and probability</h3>

--- a/docs/intro/db.ja.html
+++ b/docs/intro/db.ja.html
@@ -144,7 +144,8 @@ environment prod {
 
   environment prod {
     schema 0..3;
-    active server_v2 when schema 1..3;
+    flag email_v2 { off, on } default off;
+    active server_v2 when schema 1..3 when flag email_v2=on;
     supported server_v2 when schema 1..3;
     may_exist ios_v1 when schema 0..3;
   }
@@ -178,7 +179,8 @@ fslc verify examples/db/safe_add_nullable_column.fsl --depth 8
 fslc db check examples/db/safe_add_nullable_column.fsl
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
-fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre>
+fslc db import examples/db/minimal_import.sql --name ImportedFromSql
+fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrisma</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>結果</th><th>読み方</th></tr>
@@ -204,7 +206,7 @@ fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre
       </div>
       <div class="syntax-card">
         <h3>API / offline / feature flag</h3>
-        <p>API operation、response field、offline payload TTL は有限の capability/tick として記述できます。feature flag は artifact/window として近似します。</p>
+        <p>API operation、response field、offline payload TTL、feature flag は有限の capability/tick/variant として記述できます。割合や確率の証明ではなく、有限 snapshot です。</p>
       </div>
       <div class="syntax-card">
         <h3>runtime observation</h3>
@@ -212,7 +214,11 @@ fslc db import examples/db/minimal_import.sql --name ImportedFromSql</code></pre
       </div>
       <div class="syntax-card">
         <h3>SQL/ORM import</h3>
-        <p><code>fslc db import</code> は最小 SQL DDL を <code>dbsystem</code> に変換します。Prisma、Rails、Drizzle などの ORM 専用 importer は拡張点です。</p>
+        <p><code>fslc db import</code> は最小 SQL DDL と Prisma schema の scalar field を <code>dbsystem</code> に変換します。未対応構文は明示 warning になります。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>外部 evidence</h3>
+        <p>本番データの diff/audit evidence と DB engine dry-run evidence は、<code>formal_result: "not_run"</code> の別JSON schemaで扱います。</p>
       </div>
       <div class="syntax-card">
         <h3>時間・確率</h3>

--- a/examples/db/README.md
+++ b/examples/db/README.md
@@ -10,8 +10,10 @@ Run:
 fslc db check examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl --engine induction
 fslc db check examples/db/unsafe_drop_column_with_old_server.fsl
 fslc db check examples/db/unsafe_api_response_field_removed.fsl
+fslc db check examples/db/safe_feature_flag_kill_switch_compat.fsl
 fslc db observe examples/db/runtime_observation_target.fsl --trace examples/db/runtime_observation_mismatch.json
 fslc db import examples/db/minimal_import.sql --name ImportedFromSql
+fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrisma
 ```
 
 Coverage highlights:
@@ -20,9 +22,12 @@ Coverage highlights:
 - destructive drop annotation enforcement
 - bounded rename/split/merge preservation and rollback checks
 - API response and offline payload compatibility across artifacts
+- finite feature flag variants and kill-switch compatibility windows
 - runtime observation evidence separated from formal verification
-- minimal SQL DDL import with explicit unsupported-construct warnings
+- minimal SQL DDL and Prisma schema import with explicit unsupported-construct warnings
+- external preservation and engine evidence fixtures that keep `formal_result: "not_run"`
 
 The model is intentionally finite: schema ranges are reachable rollout
-snapshots, offline TTLs are logical ticks, and preservation/rollback checks use a
-bounded abstract row model rather than full production-data proof.
+snapshots, feature flags are declared variants, offline TTLs are logical ticks,
+and preservation/rollback checks use a bounded abstract row model rather than
+full production-data proof.

--- a/examples/db/engine_evidence_dry_run.json
+++ b/examples/db/engine_evidence_dry_run.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "fsl-db-engine-evidence.v0",
+  "formal_result": "not_run",
+  "result": "engine_evidence_supported",
+  "engine": {
+    "vendor": "postgresql",
+    "version": "16",
+    "configuration_fingerprint": "staging-like-prod-2026-07"
+  },
+  "adapter": {
+    "kind": "migration_dry_run",
+    "tool": "vendor-online-ddl-checker",
+    "tool_version": "1.0"
+  },
+  "migration": "add_email_normalized",
+  "checks": [
+    {
+      "kind": "lock_timeout",
+      "status": "passed",
+      "max_wait_ms": 5000
+    },
+    {
+      "kind": "online_ddl_validator",
+      "status": "passed"
+    }
+  ],
+  "redaction": {
+    "policy": "engine evidence contains identifiers and aggregate timings only",
+    "forbidden_fields": ["row_values", "query_text", "secrets", "payload_bodies"]
+  },
+  "assumptions": [
+    {
+      "id": "DB-ENGINE-ASSUME-STAGING-LIKE-PROD",
+      "text": "dry-run environment matches production engine settings relevant to this check"
+    }
+  ]
+}

--- a/examples/db/minimal_prisma_schema.prisma
+++ b/examples/db/minimal_prisma_schema.prisma
@@ -1,0 +1,5 @@
+model User {
+  id Int @id
+  email String?
+  displayName String
+}

--- a/examples/db/preservation_evidence_fail.json
+++ b/examples/db/preservation_evidence_fail.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "fsl-db-preservation-evidence.v0",
+  "formal_result": "not_run",
+  "result": "evidence_failed",
+  "dbsystem": "UnsafeLossySplitPreservation",
+  "evidence_id": "prod-split-display-name-audit-2026-07-08",
+  "evidence_kind": "sampled_diff",
+  "target": {
+    "rule": "data_preserved",
+    "migration": "split_full_name",
+    "schema_elements": ["users.display_name", "users.first_name", "users.last_name"]
+  },
+  "scope": {
+    "environment": "prod",
+    "sample_count": 10000,
+    "mismatch_count": 17,
+    "source_snapshot": "pre_migration",
+    "target_snapshot": "post_migration"
+  },
+  "redaction": {
+    "policy": "schema identifiers and aggregate counts only",
+    "forbidden_fields": ["row_values", "sql_literals", "secrets", "payload_bodies"]
+  },
+  "assumptions": [
+    {
+      "id": "DB-EVIDENCE-ASSUME-SAMPLE-REPRESENTATIVE",
+      "text": "sampled evidence is operational evidence, not a full production-row proof"
+    }
+  ],
+  "findings": [
+    {
+      "kind": "sampled_preservation_mismatch",
+      "severity": "error",
+      "message": "aggregate mismatch count is non-zero for the sampled diff"
+    }
+  ]
+}

--- a/examples/db/preservation_evidence_pass.json
+++ b/examples/db/preservation_evidence_pass.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "fsl-db-preservation-evidence.v0",
+  "formal_result": "not_run",
+  "result": "evidence_supported",
+  "dbsystem": "SafeRenamePreservation",
+  "evidence_id": "prod-rename-display-name-audit-2026-07-08",
+  "evidence_kind": "offline_diff_job",
+  "target": {
+    "rule": "data_preserved",
+    "migration": "rename_legacy_name",
+    "schema_elements": ["users.legacy_name", "users.display_name"]
+  },
+  "scope": {
+    "environment": "prod",
+    "sample_count": 10000,
+    "mismatch_count": 0,
+    "source_snapshot": "pre_migration",
+    "target_snapshot": "post_migration"
+  },
+  "redaction": {
+    "policy": "schema identifiers and aggregate counts only",
+    "forbidden_fields": ["row_values", "sql_literals", "secrets", "payload_bodies"]
+  },
+  "assumptions": [
+    {
+      "id": "DB-EVIDENCE-ASSUME-SAMPLE-REPRESENTATIVE",
+      "text": "offline diff sample selection is owned by the deployment process"
+    }
+  ],
+  "findings": []
+}

--- a/examples/db/safe_feature_flag_kill_switch_compat.fsl
+++ b/examples/db/safe_feature_flag_kill_switch_compat.fsl
@@ -1,0 +1,39 @@
+dbsystem SafeFeatureFlagKillSwitchCompat {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column email_normalized: Text absent;
+    }
+  }
+
+  migration add_email_normalized from 0 to 1 {
+    add users.email_normalized nullable;
+  }
+
+  artifact server_legacy {
+    responds response.email;
+  }
+
+  artifact server_new {
+    reads users.email_normalized;
+    responds response.email_normalized;
+  }
+
+  artifact ios_legacy {
+    expects response.email;
+  }
+
+  artifact ios_new {
+    expects response.email_normalized;
+  }
+
+  environment prod {
+    schema 0..1;
+    flag email_v2 { off, on } default off;
+    active server_legacy when schema 0..1 when flag email_v2=off;
+    active server_new when schema 1..1 when flag email_v2=on;
+    may_exist ios_legacy when schema 0..1 when flag email_v2=off;
+    may_exist ios_new when schema 1..1 when flag email_v2=on;
+  }
+}

--- a/examples/db/unsafe_feature_flag_provider_gap.fsl
+++ b/examples/db/unsafe_feature_flag_provider_gap.fsl
@@ -1,0 +1,34 @@
+dbsystem UnsafeFeatureFlagProviderGap {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column email_normalized: Text absent;
+    }
+  }
+
+  migration add_email_normalized from 0 to 1 {
+    add users.email_normalized nullable;
+  }
+
+  artifact server_legacy {
+    responds response.email;
+  }
+
+  artifact server_new {
+    reads users.email_normalized;
+    responds response.email_normalized;
+  }
+
+  artifact ios_new {
+    expects response.email_normalized;
+  }
+
+  environment prod {
+    schema 0..1;
+    flag email_v2 { off, on } default off;
+    active server_legacy when schema 0..1 when flag email_v2=off;
+    active server_new when schema 1..1 when flag email_v2=on;
+    may_exist ios_new when schema 0..1 when flag email_v2=on;
+  }
+}

--- a/examples/db/unsupported_prisma_schema.prisma
+++ b/examples/db/unsupported_prisma_schema.prisma
@@ -1,0 +1,10 @@
+model User {
+  id Int @id
+  posts Post[]
+}
+
+model Post {
+  id Int @id
+  author User @relation(fields: [authorId], references: [id])
+  authorId Int
+}

--- a/schemas/fslc/db/engine-evidence.v0.schema.json
+++ b/schemas/fslc/db/engine-evidence.v0.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ymm-oss/fsl/schemas/fslc/db/engine-evidence.v0.schema.json",
+  "title": "fsl-db engine evidence v0",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "formal_result",
+    "result",
+    "engine",
+    "adapter",
+    "migration",
+    "checks",
+    "redaction",
+    "assumptions"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "fsl-db-engine-evidence.v0"
+    },
+    "formal_result": {
+      "const": "not_run"
+    },
+    "result": {
+      "enum": [
+        "engine_evidence_supported",
+        "engine_evidence_failed",
+        "engine_evidence_inconclusive",
+        "engine_evidence_invalid"
+      ]
+    },
+    "engine": {
+      "type": "object",
+      "required": ["vendor"],
+      "properties": {
+        "vendor": {"type": "string"},
+        "version": {"type": "string"},
+        "configuration_fingerprint": {"type": "string"}
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "required": ["kind", "tool"],
+      "properties": {
+        "kind": {
+          "enum": [
+            "migration_dry_run",
+            "lock_timeout_report",
+            "online_ddl_validator",
+            "optimizer_plan_check",
+            "vendor_tool_output"
+          ]
+        },
+        "tool": {"type": "string"},
+        "tool_version": {"type": "string"}
+      }
+    },
+    "migration": {
+      "type": "string"
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "status"],
+        "properties": {
+          "kind": {"type": "string"},
+          "status": {"enum": ["passed", "failed", "inconclusive"]},
+          "message": {"type": "string"},
+          "max_wait_ms": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "required": ["policy"],
+      "properties": {
+        "policy": {"type": "string"},
+        "forbidden_fields": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "text"],
+        "properties": {
+          "id": {"type": "string"},
+          "text": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/schemas/fslc/db/observation.v0.schema.json
+++ b/schemas/fslc/db/observation.v0.schema.json
@@ -47,6 +47,13 @@
         "target": {
           "type": "string",
           "description": "Schema identifier only, e.g. users.email or api.CreateUserV1"
+        },
+        "flags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional finite feature-flag snapshot, e.g. {\"email_v2\":\"on\"}"
         }
       }
     }

--- a/schemas/fslc/db/preservation-evidence.v0.schema.json
+++ b/schemas/fslc/db/preservation-evidence.v0.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ymm-oss/fsl/schemas/fslc/db/preservation-evidence.v0.schema.json",
+  "title": "fsl-db production preservation evidence v0",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "formal_result",
+    "result",
+    "dbsystem",
+    "evidence_id",
+    "evidence_kind",
+    "target",
+    "scope",
+    "redaction",
+    "assumptions",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "fsl-db-preservation-evidence.v0"
+    },
+    "formal_result": {
+      "const": "not_run"
+    },
+    "result": {
+      "enum": [
+        "evidence_supported",
+        "evidence_failed",
+        "evidence_inconclusive",
+        "evidence_invalid"
+      ]
+    },
+    "dbsystem": {
+      "type": "string"
+    },
+    "evidence_id": {
+      "type": "string"
+    },
+    "evidence_kind": {
+      "enum": [
+        "sampled_diff",
+        "offline_diff_job",
+        "shadow_read",
+        "dual_read_comparison",
+        "post_migration_audit"
+      ]
+    },
+    "target": {
+      "type": "object",
+      "required": ["rule", "migration"],
+      "properties": {
+        "rule": {
+          "enum": ["data_preserved", "rollback_equivalent"]
+        },
+        "migration": {
+          "type": "string"
+        },
+        "schema_elements": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "required": ["environment", "sample_count"],
+      "properties": {
+        "environment": {"type": "string"},
+        "sample_count": {"type": "integer", "minimum": 0},
+        "mismatch_count": {"type": "integer", "minimum": 0},
+        "source_snapshot": {"type": "string"},
+        "target_snapshot": {"type": "string"}
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "required": ["policy"],
+      "properties": {
+        "policy": {"type": "string"},
+        "forbidden_fields": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "text"],
+        "properties": {
+          "id": {"type": "string"},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "severity", "message"],
+        "properties": {
+          "kind": {"type": "string"},
+          "severity": {"enum": ["info", "warning", "error"]},
+          "message": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,8 +32,9 @@ re-verified as it changes (regression, drift, cross-layer change-impact via
 
 The shared `fsl/` reference also covers the `dbsystem` database compatibility
 dialect. Use it for schema migration / artifact read-write compatibility checks
-and `fslc db check` findings; SQL/ORM importers, runtime observation, and data
-preservation proofs are intentionally post-MVP.
+and `fslc db check` findings; SQL/Prisma importers, runtime observation,
+bounded preservation checks, finite feature flags, and external DB evidence
+schemas are covered as explicit boundaries.
 
 The role-specific skills delegate syntax and verifier details to `fsl/`. Use the
 narrowest role skill for authoring, then load `fsl/` when writing syntax or

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -116,7 +116,8 @@ dbsystem <Name> {
   }
   environment <env> {
     schema <lo>..<hi>;
-    active <version> when schema <lo>..<hi>;
+    flag <flag_name> { <variant>, ... } default <variant>;
+    active <version> when schema <lo>..<hi> when flag <flag_name>=<variant>;
     supported <version> when schema <lo>..<hi>;
     may_exist <version> when schema <lo>..<hi>;
   }
@@ -137,13 +138,18 @@ dbsystem <Name> {
 ```
 
 `dbsystem` checks migration compatibility across DB schema, artifacts, API/offline
-payloads, and environments. It does not model DB-engine locks/optimizers,
-probability, wall-clock TTL, or full production-data completeness. Schema ranges
-are finite reachable rollout snapshots; percentages and offline TTLs must be
-modeled as finite coexistence windows/ticks. Use `fslc db check` for stable
-fsl-db findings (`verified_under_assumptions` on success). Use
-`fslc db observe` for runtime evidence only (`observed_mismatch`, not formal
-violation) and `fslc db import` for the minimal SQL DDL importer boundary.
+payloads, and environments. Feature flags are finite declared variants inside an
+environment and may gate artifact windows with `when flag name=value`; success
+then reports `DB-ASSUME-FINITE-FLAG-STATE`. It does not model DB-engine
+locks/optimizers, probability, wall-clock TTL, or full production-data
+completeness. Schema ranges are finite reachable rollout snapshots; percentages,
+flag rollout, and offline TTLs must be modeled as finite coexistence
+windows/ticks. Use `fslc db check` for stable fsl-db findings
+(`verified_under_assumptions` on success). Use `fslc db observe` for runtime
+evidence only (`observed_mismatch`, not formal violation) and `fslc db import`
+for SQL DDL or minimal Prisma schema importers. Production-data preservation and
+DB-engine evidence use JSON schemas under `schemas/fslc/db/` with
+`formal_result: "not_run"`, not `verified`/`proved`.
 
 AI hard-contract dialect (Phase 1; expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):
@@ -428,7 +434,8 @@ fslc html <f> [--depth K] [-o report.html]      # self-contained HTML review rep
 fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md]  # business audit ledger by requirement id (PM/audit)
 fslc db check <f> [--depth K] [--engine bmc|induction]  # dbsystem compatibility findings
 fslc db observe <f> --trace events.json                 # runtime observation evidence
-fslc db import <sql> [--name Name] [-o out.fsl]         # minimal SQL DDL -> dbsystem
+fslc db import <sql|schema.prisma> [--source auto|sql|prisma] [--name Name] [-o out.fsl]
+                                                        # SQL DDL / minimal Prisma -> dbsystem
 fslc ai check <f> [--depth K] [--engine bmc|induction]  # ai_component hard-contract findings
 fslc ai replay <f> --logs events.jsonl                  # AI runtime replay evidence, not proof
 ```

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -42,7 +42,7 @@ from .analysis import (
 from .analysis.projections import SUPPORTED_PROJECTIONS
 from .analysis.schema import FINDINGS_SCHEMA_VERSION
 from .db_check import check_dbsystem, load_dbsystem, observe_dbsystem
-from .db_import import import_sql_file
+from .db_import import import_db_file
 from .ai_check import check_ai_component, load_ai_component, replay_ai_events
 
 FSL_VERSION = "1.0"
@@ -1257,13 +1257,13 @@ def run_db_observe(file, trace):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
-def run_db_import(file, name="ImportedDb", output=None):
+def run_db_import(file, name="ImportedDb", output=None, source_format="auto"):
     try:
-        imported = import_sql_file(file, name=name)
+        imported = import_db_file(file, name=name, source_format=source_format)
         result = {
             "result": "imported_with_warnings" if imported.warnings else "imported",
             "dialect": "fsl-db-mvp.v0",
-            "source_format": "sql-ddl-minimal.v0",
+            "source_format": imported.source_format,
             "dbsystem": imported.system.name,
             "warnings": imported.warnings,
             "dbsystem_source": imported.source,
@@ -1499,9 +1499,11 @@ def _build_arg_parser():
     dbo = db_sub.add_parser("observe", help="compare runtime observation logs to dbsystem declarations")
     dbo.add_argument("file")
     dbo.add_argument("--trace", required=True)
-    dbi = db_sub.add_parser("import", help="import a minimal SQL DDL subset into dbsystem")
+    dbi = db_sub.add_parser("import", help="import SQL DDL or a minimal ORM schema into dbsystem")
     dbi.add_argument("file")
     dbi.add_argument("--name", default="ImportedDb")
+    dbi.add_argument("--source", choices=["auto", "sql", "prisma"], default="auto",
+                     help="source format to import (default: auto by extension)")
     dbi.add_argument("-o", "--output")
 
     ai = sub.add_parser("ai", help="AI hard-contract dialect commands")
@@ -1621,7 +1623,12 @@ def _dispatch(args):
             result = run_db_observe(args.file, args.trace)
             print(json.dumps(result, indent=2, ensure_ascii=False))
         elif args.db_cmd == "import":
-            result = run_db_import(args.file, name=args.name, output=args.output)
+            result = run_db_import(
+                args.file,
+                name=args.name,
+                output=args.output,
+                source_format=args.source,
+            )
             if result.get("result") == "imported" and not args.output:
                 sys.stdout.write(result["dbsystem_source"])
                 sys.exit(0)

--- a/src/fslc/db_check.py
+++ b/src/fslc/db_check.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import itertools
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -171,67 +172,83 @@ def _static_findings(system, assumptions):
             lo = max(env.schema_window[0], window[0])
             hi = min(env.schema_window[1], window[1])
             for schema_version in range(lo, hi + 1):
+                flag_states = [
+                    state for state in _flag_snapshots(env)
+                    if _entry_active_at(env, entry, schema_version, state)
+                ]
+                if not flag_states:
+                    continue
                 state = states[schema_version]
                 source = sources.get(schema_version)
-                for column in artifact.reads:
-                    if not state[column]["exists"]:
-                        findings.append(_finding(
-                            kind="column_removed_while_still_read",
-                            severity="error",
-                            environment=env.name,
-                            migration=source.name if source else None,
-                            schema_element=column_label(column),
-                            artifact=entry.artifact,
-                            artifact_version=entry.artifact,
-                            failed_rule="all_active_reads_exist",
-                            witness={
+                for flag_state in flag_states:
+                    for column in artifact.reads:
+                        if not state[column]["exists"]:
+                            witness = {
                                 "schema_version": schema_version,
                                 "environment_role": entry.role,
                                 "declared_capability": "reads",
-                            },
-                            minimal_conflict_set={
+                            }
+                            witness.update(_flag_witness(flag_state))
+                            conflict = {
                                 "environment": env.name,
                                 "artifact": entry.artifact,
                                 "migration": source.name if source else None,
                                 "schema_element": column_label(column),
-                            },
-                            repair_candidates=_compat_repairs("reads", entry.artifact, column, env.name),
-                            assumptions=assumptions,
-                        ))
-                for column in artifact.writes:
-                    if not state[column]["exists"]:
-                        findings.append(_finding(
-                            kind="column_removed_while_still_written",
-                            severity="error",
-                            environment=env.name,
-                            migration=source.name if source else None,
-                            schema_element=column_label(column),
-                            artifact=entry.artifact,
-                            artifact_version=entry.artifact,
-                            failed_rule="all_active_writes_exist",
-                            witness={
+                            }
+                            conflict.update(_flag_witness(flag_state))
+                            findings.append(_finding(
+                                kind="column_removed_while_still_read",
+                                severity="error",
+                                environment=env.name,
+                                migration=source.name if source else None,
+                                schema_element=column_label(column),
+                                artifact=entry.artifact,
+                                artifact_version=entry.artifact,
+                                failed_rule="all_active_reads_exist",
+                                witness=witness,
+                                minimal_conflict_set=conflict,
+                                repair_candidates=_compat_repairs("reads", entry.artifact, column, env.name),
+                                assumptions=assumptions,
+                            ))
+                    for column in artifact.writes:
+                        if not state[column]["exists"]:
+                            witness = {
                                 "schema_version": schema_version,
                                 "environment_role": entry.role,
                                 "declared_capability": "writes",
-                            },
-                            minimal_conflict_set={
+                            }
+                            witness.update(_flag_witness(flag_state))
+                            conflict = {
                                 "environment": env.name,
                                 "artifact": entry.artifact,
                                 "migration": source.name if source else None,
                                 "schema_element": column_label(column),
-                            },
-                            repair_candidates=_compat_repairs("writes", entry.artifact, column, env.name),
-                            assumptions=assumptions,
-                        ))
-                findings.extend(_api_offline_findings(
-                    system,
-                    env,
-                    entry,
-                    artifact,
-                    schema_version,
-                    rules,
-                    assumptions,
-                ))
+                            }
+                            conflict.update(_flag_witness(flag_state))
+                            findings.append(_finding(
+                                kind="column_removed_while_still_written",
+                                severity="error",
+                                environment=env.name,
+                                migration=source.name if source else None,
+                                schema_element=column_label(column),
+                                artifact=entry.artifact,
+                                artifact_version=entry.artifact,
+                                failed_rule="all_active_writes_exist",
+                                witness=witness,
+                                minimal_conflict_set=conflict,
+                                repair_candidates=_compat_repairs("writes", entry.artifact, column, env.name),
+                                assumptions=assumptions,
+                            ))
+                    findings.extend(_api_offline_findings(
+                        system,
+                        env,
+                        entry,
+                        artifact,
+                        schema_version,
+                        flag_state,
+                        rules,
+                        assumptions,
+                    ))
     return findings
 
 
@@ -467,16 +484,35 @@ def _breaks_rollback_equivalence(op: DbMigrationOp, annotations, before_state):
     return False
 
 
-def _entry_active_at(env, entry, schema_version):
+def _flag_snapshots(env):
+    if not env.flags:
+        return [{}]
+    names = [flag.name for flag in env.flags]
+    domains = [flag.variants for flag in env.flags]
+    return [dict(zip(names, values)) for values in itertools.product(*domains)]
+
+
+def _flag_witness(flag_state):
+    return {"flags": dict(flag_state)} if flag_state else {}
+
+
+def _entry_active_at(env, entry, schema_version, flag_state=None):
     window = entry.schema_window or env.schema_window
-    return window[0] <= schema_version <= window[1]
+    if not (window[0] <= schema_version <= window[1]):
+        return False
+    if flag_state is None:
+        return True
+    return all(
+        flag_state.get(condition.flag) == condition.variant
+        for condition in entry.flag_conditions
+    )
 
 
-def _providers_for(system, env, schema_version, capability, target):
+def _providers_for(system, env, schema_version, capability, target, flag_state=None):
     providers = []
     artifacts = system.artifact_map()
     for entry in env.artifacts:
-        if entry.role == "may_exist" or not _entry_active_at(env, entry, schema_version):
+        if entry.role == "may_exist" or not _entry_active_at(env, entry, schema_version, flag_state):
             continue
         artifact = artifacts[entry.artifact]
         if target in getattr(artifact, capability):
@@ -484,37 +520,39 @@ def _providers_for(system, env, schema_version, capability, target):
     return providers
 
 
-def _api_offline_findings(system, env, entry, artifact, schema_version, rules, assumptions):
+def _api_offline_findings(system, env, entry, artifact, schema_version, flag_state, rules, assumptions):
     findings = []
     if "api_calls_accepted" in rules:
         for target in artifact.calls:
-            if not _providers_for(system, env, schema_version, "accepts", target):
+            if not _providers_for(system, env, schema_version, "accepts", target, flag_state):
                 findings.append(_capability_finding(
                     "api_call_not_accepted",
                     "api_calls_accepted",
                     env.name,
                     entry,
                     schema_version,
+                    flag_state,
                     "calls",
                     target,
                     assumptions,
                 ))
     if "api_responses_expected" in rules:
         for target in artifact.expects:
-            if not _providers_for(system, env, schema_version, "responds", target):
+            if not _providers_for(system, env, schema_version, "responds", target, flag_state):
                 findings.append(_capability_finding(
                     "api_response_field_missing",
                     "api_responses_expected",
                     env.name,
                     entry,
                     schema_version,
+                    flag_state,
                     "expects",
                     target,
                     assumptions,
                 ))
     if "offline_payloads_accepted" in rules:
         for target in artifact.emits_offline:
-            if not _providers_for(system, env, schema_version, "accepts", target):
+            if not _providers_for(system, env, schema_version, "accepts", target, flag_state):
                 ttl = artifact.offline_ttls.get(target)
                 findings.append(_capability_finding(
                     "offline_payload_not_accepted",
@@ -522,6 +560,7 @@ def _api_offline_findings(system, env, entry, artifact, schema_version, rules, a
                     env.name,
                     entry,
                     schema_version,
+                    flag_state,
                     "emits_offline",
                     target,
                     assumptions,
@@ -536,6 +575,7 @@ def _capability_finding(
         env_name,
         entry,
         schema_version,
+        flag_state,
         capability,
         target,
         assumptions,
@@ -546,8 +586,15 @@ def _capability_finding(
         "declared_capability": capability,
         "target": column_label(target),
     }
+    witness.update(_flag_witness(flag_state))
     if extra_witness:
         witness.update(extra_witness)
+    conflict = {
+        "environment": env_name,
+        "artifact": entry.artifact,
+        "schema_element": column_label(target),
+    }
+    conflict.update(_flag_witness(flag_state))
     return _finding(
         kind=kind,
         severity="error",
@@ -558,11 +605,7 @@ def _capability_finding(
         artifact_version=entry.artifact,
         failed_rule=failed_rule,
         witness=witness,
-        minimal_conflict_set={
-            "environment": env_name,
-            "artifact": entry.artifact,
-            "schema_element": column_label(target),
-        },
+        minimal_conflict_set=conflict,
         repair_candidates=_capability_repairs(capability, entry.artifact, target, env_name),
         assumptions=assumptions,
     )
@@ -600,7 +643,13 @@ def _observation_findings(system, events, assumptions):
         capability = event.get("capability")
         target = _target_key(event.get("target"))
         schema_version = event.get("schema_version")
-        if env is None or artifact_name not in artifacts or not _artifact_declared_in_env(env, artifact_name, schema_version):
+        flag_state = _event_flag_state(event)
+        if env is None or artifact_name not in artifacts or not _artifact_declared_in_env(
+                env,
+                artifact_name,
+                schema_version,
+                flag_state,
+        ):
             findings.append(_observation_finding(
                 "unsupported_artifact_observed",
                 event,
@@ -621,7 +670,14 @@ def _observation_findings(system, events, assumptions):
                 assumptions,
                 "observed DB access is not declared as an artifact capability",
             ))
-        elif capability == "calls" and not _providers_for(system, env, int(schema_version), "accepts", target):
+        elif capability == "calls" and not _providers_for(
+                system,
+                env,
+                int(schema_version),
+                "accepts",
+                target,
+                flag_state,
+        ):
             findings.append(_observation_finding(
                 "legacy_api_still_called",
                 event,
@@ -633,18 +689,29 @@ def _observation_findings(system, events, assumptions):
     return findings
 
 
-def _artifact_declared_in_env(env, artifact_name, schema_version):
+def _event_flag_state(event):
+    flags = event.get("flags")
+    return flags if isinstance(flags, dict) else None
+
+
+def _artifact_declared_in_env(env, artifact_name, schema_version, flag_state=None):
     try:
         version = int(schema_version)
     except (TypeError, ValueError):
         return False
     return any(
-        entry.artifact == artifact_name and _entry_active_at(env, entry, version)
+        entry.artifact == artifact_name and _entry_active_at(env, entry, version, flag_state)
         for entry in env.artifacts
     )
 
 
 def _observation_finding(kind, event, index, target, assumptions, reason):
+    conflict = {
+        "environment": event.get("environment"),
+        "artifact": event.get("artifact"),
+        "schema_element": column_label(target),
+    }
+    conflict.update(_flag_witness(_event_flag_state(event) or {}))
     return _finding(
         kind=kind,
         severity="error",
@@ -660,12 +727,9 @@ def _observation_finding(kind, event, index, target, assumptions, reason):
             "capability": event.get("capability"),
             "target": column_label(target),
             "reason": reason,
+            **_flag_witness(_event_flag_state(event) or {}),
         },
-        minimal_conflict_set={
-            "environment": event.get("environment"),
-            "artifact": event.get("artifact"),
-            "schema_element": column_label(target),
-        },
+        minimal_conflict_set=conflict,
         repair_candidates=_observation_repairs(event, target),
         assumptions=assumptions,
         result="observed_mismatch",

--- a/src/fslc/db_expand.py
+++ b/src/fslc/db_expand.py
@@ -212,6 +212,26 @@ def validate_dbsystem(system):
             _err(f"duplicate environment '{env.name}'", loc=env.loc)
         env_names.add(env.name)
         _validate_window(env.schema_window, "environment schema", env.loc)
+        flags = {}
+        for flag in env.flags:
+            if flag.name in flags:
+                _err(f"duplicate flag '{flag.name}' in environment '{env.name}'", loc=flag.loc)
+            if not flag.variants:
+                _err(f"flag '{flag.name}' requires at least one variant", loc=flag.loc)
+            seen_variants = set()
+            for variant in flag.variants:
+                if variant in seen_variants:
+                    _err(
+                        f"duplicate variant '{variant}' on flag '{flag.name}'",
+                        loc=flag.loc,
+                    )
+                seen_variants.add(variant)
+            if flag.default not in seen_variants:
+                _err(
+                    f"flag '{flag.name}' default '{flag.default}' is not a declared variant",
+                    loc=flag.loc,
+                )
+            flags[flag.name] = flag
         for version in range(env.schema_window[0], env.schema_window[1] + 1):
             if version not in reached_versions:
                 _err(
@@ -231,6 +251,26 @@ def validate_dbsystem(system):
                     f"{env.schema_window[0]}..{env.schema_window[1]}",
                     loc=entry.loc,
                 )
+            seen_conditions = set()
+            for condition in entry.flag_conditions:
+                if condition.flag in seen_conditions:
+                    _err(
+                        f"artifact '{entry.artifact}' repeats flag condition '{condition.flag}'",
+                        loc=condition.loc,
+                    )
+                seen_conditions.add(condition.flag)
+                flag = flags.get(condition.flag)
+                if flag is None:
+                    _err(
+                        f"artifact '{entry.artifact}' references unknown flag '{condition.flag}'",
+                        loc=condition.loc,
+                    )
+                if condition.variant not in set(flag.variants):
+                    _err(
+                        f"artifact '{entry.artifact}' references unknown variant "
+                        f"'{condition.variant}' for flag '{condition.flag}'",
+                        loc=condition.loc,
+                    )
 
     if not system.environments:
         _err("dbsystem requires at least one environment", loc=system.loc)
@@ -303,6 +343,15 @@ def _rule_text(rule, env, role, artifact, column):
         f"column {column_label(column)} may be removed only after {artifact} "
         f"is outside the {env} compatibility window"
     )
+
+
+def _entry_name_parts(entry):
+    parts = []
+    if entry.schema_window:
+        parts.extend(["schema", str(entry.schema_window[0]), str(entry.schema_window[1])])
+    for condition in entry.flag_conditions:
+        parts.extend(["flag", condition.flag, condition.variant])
+    return parts or ["all"]
 
 
 def expand_dbsystem(system):
@@ -442,7 +491,14 @@ def expand_dbsystem(system):
             if "all_active_reads_exist" in rules or "removed_only_after_unused" in rules:
                 for key in artifact.reads:
                     name = _inv_name(
-                        "db_read", env.name, entry.role, entry.artifact, key[0], key[1])
+                        "db_read",
+                        env.name,
+                        entry.role,
+                        entry.artifact,
+                        *_entry_name_parts(entry),
+                        key[0],
+                        key[1],
+                    )
                     expr = _compat_expr(window, col_member[key])
                     rule = "all_active_reads_exist"
                     meta = _meta("DB-COMPAT-READ", _rule_text(rule, env.name, entry.role, entry.artifact, key))
@@ -453,7 +509,14 @@ def expand_dbsystem(system):
             if "all_active_writes_exist" in rules or "removed_only_after_unused" in rules:
                 for key in artifact.writes:
                     name = _inv_name(
-                        "db_write", env.name, entry.role, entry.artifact, key[0], key[1])
+                        "db_write",
+                        env.name,
+                        entry.role,
+                        entry.artifact,
+                        *_entry_name_parts(entry),
+                        key[0],
+                        key[1],
+                    )
                     expr = _compat_expr(window, col_member[key])
                     rule = "all_active_writes_exist"
                     meta = _meta("DB-COMPAT-WRITE", _rule_text(rule, env.name, entry.role, entry.artifact, key))
@@ -483,6 +546,15 @@ def expand_dbsystem(system):
         assumptions.append({
             "id": "DB-ASSUME-OFFLINE-TTL-FINITE",
             "text": "offline TTL values are finite logical ticks, not wall-clock time or probability",
+        })
+    if any(env.flags for env in system.environments):
+        assumptions.append({
+            "id": "DB-ASSUME-FINITE-FLAG-STATE",
+            "text": (
+                "feature flags are modeled as finite declared variants; rollout "
+                "percentages and experimentation populations are approximated as "
+                "compatibility snapshots, not probability proofs"
+            ),
         })
     if "data_preserved" in rules or "rollback_equivalent" in rules:
         assumptions.append({

--- a/src/fslc/db_import.py
+++ b/src/fslc/db_import.py
@@ -28,7 +28,16 @@ from .db_ir import (
 class DbImportResult:
     system: DbSystem
     source: str
+    source_format: str
     warnings: List[dict] = field(default_factory=list)
+
+
+def import_db_file(path, name="ImportedDb", source_format="auto"):
+    text = Path(path).read_text(encoding="utf-8")
+    selected = _select_source_format(path, source_format)
+    if selected == "prisma":
+        return import_prisma(text, name=name)
+    return import_sql(text, name=name)
 
 
 def import_sql_file(path, name="ImportedDb"):
@@ -115,7 +124,145 @@ def import_sql(sql, name="ImportedDb"):
         environments=[environment],
         check=DbCheck(),
     )
-    return DbImportResult(system=system, source=dbsystem_to_source(system), warnings=warnings)
+    return DbImportResult(
+        system=system,
+        source=dbsystem_to_source(system),
+        source_format="sql-ddl-minimal.v0",
+        warnings=warnings,
+    )
+
+
+def import_prisma(schema, name="ImportedDb"):
+    warnings: List[dict] = []
+    models = _prisma_models(schema)
+    model_names = {model_name for model_name, _ in models}
+    columns: Dict[ColumnKey, DbColumn] = {}
+
+    for model_name, body in models:
+        for raw in body.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("//"):
+                continue
+            if line.startswith("@@"):
+                warnings.append(_unsupported_prisma(line, "model-level attributes are not imported"))
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                warnings.append(_unsupported_prisma(line, "Prisma importer expects '<field> <type>' field lines"))
+                continue
+            field, raw_type = parts[0], parts[1]
+            type_name = raw_type.rstrip("?")
+            if type_name.endswith("[]"):
+                warnings.append(_unsupported_prisma(line, "list/relation fields are not imported"))
+                continue
+            if type_name in model_names or "@relation" in line:
+                warnings.append(_unsupported_prisma(line, "relation fields are not imported"))
+                continue
+            db_type = _prisma_db_type(type_name)
+            if db_type is None:
+                warnings.append(_unsupported_prisma(line, f"unsupported Prisma scalar type '{type_name}'"))
+                continue
+            not_null = not raw_type.endswith("?")
+            columns[(model_name, field)] = DbColumn(
+                table=model_name,
+                name=field,
+                db_type=db_type,
+                present=True,
+                backfilled=True,
+                not_null=not_null,
+            )
+
+    if not columns:
+        columns[("imported", "id")] = DbColumn(
+            table="imported",
+            name="id",
+            db_type="Int",
+            present=True,
+            backfilled=True,
+            not_null=True,
+        )
+        warnings.append({
+            "kind": "empty_import",
+            "message": "no supported Prisma model fields were found; emitted a placeholder schema",
+        })
+
+    tables = []
+    for table in sorted({key[0] for key in columns}):
+        tables.append(DbTable(
+            name=table,
+            columns=[columns[key] for key in sorted(columns) if key[0] == table],
+        ))
+
+    final_columns = [key for key in sorted(columns)]
+    artifact = DbArtifact(
+        name="imported_artifact",
+        reads=final_columns,
+        writes=final_columns,
+    )
+    environment = DbEnvironment(
+        name="imported",
+        schema_window=(0, 0),
+        artifacts=[
+            DbEnvironmentArtifact("active", artifact.name, (0, 0)),
+            DbEnvironmentArtifact("supported", artifact.name, (0, 0)),
+        ],
+    )
+    system = DbSystem(
+        name=name,
+        database=DbDatabase(
+            name="imported",
+            initial_schema=0,
+            tables=tables,
+        ),
+        artifacts=[artifact],
+        environments=[environment],
+        check=DbCheck(),
+    )
+    return DbImportResult(
+        system=system,
+        source=dbsystem_to_source(system),
+        source_format="prisma-schema-minimal.v0",
+        warnings=warnings,
+    )
+
+
+def _select_source_format(path, source_format):
+    if source_format != "auto":
+        return source_format
+    suffix = Path(path).suffix.lower()
+    if suffix == ".prisma":
+        return "prisma"
+    return "sql"
+
+
+def _prisma_models(schema):
+    cleaned = re.sub(r"/\*.*?\*/", "", schema, flags=re.S)
+    return [
+        (match.group(1), match.group(2))
+        for match in re.finditer(r"\bmodel\s+(\w+)\s*\{(.*?)\}", cleaned, re.S)
+    ]
+
+
+def _prisma_db_type(type_name):
+    return {
+        "Int": "Int",
+        "BigInt": "Int",
+        "String": "Text",
+        "Boolean": "Bool",
+        "DateTime": "Text",
+        "Float": "Value",
+        "Decimal": "Value",
+        "Json": "Value",
+        "Bytes": "Value",
+    }.get(type_name)
+
+
+def _unsupported_prisma(statement, message):
+    return {
+        "kind": "unsupported_prisma",
+        "statement": statement,
+        "message": message,
+    }
 
 def _statements(sql):
     cleaned = re.sub(r"--[^\n]*", "", sql)
@@ -264,13 +411,21 @@ def dbsystem_to_source(system: DbSystem):
     for env in system.environments:
         lines.append(f"  environment {env.name} {{")
         lines.append(f"    schema {env.schema_window[0]}..{env.schema_window[1]};")
+        for flag in env.flags:
+            default = f" default {flag.default}" if flag.default else ""
+            lines.append(f"    flag {flag.name} {{ {', '.join(flag.variants)} }}{default};")
         for entry in env.artifacts:
+            conditions = "".join(
+                f" when flag {condition.flag}={condition.variant}"
+                for condition in entry.flag_conditions
+            )
             if entry.schema_window:
                 lines.append(
-                    f"    {entry.role} {entry.artifact} when schema {entry.schema_window[0]}..{entry.schema_window[1]};"
+                    f"    {entry.role} {entry.artifact} "
+                    f"when schema {entry.schema_window[0]}..{entry.schema_window[1]}{conditions};"
                 )
             else:
-                lines.append(f"    {entry.role} {entry.artifact};")
+                lines.append(f"    {entry.role} {entry.artifact}{conditions};")
         lines.append("  }")
         lines.append("")
     lines.append("  check compatibility {")

--- a/src/fslc/db_ir.py
+++ b/src/fslc/db_ir.py
@@ -85,10 +85,26 @@ class DbArtifact:
 
 
 @dataclass(frozen=True)
+class DbFlag:
+    name: str
+    variants: Tuple[str, ...]
+    default: str
+    loc: Optional[dict] = None
+
+
+@dataclass(frozen=True)
+class DbFlagCondition:
+    flag: str
+    variant: str
+    loc: Optional[dict] = None
+
+
+@dataclass(frozen=True)
 class DbEnvironmentArtifact:
     role: str
     artifact: str
     schema_window: Optional[SchemaWindow] = None
+    flag_conditions: Tuple[DbFlagCondition, ...] = ()
     loc: Optional[dict] = None
 
 
@@ -97,6 +113,7 @@ class DbEnvironment:
     name: str
     schema_window: SchemaWindow
     artifacts: List[DbEnvironmentArtifact] = field(default_factory=list)
+    flags: List[DbFlag] = field(default_factory=list)
     loc: Optional[dict] = None
 
 

--- a/src/fslc/db_parser.py
+++ b/src/fslc/db_parser.py
@@ -16,6 +16,8 @@ from .db_ir import (
     DbDatabase,
     DbEnvironment,
     DbEnvironmentArtifact,
+    DbFlag,
+    DbFlagCondition,
     DbMigration,
     DbMigrationOp,
     DbSystem,
@@ -74,13 +76,17 @@ col_ref_list: col_ref ("," col_ref)*
 col_ref: NAME "." NAME
 
 environment_def: "environment" NAME "{" environment_item* "}"
-?environment_item: env_schema | env_artifact
+?environment_item: env_schema | env_flag | env_artifact
 env_schema: "schema" INT ".." INT ";"?
-env_artifact: env_role NAME env_window? ";"?
+env_flag: "flag" NAME "{" flag_variant_list "}" flag_default? ";"?
+flag_variant_list: NAME ("," NAME)* ","?
+flag_default: "default" NAME
+env_artifact: env_role NAME env_window? env_flag_condition* ";"?
 env_role: "active" -> env_active
         | "supported" -> env_supported
         | "may_exist" -> env_may_exist
 env_window: "when" "schema" INT ".." INT
+env_flag_condition: "when" "flag" NAME "=" NAME
 
 check_def: "check" "compatibility" "{" check_item* "}"
 check_item: "rule" NAME ";"?
@@ -295,27 +301,51 @@ class DbAst(Transformer):
         return "may_exist"
 
     def env_window(self, meta, lo, hi):
-        return (lo, hi)
+        return ("schema_window", (lo, hi))
+
+    def flag_variant_list(self, meta, *variants):
+        return list(variants)
+
+    def flag_default(self, meta, default):
+        return default
+
+    def env_flag(self, meta, name, variants, default=None):
+        if not variants:
+            raise FslError(f"flag '{name}' requires at least one variant", loc=_loc(meta))
+        return DbFlag(name, tuple(variants), default or variants[0], _loc(meta))
 
     def env_schema(self, meta, lo, hi):
         return ("schema", (lo, hi), _loc(meta))
 
-    def env_artifact(self, meta, role, artifact, window=None):
-        return DbEnvironmentArtifact(role, artifact, window, _loc(meta))
+    def env_flag_condition(self, meta, flag, variant):
+        return DbFlagCondition(flag, variant, _loc(meta))
+
+    def env_artifact(self, meta, role, artifact, *parts):
+        window = None
+        conditions = []
+        for part in parts:
+            if isinstance(part, tuple) and part[0] == "schema_window":
+                window = part[1]
+            else:
+                conditions.append(part)
+        return DbEnvironmentArtifact(role, artifact, window, tuple(conditions), _loc(meta))
 
     def environment_def(self, meta, name, *items):
         schema_window = None
         artifacts = []
+        flags = []
         for item in items:
             if isinstance(item, tuple) and item[0] == "schema":
                 if schema_window is not None:
                     raise FslError("environment schema may be declared at most once", loc=item[2])
                 schema_window = item[1]
+            elif isinstance(item, DbFlag):
+                flags.append(item)
             else:
                 artifacts.append(item)
         if schema_window is None:
             raise FslError("environment requires `schema <lo>..<hi>`", loc=_loc(meta))
-        return DbEnvironment(name, schema_window, artifacts, _loc(meta))
+        return DbEnvironment(name, schema_window, artifacts, flags, _loc(meta))
 
     def check_item(self, meta, name):
         return name

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -161,6 +161,12 @@
       "warnings": []
     }
   },
+  "examples/db/safe_feature_flag_kill_switch_compat.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/db/safe_rename_preservation.fsl": {
     "check": {
       "result": "ok",
@@ -200,6 +206,12 @@
     }
   },
   "examples/db/unsafe_drop_column_with_worker.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
+  "examples/db/unsafe_feature_flag_provider_gap.fsl": {
     "check": {
       "result": "ok",
       "warnings": []

--- a/tests/test_db_dialect.py
+++ b/tests/test_db_dialect.py
@@ -18,6 +18,7 @@ from fslc.cli import (
 
 ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES = ROOT / "examples" / "db"
+DB_SCHEMAS = ROOT / "schemas" / "fslc" / "db"
 
 
 def _example(name):
@@ -207,6 +208,46 @@ def test_db_api_and_offline_compatibility_are_environment_scoped():
     assert "DB-ASSUME-OFFLINE-TTL-FINITE" in _assumption_ids(rejected_offline)
 
 
+def test_db_feature_flags_are_finite_snapshot_conditions():
+    safe = run_db_check(_example("safe_feature_flag_kill_switch_compat.fsl"))
+    assert safe["result"] == "verified_under_assumptions"
+    assert "DB-ASSUME-FINITE-FLAG-STATE" in _assumption_ids(safe)
+
+    unsafe = run_db_check(_example("unsafe_feature_flag_provider_gap.fsl"))
+    assert unsafe["result"] == "violated"
+    finding = unsafe["findings"][0]
+    assert finding["kind"] == "api_response_field_missing"
+    assert finding["witness"]["flags"] == {"email_v2": "on"}
+    assert finding["witness"]["schema_version"] == 0
+    assert finding["minimal_conflict_set"]["flags"] == {"email_v2": "on"}
+    assert "DB-ASSUME-FINITE-FLAG-STATE" in _assumption_ids(unsafe)
+
+
+def test_db_feature_flag_references_are_validated(tmp_path):
+    path = tmp_path / "bad_flag.fsl"
+    path.write_text(
+        """dbsystem BadFlag {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; }
+  }
+  artifact server_v1 { reads users.id; }
+  environment prod {
+    schema 0..0;
+    active server_v1 when schema 0..0 when flag missing=on;
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    out = run_check(str(path))
+
+    assert out["result"] == "error"
+    assert out["kind"] == "semantics"
+    assert "unknown flag 'missing'" in out["message"]
+
+
 def test_db_runtime_observation_reports_observed_mismatch_not_formal_violation():
     out = run_db_observe(
         _example("runtime_observation_target.fsl"),
@@ -268,3 +309,45 @@ def test_db_sql_importer_reports_unsupported_constructs():
     assert imported["warnings"][0]["kind"] == "unsupported_sql"
     assert "CREATE INDEX" in imported["warnings"][0]["statement"]
     assert exit_code(imported) == 0
+
+
+def test_db_prisma_importer_emits_checkable_dbsystem(tmp_path):
+    output = tmp_path / "imported_prisma.fsl"
+    imported = run_db_import(
+        _example("minimal_prisma_schema.prisma"),
+        name="ImportedFromPrisma",
+        output=str(output),
+    )
+
+    assert imported["result"] == "imported"
+    assert imported["source_format"] == "prisma-schema-minimal.v0"
+    checked = run_db_check(str(output))
+    assert checked["result"] == "verified_under_assumptions"
+
+
+def test_db_prisma_importer_reports_unsupported_constructs():
+    imported = run_db_import(_example("unsupported_prisma_schema.prisma"), name="ImportedFromPrisma")
+
+    assert imported["result"] == "imported_with_warnings"
+    assert imported["source_format"] == "prisma-schema-minimal.v0"
+    assert {warning["kind"] for warning in imported["warnings"]} == {"unsupported_prisma"}
+
+
+def test_db_external_evidence_schemas_and_fixtures_are_non_formal():
+    for filename in [
+        "preservation-evidence.v0.schema.json",
+        "engine-evidence.v0.schema.json",
+    ]:
+        schema = json.loads((DB_SCHEMAS / filename).read_text(encoding="utf-8"))
+        assert schema["$id"].endswith(filename)
+        assert "formal_result" in schema["required"]
+
+    for filename in [
+        "preservation_evidence_pass.json",
+        "preservation_evidence_fail.json",
+        "engine_evidence_dry_run.json",
+    ]:
+        fixture = json.loads((EXAMPLES / filename).read_text(encoding="utf-8"))
+    assert fixture["formal_result"] == "not_run"
+    assert fixture["result"] not in {"verified", "proved", "verified_under_assumptions"}
+    assert "redaction" in fixture


### PR DESCRIPTION
## Summary
- add finite feature-flag variants to dbsystem environments and evaluate DB/API/offline compatibility per flag snapshot
- add a minimal Prisma schema importer beside the existing SQL DDL importer
- define external production-preservation and DB-engine evidence schemas and fixtures with formal_result:not_run
- update DB docs, intro pages, language reference, skills, examples, changelog, and corpus snapshot

## Validation
- .venv/bin/python -m pytest tests/test_db_dialect.py -q
- .venv/bin/python -m pytest tests/test_corpus_snapshot.py -q
- .venv/bin/python -m pytest tests/test_mutate.py -q
- .venv/bin/python -m pytest tests/test_vacuity.py -q
- .venv/bin/python -m pytest tests/test_v1.py -q
- .venv/bin/python -m compileall -q src/fslc
- .venv/bin/python -m pytest -q (978 passed, 78 skipped)

Closes #144
Closes #145
Closes #146
Closes #147