### PR TITLE
fix: 6 bugs found in a thorough audit (2 soundness, exit codes, LSP, perf, dialect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,92 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   enveloped result tree reserves `kind` for the diagnostic discriminator.)
 
 ### Fixed
+- **Soundness**: `fslc verify --engine induction` could report a `leadsTo
+  ... decreases ... helpful` property `"proved"` when it was genuinely false.
+  With two or more distinct `helpful` action declarations,
+  `_prove_leadsto_rank_no_deadlock` only checked that *some* helpful match is
+  enabled at every pending state (a disjunction); if which instance is
+  enabled alternates (e.g. two helpful actions gated on opposite parity of
+  some other variable), no single instance is ever *continuously* enabled,
+  so its `fair` declaration never actually obligates it to run under weak
+  fairness, and an unrelated action can stall the obligation forever. Added
+  `_prove_leadsto_rank_helpful_sticky` (`src/fslc/bmc.py`), a new induction
+  proof obligation requiring each helpful instance to stay enabled (or `Q`
+  resolve) until it fires, reported as `rank_failure:
+  "helpful_action_enabledness_not_sticky"` when it can't be shown. Wired into
+  both the explicit-`decreases` path and the auto-synthesized-measure path
+  in `_prove_ranked_leadstos` (the latter was missed in an earlier pass of
+  this fix and reached the same false "proved, synthesized: true" outcome
+  through a separate candidate loop). The common single-helpful-action idiom
+  is unaffected (`tests/test_helpful_leadsto.py`, `docs/LANGUAGE.md`,
+  `skills/fsl/reference.md`).
+- **Soundness**: a second, independent false-`"proved"` gap in the same
+  `helpful`/`decreases` ranking rule, reproducible even with a single
+  `helpful` action — `_prove_leadsto_rank_progress` only required a
+  non-helpful action to keep the leadsTo obligation pending
+  (`Or(q_next, p_next)`), not to avoid *increasing* the measure. A fair,
+  always-enabled helpful action decreasing the measure by a bounded amount
+  each time it fires does not guarantee eventual convergence if an unrelated
+  action can increase the measure by more than that in between — the
+  helpful action still fires under weak fairness, but the measure can
+  diverge instead of reaching zero. `pending_preserved` now additionally
+  requires `measure_next <= measure` for the non-helpful branch, reported as
+  `rank_failure: "non_helpful_action_increases_measure"` when it can't be
+  shown (`src/fslc/bmc.py`, `tests/test_helpful_leadsto.py`,
+  `docs/LANGUAGE.md`, `skills/fsl/reference.md`).
+- `runtime.py`'s concrete `Monitor` rejected every fsl-db-generated spec
+  (15/18 `examples/db/*.fsl`) with a spurious `state variable 'column_exists'
+  assigned more than once in init`, because the duplicate-init-assignment
+  check keyed on the base Map variable alone; `db_expand.py` legitimately
+  writes one flat `column_exists[Col] = ...` statement per column, each to a
+  different key of the same map. This silently disabled the dual-evaluator
+  agreement safety net (oracle/agreement/trace-soundness tests, `replay`,
+  `testgen`) for the whole dbsystem dialect, since BMC accepted these specs
+  fine. `_check_deterministic_init` now disambiguates a Map/index target by
+  `(base, key)` when the key is a concrete (non-forall-bound) value, so
+  distinct keys of the same map no longer collide; a genuine same-key
+  duplicate is still rejected, and a `forall`-keyed init is unaffected.
+- The FSL language server's raw-tree index (`src/fslc/lsp/index.py`) no
+  longer hard-codes the kernel-only grammar: `build_index` now picks
+  `ai_parser.AI_PARSER`/`db_parser.DB_PARSER` for `ai_component`/`dbsystem`
+  sources (same dialect-sniffing already used by `parser.parse_src`), so
+  go-to-definition/references/hover/semantic-tokens no longer go dark with an
+  uncaught `UnexpectedCharacters` for those files (`fslc check` diagnostics
+  were unaffected, since they go through a different path). Added indexing
+  for `tool`/`table`/`column`/`artifact`/`migration`/`environment`
+  declarations and their references (`authority` tool lists, `col_ref`,
+  `env_artifact`). Also fixed two kernel-grammar indexing gaps found in the
+  same audit: a `leadsTo ... helpful NAME(...)` action name was a bare Token
+  the generic child walk skipped, so it never resolved or showed up in
+  find-references; and `deadline NAME <= expr` registered `NAME` as a new
+  `property` symbol instead of a reference to the already-declared
+  `age NAME[...]` variable it targets. Added `helpful`/`relation`/`acyclic`/
+  `functional`/`injective`/`domain`/`range` to the completion keyword list.
+- `ai_component` rejects two `fallback` entries that share the same `reason`
+  (they would silently collide into one generated `fallback_<reason>`
+  action). `docs/DESIGN-ai-hard.md` now also documents explicitly that
+  `fallback` is structural-only in Phase 1 — no invariant is generated over
+  `fallback_required`, since `target` has no corresponding kernel action to
+  check it against yet (`src/fslc/ai_expand.py` `validate_ai_component`).
+- `fslc refine` no longer silently merges a same-named impl/abs enum (or
+  struct) that has a different member list (or field set): it now rejects
+  the pair as a `kind: "type"` static error instead of letting an impl-only
+  member get reinterpreted as whichever abs member sits at the same ordinal
+  index, which could previously turn a real refinement violation into a
+  false `"refines"`. Domain types (`lo..hi`) still may share a name with
+  different bounds (`src/fslc/refine.py` `_merge_types_meta`/
+  `_type_defs_conflict`; `docs/DESIGN-refinement.md`, `docs/LANGUAGE.md`,
+  `skills/fsl/reference.md`).
+- The `acyclic`/`reachable` relation helpers no longer unroll an unmemoized
+  O(n^n) Z3 expression tree, which made verification of a self-relation with
+  as few as 7 domain values effectively hang; `_relation_reachable_expr`
+  (`src/fslc/bmc.py`) now memoizes the bounded-path recursion into an
+  O(n^2)-node shared DAG.
+- `fslc db observe` and `fslc db import` no longer return exit code 3
+  (reserved for internal errors) for their normal result values
+  (`observed_conformant`/`observed_mismatch`/`imported`/
+  `imported_with_warnings`); `exit_code()` in `src/fslc/cli.py` now maps them
+  to the documented 0/1 contract.
 - Restored `docs/index.html` to a language selector only and added bilingual
   `docs/intro/db.{ja,en}.html` content pages for the fsl-db DB /
   multi-environment compatibility manual entry.

--- a/docs/DESIGN-ai-hard.md
+++ b/docs/DESIGN-ai-hard.md
@@ -29,6 +29,18 @@ No probability, percentile, evaluator scoring, model-distribution, or stochastic
 semantics are added to the kernel. Runtime replay is observation evidence, not
 formal proof.
 
+`fallback` declarations are structural only in Phase 1: each `when <reason>
+require <target>` lowers to a `fallback_<reason>` action that sets the ghost
+`fallback_required: Bool`, but — unlike forbidden tools and approval-before-
+execution — **no invariant is generated over it**, because `target` is a free
+label with no corresponding tool/action in the grammar, so "the target was
+actually taken" is not expressible in the kernel yet. `fallback_required` is
+kept as observable state for `fslc explain`/`fslc html` and as a hook for a
+future phase that ties `target` to a real action; it is not proof that any
+fallback routing happens. Each `reason` must be unique per component
+(`validate_ai_component`) since two entries sharing a reason would collide on
+the same generated action name.
+
 ## Guarantee Boundary
 
 | Contract class | Examples | Phase 1 handling | Result vocabulary |

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -74,6 +74,12 @@ Concrete execution requires a deterministic initial state. Static check at
 `Monitor` construction:
 
 - init assigns to every state variable **exactly once** (forall bulk assignment allowed).
+  For a Map/index target (`m[K] = ...`), "once" is per concrete key when the
+  key is a literal or enum member rather than a `forall`-bound variable: flat
+  `m[K1] = ...` / `m[K2] = ...` statements for two *different* keys are not a
+  duplicate (this is exactly how a dialect like fsl-db populates a map one
+  column at a time); the same key assigned twice, or a key that is itself a
+  bound loop variable (where two iterations could alias), still is.
 - The RHS of init may reference only const and **already-assigned** state
   variables (evaluated top to bottom). A violation is `FslError(kind="semantics")`
   + hint "runtime monitor requires a deterministic init".

--- a/docs/DESIGN-induction.md
+++ b/docs/DESIGN-induction.md
@@ -84,6 +84,46 @@ ranking argument only proves the response while the pending obligation remains
 inside the ranked region. Fairness is not consulted here; every enabled action
 must make progress or establish `Q`.
 
