### PR TITLE
docs(site): deepen the fsl-domain and fsl-ai manual pages

### DIFF
--- a/docs/intro/ai.en.html
+++ b/docs/intro/ai.en.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>AI Hard Contracts and Agent Structures with fsl-ai — FSL Manual</title>
-<meta name="description" content="How to use fsl-ai ai_component and agent to check AI tool authority, human approval guards, recursive agent structure, runtime replay, and AI-readable findings." />
+<title>AI Hard Contracts, Agent Structure, and Statistical Evidence with fsl-ai — FSL Manual</title>
+<meta name="description" content="How to use fsl-ai ai_component, agent, dataset, evaluator, statistical_property, ai_migration, and observed_property to check AI tool boundaries, recursive agent structure, Wilson-interval statistical evidence, migration regression, and operational drift." />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="ai">
@@ -17,33 +17,63 @@
 <section class="hero">
   <div class="wrap narrow center">
     <nav class="breadcrumb" data-nav></nav>
-    <p class="kicker reveal">AI hard-contracts</p>
-    <h1 class="reveal">Guard AI tools and agent structure with fsl-ai</h1>
-    <p class="lead reveal">fsl-ai models deterministic AI boundaries: <code>ai_component</code> for declared tools, authority, approval, forbidden tools, fallback, and replay; <code>agent</code> for recursive scope, grants, visibility, orchestration, and failure policy.</p>
-    <p class="reveal dim" style="margin-top:18px">Implementation details live in <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a>.</p>
+    <p class="kicker reveal">AI hard-contracts / statistical evidence</p>
+    <h1 class="reveal">One discipline for AI tool boundaries, agent structure, and statistical quality</h1>
+    <p class="lead reveal">fsl-ai covers AI systems in three layers. <code>ai_component</code> is the hard-contract layer: tool authority, human approval, and forbidden tools checked through kernel expansion. <code>agent</code> is the structural layer: recursive agent grants, visibility, and orchestration. And <code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code> / <code>ai_migration</code> / <code>observed_property</code> form the evidence layer, which treats statistical quality, migration regression, and operational drift as external evidence with <code>formal_result: "not_run"</code>.</p>
+    <p class="reveal dim" style="margin-top:18px">Implementation details live in <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a> and <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-stochastic.md">DESIGN-stochastic.md</a>.</p>
   </div>
 </section>
 
 <section>
   <div class="wrap">
-    <p class="kicker reveal">Boundary</p>
-    <h2 class="reveal">Hard contracts are separate from evaluator and statistical evidence</h2>
-    <p class="lead narrow reveal">fsl-ai does not try to prove that natural-language answers are true. It checks structural and guard-backed execution facts, and treats statistical quality, migration regression, and drift as external evidence rather than proof.</p>
+    <p class="kicker reveal">What it prevents</p>
+    <h2 class="reveal">Catch four kinds of "it looks fine" AI failures</h2>
+    <p class="lead narrow reveal">fsl-ai does not try to prove that natural-language answers are true. Instead, it separates boundaries that can be checked deterministically by pre-execution guards from claims that must be handled honestly as statistics or observation, and reports each failure with a dedicated finding.</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
+      <div class="syntax-card">
+        <h3>Tool-boundary breaches</h3>
+        <p>Forbidden tool execution and irreversible execution without human approval are detected both by kernel invariants and by runtime replay.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Agent authority leaks</h3>
+        <p>Structural analysis detects child grants exceeding the parent boundary, visibility leaks across siblings, low-trust paths reaching high-authority tools, and review-gate bypass.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Point-estimate release decisions</h3>
+        <p>A bare "accuracy was 0.92" claim is rejected. Nothing becomes <code>statistically_supported</code> unless the Wilson interval's lower bound supports the threshold.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Silent regression and drift</h3>
+        <p>Metric regressions from prompt/model/retriever migrations are caught by <code>fslc ai regress</code>; production telemetry threshold breaches and drift by <code>fslc ai drift</code> — both as threshold-bearing evidence.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Guarantee boundary</p>
+    <h2 class="reveal">Fix upfront what may be called proved — and what may not</h2>
+    <p class="lead narrow reveal">The core of fsl-ai is a guarantee boundary that fixes, per contract class, how the claim is handled and which vocabulary reports it. Every result and finding carries this classification.</p>
     <table class="matrix reveal">
-      <tr><th>Contract</th><th>Examples</th><th>How fsl-ai reports it</th></tr>
-      <tr><td><code>syntactic_hard</code></td><td>Tool schema, approval token, forbidden tool, precondition evidence.</td><td>Kernel expansion and <code>ai_hard_contract_violation</code>.</td></tr>
-      <tr><td><code>agent_structural</code></td><td>Nested agent grants, visibility, delegation, review gates, tool reachability.</td><td><code>agent_structural_violation</code>; structural evidence, not proof.</td></tr>
-      <tr><td><code>runtime_observed</code></td><td>Undeclared tool or schema mismatch observed in logs.</td><td><code>observed_contract_violation</code>; not proof.</td></tr>
-      <tr><td><code>evaluator_supported</code></td><td>Groundedness, source support, prompt-injection judgment.</td><td>Future phase; never displayed as <code>proved</code>.</td></tr>
-      <tr><td><code>statistically_supported</code></td><td>Accuracy, recall, hallucination rate, slice metrics.</td><td><code>fslc ai eval</code>; confidence-bound evidence, not proof.</td></tr>
+      <tr><th>Contract class</th><th>Examples</th><th>Handling</th><th>Result vocabulary</th></tr>
+      <tr><td>syntactic / structural hard</td><td>Tool schema, authority, forbidden tool, human approval token, symbolic precondition evidence.</td><td>Static check, kernel expansion, runtime guard/replay finding.</td><td><code>verified_under_assumptions</code>, <code>violated</code>, finding kind <code>ai_hard_contract_violation</code>.</td></tr>
+      <tr><td>agent structural</td><td>Nested agent grants, visibility, delegation, review gates, tool reachability.</td><td>Structural evidence from graph analysis; not proof.</td><td><code>agent_analyzed</code>, finding kind <code>agent_structural_violation</code>.</td></tr>
+      <tr><td>evaluator-backed</td><td>Groundedness, source support, prompt-injection judgment.</td><td>External evaluator evidence; not kernel proof.</td><td><code>evaluator_supported</code>; never displayed as <code>proved</code>.</td></tr>
+      <tr><td>statistical</td><td>Accuracy, recall, hallucination rate, per-slice metrics.</td><td>External stochastic evidence layer (<code>fslc ai eval</code> / <code>regress</code>).</td><td><code>statistically_supported</code> / <code>statistically_unsupported</code>.</td></tr>
+      <tr><td>observed</td><td>Undeclared tool execution, schema mismatch in logs, production telemetry drift.</td><td><code>fslc ai replay</code> / <code>fslc ai drift</code> observation evidence only.</td><td><code>replay_conformant</code> / <code>replay_nonconformant</code>, <code>observed_supported</code> / <code>observed_mismatch</code>, finding kind <code>observed_contract_violation</code>.</td></tr>
     </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">Prompt injection and RAG groundedness may be called "hard" only when the checked predicate is structural and guard-backed — for example "no tool call executes when the event marks <code>schema_valid=false</code>" or "a citation ID is in a declared finite allow-list." A semantic claim such as "the answer is supported by the source" requires an evaluator and cannot be displayed as formal proof.</p>
