### PR TITLE
docs(analysis): define agent-side NL review boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Documented the agent-side natural-language review boundary for
+  `fslc analyze`: `fslc` remains deterministic and language-agnostic, while AI
+  agents may add non-authoritative review suggestions only when they cite source
+  text and graph nodes, keep `formal_status:"not_a_violation"`, and respect
+  explicit privacy opt-in for external model calls. (#117)
 - fsl-ai recursive `agent` composition: `fslc ai check` now parses nested
   agents as ordinary scoped agents, emits deterministic AI-readable
   `agent_ir`/graph summaries, validates explicit authority/context grant

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -9,6 +9,55 @@ review?
 signals and carry `formal_status: "not_a_violation"` unless a future finding is
 explicitly backed by existing `verify`, `refine`, or `replay` semantics.
 
+## Agent-side natural-language review boundary
+
+Natural-language interpretation is an AI-agent responsibility, not an `fslc`
+feature. `fslc analyze` may carry requirement text, comments, tags, and source
+locations through deterministic JSON, but it must not infer from English,
+Japanese, or any other language that a word or sentence means retry, approval,
+timeout, progress, or any other formal property.
+
+An AI agent may consume `analyze` JSON together with the source text and produce
+review suggestions, but those suggestions are outside fslc semantics:
+
+- Do not add a core `fslc-nl-review` command for this boundary unless a future
+  issue explicitly moves the responsibility back into this repository.
+- Do not fail CI, `check`, `verify`, `refine`, or `replay` from
+  natural-language suggestions.
+- Mark agent-side suggestions with `formal_status: "not_a_violation"` and never
+  present them as formal violations.
+- Cite the exact source text and graph node ids used as evidence, such as
+  `requirement:REQ-1` or `action:submit`.
+- Handle non-English text by using the agent's language capability, a
+  user-approved reviewer, or a pluggable reviewer; do not add hard-coded English
+  keyword rules to `fslc`.
+- Treat privacy and external model calls as agent-side policy. Do not send
+  source text, requirement text, comments, or analyze JSON to an external service
+  unless the user or execution environment has explicitly opted in.
+
+Suggested agent-owned output shape:
+
+```json
+{
+  "result": "reviewed",
+  "source": "analysis-findings.v0",
+  "reviewer": "agent-side-nl",
+  "suggestions": [
+    {
+      "kind": "possible_missing_progress_story",
+      "confidence": 0.42,
+      "evidence_nodes": ["action:retry", "requirement:REQ-1"],
+      "quoted_source": "...",
+      "formal_status": "not_a_violation",
+      "do_not_assume": [
+        "The suggestion is correct",
+        "The spec violates liveness"
+      ]
+    }
+  ]
+}
+```
+
 ## 1. CLI
 
 ```bash

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -274,6 +274,11 @@ the formalization memo.**
    `traceability_graph`, DOT/Mermaid graph exports, and JSON schemas under
    `schemas/fslc/analysis/`. These are review signals with
    `formal_status:"not_a_violation"`, not proof failures),
+   When you add natural-language judgment on top of `analyze` output, keep it
+   agent-side: cite exact source text and TSG node ids, keep
+   `formal_status:"not_a_violation"`, do not turn suggestions into fslc
+   violations or CI failures, and do not send source/requirement/comment text to
+   an external model unless the user or environment has explicitly opted in,
    `fslc mutate file.fsl --depth 8 --by-requirement`
    (shows how many model mutations the spec's properties kill; a survivor is not a
    failure but a candidate for a missing invariant / acceptance / forbidden. For a

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -508,6 +508,18 @@ graph projections can export DOT or Mermaid with `--format dot|mermaid`.
 `verify`/`refine`/`replay` evidence. Versioned schemas live under
 `schemas/fslc/analysis/`.
 
+Natural-language interpretation on top of `analyze` is agent-side only. The core
+analyzer must not infer semantics from English, Japanese, or other free text.
+If an agent reviews requirement text, comments, or source excerpts together with
+the TSG, it must cite the exact text and graph node ids it used, keep
+`formal_status:"not_a_violation"`, and never convert that suggestion into an
+`fslc` violation, proof result, or CI failure. Non-English text should be handled
+by the agent's language capability or a user-approved reviewer, not by hard-coded
+keywords in this repository. External model calls are an agent privacy decision:
+do not send source text, requirement text, comments, or analysis JSON outside the
+local environment unless the user or execution environment has explicitly opted
+in.
+
 `ledger` (issue #24) re-organizes `verify`/`scenarios`/`replay` findings **by
 requirement id** into a Markdown audit ledger a PM / governance / internal-audit
 reader can decide approve/reject/risk-accept from. It is a presentation layer


### PR DESCRIPTION
## Summary
- Documents that natural-language interpretation over `fslc analyze` output is an AI-agent responsibility, not an `fslc` feature.
- Adds agent-facing rules to cite exact source text and TSG node ids, keep `formal_status:"not_a_violation"`, avoid CI/verifier failures from NL suggestions, and require explicit opt-in before external model calls.
- Mirrors the rule in `skills/fsl/SKILL.md` and `skills/fsl/reference.md` so agents get the instruction at point of use.

## Why
- **Goal**: Resolve #117 without adding an in-repo NL reviewer command or hard-coded language heuristics.
- **Reason**: The AI agent already owns natural-language reading and privacy decisions; `fslc` should remain deterministic and language-agnostic.
- **Alternative**: Add a prototype `fslc-nl-review` command. Rejected for now because it would move LLM/privacy policy into the core repo without a stronger product need.

## Invariants
- `fslc analyze` remains structural observation, not verifier semantics.
- Agent-side NL suggestions remain non-authoritative review candidates.
- No source text is sent to an external service without explicit opt-in.

## Evidence
- `git diff --check`

## Rollback
- Revert the docs/skill commit; no runtime state or schema migration is involved.

## Related
Closes #117