+**With one or more `helpful action(args)` lines**, the third obligation is
+relaxed for non-matching actions, and two extra obligations are added to
+compensate (`bmc.py` `_prove_leadsto_rank_helpful_fairness`,
+`_prove_leadsto_rank_helpful_sticky`, `_prove_leadsto_rank_no_deadlock`,
+`_prove_leadsto_rank_progress`):
+
+```
+// every matching helpful instance i must be a fair action           (helpful_fairness)
+Inv(s) ∧ P(s) ∧ ¬Q(s)                          ⇒ ∃ i. enabled_i(s)     (no_deadlock: disjunction)
+Inv(s) ∧ P(s) ∧ ¬Q(s) ∧ enabled_i(s) ∧ T_a(s,s'), a ≠ i, ¬Q(s')
+                                                ⇒ enabled_i(s')         (helpful_sticky, i indexed)
+Inv(s) ∧ P(s) ∧ ¬Q(s) ∧ T_i(s,s')              ⇒ Q(s') ∨ (P(s') ∧ M(s') < M(s))
+Inv(s) ∧ P(s) ∧ ¬Q(s) ∧ T_a(s,s'), a ∉ helpful ⇒ Q(s') ∨ (P(s') ∧ M(s') ≤ M(s))
+```
+
+The disjunctive `no_deadlock` obligation ("some helpful instance is enabled")
+is not by itself enough to invoke any single instance's fairness: with two or
+more helpful instances, *which* one is enabled can differ from state to
+state, so no single instance is necessarily *continuously* enabled and its
+`fair` declaration is never obligated to fire. `helpful_sticky` closes this
+gap by requiring that once instance `i` becomes enabled while pending, no
+other action can disable it again before it fires (or `Q` holds) -- only then
+does `no_deadlock` + `fair` actually license weak fairness for that instance.
+(With a single helpful instance, `helpful_sticky` is vacuous: `no_deadlock`
+alone already proves it enabled at every pending state, i.e. continuously
+enabled while pending.)
+
+The last obligation is the other half: a non-helpful action must not
+*increase* the measure either, only the helpful instance's own transition
+must strictly decrease it. Without this bound, an unrelated action could pump
+the measure up by more than the helpful action brings it down each time it
+fires, so `Q` would never be reached even though the helpful action keeps
+firing under fairness.
+
+Failure of any of these is `unknown_cti` / `rank_failure`:
+`progress_action_not_fair`, `helpful_action_not_enabled`,
+`helpful_action_enabledness_not_sticky`, `non_decreasing_helpful_action`, or
+`non_helpful_action_increases_measure` (§2.6 of `DESIGN-temporal.md`, §10 of
+`LANGUAGE.md`).
+
 ### 2.4 Soundness notes (for implementers)
 
 - Do **not** put Init into the premise (doing so makes it the same as BMC and not a proof).

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -340,6 +340,17 @@ change abs's stock) → `impl_checkout` consumes the reserved stock) +
 6. **static checks**: missing map / unknown action / missing correspondence →
    kind: type, exit 2.
 7. **bounds**: the mapping value is out of the abs type range → map_out_of_bounds.
+8. **conflicting same-named type**: impl and abs both declare a type with the
+   same name but a different shape (an enum with different members, or a
+   struct with different fields) → kind: type, exit 2. Type metadata is
+   merged by name for refinement checking (`_merge_types_meta`); a same name
+   with a different member list would otherwise let an impl-only member get
+   silently reinterpreted as whichever abs member sits at the same ordinal
+   index, turning a real refinement violation into a false "refines". Domain
+   types with different bounds are still allowed to share a name — an
+   out-of-range impl value there is already caught downstream as
+   `abs_state_mismatch`, so merging is safe. The fix: give impl and abs
+   layers distinct type names.
 8. No regression of existing features (refine is a completely independent CLI
    path).
 

--- a/docs/DESIGN-temporal.md
+++ b/docs/DESIGN-temporal.md
@@ -176,6 +176,19 @@ that persistence condition, a trigger could disappear before `Q` and the rank
 would no longer justify the original response property. Fairness annotations are
 not used by the ranking proof; every enabled action must make ranked progress.
 
+With one or more `helpful action(args)` lines, only the matching instance(s)
+must decrease `M`; other actions must instead keep the obligation pending
+(or resolve it) *without increasing* `M`. Two extra obligations then license
+using each matching instance's `fair` declaration: every matching instance
+must itself be `fair` (`helpful_fairness`), and -- when two or more distinct
+`helpful` actions are declared -- once an instance becomes enabled while
+pending, no other action may disable it again before it fires or `Q` holds
+(`helpful_sticky`). Without `helpful_sticky`, the weaker "some helpful match
+is enabled at every pending state" does not by itself prove any single
+instance continuously enabled (which instance is enabled can vary by state),
+so its `fair` declaration is never actually obligated to fire. See
+`DESIGN-induction.md` §2.3 for the full obligation set and rationale.
+
 ## 3. Positioning and Result of the Check
 
 - **violated (counterexample found) is a definite violation** (the lasso is a
@@ -240,7 +253,11 @@ For a ranked response proved by induction:
 
 If a ranking obligation fails, induction returns `unknown_cti` with
 `violation_kind: "leadsTo_rank"`, `rank_failure` (`unbounded_below`,
-`deadlock`, `non_decreasing_action`, or `pending_not_preserved`), the relevant
+`deadlock`, `non_decreasing_action`, or `pending_not_preserved`; with
+`helpful`, also `progress_action_not_fair`, `helpful_action_not_enabled`,
+`non_decreasing_helpful_action`, `non_helpful_action_increases_measure`, and
+-- with two or more distinct helpful actions --
+`helpful_action_enabledness_not_sticky`), the relevant
 binding, a logical-state CTI, and the selected action/measure values when the
 failure is a transition-progress failure.
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -228,13 +228,30 @@ false: the measure is non-negative; progress is possible; and the enabled-action
 discipline is satisfied. Without `helpful`, every enabled action must either make
 `Q` true or keep `P` true while strictly decreasing the measure. With one or more
 `helpful action(args...)` lines, only the matching helpful action instance must
-strictly decrease the measure when it fires; unrelated action instances only need
-to keep the pending obligation true unless they make `Q` true. The matching
+strictly decrease the measure when it fires; unrelated action instances must
+keep the pending obligation true (unless they make `Q` true) and must not
+increase the measure -- an unbounded increase between helpful firings could
+outpace the guaranteed decrease and prevent `Q` from ever being reached, even
+though the helpful action keeps firing under fairness. The matching
 helpful action must be a lower-layer `fair action` and must be enabled whenever
 the obligation is pending. `helpful` is metadata for the ranked proof: it does
 not create a fairness assumption. Ranked proof success is independent of
 `--depth`; `--depth` is still used for the base BMC check and
 reachable/coverage evidence.
+
+**With two or more distinct `helpful` action names**, each instance's
+enabledness must not flicker: once a helpful instance becomes enabled while
+the obligation is pending, it must stay enabled until it fires (or `Q` holds).
+"Some helpful match is enabled at every pending state" is not enough on its
+own -- if *which* instance is enabled keeps changing (e.g. two helpful
+actions enabled on alternating conditions), no single instance is ever
+*continuously* enabled, so its `fair` declaration never actually obligates it
+to run, and the leadsTo can be genuinely false even though the disjunctive
+enabledness check passes. This is reported as
+`rank_failure:"helpful_action_enabledness_not_sticky"`. The common single
+per-binding `helpful step(c)` idiom above is unaffected: with one helpful
+action, "always enabled while pending" already implies it is continuously
+enabled.
 
 **Placement.** `decreases` is a sibling of the response body inside the
 `leadsTo` block, *outside* any `forall` wrapper — never nested inside the