+    </div>
   </div>
 </section>
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
-    <p class="kicker reveal">Syntax</p>
-    <h2 class="reveal">Declare tools and authority explicitly</h2>
+    <p class="kicker reveal">Hard contract</p>
+    <h2 class="reveal">Declare tools and authority explicitly with <code>ai_component</code></h2>
+    <p class="lead narrow reveal">The hard-contract layer models an AI component only at its observable tool boundary: model/prompt/input/output metadata, tool declarations with schema names, symbolic preconditions, authority, fallback, and rule selection via <code>check hard</code>.</p>
     <div class="panel reveal">
       <pre><code>ai_component RefundAgentToolSafety {
   model refund_model_v1;
@@ -54,16 +84,19 @@
   tool SearchOrder {
     schema SearchOrderV1;
     precondition order_exists;
+    effect read_order;
   }
 
   tool RefundPayment irreversible {
     schema RefundPaymentV1;
     precondition order_paid;
     precondition amount_refundable;
+    effect payment_refunded;
   }
 
   tool DeleteCustomerData irreversible {
     schema DeleteCustomerDataV1;
+    effect customer_data_deleted;
   }
 
   authority {
@@ -74,46 +107,28 @@
 
   fallback {
     when low_confidence require human_review;
+    when missing_order_evidence require refuse_with_reason;
+  }
+
+  check hard {
+    rule tool_authority;
+    rule human_approval_required;
+    rule forbidden_tool_blocked;
+    rule tool_schema_declared;
+    rule tool_precondition_declared;
   }
 }</code></pre>
     </div>
-  </div>
-</section>
-
-<section>
-  <div class="wrap">
-    <p class="kicker reveal">Recursive agents</p>
-    <h2 class="reveal">Nested agents are scoped agents, not <code>sub_agent</code>s</h2>
-    <p class="lead narrow reveal"><code>agent Parent { agent Child { ... } }</code> creates a lexical namespace such as <code>Parent.Child</code>. Parent authority and context are not inherited; children must receive explicit grants. Runtime collaboration stays separate in <code>orchestration</code>.</p>
-    <div class="panel reveal">
-      <pre><code>agent SupportOrchestrator {
-  context [CustomerTicket, ApprovedSupportDocs];
-  tools [SearchDocs, CheckPolicy];
-  authority { may_execute [SearchDocs, CheckPolicy]; }
-
-  agent RetrievalAgent {
-    grant authority [SearchDocs];
-    grant context [ApprovedSupportDocs];
-    tools [SearchDocs];
-    authority { may_execute [SearchDocs]; }
-    output RetrievedSources visibility [parent, PolicyCheckAgent];
-  }
-
-  agent PolicyCheckAgent {
-    grant authority [CheckPolicy];
-    grant context [CustomerTicket, ApprovedSupportDocs];
-    tools [CheckPolicy];
-    authority { may_execute [CheckPolicy]; }
-  }
-
-  orchestration {
-    RetrievalAgent -> PolicyCheckAgent;
-  }
-
-  failure_policy {
-    when RetrievalAgent.failed -> retry up_to 2;
-  }
-}</code></pre>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>Rule</th><th>What it checks</th></tr>
+      <tr><td><code>tool_authority</code></td><td>A forbidden tool cannot also be executable.</td></tr>
+      <tr><td><code>human_approval_required</code></td><td>An <code>irreversible</code> executable tool must be in <code>requires_human_approval</code>.</td></tr>
+      <tr><td><code>forbidden_tool_blocked</code></td><td>The generated kernel state machine has no transition that can make a forbidden tool's <code>tool_executed</code> entry true.</td></tr>
+      <tr><td><code>tool_schema_declared</code></td><td>Executable tools must declare a schema name.</td></tr>
+      <tr><td><code>tool_precondition_declared</code></td><td>Declared symbolic preconditions are checked during replay as business precondition evidence, distinct from tool-schema conformance.</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">Omitting <code>check hard</code> checks all five rules — the safe default. Also, unlike the business/requirements dialects, no field on <code>ai_component</code> accepts a <code>"description text"</code> tag: everything here is a bare identifier or number.</p>
     </div>
   </div>
 </section>
@@ -122,19 +137,23 @@
   <div class="wrap">
     <p class="kicker reveal">Lowering</p>
     <h2 class="reveal"><code>ai_component</code> lowers to the existing kernel</h2>
-    <p class="lead narrow reveal">The AI dialect adds no probability or evaluator semantics to the verifier. The hard contract becomes finite state and ordinary invariants.</p>
+    <p class="lead narrow reveal">The AI dialect adds no probability, percentile, or evaluator semantics to the verifier. The hard contract becomes finite state and ordinary invariants, checked by <code>fslc ai check</code> (BMC or k-induction underneath).</p>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>Finite tool state</h3>
-        <p><code>Tool</code>, <code>human_approved</code>, <code>tool_executed</code>, and <code>tool_suggested</code> are ordinary kernel state.</p>
+        <p>A <code>Tool</code> enum, <code>Map&lt;Tool, Bool&gt;</code> state for <code>human_approved</code>, <code>tool_executed</code>, and <code>tool_suggested</code>, plus <code>fallback_required: Bool</code> become ordinary kernel state.</p>
       </div>
       <div class="syntax-card">
         <h3>Generated actions</h3>
-        <p><code>approve_*</code> and <code>execute_*</code> actions model approval tokens and guarded execution.</p>
+        <p><code>suggest_*</code>, <code>approve_*</code>, <code>execute_*</code>, and <code>fallback_*</code> actions model approval tokens and guarded execution.</p>
       </div>
       <div class="syntax-card">
         <h3>Generated invariants</h3>
         <p>Forbidden tools never execute, and irreversible or approval-required tools execute only after approval.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Fallback is structural only</h3>
+        <p><code>when &lt;reason&gt; require &lt;target&gt;</code> lowers to a <code>fallback_&lt;reason&gt;</code> action and ghost state, but <code>target</code> is a free label, so no invariant is generated — this is not proof that the fallback route was actually taken. Each reason must be unique per component.</p>
       </div>
     </div>
   </div>
@@ -142,44 +161,314 @@
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
+    <p class="kicker reveal">Recursive agents</p>
+    <h2 class="reveal">Nested agents are scoped agents, not <code>sub_agent</code>s</h2>
+    <p class="lead narrow reveal"><code>agent Parent { agent Child { ... } }</code> creates a lexical namespace such as <code>Parent.Child</code>. Parent authority and context are never implicitly inherited; children receive them through explicit <code>grant</code> declarations, which must stay inside the immediate parent's boundary. Runtime collaboration is the separate <code>orchestration</code> graph.</p>
+    <div class="panel reveal">
+      <pre><code>agent SupportOrchestrator {
+  context [CustomerTicket, ApprovedSupportDocs];
+  tools [SearchDocs, CheckPolicy, SendEmail];
+  authority {
+    may_execute [SearchDocs, CheckPolicy];
+    requires_human_approval [SendEmail];
+  }
+  review_gate PolicyCheckAgent;
+
+  agent RetrievalAgent {
+    trust medium;
+    grant authority [SearchDocs];
+    grant context [ApprovedSupportDocs];
+    tools [SearchDocs];
+    authority { may_execute [SearchDocs]; }
+    output RetrievedSources visibility [parent, PolicyCheckAgent];
+  }
+
+  agent PolicyCheckAgent {
+    trust high;
+    grant authority [CheckPolicy];
+    grant context [CustomerTicket, ApprovedSupportDocs];
+    tools [CheckPolicy];
+    authority { may_execute [CheckPolicy]; }
+    contract { hard { rule PolicyDecisionCited; } }
+    output PolicyDecision visibility parent;
+  }
+
+  agent SendAgent {
+    trust high;
+    grant authority [SendEmail];
+    grant context [CustomerTicket];
+    tool SendEmail irreversible {
+      schema SendEmailV1;
+    }
+    authority { requires_human_approval [SendEmail]; }
+    output SendResult visibility parent;
+  }
+
+  orchestration {
+    RetrievalAgent -> PolicyCheckAgent;
+    PolicyCheckAgent -> SendAgent;
+  }
+
+  failure_policy {
+    when RetrievalAgent.failed -> retry up_to 2;
+    when RetrievalAgent.failed_after_retry -> HumanReviewPending;
+  }
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px"><code>fslc ai check</code> analyzes this as <code>agent_analyzed</code> (<code>formal_result: "not_run"</code>) and returns six separated graphs in <code>graph_summary</code> — <code>scope_tree</code>, <code>delegation_graph</code>, <code>authority_graph</code>, <code>information_flow_graph</code>, <code>tool_reachability_graph</code>, and <code>failure_policy</code>. Structural violations are reported as finding kind <code>agent_structural_violation</code>.</p>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>Violation</th><th>Meaning</th></tr>
+      <tr><td><code>child_authority_exceeds_parent_authority</code></td><td>A child's grants/tools/authority exceed the immediate parent boundary.</td></tr>
+      <tr><td><code>child_context_exceeds_parent_context</code></td><td>A child uses context beyond its granted context.</td></tr>
+      <tr><td><code>visibility_leak_across_sibling_agents</code></td><td>Output visibility to a sibling with no delegation path.</td></tr>
+      <tr><td><code>low_trust_agent_path_to_high_authority_tool</code></td><td>A path from a <code>trust low</code> agent to a high-authority tool. Changing <code>RetrievalAgent</code> in the snippet above to <code>trust low</code> really does return this finding.</td></tr>
+      <tr><td><code>irreversible_operation_without_human_approval_path</code></td><td>A path to an irreversible tool without <code>requires_human_approval</code>.</td></tr>
+      <tr><td><code>policy_review_bypass_in_orchestration</code></td><td>An orchestration path reaching high-authority tooling that skips all declared <code>review_gate</code> children.</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">Mind the exact scope. <code>trust</code> is a free identifier; only the literal <code>low</code> has a dedicated check (<code>low_trust_agent_path_to_high_authority_tool</code>) — <code>medium</code> and <code>high</code> parse but have no dedicated check yet. <code>contract { hard { rule &lt;Name&gt;; } }</code> is parsed and echoed under each agent's <code>agent_ir.contracts</code> (e.g. <code>{"hard_rules": ["PolicyDecisionCited"]}</code>) but is not yet cross-checked against anything — it is forward-declared metadata. As with <code>ai_component</code>, no field here accepts a <code>"description text"</code> tag.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Statistical evidence</p>
+    <h2 class="reveal">Bind quality to evidence with <code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code></h2>
+    <p class="lead narrow reveal"><code>fslc ai eval</code> is a deterministic checker over precomputed eval JSONL. It runs no AI model and no evaluator; it supports only Bernoulli/proportion metrics (accuracy, recall, hallucination_rate, wrong_tool_call_rate, and other 0/1 metrics), judged with Wilson intervals. Results always carry <code>formal_result: "not_run"</code>.</p>
+    <div class="panel reveal">
+      <pre><code>dataset SupportEvalV3 {
+  source "examples/ai/support_eval_v3.jsonl"
+
+  population {
+    language in ["ja", "en"]
+    ticket_type in ["refund", "bug", "urgent"]
+  }
+
+  slice JapaneseRefundTickets {
+    language == "ja"
+    ticket_type == "refund"
+  }
+}
+
+evaluator SupportAnswerJudge {
+  input question: Question
+  input answer: Answer
+  output grounded: Bool
+  output confidence: Float
+
+  calibration {
+    dataset HumanLabeledGroundednessV2
+    require agreement_with_human >= 0.90
+  }
+}
+
+statistical_property LooseQuality {
+  target SupportAnswerAgent
+  dataset SupportEvalV3
+  evaluator SupportAnswerJudge
+  confidence 0.95
+
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+
+  slice JapaneseRefundTickets {
+    require min_samples >= 5
+    require ci_lower(metric.accuracy, 0.95) >= 0.35
+  }
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px">One eval record is one Bernoulli observation (schema <code>fsl-ai-eval-record.v0</code>; <code>case_id</code>, <code>slice</code>, <code>metric</code>, boolean <code>outcome</code>, and <code>evaluator.id</code> are required, and duplicate <code>(case_id, slice, metric)</code> records are <code>dataset_invalid</code>):</p>
+    <div class="panel reveal" style="margin-top:16px">
+      <pre><code>{"schema_version":"fsl-ai-eval-record.v0","case_id":"support-001","component":"SupportAnswerAgent","dataset":"SupportEvalV3","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px">With <code>k</code> successes out of <code>n</code> observations, <code>estimate = k / n</code>, and the Wilson interval at confidence <code>c</code> yields <code>ci_lower</code> / <code>ci_upper</code>. Requirements must take the form <code>ci_lower(metric.X, 0.95) &gt;= T</code> or <code>ci_upper(metric.X, 0.95) &lt;= T</code>. Actually running the examples gives:</p>
+    <table class="matrix reveal" style="margin-top:16px">
+      <tr><th>Property</th><th>Slice</th><th>n</th><th>Estimate</th><th>ci_lower (95%)</th><th>Threshold</th><th>Result</th></tr>
+      <tr><td><code>LooseQuality</code></td><td><code>all</code></td><td>10</td><td>0.80</td><td>≈ 0.490</td><td>≥ 0.45</td><td class="good"><code>statistically_supported</code></td></tr>
+      <tr><td><code>LooseQuality</code></td><td><code>JapaneseRefundTickets</code></td><td>5</td><td>1.00</td><td>≈ 0.566</td><td>≥ 0.35 (+ <code>min_samples &gt;= 5</code>)</td><td class="good"><code>statistically_supported</code></td></tr>
+      <tr><td><code>StrictQuality</code></td><td><code>JapaneseRefundTickets</code></td><td>5</td><td>1.00</td><td>≈ 0.566</td><td>≥ 0.80</td><td class="bad"><code>statistically_unsupported</code></td></tr>
+    </table>
+    <p class="lead narrow reveal" style="margin-top:16px">The third row is the point. Even a perfect 5/5 on the slice (estimate 1.00) gives a Wilson lower bound of only about 0.566 at n=5, so a 0.80 claim is not supported. Rejecting "it all passed, so we're fine" — sample size included — is this layer's job.</p>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>Priority</th><th>Status</th><th>Meaning</th></tr>
+      <tr><td>1</td><td><code>dataset_invalid</code></td><td>Record schema violation, duplicate case for a slice/metric, or a required slice field is missing.</td></tr>
+      <tr><td>2</td><td><code>evaluator_untrusted</code></td><td>Evaluator calibration evidence is missing or below the declared trust threshold.</td></tr>
+      <tr><td>3</td><td><code>insufficient_samples</code></td><td>Some required slice has <code>n &lt; min_samples</code>.</td></tr>
+      <tr><td>4</td><td><code>inconclusive</code></td><td>The declared metric or interval method cannot be computed. Point-estimate-only requirements are rejected here too.</td></tr>
+      <tr><td>5</td><td><code>statistically_unsupported</code></td><td>Enough samples, but the Wilson bound does not support the threshold.</td></tr>
+      <tr><td>6</td><td><code>statistically_supported</code></td><td>Every required gate and bound check passes.</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">A point-estimate-only requirement such as <code>require accuracy &gt;= 0.92</code> is rejected at eval time as <code>inconclusive</code> (exit 1) — it does not pass with a warning. Each slice is an independent gate: the overall result is supported only when every slice passes its own <code>min_samples</code> and bound check. No family-wise multiple-testing correction is claimed by this layer.</p>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Migration / drift / compat</p>
+    <h2 class="reveal">Migration regression, production drift, and environment compatibility under the same discipline</h2>
+    <p class="lead narrow reveal"><code>ai_migration</code> declares, across a prompt/model/retriever migration, that the hard contract is preserved and metrics do not regress; <code>observed_property</code> declares production telemetry thresholds and drift. Both are external evidence with <code>formal_result: "not_run"</code>.</p>
+    <div class="panel reveal">
+      <pre><code>ai_migration PromptV7ToV8 {
+  from SupportAnswerAgent {
+    model gpt_5_5
+    prompt support_answer_prompt_v7
+    retriever support_docs_index_v12
+  }
+
+  to SupportAnswerAgent {
+    model gpt_5_5
+    prompt support_answer_prompt_v8
+    retriever support_docs_index_v14
+  }
+
+  preserve {
+    hard_contract SupportAnswerContract.hard
+
+    no_regression {
+      dataset SupportEvalV3
+      metric accuracy drop &lt;= 0.05
+      metric hallucination_rate increase &lt;= 0.02
+    }
+  }
+}
+
+observed_property SupportAgentOperationalQuality {
+  target SupportAnswerAgent
+  source production_logs
+  window last_7_days
+
+  require observed(metric.hallucination_rate) &lt;= 0.30
+  require drift(metric.refusal_rate) &lt;= 0.10 compared_to previous_7_days
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px">Actually running the example v7→v8 comparison (with deliberately regressed data):</p>
+    <table class="matrix reveal" style="margin-top:16px">
+      <tr><th>Command</th><th>Check</th><th>Measured</th><th>Verdict</th></tr>
+      <tr><td><code>fslc ai regress</code></td><td><code>accuracy drop &lt;= 0.05</code></td><td>1.00 (10/10) → 0.80 (8/10), <code>observed_delta</code> 0.20 &gt; <code>allowed_delta</code> 0.05</td><td class="bad"><code>passed: false</code> → finding <code>ai_migration_regression</code></td></tr>
+      <tr><td><code>fslc ai regress</code></td><td><code>hallucination_rate increase &lt;= 0.02</code></td><td>0.00 (0/5) → 0.20 (1/5), <code>observed_delta</code> 0.20 &gt; <code>allowed_delta</code> 0.02</td><td class="bad"><code>passed: false</code>; overall result <code>statistically_unsupported</code></td></tr>
+      <tr><td><code>fslc ai compare</code></td><td>Delta report, no threshold claim</td><td>accuracy <code>delta</code> −0.20, hallucination_rate <code>delta</code> +0.20</td><td class="ok"><code>result: "compared"</code> (no findings)</td></tr>
+      <tr><td><code>fslc ai drift</code></td><td><code>observed(metric.hallucination_rate) &lt;= 0.30</code></td><td>Current 0.25 (n=4)</td><td class="good"><code>passed: true</code></td></tr>
+      <tr><td><code>fslc ai drift</code></td><td><code>drift(metric.refusal_rate) &lt;= 0.10</code></td><td>Baseline 0.10 → current ≈0.667, <code>drift</code> ≈ 0.567</td><td class="bad"><code>passed: false</code> → <code>observed_mismatch</code>, finding <code>ai_observed_drift</code> (<code>guarantee_kind: "runtime_observed"</code>)</td></tr>
+    </table>
+    <p class="lead narrow reveal" style="margin-top:24px">Environment compatibility is shared with fsl-db. <code>fslc ai compat --environment prod</code> generates the component's model/prompt/retriever/tool/output-schema needs as a <code>dbsystem</code> artifact capability profile (<code>result: "compat_profile_generated"</code>):</p>
+    <div class="panel reveal" style="margin-top:16px">
+      <pre><code>artifact support_answer_agent {
+  requires model.gpt_5_5, prompt.support_answer_prompt_v8,
+           retriever.support_docs_index_v14, tool.CreateTicket, tool.SearchDocs;
+  provides output.AnswerSchemaV2;
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:16px">Fold this fragment into a <code>dbsystem</code> environment and check it with <code>fslc compat check --include-ai</code> — AI capabilities join server/mobile/DB artifacts in the same finite snapshot compatibility model. A provider gap is reported as <code>required_capability_missing</code>.</p>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
     <p class="kicker reveal">Run it</p>
-    <h2 class="reveal">Use AI-specific findings for guard and replay failures</h2>
+    <h2 class="reveal">Map each layer's commands to its result vocabulary</h2>
     <div class="panel reveal">
       <pre><code>fslc ai check examples/ai/refund_agent_tool_safety.fsl
 fslc ai check examples/ai/recursive_support_agent.fsl
 fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_conformant.jsonl
 fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_human_approval_bypass.jsonl
-fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_observed_mismatch.jsonl</code></pre>
+fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_forbidden_tool.jsonl
+fslc ai eval examples/ai/support_answer_quality.fsl --property LooseQuality
+fslc ai eval examples/ai/support_answer_quality.fsl --property StrictQuality
+fslc ai regress examples/ai/support_answer_quality.fsl --migration PromptV7ToV8 \
+  --before-records examples/ai/support_eval_v7.jsonl --after-records examples/ai/support_eval_v8_regressed.jsonl
+fslc ai compare --from examples/ai/support_eval_v7.jsonl --to examples/ai/support_eval_v8_regressed.jsonl --dataset SupportEvalV3
+fslc ai drift examples/ai/support_answer_quality.fsl --logs examples/ai/runtime_drift_current.jsonl \
+  --baseline-logs examples/ai/runtime_drift_baseline.jsonl
+fslc ai compat examples/ai/support_answer_quality.fsl --environment prod</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>Result</th><th>How to read it</th></tr>
-      <tr><td><code>verified_under_assumptions</code></td><td>The finite hard-contract expansion verifies under complete capability declarations and runtime guard assumptions.</td></tr>
+      <tr><td><code>verified_under_assumptions</code></td><td>The finite hard-contract expansion verifies under complete capability declarations (<code>AI-ASSUME-CAPABILITY-DECLARATIONS</code>) and runtime guards (<code>AI-ASSUME-RUNTIME-GUARD</code>). <code>formal_result</code> carries the kernel's <code>verified</code>.</td></tr>
       <tr><td><code>agent_analyzed</code></td><td>The recursive agent graph is structurally consistent; <code>formal_result</code> stays <code>not_run</code>.</td></tr>
-      <tr><td><code>replay_conformant</code></td><td>The observed event log matched the declared hard boundary; this is evidence, not proof.</td></tr>
-      <tr><td><code>ai_hard_contract_violation</code></td><td>A forbidden tool, approval bypass, schema invalidity, or business precondition mismatch was observed.</td></tr>
-      <tr><td><code>observed_contract_violation</code></td><td>Runtime used a capability outside the declared component boundary.</td></tr>
+      <tr><td><code>ai_project_analyzed</code></td><td><code>fslc ai check</code> on a file containing <code>dataset</code> and other project declarations — a declaration listing, not verification.</td></tr>
+      <tr><td><code>replay_conformant</code> / <code>replay_nonconformant</code></td><td>Whether the observed event log matched the declared hard boundary. The nonconformant side carries finding kinds <code>ai_hard_contract_violation</code> (approval bypass, forbidden tool execution, schema invalidity, precondition mismatch) and <code>observed_contract_violation</code> (undeclared tool/capability). Observation, not proof.</td></tr>
+      <tr><td><code>statistically_supported</code> / <code>statistically_unsupported</code></td><td>Whether the Wilson bound supports the threshold (<code>ai eval</code> / <code>ai regress</code>).</td></tr>
+      <tr><td><code>compared</code></td><td>The <code>ai compare</code> delta report. No threshold judgment included.</td></tr>
+      <tr><td><code>observed_supported</code> / <code>observed_mismatch</code></td><td>The <code>ai drift</code> telemetry threshold/drift verdict. Observation evidence.</td></tr>
+      <tr><td><code>compat_profile_generated</code></td><td><code>ai compat</code> generated a dbsystem capability profile.</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Finding contract</p>
+    <h2 class="reveal">Every finding has the same shape: <code>fsl-ai-finding.v0</code></h2>
+    <p class="lead narrow reveal">Hard-contract violations, agent structural violations, unsupported statistics, and drift all come back through one finding schema. The required fields are <code>fsl</code>, <code>result</code>, <code>kind</code>, <code>severity</code>, <code>component</code>, <code>contract</code>, <code>tool</code>, <code>failed_rule</code>, <code>violation</code>, <code>guarantee_kind</code>, <code>evidence</code>, <code>witness</code>, <code>minimal_conflict_set</code>, <code>repair_candidates</code>, and <code>assumptions</code>. Each repair candidate carries a <code>weakens_spec</code> flag, so "make it pass by weakening the spec" repairs are explicitly marked.</p>
+    <table class="matrix reveal">
+      <tr><th><code>guarantee_kind</code></th><th>Emitted by</th><th>Meaning</th></tr>
+      <tr><td><code>syntactic_hard</code></td><td>Hard-contract violations from <code>ai check</code> / <code>ai replay</code></td><td>Deterministic facts over declared boundaries and guard assumptions.</td></tr>
+      <tr><td><code>agent_structural</code></td><td>Recursive agent analysis</td><td>Structural evidence over graphs; not proof.</td></tr>
+      <tr><td><code>runtime_observed</code></td><td>Log mismatches in replay, <code>ai drift</code></td><td>Observation evidence; absence from logs is not proof of unused behavior.</td></tr>
+      <tr><td><code>evaluator_supported</code></td><td>Future evaluator findings</td><td>Evaluator evidence; never displayed as <code>proved</code>.</td></tr>
+      <tr><td><code>statistically_supported</code> / <code>statistically_unsupported</code></td><td><code>ai eval</code> / <code>ai regress</code></td><td>Wilson-bound statistical evidence; never displayed as <code>proved</code>.</td></tr>
     </table>
   </div>
 </section>
 
 <section>
   <div class="wrap">
+    <p class="kicker reveal">Boundary</p>
+    <h2 class="reveal">Do not confuse what is checked with what is merely recognized</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>Unchecked block boundaries</h3>
+        <p><code>ai_action</code>, a standalone <code>retriever</code> block, <code>trust_boundary</code>, and a top-level <code>authority { target ... }</code> (the example's <code>ai_contract</code> behaves the same way) are recognized only as block <em>boundaries</em>. The parser never descends into their bodies, so even garbage inside passes <code>check</code>. They are echoed as bare <code>{kind, name}</code> entries under <code>raw_blocks</code> and constrain nothing.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>The checked surface, exactly</h3>
+        <p>Kernel-backed <code>ai_component</code> / <code>agent</code>, plus external-evidence <code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code> / <code>ai_migration</code> / <code>observed_property</code>. Writing a contract anywhere else has no effect.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Forward-declared metadata</h3>
+        <p>An agent's <code>contract { hard { rule ...; } }</code> and <code>failure_mode</code> blocks are parsed and listed under <code>agent_ir.contracts</code> / <code>failure_modes</code>, but not yet cross-checked against evidence. Tracked metadata, not verified claims.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>No evaluator execution</h3>
+        <p><code>fslc ai eval</code> only reads precomputed JSONL. It does not run LLM evaluators, sample providers, or mutate prompts. Only boolean outcomes are supported; continuous scores are out of scope. Evaluator trust is a calibration-evidence question (missing evidence means <code>evaluator_untrusted</code>).</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>formal_result: "not_run"</code>, consistently</h3>
+        <p>Replay, agent analysis, eval, regress, compare, drift, and compat results all carry <code>formal_result: "not_run"</code>. None of them may be displayed as <code>proved</code> or <code>verified</code>. Only the <code>ai_component</code> hard-contract expansion carries a kernel formal result.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Time, probability, LLM truth</h3>
+        <p>A "last 7 days" window is a log-selection label, not a wall-clock proof, and drift is the difference between two observation windows. The truth or groundedness of LLM output itself is proved by no layer of this dialect.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
     <p class="kicker reveal">Next</p>
     <h2 class="reveal">Read the design and examples</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>Design decisions</h3>
-        <p>Guarantee boundaries, lowering, event schema, findings, and external-evidence boundaries are described in the design document.</p>
-        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a></p>
+        <p>The guarantee boundary, lowering, event schema, and findings live in the hard-contract design doc; Wilson intervals, status priority, and the eval-record schema in the stochastic design doc.</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a> <a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-stochastic.md">DESIGN-stochastic.md</a></p>
       </div>
       <div class="syntax-card">
-        <h3>Working example</h3>
-        <p>The examples cover refund-agent approval/replay and recursive support-agent structure.</p>
+        <h3>Working examples</h3>
+        <p>Refund-agent approval/replay, recursive support-agent analysis, and every eval/regress/drift/compat command are reproducible from the examples.</p>
         <p><a class="btn" href="../../examples/ai/README.md">examples/ai</a></p>
       </div>
       <div class="syntax-card">
+        <h3>Environment compatibility</h3>
+        <p>The capability profile generated by <code>fslc ai compat</code> flows into fsl-db's <code>dbsystem</code> artifact/environment model.</p>
+        <p><a class="btn" href="db.en.html">fsl-db page</a></p>
+      </div>
+      <div class="syntax-card">
         <h3>Core syntax</h3>
-        <p><code>ai_component</code> lowers to the existing verifier; <code>agent</code> is structural analysis.</p>
+        <p><code>ai_component</code> lowers to the existing verifier. The syntax guide covers the core forms it expands into.</p>
         <p><a class="btn" href="syntax.en.html">Syntax Guide</a></p>
       </div>
     </div>

--- a/docs/intro/ai.ja.html
+++ b/docs/intro/ai.ja.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>fsl-ai によるAI hard contractとagent構造解析 — FSL 日本語マニュアル</title>
-<meta name="description" content="fsl-aiのai_componentとagentで、AI tool authority、human approval guard、recursive agent構造、runtime replay、AI-readable findingを確認する方法。" />
+<title>fsl-ai によるAI hard contract・agent構造・統計evidence — FSL 日本語マニュアル</title>
+<meta name="description" content="fsl-aiのai_component/agent/dataset/evaluator/statistical_property/ai_migration/observed_propertyで、AI tool境界、recursive agent構造、Wilson区間による統計evidence、migration regression、運用driftを確認する方法。" />
 <link rel="stylesheet" href="assets/site.css" />
 </head>
 <body class="docs-page" data-page="ai">
@@ -17,33 +17,63 @@
 <section class="hero">
   <div class="wrap narrow center">
     <nav class="breadcrumb" data-nav></nav>
-    <p class="kicker reveal">AI hard-contracts</p>
-    <h1 class="reveal">fsl-ai でAIのtool境界とagent構造を守る</h1>
-    <p class="lead reveal">fsl-ai は、決定的に検査できるAI境界を扱います。<code>ai_component</code> はtool宣言、authority、human approval、forbidden tool、fallback、runtime event replayを、<code>agent</code> はrecursive scope、grant、visibility、orchestration、failure policyを扱います。</p>
-    <p class="reveal dim" style="margin-top:18px">設計の詳細は <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a> にあります。</p>
+    <p class="kicker reveal">AI hard-contracts / statistical evidence</p>
+    <h1 class="reveal">fsl-ai でAIのtool境界・agent構造・統計品質を1つの規律で扱う</h1>
+    <p class="lead reveal">fsl-ai は3つの層でAIシステムを扱います。<code>ai_component</code> はtool authority・human approval・forbidden toolをkernel展開で検査するhard contract層、<code>agent</code> はrecursive agentのgrant・visibility・orchestrationを解析する構造層、そして <code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code> / <code>ai_migration</code> / <code>observed_property</code> は統計品質・migration regression・運用driftを <code>formal_result: "not_run"</code> の外部証拠として扱うevidence層です。</p>
+    <p class="reveal dim" style="margin-top:18px">設計の詳細は <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a> と <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-stochastic.md">DESIGN-stochastic.md</a> にあります。</p>
   </div>
 </section>
 
 <section>
   <div class="wrap">
-    <p class="kicker reveal">境界</p>
-    <h2 class="reveal">hard contract と evaluator / statistical evidence を分ける</h2>
-    <p class="lead narrow reveal">fsl-aiは、自然言語回答の真偽を証明しようとはしません。実行前guardの構造事実を検査し、統計品質・migration regression・driftは証明ではなく外部証拠として扱います。</p>
+    <p class="kicker reveal">何を防ぐか</p>
+    <h2 class="reveal">「動いているように見えるAI」の4種類の事故を検出する</h2>
+    <p class="lead narrow reveal">fsl-aiは、自然言語回答の真偽を証明しようとはしません。代わりに、実行前guardで決定的に検査できる境界と、統計・観測として正直に扱うべき証拠を分離し、それぞれの事故を専用findingで返します。</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
+      <div class="syntax-card">
+        <h3>tool境界の突破</h3>
+        <p>forbidden toolの実行、human approvalなしのirreversible実行を、kernel invariantとruntime replayの両方で検出します。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>agent権限の漏れ</h3>
+        <p>子agentのgrant超過、sibling間のvisibility leak、low-trust agentからhigh-authority toolへの到達、review-gate bypassを構造解析で検出します。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>点推定だけのリリース判断</h3>
+        <p>「accuracyが0.92だった」だけの主張を拒否します。Wilson intervalの下限が閾値を支持しない限り <code>statistically_supported</code> にはなりません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>静かなregressionとdrift</h3>
+        <p>prompt/model/retriever移行によるmetric悪化を <code>fslc ai regress</code> で、本番telemetryの閾値超過とdriftを <code>fslc ai drift</code> で、閾値つき証拠として検出します。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Guarantee boundary</p>
+    <h2 class="reveal">provedと言えるもの・言えないものを最初に固定する</h2>
+    <p class="lead narrow reveal">fsl-aiの中心は、契約の種類ごとに「どう扱い、どの語彙で報告するか」を固定したguarantee boundaryです。すべての結果とfindingがこの区分を運びます。</p>
     <table class="matrix reveal">
-      <tr><th>契約</th><th>例</th><th>fsl-aiでの扱い</th></tr>
-      <tr><td><code>syntactic_hard</code></td><td>tool schema、approval token、forbidden tool、precondition evidence。</td><td>kernel展開と <code>ai_hard_contract_violation</code>。</td></tr>
-      <tr><td><code>agent_structural</code></td><td>nested agent grant、visibility、delegation、review gate、tool reachability。</td><td><code>agent_structural_violation</code>。構造証拠であり証明ではない。</td></tr>
-      <tr><td><code>runtime_observed</code></td><td>未宣言toolやschema mismatchがログに出た。</td><td><code>observed_contract_violation</code>。証明ではなく観測。</td></tr>
-      <tr><td><code>evaluator_supported</code></td><td>groundedness、source support、prompt injection判定。</td><td>後続phase。<code>proved</code> とは表示しない。</td></tr>
-      <tr><td><code>statistically_supported</code></td><td>accuracy、recall、hallucination rate、slice指標。</td><td><code>fslc ai eval</code>。信頼区間つき証拠であり証明ではない。</td></tr>
+      <tr><th>Contract class</th><th>例</th><th>扱い</th><th>Result vocabulary</th></tr>
+      <tr><td>syntactic / structural hard</td><td>tool schema、authority、forbidden tool、human approval token、symbolic precondition evidence。</td><td>静的検査、kernel展開、runtime guard/replay finding。</td><td><code>verified_under_assumptions</code>、<code>violated</code>、finding kind <code>ai_hard_contract_violation</code>。</td></tr>
+      <tr><td>agent structural</td><td>nested agentのgrant、visibility、delegation、review gate、tool reachability。</td><td>graph解析による構造的証拠。証明ではない。</td><td><code>agent_analyzed</code>、finding kind <code>agent_structural_violation</code>。</td></tr>
+      <tr><td>evaluator-backed</td><td>groundedness、source support、prompt-injection判定。</td><td>external evaluator evidence。kernel proofではない。</td><td><code>evaluator_supported</code>。<code>proved</code> とは決して表示しない。</td></tr>
+      <tr><td>statistical</td><td>accuracy、recall、hallucination rate、sliceごとの指標。</td><td>external stochastic evidence layer（<code>fslc ai eval</code> / <code>regress</code>）。</td><td><code>statistically_supported</code> / <code>statistically_unsupported</code>。</td></tr>
+      <tr><td>observed</td><td>未宣言toolの実行、log上のschema mismatch、本番telemetryのdrift。</td><td><code>fslc ai replay</code> / <code>fslc ai drift</code> の観測証拠のみ。</td><td><code>replay_conformant</code> / <code>replay_nonconformant</code>、<code>observed_supported</code> / <code>observed_mismatch</code>、finding kind <code>observed_contract_violation</code>。</td></tr>
     </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">prompt injectionやRAG groundednessを「hard」と呼べるのは、検査される述語が構造的でguardに裏づけられている場合だけです。例えば「<code>schema_valid=false</code> のeventではtool callを実行しない」「citation IDが宣言済みの有限allow-listに含まれる」は hard です。「回答がsourceに支持されている」という意味論的主張はevaluatorが必要で、形式証明としては表示できません。</p>
+    </div>
   </div>
 </section>
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
-    <p class="kicker reveal">構文</p>
-    <h2 class="reveal">tool と authority を明示する</h2>
+    <p class="kicker reveal">Hard contract</p>
+    <h2 class="reveal"><code>ai_component</code> でtoolとauthorityを明示する</h2>
+    <p class="lead narrow reveal">hard contract層は、AI componentを観測可能なtool境界だけでモデル化します。model/prompt/input/outputのmetadata、tool宣言とschema名、symbolic precondition、authority、fallback、そして <code>check hard</code> のrule選択です。</p>
     <div class="panel reveal">
       <pre><code>ai_component RefundAgentToolSafety {
   model refund_model_v1;
@@ -54,16 +84,19 @@
   tool SearchOrder {
     schema SearchOrderV1;
     precondition order_exists;
+    effect read_order;
   }
 
   tool RefundPayment irreversible {
     schema RefundPaymentV1;
     precondition order_paid;
     precondition amount_refundable;
+    effect payment_refunded;
   }
 
   tool DeleteCustomerData irreversible {
     schema DeleteCustomerDataV1;
+    effect customer_data_deleted;
   }
 
   authority {
@@ -74,46 +107,28 @@
 
   fallback {
     when low_confidence require human_review;
+    when missing_order_evidence require refuse_with_reason;
+  }
+
+  check hard {
+    rule tool_authority;
+    rule human_approval_required;
+    rule forbidden_tool_blocked;
+    rule tool_schema_declared;
+    rule tool_precondition_declared;
   }
 }</code></pre>
     </div>
-  </div>
-</section>
-
-<section>
-  <div class="wrap">
-    <p class="kicker reveal">Recursive agents</p>
-    <h2 class="reveal">入れ子agentは <code>sub_agent</code> ではなく、scope付きagent</h2>
-    <p class="lead narrow reveal"><code>agent Parent { agent Child { ... } }</code> は <code>Parent.Child</code> のようなlexical namespaceを作ります。親のauthority/contextは暗黙継承されず、子には明示grantが必要です。実行時の協調は別に <code>orchestration</code> で書きます。</p>
-    <div class="panel reveal">
-      <pre><code>agent SupportOrchestrator {
-  context [CustomerTicket, ApprovedSupportDocs];
-  tools [SearchDocs, CheckPolicy];
-  authority { may_execute [SearchDocs, CheckPolicy]; }
-
-  agent RetrievalAgent {
-    grant authority [SearchDocs];
-    grant context [ApprovedSupportDocs];
-    tools [SearchDocs];
-    authority { may_execute [SearchDocs]; }
-    output RetrievedSources visibility [parent, PolicyCheckAgent];
-  }
-
-  agent PolicyCheckAgent {
-    grant authority [CheckPolicy];
-    grant context [CustomerTicket, ApprovedSupportDocs];
-    tools [CheckPolicy];
-    authority { may_execute [CheckPolicy]; }
-  }
-
-  orchestration {
-    RetrievalAgent -> PolicyCheckAgent;
-  }
-
-  failure_policy {
-    when RetrievalAgent.failed -> retry up_to 2;
-  }
-}</code></pre>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>rule</th><th>検査内容</th></tr>
+      <tr><td><code>tool_authority</code></td><td>forbidden toolが同時にexecutableになっていないこと。</td></tr>
+      <tr><td><code>human_approval_required</code></td><td><code>irreversible</code> なexecutable toolが <code>requires_human_approval</code> に入っていること。</td></tr>
+      <tr><td><code>forbidden_tool_blocked</code></td><td>生成されたkernel状態機械に、forbidden toolの <code>tool_executed</code> をtrueにできる遷移が存在しないこと。</td></tr>
+      <tr><td><code>tool_schema_declared</code></td><td>executable toolがschema名を宣言していること。</td></tr>
+      <tr><td><code>tool_precondition_declared</code></td><td>宣言されたsymbolic preconditionが、replay時にbusiness precondition evidenceとして照合されること（tool schema適合とは別）。</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0"><code>check hard</code> を省略すると5 rule全部が検査されます（安全なdefault）。また、business/requirements dialectと違い、<code>ai_component</code> のどのフィールドも <code>"description text"</code> tagを受け付けません — すべてbareな識別子か数値です。</p>
     </div>
   </div>
 </section>
@@ -122,19 +137,23 @@
   <div class="wrap">
     <p class="kicker reveal">展開</p>
     <h2 class="reveal"><code>ai_component</code> は既存kernelへ展開される</h2>
-    <p class="lead narrow reveal">AI dialect は verifier に確率や evaluator semantics を追加しません。hard contract は有限状態と通常の不変条件になります。</p>
+    <p class="lead narrow reveal">AI dialectは、verifierに確率・percentile・evaluator semanticsを一切追加しません。hard contractは有限状態と通常の不変条件になり、<code>fslc ai check</code>（内部でBMCまたはk-induction）で検査されます。</p>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>有限のtool状態</h3>
-        <p><code>Tool</code>、<code>human_approved</code>、<code>tool_executed</code>、<code>tool_suggested</code> は通常のkernel stateです。</p>
+        <p><code>Tool</code> enumと、<code>human_approved</code>、<code>tool_executed</code>、<code>tool_suggested</code> の <code>Map&lt;Tool, Bool&gt;</code>、そして <code>fallback_required: Bool</code> が通常のkernel stateになります。</p>
       </div>
       <div class="syntax-card">
         <h3>生成action</h3>
-        <p><code>approve_*</code> と <code>execute_*</code> が、approval token とguardされた実行を表します。</p>
+        <p><code>suggest_*</code>、<code>approve_*</code>、<code>execute_*</code>、<code>fallback_*</code> actionが、approval tokenとguardされた実行を表します。</p>
       </div>
       <div class="syntax-card">
         <h3>生成invariant</h3>
-        <p>forbidden tool は実行されず、irreversibleまたはapproval-requiredなtoolは承認後だけ実行できます。</p>
+        <p>forbidden toolは決して実行されず、irreversible / approval-requiredなtoolはapproval後だけ実行できる、という不変条件が生成されます。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>fallbackは構造のみ</h3>
+        <p><code>when &lt;reason&gt; require &lt;target&gt;</code> は <code>fallback_&lt;reason&gt;</code> actionとghost状態に展開されますが、<code>target</code> は自由ラベルなのでinvariantは生成されません。「fallback先が実際に実行された」ことの証明ではありません。reasonはcomponent内で一意である必要があります。</p>
       </div>
     </div>
   </div>
@@ -142,44 +161,314 @@
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
+    <p class="kicker reveal">Recursive agents</p>
+    <h2 class="reveal">入れ子agentは <code>sub_agent</code> ではなく、scope付きagent</h2>
+    <p class="lead narrow reveal"><code>agent Parent { agent Child { ... } }</code> は <code>Parent.Child</code> というlexical namespaceを作ります。親のauthority/contextは暗黙継承されず、子は明示的な <code>grant</code> で受け取ります。grantは直接の親の境界のsubsetでなければなりません。実行時の協調は別の <code>orchestration</code> graphです。</p>
+    <div class="panel reveal">
+      <pre><code>agent SupportOrchestrator {
+  context [CustomerTicket, ApprovedSupportDocs];
+  tools [SearchDocs, CheckPolicy, SendEmail];
+  authority {
+    may_execute [SearchDocs, CheckPolicy];
+    requires_human_approval [SendEmail];
+  }
+  review_gate PolicyCheckAgent;
+
+  agent RetrievalAgent {
+    trust medium;
+    grant authority [SearchDocs];
+    grant context [ApprovedSupportDocs];
+    tools [SearchDocs];
+    authority { may_execute [SearchDocs]; }
+    output RetrievedSources visibility [parent, PolicyCheckAgent];
+  }
+
+  agent PolicyCheckAgent {
+    trust high;
+    grant authority [CheckPolicy];
+    grant context [CustomerTicket, ApprovedSupportDocs];
+    tools [CheckPolicy];
+    authority { may_execute [CheckPolicy]; }
+    contract { hard { rule PolicyDecisionCited; } }
+    output PolicyDecision visibility parent;
+  }
+
+  agent SendAgent {
+    trust high;
+    grant authority [SendEmail];
+    grant context [CustomerTicket];
+    tool SendEmail irreversible {
+      schema SendEmailV1;
+    }
+    authority { requires_human_approval [SendEmail]; }
+    output SendResult visibility parent;
+  }
+
+  orchestration {
+    RetrievalAgent -> PolicyCheckAgent;
+    PolicyCheckAgent -> SendAgent;
+  }
+
+  failure_policy {
+    when RetrievalAgent.failed -> retry up_to 2;
+    when RetrievalAgent.failed_after_retry -> HumanReviewPending;
+  }
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px"><code>fslc ai check</code> はこれを <code>agent_analyzed</code>（<code>formal_result: "not_run"</code>）として解析し、<code>graph_summary</code> に6つのgraph — <code>scope_tree</code>、<code>delegation_graph</code>、<code>authority_graph</code>、<code>information_flow_graph</code>、<code>tool_reachability_graph</code>、<code>failure_policy</code> — を分離して返します。構造違反はfinding kind <code>agent_structural_violation</code> で報告されます。</p>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>violation</th><th>意味</th></tr>
+      <tr><td><code>child_authority_exceeds_parent_authority</code></td><td>子のgrant/tool/authorityが直接の親の境界を超えている。</td></tr>
+      <tr><td><code>child_context_exceeds_parent_context</code></td><td>子のcontext使用がgrantされたcontextを超えている。</td></tr>
+      <tr><td><code>visibility_leak_across_sibling_agents</code></td><td>delegation pathのないsiblingへのoutput visibility。</td></tr>
+      <tr><td><code>low_trust_agent_path_to_high_authority_tool</code></td><td><code>trust low</code> のagentからhigh-authority toolへの経路。上のsnippetの <code>RetrievalAgent</code> を <code>trust low</code> に変えると実際にこのfindingが返ります。</td></tr>
+      <tr><td><code>irreversible_operation_without_human_approval_path</code></td><td>irreversible toolへの経路に <code>requires_human_approval</code> がない。</td></tr>
+      <tr><td><code>policy_review_bypass_in_orchestration</code></td><td>high-authority toolに到達するorchestration pathが、宣言された <code>review_gate</code> の子を全部すり抜けている。</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">正確な範囲に注意してください。<code>trust</code> は自由識別子で、文字列 <code>low</code> だけが専用チェック（<code>low_trust_agent_path_to_high_authority_tool</code>）を持ちます。<code>medium</code> / <code>high</code> は構文上通りますが専用チェックはまだありません。<code>contract { hard { rule &lt;Name&gt;; } }</code> はparseされて各agentの <code>agent_ir.contracts</code>（例: <code>{"hard_rules": ["PolicyDecisionCited"]}</code>）に載るだけで、まだ何とも相互検証されません — forward-declaredなmetadataです。<code>ai_component</code> と同様、<code>"description text"</code> tagはどのフィールドも受け付けません。</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">統計evidence</p>
+    <h2 class="reveal"><code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code> で品質を証拠として縛る</h2>
+    <p class="lead narrow reveal"><code>fslc ai eval</code> はprecomputedなeval JSONLを読むdeterministic checkerです。AIモデルもevaluatorも実行せず、Bernoulli/proportion metric（accuracy、recall、hallucination_rate、wrong_tool_call_rate など0/1のもの）だけをWilson intervalで判定します。結果は常に <code>formal_result: "not_run"</code> です。</p>
+    <div class="panel reveal">
+      <pre><code>dataset SupportEvalV3 {
+  source "examples/ai/support_eval_v3.jsonl"
+
+  population {
+    language in ["ja", "en"]
+    ticket_type in ["refund", "bug", "urgent"]
+  }
+
+  slice JapaneseRefundTickets {
+    language == "ja"
+    ticket_type == "refund"
+  }
+}
+
+evaluator SupportAnswerJudge {
+  input question: Question
+  input answer: Answer
+  output grounded: Bool
+  output confidence: Float
+
+  calibration {
+    dataset HumanLabeledGroundednessV2
+    require agreement_with_human >= 0.90
+  }
+}
+
+statistical_property LooseQuality {
+  target SupportAnswerAgent
+  dataset SupportEvalV3
+  evaluator SupportAnswerJudge
+  confidence 0.95
+
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+
+  slice JapaneseRefundTickets {
+    require min_samples >= 5
+    require ci_lower(metric.accuracy, 0.95) >= 0.35
+  }
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px">eval recordは1行 = 1つのBernoulli観測です（schema <code>fsl-ai-eval-record.v0</code>。<code>case_id</code> / <code>slice</code> / <code>metric</code> / boolean <code>outcome</code> / <code>evaluator.id</code> が必須で、同一 <code>(case_id, slice, metric)</code> の重複は <code>dataset_invalid</code>）。</p>
+    <div class="panel reveal" style="margin-top:16px">
+      <pre><code>{"schema_version":"fsl-ai-eval-record.v0","case_id":"support-001","component":"SupportAnswerAgent","dataset":"SupportEvalV3","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px"><code>n</code> 個の観測中 <code>k</code> 個成功なら <code>estimate = k / n</code> で、confidence <code>c</code> のWilson intervalから <code>ci_lower</code> / <code>ci_upper</code> が出ます。requireは <code>ci_lower(metric.X, 0.95) &gt;= T</code> か <code>ci_upper(metric.X, 0.95) &lt;= T</code> の形だけです。実際にexampleを走らせた結果:</p>
+    <table class="matrix reveal" style="margin-top:16px">
+      <tr><th>property</th><th>slice</th><th>n</th><th>estimate</th><th>ci_lower (95%)</th><th>閾値</th><th>result</th></tr>
+      <tr><td><code>LooseQuality</code></td><td><code>all</code></td><td>10</td><td>0.80</td><td>≈ 0.490</td><td>≥ 0.45</td><td class="good"><code>statistically_supported</code></td></tr>
+      <tr><td><code>LooseQuality</code></td><td><code>JapaneseRefundTickets</code></td><td>5</td><td>1.00</td><td>≈ 0.566</td><td>≥ 0.35（+ <code>min_samples &gt;= 5</code>）</td><td class="good"><code>statistically_supported</code></td></tr>
+      <tr><td><code>StrictQuality</code></td><td><code>JapaneseRefundTickets</code></td><td>5</td><td>1.00</td><td>≈ 0.566</td><td>≥ 0.80</td><td class="bad"><code>statistically_unsupported</code></td></tr>
+    </table>
+    <p class="lead narrow reveal" style="margin-top:16px">3行目が要点です。sliceで5/5全問正解（estimate 1.00）でも、n=5ではWilson下限は約0.566にしかならず、0.80という主張は支持されません。「全部通ったからOK」をサンプル数ごと拒否するのがこの層の仕事です。</p>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>優先順位</th><th>status</th><th>意味</th></tr>
+      <tr><td>1</td><td><code>dataset_invalid</code></td><td>record schema違反、slice/metricの重複case、必須sliceフィールド欠落。</td></tr>
+      <tr><td>2</td><td><code>evaluator_untrusted</code></td><td>evaluatorのcalibration evidenceが欠落、または宣言されたtrust閾値未満。</td></tr>
+      <tr><td>3</td><td><code>insufficient_samples</code></td><td>必須sliceのどれかが <code>n &lt; min_samples</code>。</td></tr>
+      <tr><td>4</td><td><code>inconclusive</code></td><td>宣言されたmetricやinterval methodが計算できない。点推定のみのrequireもここで拒否。</td></tr>
+      <tr><td>5</td><td><code>statistically_unsupported</code></td><td>サンプルは足りているが、Wilson boundが閾値を支持しない。</td></tr>
+      <tr><td>6</td><td><code>statistically_supported</code></td><td>すべての必須gateとbound checkが通過。</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0"><code>require accuracy &gt;= 0.92</code> のような点推定のみの要求は、警告で通過するのではなく、eval時に <code>inconclusive</code>（exit 1）として拒否されます。また各sliceは独立したgateで、全sliceが自分の <code>min_samples</code> とbound checkを通ったときだけ全体が supported になります。family-wiseな多重検定補正はこの層では主張されません。</p>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Migration / drift / compat</p>
+    <h2 class="reveal">移行のregression、本番のdrift、環境互換性も同じ規律で扱う</h2>
+    <p class="lead narrow reveal"><code>ai_migration</code> はprompt/model/retriever移行の前後で「hard contractの維持」と「metricの非退行」を宣言し、<code>observed_property</code> は本番telemetryの閾値とdriftを宣言します。どちらも外部証拠で、<code>formal_result: "not_run"</code> です。</p>
+    <div class="panel reveal">
+      <pre><code>ai_migration PromptV7ToV8 {
+  from SupportAnswerAgent {
+    model gpt_5_5
+    prompt support_answer_prompt_v7
+    retriever support_docs_index_v12
+  }
+
+  to SupportAnswerAgent {
+    model gpt_5_5
+    prompt support_answer_prompt_v8
+    retriever support_docs_index_v14
+  }
+
+  preserve {
+    hard_contract SupportAnswerContract.hard
+
+    no_regression {
+      dataset SupportEvalV3
+      metric accuracy drop &lt;= 0.05
+      metric hallucination_rate increase &lt;= 0.02
+    }
+  }
+}
+
+observed_property SupportAgentOperationalQuality {
+  target SupportAnswerAgent
+  source production_logs
+  window last_7_days
+
+  require observed(metric.hallucination_rate) &lt;= 0.30
+  require drift(metric.refusal_rate) &lt;= 0.10 compared_to previous_7_days
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:24px">exampleのv7→v8（意図的にregressさせたデータ）を実際に走らせた結果:</p>
+    <table class="matrix reveal" style="margin-top:16px">
+      <tr><th>コマンド</th><th>検査</th><th>実測</th><th>判定</th></tr>
+      <tr><td><code>fslc ai regress</code></td><td><code>accuracy drop &lt;= 0.05</code></td><td>1.00 (10/10) → 0.80 (8/10)、<code>observed_delta</code> 0.20 &gt; <code>allowed_delta</code> 0.05</td><td class="bad"><code>passed: false</code> → finding <code>ai_migration_regression</code></td></tr>
+      <tr><td><code>fslc ai regress</code></td><td><code>hallucination_rate increase &lt;= 0.02</code></td><td>0.00 (0/5) → 0.20 (1/5)、<code>observed_delta</code> 0.20 &gt; <code>allowed_delta</code> 0.02</td><td class="bad"><code>passed: false</code>、全体は <code>statistically_unsupported</code></td></tr>
+      <tr><td><code>fslc ai compare</code></td><td>閾値判定なしのdelta報告</td><td>accuracy <code>delta</code> −0.20、hallucination_rate <code>delta</code> +0.20</td><td class="ok"><code>result: "compared"</code>（findingなし）</td></tr>
+      <tr><td><code>fslc ai drift</code></td><td><code>observed(metric.hallucination_rate) &lt;= 0.30</code></td><td>現在 0.25（n=4）</td><td class="good"><code>passed: true</code></td></tr>
+      <tr><td><code>fslc ai drift</code></td><td><code>drift(metric.refusal_rate) &lt;= 0.10</code></td><td>baseline 0.10 → 現在 ≈0.667、<code>drift</code> ≈ 0.567</td><td class="bad"><code>passed: false</code> → <code>observed_mismatch</code>、finding <code>ai_observed_drift</code>（<code>guarantee_kind: "runtime_observed"</code>）</td></tr>
+    </table>
+    <p class="lead narrow reveal" style="margin-top:24px">環境互換性はfsl-dbと共有です。<code>fslc ai compat --environment prod</code> は、componentのmodel/prompt/retriever/tool/output schemaを <code>dbsystem</code> のartifact capability profileとして生成します（<code>result: "compat_profile_generated"</code>）:</p>
+    <div class="panel reveal" style="margin-top:16px">
+      <pre><code>artifact support_answer_agent {
+  requires model.gpt_5_5, prompt.support_answer_prompt_v8,
+           retriever.support_docs_index_v14, tool.CreateTicket, tool.SearchDocs;
+  provides output.AnswerSchemaV2;
+}</code></pre>
+    </div>
+    <p class="lead narrow reveal" style="margin-top:16px">この断片を <code>dbsystem</code> のenvironmentに組み込み、<code>fslc compat check --include-ai</code> で、server/mobile/DB artifactと同じ有限snapshot上のcapability互換性として検査します。provider側の欠落は <code>required_capability_missing</code> になります。</p>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
     <p class="kicker reveal">実行</p>
-    <h2 class="reveal">guardとreplayの失敗はAI専用findingで読む</h2>
+    <h2 class="reveal">層ごとのコマンドと結果語彙を対応づけて読む</h2>
     <div class="panel reveal">
       <pre><code>fslc ai check examples/ai/refund_agent_tool_safety.fsl
 fslc ai check examples/ai/recursive_support_agent.fsl
 fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_conformant.jsonl
 fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_human_approval_bypass.jsonl
-fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_observed_mismatch.jsonl</code></pre>
+fslc ai replay examples/ai/refund_agent_tool_safety.fsl --logs examples/ai/runtime_forbidden_tool.jsonl
+fslc ai eval examples/ai/support_answer_quality.fsl --property LooseQuality
+fslc ai eval examples/ai/support_answer_quality.fsl --property StrictQuality
+fslc ai regress examples/ai/support_answer_quality.fsl --migration PromptV7ToV8 \
+  --before-records examples/ai/support_eval_v7.jsonl --after-records examples/ai/support_eval_v8_regressed.jsonl
+fslc ai compare --from examples/ai/support_eval_v7.jsonl --to examples/ai/support_eval_v8_regressed.jsonl --dataset SupportEvalV3
+fslc ai drift examples/ai/support_answer_quality.fsl --logs examples/ai/runtime_drift_current.jsonl \
+  --baseline-logs examples/ai/runtime_drift_baseline.jsonl
+fslc ai compat examples/ai/support_answer_quality.fsl --environment prod</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
       <tr><th>結果</th><th>読み方</th></tr>
-      <tr><td><code>verified_under_assumptions</code></td><td>有限のhard-contract展開が、完全なcapability宣言とruntime guardを前提に検証された状態。</td></tr>
-      <tr><td><code>agent_analyzed</code></td><td>recursive agent graph が構造的に整合している状態。<code>formal_result</code> は <code>not_run</code> のまま。</td></tr>
-      <tr><td><code>replay_conformant</code></td><td>観測event logが宣言されたhard境界に合っていた。証明ではなく証拠。</td></tr>
-      <tr><td><code>ai_hard_contract_violation</code></td><td>forbidden tool、approval bypass、schema invalidity、business precondition mismatch が観測された。</td></tr>
-      <tr><td><code>observed_contract_violation</code></td><td>runtime が宣言外のcapabilityを使った。</td></tr>
+      <tr><td><code>verified_under_assumptions</code></td><td>有限のhard-contract展開が、完全なcapability宣言（<code>AI-ASSUME-CAPABILITY-DECLARATIONS</code>）とruntime guard（<code>AI-ASSUME-RUNTIME-GUARD</code>）を前提に検証された。<code>formal_result</code> にはkernelの <code>verified</code> が入ります。</td></tr>
+      <tr><td><code>agent_analyzed</code></td><td>recursive agent graphが構造的に整合。<code>formal_result</code> は <code>not_run</code>。</td></tr>
+      <tr><td><code>ai_project_analyzed</code></td><td><code>dataset</code> などのproject宣言を含むfileの <code>fslc ai check</code>。検証ではなく宣言の一覧です。</td></tr>
+      <tr><td><code>replay_conformant</code> / <code>replay_nonconformant</code></td><td>観測event logが宣言されたhard境界に合っていたか。nonconformant側はfinding kind <code>ai_hard_contract_violation</code>（approval bypass、forbidden tool実行、schema invalidity、precondition mismatch）や <code>observed_contract_violation</code>（宣言外のtool/capability）を運びます。証明ではなく観測です。</td></tr>
+      <tr><td><code>statistically_supported</code> / <code>statistically_unsupported</code></td><td>Wilson boundが閾値を支持したか（<code>ai eval</code> / <code>ai regress</code>）。</td></tr>
+      <tr><td><code>compared</code></td><td><code>ai compare</code> のdelta報告。閾値判定を含みません。</td></tr>
+      <tr><td><code>observed_supported</code> / <code>observed_mismatch</code></td><td><code>ai drift</code> のtelemetry閾値・drift判定。観測証拠です。</td></tr>
+      <tr><td><code>compat_profile_generated</code></td><td><code>ai compat</code> がdbsystem用capability profileを生成した。</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Finding contract</p>
+    <h2 class="reveal">すべてのfindingは <code>fsl-ai-finding.v0</code> で同じ形をしている</h2>
+    <p class="lead narrow reveal">hard contract違反も、agent構造違反も、統計不支持も、driftも、全部同じfinding schemaで返ります。必須フィールドは <code>fsl</code>、<code>result</code>、<code>kind</code>、<code>severity</code>、<code>component</code>、<code>contract</code>、<code>tool</code>、<code>failed_rule</code>、<code>violation</code>、<code>guarantee_kind</code>、<code>evidence</code>、<code>witness</code>、<code>minimal_conflict_set</code>、<code>repair_candidates</code>、<code>assumptions</code> です。<code>repair_candidates</code> は各候補に <code>weakens_spec</code> flagを持ち、「specを弱めて通す」修理を明示的に区別します。</p>
+    <table class="matrix reveal">
+      <tr><th><code>guarantee_kind</code></th><th>発行元</th><th>意味</th></tr>
+      <tr><td><code>syntactic_hard</code></td><td><code>ai check</code> / <code>ai replay</code> のhard-contract violation</td><td>宣言境界とguard前提の上の決定的事実。</td></tr>
+      <tr><td><code>agent_structural</code></td><td>recursive agent解析</td><td>graph上の構造的証拠。証明ではない。</td></tr>
+      <tr><td><code>runtime_observed</code></td><td>replayのlog mismatch、<code>ai drift</code></td><td>観測証拠。logにないことは未使用の証明ではない。</td></tr>
+      <tr><td><code>evaluator_supported</code></td><td>将来のevaluator finding</td><td>evaluator証拠。<code>proved</code> とは表示しない。</td></tr>
+      <tr><td><code>statistically_supported</code> / <code>statistically_unsupported</code></td><td><code>ai eval</code> / <code>ai regress</code></td><td>Wilson boundつき統計証拠。<code>proved</code> とは表示しない。</td></tr>
     </table>
   </div>
 </section>
 
 <section>
   <div class="wrap">
+    <p class="kicker reveal">境界</p>
+    <h2 class="reveal">検査されるものと、認識されるだけのものを混同しない</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>検査されないblock境界</h3>
+        <p><code>ai_action</code>、単独の <code>retriever</code> block、<code>trust_boundary</code>、トップレベルの <code>authority { target ... }</code>（exampleの <code>ai_contract</code> も同様）は、block<em>境界</em>としてのみ認識されます。parserは本文に一切降りないため、中身がgarbageでも <code>check</code> を通ります。<code>raw_blocks</code> に <code>{kind, name}</code> として列挙されるだけで、何も制約しません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>検査される面はこれだけ</h3>
+        <p>kernel裏づけの <code>ai_component</code> / <code>agent</code> と、外部証拠の <code>dataset</code> / <code>evaluator</code> / <code>statistical_property</code> / <code>ai_migration</code> / <code>observed_property</code>。この外にあるものに契約を書いても効きません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>forward-declaredなmetadata</h3>
+        <p>agentの <code>contract { hard { rule ...; } }</code> と <code>failure_mode</code> は、parseされて <code>agent_ir.contracts</code> / <code>failure_modes</code> に載りますが、まだevidenceと相互検証されません。追跡されるmetadataであって、検証済みの主張ではありません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>evaluatorを実行しない</h3>
+        <p><code>fslc ai eval</code> はprecomputed JSONLを読むだけです。LLM evaluatorの実行、provider sampling、promptの変異は行いません。boolean outcomeのみ対象で、連続scoreは対象外です。evaluatorの信頼はcalibration evidenceの問題として扱われます（欠落は <code>evaluator_untrusted</code>）。</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>formal_result: "not_run"</code> の一貫</h3>
+        <p>replay、agent解析、eval、regress、compare、drift、compatの結果はすべて <code>formal_result: "not_run"</code> を運びます。これらを <code>proved</code> / <code>verified</code> として表示してはいけません。kernelの形式結果を持つのは <code>ai_component</code> のhard-contract展開だけです。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>時間・確率・LLM真偽</h3>
+        <p>「7日間window」はlog選別のラベルであって実時間の証明ではなく、driftは2つの観測窓の差です。LLM出力の真偽・groundednessそのものは、この dialect のどの層でも証明されません。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
     <p class="kicker reveal">次に読む</p>
     <h2 class="reveal">設計と例へ進む</h2>
     <div class="syntax-grid reveal">
       <div class="syntax-card">
         <h3>設計判断</h3>
-        <p>保証境界、lowering、event schema、finding、外部証拠として扱う境界は design doc にまとまっています。</p>
-        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a></p>
+        <p>guarantee boundary、lowering、event schema、findingはhard-contract設計文書に、Wilson区間・status優先順位・eval record schemaはstochastic設計文書にあります。</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ai-hard.md">DESIGN-ai-hard.md</a> <a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-stochastic.md">DESIGN-stochastic.md</a></p>
       </div>
       <div class="syntax-card">
         <h3>動く例</h3>
-        <p>refund agent のapproval/replayと、recursive support agentの構造解析を確認できます。</p>
+        <p>refund agentのapproval/replay、recursive support agentの構造解析、eval/regress/drift/compatの全コマンドがexamplesで再現できます。</p>
         <p><a class="btn" href="../../examples/ai/README.md">examples/ai</a></p>
       </div>
       <div class="syntax-card">
+        <h3>環境互換性</h3>
+        <p><code>fslc ai compat</code> が生成するcapability profileは、fsl-dbの <code>dbsystem</code> artifact/environmentモデルに合流します。</p>
+        <p><a class="btn" href="db.ja.html">fsl-db のページへ</a></p>
+      </div>
+      <div class="syntax-card">
         <h3>通常の文法</h3>
-        <p><code>ai_component</code> は既存 verifier に展開され、<code>agent</code> は構造解析として扱われます。</p>
+        <p><code>ai_component</code> は既存verifierに展開されます。展開先の基本構文は文法ページで確認できます。</p>
         <p><a class="btn" href="syntax.ja.html">文法・構文へ</a></p>
       </div>
     </div>

--- a/docs/intro/domain.en.html
+++ b/docs/intro/domain.en.html
@@ -18,36 +18,33 @@
   <div class="wrap narrow center">
     <nav class="breadcrumb" data-nav></nav>
     <p class="kicker reveal">Functional DDD / async effects</p>
-    <h1 class="reveal">Describe domain transitions with <code>domain</code></h1>
-    <p class="lead reveal">fsl-domain makes aggregate ownership, command intent, accepted events, pure <code>decide/evolve</code> logic, saga/process-manager coordination, and async effect lifecycles explicit enough to verify, replay, and generate implementation scaffolds.</p>
+    <h1 class="reveal">Check domain transitions and async effects as a spec with <code>domain</code></h1>
+    <p class="lead reveal">fsl-domain puts aggregate ownership, command intent, accepted events, pure <code>decide/evolve</code> logic, async effect lifecycles, and saga/process-manager coordination into one specification. The spec lowers to the existing kernel for formal verification, structural risks come back as stable JSON findings, and real runtime behavior is checked as replay observation evidence.</p>
     <p class="reveal dim" style="margin-top:18px">Implementation details live in <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-domain.md">DESIGN-domain.md</a> and <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-effect.md">DESIGN-effect.md</a>.</p>
   </div>
 </section>
 
 <section>
   <div class="wrap">
-    <p class="kicker reveal">Model</p>
-    <h2 class="reveal">Keep the domain core pure</h2>
-    <div class="syntax-grid reveal">
+    <p class="kicker reveal">What it prevents</p>
+    <h2 class="reveal">Find domain-boundary and async breakage before release</h2>
+    <p class="lead narrow reveal">In real implementations, I/O leaks into command acceptance logic, a completion event arrives with no way to tell which request it completes, and an irreversible operation such as a payment capture runs twice after a retry. fsl-domain lowers the domain to a finite transition system and reports these risks mechanically, as verification results and findings.</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
       <div class="syntax-card">
-        <h3>Aggregate</h3>
-        <p>Owns state, commands, events, errors, invariants, and the consistency boundary.</p>
+        <h3>Pure-core completeness</h3>
+        <p>Every command must have a <code>decide</code>, every event must have an <code>evolve</code>, and no <code>evolve</code> may write state outside its aggregate.</p>
       </div>
       <div class="syntax-card">
-        <h3>Decide</h3>
-        <p>Maps state plus command to accepted events or rejected intent. No I/O belongs here.</p>
+        <h3>Correlation</h3>
+        <p>An async effect completion requires a prior pending request tied by <code>correlation_id</code>. A missing declaration is <code>uncorrelated_async_completion</code>.</p>
       </div>
       <div class="syntax-card">
-        <h3>Evolve</h3>
-        <p>Applies accepted events to state as pure transition logic.</p>
+        <h3>Idempotency</h3>
+        <p>An irreversible effect must declare an <code>idempotency_key</code>. If it is missing, an error finding stops formal verification itself.</p>
       </div>
       <div class="syntax-card">
-        <h3>Effect</h3>
-        <p>Models external async work with correlation, retry, timeout, and idempotency boundaries.</p>
-      </div>
-      <div class="syntax-card">
-        <h3>Saga</h3>
-        <p>Coordinates eventual steps, awaits outcomes, and declares compensation across boundaries.</p>
+        <h3>Stuck processes</h3>
+        <p>Effects left pending with no exit, saga steps that never observe completion, and cyclic waits are reported as warning or error findings.</p>
       </div>
     </div>
   </div>
@@ -55,8 +52,30 @@
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
+    <p class="kicker reveal">Model</p>
+    <h2 class="reveal"><code>domain</code> lowers to the existing kernel</h2>
+    <p class="lead narrow reveal"><code>domain</code> is not a new verifier kernel. Declarations are parsed into a typed IR and lowered to the existing state-machine kernel. You can inspect the generated kernel spec directly with <code>fslc domain expand</code>.</p>
+    <table class="matrix reveal">
+      <tr><th>domain element</th><th>Lowered shape</th><th>Real example (from <code>fslc domain expand</code>)</th></tr>
+      <tr><td>Aggregate state field</td><td>A snake_case kernel state variable.</td><td><code>Order.status</code> → <code>order_status: OrderStatus</code></td></tr>
+      <tr><td>Command + <code>decide</code> + <code>evolve</code></td><td>One kernel action. <code>requires</code> becomes a guard; <code>rejects E when C</code> becomes <code>requires not (C)</code>.</td><td><code>RequestPaymentCapture</code> → <code>order_request_payment_capture(payment_request_id)</code></td></tr>
+      <tr><td>Event occurrence</td><td>A per-step Bool flag recording which event just happened.</td><td><code>event_PaymentCaptured: Bool</code></td></tr>
+      <tr><td>Enum member</td><td>A namespaced member, so separate enums can reuse the same word without collision.</td><td><code>Pending</code> → <code>OrderStatus_Pending</code></td></tr>
+      <tr><td>Aggregate invariant / <code>can(Command)</code></td><td>A kernel invariant. <code>can(C)</code> expands to C's decide preconditions: all <code>requires</code> clauses plus the negation of every <code>rejects ... when</code> condition.</td><td><code>noDuplicateCapture</code> → <code>Order_noDuplicateCapture</code></td></tr>
+      <tr><td>Effect lifecycle</td><td>Finite per-correlation maps plus completion and retry kernel actions.</td><td><code>capture_payment_status: Map&lt;PaymentRequestId, CapturePaymentEffectStatus&gt;</code>, <code>capture_payment_attempts</code> (<code>0..3</code>)</td></tr>
+      <tr><td>Saga step / compensation</td><td>Kernel actions guarded by event flags, plus observe actions for completions.</td><td><code>saga_order_fulfillment_capture_payment</code>, <code>saga_order_fulfillment_observe_payment_captured</code></td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">The effect lifecycle is a finite state machine keyed by <code>correlation_id</code>: <code>NotStarted -&gt; Pending -&gt; Succeeded | Failed | TimedOut | Cancelled | Compensated</code>. Completion actions require that correlation to be <code>Pending</code>, retry actions require a <code>Failed / TimedOut</code> status with <code>attempts &lt; max_attempts</code>, and <code>Succeeded</code> is sticky — enforced by the generated transition check <code>CapturePayment_SuccessSticky</code>.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
     <p class="kicker reveal">Shape</p>
-    <h2 class="reveal">Write commands, events, and effect outcomes together</h2>
+    <h2 class="reveal">Write the aggregate and its effects in one spec</h2>
+    <p class="lead narrow reveal"><code>decide</code> is a pure function from state and command to either accepted events or a named rejection; <code>evolve</code> is a pure function applying an accepted event to state. I/O lives only on the effect side.</p>
     <div class="panel reveal">
       <pre><code>domain OrderAsyncEffect {
   implementation_profile functional_ddd
@@ -71,22 +90,50 @@
       payment_status: PaymentStatus = NotRequested;
     }
 
+    command ApproveOrder {}
+    command CancelOrder {}
     command RequestPaymentCapture { input payment_request_id: PaymentRequestId }
+
+    event OrderApproved {}
+    event OrderCancelled {}
     event PaymentCaptureRequested { payment_request_id: PaymentRequestId }
     event PaymentCaptured { payment_request_id: PaymentRequestId }
     event PaymentFailed { payment_request_id: PaymentRequestId }
     event PaymentCaptureTimedOut { payment_request_id: PaymentRequestId }
+
+    error CannotCancelCapturedOrder
     error CannotCaptureUnapprovedOrder
+    error DuplicatePaymentCapture
+
+    decide ApproveOrder {
+      requires status == Pending
+      emits OrderApproved
+    }
+
+    decide CancelOrder {
+      rejects CannotCancelCapturedOrder when payment_status == Captured
+      requires status in [Pending, Approved]
+      emits OrderCancelled
+    }
 
     decide RequestPaymentCapture {
       rejects CannotCaptureUnapprovedOrder when status != Approved
+      rejects DuplicatePaymentCapture when payment_status in [PaymentPending, Captured]
       emits PaymentCaptureRequested
     }
 
+    evolve OrderApproved { status = Approved }
+    evolve OrderCancelled { status = Cancelled }
     evolve PaymentCaptureRequested { payment_status = PaymentPending }
     evolve PaymentCaptured {
       requires status != Cancelled
       payment_status = Captured
+    }
+    evolve PaymentFailed { payment_status = Failed }
+    evolve PaymentCaptureTimedOut { payment_status = TimedOut }
+
+    invariant noDuplicateCapture {
+      payment_status == Captured -> not can(RequestPaymentCapture)
     }
   }
 
@@ -97,10 +144,71 @@
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
-    retry { max_attempts 3 }
+    retry {
+      max_attempts 3
+      backoff exponential
+    }
     timeout after 10m emits PaymentCaptureTimedOut
+    compensation {
+      emits PaymentFailed
+    }
   }
 }</code></pre>
+    </div>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>Effect declaration</th><th>Meaning</th></tr>
+      <tr><td><code>async</code></td><td>An effect whose completion arrives in a later step. It makes <code>correlation_id</code> mandatory.</td></tr>
+      <tr><td><code>irreversible</code></td><td>A side effect that cannot be undone, such as a payment. It requires an <code>idempotency_key</code>, and missing compensation is a warning.</td></tr>
+      <tr><td><code>correlation_id Event.field</code></td><td>The key tying a request to its completion; it indexes the lifecycle maps.</td></tr>
+      <tr><td><code>idempotency_key Order.id</code></td><td>A declared stable key that guards against double commits.</td></tr>
+      <tr><td><code>handles</code> / <code>emits one_of [...]</code></td><td>The request event it consumes and the set of completion events it may produce.</td></tr>
+      <tr><td><code>retry { max_attempts 3 }</code></td><td>The retry bound after failure or timeout. In the kernel it becomes an <code>attempts &lt; 3</code> guard.</td></tr>
+      <tr><td><code>timeout after 10m emits ...</code></td><td>The exit from pending. <code>10m</code> is a modeled event, not wall-clock time.</td></tr>
+      <tr><td><code>reliable</code> + <code>outbox</code></td><td>An effect claiming delivery guarantees must be paired with an outbox boundary; otherwise <code>reliable_effect_without_outbox_boundary</code> is reported.</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Saga</p>
+    <h2 class="reveal">Coordinate cross-boundary processes with a saga</h2>
+    <p class="lead narrow reveal">Multi-step eventual processes are written as a <code>saga</code>. It starts on a <code>starts_on</code> event; each step sends a request with <code>emits</code>, waits with <code>awaits one_of [...]</code>, and exits with <code>timeout after</code>. A <code>compensation</code> block declares "if X happens after Y, emit Z".</p>
+    <div class="panel reveal">
+      <pre><code>saga OrderFulfillment {
+  starts_on OrderApproved
+  outbox OrderOutbox
+  inbox FulfillmentInbox
+
+  step ReserveInventory {
+    async
+    emits InventoryReservationRequested
+    awaits one_of [InventoryReserved, InventoryReservationFailed]
+    timeout after 5m emits InventoryReservationFailed
+  }
+
+  step CapturePayment {
+    async
+    requires InventoryReserved
+    emits PaymentCaptureRequested
+    awaits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    timeout after 10m emits PaymentCaptureTimedOut
+  }
+
+  step ShipOrder {
+    requires PaymentCaptured
+    emits ShipmentRequested
+  }
+
+  compensation {
+    when PaymentFailed after InventoryReserved {
+      emits InventoryReleaseRequested
+    }
+  }
+}</code></pre>
+    </div>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">Saga <code>awaits</code> / <code>after</code> clauses enter the kernel as per-step event observation actions (generated actions such as <code>saga_order_fulfillment_observe_payment_captured</code>), and the result JSON carries the <code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code> assumption. Durable process history is not treated as an unbounded kernel proof — it is the boundary checked through finite-log observation with <code>fslc domain replay</code>.</p>
     </div>
   </div>
 </section>
@@ -108,23 +216,87 @@
 <section>
   <div class="wrap">
     <p class="kicker reveal">Run it</p>
-    <h2 class="reveal">Use kernel verification plus domain-specific findings</h2>
+    <h2 class="reveal">Use kernel verification plus the domain subcommands</h2>
+    <p class="lead narrow reveal">Because <code>domain</code> files lower to the kernel, plain <code>fslc check</code> / <code>fslc verify</code> accept them as-is. The dialect boundary — findings, scaffolds, replay — is exposed by the <code>fslc domain</code> subcommands.</p>
     <div class="panel reveal">
-      <pre><code>fslc check examples/domain/order_async_effect.fsl
-fslc verify examples/domain/order_async_effect.fsl --depth 6
-fslc domain check examples/domain/order_async_effect.fsl
-fslc domain analyze examples/domain/order_async_effect.fsl
-fslc domain expand examples/domain/order_async_effect.fsl
+      <pre><code>fslc check  examples/domain/order_async_effect.fsl
+fslc verify examples/domain/order_async_effect.fsl --depth 8
+fslc domain check   examples/domain/order_async_effect.fsl
+fslc domain analyze examples/domain/order_fulfillment_saga.fsl
+fslc domain expand  examples/domain/order_async_effect.fsl
 fslc domain generate examples/domain/order_functional_ddd.fsl --target typescript -o src/domain
-fslc domain generate examples/domain/order_functional_ddd.fsl --target python
-fslc domain testgen examples/domain/order_functional_ddd.fsl --target vitest -o order.domain.test.ts
-fslc domain replay examples/domain/order_async_effect.fsl --logs examples/domain/order_async_effect_replay.jsonl</code></pre>
+fslc domain testgen  examples/domain/order_functional_ddd.fsl --target vitest -o order.domain.test.ts
+fslc domain replay   examples/domain/order_async_effect.fsl --logs examples/domain/order_async_effect_replay.jsonl</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
-      <tr><th>Result</th><th>Meaning</th></tr>
-      <tr><td><code>verified_under_assumptions</code></td><td>The generated kernel model verified, with finite-model and scaffold assumptions stated in JSON.</td></tr>
-      <tr><td><code>violated</code></td><td>A hard domain finding blocked formal verification, or the generated kernel found a real property violation.</td></tr>
-      <tr><td><code>warning</code> finding</td><td>A design risk such as missing timeout/fallback or late completion policy. It does not claim a formal violation by itself.</td></tr>
+      <tr><th>Result</th><th>How to read it</th></tr>
+      <tr><td><code>verified_under_assumptions</code></td><td>A successful <code>domain check</code>: <code>formal_result: "verified"</code>, with the kernel details (<code>invariants_checked</code>, <code>action_coverage</code>, …) nested under <code>kernel</code>, alongside <code>generated_actions</code> and the assumption list.</td></tr>
+      <tr><td><code>violated</code> + <code>formal_result: "not_run"</code></td><td>A severity-<code>error</code> finding stopped formal verification before it ran. Exit code 1.</td></tr>
+      <tr><td><code>analyzed</code></td><td><code>domain analyze</code>: a JSON summary of aggregate / effect / saga ownership (state, commands, events, steps, compensations, outbox/inbox).</td></tr>
+      <tr><td><code>generated</code></td><td><code>domain generate</code> / <code>domain testgen</code>: returns the generated <code>files</code> list and the output location.</td></tr>
+      <tr><td><code>conformance_checked</code> / <code>nonconformant</code></td><td><code>domain replay</code>: a finite-log observation result with <code>guarantee_kind: "runtime_observed"</code>. Not a formal proof.</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">Findings</p>
+    <h2 class="reveal">Errors block verification; warnings flag design risk</h2>
+    <p class="lead narrow reveal">Findings are stable JSON under the <code>fsl-domain-finding.v0</code> schema. Severity <code>error</code> marks a structural defect that would make the kernel run overstate its guarantee, so the check returns <code>violated</code> without running the kernel. Severity <code>warning</code> is a design-review risk and does not block the kernel run by itself.</p>
+    <table class="matrix reveal">
+      <tr><th>Finding</th><th>Severity</th><th>Meaning</th></tr>
+      <tr><td><code>missing_decide_for_command</code></td><td>error</td><td>A command has no corresponding <code>decide</code>.</td></tr>
+      <tr><td><code>missing_evolve_for_event</code></td><td>error</td><td>An event has no corresponding <code>evolve</code>.</td></tr>
+      <tr><td><code>aggregate_boundary_violation</code></td><td>error</td><td>An <code>evolve</code> writes state outside its aggregate.</td></tr>
+      <tr><td><code>uncorrelated_async_completion</code></td><td>error</td><td>An async effect has no <code>correlation_id</code>. In replay, a completion with no prior request reports the same kind.</td></tr>
+      <tr><td><code>irreversible_effect_without_idempotency_key</code></td><td>error</td><td>An irreversible effect declares no <code>idempotency_key</code>.</td></tr>
+      <tr><td><code>process_wait_cycle</code></td><td>error</td><td>The saga wait graph is cyclic, so no progress is possible without external completion.</td></tr>
+      <tr><td><code>pending_effect_without_timeout_or_fallback</code></td><td>warning</td><td>No exit from pending: neither <code>timeout</code> nor <code>retry</code> is declared.</td></tr>
+      <tr><td><code>late_completion_without_stale_policy</code></td><td>warning</td><td>No stale policy for a success completion arriving late, e.g. after cancellation.</td></tr>
+      <tr><td><code>missing_compensation_for_irreversible_effect</code></td><td>warning</td><td>An irreversible effect has no compensation, either on the effect or in a saga.</td></tr>
+      <tr><td><code>reliable_effect_without_outbox_boundary</code></td><td>warning</td><td>A <code>reliable</code> claim without an outbox boundary overstates runtime delivery evidence.</td></tr>
+      <tr><td><code>saga_dead_end</code></td><td>warning</td><td>A saga with no steps, or an async step with no completion observation (<code>awaits</code> / <code>timeout</code>).</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">Real example: running <code>fslc domain check</code> on <code>examples/domain/unsafe_irreversible_effect_without_idempotency.fsl</code> returns one error (<code>irreversible_effect_without_idempotency_key</code>) and two warnings (<code>pending_effect_without_timeout_or_fallback</code>, <code>missing_compensation_for_irreversible_effect</code>). Because of the error, the result is <code>violated</code> with <code>formal_result: "not_run"</code>. Every finding carries <code>repair_candidates</code> (e.g. <code>add idempotency_key &lt;stable key&gt; to irreversible effect CapturePayment</code>) that feed straight into an LLM write→verify→repair loop.</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Scaffold and replay</p>
+    <h2 class="reveal">Connect to implementation scaffolds and runtime observation</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3><code>domain generate</code></h3>
+        <p><code>--target typescript</code> is the richest target: <code>types.ts</code>, <code>&lt;aggregate&gt;/decide.ts</code>, <code>&lt;aggregate&gt;/evolve.ts</code>, <code>&lt;aggregate&gt;/adapter.ts</code>, plus <code>effects.ts</code> when effects are declared and <code>process-manager.ts</code> when sagas are declared. <code>python | kotlin | swift | rust</code> are simple pure-domain scaffolds (python emits a single <code>domain_scaffold.py</code>).</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>domain testgen</code></h3>
+        <p>Generates a vitest conformance test scaffold. It replays a trace baked at generation time by the Monitor (the concrete evaluator) under a fixed seed; every test is skipped until you wire <code>makeAdapter()</code> to your implementation. This is the same adapter boundary as the existing <code>testgen</code> conformance tests.</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>domain replay</code></h3>
+        <p>Feeds a JSONL / JSON runtime log through the model. The four event kinds are <code>command</code> / <code>domain_event</code> / <code>effect_request</code> / <code>effect_completion</code>.</p>
+      </div>
+    </div>
+    <div class="panel reveal" style="margin-top:24px">
+      <div class="panel-head">examples/domain/order_async_effect_replay.jsonl → conformance_checked</div>
+      <pre><code>{"event":"command","aggregate":"Order","command":"ApproveOrder","params":{}}
+{"event":"command","aggregate":"Order","command":"RequestPaymentCapture","params":{"payment_request_id":"p1"}}
+{"event":"domain_event","aggregate":"Order","name":"PaymentCaptureRequested","params":{"payment_request_id":"p1"}}
+{"event":"effect_request","effect":"CapturePayment","correlation_id":"p1"}
+{"event":"effect_completion","effect":"CapturePayment","name":"PaymentCaptured","correlation_id":"p1","params":{"payment_request_id":"p1"}}</code></pre>
+    </div>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>Replay result key</th><th>Actual value (running the log above)</th></tr>
+      <tr><td><code>result</code></td><td><code>conformance_checked</code>; a log that disagrees with the model returns <code>nonconformant</code>.</td></tr>
+      <tr><td><code>events_observed</code></td><td><code>["PaymentCaptureRequested", "PaymentCaptured"]</code></td></tr>
+      <tr><td><code>pending_effects</code></td><td><code>[]</code> — the correlations left incomplete.</td></tr>
+      <tr><td><code>final_state</code></td><td>The model state after replay: <code>Order.payment_status: "PaymentStatus_Captured"</code>, correlation <code>0</code> of <code>effect.CapturePayment.status</code> at <code>Succeeded</code> with <code>attempts</code> at <code>1</code>.</td></tr>
+      <tr><td>Findings on <code>nonconformant</code></td><td><code>command_rejected_by_model</code>, <code>uncorrelated_async_completion</code>, <code>duplicate_irreversible_effect_commit</code>, <code>effect_completion_rejected_by_model</code>, and similar kinds.</td></tr>
     </table>
   </div>
 </section>
@@ -132,8 +304,57 @@ fslc domain replay examples/domain/order_async_effect.fsl --logs examples/domain
 <section style="background:var(--surface-2)">
   <div class="wrap">
     <p class="kicker reveal">Boundary</p>
-    <h2 class="reveal">What v0 proves</h2>
-    <p class="lead narrow reveal">The verifier checks the modeled transition system: aggregate invariants, command/evolve behavior, saga step guards, completion requiring a pending request, retry bounds, and sticky success. Runtime replay checks finite logs as observation evidence. Neither proves real gateway behavior, queue delivery, wall-clock timeouts, or production exactly-once semantics.</p>
+    <h2 class="reveal">Separate what is proved from what is not</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>What the kernel proves</h3>
+        <p>Bounded aggregate invariants, rejected commands being no-ops by construction (rejection conditions lower to guards, so no state changes), completion-requires-request, retry bounds, and sticky success status.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Finite-model assumption</h3>
+        <p><code>DOMAIN-ASSUME-FINITE-DOMAIN-MODEL</code>: IDs and undeclared scalar input types are modeled as finite <code>0..1</code> ranges. This is not a proof over unbounded id spaces.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Saga history</h3>
+        <p><code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code>: <code>awaits</code> / <code>after</code> are per-step observation flags. Durable process history is checked through replay evidence.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>The outside world</h3>
+        <p>Real payment gateways, queue delivery, wall-clock time (<code>10m</code> is a modeled event), and production idempotency across unbounded keys are not proved.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Generated code</h3>
+        <p><code>DOMAIN-ASSUME-GENERATED-SCAFFOLD</code>: the output is a scaffold, not production architecture proof. Runtime conformance still needs the adapter / replay evidence boundary.</p>
+      </div>
+      <div class="syntax-card">
+        <h3>Replay is observation</h3>
+        <p><code>conformance_checked</code> means this finite log matched the model — observation evidence, not formal proof. Log absence is not proof of non-occurrence.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">Next</p>
+    <h2 class="reveal">Read the design and examples</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>Design decisions</h3>
+        <p>The lowering, finding schema, effect lifecycle semantics, and remaining boundaries are described in the design documents.</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-domain.md">DESIGN-domain.md</a> <a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-effect.md">DESIGN-effect.md</a></p>
+      </div>
+      <div class="syntax-card">
+        <h3>Working examples</h3>
+        <p>The fixtures cover an async effect, a saga with compensation, the Functional DDD baseline, an unsafe missing-idempotency example, and a replay log.</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/tree/main/examples/domain">examples/domain</a></p>
+      </div>
+      <div class="syntax-card">
+        <h3>Core syntax</h3>
+        <p><code>domain</code> lowers to the existing FSL verifier. The syntax guide covers the core forms it expands into.</p>
+        <p><a class="btn" href="syntax.en.html">Syntax Guide</a></p>
+      </div>
+    </div>
   </div>
 </section>
 </main>

--- a/docs/intro/domain.ja.html
+++ b/docs/intro/domain.ja.html
@@ -18,36 +18,33 @@
   <div class="wrap narrow center">
     <nav class="breadcrumb" data-nav></nav>
     <p class="kicker reveal">Functional DDD / async effects</p>
-    <h1 class="reveal"><code>domain</code> でドメイン遷移を明示する</h1>
-    <p class="lead reveal">fsl-domain は、aggregate の所有範囲、command の意図、受理された event、純粋な <code>decide/evolve</code>、saga/process-manager、非同期 effect lifecycle を、検証・replay・scaffold 生成に使える形で書く dialect です。</p>
+    <h1 class="reveal"><code>domain</code> でドメイン遷移と非同期 effect を仕様として確認する</h1>
+    <p class="lead reveal">fsl-domain は、aggregate の所有範囲、command の意図、受理された event、純粋な <code>decide/evolve</code>、非同期 effect lifecycle、saga/process-manager を1つの仕様にまとめる dialect です。仕様は既存 kernel へ lower されて形式検証され、構造的なリスクは安定 JSON の finding として、runtime の実挙動は replay の観測証拠として返ります。</p>
     <p class="reveal dim" style="margin-top:18px">設計の詳細は <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-domain.md">DESIGN-domain.md</a> と <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-effect.md">DESIGN-effect.md</a> にあります。</p>
   </div>
 </section>
 
 <section>
   <div class="wrap">
-    <p class="kicker reveal">モデル</p>
-    <h2 class="reveal">domain core を純粋に保つ</h2>
-    <div class="syntax-grid reveal">
+    <p class="kicker reveal">何を防ぐか</p>
+    <h2 class="reveal">ドメイン境界と非同期の破れをリリース前に見つける</h2>
+    <p class="lead narrow reveal">実装では、command の受理判定に I/O が混ざる、届いた完了イベントがどのリクエストの完了か分からない、決済のような取り消せない処理が再送で二重に走る、といった破れが起きます。fsl-domain はドメインを有限の遷移系として lower し、こうしたリスクを検証と finding で機械的に返します。</p>
+    <div class="syntax-grid reveal" style="margin-top:24px">
       <div class="syntax-card">
-        <h3>Aggregate</h3>
-        <p>状態、command、event、error、不変条件、整合性境界を所有します。</p>
+        <h3>純粋な core の完全性</h3>
+        <p>すべての command に <code>decide</code> が、すべての event に <code>evolve</code> があること、<code>evolve</code> が aggregate 外の状態を書かないことを検査します。</p>
       </div>
       <div class="syntax-card">
-        <h3>Decide</h3>
-        <p>state と command から、受理 event または reject を決めます。I/O は入りません。</p>
+        <h3>correlation</h3>
+        <p>async effect の完了は、<code>correlation_id</code> で結ばれた pending なリクエストが先に存在することを要求します。宣言が欠ければ <code>uncorrelated_async_completion</code> です。</p>
       </div>
       <div class="syntax-card">
-        <h3>Evolve</h3>
-        <p>受理された event を state に適用する純粋な遷移です。</p>
+        <h3>idempotency</h3>
+        <p>irreversible な effect には <code>idempotency_key</code> が必須です。欠けていれば error finding が形式検証そのものを止めます。</p>
       </div>
       <div class="syntax-card">
-        <h3>Effect</h3>
-        <p>外部非同期処理を correlation、retry、timeout、idempotency の境界として表します。</p>
-      </div>
-      <div class="syntax-card">
-        <h3>Saga</h3>
-        <p>eventual な step、await、compensation を境界越しに調整します。</p>
+        <h3>止まらない process</h3>
+        <p>pending のまま離脱手段がない effect、完了観測のない saga step、循環する wait を warning / error として報告します。</p>
       </div>
     </div>
   </div>
@@ -55,8 +52,30 @@
 
 <section style="background:var(--surface-2)">
   <div class="wrap">
+    <p class="kicker reveal">モデル</p>
+    <h2 class="reveal"><code>domain</code> は既存カーネルへ lower される</h2>
+    <p class="lead narrow reveal"><code>domain</code> は新しい verifier kernel ではありません。宣言を typed IR に読み込み、既存の状態機械 kernel へ展開します。展開結果は <code>fslc domain expand</code> でそのまま FSL として確認できます。</p>
+    <table class="matrix reveal">
+      <tr><th>domain の要素</th><th>展開後の形</th><th>実際の例（<code>fslc domain expand</code> の出力）</th></tr>
+      <tr><td>aggregate の state field</td><td>snake_case の kernel state 変数。</td><td><code>Order.status</code> → <code>order_status: OrderStatus</code></td></tr>
+      <tr><td>command + <code>decide</code> + <code>evolve</code></td><td>1つの kernel action。<code>requires</code> は guard に、<code>rejects E when C</code> は <code>requires not (C)</code> になります。</td><td><code>RequestPaymentCapture</code> → <code>order_request_payment_capture(payment_request_id)</code></td></tr>
+      <tr><td>event の発生</td><td>step ごとの Bool flag。直前 step でどの event が起きたかを表します。</td><td><code>event_PaymentCaptured: Bool</code></td></tr>
+      <tr><td>enum member</td><td>namespace 化された member。別の enum が同じ語を使っても衝突しません。</td><td><code>Pending</code> → <code>OrderStatus_Pending</code></td></tr>
+      <tr><td>aggregate invariant / <code>can(Command)</code></td><td>kernel invariant。<code>can(C)</code> は C の decide 前提条件（すべての <code>requires</code> と各 <code>rejects ... when</code> の否定）に展開されます。</td><td><code>noDuplicateCapture</code> → <code>Order_noDuplicateCapture</code></td></tr>
+      <tr><td>effect の lifecycle</td><td>correlation ごとの有限 map と、completion / retry の kernel action。</td><td><code>capture_payment_status: Map&lt;PaymentRequestId, CapturePaymentEffectStatus&gt;</code>、<code>capture_payment_attempts</code>（<code>0..3</code>）</td></tr>
+      <tr><td>saga の step / compensation</td><td>event flag で guard された kernel action と、完了を観測する observe action。</td><td><code>saga_order_fulfillment_capture_payment</code>、<code>saga_order_fulfillment_observe_payment_captured</code></td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">effect の lifecycle は <code>correlation_id</code> を key とする有限状態機械 <code>NotStarted -&gt; Pending -&gt; Succeeded | Failed | TimedOut | Cancelled | Compensated</code> です。completion action は該当 correlation が <code>Pending</code> であることを要求し、retry action は <code>Failed / TimedOut</code> かつ <code>attempts &lt; max_attempts</code> を要求します。<code>Succeeded</code> は sticky で、生成 kernel の transition 検査 <code>CapturePayment_SuccessSticky</code> がそれを担保します。</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
     <p class="kicker reveal">基本形</p>
-    <h2 class="reveal">command、event、effect outcome を同じ仕様に書く</h2>
+    <h2 class="reveal">aggregate と effect を同じ仕様に書く</h2>
+    <p class="lead narrow reveal"><code>decide</code> は state と command から「受理 event か、名前つき reject か」を決める純粋関数、<code>evolve</code> は受理 event を state に適用する純粋関数です。I/O は effect の側だけに置きます。</p>
     <div class="panel reveal">
       <pre><code>domain OrderAsyncEffect {
   implementation_profile functional_ddd
@@ -71,22 +90,50 @@
       payment_status: PaymentStatus = NotRequested;
     }
 
+    command ApproveOrder {}
+    command CancelOrder {}
     command RequestPaymentCapture { input payment_request_id: PaymentRequestId }
+
+    event OrderApproved {}
+    event OrderCancelled {}
     event PaymentCaptureRequested { payment_request_id: PaymentRequestId }
     event PaymentCaptured { payment_request_id: PaymentRequestId }
     event PaymentFailed { payment_request_id: PaymentRequestId }
     event PaymentCaptureTimedOut { payment_request_id: PaymentRequestId }
+
+    error CannotCancelCapturedOrder
     error CannotCaptureUnapprovedOrder
+    error DuplicatePaymentCapture
+
+    decide ApproveOrder {
+      requires status == Pending
+      emits OrderApproved
+    }
+
+    decide CancelOrder {
+      rejects CannotCancelCapturedOrder when payment_status == Captured
+      requires status in [Pending, Approved]
+      emits OrderCancelled
+    }
 
     decide RequestPaymentCapture {
       rejects CannotCaptureUnapprovedOrder when status != Approved
+      rejects DuplicatePaymentCapture when payment_status in [PaymentPending, Captured]
       emits PaymentCaptureRequested
     }
 
+    evolve OrderApproved { status = Approved }
+    evolve OrderCancelled { status = Cancelled }
     evolve PaymentCaptureRequested { payment_status = PaymentPending }
     evolve PaymentCaptured {
       requires status != Cancelled
       payment_status = Captured
+    }
+    evolve PaymentFailed { payment_status = Failed }
+    evolve PaymentCaptureTimedOut { payment_status = TimedOut }
+
+    invariant noDuplicateCapture {
+      payment_status == Captured -> not can(RequestPaymentCapture)
     }
   }
 
@@ -97,10 +144,71 @@
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
-    retry { max_attempts 3 }
+    retry {
+      max_attempts 3
+      backoff exponential
+    }
     timeout after 10m emits PaymentCaptureTimedOut
+    compensation {
+      emits PaymentFailed
+    }
   }
 }</code></pre>
+    </div>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>effect の宣言</th><th>意味</th></tr>
+      <tr><td><code>async</code></td><td>完了が別の step で届く非同期 effect。<code>correlation_id</code> が必須になります。</td></tr>
+      <tr><td><code>irreversible</code></td><td>取り消せない副作用（決済など）。<code>idempotency_key</code> が必須で、compensation がなければ warning です。</td></tr>
+      <tr><td><code>correlation_id Event.field</code></td><td>リクエストと完了を結ぶ key。lifecycle map の添字になります。</td></tr>
+      <tr><td><code>idempotency_key Order.id</code></td><td>二重コミットを防ぐための安定 key の宣言。</td></tr>
+      <tr><td><code>handles</code> / <code>emits one_of [...]</code></td><td>受けるリクエスト event と、返しうる完了 event の集合。</td></tr>
+      <tr><td><code>retry { max_attempts 3 }</code></td><td>失敗・タイムアウト後の再試行上限。kernel では <code>attempts &lt; 3</code> guard になります。</td></tr>
+      <tr><td><code>timeout after 10m emits ...</code></td><td>pending からの離脱。<code>10m</code> は wall-clock ではなくモデル上の event です。</td></tr>
+      <tr><td><code>reliable</code> + <code>outbox</code></td><td>配送保証を主張する effect は outbox 境界とペアで書きます。なければ <code>reliable_effect_without_outbox_boundary</code> warning です。</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">saga</p>
+    <h2 class="reveal">saga で境界越しの process を調整する</h2>
+    <p class="lead narrow reveal">複数 step の eventual な process は <code>saga</code> で書きます。<code>starts_on</code> の event で開始し、各 step は <code>emits</code> でリクエストを出し、<code>awaits one_of [...]</code> で完了を待ち、<code>timeout after</code> で離脱します。<code>compensation</code> は「X が Y の後に起きたら Z を出す」という補償を宣言します。</p>
+    <div class="panel reveal">
+      <pre><code>saga OrderFulfillment {
+  starts_on OrderApproved
+  outbox OrderOutbox
+  inbox FulfillmentInbox
+
+  step ReserveInventory {
+    async
+    emits InventoryReservationRequested
+    awaits one_of [InventoryReserved, InventoryReservationFailed]
+    timeout after 5m emits InventoryReservationFailed
+  }
+
+  step CapturePayment {
+    async
+    requires InventoryReserved
+    emits PaymentCaptureRequested
+    awaits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    timeout after 10m emits PaymentCaptureTimedOut
+  }
+
+  step ShipOrder {
+    requires PaymentCaptured
+    emits ShipmentRequested
+  }
+
+  compensation {
+    when PaymentFailed after InventoryReserved {
+      emits InventoryReleaseRequested
+    }
+  }
+}</code></pre>
+    </div>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">saga の <code>awaits</code> / <code>after</code> は、step ごとの event 観測 action（<code>saga_order_fulfillment_observe_payment_captured</code> のような生成 action）として kernel に入り、結果 JSON に <code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code> という assumption が付きます。durable な process history は無限の kernel proof としては扱わず、<code>fslc domain replay</code> の有限ログ観測で確認する境界です。</p>
     </div>
   </div>
 </section>
@@ -108,23 +216,87 @@
 <section>
   <div class="wrap">
     <p class="kicker reveal">実行</p>
-    <h2 class="reveal">kernel 検証と domain 専用所見を使う</h2>
+    <h2 class="reveal">kernel 検証と domain 専用コマンドを使う</h2>
+    <p class="lead narrow reveal"><code>domain</code> ファイルは kernel へ lower されるため、通常の <code>fslc check</code> / <code>fslc verify</code> もそのまま通ります。dialect の境界（finding、scaffold、replay）は <code>fslc domain</code> サブコマンドが担います。</p>
     <div class="panel reveal">
-      <pre><code>fslc check examples/domain/order_async_effect.fsl
-fslc verify examples/domain/order_async_effect.fsl --depth 6
-fslc domain check examples/domain/order_async_effect.fsl
-fslc domain analyze examples/domain/order_async_effect.fsl
-fslc domain expand examples/domain/order_async_effect.fsl
+      <pre><code>fslc check  examples/domain/order_async_effect.fsl
+fslc verify examples/domain/order_async_effect.fsl --depth 8
+fslc domain check   examples/domain/order_async_effect.fsl
+fslc domain analyze examples/domain/order_fulfillment_saga.fsl
+fslc domain expand  examples/domain/order_async_effect.fsl
 fslc domain generate examples/domain/order_functional_ddd.fsl --target typescript -o src/domain
-fslc domain generate examples/domain/order_functional_ddd.fsl --target python
-fslc domain testgen examples/domain/order_functional_ddd.fsl --target vitest -o order.domain.test.ts
-fslc domain replay examples/domain/order_async_effect.fsl --logs examples/domain/order_async_effect_replay.jsonl</code></pre>
+fslc domain testgen  examples/domain/order_functional_ddd.fsl --target vitest -o order.domain.test.ts
+fslc domain replay   examples/domain/order_async_effect.fsl --logs examples/domain/order_async_effect_replay.jsonl</code></pre>
     </div>
     <table class="matrix reveal" style="margin-top:24px">
-      <tr><th>結果</th><th>意味</th></tr>
-      <tr><td><code>verified_under_assumptions</code></td><td>生成された kernel model が検証され、有限モデルと scaffold の仮定が JSON に出ています。</td></tr>
-      <tr><td><code>violated</code></td><td>hard な domain finding が形式検証を止めた、または生成 kernel が実際の性質違反を見つけました。</td></tr>
-      <tr><td><code>warning</code> finding</td><td>timeout/fallback 不足や late completion policy 不足などの設計リスクです。それ単体では形式違反とは扱いません。</td></tr>
+      <tr><th>結果</th><th>読み方</th></tr>
+      <tr><td><code>verified_under_assumptions</code></td><td><code>domain check</code> の成功。<code>formal_result: "verified"</code> で、kernel の詳細（<code>invariants_checked</code>、<code>action_coverage</code> など）は <code>kernel</code> にネストされ、<code>generated_actions</code> と assumption 一覧が並びます。</td></tr>
+      <tr><td><code>violated</code> + <code>formal_result: "not_run"</code></td><td>severity <code>error</code> の finding が形式検証の前に止めました。exit code は 1 です。</td></tr>
+      <tr><td><code>analyzed</code></td><td><code>domain analyze</code>。aggregate / effect / saga の所有関係（state、commands、events、steps、compensations、outbox/inbox）の要約 JSON です。</td></tr>
+      <tr><td><code>generated</code></td><td><code>domain generate</code> / <code>domain testgen</code>。生成された <code>files</code> の一覧と出力先を返します。</td></tr>
+      <tr><td><code>conformance_checked</code> / <code>nonconformant</code></td><td><code>domain replay</code>。有限ログの観測結果で、<code>guarantee_kind: "runtime_observed"</code> が付きます。形式証明ではありません。</td></tr>
+    </table>
+  </div>
+</section>
+
+<section style="background:var(--surface-2)">
+  <div class="wrap">
+    <p class="kicker reveal">finding</p>
+    <h2 class="reveal">error は検証を止め、warning は設計リスクを知らせる</h2>
+    <p class="lead narrow reveal">finding は <code>fsl-domain-finding.v0</code> schema の安定 JSON です。severity <code>error</code> は「このまま kernel を回すと保証を過大に主張してしまう」構造的欠陥で、kernel を実行せずに <code>violated</code> を返します。severity <code>warning</code> は設計レビュー上のリスクで、それ単体では kernel の実行を止めません。</p>
+    <table class="matrix reveal">
+      <tr><th>finding</th><th>severity</th><th>意味</th></tr>
+      <tr><td><code>missing_decide_for_command</code></td><td>error</td><td>command に対応する <code>decide</code> がありません。</td></tr>
+      <tr><td><code>missing_evolve_for_event</code></td><td>error</td><td>event に対応する <code>evolve</code> がありません。</td></tr>
+      <tr><td><code>aggregate_boundary_violation</code></td><td>error</td><td><code>evolve</code> が aggregate の外の状態を直接書いています。</td></tr>
+      <tr><td><code>uncorrelated_async_completion</code></td><td>error</td><td>async effect に <code>correlation_id</code> がありません。replay では「先行リクエストのない完了」も同じ kind で報告されます。</td></tr>
+      <tr><td><code>irreversible_effect_without_idempotency_key</code></td><td>error</td><td>irreversible な effect に <code>idempotency_key</code> がありません。</td></tr>
+      <tr><td><code>process_wait_cycle</code></td><td>error</td><td>saga の wait graph が循環していて、外部の完了なしには進めません。</td></tr>
+      <tr><td><code>pending_effect_without_timeout_or_fallback</code></td><td>warning</td><td>pending からの離脱手段（<code>timeout</code> / <code>retry</code>）がありません。</td></tr>
+      <tr><td><code>late_completion_without_stale_policy</code></td><td>warning</td><td>キャンセル後などに遅れて届く成功完了への stale policy がありません。</td></tr>
+      <tr><td><code>missing_compensation_for_irreversible_effect</code></td><td>warning</td><td>irreversible な effect に compensation（effect 直付けまたは saga 側）がありません。</td></tr>
+      <tr><td><code>reliable_effect_without_outbox_boundary</code></td><td>warning</td><td><code>reliable</code> 宣言に outbox 境界が伴っておらず、runtime の配送証拠を過大に主張しています。</td></tr>
+      <tr><td><code>saga_dead_end</code></td><td>warning</td><td>step のない saga、または完了観測（<code>awaits</code> / <code>timeout</code>）のない async step です。</td></tr>
+    </table>
+    <div class="callout reveal" style="margin-top:24px">
+      <p style="margin:0">実例: <code>examples/domain/unsafe_irreversible_effect_without_idempotency.fsl</code> に <code>fslc domain check</code> を実行すると、error 1件（<code>irreversible_effect_without_idempotency_key</code>）と warning 2件（<code>pending_effect_without_timeout_or_fallback</code>、<code>missing_compensation_for_irreversible_effect</code>）が返り、error があるため <code>result: "violated"</code>、<code>formal_result: "not_run"</code> になります。各 finding には <code>repair_candidates</code>（例: <code>add idempotency_key &lt;stable key&gt; to irreversible effect CapturePayment</code>）が付き、LLM の write→verify→repair ループにそのまま渡せます。</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">scaffold と replay</p>
+    <h2 class="reveal">実装 scaffold と runtime 観測へつなぐ</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3><code>domain generate</code></h3>
+        <p><code>--target typescript</code> が最も充実しています: <code>types.ts</code>、<code>&lt;aggregate&gt;/decide.ts</code>、<code>&lt;aggregate&gt;/evolve.ts</code>、<code>&lt;aggregate&gt;/adapter.ts</code>、effect があれば <code>effects.ts</code>、saga があれば <code>process-manager.ts</code>。<code>python | kotlin | swift | rust</code> は pure-domain の簡易 scaffold です（python は <code>domain_scaffold.py</code> 1ファイル）。</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>domain testgen</code></h3>
+        <p>vitest の conformance test scaffold を生成します。Monitor（具象 evaluator）が固定 seed で焼き込んだ trace を replay する形で、adapter（<code>makeAdapter()</code>）を実装に接続するまで各テストは skip されます。既存 <code>testgen</code> と同じ adapter boundary に繋がります。</p>
+      </div>
+      <div class="syntax-card">
+        <h3><code>domain replay</code></h3>
+        <p>JSONL / JSON の runtime log をモデルに流します。event kind は <code>command</code> / <code>domain_event</code> / <code>effect_request</code> / <code>effect_completion</code> の4種です。</p>
+      </div>
+    </div>
+    <div class="panel reveal" style="margin-top:24px">
+      <div class="panel-head">examples/domain/order_async_effect_replay.jsonl → conformance_checked</div>
+      <pre><code>{"event":"command","aggregate":"Order","command":"ApproveOrder","params":{}}
+{"event":"command","aggregate":"Order","command":"RequestPaymentCapture","params":{"payment_request_id":"p1"}}
+{"event":"domain_event","aggregate":"Order","name":"PaymentCaptureRequested","params":{"payment_request_id":"p1"}}
+{"event":"effect_request","effect":"CapturePayment","correlation_id":"p1"}
+{"event":"effect_completion","effect":"CapturePayment","name":"PaymentCaptured","correlation_id":"p1","params":{"payment_request_id":"p1"}}</code></pre>
+    </div>
+    <table class="matrix reveal" style="margin-top:24px">
+      <tr><th>replay 結果の key</th><th>実際の値（上記ログでの実行結果）</th></tr>
+      <tr><td><code>result</code></td><td><code>conformance_checked</code>。ログがモデルと食い違うと <code>nonconformant</code> です。</td></tr>
+      <tr><td><code>events_observed</code></td><td><code>["PaymentCaptureRequested", "PaymentCaptured"]</code></td></tr>
+      <tr><td><code>pending_effects</code></td><td><code>[]</code> — 未完了のまま残った correlation の一覧です。</td></tr>
+      <tr><td><code>final_state</code></td><td>replay 後のモデル状態。<code>Order.payment_status: "PaymentStatus_Captured"</code>、<code>effect.CapturePayment.status</code> の correlation <code>0</code> が <code>Succeeded</code>、<code>attempts</code> が <code>1</code> になります。</td></tr>
+      <tr><td><code>nonconformant</code> 時の finding</td><td><code>command_rejected_by_model</code>、<code>uncorrelated_async_completion</code>、<code>duplicate_irreversible_effect_commit</code>、<code>effect_completion_rejected_by_model</code> など。</td></tr>
     </table>
   </div>
 </section>
@@ -132,8 +304,57 @@ fslc domain replay examples/domain/order_async_effect.fsl --logs examples/domain
 <section style="background:var(--surface-2)">
   <div class="wrap">
     <p class="kicker reveal">境界</p>
-    <h2 class="reveal">v0 で証明すること</h2>
-    <p class="lead narrow reveal">検証対象は、モデル化された遷移系です。aggregate invariant、command/evolve、saga step guard、pending request がある completion、retry bound、success status の stickiness は確認できます。runtime replay は有限ログの観測証拠です。実 payment gateway、queue delivery、wall-clock timeout、本番の exactly-once は証明しません。</p>
+    <h2 class="reveal">証明できることと、できないことを分ける</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>kernel が証明すること</h3>
+        <p>bounded な aggregate invariant、rejected な command が no-op であること（reject 条件は guard に lower されるため状態を変えません）、completion-requires-request、retry bound、success status の stickiness。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>有限モデル仮定</h3>
+        <p><code>DOMAIN-ASSUME-FINITE-DOMAIN-MODEL</code>: 明示宣言のない ID・scalar 入力型は <code>0..1</code> の有限範囲としてモデル化されます。無限の id 空間への証明ではありません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>saga history</h3>
+        <p><code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code>: <code>awaits</code> / <code>after</code> は step ごとの観測 flag です。durable な process history は replay evidence で確認します。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>外部世界</h3>
+        <p>実際の payment gateway、queue delivery、wall-clock time（<code>10m</code> はモデル上の event です）、無限 key 空間にわたる本番 idempotency は証明しません。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>生成コード</h3>
+        <p><code>DOMAIN-ASSUME-GENERATED-SCAFFOLD</code>: 生成物は scaffold であり、本番アーキテクチャの証明ではありません。runtime conformance には adapter / replay の evidence 境界が必要です。</p>
+      </div>
+      <div class="syntax-card">
+        <h3>replay は観測証拠</h3>
+        <p><code>conformance_checked</code> は「この有限ログがモデルと一致した」という観測であり、形式証明ではありません。ログの不在は非発生の証明にはなりません。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <p class="kicker reveal">次に読む</p>
+    <h2 class="reveal">設計と例へ進む</h2>
+    <div class="syntax-grid reveal">
+      <div class="syntax-card">
+        <h3>設計判断</h3>
+        <p>lowering、finding schema、effect lifecycle の意味論、残る境界は design doc にまとまっています。</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-domain.md">DESIGN-domain.md</a> <a class="btn" href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-effect.md">DESIGN-effect.md</a></p>
+      </div>
+      <div class="syntax-card">
+        <h3>動く例</h3>
+        <p>async effect、saga と compensation、Functional DDD の基本形、idempotency 欠如の unsafe 例、replay 用ログの fixture があります。</p>
+        <p><a class="btn" href="https://github.com/ymm-oss/fsl/tree/main/examples/domain">examples/domain</a></p>
+      </div>
+      <div class="syntax-card">
+        <h3>通常の文法</h3>
+        <p><code>domain</code> は FSL の既存 verifier に展開されます。展開先の基本構文は文法ページで確認できます。</p>
+        <p><a class="btn" href="syntax.ja.html">文法・構文へ</a></p>
+      </div>
+    </div>
   </div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- `docs/intro/domain.ja.html` / `domain.en.html` and `docs/intro/ai.ja.html` / `ai.en.html` were thin (144 / 193 lines) and left readers without a real mental model of either dialect — this was flagged as immature relative to sibling pages.
- Rewrote the `<main>` content of all four pages to match the depth/structure of the site's most mature sibling page, `db.*.html` (hero → what-it-prevents → model → worked example → run/results → boundary → next-reading).
- For **fsl-ai**, added an entire missing layer: the statistical/evaluator/migration/drift/compat evidence surface (`dataset`, `evaluator`, `statistical_property`, `ai_migration`, `observed_property`, and `fslc ai eval/regress/compare/drift/compat`), which the previous page never mentioned at all, alongside a deepened hard-contract and recursive-agent explanation (including the "block boundary only, not validated" nuance for `ai_action`/standalone `retriever`/`trust_boundary`/top-level `authority{target...}`).
- For **fsl-domain**, added the lowering-rule mapping (with real `fslc domain expand` output), the full finding-kind/severity table, saga/compensation semantics, and the generated-scaffold/replay boundary.

## Changes
- `docs/intro/domain.ja.html`, `docs/intro/domain.en.html` — 144 → 365 lines.
- `docs/intro/ai.ja.html`, `docs/intro/ai.en.html` — 193 → 482 lines.
- No other files touched: `<head>`/`<header>`/`<aside>`/`<footer>`/`<script>` chrome, `docs/intro/assets/site.css`, and `docs/intro/assets/site.js` are all byte-identical to before (verified via `git diff`). Only existing CSS classes are used.

## Verification
- Every command output, JSON key, and finding kind quoted in the new prose was taken from actually running the corresponding commands (not written from memory):
  ```bash
  fslc domain check/analyze/expand/replay examples/domain/*.fsl
  fslc ai check/replay/eval/regress/compare/drift/compat examples/ai/*.fsl
  ```
- Finding severities in the fsl-domain table were cross-checked line-by-line against `src/fslc/domain_expand.py`.
- fsl-ai claims (`agent_structural_violation`, `graph_summary` sub-graph names, `observed_supported`/`observed_mismatch`, `required_capability_missing`, `--include-ai`, and the "block boundary only" parser behavior) were cross-checked against `src/fslc/ai_agent.py`, `src/fslc/ai_stochastic.py`, `src/fslc/db_check.py`, `src/fslc/cli.py`, and `skills/fsl/reference.md`.
- HTML sanity: `<section>`/`<div>`/`<table>`/`<main>` tag counts are balanced in all four files; no test in `tests/` references these hand-authored pages (only the generated `language.html`/`cli.html` pages have a snapshot test), so no snapshot regeneration is needed.
- Not run: no visual/browser render check of the pages (no dev server for this static site in this session).

## Risk / Review Notes
- Docs-only change; no code, schema, or CLI behavior touched. No migration/security/compat risk.
- Scope is intentionally limited to `domain`/`ai` pages named in the request; other thin pages (`errors`, `examples`, `design-notes`, `glossary`, `quickstart`) were not touched.
- ja/en pairs are parallel in structure and depth but are independent technical rewrites per language, not literal translations of each other.

## Follow-Up / Post-Merge Checks
- Open the 4 pages in a browser to confirm layout/rendering (`reveal` animations, sidebar nav, breadcrumb) looks right in context — not done in this session.