### PR TITLE
fix(ci): add missing test_site_reference_snapshot.py to a shard

### DIFF
--- a/.github/ci-shards/shard-2.txt
+++ b/.github/ci-shards/shard-2.txt
@@ -27,6 +27,7 @@ tests/test_robustness.py
 tests/test_runtime.py
 tests/test_self_examples.py
 tests/test_seq.py
+tests/test_site_reference_snapshot.py
 tests/test_strict_tags.py
 tests/test_sweep.py
 tests/test_ui_spike.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   enveloped result tree reserves `kind` for the diagnostic discriminator.)
 
 ### Fixed
+- **CI**: `tests/test_site_reference_snapshot.py` (added with the doc-site
+  rebuild) was missing from every `.github/ci-shards/shard-*.txt`, so
+  `pr-shard-coverage` was failing on any PR touching the test suite. Added it
+  to `shard-2.txt`.
 - **Soundness**: `fslc verify --engine induction` could report a `leadsTo
   ... decreases ... helpful` property `"proved"` when it was genuinely false.
   With two or more distinct `helpful` action declarations,


### PR DESCRIPTION
## Summary
- `tests/test_site_reference_snapshot.py` (added by the doc-site rebuild, `fc37d43`) was never added to any `.github/ci-shards/shard-*.txt`, so the `pr-shard-coverage` job's exact-partition check has been failing since. Found while touching shard files for #167. Added it to `shard-2.txt` (fast, ~0.7s).

## Test plan
- [x] `cat .github/ci-shards/shard-*.txt | sort` now exactly matches `ls tests/test_*.py | sort` (verified locally, mirrors the `pr-shard-coverage` job's own check)
- [x] `pytest tests/test_site_reference_snapshot.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)