### PR TITLE
test(lsp): coupled-change metatests + fix domain/ai-project LSP gaps (issue #168)

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -1,5 +1,6 @@
 tests/test_cli_bounds_override.py
 tests/test_corpus_snapshot.py
+tests/test_coupled_change_meta.py
 tests/test_logic_temporal_sugar.py
 tests/test_ranking_synthesis.py
 tests/test_self.py

--- a/.github/ci-shards/shard-2.txt
+++ b/.github/ci-shards/shard-2.txt
@@ -27,6 +27,7 @@ tests/test_robustness.py
 tests/test_runtime.py
 tests/test_self_examples.py
 tests/test_seq.py
+tests/test_site_reference_snapshot.py
 tests/test_strict_tags.py
 tests/test_sweep.py
 tests/test_ui_spike.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Coupled-change metatests (issue #168): `tests/test_coupled_change_meta.py`
+  mechanizes the "grammar/dialect/CLI command moves its LSP index entry and
+  DESIGN doc together" discipline that was previously only a human checklist.
+  A corpus-wide, two-stage check (structural scan + position cross-check)
+  verifies every grammar production's NAME/REQ_ID tokens reach
+  `src/fslc/lsp/index.py`'s symbols/references, with a reviewed, staleness-
+  checked allowlist for genuine free-form labels; a second check verifies
+  every kernel dialect and CLI command maps to an existing
+  `docs/DESIGN-*.md`, and that `docs/README.md`'s DESIGN-doc map is
+  bidirectional. Prototyping this metatest re-found the same class of bug
+  `d1770c4` fixed, twice more, fixed in this PR: fsl-domain sources crashed
+  the LSP entirely (`_parser_for_source` never dispatched to the domain
+  grammar), fsl-ai project files (multi-block bundles that happen to start
+  with `ai_component`) crashed it too (now indexed via
+  `ai_project._top_blocks` directly, matching how that dialect is actually
+  parsed), and several fsl-db/fsl-ai productions
+  (`env_flag`/`database_def`/`delegation_edge`/`agent_event`/
+  `agent_output_def`) were silently unindexed -- including a pre-existing
+  bug in `_visit_env_artifact` that dropped every `when flag F=V` condition
+  on a database artifact. See `docs/DESIGN-coupled-change-metatest.md`.
 - Rebuilt the `docs/intro/` manual site's information architecture around 4
   fixed categories (Get Started / Guides / Reference / Examples & Background),
   designed with the Relational Design plugin (decisions in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,12 @@ behavior.**
   update the corresponding `docs/DESIGN-*.md` as well.
 - **Adding a language feature**: Update grammar/model/bmc (and runtime if needed)
   consistently, reflect the change in `docs/LANGUAGE.md` and
-  `skills/fsl/reference.md`, and leave a `docs/DESIGN-<feature>.md`.
+  `skills/fsl/reference.md`, and leave a `docs/DESIGN-<feature>.md`. These
+  couplings are enforced by `tests/test_coupled_change_meta.py`: a new grammar
+  production, dialect, or CLI subcommand fails CI until it is indexed in
+  `src/fslc/lsp/index.py` and mapped to a `docs/DESIGN-<feature>.md` in
+  `docs/README.md`, or recorded in the test's allowlist with an explicit
+  reason (see `docs/DESIGN-coupled-change-metatest.md`).
 - **Adding or changing specs (`.fsl`)**: Run `fslc check` → `verify` →
   `--engine induction`, and also confirm the spec is non-vacuous (`fslc mutate`
   kill-rate, `--vacuity`). Avoid hollowing out specs (weakening invariants to

--- a/docs/DESIGN-coupled-change-metatest.md
+++ b/docs/DESIGN-coupled-change-metatest.md
@@ -1,0 +1,152 @@
+# FSL — coupled-change metatests (LSP index coverage + DESIGN-doc coverage)
+
+Motivation: issue #168. CLAUDE.md/CONTRIBUTING.md state the discipline "a language
+feature moves all of its files together", but it was a human checklist. `d1770c4`
+showed the failure mode: `src/fslc/lsp/index.py` was outside the list, so the
+`ai_component`/`dbsystem` dialects shipped with the LSP entirely dark. Prototyping
+this metatest re-found the same class **twice more**: `_parser_for_source` still
+does not dispatch `domain` sources (all 4 `examples/domain/*.fsl` crash
+`build_index` with `UnexpectedCharacters`), and `is_ai_project_source` files
+(`examples/ai/support_answer_quality.fsl`) sniff as `ai` but fail `AI_PARSER`.
+The structure that produced d1770c4 is intact; these tests mechanize the check.
+
+One test module, `tests/test_coupled_change_meta.py`, no Z3 dependency (lark +
+file scans only; runs in seconds).
+
+## 1. LSP index coverage (grammar production ↔ visitor handler)
+
+`_IndexBuilder.visit` dispatches by reflection: `getattr(self, f"_visit_{node.data}")`,
+falling back to a generic child walk that **skips bare Tokens**. So a production
+whose NAME/REQ_ID token is a direct child of an unhandled `node.data` silently
+drops that token from symbols/references — exactly the `helpful`/`deadline` bugs
+of d1770c4. The dispatch mechanism makes coverage introspectable:
+`hasattr(_IndexBuilder, f"_visit_{data}")`.
+
+### Corpus and parser selection
+
+Corpus = `specs/*.fsl` + `examples/**/*.fsl` (~180 files; every dialect is
+exercised), minus `examples/gallery/errors/` (intentionally invalid sources).
+Each file is parsed with the LSP's own `_parser_for_source(source)` — not a
+shadow copy — so a dialect the LSP cannot dispatch surfaces as a loud
+"corpus file unparseable by LSP" finding instead of being skipped.
+
+### Two-stage check (per file)
+
+1. **Structural scan** — walk the raw tree; for every subtree whose direct
+   children include a `NAME`/`REQ_ID` Token, record whether
+   `_visit_{node.data}` exists. Stage 1 alone over-reports: e.g. `field_suffix`
+   has no handler but its tokens are consumed by the parent `_visit_postfix`
+   (50 files, zero missing tokens). So stage 1 only *attributes* findings.
+2. **Position cross-check** — `idx = build_index(source, path)`; collect
+   `{sym.selection_range.start_tuple} ∪ {ref.range.start_tuple}`; every
+   NAME/REQ_ID token in the raw tree must have `(line-1, column-1)` in that set
+   (lark is 1-based, LSP 0-based). A missing token is a finding keyed by
+   `(parser_id, node.data)` where `parser_id ∈ {kernel, ai, db, domain}`.
+
+A finding fails the test unless its key is in the allowlist. Stage 1 enriches
+the failure message ("no handler at all" vs "handler exists but drops tokens").
+
+### Allowlist
+
+`INTENTIONALLY_UNINDEXED: dict[tuple[str, str], str]` — `(parser_id, node.data)`
+→ human-readable reason — lives at the top of the test module, one entry per
+recorded design decision (issue #167's "loud, not silent"). **Staleness rule**:
+every allowlisted `node.data` must still occur in the corpus scan for that
+parser; a stale entry fails the test. Initial contents (verified against the
+current corpus):
+
+| key | reason |
+|---|---|
+| `(kernel, control_severity)` | `severity high` — free severity word, not an in-file symbol |
+| `(db, column_type)` | `column x: int` — engine scalar-type words; dbsystem has no in-file type decls |
+| `(db, check_item)` | `rule <name>` names built-in compatibility rules |
+| `(ai, check_item)` | `check hard { rule … }` names built-in hard-check rules |
+| `(ai, tool_precondition)` | free-form semantic label (`precondition order_paid`) |
+| `(ai, tool_effect)` | free-form effect label |
+| `(ai, trust_def)` | `trust medium` — free trust-level word |
+| `(ai, atom_name)` | `model gpt_5_5` / `prompt …_v8` — external artifact ids |
+| `(ai, failure_target)` | `-> HumanReviewPending` — policy-outcome label, not an in-file symbol |
+
+`(kernel, preservation_refinement)` was considered but dropped: its grammar
+(`"checked_by" "refinement" STRING`) has no NAME/REQ_ID child at all, so it
+structurally never reaches stage 1 and an allowlist entry for it would always
+be flagged stale.
+
+### Real gaps the first run found — fixed in this PR, not allowlisted
+
+- `_parser_for_source` lacked `is_domain_source` → `DOMAIN_PARSER` dispatch
+  (every `examples/domain/*.fsl` crashed `build_index`). Added the dispatch
+  plus ~35 domain handlers (`domain_def`, `aggregate_def`, `command_def`,
+  `event_def`, `effect_def`, `saga_def`, `state_field`, `decide_def`/
+  `evolve_def` (reference the command/event, not fresh declarations), …).
+- `is_ai_project_source` sources start with `ai_component` (so a naive
+  `startswith` check claims them) but are a bundle of independently-parsed
+  blocks (`ai_project._top_blocks`), not one Lark tree; `build_index` now
+  special-cases them, indexing each top-level block by name/kind directly
+  instead of crashing.
+- db: `database_def` is now a symbol; the feature-flag family (`env_flag`,
+  `flag_variant_list`, `flag_default`, `env_flag_condition`) is now indexed.
+  Finding this also surfaced a **pre-existing, unrelated bug**: `_visit_env_artifact`
+  (added in `d1770c4`) only ever read the artifact's own direct-child NAME
+  token and returned, silently dropping every `env_window`/`env_flag_condition`
+  Tree child — every `when flag F=V` condition on a database artifact was
+  unindexed. Fixed by visiting Tree children after the artifact ref.
+- ai: orchestration `delegation_edge` (`A -> B`), `agent_event`
+  (`Agent.failed` — the agent half is a reference, the status half is
+  recorded as a non-exported informational symbol, same treatment as
+  `_visit_fallback_item`), and `agent_output_def` (visibility list entries
+  are agent references, collected directly rather than through the shared
+  `name_list` handler, which would mislabel them as `"tool"`) are indexed.
+
+A node.data whose fix is out of scope for the PR that finds it may still land
+as a `(parser_id, node.data) → "known gap, #NNN"` entry, but the entry text
+must carry an issue reference — an allowlist reason is a design decision, not
+a parking lot.
+
+## 2. DESIGN-doc coverage (dialect/feature ↔ docs/DESIGN-*.md)
+
+Three assertions, from mechanical sources of truth (CHANGELOG prose was
+rejected as unparseable; README-only was rejected because a feature absent from
+README is silent by omission):
+
+1. **README map is bidirectional** — `re.findall(r"DESIGN-[a-z0-9-]+\.md", docs/README.md)`
+   must equal `{p.name for p in docs.glob("DESIGN-*.md")}` exactly. Catches both
+   "linked but missing on disk" and "on disk but unlinked" (currently 34 = 34;
+   this very file must be added to the README map when the test lands).
+2. **Kernel dialects** — the alternatives of the `top_def:` rule extracted from
+   `fslc.grammar.GRAMMAR` (`spec_def | refinement_def | compose_def |
+   requirements_def | business_def | governance_def`) must each be a key of
+   `TOP_DEF_DESIGN_DOCS`, whose values are existing doc names
+   (`spec_def → DESIGN-v1.md`, `refinement_def → DESIGN-refinement.md`,
+   `compose_def → DESIGN-compose.md`, `requirements_def`/`business_def`/
+   `governance_def → DESIGN-dialects.md`). A new `top_def` alternative fails
+   until mapped.
+3. **CLI commands** — enumerate subcommands by introspecting
+   `cli._build_arg_parser()` (`argparse._SubParsersAction.choices`); every
+   command must be a key of `COMMAND_DESIGN_DOCS: dict[str, tuple[str, ...] | str]`.
+   A tuple lists required docs (all must exist on disk); a `str` is an explicit
+   waiver reason (e.g. `version`, and `sweep` — a scope-grid driver over
+   `verify` with no standalone semantics, documented in LANGUAGE.md). Unknown
+   command → fail; stale map key (command removed) → fail. The raw-dialect
+   parsers are reached through their commands (`db`, `ai`, `domain`, `compat`),
+   so a new dialect needs both its command mapping and its doc.
+
+Gap reporting is a plain assertion diff: the failure message lists the unmapped
+keys / missing files / stale entries, nothing else.
+
+## Non-goals
+
+- No check that every grammar production is *exercised* by the corpus (alias
+  rules and token-only rules make that noisy); coverage is corpus-driven, which
+  matches how the repo treats `specs/`+`examples/` as the behavioral corpus
+  (`test_corpus_snapshot.py`).
+- No semantic check that a handler indexes tokens with the *right* role/scope —
+  that stays in `tests/test_lsp_index.py` unit tests.
+- No enforcement that DESIGN docs are up to date, only that they exist and are
+  mapped; content freshness remains review territory.
+
+## CI placement
+
+`tests/test_coupled_change_meta.py` joins one `.github/ci-shards/shard-N.txt`
+(the `pr-shard-coverage` job fails if a test file is in no shard — the same
+"exact partition" discipline this test applies to grammar/docs).

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@
 | [`DESIGN-explain.md`](DESIGN-explain.md) | `fslc explain --readable` (verification bounds, skeleton enumeration, counterfactuals, witness narration) |
 | [`DESIGN-html-report.md`](DESIGN-html-report.md) | `fslc html` (self-contained visual review report from explain + verify evidence) |
 | [`DESIGN-typestate.md`](DESIGN-typestate.md) | `fslc typestate` (applicability check for state machine → typestate + TS scaffold) |
+| [`DESIGN-coupled-change-metatest.md`](DESIGN-coupled-change-metatest.md) | Coupled-change metatests (`tests/test_coupled_change_meta.py`): LSP index coverage (grammar production ↔ visitor handler, corpus-driven, two-stage) and DESIGN-doc coverage (dialect/CLI command ↔ `docs/DESIGN-*.md`) |
 | [`DESIGN-analysis.md`](DESIGN-analysis.md) | `fslc analyze` (Typed Semantic Graph, graph projections, focus impact slices, action dependency/conflict graphs, structural metrics, batch mode, refinement/project traceability graphs, DOT/Mermaid exports, schemas, AI-readable structural review findings/candidates) |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
 | [`DESIGN-domain.md`](DESIGN-domain.md) | fsl-domain (`domain`) Functional DDD / async effect dialect: aggregate ownership, command/event decide/evolve lowering, saga/process-manager actions, effect lifecycle state, findings, multi-target scaffolds, and runtime replay |

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -6,12 +6,22 @@
 This module intentionally reads ``fslc.grammar.PARSER`` directly and does not
 touch the tuple AST transformer or verifier kernel. FSL keywords are mostly
 contextual, so declarations and references are classified by parse-tree
-position, not by spelling. The `ai_component`/`agent`/`dbsystem` frontend dialects
-have their own Lark grammars (``fslc.ai_parser``/``fslc.db_parser``) that
-never reach the kernel grammar at all -- ``build_index`` picks the matching
-raw parser via ``is_ai_source``/``is_dbsystem_source`` before
-falling back to the kernel ``PARSER``, so those files no longer fail to
-parse here just because indexing hard-codes the kernel grammar.
+position, not by spelling. The `ai_component`/`agent`/`dbsystem`/`domain`
+frontend dialects have their own Lark grammars (``fslc.ai_parser``/
+``fslc.db_parser``/``fslc.domain_parser``) that never reach the kernel
+grammar at all -- ``build_index`` picks the matching raw parser via
+``is_ai_source``/``is_dbsystem_source``/``is_domain_source`` before falling
+back to the kernel ``PARSER``, so those files no longer fail to parse here
+just because indexing hard-codes the kernel grammar. fsl-ai *project* files
+(``is_ai_project_source``) are a further special case: they are not
+Lark-parsed at all (``ai_project.py`` scans top-level blocks with regexes),
+so ``build_index`` indexes them directly from ``ai_project._top_blocks``
+instead of building a tree.
+
+``tests/test_coupled_change_meta.py`` corpus-scans every grammar production
+against this module's ``_visit_*`` handlers and fails CI if a new one ships
+unindexed (or undocumented as an intentional exclusion) -- see
+``docs/DESIGN-coupled-change-metatest.md``.
 """
 from __future__ import annotations
 
@@ -24,7 +34,9 @@ from lark import Tree, Token
 
 from fslc.grammar import PARSER
 from fslc.ai_parser import AI_PARSER, is_ai_source
+from fslc.ai_project import _top_blocks, is_ai_project_source
 from fslc.db_parser import DB_PARSER, is_dbsystem_source
+from fslc.domain_parser import PARSER as DOMAIN_PARSER, is_domain_source
 
 
 VALUE_ROLES = {
@@ -559,14 +571,51 @@ class DocumentIndex:
 def _parser_for_source(source: str):
     if is_dbsystem_source(source):
         return DB_PARSER
+    if is_domain_source(source):
+        return DOMAIN_PARSER
     if is_ai_source(source):
         return AI_PARSER
     return PARSER
 
 
+def _build_ai_project_index(source: str, path: Optional[str]) -> "DocumentIndex":
+    """fsl-ai project files (``is_ai_project_source``) are not Lark-parsed at
+    all -- ``ai_project.py`` scans top-level ``kind name { ... }`` blocks with
+    regexes/brace-matching (``_top_blocks``). Index each top-level block as an
+    outline symbol (kind as role) so go-to-definition/outline at least finds
+    the block; nested content (dataset records, statistical thresholds, ...)
+    is this dialect's own semantics, not the LSP's, and stays unindexed."""
+    symbols: List[Symbol] = []
+    for block in _top_blocks(source):
+        if not block.name:
+            continue
+        header_line = block.text.split("\n", 1)[0]
+        col = header_line.find(block.name)
+        if col < 0:
+            col = 0
+        pos = Position(block.line - 1, col)
+        sel_range = Range(pos, Position(pos.line, pos.character + len(block.name)))
+        symbols.append(Symbol(
+            name=block.name,
+            role=block.kind,
+            range=sel_range,
+            selection_range=sel_range,
+            detail=block.kind,
+        ))
+    return DocumentIndex(
+        source=source,
+        path=_normalize_path(path),
+        symbols=symbols,
+        references=[],
+        imports=[],
+    )
+
+
 def build_index(source: str, path: Optional[str] = None) -> DocumentIndex:
     """Parse ``source`` and return a raw-tree symbol/reference index."""
 
+    if is_ai_project_source(source):
+        return _build_ai_project_index(source, path)
     tree = _parser_for_source(source).parse(source)
     builder = _IndexBuilder(source, path)
     builder.visit(tree, None, None)
@@ -828,6 +877,37 @@ class _IndexBuilder:
             self._add_symbol(names[1], "fallback_target", _tree_range(node), parent=parent,
                               detail="fallback target", exported=False)
 
+    def _visit_delegation_edge(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `AgentA -> AgentB` in an `orchestration { ... }` block: both sides
+        # reference sibling `agent` declarations.
+        for token in _name_tokens(node):
+            self._add_ref(token, "agent")
+
+    def _visit_agent_event(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `AgentName.status` in a `failure_policy { ... }` block: the first
+        # NAME references an agent; the status word (failed/uncertain/...) is
+        # fixed vocabulary, not an in-file declaration -- recorded as a
+        # non-exported symbol so it still shows up on hover instead of
+        # silently vanishing (same treatment as `_visit_fallback_item`).
+        names = _name_tokens(node)
+        if names:
+            self._add_ref(names[0], "agent")
+        if len(names) > 1:
+            self._add_symbol(names[1], "agent_status", _tree_range(node), parent=parent,
+                              detail="agent status", exported=False)
+
+    def _visit_agent_output_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `output Name visibility [parent, OtherAgent, ...]`: the declared
+        # output name, then a visibility list of sibling agent references
+        # (plus the literal "parent") -- collected directly rather than via
+        # the shared name_list handler, which would mislabel them as "tool".
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "agent_output", _tree_range(node), parent=parent,
+                              detail="agent output", exported=False)
+        for ref_token in _all_name_tokens(node)[1:]:
+            self._add_ref(ref_token, "agent")
+
     def _visit_table_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
         token = _first_token(node)
         idx = parent
@@ -879,6 +959,305 @@ class _IndexBuilder:
         names = [c for c in node.children if isinstance(c, Token) and c.type == "NAME"]
         if names:
             self._add_ref(names[0], "artifact")
+        # `env_window`/`env_flag_condition*` are Tree children (the artifact
+        # NAME itself is the only bare Token) -- visit them too, or a
+        # `when flag F=V` condition on this artifact silently vanishes
+        # (pre-existing gap, found by the corpus-wide LSP coverage scan).
+        for child in node.children:
+            if isinstance(child, Tree):
+                self.visit(child, parent, local_scope)
+
+    def _visit_database_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "database", _tree_range(node), parent=parent, detail="database")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_env_flag(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "feature_flag", _tree_range(node), parent=parent, detail="feature flag")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_flag_variant_list(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _name_tokens(node):
+            self._add_symbol(token, "flag_variant", _token_range(token), parent=parent,
+                              detail="flag variant", exported=False)
+
+    def _visit_flag_default(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "flag_variant")
+
+    def _visit_env_flag_condition(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        names = _name_tokens(node)
+        if len(names) == 2:
+            self._add_ref(names[0], "feature_flag")
+            self._add_ref(names[1], "flag_variant")
+
+    # -- fsl-domain dialect (own grammar, see _parser_for_source) --
+    #
+    # ``state_def``/``invariant_def`` reuse the kernel handlers below
+    # unchanged: both are generic (first-token + safely-skip-Token-children),
+    # and domain's shapes ("state" "{" state_field* "}" / "invariant" NAME "{"
+    # RAW_EXPR "}") satisfy them correctly. Reference-bearing productions that
+    # wrap their NAME(s) in domain's inlined ``emit_names``/``bracket_name_list``/
+    # ``name_list`` helper rules are handled by directly collecting every NAME
+    # under the node (``_all_name_tokens``) and registering it, rather than
+    # letting the generic child-walk reach ``name_list`` -- that rule already
+    # has an ai_component-specific handler (tool authority lists) that would
+    # mislabel a domain event/field reference as a "tool".
+
+    def _visit_domain_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_named_container(node, "domain", None)
+
+    def _visit_implementation_profile_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "implementation_profile", _tree_range(node), parent=parent,
+                              detail="implementation profile", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_type_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # NOTE: the kernel grammar also has a (differently-shaped) `type_def`
+        # rule (`type_def: plain_type_def | symmetric_type_def`, an unaliased
+        # wrapper with no NAME child of its own) -- `_first_token` returning
+        # None there is what tells the two shapes apart; falling through to
+        # `_visit_children_after_first_token` is what still reaches
+        # `plain_type_def`/`symmetric_type_def`'s own handlers in that case.
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "domain_type", _tree_range(node), parent=parent, detail="type")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_value_object_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "value_object", _tree_range(node), parent=parent, detail="value object")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_aggregate_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "aggregate", _tree_range(node), parent=parent, detail="aggregate")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_id_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "aggregate_id", _tree_range(node), parent=parent, detail="id", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_state_field(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "state_field", _tree_range(node), scope_range=local_scope,
+                              parent=parent, detail="state field", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_input_field(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "field", _tree_range(node), parent=parent, detail="field", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_bare_field(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_input_field(node, parent, local_scope)
+
+    def _visit_command_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "command", _tree_range(node), parent=parent, detail="command")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_event_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "event", _tree_range(node), parent=parent, detail="event")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_error_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "domain_error", _tree_range(node), parent=parent, detail="error")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_decide_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `decide CommandName { requires ...; rejects ...; emits ... }` --
+        # the NAME references the command being decided, it is not a fresh
+        # declaration (see examples/domain/*.fsl).
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "command")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_rejects_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "domain_error")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_emits_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _all_name_tokens(node):
+            self._add_ref(token, "event")
+
+    def _visit_evolve_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `evolve EventName { ... assign_def* }` -- NAME references the event
+        # being evolved; assign_def children still need their own handler.
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "event")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_lvalue(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _name_tokens(node):
+            self._add_ref(token, "state_field")
+
+    def _visit_projection_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "projection", _tree_range(node), parent=parent, detail="projection")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_projection_from(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "aggregate")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_projection_fields(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _all_name_tokens(node):
+            self._add_ref(token, "state_field")
+
+    def _visit_on_stale_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "projection")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_effect_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "effect", _tree_range(node), parent=parent, detail="effect")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_handles_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "command")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_request_event_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "event")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_success_event_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_request_event_def(node, parent, local_scope)
+
+    def _visit_failure_event_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_request_event_def(node, parent, local_scope)
+
+    def _visit_timeout_event_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_request_event_def(node, parent, local_scope)
+
+    def _visit_backoff_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `backoff exponential` -- a free retry-policy word, not a reference
+        # to anything declared in-file (see docs/DESIGN-domain.md).
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "backoff_policy", _tree_range(node), parent=parent,
+                              detail="backoff policy", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_timeout_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "event")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_waits_for_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _all_name_tokens(node):
+            self._add_ref(token, "event")
+
+    def _visit_await_on_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _all_name_tokens(node):
+            self._add_ref(token, "event")
+
+    def _visit_await_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "await", _tree_range(node), parent=parent, detail="await")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_saga_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "saga", _tree_range(node), parent=parent, detail="saga")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_starts_on_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "event")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_saga_step_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        idx = parent
+        if token is not None:
+            idx = self._add_symbol(token, "saga_step", _tree_range(node), parent=parent, detail="saga step")
+        self._visit_children_after_first_token(node, idx, local_scope)
+
+    def _visit_awaits_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _all_name_tokens(node):
+            self._add_ref(token, "event")
+
+    def _visit_saga_compensation_item(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        # `when EventA after EventB { emits ... }` -- both NAMEs reference
+        # events; the stale_item* (emits_def) children still need visiting.
+        for token in _name_tokens(node):
+            self._add_ref(token, "event")
+        for child in node.children:
+            if isinstance(child, Tree):
+                self.visit(child, parent, local_scope)
+
+    def _visit_outbox_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "outbox", _tree_range(node), parent=parent, detail="outbox", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_inbox_def(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_symbol(token, "inbox", _tree_range(node), parent=parent, detail="inbox", exported=False)
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_type_name(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        token = _first_token(node)
+        if token is not None:
+            self._add_ref(token, "domain_type")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_type_generic1(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        for token in _name_tokens(node):
+            self._add_ref(token, "domain_type")
+        self._visit_children_after_first_token(node, parent, local_scope)
+
+    def _visit_type_generic2(self, node: Tree, parent: Optional[int], local_scope: Optional[Range]) -> None:
+        self._visit_type_generic1(node, parent, local_scope)
 
     def _visit_named_container(
         self,
@@ -1820,6 +2199,22 @@ def _first_token(tree: Tree, token_types: Sequence[str] = ("NAME", "REQ_ID")) ->
 
 def _name_tokens(tree: Tree) -> List[Token]:
     return [child for child in tree.children if isinstance(child, Token) and child.type == "NAME"]
+
+
+def _all_name_tokens(node: object) -> List[Token]:
+    """Every NAME token anywhere under ``node``, regardless of nesting --
+    used for fsl-domain reference lists (``emits``/``awaits``/``waits_for``)
+    whose grammar wraps them in inlined/aliased helper rules
+    (``one_of_names``/``bracket_name_list``/``name_list``) that would
+    otherwise need their own handlers duplicating this same walk."""
+    tokens: List[Token] = []
+    if isinstance(node, Token):
+        if node.type == "NAME":
+            tokens.append(node)
+    elif isinstance(node, Tree):
+        for child in node.children:
+            tokens.extend(_all_name_tokens(child))
+    return tokens
 
 
 def _req_id_tokens(tree: Tree) -> List[Token]:

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Coupled-change metatests (issue #168).
+
+CLAUDE.md/CONTRIBUTING.md state "a language feature moves grammar/model/bmc
+(+runtime) + docs/LANGUAGE.md + skills/fsl/reference.md + a
+docs/DESIGN-<feature>.md + tests together" -- until now that was a human
+checklist. `d1770c4` showed the failure mode: `src/fslc/lsp/index.py` was
+outside the list, so the `ai_component`/`dbsystem` dialects shipped with the
+LSP entirely dark. Prototyping this metatest re-found the same class twice
+more (fsl-domain, fsl-ai project files) -- fixed in the same PR that adds
+this file (see docs/DESIGN-coupled-change-metatest.md).
+
+Two independent checks, no Z3 dependency (lark + file scans only):
+1. LSP index coverage -- every grammar production with a NAME/REQ_ID token
+   either has a `_visit_<rule>` handler, or its tokens are proven to reach
+   `symbols`/`references` through a parent handler, or it is an explicit,
+   reviewed allowlist entry.
+2. DESIGN-doc coverage -- docs/README.md's DESIGN-*.md map is bidirectional,
+   every kernel dialect (`top_def` alternative) maps to a doc, and every CLI
+   command maps to a doc (or an explicit waiver reason).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from lark import Token, Tree
+
+from fslc.ai_parser import is_ai_agent_source, is_ai_source
+from fslc.ai_project import is_ai_project_source
+from fslc.cli import _build_arg_parser
+from fslc.db_parser import is_dbsystem_source
+from fslc.domain_parser import is_domain_source
+from fslc.grammar import GRAMMAR
+from fslc.lsp.index import DOMAIN_PARSER, _IndexBuilder, _parser_for_source, build_index
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+# ---------------------------------------------------------------------------
+# 1. LSP index coverage
+# ---------------------------------------------------------------------------
+
+# (parser_id, node.data) -> reason. A grammar production whose NAME/REQ_ID
+# token is genuinely a free label / external artifact id / engine keyword,
+# not an in-file symbol or reference -- reviewed design decisions, not a
+# parking lot. Staleness is enforced by test_lsp_allowlist_not_stale below:
+# every entry must still occur in the corpus for its parser.
+INTENTIONALLY_UNINDEXED = {
+    ("kernel", "control_severity"): "`severity high` -- free severity word, not an in-file symbol",
+    ("db", "column_type"): "`column x: int` -- engine scalar-type words, dbsystem has no in-file type decls",
+    ("db", "check_item"): "`rule <name>` names a built-in compatibility rule, not an in-file declaration",
+    ("ai", "check_item"): "`check hard { rule ... }` names a built-in hard-check rule",
+    ("ai", "tool_precondition"): "free-form semantic label (`precondition order_paid`)",
+    ("ai", "tool_effect"): "free-form effect label",
+    ("ai", "trust_def"): "`trust medium` -- free trust-level word",
+    ("ai", "atom_name"): "`model gpt_5_5` / `prompt ..._v8` -- external artifact ids",
+    ("ai", "failure_target"): "`-> HumanReviewPending` -- policy-outcome label, not an in-file symbol",
+}
+
+_CORPUS_ROOTS = ("specs", "examples")
+_EXCLUDED_DIRS = (ROOT / "examples" / "gallery" / "errors",)
+
+
+def _corpus_files() -> list[Path]:
+    paths: set[Path] = set()
+    for root in _CORPUS_ROOTS:
+        paths.update((ROOT / root).rglob("*.fsl"))
+    excluded = {p for p in paths if any(str(p).startswith(str(d)) for d in _EXCLUDED_DIRS)}
+    return sorted(paths - excluded)
+
+
+def _parser_id(src: str) -> "str | None":
+    """None means the source is not Lark-parsed at all by the LSP (fsl-ai
+    project files: indexed by ai_project._top_blocks scanning instead, see
+    lsp/index.py's build_index)."""
+    if is_ai_project_source(src):
+        return None
+    if is_dbsystem_source(src):
+        return "db"
+    if is_domain_source(src):
+        return "domain"
+    if is_ai_source(src):
+        return "ai"
+    return "kernel"
+
+
+def _walk(node) -> "list":
+    out = [node]
+    if isinstance(node, Tree):
+        for child in node.children:
+            out.extend(_walk(child))
+    return out
+
+
+def _direct_name_tokens(node: Tree) -> list:
+    return [c for c in node.children if isinstance(c, Token) and c.type in ("NAME", "REQ_ID")]
+
+
+def test_lsp_index_covers_corpus_grammar():
+    assert _EXCLUDED_DIRS[0].is_dir() and any(_EXCLUDED_DIRS[0].glob("*.fsl")), (
+        "examples/gallery/errors must stay non-empty, or this exclusion is silently vacuous"
+    )
+
+    candidates: dict = {}  # (parser_id, node.data) -> list[(file, line)]
+    for path in _corpus_files():
+        src = path.read_text(encoding="utf-8")
+        parser_id = _parser_id(src)
+        if parser_id is None:
+            continue
+        try:
+            tree = _parser_for_source(src).parse(src)
+        except Exception as exc:  # noqa: BLE001 -- a corpus file the LSP cannot even parse is itself the finding
+            raise AssertionError(f"{path}: LSP parser ({parser_id}) could not parse this corpus file: {exc}") from exc
+
+        try:
+            idx = build_index(src, str(path))
+        except Exception as exc:  # noqa: BLE001
+            raise AssertionError(f"{path}: build_index raised: {exc}") from exc
+        indexed_positions = {s.selection_range.start_tuple for s in idx.symbols} | {
+            r.range.start_tuple for r in idx.references
+        }
+
+        for node in _walk(tree):
+            if not isinstance(node, Tree):
+                continue
+            names = _direct_name_tokens(node)
+            if not names:
+                continue
+            key = (parser_id, node.data)
+            handled = hasattr(_IndexBuilder, f"_visit_{node.data}")
+            missing = [tok for tok in names if (tok.line - 1, tok.column - 1) not in indexed_positions]
+            if missing:
+                candidates.setdefault(key, []).append(
+                    (path.relative_to(ROOT).as_posix(), missing[0].line, handled)
+                )
+
+    unallowed = {k: v for k, v in candidates.items() if k not in INTENTIONALLY_UNINDEXED}
+    assert not unallowed, {
+        f"{parser_id}:{node_data}": f"{len(hits)} miss(es), e.g. {hits[0][0]}:{hits[0][1]} (handler exists: {hits[0][2]})"
+        for (parser_id, node_data), hits in unallowed.items()
+    }
+
+
+def test_lsp_allowlist_not_stale():
+    seen: set = set()
+    for path in _corpus_files():
+        src = path.read_text(encoding="utf-8")
+        parser_id = _parser_id(src)
+        if parser_id is None:
+            continue
+        tree = _parser_for_source(src).parse(src)
+        for node in _walk(tree):
+            if isinstance(node, Tree) and _direct_name_tokens(node):
+                seen.add((parser_id, node.data))
+    stale = set(INTENTIONALLY_UNINDEXED) - seen
+    assert not stale, f"allowlist entries no longer occur in the corpus, remove them: {stale}"
+
+
+def test_domain_parser_exported_for_lsp_dispatch():
+    # Guards the specific bug this issue closed: a dedicated Lark instance
+    # for fsl-domain must exist and be reachable from lsp/index.py, or every
+    # examples/domain/*.fsl silently fails to parse there again.
+    assert DOMAIN_PARSER is not None
+
+
+def test_ai_agent_dialect_still_dispatches_through_ai_parser():
+    # A distinct guard from the metatest above: `agent` recursive-composition
+    # files (unlike `ai_component` hard-contract files) must keep resolving
+    # through the same AI_PARSER path, not regress into the ai-project branch.
+    sample = next(
+        p for p in _corpus_files()
+        if is_ai_source(p.read_text(encoding="utf-8")) and is_ai_agent_source(p.read_text(encoding="utf-8"))
+    )
+    src = sample.read_text(encoding="utf-8")
+    assert not is_ai_project_source(src)
+    idx = build_index(src, str(sample))
+    assert idx.symbols, f"{sample}: expected at least one indexed symbol"
+
+
+# ---------------------------------------------------------------------------
+# 2. DESIGN-doc coverage
+# ---------------------------------------------------------------------------
+
+TOP_DEF_DESIGN_DOCS = {
+    "spec_def": ("DESIGN-v1.md",),
+    "refinement_def": ("DESIGN-refinement.md",),
+    "compose_def": ("DESIGN-compose.md",),
+    "requirements_def": ("DESIGN-dialects.md",),
+    "business_def": ("DESIGN-dialects.md",),
+    "governance_def": ("DESIGN-dialects.md",),
+}
+
+# command -> tuple of required docs, or a str waiver reason.
+COMMAND_DESIGN_DOCS = {
+    "version": "CLI plumbing, no design doc of its own",
+    "check": ("DESIGN-v1.md",),
+    "verify": ("DESIGN-v1.md", "DESIGN-induction.md"),
+    "sweep": "scope-grid driver over verify; no standalone semantics (documented in LANGUAGE.md)",
+    "scenarios": ("DESIGN-scenarios.md",),
+    "replay": ("DESIGN-bridge.md",),
+    "testgen": ("DESIGN-bridge.md",),
+    "mutate": ("DESIGN-mutate.md",),
+    "explain": ("DESIGN-explain.md",),
+    "html": ("DESIGN-html-report.md",),
+    "ledger": ("DESIGN-ledger.md",),
+    "refine": ("DESIGN-refinement.md",),
+    "chain": ("DESIGN-layers.md",),
+    "typestate": ("DESIGN-typestate.md",),
+    "analyze": ("DESIGN-analysis.md",),
+    "db": ("DESIGN-db.md",),
+    "compat": ("DESIGN-db.md",),
+    "ai": ("DESIGN-ai-hard.md", "DESIGN-stochastic.md"),
+    "domain": ("DESIGN-domain.md", "DESIGN-effect.md"),
+}
+
+
+def test_design_docs_readme_map_bidirectional():
+    readme = (DOCS / "README.md").read_text(encoding="utf-8")
+    linked = set(re.findall(r"DESIGN-[A-Za-z0-9-]+\.md", readme))
+    on_disk = {p.name for p in DOCS.glob("DESIGN-*.md")}
+    missing_on_disk = linked - on_disk
+    unlinked = on_disk - linked
+    assert not missing_on_disk, f"docs/README.md links a DESIGN doc that doesn't exist: {missing_on_disk}"
+    assert not unlinked, f"DESIGN doc(s) on disk but not linked from docs/README.md: {unlinked}"
+
+
+def test_top_level_dialects_map_to_design_docs():
+    match = re.search(r"^top_def:\s*(.+)$", GRAMMAR, re.MULTILINE)
+    assert match, "could not find the top_def rule in fslc.grammar.GRAMMAR"
+    alternatives = [alt.strip() for alt in match.group(1).split("|")]
+    assert set(alternatives) == set(TOP_DEF_DESIGN_DOCS), (
+        f"top_def alternatives {sorted(alternatives)} != TOP_DEF_DESIGN_DOCS keys "
+        f"{sorted(TOP_DEF_DESIGN_DOCS)} -- map the new/removed alternative"
+    )
+    for alt, docs in TOP_DEF_DESIGN_DOCS.items():
+        for doc in docs:
+            assert (DOCS / doc).exists(), f"{alt} -> {doc}, but {doc} does not exist"
+
+
+def test_cli_commands_map_to_design_docs():
+    parser = _build_arg_parser()
+    sub_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    commands = set(sub_action.choices)
+    assert commands == set(COMMAND_DESIGN_DOCS), (
+        f"CLI commands {sorted(commands)} != COMMAND_DESIGN_DOCS keys {sorted(COMMAND_DESIGN_DOCS)} "
+        "-- map the new/removed command (a tuple of required docs, or a str waiver reason)"
+    )
+    for command, docs in COMMAND_DESIGN_DOCS.items():
+        if isinstance(docs, str):
+            continue
+        for doc in docs:
+            assert (DOCS / doc).exists(), f"{command} -> {doc}, but {doc} does not exist"


### PR DESCRIPTION
## Summary
- New `tests/test_coupled_change_meta.py`: mechanizes the "a language feature moves grammar/model/bmc + docs/LANGUAGE.md + skills/fsl/reference.md + a DESIGN doc + the LSP index together" discipline that was previously only a human checklist (CLAUDE.md/CONTRIBUTING.md).
  - **LSP index coverage**: corpus-wide, two-stage check (structural scan of every grammar production for direct NAME/REQ_ID tokens, then a position cross-check against the actual built index) so a production whose tokens silently never reach `symbols`/`references` fails CI — with a small, reviewed, staleness-checked allowlist for genuinely free-form labels (`severity high`, `model gpt_5_5`, etc).
  - **DESIGN-doc coverage**: every kernel dialect (`top_def` alternative) and every CLI command maps to an existing `docs/DESIGN-*.md` (or an explicit waiver reason), and `docs/README.md`'s DESIGN-doc map is bidirectional (linked ⇔ on disk).
- Prototyping this metatest re-found the same class of bug `d1770c4` fixed, twice more — **fixed here, not allowlisted**:
  - fsl-domain sources crashed `build_index` entirely (`_parser_for_source` never dispatched to the domain grammar). Added the dispatch + ~35 domain-dialect LSP handlers.
  - fsl-ai *project* files (multi-block bundles whose first block happens to be `ai_component`, e.g. `support_answer_quality.fsl`) also crashed — they aren't Lark-parsed at all (`ai_project.py` scans top-level blocks with regexes/brace-matching). `build_index` now indexes them directly from `ai_project._top_blocks`.
  - Several fsl-db/fsl-ai productions (`env_flag`/`database_def`/`delegation_edge`/`agent_event`/`agent_output_def`) were unindexed — including a **pre-existing, unrelated bug**: `_visit_env_artifact` (added in `d1770c4` itself) only ever read the artifact's own NAME token and returned, silently dropping every `when flag F=V` condition on a database artifact.
- Design produced independently by the `fable` model (`docs/DESIGN-coupled-change-metatest.md`); implementation follows it, with one correction (dropped an allowlist entry for a rule that structurally has no NAME/REQ_ID child and so can never be flagged in the first place).
- `CONTRIBUTING.md` gains a note that these couplings are now CI-enforced, not just documented.

Closes #168.

## Test plan
- [x] `pytest tests/test_coupled_change_meta.py tests/test_lsp_index.py tests/test_lsp_server.py -q` → all pass
- [x] Manually confirmed each domain/ai-project example file indexes without crashing and with the expected symbol/reference counts
- [x] Full suite: `pytest -q` → 1037 passed, 78 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)