### PR TITLE
ci: add missing test_site_reference_snapshot.py to a pytest shard

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -3,5 +3,6 @@ tests/test_corpus_snapshot.py
 tests/test_logic_temporal_sugar.py
 tests/test_ranking_synthesis.py
 tests/test_self.py
+tests/test_site_reference_snapshot.py
 tests/test_spec_domains.py
 tests/test_trans.py


### PR DESCRIPTION
## Summary
- The 3-way pytest shard split introduced in #164 (`ci: split pr-full pytest run into 3 balanced shards`) omitted `tests/test_site_reference_snapshot.py` from `.github/ci-shards/shard-*.txt`.
- The new `shard coverage check` job (`.github/workflows/*.yml`, `pr-shard-coverage`) diffs the union of the shard files against `tests/test_*.py` and fails if they don't match exactly — so this currently fails on **every** PR against `main`, independent of what the PR changes. Discovered while investigating an unrelated docs PR (#165) whose only failing check was this one.

## Changes
- `.github/ci-shards/shard-1.txt` — add `tests/test_site_reference_snapshot.py` (alphabetically placed). It's a fast file-diff/freshness test (~0.1s), so it doesn't materially change shard-1's runtime balance.

## Verification
```bash
cat .github/ci-shards/shard-*.txt | sort > /tmp/covered.txt
ls tests/test_*.py | sort > /tmp/actual.txt
diff -u /tmp/actual.txt /tmp/covered.txt   # empty diff now
pytest -q tests/test_site_reference_snapshot.py   # 2 passed
```

## Risk / Review Notes
- CI-only change, no test/source semantics touched. Zero risk to shard runtime balance given the test's cost.

## Follow-Up / Post-Merge Checks
- None.