### PR TITLE
feat(replay): add production log mapping adapter

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -9,3 +9,4 @@ tests/test_self.py
 tests/test_spec_domains.py
 tests/test_trans.py
 tests/test_verify_cache.py
+tests/test_log_replay.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Production-log replay mappings (issue #174): `fslc replay SPEC --from-log
+  events.jsonl --mapping log_mapping.fsl` reuses the refinement parser and
+  mapping expressions to translate external action/parameter names and observed
+  post-action state into the target spec. The Z3-free Monitor stops at the first
+  rejected action, mapping failure, or state mismatch and reports both the
+  zero-based record index and one-based JSONL line. The initial contract requires
+  complete observed state; missing fields are nonconformant rather than silently
+  unconstrained. See `docs/DESIGN-log-replay.md`.
 - Assurance classes (issue #171): a shared `fslc.assurance` classifier turns
   every command's result dict (BMC `verify`, k-induction `prove`, and the
   fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"` producers — replay,

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -102,6 +102,11 @@ evaluates with the Python values of §1.1. Note the following:
 
 ## 2. `fslc replay` — conformance checking of event logs
 
+The original `--trace` form below accepts already-normalized spec actions. For
+production JSONL whose action/state names differ from the spec, use
+`--from-log ... --mapping ...`; that extension reuses refinement mapping syntax
+and is specified in `DESIGN-log-replay.md`.
+
 ```
 fslc replay <file.fsl> --trace <events.json>
 ```

--- a/docs/DESIGN-log-replay.md
+++ b/docs/DESIGN-log-replay.md
@@ -1,0 +1,112 @@
+# Production Log Replay through Refinement Mappings
+
+Status: implemented for issue #174.
+
+## 1. Goal and boundary
+
+`fslc replay SPEC --from-log events.jsonl --mapping log_mapping.fsl` checks
+production JSONL records with the Z3-free `Monitor`. The mapping file is parsed
+by `parse_refinement`; no log-specific FSL grammar is added. It maps external
+action names/parameters to spec actions and maps the observed post-action state
+to the spec's logical state.
+
+This is finite runtime evidence, not a proof. It does not check `leadsTo`, infer
+missing state, query production systems, or replace the existing fsl-db,
+fsl-ai, and fsl-domain evidence commands.
+
+## 2. Record and mapping contracts
+
+Every non-empty JSONL line is one object:
+
+```json
+{"action":"cart_item_added","params":{"user":0,"item":1},"state":{"inventory":{"0":2,"1":1},"active_cart":{"0":1}}}
+```
+
+- `action`: external action name.
+- `params`: object whose keys exactly match the mapping's external formal
+  parameters.
+- `state`: the complete external post-action state needed by every `map`
+  expression.
+
+The mapping is ordinary refinement syntax:
+
+```fsl
+refinement ProductionLogToShoppingCart {
+  impl ProductionLog
+  abs ShoppingCart
+
+  map stock[i: ItemId] = inventory[i]
+  map cart[u: UserId] = active_cart[u]
+
+  action cart_item_added(user, item) -> add_to_cart(user, item)
+  action order_checked_out(user) -> checkout(user)
+  action metrics_flushed() -> stutter
+}
+```
+
+`impl` labels the external log schema; there is no second FSL spec on the CLI.
+`abs` must equal `SPEC`'s name. Every target state variable needs a `map`.
+`maps auto` supplies same-name state mappings and same-name action mappings on
+demand. `preserve progress` is rejected because finite logs cannot establish
+liveness.
+
+Mapping expressions use the refinement expression AST and concrete FSL
+operators. JSON objects support field access (`snapshot.count`) and indexed
+access (`inventory[i]`); numeric JSON object keys are matched to bounded-domain
+indices, and enum member strings are converted through the target spec's enum
+metadata.
+
+## 3. Execution algorithm
+
+For each record, in order:
+
+1. Select the external action mapping and evaluate its target arguments.
+2. Execute the mapped action with `Monitor.step`, or preserve the current state
+   for `stutter`.
+3. Evaluate every state mapping against the record's `state`.
+4. Convert the result to the target spec's logical JSON representation and
+   compare it with `Monitor.state`.
+5. Stop on the first rejected action, mapping failure, or state mismatch.
+
+The monitor always begins at the spec's deterministic `init`. The observed
+state is therefore a post-action assertion, not a replacement initial state.
+
+## 4. Result contract
+
+Success returns `result:"conformant"`, `source:"jsonl_mapping"`, the mapping
+name, `steps_checked`, and `final_state`.
+
+Failure returns `result:"nonconformant"` and preserves the existing
+`failed_at_event` field while adding:
+
+- `failed_at_record`: zero-based non-empty JSONL record index;
+- `log_line`: one-based physical line number;
+- `violation.kind`: the Monitor violation kind, `log_mapping`, or
+  `state_mismatch`;
+- for state mismatch, `expected_state`, `observed_state`, and leaf
+  `mismatches[]` paths.
+
+Malformed JSONL or invalid mapping files are command errors (exit 2). A
+well-formed record that cannot be mapped or that leaves the spec world is
+nonconformant (exit 1).
+
+## 5. Partial observation and external dialects
+
+The first version deliberately requires complete mapped state. A missing
+field/key is `log_mapping`, not an unconstrained value: treating absence as a
+free variable would let incomplete telemetry appear conformant. A future
+partial-observation mode needs an explicit three-valued/constraint contract and
+must remain visibly weaker in the JSON faithfulness metadata.
+
+The existing `db observe`, `ai replay`, and `domain replay` commands carry
+domain-specific correlation and finding schemas. They are not rewritten here.
+They could reuse this core only after their event shapes can preserve those
+diagnostics; sharing a generic mapper must not erase domain evidence.
+
+## 6. Coupled-change and tests
+
+The implementation is in `src/fslc/log_replay.py`; CLI dispatch remains in
+`src/fslc/cli.py`. `tests/test_log_replay.py` covers conformant replay, first
+action/state divergence, incomplete observation, parser/AST identity with
+refinement, indexed Map + enum conversion, object-field access, malformed
+JSONL line reporting, and the public CLI.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -584,7 +584,9 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
 fslc sweep     <file.fsl> --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
-fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
+fslc replay    <file.fsl> --trace <events.json>  # spec-action trace conformance (§12)
+fslc replay    <file.fsl> --from-log <events.jsonl> --mapping <mapping.fsl>
+                                                 # production log mapping + conformance (§12)
 fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
@@ -1145,6 +1147,7 @@ r = mon.step("add_to_cart", {"u": 0, "i": 0})   # ok / kind / state / changes
 
 ```bash
 fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
+fslc replay specs/cart_v1.fsl --from-log production.jsonl --mapping log_mapping.fsl
 fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
@@ -1152,6 +1155,23 @@ fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self
 fslc testgen specs/cart_v1.fsl --target dart -o cart_conformance_test.dart  # self-contained package:test scaffold
 fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # self-contained PHPUnit scaffold
 ```
+
+The `--from-log` form reuses the exact refinement mapping grammar to translate
+external JSONL records into spec actions and logical state; it does not add a
+second mapping language. Each non-empty line is
+`{"action":"external_name","params":{...},"state":{...}}`, where `state`
+is the observed post-action state. In the mapping, `impl` labels the external
+log schema, `abs` must name the replayed spec, `map` entries cover every spec
+state variable, and `action external(params) -> spec_action(exprs)` (or
+`stutter`) maps the event. The Monitor executes the mapped action and compares
+its result with the mapped observed state on every line. The first divergence
+reports zero-based `failed_at_record` / `failed_at_event`, one-based `log_line`,
+and either the Monitor violation or a `state_mismatch` with leaf paths.
+
+This first version requires full observation: a missing field or Map key is a
+`log_mapping` nonconformance, not an unconstrained value. See
+`DESIGN-log-replay.md` for the record schema, mapping example, and the boundary
+with `db observe` / `ai replay` / `domain replay`.
 
 Since `replay` checks only finite logs, **`leadsTo` is out of scope** (stated
 explicitly in the output `note`). `Monitor` requires init to be deterministic

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@
 | [`DESIGN-refinement.md`](DESIGN-refinement.md) | Refinement checking (mapping files, conditional expressions, preserve progress) |
 | [`DESIGN-compose.md`](DESIGN-compose.md) | Spec composition (namespaces, synchronized actions, internal) |
 | [`DESIGN-bridge.md`](DESIGN-bridge.md) | Implementation bridge (runtime Monitor / replay / testgen) |
+| [`DESIGN-log-replay.md`](DESIGN-log-replay.md) | Production JSONL replay through refinement mapping syntax: record contract, complete-observation boundary, first-divergence JSON, and Monitor execution |
 | [`DESIGN-scenarios.md`](DESIGN-scenarios.md) | scenarios and the unsat-core diagnostics for coverage |
 | [`DESIGN-seq.md`](DESIGN-seq.md) | Seq<T,N> (partial_op, type whitelist) |
 | [`DESIGN-option-struct.md`](DESIGN-option-struct.md) | Option fields in structs |

--- a/docs/intro/cli.en.html
+++ b/docs/intro/cli.en.html
@@ -158,14 +158,19 @@ options:
   --depth DEPTH
   --deadlock {warn,error,ignore}
 </pre></div></details>
-<details><summary>fslc replay</summary><div class="tree-body"><pre>usage: fslc replay [-h] --trace TRACE file
+<details><summary>fslc replay</summary><div class="tree-body"><pre>usage: fslc replay [-h] (--trace TRACE | --from-log FROM_LOG)
+                   [--mapping MAPPING]
+                   file
 
 positional arguments:
   file
 
 options:
-  -h, --help     show this help message and exit
+  -h, --help           show this help message and exit
   --trace TRACE
+  --from-log FROM_LOG  production JSONL records to map and replay
+  --mapping MAPPING    refinement-syntax log mapping (required with --from-
+                       log)
 </pre></div></details>
 <details><summary>fslc testgen</summary><div class="tree-body"><pre>usage: fslc testgen [-h] [--depth DEPTH] [-o OUTPUT]
                     [--target {pytest,vitest,swift,kotlin,dart,phpunit}]

--- a/docs/intro/cli.ja.html
+++ b/docs/intro/cli.ja.html
@@ -158,14 +158,19 @@ options:
   --depth DEPTH
   --deadlock {warn,error,ignore}
 </pre></div></details>
-<details><summary>fslc replay</summary><div class="tree-body"><pre>usage: fslc replay [-h] --trace TRACE file
+<details><summary>fslc replay</summary><div class="tree-body"><pre>usage: fslc replay [-h] (--trace TRACE | --from-log FROM_LOG)
+                   [--mapping MAPPING]
+                   file
 
 positional arguments:
   file
 
 options:
-  -h, --help     show this help message and exit
+  -h, --help           show this help message and exit
   --trace TRACE
+  --from-log FROM_LOG  production JSONL records to map and replay
+  --mapping MAPPING    refinement-syntax log mapping (required with --from-
+                       log)
 </pre></div></details>
 <details><summary>fslc testgen</summary><div class="tree-body"><pre>usage: fslc testgen [-h] [--depth DEPTH] [-o OUTPUT]
                     [--target {pytest,vitest,swift,kotlin,dart,phpunit}]

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -668,7 +668,9 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
-fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # conformance check of an event log (§12)
+fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # spec-action trace conformance (§12)
+fslc replay    &lt;file.fsl&gt; --from-log &lt;events.jsonl&gt; --mapping &lt;mapping.fsl&gt;
+                                                 # production log mapping + conformance (§12)
 fslc testgen   &lt;file.fsl&gt; [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    &lt;impl&gt; &lt;abs&gt; &lt;mapping&gt; [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
@@ -1200,6 +1202,7 @@ mon.reset()
 r = mon.step(&quot;add_to_cart&quot;, {&quot;u&quot;: 0, &quot;i&quot;: 0})   # ok / kind / state / changes
 </code></pre>
 <pre><code class="language-bash">fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
+fslc replay specs/cart_v1.fsl --from-log production.jsonl --mapping log_mapping.fsl
 fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
@@ -1207,6 +1210,21 @@ fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self
 fslc testgen specs/cart_v1.fsl --target dart -o cart_conformance_test.dart  # self-contained package:test scaffold
 fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # self-contained PHPUnit scaffold
 </code></pre>
+<p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate
+external JSONL records into spec actions and logical state; it does not add a
+second mapping language. Each non-empty line is
+<code>{"action":"external_name","params":{...},"state":{...}}</code>, where <code>state</code>
+is the observed post-action state. In the mapping, <code>impl</code> labels the external
+log schema, <code>abs</code> must name the replayed spec, <code>map</code> entries cover every spec
+state variable, and <code>action external(params) -&gt; spec_action(exprs)</code> (or
+<code>stutter</code>) maps the event. The Monitor executes the mapped action and compares
+its result with the mapped observed state on every line. The first divergence
+reports zero-based <code>failed_at_record</code> / <code>failed_at_event</code>, one-based <code>log_line</code>,
+and either the Monitor violation or a <code>state_mismatch</code> with leaf paths.</p>
+<p>This first version requires full observation: a missing field or Map key is a
+<code>log_mapping</code> nonconformance, not an unconstrained value. See
+<code>DESIGN-log-replay.md</code> for the record schema, mapping example, and the boundary
+with <code>db observe</code> / <code>ai replay</code> / <code>domain replay</code>.</p>
 <p>Since <code>replay</code> checks only finite logs, <strong><code>leadsTo</code> is out of scope</strong> (stated
 explicitly in the output <code>note</code>). <code>Monitor</code> requires init to be deterministic
 (forall bulk assignment is allowed). For a Map/index target (<code>m[K] = ...</code>),

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -668,7 +668,9 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
-fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # conformance check of an event log (§12)
+fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # spec-action trace conformance (§12)
+fslc replay    &lt;file.fsl&gt; --from-log &lt;events.jsonl&gt; --mapping &lt;mapping.fsl&gt;
+                                                 # production log mapping + conformance (§12)
 fslc testgen   &lt;file.fsl&gt; [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    &lt;impl&gt; &lt;abs&gt; &lt;mapping&gt; [--depth K]# fidelity check of a detailed spec (§10)
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
@@ -1200,6 +1202,7 @@ mon.reset()
 r = mon.step(&quot;add_to_cart&quot;, {&quot;u&quot;: 0, &quot;i&quot;: 0})   # ok / kind / state / changes
 </code></pre>
 <pre><code class="language-bash">fslc replay specs/cart_v1.fsl --trace events.json   # conformant / nonconformant
+fslc replay specs/cart_v1.fsl --from-log production.jsonl --mapping log_mapping.fsl
 fslc testgen specs/cart_v1.fsl -o test_cart_v1.py            # pytest (default); partial reachability warnings unless --strict
 fslc testgen specs/cart_v1.fsl --target vitest -o cart.test.ts  # self-contained Vitest (TypeScript) scaffold
 fslc testgen specs/cart_v1.fsl --target swift -o CartConformanceTests.swift  # self-contained Swift Testing scaffold
@@ -1207,6 +1210,21 @@ fslc testgen specs/cart_v1.fsl --target kotlin -o CartConformanceTest.kt  # self
 fslc testgen specs/cart_v1.fsl --target dart -o cart_conformance_test.dart  # self-contained package:test scaffold
 fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # self-contained PHPUnit scaffold
 </code></pre>
+<p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate
+external JSONL records into spec actions and logical state; it does not add a
+second mapping language. Each non-empty line is
+<code>{"action":"external_name","params":{...},"state":{...}}</code>, where <code>state</code>
+is the observed post-action state. In the mapping, <code>impl</code> labels the external
+log schema, <code>abs</code> must name the replayed spec, <code>map</code> entries cover every spec
+state variable, and <code>action external(params) -&gt; spec_action(exprs)</code> (or
+<code>stutter</code>) maps the event. The Monitor executes the mapped action and compares
+its result with the mapped observed state on every line. The first divergence
+reports zero-based <code>failed_at_record</code> / <code>failed_at_event</code>, one-based <code>log_line</code>,
+and either the Monitor violation or a <code>state_mismatch</code> with leaf paths.</p>
+<p>This first version requires full observation: a missing field or Map key is a
+<code>log_mapping</code> nonconformance, not an unconstrained value. See
+<code>DESIGN-log-replay.md</code> for the record schema, mapping example, and the boundary
+with <code>db observe</code> / <code>ai replay</code> / <code>domain replay</code>.</p>
 <p>Since <code>replay</code> checks only finite logs, <strong><code>leadsTo</code> is out of scope</strong> (stated
 explicitly in the output <code>note</code>). <code>Monitor</code> requires init to be deterministic
 (forall bulk assignment is allowed). For a Map/index target (<code>m[K] = ...</code>),

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -286,7 +286,9 @@ the formalization memo.**
    baseline result), `fslc scenarios` (integration-test skeleton JSON),
    `fslc testgen -o test_x.py`
    (implementation-conformance pytest skeleton), `fslc replay --trace events.json`
-   (log conformance), `fslc refine impl.fsl abs.fsl mapping.fsl` (faithfulness check
+   (normalized spec-action log conformance), or `fslc replay --from-log
+   events.jsonl --mapping log_mapping.fsl` (production action/state mapped through
+   refinement syntax), `fslc refine impl.fsl abs.fsl mapping.fsl` (faithfulness check
    of a detailed spec).
    For AI tool-boundary contracts, use `fslc ai check file.fsl` on
    `ai_component` specs and `fslc ai replay file.fsl --logs events.jsonl` for

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -688,6 +688,8 @@ fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emi
 fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
+fslc replay <f> --from-log <events.jsonl> --mapping <mapping.fsl>
+                                                # production JSONL -> mapped action/state -> Monitor
 fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test / PHPUnit)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
@@ -719,6 +721,17 @@ fslc ai drift <f> --logs events.jsonl [--baseline-logs p] [--window N] [--baseli
 fslc ai compat <f> [--environment <env>]                # emit a dbsystem artifact capability profile for AI compat
 fslc compat check <f> [--include-ai]                    # dbsystem compatibility check, optionally folding in AI capability profiles
 ```
+
+For production-log replay, each non-empty JSONL line is an object with
+`action`, `params`, and the observed post-action `state`. The mapping file is
+parsed by the same `parse_refinement` path as `fslc refine`: `impl` names the
+external log schema, `abs` names the target spec, `map` covers every target
+state variable, and `action external(args) -> target(exprs)` (or `stutter`)
+maps events. The Monitor executes the target action and compares its state with
+the mapped observed state. This v1 requires complete observed state; missing
+fields/keys are `log_mapping` nonconformance. The first divergence includes
+`failed_at_record` (0-based), `log_line` (1-based), and the action/state
+mismatch. Finite replay does not check `leadsTo`.
 
 `verify` is backed by a persistent verdict cache (issue #169) keyed on every
 input that can affect its output (the post-desugaring kernel AST, the raw

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -1002,9 +1002,33 @@ def run_scenarios(file, depth, deadlock_mode="warn"):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
-def run_replay(file, trace_path):
+def run_replay(file, trace_path=None, *, from_log=None, mapping_path=None):
     try:
         spec, *_rest = _read_spec(file)
+        if from_log is not None:
+            if trace_path is not None:
+                return _envelope({
+                    "result": "error",
+                    "kind": "io",
+                    "message": "--trace and --from-log are mutually exclusive",
+                })
+            if mapping_path is None:
+                return _envelope({
+                    "result": "error",
+                    "kind": "io",
+                    "message": "--mapping is required with --from-log",
+                })
+            from .log_replay import build_log_mapping, load_jsonl, replay_mapped_log
+
+            mapping_src = open(mapping_path, encoding="utf-8").read()
+            mapping = build_log_mapping(parse_refinement(mapping_src), spec)
+            return _envelope(replay_mapped_log(spec, load_jsonl(from_log), mapping))
+        if trace_path is None:
+            return _envelope({
+                "result": "error",
+                "kind": "io",
+                "message": "one of --trace or --from-log is required",
+            })
         mon = Monitor(spec)
         raw = open(trace_path, encoding="utf-8").read()
         data = json.loads(raw)
@@ -1841,7 +1865,12 @@ def _build_arg_parser():
 
     rp = sub.add_parser("replay")
     rp.add_argument("file")
-    rp.add_argument("--trace", required=True)
+    replay_input = rp.add_mutually_exclusive_group(required=True)
+    replay_input.add_argument("--trace")
+    replay_input.add_argument("--from-log", dest="from_log",
+                              help="production JSONL records to map and replay")
+    rp.add_argument("--mapping",
+                    help="refinement-syntax log mapping (required with --from-log)")
 
     tg = sub.add_parser("testgen")
     tg.add_argument("file")
@@ -2047,7 +2076,12 @@ def _dispatch(args):
                            values=args.values)
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "replay":
-        result = run_replay(args.file, args.trace)
+        result = run_replay(
+            args.file,
+            args.trace,
+            from_log=args.from_log,
+            mapping_path=args.mapping,
+        )
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "refine":
         result = run_refine(args.impl, args.abs, args.mapping, args.depth, rest=args.rest)

--- a/src/fslc/log_replay.py
+++ b/src/fslc/log_replay.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Replay production JSONL records through refinement mapping syntax."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .model import FslError, domain_range
+from .runtime import Monitor, eval_concrete
+
+
+_FINITE_LOG_NOTE = "leadsTo properties are not checked by replay (finite logs only)"
+
+
+def _err(message, kind="semantics", loc=None, hint=None):
+    raise FslError(message, kind=kind, loc=loc, hint=hint)
+
+
+def _find_action(spec, name):
+    return next((action for action in spec["actions"] if action["name"] == name), None)
+
+
+def build_log_mapping(tree, target_spec):
+    """Validate a refinement AST for JSONL-to-spec replay.
+
+    The mapping file uses the exact refinement parser and item shapes.  Its
+    ``impl`` name labels the external log schema rather than referring to a
+    second FSL spec; the ``abs`` side must name the replay target spec.
+    """
+
+    if not isinstance(tree, tuple) or tree[0] != "refinement":
+        _err("expected refinement mapping file", kind="type")
+
+    _, name, items = tree
+    impl_name = None
+    abs_name = None
+    maps_auto = False
+    maps = {}
+    actions = {}
+
+    for item in items:
+        tag = item[0]
+        if tag == "impl":
+            impl_name = item[1]
+        elif tag == "abs":
+            abs_name = item[1]
+        elif tag == "maps_auto":
+            maps_auto = True
+        elif tag == "map":
+            _, logical, binder, expr, loc = item
+            if logical in maps:
+                _err(f"duplicate map for '{logical}'", kind="type", loc=loc)
+            if logical not in target_spec["state"]:
+                _err(f"unknown abstract state variable '{logical}'", kind="type", loc=loc)
+            maps[logical] = {
+                "kind": "indexed" if binder is not None else "scalar",
+                "binder": binder,
+                "expr": expr,
+                "loc": loc,
+            }
+        elif tag == "action_map":
+            _, source_name, params, target, loc = item
+            if source_name in actions:
+                _err(f"duplicate action map for '{source_name}'", kind="type", loc=loc)
+            param_names = [param[1] for param in params]
+            if len(param_names) != len(set(param_names)):
+                _err(f"duplicate parameter in action map '{source_name}'", kind="type", loc=loc)
+            if target[0] == "stutter":
+                actions[source_name] = {
+                    "kind": "stutter",
+                    "params": param_names,
+                    "loc": loc,
+                }
+                continue
+            _, target_name, arg_exprs = target
+            target_action = _find_action(target_spec, target_name)
+            if target_action is None:
+                _err(f"unknown abstract action '{target_name}'", kind="type", loc=loc)
+            if len(arg_exprs) != len(target_action["params"]):
+                _err(
+                    f"action '{source_name}' -> '{target_name}' expects "
+                    f"{len(target_action['params'])} arguments",
+                    kind="type",
+                    loc=loc,
+                )
+            actions[source_name] = {
+                "kind": "map",
+                "params": param_names,
+                "abs_action": target_name,
+                "arg_exprs": arg_exprs,
+                "loc": loc,
+            }
+        elif tag == "preserve_progress":
+            _err(
+                "preserve progress is not available for finite production-log replay",
+                kind="semantics",
+                loc=item[-1],
+                hint=_FINITE_LOG_NOTE,
+            )
+
+    if impl_name is None:
+        _err("refinement missing impl spec name", kind="type")
+    if abs_name is None:
+        _err("refinement missing abs spec name", kind="type")
+    if abs_name != target_spec["name"]:
+        _err(
+            f"abs name '{abs_name}' does not match replay spec '{target_spec['name']}'",
+            kind="type",
+        )
+
+    if maps_auto:
+        for logical in target_spec["state"]:
+            maps.setdefault(
+                logical,
+                {
+                    "kind": "scalar",
+                    "binder": None,
+                    "expr": ("var", logical),
+                    "loc": None,
+                },
+            )
+
+    for logical in target_spec["state"]:
+        if logical not in maps:
+            _err(f"missing map for abstract state variable '{logical}'", kind="type")
+
+    return {
+        "name": name,
+        "impl": impl_name,
+        "abs": abs_name,
+        "maps": maps,
+        "actions": actions,
+        "maps_auto": maps_auto,
+        "progress": [],
+    }
+
+
+def load_jsonl(path):
+    """Load non-empty JSONL records while preserving their physical line."""
+
+    records = []
+    for line_number, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _err(f"invalid JSONL at line {line_number}: {exc.msg}", kind="io")
+        if not isinstance(record, dict):
+            _err(f"JSONL line {line_number} must be an object", kind="io")
+        records.append((line_number, record))
+    return records
+
+
+def _enum_value(value, spec):
+    if not isinstance(value, str):
+        return value
+    matches = []
+    for info in spec["types"].values():
+        if info.get("kind") == "enum" and value in info["members"]:
+            matches.append(info["members"].index(value))
+    return matches[0] if len(set(matches)) == 1 and matches else value
+
+
+def _normalize_input(value, spec):
+    if value is None:
+        return ("none",)
+    if isinstance(value, dict):
+        out = {}
+        for key, item in value.items():
+            normalized = _normalize_input(item, spec)
+            out[key] = normalized
+            if isinstance(key, str):
+                try:
+                    out[int(key)] = normalized
+                except ValueError:
+                    pass
+        return out
+    if isinstance(value, list):
+        return [_normalize_input(item, spec) for item in value]
+    return _enum_value(value, spec)
+
+
+def _eval_mapping_expr(expr, raw_state, binds, spec):
+    evaluation_spec = {**spec, "state": {}}
+    state = {name: _normalize_input(value, spec) for name, value in raw_state.items()}
+    normalized_binds = {name: _normalize_input(value, spec) for name, value in binds.items()}
+    try:
+        return eval_concrete(expr, state, normalized_binds, evaluation_spec)
+    except Exception as exc:
+        message = getattr(exc, "message", None) or str(exc)
+        _err(message or "mapping expression could not be evaluated", kind="semantics")
+
+
+def _domain_values(ty, spec):
+    if ty[0] == "bool":
+        return [False, True]
+    lo, hi = domain_range(ty, spec["types"])
+    return list(range(lo, hi + 1))
+
+
+def _display_scalar(value, ty, spec):
+    if ty[0] == "bool":
+        if not isinstance(value, bool):
+            _err(f"expected Bool value, got {value!r}", kind="type")
+        return value
+    if ty[0] == "int":
+        if not isinstance(value, int) or isinstance(value, bool):
+            _err(f"expected Int value, got {value!r}", kind="type")
+        return value
+    if ty[0] == "domain":
+        if not isinstance(value, int) or isinstance(value, bool):
+            _err(f"expected bounded integer value, got {value!r}", kind="type")
+        lo, hi = domain_range(ty, spec["types"])
+        if value < lo or value > hi:
+            _err(f"mapped value {value} is out of range [{lo}..{hi}]", kind="type")
+        return value
+    if ty[0] == "enum":
+        members = spec["types"][ty[1]]["members"]
+        if isinstance(value, str):
+            if value not in members:
+                _err(f"unknown {ty[1]} enum member '{value}'", kind="type")
+            return value
+        if not isinstance(value, int) or value < 0 or value >= len(members):
+            _err(f"mapped enum ordinal {value!r} is out of range for {ty[1]}", kind="type")
+        return members[value]
+    _err(f"unsupported scalar mapping type {ty}", kind="type")
+
+
+def _lookup_map_value(value, key, key_ty, spec):
+    candidates = [key, str(key)]
+    if key_ty[0] == "bool":
+        candidates.extend(["true" if key else "false"])
+    elif key_ty[0] == "enum":
+        candidates.append(spec["types"][key_ty[1]]["members"][key])
+    for candidate in candidates:
+        if candidate in value:
+            return value[candidate]
+    _err(f"mapped state is missing key {candidates[-1]!r}", kind="semantics")
+
+
+def _to_logical(value, ty, spec):
+    if ty[0] in ("bool", "int", "domain", "enum"):
+        return _display_scalar(value, ty, spec)
+    if ty[0] == "option":
+        if value is None or value == ("none",):
+            return None
+        if isinstance(value, tuple) and value and value[0] == "option_val":
+            if not value[1]:
+                return None
+            value = value[2]
+        return _to_logical(value, ty[1], spec)
+    if ty[0] == "struct":
+        if isinstance(value, tuple) and value and value[0] == "struct_val":
+            value = value[2]
+        if not isinstance(value, dict):
+            _err(f"expected object for struct {ty[1]}", kind="type")
+        fields = spec["types"][ty[1]]["fields"]
+        missing = [field for field in fields if field not in value]
+        if missing:
+            _err(f"mapped struct {ty[1]} is missing field '{missing[0]}'", kind="semantics")
+        return {field: _to_logical(value[field], fty, spec) for field, fty in fields.items()}
+    if ty[0] == "map":
+        if not isinstance(value, dict):
+            _err("expected object for mapped Map value", kind="type")
+        out = {}
+        for key in _domain_values(ty[1], spec):
+            display_key = (
+                "true" if key is True else "false" if key is False
+                else spec["types"][ty[1][1]]["members"][key] if ty[1][0] == "enum"
+                else str(key)
+            )
+            out[display_key] = _to_logical(
+                _lookup_map_value(value, key, ty[1], spec), ty[2], spec
+            )
+        return out
+    if ty[0] == "seq":
+        if isinstance(value, tuple) and value and value[0] == "seq_val":
+            value = value[1][: value[2]]
+        if not isinstance(value, list):
+            _err("expected array for mapped Seq value", kind="type")
+        if len(value) > ty[2]:
+            _err(f"mapped Seq length {len(value)} exceeds capacity {ty[2]}", kind="type")
+        return [_to_logical(item, ty[1], spec) for item in value]
+    if ty[0] == "set":
+        if isinstance(value, tuple) and value and value[0] == "set_val":
+            value = [key for key, present in value[1].items() if present]
+        if not isinstance(value, list):
+            _err("expected array for mapped Set value", kind="type")
+        return sorted((_to_logical(item, ty[1], spec) for item in value), key=str)
+    if ty[0] == "relation":
+        if not isinstance(value, list):
+            _err("expected array of pairs for mapped relation value", kind="type")
+        out = []
+        for pair in value:
+            if not isinstance(pair, list) or len(pair) != 2:
+                _err("mapped relation entries must be two-element arrays", kind="type")
+            out.append([
+                _to_logical(pair[0], ty[1], spec),
+                _to_logical(pair[1], ty[2], spec),
+            ])
+        return out
+    _err(f"unsupported mapped state type {ty}", kind="type")
+
+
+def _map_state(mapping, raw_state, spec):
+    if not isinstance(raw_state, dict):
+        _err("record.state must be an object", kind="type")
+    out = {}
+    for logical, ty in spec["state"].items():
+        entry = mapping["maps"][logical]
+        if entry["kind"] == "scalar":
+            value = _eval_mapping_expr(entry["expr"], raw_state, {}, spec)
+            out[logical] = _to_logical(value, ty, spec)
+            continue
+        if ty[0] != "map":
+            _err(f"indexed map on non-Map variable '{logical}'", kind="type")
+        binder = entry["binder"]
+        values = {}
+        for key in _domain_values(ty[1], spec):
+            value = _eval_mapping_expr(entry["expr"], raw_state, {binder[1]: key}, spec)
+            display_key = (
+                "true" if key is True else "false" if key is False
+                else spec["types"][ty[1][1]]["members"][key] if ty[1][0] == "enum"
+                else str(key)
+            )
+            values[display_key] = _to_logical(value, ty[2], spec)
+        out[logical] = values
+    return out
+
+
+def _map_action(mapping, record, spec):
+    source_action = record.get("action")
+    params = record.get("params", {})
+    if not isinstance(source_action, str):
+        _err("record.action must be a string", kind="type")
+    if not isinstance(params, dict):
+        _err("record.params must be an object", kind="type")
+    action_map = mapping["actions"].get(source_action)
+    if action_map is None and mapping.get("maps_auto"):
+        target = _find_action(spec, source_action)
+        if target is not None:
+            expected = [param[0] for param in target["params"]]
+            action_map = {
+                "kind": "map",
+                "params": expected,
+                "abs_action": source_action,
+                "arg_exprs": [("var", name) for name in expected],
+            }
+    if action_map is None:
+        _err(f"no action mapping for log action '{source_action}'", kind="semantics")
+    expected_params = action_map["params"]
+    if set(params) != set(expected_params):
+        _err(
+            f"parameter mismatch for log action '{source_action}': "
+            f"expected {expected_params}, got {list(params)}",
+            kind="type",
+        )
+    if action_map["kind"] == "stutter":
+        return source_action, None, {}
+    raw_state = record.get("state", {})
+    target_action = _find_action(spec, action_map["abs_action"])
+    mapped_params = {}
+    for target_param, expr in zip(target_action["params"], action_map["arg_exprs"]):
+        mapped_params[target_param[0]] = _eval_mapping_expr(expr, raw_state, params, spec)
+    return source_action, action_map["abs_action"], mapped_params
+
+
+def _mismatches(expected, observed, path=""):
+    if isinstance(expected, dict) and isinstance(observed, dict):
+        out = []
+        for key in sorted(set(expected) | set(observed), key=str):
+            child = f"{path}.{key}" if path else str(key)
+            if key not in expected:
+                out.append({"path": child, "expected": None, "observed": observed[key]})
+            elif key not in observed:
+                out.append({"path": child, "expected": expected[key], "observed": None})
+            else:
+                out.extend(_mismatches(expected[key], observed[key], child))
+        return out
+    if isinstance(expected, list) and isinstance(observed, list):
+        if expected == observed:
+            return []
+        return [{"path": path, "expected": expected, "observed": observed}]
+    if expected != observed:
+        return [{"path": path, "expected": expected, "observed": observed}]
+    return []
+
+
+def replay_mapped_log(spec, records, mapping):
+    """Map and replay JSONL records, stopping at the first divergence."""
+
+    monitor = Monitor(spec)
+    monitor.reset()
+    for record_index, (line_number, record) in enumerate(records):
+        before = monitor.state
+        try:
+            source_action, target_action, mapped_params = _map_action(mapping, record, spec)
+            if target_action is None:
+                step_result = {"ok": True, "state": before}
+            else:
+                step_result = monitor.step(target_action, mapped_params)
+            if not step_result.get("ok"):
+                violation = {
+                    **step_result,
+                    "source_action": source_action,
+                    "mapped_action": target_action,
+                }
+                return {
+                    "result": "nonconformant",
+                    "spec": spec["name"],
+                    "mapping": mapping["name"],
+                    "source": "jsonl_mapping",
+                    "failed_at_event": record_index,
+                    "failed_at_record": record_index,
+                    "log_line": line_number,
+                    "violation": violation,
+                    "state_before": before,
+                    "note": _FINITE_LOG_NOTE,
+                }
+            observed = _map_state(mapping, record.get("state"), spec)
+        except FslError as exc:
+            return {
+                "result": "nonconformant",
+                "spec": spec["name"],
+                "mapping": mapping["name"],
+                "source": "jsonl_mapping",
+                "failed_at_event": record_index,
+                "failed_at_record": record_index,
+                "log_line": line_number,
+                "violation": {
+                    "kind": "log_mapping",
+                    "message": str(exc),
+                    "loc": getattr(exc, "loc", None),
+                },
+                "state_before": before,
+                "note": _FINITE_LOG_NOTE,
+            }
+
+        expected = monitor.state
+        mismatch = _mismatches(expected, observed)
+        if mismatch:
+            return {
+                "result": "nonconformant",
+                "spec": spec["name"],
+                "mapping": mapping["name"],
+                "source": "jsonl_mapping",
+                "failed_at_event": record_index,
+                "failed_at_record": record_index,
+                "log_line": line_number,
+                "violation": {
+                    "kind": "state_mismatch",
+                    "source_action": source_action,
+                    "action": target_action or "stutter",
+                    "expected_state": expected,
+                    "observed_state": observed,
+                    "mismatches": mismatch,
+                },
+                "state_before": before,
+                "note": _FINITE_LOG_NOTE,
+            }
+
+    return {
+        "result": "conformant",
+        "spec": spec["name"],
+        "mapping": mapping["name"],
+        "source": "jsonl_mapping",
+        "steps_checked": len(records),
+        "final_state": monitor.state,
+        "note": _FINITE_LOG_NOTE,
+    }

--- a/src/fslc/values.py
+++ b/src/fslc/values.py
@@ -280,6 +280,12 @@ def eval_index(base_e, idx, state, spec, dom):
 
 
 def eval_field(base, field):
+    # Production-log mapping expressions reuse the refinement expression AST,
+    # but JSON objects arrive as ordinary dicts rather than FSL struct tuples.
+    if isinstance(base, dict):
+        if field not in base:
+            _err(f"unknown field '{field}'")
+        return base[field]
     if isinstance(base, tuple) and base[0] == "struct_map_val":
         fields = base[3]
         if field not in fields:

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -201,7 +201,7 @@ COMMAND_DESIGN_DOCS = {
     "verify": ("DESIGN-v1.md", "DESIGN-induction.md"),
     "sweep": "scope-grid driver over verify; no standalone semantics (documented in LANGUAGE.md)",
     "scenarios": ("DESIGN-scenarios.md",),
-    "replay": ("DESIGN-bridge.md",),
+    "replay": ("DESIGN-bridge.md", "DESIGN-log-replay.md"),
     "testgen": ("DESIGN-bridge.md",),
     "mutate": ("DESIGN-mutate.md",),
     "explain": ("DESIGN-explain.md",),

--- a/tests/test_log_replay.py
+++ b/tests/test_log_replay.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Production JSONL log replay through refinement mapping syntax (issue #174)."""
+
+import json
+import subprocess
+import sys
+
+from fslc import build_spec, parse
+from fslc.cli import exit_code, run_replay
+from fslc.log_replay import build_log_mapping
+from fslc.parser import parse_refinement
+from fslc.refine import build_refinement
+
+
+COUNTER_SPEC = """
+spec Counter {
+  type Count = 0..2
+  state { count: Count }
+  init { count = 0 }
+  action add(delta: Count) {
+    requires delta == 1
+    count = count + delta
+  }
+  invariant WithinBound { count <= 2 }
+}
+"""
+
+PROD_SPEC = """
+spec ProdCounter {
+  type Count = 0..2
+  state { raw_count: Count }
+  init { raw_count = 0 }
+  action increment(amount: Count) {
+    raw_count = raw_count + amount
+  }
+}
+"""
+
+MAPPING = """
+refinement ProdCounterToCounter {
+  impl ProdCounter
+  abs Counter
+  map count = raw_count
+  action increment(amount) -> add(amount)
+}
+"""
+
+
+def _write_fixture(tmp_path, records):
+    spec_path = tmp_path / "counter.fsl"
+    mapping_path = tmp_path / "log_mapping.fsl"
+    log_path = tmp_path / "events.jsonl"
+    spec_path.write_text(COUNTER_SPEC, encoding="utf-8")
+    mapping_path.write_text(MAPPING, encoding="utf-8")
+    log_path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return spec_path, log_path, mapping_path
+
+
+def test_log_replay_maps_jsonl_action_and_state_to_monitor(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [
+            {"action": "increment", "params": {"amount": 1}, "state": {"raw_count": 1}},
+            {"action": "increment", "params": {"amount": 1}, "state": {"raw_count": 2}},
+        ],
+    )
+
+    result = run_replay(
+        str(spec_path),
+        from_log=str(log_path),
+        mapping_path=str(mapping_path),
+    )
+
+    assert result["result"] == "conformant", result
+    assert result["source"] == "jsonl_mapping"
+    assert result["steps_checked"] == 2
+    assert result["final_state"] == {"count": 2}
+    assert result["mapping"] == "ProdCounterToCounter"
+    assert exit_code(result) == 0
+
+
+def test_log_replay_reports_first_state_mismatch_with_record_and_line(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [
+            {"action": "increment", "params": {"amount": 1}, "state": {"raw_count": 0}},
+            {"action": "increment", "params": {"amount": 1}, "state": {"raw_count": 2}},
+        ],
+    )
+
+    result = run_replay(
+        str(spec_path),
+        from_log=str(log_path),
+        mapping_path=str(mapping_path),
+    )
+
+    assert result["result"] == "nonconformant"
+    assert result["failed_at_event"] == 0
+    assert result["failed_at_record"] == 0
+    assert result["log_line"] == 1
+    assert result["violation"]["kind"] == "state_mismatch"
+    assert result["violation"]["action"] == "add"
+    assert result["violation"]["expected_state"] == {"count": 1}
+    assert result["violation"]["observed_state"] == {"count": 0}
+    assert result["violation"]["mismatches"] == [
+        {"path": "count", "expected": 1, "observed": 0}
+    ]
+    assert exit_code(result) == 1
+
+
+def test_log_replay_reports_action_rejection_at_source_record(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [
+            {"action": "increment", "params": {"amount": 2}, "state": {"raw_count": 2}},
+        ],
+    )
+
+    result = run_replay(
+        str(spec_path),
+        from_log=str(log_path),
+        mapping_path=str(mapping_path),
+    )
+
+    assert result["result"] == "nonconformant"
+    assert result["failed_at_record"] == 0
+    assert result["log_line"] == 1
+    assert result["violation"]["kind"] == "requires_failed"
+    assert result["violation"]["source_action"] == "increment"
+    assert result["violation"]["mapped_action"] == "add"
+
+
+def test_log_mapping_uses_same_parser_and_mapping_expressions_as_refine():
+    target = build_spec(parse(COUNTER_SPEC))
+    impl = build_spec(parse(PROD_SPEC))
+    tree = parse_refinement(MAPPING)
+
+    log_mapping = build_log_mapping(tree, target)
+    refinement = build_refinement(tree, impl, target)
+
+    assert log_mapping["maps"]["count"]["expr"] == refinement["maps"]["count"]["expr"]
+    assert (
+        log_mapping["actions"]["increment"]["arg_exprs"]
+        == refinement["actions"]["increment"]["arg_exprs"]
+    )
+    assert (
+        log_mapping["actions"]["increment"]["abs_action"]
+        == refinement["actions"]["increment"]["abs_action"]
+    )
+
+
+def test_log_replay_requires_full_observed_state(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [{"action": "increment", "params": {"amount": 1}, "state": {}}],
+    )
+
+    result = run_replay(
+        str(spec_path),
+        from_log=str(log_path),
+        mapping_path=str(mapping_path),
+    )
+
+    assert result["result"] == "nonconformant"
+    assert result["failed_at_record"] == 0
+    assert result["violation"]["kind"] == "log_mapping"
+    assert "raw_count" in result["violation"]["message"]
+
+
+def test_log_replay_rejects_invalid_jsonl_with_line_number(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(tmp_path, [])
+    log_path.write_text('{"action":"increment"}\nnot-json\n', encoding="utf-8")
+
+    result = run_replay(
+        str(spec_path),
+        from_log=str(log_path),
+        mapping_path=str(mapping_path),
+    )
+
+    assert result["result"] == "error"
+    assert result["kind"] == "io"
+    assert "line 2" in result["message"]
+
+
+def test_log_replay_supports_indexed_maps_and_enum_values(tmp_path):
+    spec = """
+spec Tickets {
+  type TicketId = 0..1
+  enum Status { Open, Closed }
+  state { status: Map<TicketId, Status> }
+  init { forall t: TicketId { status[t] = Open } }
+  action close(ticket: TicketId) {
+    requires status[ticket] == Open
+    status[ticket] = Closed
+  }
+}
+"""
+    mapping = """
+refinement ServiceLogToTickets {
+  impl ServiceLog
+  abs Tickets
+  map status[t: TicketId] = statuses[t]
+  action ticket_closed(id) -> close(id)
+}
+"""
+    spec_path = tmp_path / "tickets.fsl"
+    mapping_path = tmp_path / "mapping.fsl"
+    log_path = tmp_path / "events.jsonl"
+    spec_path.write_text(spec, encoding="utf-8")
+    mapping_path.write_text(mapping, encoding="utf-8")
+    log_path.write_text(
+        json.dumps({
+            "action": "ticket_closed",
+            "params": {"id": 1},
+            "state": {"statuses": {"0": "Open", "1": "Closed"}},
+        }) + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_replay(
+        str(spec_path), from_log=str(log_path), mapping_path=str(mapping_path)
+    )
+
+    assert result["result"] == "conformant", result
+    assert result["final_state"] == {"status": {"0": "Open", "1": "Closed"}}
+
+
+def test_log_replay_supports_json_object_field_access(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [{
+            "action": "increment",
+            "params": {"amount": 1},
+            "state": {"snapshot": {"raw_count": 1}},
+        }],
+    )
+    mapping_path.write_text(
+        MAPPING.replace("map count = raw_count", "map count = snapshot.raw_count"),
+        encoding="utf-8",
+    )
+
+    result = run_replay(
+        str(spec_path), from_log=str(log_path), mapping_path=str(mapping_path)
+    )
+
+    assert result["result"] == "conformant", result
+
+
+def test_replay_cli_accepts_from_log_and_mapping(tmp_path):
+    spec_path, log_path, mapping_path = _write_fixture(
+        tmp_path,
+        [{"action": "increment", "params": {"amount": 1}, "state": {"raw_count": 1}}],
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "fslc",
+            "replay",
+            str(spec_path),
+            "--from-log",
+            str(log_path),
+            "--mapping",
+            str(mapping_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["result"] == "conformant"


### PR DESCRIPTION
## Summary
Add `fslc replay SPEC --from-log events.jsonl --mapping log_mapping.fsl` for production logs whose action/state names differ from FSL. Each JSONL record is mapped through the existing refinement AST, executed by the Z3-free Monitor, and compared with the mapped observed post-state.

## Why
- **Goal:** make runtime log → spec state mapping a reusable kernel-adjacent bridge instead of adding another dialect-specific mapping language.
- **Reason:** refinement already defines the required action/state mapping vocabulary.
- **Alternative rejected:** a new log DSL would duplicate parser and expression semantics and create another coupled-change surface.

## What Changed
- Added JSONL loading, refinement-AST mapping validation/evaluation, Monitor replay, and first-divergence diagnostics.
- Extended `replay` with mutually exclusive `--trace` / `--from-log`; `--mapping` is required for production logs.
- Added design/language/skill documentation and regenerated the committed CLI/language website pages.

## Invariants
| Must stay true | Evidence | Failure symptom |
|---|---|---|
| Existing `--trace` replay remains compatible | `tests/test_runtime.py` | Existing normalized traces stop replaying |
| Log mappings use the refinement parser/AST | parser-equivalence regression in `tests/test_log_replay.py` | Mapping grammar drifts from refine |
| Missing observations are not silently unconstrained | incomplete-state regression | Incomplete telemetry can appear conformant |
| Finite replay does not claim liveness proof | result note + design boundary | Runtime evidence is misread as `leadsTo` proof |

## Blast Radius
- **Affected:** replay CLI/JSON, concrete mapping evaluation, generated CLI/language site pages.
- **Unchanged:** grammar, symbolic BMC/refinement proof semantics, existing db/ai/domain replay commands, exit-code classes.
- **Compatibility:** additive CLI/JSON fields; no migration or persisted data.

## Failure Modes
- Rejected mapped action → `nonconformant` with the Monitor violation.
- Mapped post-state differs → `state_mismatch` with leaf paths.
- Missing/invalid record data → first-record `log_mapping`; malformed JSONL/mapping file remains command error.

## Evidence
- [x] Full suite: `.venv/bin/pytest -q` — 1291 passed, 78 skipped.
- [x] Focused replay/runtime/refine suites: exit 0.
- [x] Site/coupled-change metatests and corpus snapshot: exit 0.
- [x] `.venv/bin/python tools/build_site_reference.py`.
- [x] `git diff --check` and `compileall`.

## Rollout & Rollback
- **Rollout:** additive command option; no feature flag or data migration.
- **Rollback:** revert commit `500a239`.
- **Cannot rollback if:** not applicable.

## Review Focus
- [ ] `src/fslc/log_replay.py`: complete-observation and type-conversion boundary.
- [ ] `src/fslc/cli.py`: old/new replay dispatch and error envelope behavior.
- [ ] `docs/DESIGN-log-replay.md`: record contract and deferred partial-observation semantics.

## Unknowns
- Partial observation is intentionally deferred; it needs explicit weaker faithfulness semantics.
- Replatforming db/ai/domain replay is not part of this PR because their domain diagnostics must be preserved.

Closes #174