@@ -270,10 +287,12 @@ leadsTo Responds {
 
 With this form, `step(c)` must be declared `fair action`, must be enabled in
 every pending state for that binding, and must strictly decrease `level[c]`
-when it fires. Other interleavings may preserve the pending obligation without
-decreasing this per-entity measure. Diagnostics distinguish
-`progress_action_not_fair`, `helpful_action_not_enabled`,
-`non_decreasing_helpful_action`, and `pending_not_preserved`.
+when it fires. Other interleavings may preserve the pending obligation
+without decreasing this per-entity measure, but must not increase it.
+Diagnostics distinguish `progress_action_not_fair`,
+`helpful_action_not_enabled`, `non_decreasing_helpful_action`,
+`non_helpful_action_increases_measure`, `pending_not_preserved`, and (with
+two or more helpful actions) `helpful_action_enabledness_not_sticky`.
 
 **Working idiom: a global sum measure.** Sum the tracked quantity across the
 domain with the built-in `sum()` aggregate (§3): `decreases sum(k: Case of

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -527,10 +527,13 @@ bound and expands the upper bound (`lo..lo`, `lo..lo+1`, ..., `lo..hi`). A
 passing sweep means "no counterexample in this grid", not an unbounded proof.
 
 Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant / refines /
-mutated / explained / analyzed / typestate / sweep_passed,
-`1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed / sweep_failed,
+mutated / explained / analyzed / typestate / sweep_passed / observed_conformant /
+imported / imported_with_warnings,
+`1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
+sweep_failed / observed_mismatch,
 `2` = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
-`--vacuity error`), `3` = internal error.
+`--vacuity error`), `3` = internal error. `observed_*` is `fslc db observe`'s
+result; `imported`/`imported_with_warnings` is `fslc db import`'s.
 
 ### Kinds of result
 
@@ -1030,7 +1033,11 @@ fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # se
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated
 explicitly in the output `note`). `Monitor` requires init to be deterministic
-(forall bulk assignment is allowed).
+(forall bulk assignment is allowed). For a Map/index target (`m[K] = ...`),
+"assign exactly once" is per concrete key, not per variable: separate flat
+`m[K1] = ...` / `m[K2] = ...` statements for two *different* keys are fine;
+the same key assigned twice, or a key that is itself a bound loop variable
+(where two iterations could alias), is still rejected.
 
 ## 13. The three-layer dialects (consulting / requirements / design) and traceability
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -796,6 +796,16 @@ with `kind` (`abs_requires_failed` / `abs_state_mismatch` / `stutter_changed_abs
 `abs_after_*`. A static error (a missing map, an unknown action, etc.) is
 `kind: "type"` (exit 2).
 
+Give impl and abs **distinct enum/struct type names**, even when a state
+variable pair is mapped 1:1. Type metadata is merged by name for refinement
+checking; a same-named enum (or struct) declared with a different member
+list (or field set) on each side is rejected as `kind: "type"` (exit 2)
+rather than merged — merging would let an impl-only member get silently
+reinterpreted as whichever abs member sits at the same ordinal index. Domain
+types (`type X = lo..hi`) may safely share a name with different bounds; an
+out-of-range value there is still caught as `map_out_of_bounds`/
+`abs_state_mismatch`.
+
 ### Chain checking (composition of mappings)
 
 The end-to-end fidelity of a layer chain (business ⊒ requirements ⊒ design …)

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -236,6 +236,14 @@ refinement <Name> {
 }
 ```
 
+Give impl and abs distinct enum/struct type names. Refinement merges type
+metadata by name; a same-named enum/struct with a different member list/field
+set on each side is rejected as `kind: "type"` (exit 2) rather than silently
+merged (merging would let an impl-only member get reinterpreted as whichever
+abs member sits at the same ordinal index). Same-named domain types
+(`lo..hi`) with different bounds are fine — an out-of-range value there is
+still caught as `map_out_of_bounds`/`abs_state_mismatch`.
+
 ## 2. Types
 
 | Type | How to write | Notes |

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -357,8 +357,17 @@ check as a type error.
      `helpful step(c) decreases level[c]`. Without `helpful`, an action advancing
      a different entity still reports `rank_failure:"non_decreasing_action"`.
      With `helpful`, diagnostics include `progress_action_not_fair`,
-     `helpful_action_not_enabled`, `non_decreasing_helpful_action`, and
-     `pending_not_preserved`.
+     `helpful_action_not_enabled`, `non_decreasing_helpful_action`,
+     `pending_not_preserved`, and (two or more distinct helpful actions)
+     `helpful_action_enabledness_not_sticky` — each helpful instance's
+     enabledness must not flicker (once enabled while pending, it must stay
+     enabled until it fires or Q holds), otherwise none is ever
+     *continuously* enabled and weak fairness never obligates it to run even
+     though "some" helpful match is always enabled — and
+     `non_helpful_action_increases_measure`: a non-helpful action may
+     preserve the pending obligation without decreasing the measure, but not
+     increase it, or an unbounded pump could outpace the helpful action's
+     guaranteed decrease and Q would never be reached.
    - **Global sum idiom**: `decreases sum(k: Case of level[k])` is still the
      simplest instances-count-independent measure when every enabled action
      decreases the total; works with `--instances` overrides too.
@@ -574,7 +583,9 @@ first failed layer and later layers are marked `skipped`.
 - leadsTo ranking failure: `unknown_cti` / `violation_kind:"leadsTo_rank"` with
   `rank_failure` (`unbounded_below`, `deadlock`, `non_decreasing_action`, or
   `pending_not_preserved`; with `helpful`, also `progress_action_not_fair`,
-  `helpful_action_not_enabled`, and `non_decreasing_helpful_action`).
+  `helpful_action_not_enabled`, `non_decreasing_helpful_action`,
+  `non_helpful_action_increases_measure`, and — with two or more distinct
+  helpful actions — `helpful_action_enabledness_not_sticky`).
 
 ### ⚠ Liveness scales differently from safety — verify it on a reduced model
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -15,7 +15,7 @@ spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadat
   struct <Name> { <field>: <type>, ... }  // field: scalar | Option<scalar>
 
   state { <var>: <type>, ... }
-  init  { <stmt>... }                     // assign exactly once to every variable (deterministic)
+  init  { <stmt>... }                     // assign exactly once per variable/Map-key (deterministic)
 
   [fair] action <name>(<p>: <type name>, ...) {
     requires <expr>                        // 0 or more. conjunction. enabled condition

--- a/src/fslc/ai_expand.py
+++ b/src/fslc/ai_expand.py
@@ -136,6 +136,12 @@ def validate_ai_component(component: AiComponent):
                     hint="declare the tool before referencing it in authority",
                 )
 
+    # Each fallback reason lowers to an action named `fallback_<reason>`
+    # (see expand_ai_component); two entries with the same reason would
+    # silently collide into one generated action, dropping the other.
+    _dedupe([fallback.reason for fallback in component.fallback],
+            "fallback reason", component.loc)
+
     _rule_set(component)
 
 

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -3161,7 +3161,9 @@ _LEADSTO_HELPFUL_PROGRESS_HINT = (
     "helpful marks which action instance is responsible for progress. The "
     "matching action must be declared `fair action`, must be enabled whenever "
     "the obligation is pending, and must strictly decrease the rank when it fires; "
-    "other actions only need to keep the pending obligation true unless they make Q true"
+    "other actions must keep the pending obligation true (unless they make Q true) "
+    "and must not increase the measure -- an unbounded increase between helpful "
+    "firings can outpace the guaranteed decrease and prevent Q from ever being reached"
 )
 
 
@@ -3381,6 +3383,86 @@ def _prove_leadsto_rank_helpful_fairness(spec, leadsto, extra_binds, binding_typ
     })
 
 
+def _prove_leadsto_rank_helpful_sticky(spec, leadsto, extra_binds, binding_types, invariants, instances):
+    """Each helpful instance must stay enabled (or Q resolve) until it fires.
+
+    `_prove_leadsto_rank_no_deadlock` only proves that *some* helpful match is
+    enabled at every pending state -- a disjunction. With a single helpful
+    match that is enough (it is then the one enabled at every such state, so
+    it is continuously enabled while pending). With more than one, the
+    disjunction can be satisfied by a *different* instance at each step (e.g.
+    two helpful actions whose enabledness alternates), in which case no
+    single instance is ever continuously enabled and its `fair` declaration
+    is never obligated to fire -- the induction would then report "proved"
+    for a leadsTo that BMC can find a genuine fair counterexample to. This
+    check additionally requires that once a helpful instance becomes enabled
+    while pending, no other action can disable it again before it either
+    fires itself or Q becomes true, which is what actually licenses invoking
+    that instance's weak fairness.
+    """
+    helpful_matches = _helpful_matches(leadsto, extra_binds, instances, spec)
+    if len(helpful_matches) < 2:
+        return None
+
+    expr_cache = {}
+    cur = make_ind_state(spec, f"rank_{leadsto['name']}_sticky_cur")
+    nxt = make_ind_state(spec, f"rank_{leadsto['name']}_sticky_next")
+    choice = z3.Int(f"__rank_sticky_choice_{leadsto['name']}")
+    solver = z3.Solver()
+    solver.add(choice >= 0, choice < len(instances))
+    solver.add(*_enum_phys_constraints(spec, cur))
+    for inv in invariants:
+        solver.add(_inv_constraint(inv, cur, spec, expr_cache))
+    with _eval_cache_scope(expr_cache, id(cur)):
+        solver.add(transition(spec, instances, cur, nxt, choice, expr_cache))
+
+    p = _eval_at_state(leadsto["P"], cur, extra_binds, spec, expr_cache)
+    q = _eval_at_state(leadsto["Q"], cur, extra_binds, spec, expr_cache)
+    q_next = _eval_at_state(leadsto["Q"], nxt, extra_binds, spec, expr_cache)
+
+    for idx, helper in helpful_matches:
+        enabled_cur = _enabled_instance(instances[idx], cur, spec, extra_binds, expr_cache)
+        enabled_next = _enabled_instance(instances[idx], nxt, spec, extra_binds, expr_cache)
+        solver.push()
+        solver.add(p, z3.Not(q), enabled_cur, choice != idx, z3.Not(q_next), z3.Not(enabled_next))
+        sat = solver.check()
+        if sat == z3.sat:
+            model = solver.model()
+            trace = _build_trace(model, [cur, nxt], [choice], instances, spec, 1)
+            solver.pop()
+            return _attach_requirement({
+                "result": "unknown_cti",
+                "spec": spec["name"],
+                "violation_kind": "leadsTo_rank",
+                "invariant": leadsto["name"],
+                "loc": leadsto.get("loc"),
+                "bindings": _display_leadsto_bindings(model, extra_binds, spec, binding_types),
+                "measure": _leadsto_measure_label(leadsto.get("decreases")),
+                "rank_failure": "helpful_action_enabledness_not_sticky",
+                "helpful_actions": _display_helpful_instances([(idx, helper)], instances, spec),
+                "last_action": _last_action(model, [choice], instances, 1, spec),
+                "cti": {
+                    "states": trace,
+                    "violated_at": 1,
+                },
+                "message": (
+                    f"helpful action '{_display_helpful_instances([(idx, helper)], instances, spec)[0]['name']}' "
+                    f"can become disabled again while leadsTo '{display_label(leadsto['name'], spec)}' is "
+                    "still pending, without itself having fired"
+                ),
+                "hint": (
+                    "with more than one `helpful` action, each instance's enabledness must not "
+                    "flicker: once a helpful instance becomes enabled while the obligation is "
+                    "pending, it must stay enabled until it fires (or Q holds) -- otherwise its "
+                    "weak fairness is never triggered, since it is never continuously enabled. "
+                    "Guard the other actions so they cannot disable a pending helpful instance, "
+                    "or split into a leadsTo per helpful action so each owns a stable region"
+                ),
+            }, leadsto)
+        solver.pop()
+    return None
+
+
 def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, invariants, instances):
     expr_cache = {}
     cur = make_ind_state(spec, f"rank_{leadsto['name']}_cur")
@@ -3404,7 +3486,12 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
     helpful_matches = _helpful_matches(leadsto, extra_binds, instances, spec)
     if helpful_matches:
         helpful_choice = z3.Or(*[choice == idx for idx, _helper in helpful_matches])
-        pending_preserved = z3.Or(q_next, p_next)
+        # A non-helpful action must not increase the measure either: an
+        # unbounded increase between successive (fairness-guaranteed, but
+        # not fairness-scheduled) helpful firings could outpace the bounded
+        # decrease each firing provides, so Q would never actually be
+        # reached even though the helpful action keeps firing.
+        pending_preserved = z3.Or(q_next, z3.And(p_next, measure_next <= measure))
         allowed = z3.Or(
             z3.And(helpful_choice, progress),
             z3.And(z3.Not(helpful_choice), pending_preserved),
@@ -3422,6 +3509,7 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
     q_next_holds = _model_bool(model, q_next)
     p_next_holds = _model_bool(model, p_next)
     decreases = _model_bool(model, measure_next < measure)
+    increases = _model_bool(model, measure_next > measure)
     choice_idx = model.eval(choice, model_completion=True).as_long()
     helpful_idx_set = {idx for idx, _helper in helpful_matches}
     rank_failure = "non_decreasing_action"
@@ -3429,6 +3517,8 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
         rank_failure = "pending_not_preserved"
     elif helpful_matches and choice_idx in helpful_idx_set and not decreases:
         rank_failure = "non_decreasing_helpful_action"
+    elif helpful_matches and choice_idx not in helpful_idx_set and increases:
+        rank_failure = "non_helpful_action_increases_measure"
     detail = {
         "result": "unknown_cti",
         "spec": spec["name"],
@@ -3461,6 +3551,12 @@ def _prove_leadsto_rank_progress(spec, leadsto, extra_binds, binding_types, inva
             f"leadsTo '{display_label(leadsto['name'], spec)}' pending without "
             "strictly decreasing the measure"
         )
+    elif rank_failure == "non_helpful_action_increases_measure":
+        detail["message"] = (
+            f"non-helpful action '{trace[1]['action']['name']}' can increase the "
+            f"measure while leadsTo '{display_label(leadsto['name'], spec)}' is "
+            "still pending, which could outpace the helpful action's guaranteed decrease"
+        )
     else:
         detail["message"] = (
             f"enabled action '{trace[1]['action']['name']}' can leave "
@@ -3485,6 +3581,10 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
                 if failure is not None:
                     return failure, None
                 failure = _prove_leadsto_rank_helpful_fairness(
+                    spec, leadsto, extra_binds, binding_types, invariants, instances)
+                if failure is not None:
+                    return failure, None
+                failure = _prove_leadsto_rank_helpful_sticky(
                     spec, leadsto, extra_binds, binding_types, invariants, instances)
                 if failure is not None:
                     return failure, None
@@ -3522,6 +3622,11 @@ def _prove_ranked_leadstos(spec, leadstos, invariants, instances):
                         candidate_failed = True
                         break
                     failure = _prove_leadsto_rank_helpful_fairness(
+                        spec, candidate_leadsto, extra_binds, binding_types, invariants, instances)
+                    if failure is not None:
+                        candidate_failed = True
+                        break
+                    failure = _prove_leadsto_rank_helpful_sticky(
                         spec, candidate_leadsto, extra_binds, binding_types, invariants, instances)
                     if failure is not None:
                         candidate_failed = True

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -1696,20 +1696,45 @@ def _relation_reachable_expr(rel, ty, src, dst, spec):
     def const(v):
         return _z3_domain_value(ty, v)
 
-    def path_at_most(k, a, b):
-        direct = _relation_contains(rel, ty, ty, a, b, spec)
-        if k <= 1:
-            return direct
-        via = [
-            z3.And(
-                _relation_contains(rel, ty, ty, a, const(mid), spec),
-                path_at_most(k - 1, const(mid), b),
-            )
-            for mid in values
-        ]
-        return z3.Or(direct, *via)
+    # path_at_most(k, a, b): "a reaches b in <= k hops". Below the top level,
+    # `a` only ever ranges over the finite domain `values` (never an arbitrary
+    # symbolic expression), so those calls are memoized on (k, a) to turn the
+    # naive O(n^n) unrolled tree into an O(n^2)-node shared DAG.
+    memo = {}
 
-    return path_at_most(len(values), src, dst)
+    def path_from_value(k, v):
+        key = (k, v)
+        cached = memo.get(key)
+        if cached is not None:
+            return cached
+        a = const(v)
+        direct = _relation_contains(rel, ty, ty, a, dst, spec)
+        if k <= 1:
+            result = direct
+        else:
+            via = [
+                z3.And(
+                    _relation_contains(rel, ty, ty, a, const(mid), spec),
+                    path_from_value(k - 1, mid),
+                )
+                for mid in values
+            ]
+            result = z3.Or(direct, *via)
+        memo[key] = result
+        return result
+
+    n = len(values)
+    direct = _relation_contains(rel, ty, ty, src, dst, spec)
+    if n <= 1:
+        return direct
+    via = [
+        z3.And(
+            _relation_contains(rel, ty, ty, src, const(mid), spec),
+            path_from_value(n - 1, mid),
+        )
+        for mid in values
+    ]
+    return z3.Or(direct, *via)
 
 
 def _relation_set_from_projection(rel, src_ty, dst_ty, spec, side):

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -1337,12 +1337,14 @@ def exit_code(result):
     r = result.get("result")
     if r in ("verified", "proved", "scenarios", "conformant", "generated",
              "refines", "typestate", "mutated", "explained", "analyzed",
-             "verified_under_assumptions", "replay_conformant"):
+             "verified_under_assumptions", "replay_conformant",
+             "observed_conformant", "imported", "imported_with_warnings"):
         return 0
     if r == "sweep_passed":
         return 0
     if r in ("violated", "reachable_failed", "unknown_cti", "nonconformant",
-             "refinement_failed", "sweep_failed", "replay_nonconformant"):
+             "refinement_failed", "sweep_failed", "replay_nonconformant",
+             "observed_mismatch"):
         return 1
     if r == "error":
         kind = result.get("kind")

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -6,7 +6,12 @@
 This module intentionally reads ``fslc.grammar.PARSER`` directly and does not
 touch the tuple AST transformer or verifier kernel. FSL keywords are mostly
 contextual, so declarations and references are classified by parse-tree
-position, not by spelling.
+position, not by spelling. The `ai_component`/`dbsystem` frontend dialects
+have their own Lark grammars (``fslc.ai_parser``/``fslc.db_parser``) that
+never reach the kernel grammar at all -- ``build_index`` picks the matching
+raw parser via ``is_ai_component_source``/``is_dbsystem_source`` before
+falling back to the kernel ``PARSER``, so those files no longer fail to
+parse here just because indexing hard-codes the kernel grammar.
 """
 from __future__ import annotations
 
@@ -18,6 +23,8 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 from lark import Tree, Token
 
 from fslc.grammar import PARSER
+from fslc.ai_parser import AI_PARSER, is_ai_component_source
+from fslc.db_parser import DB_PARSER, is_dbsystem_source
 
 
 VALUE_ROLES = {
@@ -70,6 +77,11 @@ _ROLE_TO_TOKEN_TYPE = {
     # properties / obligations (declared-name highlighting)
     "property": "event", "requirement": "event", "acceptance": "event",
     "forbidden": "event", "control": "event", "policy": "event", "goal": "event",
+    # ai_component / dbsystem dialects
+    "ai_component": "namespace", "dbsystem": "namespace",
+    "tool": "function", "table": "struct", "column": "property",
+    "artifact": "class", "migration": "function", "environment": "class",
+    "fallback_reason": "variable", "fallback_target": "variable",
 }
 
 # Roles that are synthetic block markers whose selection_range is a keyword, not an
@@ -86,7 +98,8 @@ FSL_KEYWORDS = [
     "const", "type", "symmetric", "enum", "struct", "entity", "number",
     "state", "init", "action", "fair", "requires", "ensures", "let",
     "if", "else", "forall", "exists", "invariant", "trans", "reachable",
-    "terminal", "until", "unless", "leadsTo", "decreases", "within",
+    "terminal", "until", "unless", "leadsTo", "decreases", "within", "helpful",
+    "relation", "acyclic", "functional", "injective", "domain", "range",
     "map", "maps", "auto", "impl", "abs", "preserve", "progress", "respond", "by",
     "implements", "requirement", "acceptance", "forbidden", "expect", "rejected",
     "time", "urgent", "age", "while", "deadline",
@@ -543,10 +556,18 @@ class DocumentIndex:
         return None
 
 
+def _parser_for_source(source: str):
+    if is_dbsystem_source(source):
+        return DB_PARSER
+    if is_ai_component_source(source):
+        return AI_PARSER
+    return PARSER
+
+
 def build_index(source: str, path: Optional[str] = None) -> DocumentIndex:
     """Parse ``source`` and return a raw-tree symbol/reference index."""
 
-    tree = PARSER.parse(source)
+    tree = _parser_for_source(source).parse(source)
     builder = _IndexBuilder(source, path)
     builder.visit(tree, None, None)
     return DocumentIndex(
@@ -768,6 +789,93 @@ class _IndexBuilder:
         finally:
             self._refinement_impl_name = previous_impl
             self._refinement_abs_name = previous_abs
+
+    # -- ai_component / dbsystem dialects (own grammars, see _parser_for_source) --
+
+    def _visit_ai_component(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_named_container(node, "ai_component", None)
+
+    def _visit_dbsystem(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_named_container(node, "dbsystem", None)
+
+    def _visit_tool_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "tool", _tree_range(node), parent=parent, detail="tool")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_name_list(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # authority may_suggest/may_execute/requires_human_approval/forbidden
+        # each reference a tool declared elsewhere in the same ai_component.
+        for child in node.children:
+            if isinstance(child, Token) and child.type == "NAME":
+                self._add_ref(child, "tool")
+
+    def _visit_fallback_item(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `when <reason> require <target>`: both are free labels with no
+        # corresponding declaration elsewhere in the grammar (see
+        # docs/DESIGN-ai-hard.md); record them so they still show up in
+        # outline/hover instead of silently vanishing.
+        names = [c for c in node.children if isinstance(c, Token) and c.type == "NAME"]
+        if len(names) >= 1:
+            self._add_symbol(names[0], "fallback_reason", _tree_range(node), parent=parent,
+                              detail="fallback reason", exported=False)
+        if len(names) >= 2:
+            self._add_symbol(names[1], "fallback_target", _tree_range(node), parent=parent,
+                              detail="fallback target", exported=False)
+
+    def _visit_table_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "table", _tree_range(node), parent=parent, detail="table")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_column_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(
+                token, "column", _tree_range(node),
+                scope_range=local_scope, parent=parent, detail="column", exported=False,
+            )
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_artifact_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "artifact", _tree_range(node), parent=parent, detail="artifact")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_migration_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "migration", _tree_range(node), parent=parent, detail="migration")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_environment_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "environment", _tree_range(node), parent=parent, detail="environment")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_col_ref(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `qualifier` on Reference means an import alias (resolved via
+        # import_for_alias), not "table.column" -- col_ref is same-file, so
+        # both names are plain, unqualified references (like struct `field`,
+        # column lookup is by name only and not scoped to its table).
+        names = [c for c in node.children if isinstance(c, Token) and c.type == "NAME"]
+        if len(names) == 2:
+            self._add_ref(names[0], "table")
+            self._add_ref(names[1], "column")
+
+    def _visit_env_artifact(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        names = [c for c in node.children if isinstance(c, Token) and c.type == "NAME"]
+        if names:
+            self._add_ref(names[0], "artifact")
 
     def _visit_named_container(
         self,
@@ -1071,6 +1179,15 @@ class _IndexBuilder:
     def _visit_leadsto_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         self._visit_property(node, parent, "leadsTo")
 
+    def _visit_leadsto_helpful(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `helpful NAME(args)`: NAME references an action declared elsewhere;
+        # it was previously a bare Token skipped by the generic child walk,
+        # so rename/find-references never saw it.
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "action")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
     def _visit_until_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         self._visit_property(node, parent, "until")
 
@@ -1220,9 +1337,13 @@ class _IndexBuilder:
         self._visit_children_after_first_token(node, parent, _tree_range(node))
 
     def _visit_deadline_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `deadline NAME <= expr`: NAME is a reference to an already-declared
+        # `age NAME[...]` state variable (dialects.py rejects an undeclared
+        # one as "deadline references undeclared age"), not a new property
+        # name -- multiple `deadline` lines may even target the same age var.
         token = _first_token(node)
         if token is not None:
-            self._add_symbol(token, "property", _tree_range(node), parent=parent, detail="deadline")
+            self._add_ref(token, "state_var")
         self._visit_children_after_first_token(node, parent, local_scope)
 
     def _visit_actor_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
@@ -1590,6 +1711,14 @@ def _roles_for_reference(role: str) -> set:
         return {"alias"}
     if role == "field":
         return {"field"}
+    if role == "tool":
+        return {"tool"}
+    if role == "table":
+        return {"table"}
+    if role == "column":
+        return {"column"}
+    if role == "artifact":
+        return {"artifact"}
     return set(VALUE_ROLES)
 
 

--- a/src/fslc/refine.py
+++ b/src/fslc/refine.py
@@ -104,10 +104,45 @@ def _types_compatible(abs_ty, impl_ty):
     return False
 
 
+def _type_defs_conflict(impl_info, abs_info):
+    """True if two same-named type declarations are unsafe to merge.
+
+    Domain types with different bounds are deliberately allowed to share a
+    name: an impl value outside the abs range is still caught downstream as
+    an `abs_state_mismatch` when the mapped value is checked against the abs
+    bounds. Enums (and structs) have no such downstream bounds check — an
+    impl-only member's ordinal position gets silently reinterpreted as
+    whichever abs member sits at that index, so a same name with a
+    different member list (or field set) must be rejected here instead,
+    otherwise a real refinement violation can come back as a false
+    "refines".
+    """
+    if impl_info["kind"] != abs_info["kind"]:
+        return True
+    if impl_info["kind"] == "enum":
+        return impl_info["members"] != abs_info["members"]
+    if impl_info["kind"] == "struct":
+        return impl_info["fields"] != abs_info["fields"]
+    return False
+
+
 def _merge_types_meta(impl_spec, abs_spec):
     """Merge type metadata; abs types take precedence on name clash."""
     merged = dict(impl_spec["types"])
     for name, info in abs_spec["types"].items():
+        impl_info = impl_spec["types"].get(name)
+        if impl_info is not None and _type_defs_conflict(impl_info, info):
+            _err(
+                f"type '{name}' is declared differently in the impl and abs specs "
+                f"(impl: {impl_info}, abs: {info})",
+                kind="type",
+                hint=(
+                    f"refinement merges type metadata by name, so a same-named type "
+                    f"with a different definition cannot be resolved safely; give the "
+                    f"impl and abs layers distinct type names (e.g. enum ImplStatus vs "
+                    f"enum AbsStatus) instead of reusing '{name}' for two different types"
+                ),
+            )
         merged[name] = info
     return merged
 

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -195,7 +195,29 @@ def _check_deterministic_init(spec):
             hint=_INIT_HINT,
         )
 
-    def walk(stmts, definitely_assigned, possibly_assigned, in_forall=False):
+    def dup_key(lv, bound_names):
+        # A Map/index target keyed by a concrete value -- an enum member or
+        # numeric literal, not a forall-bound variable -- is identified by
+        # (base, key) so separate flat `m[K1] = ...` / `m[K2] = ...`
+        # statements for distinct keys of the same map aren't flagged as
+        # duplicates (this is exactly how dialect-generated init code, e.g.
+        # fsl-db's per-column `column_exists[Col] = ...`, populates a map
+        # one key at a time). A symbolic/bound-variable key, or any other
+        # target shape, falls back to the base variable name alone, same as
+        # before -- unable to statically prove the keys differ.
+        if lv[0] == "index":
+            key_expr = lv[2]
+            if (
+                isinstance(key_expr, tuple)
+                and key_expr[0] == "var"
+                and key_expr[1] not in bound_names
+            ):
+                return (lv[1], key_expr)
+            if isinstance(key_expr, tuple) and key_expr[0] == "num":
+                return (lv[1], key_expr)
+        return _logical_var_from_lv(lv)
+
+    def walk(stmts, definitely_assigned, possibly_assigned, in_forall=False, bound_names=frozenset()):
         definitely_assigned = set(definitely_assigned)
         possibly_assigned = set(possibly_assigned)
         for st in stmts:
@@ -204,11 +226,12 @@ def _check_deterministic_init(spec):
                 logical = _logical_var_from_lv(st[1])
                 if logical is None:
                     _err("invalid init assignment target", kind="semantics", hint=_INIT_HINT)
-                if logical in possibly_assigned:
+                key = dup_key(st[1], bound_names)
+                if key in possibly_assigned:
                     duplicate_assignment(logical, in_forall)
                 check_expr(st[2], definitely_assigned)
                 definitely_assigned.add(logical)
-                possibly_assigned.add(logical)
+                possibly_assigned.add(key)
             elif tag == "forall_stmt":
                 if in_forall:
                     _err("nested forall in init is not supported", kind="semantics", hint=_INIT_HINT)
@@ -220,6 +243,7 @@ def _check_deterministic_init(spec):
                     definitely_assigned,
                     possibly_assigned,
                     in_forall=True,
+                    bound_names=bound_names | {binder[1]},
                 )
                 definitely_assigned = body_definite
                 possibly_assigned = body_possible
@@ -231,12 +255,14 @@ def _check_deterministic_init(spec):
                     definitely_assigned,
                     possibly_assigned,
                     in_forall=in_forall,
+                    bound_names=bound_names,
                 )
                 else_definite, else_possible = walk(
                     else_stmts,
                     definitely_assigned,
                     possibly_assigned,
                     in_forall=in_forall,
+                    bound_names=bound_names,
                 )
                 definitely_assigned = then_definite & else_definite
                 possibly_assigned = then_possible | else_possible

--- a/tests/test_ai_hard_contract.py
+++ b/tests/test_ai_hard_contract.py
@@ -125,6 +125,33 @@ def test_ai_static_check_flags_irreversible_tool_without_approval(tmp_path):
     assert out["formal_result"] == "not_run"
 
 
+def test_ai_static_check_rejects_duplicate_fallback_reason(tmp_path):
+    # Two fallback entries sharing a reason would both lower to the same
+    # generated action name (fallback_<reason>), silently colliding.
+    path = tmp_path / "dup_fallback.fsl"
+    path.write_text(
+        """ai_component DupFallbackAgent {
+  tool SearchOrder {
+    schema SearchOrderV1;
+  }
+  authority {
+    may_execute SearchOrder;
+  }
+  fallback {
+    when low_confidence require human_review;
+    when low_confidence require refuse_with_reason;
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    out = run_ai_check(str(path))
+
+    assert out["result"] == "error"
+    assert "duplicate fallback reason" in out["message"]
+
+
 def test_ai_replay_distinguishes_schema_and_business_precondition_mismatch(tmp_path):
     log = tmp_path / "bad_tool_call.jsonl"
     log.write_text(

--- a/tests/test_db_dialect.py
+++ b/tests/test_db_dialect.py
@@ -3,9 +3,17 @@
 
 """fsl-db MVP dialect coverage."""
 
+import json
 from pathlib import Path
 
-from fslc.cli import run_check, run_db_check, run_db_import, run_db_observe, run_verify
+from fslc.cli import (
+    exit_code,
+    run_check,
+    run_db_check,
+    run_db_import,
+    run_db_observe,
+    run_verify,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -214,6 +222,28 @@ def test_db_runtime_observation_reports_observed_mismatch_not_formal_violation()
     }
     assert {finding["result"] for finding in out["findings"]} == {"observed_mismatch"}
     assert "DB-ASSUME-OBSERVABILITY-COVERAGE" in _assumption_ids(out)
+    assert exit_code(out) == 1
+
+
+def test_db_runtime_observation_reports_observed_conformant_as_exit_0(tmp_path):
+    trace = tmp_path / "conformant.json"
+    trace.write_text(json.dumps({
+        "schema_version": "fsl-db-observation.v0",
+        "events": [
+            {
+                "environment": "prod",
+                "schema_version": 0,
+                "artifact": "server_v2",
+                "capability": "reads",
+                "target": "users.id",
+            },
+        ],
+    }))
+
+    out = run_db_observe(_example("runtime_observation_target.fsl"), str(trace))
+
+    assert out["result"] == "observed_conformant"
+    assert exit_code(out) == 0
 
 
 def test_db_sql_importer_emits_checkable_dbsystem(tmp_path):
@@ -226,6 +256,7 @@ def test_db_sql_importer_emits_checkable_dbsystem(tmp_path):
 
     assert imported["result"] == "imported"
     assert imported["output"] == str(output)
+    assert exit_code(imported) == 0
     checked = run_db_check(str(output))
     assert checked["result"] == "verified_under_assumptions"
 
@@ -236,3 +267,4 @@ def test_db_sql_importer_reports_unsupported_constructs():
     assert imported["result"] == "imported_with_warnings"
     assert imported["warnings"][0]["kind"] == "unsupported_sql"
     assert "CREATE INDEX" in imported["warnings"][0]["statement"]
+    assert exit_code(imported) == 0

--- a/tests/test_helpful_leadsto.py
+++ b/tests/test_helpful_leadsto.py
@@ -66,6 +66,98 @@ BLOCKED_HELPFUL_SRC = r'''spec BlockedHelpful {
 '''
 
 
+FLICKERING_HELPFUL_SRC = r'''spec HelpfulFlickering {
+  type Phase = 0..9
+  type Credit = 0..1
+  state { phase: Phase, done: Bool, credit: Credit }
+  init { phase = 0  done = false  credit = 1 }
+
+  fair action helpEven() {
+    requires phase % 2 == 0
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  fair action helpOdd() {
+    requires phase % 2 == 1
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  action rotate() {
+    requires done == false
+    phase = (phase + 1) % 10
+  }
+
+  leadsTo Finishes {
+    done == false ~> done == true
+    helpful helpEven()
+    helpful helpOdd()
+    decreases credit
+  }
+}
+'''
+
+
+FLICKERING_HELPFUL_SYNTHESIZED_SRC = r'''spec HelpfulFlickeringSynthesized {
+  type Phase = 0..9
+  type Credit = 0..1
+  state { phase: Phase, credit: Credit }
+  init { phase = 0  credit = 0 }
+
+  fair action helpEven() {
+    requires phase % 2 == 0
+    requires credit == 0
+    credit = 1
+  }
+
+  fair action helpOdd() {
+    requires phase % 2 == 1
+    requires credit == 0
+    credit = 1
+  }
+
+  action rotate() {
+    requires credit == 0
+    phase = (phase + 1) % 10
+  }
+
+  leadsTo Finishes {
+    credit == 0 ~> credit == 1
+    helpful helpEven()
+    helpful helpOdd()
+  }
+}
+'''
+
+
+PUMPED_MEASURE_SRC = r'''spec HelpfulPumpedMeasure {
+  state { x: Int }
+  init { x = 5 }
+
+  fair action work() {
+    requires x > 0
+    x = x - 1
+  }
+
+  action pump() {
+    requires x > 0
+    x = x + 2
+  }
+
+  invariant NonNeg { x >= 0 }
+
+  leadsTo Finishes {
+    x > 0 ~> x == 0
+    helpful work()
+    decreases x
+  }
+}
+'''
+
+
 def _write(tmp_path, src, name):
     path = tmp_path / name
     path.write_text(src, encoding="utf-8")
@@ -98,3 +190,76 @@ def test_blocked_helpful_action_is_reported(tmp_path):
     assert out["rank_failure"] == "helpful_action_not_enabled"
     assert out["helpful"] == ["step(c)"]
     assert out["bindings"] == {"c": 0}
+
+
+def test_multiple_helpful_actions_with_flickering_enabledness_is_not_falsely_proved(tmp_path):
+    # Regression (soundness): two `helpful` actions whose enabledness
+    # alternates by phase parity used to make induction report "proved" --
+    # `_prove_leadsto_rank_no_deadlock` only checked that *some* helpful
+    # match is enabled at every pending state (true here, disjunctively),
+    # but neither helpEven nor helpOdd is ever *continuously* enabled, so
+    # weak fairness never actually obligates either one to fire. `rotate`
+    # can cycle forever without either ever firing, so `Finishes` is
+    # genuinely false -- BMC finds the fair counterexample at a depth
+    # beyond the default induction base check, while induction must now
+    # honestly report unknown_cti instead of a false "proved".
+    spec = _write(tmp_path, FLICKERING_HELPFUL_SRC, "flickering_helpful.fsl")
+
+    induction_out = run_verify(str(spec), 8, "warn", engine="induction", k_ind=1)
+    assert induction_out["result"] == "unknown_cti"
+    assert induction_out["rank_failure"] == "helpful_action_enabledness_not_sticky"
+    assert induction_out["helpful_actions"][0]["name"] in {"helpEven", "helpOdd"}
+
+    bmc_out = run_verify(str(spec), 12, "warn", engine="bmc")
+    assert bmc_out["result"] == "violated"
+    assert bmc_out["violation_kind"] == "leadsTo"
+    assert bmc_out["invariant"] == "Finishes"
+
+
+def test_non_helpful_action_pumping_the_measure_is_not_falsely_proved(tmp_path):
+    # Regression (soundness, single-helpful-action case -- unrelated to
+    # sticky/flickering): _prove_leadsto_rank_progress's helpful branch only
+    # required a non-helpful action to keep the obligation pending
+    # (`Or(q_next, p_next)`), not to avoid *increasing* the measure. `work`
+    # is fair and always enabled while pending (so no_deadlock/sticky/
+    # fairness all trivially hold with only one helpful match), but the
+    # non-fair `pump` action can add more to `x` than `work` ever removes,
+    # so a fair execution (work fires regularly, satisfying its own
+    # fairness) can still drive `x` to infinity and never reach 0. Induction
+    # must report unknown_cti; BMC finds the genuine fair counterexample.
+    spec = _write(tmp_path, PUMPED_MEASURE_SRC, "pumped_measure.fsl")
+
+    induction_out = run_verify(str(spec), 8, "warn", engine="induction", k_ind=1)
+    assert induction_out["result"] == "unknown_cti"
+    assert induction_out["rank_failure"] == "non_helpful_action_increases_measure"
+    assert induction_out["last_action"]["name"] == "pump"
+
+    bmc_out = run_verify(str(spec), 8, "warn", engine="bmc")
+    assert bmc_out["result"] == "violated"
+    assert bmc_out["violation_kind"] == "leadsTo"
+    assert bmc_out["invariant"] == "Finishes"
+
+
+def test_synthesized_measure_does_not_falsely_claim_unbounded_ranking_proof(tmp_path):
+    # Regression: the same flickering-enabledness unsoundness reached the
+    # *auto-synthesized* measure path too, via a separate loop in
+    # _prove_ranked_leadstos (candidates from _synthesize_leadsto_measures)
+    # that originally called lower_bound/helpful_fairness/no_deadlock/progress
+    # but not the new helpful_sticky check. Without sticky wired into both
+    # loops, this spec's synthesized measure `1 - credit` passed every other
+    # check and induction reported leads_to.Finishes with
+    # `proof:"ranking", synthesized:true, completeness:"unbounded"` -- a
+    # false unbounded claim for a leadsTo that is genuinely violated (same
+    # flickering helpEven/helpOdd pattern, no explicit `decreases`).
+    spec = _write(tmp_path, FLICKERING_HELPFUL_SYNTHESIZED_SRC, "flickering_synth.fsl")
+
+    induction_out = run_verify(str(spec), 8, "warn", engine="induction", k_ind=1)
+    assert induction_out["result"] == "proved"  # base invariants only, not the leadsTo
+    finishes = induction_out["leads_to"]["Finishes"]
+    assert "proof" not in finishes
+    assert finishes.get("completeness") != "unbounded"
+
+    bmc_out = run_verify(str(spec), 12, "warn", engine="bmc")
+    assert bmc_out["result"] == "violated"
+    assert bmc_out["violation_kind"] == "leadsTo"
+    assert bmc_out["invariant"] == "Finishes"

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -621,3 +621,139 @@ def test_completion_member_after_alias_dot():
     exported_names = {sym.name for sym in cart_index.symbols if sym.exported}
     labels = {c.label for c in completions}
     assert labels == exported_names
+
+
+def test_leadsto_helpful_action_name_is_indexed_as_a_reference():
+    # Regression: `helpful NAME(...)` inside `leadsTo` used to be a bare
+    # Token skipped by the generic child walk, so go-to-definition and
+    # find-references never saw the helpful action name.
+    source = '''spec HelpfulRefDemo {
+  state { x: Int }
+  init { x = 0 }
+  fair action step() {
+    requires x < 3
+    x = x + 1
+  }
+  leadsTo Finishes {
+    x == 0 ~> x == 3
+    helpful step()
+  }
+}
+'''
+    index = build_index(source)
+    step_decl = _symbol(index, "step", "action")
+    helpful_ref = _reference(index, "step", "action")
+
+    loc = index.definition_at(helpful_ref.range.start.line, helpful_ref.range.start.character)
+    assert loc is not None
+    assert loc.range == step_decl.selection_range
+
+    refs = index.references_at(
+        step_decl.selection_range.start.line,
+        step_decl.selection_range.start.character,
+    )
+    assert helpful_ref.range in refs
+    assert step_decl.selection_range in refs
+
+
+def test_deadline_name_is_a_reference_to_the_declared_age_not_a_new_property():
+    # Regression: `deadline NAME <= expr` used to register NAME as a new
+    # "property" symbol instead of a reference to the already-declared
+    # `age NAME[...]` variable, so it neither resolved to nor showed up in
+    # find-references for the age declaration.
+    source = '''requirements DeadlineRefDemo {
+  type CaseId = 0..0
+  enum St { Waiting, Accepted, Responded }
+
+  state {
+    cases: Map<CaseId, St>
+  }
+  init {
+    forall c: CaseId { cases[c] = Waiting }
+  }
+
+  requirement REQ-1 "accept" {
+    fair action accept(c: CaseId) {
+      requires cases[c] == Waiting
+      cases[c] = Accepted
+    }
+  }
+
+  time {
+    age resp_age[c: CaseId] while cases[c] == Accepted
+  }
+
+  requirement REQ-2 "respond within deadline" {
+    fair action respond(c: CaseId) {
+      requires cases[c] == Accepted
+      cases[c] = Responded
+    }
+    deadline resp_age <= 3
+  }
+}
+'''
+    index = build_index(source)
+    age_decl = _symbol(index, "resp_age", "state_var")
+    assert not any(sym.name == "resp_age" and sym.role == "property" for sym in index.symbols)
+
+    deadline_ref = _reference(index, "resp_age", "state_var")
+    loc = index.definition_at(deadline_ref.range.start.line, deadline_ref.range.start.character)
+    assert loc is not None
+    assert loc.range == age_decl.selection_range
+
+    refs = index.references_at(age_decl.selection_range.start.line, age_decl.selection_range.start.character)
+    assert deadline_ref.range in refs
+
+
+def test_build_index_handles_ai_component_dialect_without_crashing():
+    # Regression: build_index hard-coded the kernel-only PARSER, so any
+    # ai_component/dbsystem file threw UnexpectedCharacters and every LSP
+    # feature (go-to-def, references, hover, semanticTokens) went dark for
+    # that file even though `fslc check` (parse_src) handled it fine.
+    source = '''ai_component RefDemo {
+  tool SearchOrder {
+    schema SearchOrderV1;
+  }
+  authority {
+    may_execute SearchOrder;
+  }
+}
+'''
+    index = build_index(source, "ref_demo.fsl")
+    component = _symbol(index, "RefDemo", "ai_component")
+    tool_decl = _symbol(index, "SearchOrder", "tool")
+    tool_ref = _reference(index, "SearchOrder", "tool")
+
+    loc = index.definition_at(tool_ref.range.start.line, tool_ref.range.start.character)
+    assert loc is not None
+    assert loc.range == tool_decl.selection_range
+    assert component.range.start.line == 0
+
+
+def test_build_index_handles_dbsystem_dialect_without_crashing():
+    source = '''dbsystem RefDbDemo {
+  database app {
+    schema 0
+    table users {
+      column id: Int present not_null;
+    }
+  }
+  artifact server {
+    reads users.id;
+  }
+}
+'''
+    index = build_index(source, "ref_db_demo.fsl")
+    _symbol(index, "RefDbDemo", "dbsystem")
+    table_decl = _symbol(index, "users", "table")
+    column_decl = _symbol(index, "id", "column")
+    table_ref = _reference(index, "users", "table")
+    column_ref = _reference(index, "id", "column")
+
+    table_loc = index.definition_at(table_ref.range.start.line, table_ref.range.start.character)
+    assert table_loc is not None
+    assert table_loc.range == table_decl.selection_range
+
+    column_loc = index.definition_at(column_ref.range.start.line, column_ref.range.start.character)
+    assert column_loc is not None
+    assert column_loc.range == column_decl.selection_range

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -152,6 +152,58 @@ def test_refinement_action_param_type_annotation_mismatch_is_type_error(tmp_path
     assert exit_code(r) == 2
 
 
+_CONFLICTING_ENUM_ABS = """
+spec ConflEnumAbs {
+  type Id = 0..0
+  enum Status { Open, Closed }
+  state { st: Map<Id, Status> }
+  init { forall c: Id { st[c] = Open } }
+  fair action close(c: Id) { requires st[c] == Open  st[c] = Closed }
+}
+"""
+
+
+_CONFLICTING_ENUM_IMPL = """
+spec ConflEnumImpl {
+  type Id = 0..0
+  enum Status { Open, Stuck, Closed }
+  state { st: Map<Id, Status> }
+  init { forall c: Id { st[c] = Open } }
+  action close(c: Id) { requires st[c] == Open  st[c] = Stuck }
+}
+"""
+
+
+_CONFLICTING_ENUM_MAP = """
+refinement ConflEnumRefines {
+  impl ConflEnumImpl
+  abs ConflEnumAbs
+  map st[c: Id] = st[c]
+  action close(c) -> close(c)
+}
+"""
+
+
+def test_same_named_enum_with_different_members_is_rejected_not_merged(tmp_path):
+    # Regression: impl's `Stuck` (index 1) used to get silently reinterpreted
+    # as abs's `Closed` (also index 1) because _merge_types_meta merged same-
+    # named enums by name only. impl never truly reaches Closed here, so a
+    # "refines" verdict would be a false positive; it must be rejected instead.
+    abs_file = tmp_path / "abs.fsl"
+    impl_file = tmp_path / "impl.fsl"
+    map_file = tmp_path / "map.fsl"
+    abs_file.write_text(_CONFLICTING_ENUM_ABS, encoding="utf-8")
+    impl_file.write_text(_CONFLICTING_ENUM_IMPL, encoding="utf-8")
+    map_file.write_text(_CONFLICTING_ENUM_MAP, encoding="utf-8")
+
+    r = run_refine(str(impl_file), str(abs_file), str(map_file), depth=6)
+
+    assert r["result"] == "error"
+    assert r["kind"] == "type"
+    assert "Status" in r["message"]
+    assert exit_code(r) == 2
+
+
 def test_seat_conditional_map_refines_booking():
     r = run_refine(
         str(SPECS / "seat_booking_impl.fsl"),

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -3,6 +3,8 @@
 
 """Typed relation layer coverage (#108)."""
 
+import time
+
 from fslc.cli import run_verify
 from fslc.runtime import Monitor
 
@@ -119,3 +121,27 @@ def test_relation_trace_displays_counterexample_pairs(tmp_path):
     assert out["invariant"] == "DelegatesAcyclic"
     states = out["trace"]
     assert states[-1]["state"]["delegates"] == [[0, 1], [1, 0]]
+
+
+def test_reachable_and_acyclic_encoding_does_not_blow_up(tmp_path):
+    # Regression guard: _relation_reachable_expr used to unroll an
+    # unmemoized O(n^n) tree, which made a 7-node self-relation time out.
+    # With memoization this stays well under a second for 12 nodes.
+    src = '''spec RelPerf {
+  type Node = 0..11
+  state { r: relation Node -> Node }
+  init { r = Set {} }
+  action link(a: Node, b: Node) {
+    r = r.add(a, b)
+  }
+  invariant NoSelfReach {
+    (not acyclic(r)) or (not reachable(r, 0, 0))
+  }
+}
+'''
+    spec = _write(tmp_path, src, "rel_perf.fsl")
+    started = time.time()
+    out = run_verify(str(spec), 2, "warn")
+    elapsed = time.time() - started
+    assert out["result"] == "verified"
+    assert elapsed < 30

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -243,6 +243,70 @@ def test_monitor_missing_fsl_path_raises_io():
     assert str(exc.value) == "file not found: specs/nonexistent.fsl"
 
 
+def test_init_duplicate_assignment_check_is_per_key_not_per_map():
+    # Regression: the duplicate-init-assignment check used to key on the
+    # base map variable alone, so two flat (non-forall) `m[K1] = ...` /
+    # `m[K2] = ...` statements for two DIFFERENT keys of the same map were
+    # rejected as "assigned more than once" even though they don't collide
+    # -- exactly the shape fsl-db's per-column init generates
+    # (column_exists[Col1] = ..., column_exists[Col2] = ..., ...).
+    distinct_keys_src = """
+spec DistinctMapKeys {
+  enum Col { A, B }
+  state { m: Map<Col, Bool> }
+  init {
+    m[A] = true
+    m[B] = false
+  }
+  action noop() { }
+}
+"""
+    mon = Monitor(build_spec(parse(distinct_keys_src)))
+    assert mon.state["m"] == {"A": True, "B": False}
+
+    # A genuine duplicate -- the same key assigned twice -- must still be caught.
+    same_key_src = """
+spec DupMapKey {
+  enum Col { A, B }
+  state { m: Map<Col, Bool> }
+  init {
+    m[A] = true
+    m[A] = false
+  }
+  action noop() { }
+}
+"""
+    with pytest.raises(FslError) as exc:
+        Monitor(build_spec(parse(same_key_src)))
+    assert exc.value.kind == "semantics"
+    assert "assigned more than once" in str(exc.value)
+
+    # A forall over the map's own key type still works (unaffected by the fix).
+    forall_src = """
+spec ForallMapInit {
+  type Id = 0..2
+  state { m: Map<Id, Bool> }
+  init {
+    forall c: Id { m[c] = true }
+  }
+  action noop() { }
+}
+"""
+    mon2 = Monitor(build_spec(parse(forall_src)))
+    assert mon2.state["m"] == {"0": True, "1": True, "2": True}
+
+
+def test_db_dialect_examples_load_in_monitor():
+    # Regression: db_expand.py's per-column init (column_exists[Col] = ...,
+    # one flat assign per column) used to fail every fsl-db example in the
+    # concrete Monitor, silently disabling the dual-evaluator agreement
+    # safety net for the whole dialect (BMC accepted these specs fine).
+    db_examples = sorted((ROOT / "examples" / "db").glob("*.fsl"))
+    assert db_examples
+    for path in db_examples:
+        Monitor(str(path))
+
+
 def test_monitor_accepts_direct_fsl_source_string():
     src = """
 spec DirectSource {


### PR DESCRIPTION
## Summary

This PR fixes 6 bugs found in a full-repo audit of `fslc` (verify/check/refine/CLI/LSP), ranked by severity. Every existing test still passes (`pytest -q`: 984 passed, 0 failed, 78 skipped — unchanged skip set), and each fix ships with new regression tests plus doc/skill updates per the repo's coupled-change convention.

### 1. Soundness: false `"proved"` in `helpful`/`decreases` leadsTo ranking (2 independent gaps)
`fslc verify --engine induction` could report a `leadsTo ... decreases ... helpful` property `"proved"` when BMC finds a real counterexample.
- With **two or more distinct `helpful` actions**, the induction rule only checked that *some* helpful match is enabled at every pending state (a disjunction) — if which instance is enabled alternates, no single instance is ever *continuously* enabled, so its `fair` declaration never actually obligates it to run. Added a new "sticky enabledness" proof obligation, wired into both the explicit-`decreases` and the auto-synthesized-measure paths (the second path was missed on the first pass and caught by an independent review — see commit history).
- **Independent of the above**, reproducible with a single helpful action: a non-helpful action was allowed to *increase* the measure without bound, which can outpace the helpful action's guaranteed decrease and prevent convergence even though it keeps firing under fairness.

### 2. `fslc refine` merges same-named enum/struct by name, risking a false `"refines"`
Refinement checking merged impl/abs type metadata by name (abs wins on clash). A same-named enum with a different member list was merged silently, letting an impl-only member get reinterpreted as whichever abs member sits at the same ordinal index — turning a real refinement violation into a false `"refines"`. Now rejected as a static `kind:"type"` error. Domain types with different bounds still safely share a name (already caught downstream as `abs_state_mismatch`/`map_out_of_bounds`).

### 3. fsl-db specs couldn't load in the concrete `Monitor`
The duplicate-init-assignment check keyed on the base Map variable alone, so `db_expand.py`'s legitimate one-flat-assignment-per-column init pattern (`column_exists[Col1] = ...`, `column_exists[Col2] = ...`, ...) was rejected as "assigned more than once". This silently disabled the dual-evaluator agreement safety net (oracle/agreement/trace-soundness, `replay`, `testgen`) for the entire dbsystem dialect, since BMC accepted these specs fine. Now disambiguated by `(base, key)` when the key is concrete.

### 4. `fslc db observe`/`fslc db import` always exited 3 (internal error)
`exit_code()` had no entries for `observed_conformant`/`observed_mismatch`/`imported`/`imported_with_warnings`, so these commands returned exit 3 regardless of success or failure — breaking the JSON+exit-code contract the write→verify→repair loop depends on.

### 5. LSP failed entirely on `ai_component`/`dbsystem` files
The language server's raw-tree index hard-coded the kernel-only grammar parser. Since `ai_component`/`dbsystem` have their own Lark grammars, opening one threw `UnexpectedCharacters` and every LSP feature (go-to-definition, references, hover, semantic tokens) went dark for that file (diagnostics were unaffected — different code path). Fixed by picking the matching parser, plus added indexing for `tool`/`table`/`column`/`artifact`/`migration`/`environment` symbols. Also fixed two unrelated kernel-grammar indexing gaps found in the same audit: `helpful NAME(...)` inside `leadsTo` wasn't indexed as a reference, and `deadline NAME <= expr` mis-registered `NAME` as a new declaration instead of a reference to the existing `age` variable.

### 6. `acyclic`/`reachable` relation encoding was exponential
Unmemoized recursion built an O(n^n) Z3 expression tree, making a 7-node self-relation effectively hang. Memoized into an O(n^2)-node shared DAG (same formula, same verdict, no functional change).

Also: `ai_component` now rejects two `fallback` entries sharing the same `reason` (they'd silently collide into one generated action), and `docs/DESIGN-ai-hard.md` now states explicitly that `fallback` is structural-only in Phase 1 (a mutation-testing audit flagged it as an unchecked "dead ghost" — the correct fix was documenting the boundary, not fabricating an invariant with no real target to check against).

## Test plan
- [x] `pytest -q` — 984 passed, 0 failed, 78 skipped (full suite, run twice)
- [x] New regression test per fix (`tests/test_helpful_leadsto.py` ×3 new, `tests/test_refine.py`, `tests/test_runtime.py`, `tests/test_db_dialect.py`, `tests/test_relation.py`, `tests/test_lsp_index.py` ×4 new, `tests/test_ai_hard_contract.py`)
- [x] `tests/test_corpus_snapshot.py` unchanged (no existing spec's verdict changed by any fix)
- [x] Independent soundness re-review of the two `bmc.py` leadsTo-ranking fixes (found the synthesized-measure-path gap, now fixed)
- [x] Independent coupled-change re-review of all 10 commits (found 3 doc gaps, now closed)
- [x] `docs/LANGUAGE.md`, `skills/fsl/reference.md`, and relevant `docs/DESIGN-*.md` updated for every behavior change
- [x] `CHANGELOG.md` `[Unreleased]` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)