### PR TITLE
feat(verify): add predictive BMC from state

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -9,3 +9,4 @@ tests/test_self.py
 tests/test_spec_domains.py
 tests/test_trans.py
 tests/test_verify_cache.py
+tests/test_from_state.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Predictive BMC from a state snapshot (issue #175): `fslc verify SPEC
+  --from-state state.json` replaces the declared init with a complete
+  Monitor/replay logical-state JSON and searches for violations from that point.
+  Snapshot runs are BMC-only, bypass the verdict cache, preserve concrete
+  identities by disabling symmetry reduction, and stamp
+  `faithfulness.scope:"bounded_from_snapshot"` with `spec_init:"not_used"`.
+  Full type/shape validation covers every kernel state type; partial snapshots
+  are rejected rather than treated as unconstrained. See
+  `docs/DESIGN-from-state.md`.
 - Assurance classes (issue #171): a shared `fslc.assurance` classifier turns
   every command's result dict (BMC `verify`, k-induction `prove`, and the
   fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"` producers — replay,

--- a/docs/DESIGN-from-state.md
+++ b/docs/DESIGN-from-state.md
@@ -1,0 +1,103 @@
+# Predictive BMC from a State Snapshot
+
+Status: implemented for issue #175.
+
+## 1. Goal and command
+
+`fslc verify SPEC --from-state state.json --depth K` asks whether the complete
+logical state in `state.json` can reach a violation within `K` steps. It replaces
+the spec's `init` constraints for this BMC run; it does not add the snapshot on
+top of `init`.
+
+The feature is intended for incident what-if analysis, pre-operation risk
+checks, and warnings from a current production snapshot. It is not a claim that
+the snapshot itself was produced by the spec or reached from `init`.
+
+## 2. Snapshot contract
+
+The input is the same complete logical-state JSON shape emitted by
+`Monitor.state`, replay traces, and generated conformance adapters:
+
+- every state variable is present and no unknown variable is accepted;
+- enums use member names, Option uses JSON `null` or its contained value;
+- Map keys use the displayed strings (`"0"`, enum member, `"true"`/`"false"`);
+- struct and Map-of-struct objects contain every field;
+- Set/Seq are arrays; relation is an array of two-element arrays;
+- domain bounds, Seq capacity, duplicate Set elements, and duplicate relation
+  pairs are checked before solving.
+
+`model.validate_state_snapshot` owns this validation and converts the public
+logical form into typed internal values. `bmc.state_snapshot_constraints` then
+pins the symbolic initial state. Maps cover every bounded key. Set/relation
+arrays are equated to complete constant-store arrays so values outside the
+logical domain cannot manufacture a false type-bound counterexample. Unused Seq
+slots receive a valid default because they are physically present but absent
+from the logical JSON shape.
+
+Partial snapshots are deliberately rejected. Treating an absent variable as a
+free symbolic value would answer a different existential question and could
+make an unsafe production state look safe.
+
+## 3. BMC-only semantics
+
+`--from-state` is accepted only by the BMC engine. K-induction proves a contract
+from all states satisfying its induction hypothesis and uses the spec's base
+case; replacing that base with one production point would change the meaning of
+`proved`. Combining `--engine induction --from-state` is therefore a semantics
+error, not a downgraded proof.
+
+The snapshot names concrete entity identities, so symmetry reduction is
+disabled for the run. Otherwise a valid labeled production state could be
+discarded merely because it is not the canonical representative of its
+symmetry class.
+
+All ordinary bounded checks still run: invariants, transition invariants,
+reachables, action coverage, deadlocks, and bounded liveness. Property filters,
+scope overrides, deadlock mode, and vacuity mode keep their existing meanings.
+Acceptance/forbidden self-checks and an `implements` seam remain spec-level
+checks; they are not rewritten as production-snapshot procedures.
+
+## 4. Faithfulness and cache contract
+
+Every successful BMC invocation (whether its result is `verified` or
+`violated`) adds:
+
+```json
+{
+  "initial_state": {
+    "source": "snapshot",
+    "path": "state.json",
+    "complete": true,
+    "replaces_spec_init": true
+  },
+  "faithfulness": {
+    "scope": "bounded_from_snapshot",
+    "spec_init": "not_used",
+    "induction": "not_applicable"
+  }
+}
+```
+
+This prevents the ordinary `verified` label from being read as “verified from
+the declared init.” The existing bounded `completeness` and `checked_to_depth`
+fields still describe the search horizon.
+
+Snapshot runs bypass the persistent verdict cache. The current cache key is
+defined over the spec and verify flags, not arbitrary external state content;
+reusing a normal-init or different-snapshot verdict would be unsound. A future
+cache may opt in only after hashing the canonical typed snapshot into the key.
+
+## 5. Failure and rollout boundaries
+
+- Invalid JSON is an `io` error with line/column.
+- Missing/extra variables, wrong types, or out-of-range values are `type`
+  errors before Z3 runs.
+- A snapshot that already violates an invariant returns a shortest trace with
+  `violated_at_step: 0`.
+- No schema migration, daemon, production connection, or snapshot persistence
+  is introduced.
+
+The implementation touches `model.py`, `bmc.py`, and `cli.py`. Regression tests
+in `tests/test_from_state.py` cover step-zero violation, safe bounded results,
+faithfulness metadata, induction rejection, CLI behavior, and Monitor-state
+round trips across scalar, enum, Option, struct, Map, Set, Seq, and relation.

--- a/docs/DESIGN-incremental-verify.md
+++ b/docs/DESIGN-incremental-verify.md
@@ -21,6 +21,10 @@ and re-wraps it with `_envelope` on a hit. It is **not** inside `bmc.py` or `run
 
 - `fslc mutate` calls `bmc.verify` directly → mutant verdicts never enter the cache and the
   kill-rate signal is never served from it.
+- `fslc verify --from-state` deliberately bypasses lookup and storage. The external
+  snapshot changes the initial constraint, and v1 does not include canonical snapshot
+  content in the cache key; bypassing is fail-closed and guarded by a signature-classification
+  metatest plus a normal-init-vs-snapshot regression.
 - The dual-evaluator cross-checks (`tests/test_evaluator_agreement.py`) and the Z3-independent
   oracle (`tests/oracle.py`) exercise `bmc`/`runtime` below the cache — they stay cache-free
   by construction, so the correctness safety net is unaffected.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -575,6 +575,7 @@ variable.
 fslc check     <file.fsl>                        # syntax / names / types only (fast)
 fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
                [--deadlock warn|error|ignore]
                [--vacuity warn|error|ignore]     # vacuity check (§15)
                [--property <Name>]               # check one named property in isolation —
@@ -606,6 +607,18 @@ fslc db import <file.sql> [--name Name] [-o out.fsl]            # minimal SQL DD
 fslc ai check <file.fsl> [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay <file.fsl> --logs events.jsonl                   # AI runtime event replay evidence
 ```
+
+`verify --from-state state.json` replaces the declared `init` for one bounded
+run and asks what can happen from that complete current state. The JSON shape is
+exactly `Monitor.state` / replay logical state: all variables and Map keys are
+required, enums are member names, Option is value or `null`, Set/Seq are arrays,
+and relation is an array of pairs. Missing/extra/type-invalid values are rejected
+before solving. Snapshot runs bypass the verdict cache, disable symmetry
+reduction (the identities are concrete), and reject `--engine induction`.
+Results add `initial_state.source:"snapshot"` and
+`faithfulness:{scope:"bounded_from_snapshot",spec_init:"not_used",induction:"not_applicable"}`
+so bounded `verified` cannot be mistaken for verification from the spec init.
+See `DESIGN-from-state.md`.
 
 In addition to `reachable` and action coverage, `scenarios` outputs, for each
 `leadsTo P ~> Q`, a `respond_<Name>[_<binding>]` scenario. Each scenario has

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 | [`DESIGN-dialects.md`](DESIGN-dialects.md) | Implementation spec for the dialects (declaration tags, fsl-req, fsl-biz) |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
+| [`DESIGN-from-state.md`](DESIGN-from-state.md) | Predictive BMC from a complete Monitor/replay logical-state snapshot (`verify --from-state`), including type validation, faithfulness metadata, cache/symmetry boundaries, and induction exclusion |
 | [`DESIGN-trans.md`](DESIGN-trans.md) | `trans` (transition invariant / two-state safety) |
 | [`DESIGN-temporal.md`](DESIGN-temporal.md) | leadsTo, weak fairness (lasso counterexamples), and respond scenarios |
 | [`DESIGN-refinement.md`](DESIGN-refinement.md) | Refinement checking (mapping files, conditional expressions, preserve progress) |

--- a/docs/intro/cli.en.html
+++ b/docs/intro/cli.en.html
@@ -93,6 +93,7 @@ options:
                    [--exclude-property EXCLUDE_PROPERTY_NAMES]
                    [--instances INSTANCES] [--values VALUES] [--strict-tags]
                    [--requirements REQUIREMENTS] [--no-cache]
+                   [--from-state FROM_STATE]
                    file
 
 positional arguments:
@@ -121,6 +122,9 @@ options:
   --requirements REQUIREMENTS
   --no-cache            skip the persistent verdict cache for this run
                         (neither reads nor writes it)
+  --from-state FROM_STATE
+                        replace spec init with a complete Monitor/replay
+                        logical-state JSON snapshot (BMC only)
 </pre></div></details>
 <details><summary>fslc sweep</summary><div class="tree-body"><pre>usage: fslc sweep [-h] [--depth DEPTH] [--engine {bmc,induction}] [--k K_IND]
                   [--deadlock {warn,error,ignore}]

--- a/docs/intro/cli.ja.html
+++ b/docs/intro/cli.ja.html
@@ -93,6 +93,7 @@ options:
                    [--exclude-property EXCLUDE_PROPERTY_NAMES]
                    [--instances INSTANCES] [--values VALUES] [--strict-tags]
                    [--requirements REQUIREMENTS] [--no-cache]
+                   [--from-state FROM_STATE]
                    file
 
 positional arguments:
@@ -121,6 +122,9 @@ options:
   --requirements REQUIREMENTS
   --no-cache            skip the persistent verdict cache for this run
                         (neither reads nor writes it)
+  --from-state FROM_STATE
+                        replace spec init with a complete Monitor/replay
+                        logical-state JSON snapshot (BMC only)
 </pre></div></details>
 <details><summary>fslc sweep</summary><div class="tree-body"><pre>usage: fslc sweep [-h] [--depth DEPTH] [--engine {bmc,induction}] [--k K_IND]
                   [--deadlock {warn,error,ignore}]

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -659,6 +659,7 @@ variable.</p></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
                [--deadlock warn|error|ignore]
                [--vacuity warn|error|ignore]     # vacuity check (§15)
                [--property &lt;Name&gt;]               # check one named property in isolation —
@@ -690,6 +691,17 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p><code>verify --from-state state.json</code> replaces the declared <code>init</code> for one bounded
+run and asks what can happen from that complete current state. The JSON shape is
+exactly <code>Monitor.state</code> / replay logical state: all variables and Map keys are
+required, enums are member names, Option is value or <code>null</code>, Set/Seq are arrays,
+and relation is an array of pairs. Missing/extra/type-invalid values are rejected
+before solving. Snapshot runs bypass the verdict cache, disable symmetry
+reduction (the identities are concrete), and reject <code>--engine induction</code>.
+Results add <code>initial_state.source:"snapshot"</code> and
+<code>faithfulness:{scope:"bounded_from_snapshot",spec_init:"not_used",induction:"not_applicable"}</code>
+so bounded <code>verified</code> cannot be mistaken for verification from the spec init.
+See <code>DESIGN-from-state.md</code>.</p>
 <p>In addition to <code>reachable</code> and action coverage, <code>scenarios</code> outputs, for each
 <code>leadsTo P ~&gt; Q</code>, a <code>respond_&lt;Name&gt;[_&lt;binding&gt;]</code> scenario. Each scenario has
 <code>kind: "leadsTo"</code>, <code>pending_at</code>, <code>satisfied_at</code>, <code>bindings</code>, <code>steps</code>,

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -659,6 +659,7 @@ variable.</p></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
                [--deadlock warn|error|ignore]
                [--vacuity warn|error|ignore]     # vacuity check (§15)
                [--property &lt;Name&gt;]               # check one named property in isolation —
@@ -690,6 +691,17 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p><code>verify --from-state state.json</code> replaces the declared <code>init</code> for one bounded
+run and asks what can happen from that complete current state. The JSON shape is
+exactly <code>Monitor.state</code> / replay logical state: all variables and Map keys are
+required, enums are member names, Option is value or <code>null</code>, Set/Seq are arrays,
+and relation is an array of pairs. Missing/extra/type-invalid values are rejected
+before solving. Snapshot runs bypass the verdict cache, disable symmetry
+reduction (the identities are concrete), and reject <code>--engine induction</code>.
+Results add <code>initial_state.source:"snapshot"</code> and
+<code>faithfulness:{scope:"bounded_from_snapshot",spec_init:"not_used",induction:"not_applicable"}</code>
+so bounded <code>verified</code> cannot be mistaken for verification from the spec init.
+See <code>DESIGN-from-state.md</code>.</p>
 <p>In addition to <code>reachable</code> and action coverage, <code>scenarios</code> outputs, for each
 <code>leadsTo P ~&gt; Q</code>, a <code>respond_&lt;Name&gt;[_&lt;binding&gt;]</code> scenario. Each scenario has
 <code>kind: "leadsTo"</code>, <code>pending_at</code>, <code>satisfied_at</code>, <code>bindings</code>, <code>steps</code>,

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -254,6 +254,9 @@ the formalization memo.**
    ok/verified/proved do untagged declarations and unreferenced requirement IDs
    become warnings.
 2. `fslc verify file.fsl --depth 8` → see the table below for what each result means
+   To ask a bounded operational what-if from a complete `Monitor.state` JSON,
+   use `fslc verify file.fsl --from-state state.json --depth 8`; this replaces
+   `init`, is BMC-only, and is stamped `bounded_from_snapshot`.
 3. Once verified, run `fslc verify file.fsl --engine induction` → done at `proved`
    (note: `--depth K` **includes** step K. Invariants become infinite-depth under
    `proved`; `leadsTo` remains bounded unless it declares `decreases <int expr>`,

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -681,6 +681,7 @@ fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--exclude-property <Name>]...       # skip named invariant/trans/leadsTo/reachable
                [--instances NAME=N]...              # override verify-block `instances NAME = N`
                [--values NAME=LO..HI]...            # override verify-block `values NAME = LO..HI`
+               [--from-state state.json]            # complete Monitor/replay state; replaces init (BMC only)
                [--strict-tags] [--requirements ids.txt] [--no-cache]
 fslc sweep <f> --instances NAME=LO..HI --depth LO..HI [--property Name]
                                                      # grid of verify runs; JSON sweep.results/minimal_counterexample
@@ -719,6 +720,17 @@ fslc ai drift <f> --logs events.jsonl [--baseline-logs p] [--window N] [--baseli
 fslc ai compat <f> [--environment <env>]                # emit a dbsystem artifact capability profile for AI compat
 fslc compat check <f> [--include-ai]                    # dbsystem compatibility check, optionally folding in AI capability profiles
 ```
+
+Use `verify --from-state` for bounded prediction from a current concrete state,
+not for proof. The input must be the complete logical JSON emitted by
+`Monitor.state`/replay (enum names, Option as value/`null`, complete Map keys,
+Set/Seq arrays, relation pairs). It replaces `init`, bypasses the verdict cache,
+disables symmetry reduction for concrete identities, and is rejected with the
+induction engine. Results always stamp
+`faithfulness.scope:"bounded_from_snapshot"`, `spec_init:"not_used"`, and
+`induction:"not_applicable"`. A step-zero invariant violation is a valid
+predictive result. Do not fill missing variables: partial snapshots are a
+different, weaker existential query and are rejected.
 
 `verify` is backed by a persistent verdict cache (issue #169) keyed on every
 input that can affect its output (the post-desugaring kernel AST, the raw

--- a/src/fslc/bmc.py
+++ b/src/fslc/bmc.py
@@ -22,6 +22,7 @@ from .model import (
     eval_const,
     phys_z3_sort,
     resolve_action_name,
+    validate_state_snapshot,
     z3_sort,
 )
 from .values import (
@@ -1513,6 +1514,118 @@ def init_constraints(spec, s0):
 
     for st in spec["init"]:
         run(st, {})
+    return cons
+
+
+def _snapshot_scalar_expr(value, ty):
+    if ty[0] == "bool":
+        return z3.BoolVal(value)
+    return z3.IntVal(value)
+
+
+def _snapshot_default_scalar(ty):
+    if ty[0] == "bool":
+        return False
+    if ty[0] == "domain":
+        return ty[1]
+    return 0
+
+
+def state_snapshot_constraints(spec, state, snapshot):
+    """Pin a symbolic state to complete Monitor/replay logical-state JSON."""
+
+    normalized = validate_state_snapshot(spec, snapshot)
+    cons = []
+
+    def add_scalar(phys, ty, value):
+        cons.append(state[phys] == _snapshot_scalar_expr(value, ty))
+
+    def add_value(name, ty, value):
+        if ty[0] in ("int", "bool", "domain", "enum"):
+            add_scalar(_phys_for_logical(spec, name), ty, value)
+            return
+        if ty[0] == "option":
+            present = value is not None
+            cons.append(state[f"{name}__present"] == z3.BoolVal(present))
+            if present:
+                add_scalar(f"{name}__value", ty[1], value)
+            return
+        if ty[0] == "struct":
+            for field, field_ty in spec["types"][ty[1]]["fields"].items():
+                field_value = value[field]
+                if field_ty[0] == "option":
+                    present = field_value is not None
+                    cons.append(state[f"{name}__{field}__present"] == z3.BoolVal(present))
+                    if present:
+                        add_scalar(f"{name}__{field}__value", field_ty[1], field_value)
+                else:
+                    add_scalar(f"{name}__{field}", field_ty, field_value)
+            return
+        if ty[0] == "map":
+            key_ty, value_ty = ty[1], ty[2]
+            for key, item in value.items():
+                zkey = _z3_domain_value(key_ty, key)
+                if value_ty[0] == "option":
+                    present = item is not None
+                    cons.append(z3.Select(state[f"{name}__present"], zkey) == present)
+                    if present:
+                        cons.append(
+                            z3.Select(state[f"{name}__value"], zkey)
+                            == _snapshot_scalar_expr(item, value_ty[1])
+                        )
+                elif value_ty[0] == "struct":
+                    for field, field_ty in spec["types"][value_ty[1]]["fields"].items():
+                        field_value = item[field]
+                        if field_ty[0] == "option":
+                            present = field_value is not None
+                            cons.append(
+                                z3.Select(state[f"{name}__{field}__present"], zkey) == present
+                            )
+                            if present:
+                                cons.append(
+                                    z3.Select(state[f"{name}__{field}__value"], zkey)
+                                    == _snapshot_scalar_expr(field_value, field_ty[1])
+                                )
+                        else:
+                            cons.append(
+                                z3.Select(state[f"{name}__{field}"], zkey)
+                                == _snapshot_scalar_expr(field_value, field_ty)
+                            )
+                else:
+                    cons.append(
+                        z3.Select(state[name], zkey) == _snapshot_scalar_expr(item, value_ty)
+                    )
+            return
+        if ty[0] == "set":
+            array = z3.K(state[name].sort().domain(), z3.BoolVal(False))
+            for item in value:
+                array = z3.Store(array, _z3_domain_value(ty[1], item), z3.BoolVal(True))
+            cons.append(state[name] == array)
+            return
+        if ty[0] == "seq":
+            cons.append(state[f"{name}__len"] == z3.IntVal(len(value)))
+            for index in range(ty[2]):
+                item = value[index] if index < len(value) else _snapshot_default_scalar(ty[1])
+                cons.append(
+                    z3.Select(state[f"{name}__data"], z3.IntVal(index))
+                    == _snapshot_scalar_expr(item, ty[1])
+                )
+            return
+        if ty[0] == "relation":
+            array = z3.K(state[name].sort().domain(), z3.BoolVal(False))
+            for source, target in value:
+                key = _relation_key(
+                    ty[1], ty[2],
+                    _z3_domain_value(ty[1], source),
+                    _z3_domain_value(ty[2], target), spec,
+                )
+                array = z3.Store(array, key, z3.BoolVal(True))
+            cons.append(state[name] == array)
+            return
+        _err(f"unsupported state snapshot type {ty}", kind="type")
+
+    for logical, ty in spec["state"].items():
+        add_value(logical, ty, normalized[logical])
     return cons
 
 
@@ -4886,7 +4999,8 @@ def _build_cover_trace(s, states, choices, instances, spec, step, idx, expr_cach
 
 
 def _bmc_explore(
-        spec, depth, deadlock_mode="warn", track_cover=False, vacuity_mode="warn"):
+        spec, depth, deadlock_mode="warn", track_cover=False, vacuity_mode="warn",
+        initial_snapshot=None):
     invariants = spec.get("invariants", [])
     transitions = spec.get("transitions", [])
     leadstos = spec.get("leadstos", [])
@@ -4900,7 +5014,11 @@ def _bmc_explore(
     s.set(unsat_core=True)
     inv_s = z3.Solver()
     with _eval_cache_scope(expr_cache, id(states[0])):
-        init_cons = init_constraints(spec, states[0])
+        init_cons = (
+            init_constraints(spec, states[0])
+            if initial_snapshot is None
+            else state_snapshot_constraints(spec, states[0], initial_snapshot)
+        )
     s.add(*init_cons)
     inv_s.add(*init_cons)
 
@@ -5254,18 +5372,23 @@ def _bmc_explore(
 
 def verify(
         spec, depth, deadlock_mode="warn", source_lines=None, vacuity_mode="warn",
-        property_name=None, exclude_property_names=None):
+        property_name=None, exclude_property_names=None, initial_snapshot=None):
     started = time.perf_counter()
     filtered, property_error = _select_properties(
         spec, property_name, exclude_property_names)
     if property_error is not None:
         return _finish_result(property_error, spec, depth, started, completeness="bounded")
     spec = filtered
+    if initial_snapshot is not None:
+        # A production snapshot names concrete identities; symmetry reduction
+        # must not discard it merely because its labels are non-canonical.
+        spec = {**spec, "symmetry": {}}
     explored = _bmc_explore(
         spec,
         depth,
         deadlock_mode=deadlock_mode,
         vacuity_mode=vacuity_mode,
+        initial_snapshot=initial_snapshot,
     )
     if explored["result"] != "explored":
         return _finish_result(explored, spec, depth, started, completeness="bounded")

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 from .diagnostics import with_faithfulness, trace_type_for
 from .parser import parse, parse_src, parse_refinement
-from .model import build_spec, check_spec, FslError, strict_tag_warnings
+from .model import (
+    build_spec,
+    check_spec,
+    FslError,
+    strict_tag_warnings,
+    validate_state_snapshot,
+)
 from .bmc import verify, prove, scenarios
 from . import verify_cache
 from .refine import build_refinement, refine, refine_chain
@@ -878,11 +884,30 @@ def _verify_cache_lookup(ast, display_names, src, engine, depth, k_ind, deadlock
 def run_verify(
         file, depth, deadlock_mode, engine="bmc", k_ind=1, vacuity_mode="warn",
         strict_tags=False, requirements=None, property_name=None,
-        exclude_property_names=None, instances=None, values=None, use_cache=True):
+        exclude_property_names=None, instances=None, values=None, use_cache=True,
+        from_state=None):
     try:
+        if from_state is not None and engine != "bmc":
+            raise FslError(
+                "--from-state is available only with the BMC engine; induction "
+                "proves the spec init contract and cannot start from one snapshot",
+                kind="semantics",
+            )
         bounds_overrides = _build_bounds_overrides(instances, values)
         has_bounds_overrides = bool(bounds_overrides["instances"] or bounds_overrides["values"])
         spec, source_lines, ast, display_names, src = _read_spec(file, bounds_overrides)
+        initial_snapshot = None
+        if from_state is not None:
+            try:
+                initial_snapshot = json.loads(Path(from_state).read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                raise FslError(f"file not found: {from_state}", kind="io")
+            except json.JSONDecodeError as exc:
+                raise FslError(
+                    f"invalid state JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+                    kind="io",
+                )
+            validate_state_snapshot(spec, initial_snapshot)
         acc, acc_skipped = _acceptance_error(spec, skip_out_of_range=has_bounds_overrides)
         if acc:
             return _envelope(acc)
@@ -891,7 +916,7 @@ def run_verify(
             return _envelope(forb)
 
         cache_key = xdepth_key = cached = None
-        if use_cache:
+        if use_cache and initial_snapshot is None:
             cache_key, xdepth_key, cached = _verify_cache_lookup(
                 ast, display_names, src, engine, depth, k_ind, deadlock_mode, vacuity_mode,
                 property_name, exclude_property_names, strict_tags, requirements,
@@ -921,6 +946,7 @@ def run_verify(
                 vacuity_mode=vacuity_mode,
                 property_name=property_name,
                 exclude_property_names=exclude_property_names,
+                initial_snapshot=initial_snapshot,
             )
         if verify_mode:
             cached_out, _source = cached
@@ -949,6 +975,19 @@ def run_verify(
             out["bounds_overrides"] = {
                 "instances": dict(bounds_overrides["instances"]),
                 "values": {k: [lo, hi] for k, (lo, hi) in bounds_overrides["values"].items()},
+            }
+        if initial_snapshot is not None:
+            out = dict(out)
+            out["initial_state"] = {
+                "source": "snapshot",
+                "path": str(from_state),
+                "complete": True,
+                "replaces_spec_init": True,
+            }
+            out["faithfulness"] = {
+                "scope": "bounded_from_snapshot",
+                "spec_init": "not_used",
+                "induction": "not_applicable",
             }
         if cache_key is not None and cached is None:
             try:
@@ -1815,6 +1854,9 @@ def _build_arg_parser():
     v.add_argument("--requirements", default=None)
     v.add_argument("--no-cache", action="store_true",
                    help="skip the persistent verdict cache for this run (neither reads nor writes it)")
+    v.add_argument("--from-state", default=None,
+                   help="replace spec init with a complete Monitor/replay logical-state "
+                        "JSON snapshot (BMC only)")
 
     sw = sub.add_parser("sweep", help="run bounded verification across a scope grid")
     sw.add_argument("file")
@@ -2258,7 +2300,8 @@ def _dispatch(args):
                             exclude_property_names=args.exclude_property_names,
                             instances=args.instances,
                             values=args.values,
-                            use_cache=not args.no_cache)
+                            use_cache=not args.no_cache,
+                            from_state=args.from_state)
         print(json.dumps(result, indent=2, ensure_ascii=False))
 
     sys.exit(exit_code(result))

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -165,6 +165,147 @@ def domain_range(ty, types_meta):
     _err(f"expected bounded type, got {ty}", kind="type")
 
 
+def _snapshot_scalar(value, ty, types_meta, path):
+    if ty[0] == "bool":
+        if not isinstance(value, bool):
+            _err(f"{path}: expected Bool, got {value!r}", kind="type")
+        return value
+    if ty[0] == "int":
+        if not isinstance(value, int) or isinstance(value, bool):
+            _err(f"{path}: expected Int, got {value!r}", kind="type")
+        return value
+    if ty[0] == "domain":
+        if not isinstance(value, int) or isinstance(value, bool):
+            _err(f"{path}: expected bounded integer, got {value!r}", kind="type")
+        lo, hi = domain_range(ty, types_meta)
+        if value < lo or value > hi:
+            _err(f"{path}: value {value} is out of range [{lo}..{hi}]", kind="type")
+        return value
+    if ty[0] == "enum":
+        members = types_meta[ty[1]]["members"]
+        if not isinstance(value, str) or value not in members:
+            _err(
+                f"{path}: expected {ty[1]} enum member {members}, got {value!r}",
+                kind="type",
+            )
+        return members.index(value)
+    _err(f"{path}: expected scalar type, got {ty}", kind="type")
+
+
+def _snapshot_domain_values(ty, types_meta):
+    if ty[0] == "bool":
+        return [False, True]
+    lo, hi = domain_range(ty, types_meta)
+    return list(range(lo, hi + 1))
+
+
+def _snapshot_display_key(key, ty, types_meta):
+    if ty[0] == "bool":
+        return "true" if key else "false"
+    if ty[0] == "enum":
+        return types_meta[ty[1]]["members"][key]
+    return str(key)
+
+
+def _validate_snapshot_value(value, ty, types_meta, path):
+    if ty[0] in ("bool", "int", "domain", "enum"):
+        return _snapshot_scalar(value, ty, types_meta, path)
+    if ty[0] == "option":
+        if value is None:
+            return None
+        return _validate_snapshot_value(value, ty[1], types_meta, path)
+    if ty[0] == "struct":
+        if not isinstance(value, dict):
+            _err(f"{path}: expected object for struct {ty[1]}", kind="type")
+        fields = types_meta[ty[1]]["fields"]
+        missing = sorted(set(fields) - set(value))
+        extra = sorted(set(value) - set(fields))
+        if missing:
+            _err(f"{path}: missing struct field '{missing[0]}'", kind="type")
+        if extra:
+            _err(f"{path}: unknown struct field '{extra[0]}'", kind="type")
+        return {
+            field: _validate_snapshot_value(value[field], field_ty, types_meta,
+                                            f"{path}.{field}")
+            for field, field_ty in fields.items()
+        }
+    if ty[0] == "map":
+        if not isinstance(value, dict):
+            _err(f"{path}: expected object for Map", kind="type")
+        expected = {
+            _snapshot_display_key(key, ty[1], types_meta): key
+            for key in _snapshot_domain_values(ty[1], types_meta)
+        }
+        missing = sorted(set(expected) - set(value))
+        extra = sorted(set(value) - set(expected))
+        if missing:
+            _err(f"{path}: missing Map key '{missing[0]}'", kind="type")
+        if extra:
+            _err(f"{path}: unknown Map key '{extra[0]}'", kind="type")
+        return {
+            key: _validate_snapshot_value(
+                value[display], ty[2], types_meta, f"{path}[{display}]"
+            )
+            for display, key in expected.items()
+        }
+    if ty[0] == "set":
+        if not isinstance(value, list):
+            _err(f"{path}: expected array for Set", kind="type")
+        normalized = [
+            _validate_snapshot_value(item, ty[1], types_meta, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+        if len(normalized) != len(set(normalized)):
+            _err(f"{path}: duplicate Set element", kind="type")
+        return frozenset(normalized)
+    if ty[0] == "seq":
+        if not isinstance(value, list):
+            _err(f"{path}: expected array for Seq", kind="type")
+        if len(value) > ty[2]:
+            _err(f"{path}: Seq length {len(value)} exceeds capacity {ty[2]}", kind="type")
+        return [
+            _validate_snapshot_value(item, ty[1], types_meta, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    if ty[0] == "relation":
+        if not isinstance(value, list):
+            _err(f"{path}: expected array of pairs for relation", kind="type")
+        normalized = []
+        for index, pair in enumerate(value):
+            if not isinstance(pair, list) or len(pair) != 2:
+                _err(f"{path}[{index}]: relation entry must be a two-element array",
+                     kind="type")
+            normalized.append((
+                _validate_snapshot_value(pair[0], ty[1], types_meta, f"{path}[{index}][0]"),
+                _validate_snapshot_value(pair[1], ty[2], types_meta, f"{path}[{index}][1]"),
+            ))
+        if len(normalized) != len(set(normalized)):
+            _err(f"{path}: duplicate relation pair", kind="type")
+        return frozenset(normalized)
+    _err(f"{path}: unsupported snapshot type {ty}", kind="type")
+
+
+def validate_state_snapshot(spec, snapshot):
+    """Validate Monitor/replay logical-state JSON and return internal values."""
+
+    if not isinstance(snapshot, dict):
+        _err("state snapshot must be a JSON object", kind="type")
+    display_names = spec.get("display_names") or {}
+    public_to_logical = {display_names.get(name, name): name for name in spec["state"]}
+    missing = sorted(set(public_to_logical) - set(snapshot))
+    extra = sorted(set(snapshot) - set(public_to_logical))
+    if missing:
+        _err(f"missing state variable '{missing[0]}'", kind="type")
+    if extra:
+        _err(f"unknown state variable '{extra[0]}'", kind="type")
+    return {
+        logical: _validate_snapshot_value(
+            snapshot[public], spec["state"][logical], spec["types"], f"state.{public}"
+        )
+        for public, logical in public_to_logical.items()
+    }
+
+
 def enum_member_index(types_meta, member_name):
     for ename, info in types_meta.items():
         if info["kind"] == "enum" and member_name in info["members"]:

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -198,7 +198,7 @@ TOP_DEF_DESIGN_DOCS = {
 COMMAND_DESIGN_DOCS = {
     "version": "CLI plumbing, no design doc of its own",
     "check": ("DESIGN-v1.md",),
-    "verify": ("DESIGN-v1.md", "DESIGN-induction.md"),
+    "verify": ("DESIGN-v1.md", "DESIGN-induction.md", "DESIGN-from-state.md"),
     "sweep": "scope-grid driver over verify; no standalone semantics (documented in LANGUAGE.md)",
     "scenarios": ("DESIGN-scenarios.md",),
     "replay": ("DESIGN-bridge.md",),

--- a/tests/test_from_state.py
+++ b/tests/test_from_state.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Predictive BMC from a concrete logical-state snapshot (issue #175)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from fslc import build_spec, parse
+from fslc.bmc import verify
+from fslc.cli import exit_code, run_verify
+from fslc.runtime import Monitor
+
+
+PREDICT_SPEC = """
+spec PredictiveCounter {
+  type Count = 0..2
+  state { count: Count }
+  init { count = 0 }
+  action increment() {
+    requires count < 1
+    count = count + 1
+  }
+  invariant Safe { count <= 1 }
+}
+"""
+
+SHAPES_SPEC = """
+spec SnapshotShapes {
+  const CAP = 2
+  type Id = 0..1
+  enum Phase { Open, Closed }
+  struct Item { phase: Phase, owner: Option<Id> }
+  state {
+    flag: Bool,
+    count: Int,
+    phase: Phase,
+    selected: Option<Id>,
+    item: Item,
+    rows: Map<Id, Item>,
+    seen: Set<Id>,
+    queue: Seq<Id, CAP>,
+    links: relation Id -> Id
+  }
+  init {
+    flag = false
+    count = 0
+    phase = Open
+    selected = none
+    item = Item { phase: Open, owner: none }
+    forall i: Id { rows[i] = Item { phase: Open, owner: none } }
+    seen = Set {}
+    queue = Seq {}
+    links = Set {}
+  }
+  action populate() {
+    flag = true
+    count = 1
+    phase = Closed
+    selected = some(1)
+    item = Item { phase: Closed, owner: some(1) }
+    rows[1] = Item { phase: Closed, owner: some(1) }
+    seen = seen.add(1)
+    queue = queue.push(1)
+    links = links.add(0, 1)
+  }
+  invariant CountBound { count <= 1 }
+}
+"""
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_spec(tmp_path, source=PREDICT_SPEC):
+    path = tmp_path / "predictive.fsl"
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _write_state(tmp_path, state, name="state.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(state), encoding="utf-8")
+    return path
+
+
+def test_from_state_finds_step_zero_violation_unreachable_from_spec_init(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    snapshot_path = _write_state(tmp_path, {"count": 2})
+
+    normal = run_verify(
+        str(spec_path), 0, "ignore", use_cache=False
+    )
+    predicted = run_verify(
+        str(spec_path), 0, "ignore", from_state=str(snapshot_path)
+    )
+
+    assert normal["result"] == "verified"
+    assert predicted["result"] == "violated"
+    assert predicted["violation_kind"] == "invariant"
+    assert predicted["violated_at_step"] == 0
+    assert predicted["trace"][0]["state"] == {"count": 2}
+    assert exit_code(predicted) == 1
+
+
+def test_from_state_can_verify_safe_snapshot_and_stamps_faithfulness(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    snapshot_path = _write_state(tmp_path, {"count": 1})
+
+    result = run_verify(
+        str(spec_path), 1, "ignore", from_state=str(snapshot_path)
+    )
+
+    assert result["result"] == "verified"
+    assert result["initial_state"] == {
+        "source": "snapshot",
+        "path": str(snapshot_path),
+        "complete": True,
+        "replaces_spec_init": True,
+    }
+    assert result["faithfulness"] == {
+        "scope": "bounded_from_snapshot",
+        "spec_init": "not_used",
+        "induction": "not_applicable",
+    }
+    assert "cache" not in result
+
+
+def test_verify_library_accepts_initial_snapshot_without_cli(tmp_path):
+    del tmp_path
+    spec = build_spec(parse(PREDICT_SPEC))
+
+    result = verify(spec, 0, deadlock_mode="ignore", initial_snapshot={"count": 2})
+
+    assert result["result"] == "violated"
+    assert result["violated_at_step"] == 0
+
+
+def test_monitor_logical_state_json_round_trips_into_from_state(tmp_path):
+    spec_path = ROOT / "specs" / "cart_v1.fsl"
+    monitor = Monitor(str(spec_path))
+    monitor.reset()
+    step = monitor.step("add_to_cart", {"u": 0, "i": 1})
+    assert step["ok"] is True
+    snapshot_path = _write_state(tmp_path, monitor.state)
+
+    result = run_verify(
+        str(spec_path), 0, "ignore", from_state=str(snapshot_path),
+        exclude_property_names=["SoldOut"],
+    )
+
+    assert result["result"] == "verified"
+    assert result["initial_state"]["source"] == "snapshot"
+
+
+def test_all_monitor_state_shapes_round_trip_into_snapshot_constraints(tmp_path):
+    spec_path = _write_spec(tmp_path, SHAPES_SPEC)
+    monitor = Monitor(str(spec_path))
+    monitor.reset()
+    step = monitor.step("populate", {})
+    assert step["ok"] is True
+    snapshot_path = _write_state(tmp_path, monitor.state)
+
+    result = run_verify(
+        str(spec_path), 0, "ignore", from_state=str(snapshot_path)
+    )
+
+    assert result["result"] == "verified", result
+    assert result["initial_state"]["complete"] is True
+
+
+def test_composed_monitor_display_keys_are_accepted_by_library_snapshot():
+    monitor = Monitor(str(ROOT / "specs" / "order_system.fsl"))
+    snapshot = monitor.reset()
+    excluded = [item["name"] for item in monitor.spec.get("reachables", [])]
+
+    result = verify(
+        monitor.spec,
+        0,
+        deadlock_mode="ignore",
+        exclude_property_names=excluded,
+        initial_snapshot=snapshot,
+    )
+
+    assert result["result"] == "verified", result
+
+
+def test_from_state_requires_complete_exact_state_shape(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    missing = _write_state(tmp_path, {}, "missing.json")
+    extra = _write_state(tmp_path, {"count": 0, "other": 1}, "extra.json")
+
+    missing_result = run_verify(str(spec_path), 0, "ignore", from_state=str(missing))
+    extra_result = run_verify(str(spec_path), 0, "ignore", from_state=str(extra))
+
+    assert missing_result["result"] == "error"
+    assert missing_result["kind"] == "type"
+    assert "missing state variable 'count'" in missing_result["message"]
+    assert extra_result["result"] == "error"
+    assert extra_result["kind"] == "type"
+    assert "unknown state variable 'other'" in extra_result["message"]
+
+
+def test_from_state_rejects_wrong_type_and_out_of_range_value(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    wrong_type = _write_state(tmp_path, {"count": "1"}, "wrong.json")
+    out_of_range = _write_state(tmp_path, {"count": 3}, "range.json")
+
+    wrong_result = run_verify(str(spec_path), 0, "ignore", from_state=str(wrong_type))
+    range_result = run_verify(str(spec_path), 0, "ignore", from_state=str(out_of_range))
+
+    assert wrong_result["result"] == "error"
+    assert wrong_result["kind"] == "type"
+    assert "state.count" in wrong_result["message"]
+    assert range_result["result"] == "error"
+    assert range_result["kind"] == "type"
+    assert "out of range [0..2]" in range_result["message"]
+
+
+def test_from_state_is_bmc_only_and_rejects_induction(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    snapshot_path = _write_state(tmp_path, {"count": 1})
+
+    result = run_verify(
+        str(spec_path), 1, "ignore", engine="induction", from_state=str(snapshot_path)
+    )
+
+    assert result["result"] == "error"
+    assert result["kind"] == "semantics"
+    assert "BMC" in result["message"]
+    assert exit_code(result) == 2
+
+
+def test_from_state_reports_invalid_json_as_io_error(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    snapshot_path = tmp_path / "broken.json"
+    snapshot_path.write_text('{"count":', encoding="utf-8")
+
+    result = run_verify(
+        str(spec_path), 0, "ignore", from_state=str(snapshot_path)
+    )
+
+    assert result["result"] == "error"
+    assert result["kind"] == "io"
+    assert "invalid state JSON" in result["message"]
+
+
+def test_verify_cli_accepts_from_state(tmp_path):
+    spec_path = _write_spec(tmp_path)
+    snapshot_path = _write_state(tmp_path, {"count": 2})
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "fslc",
+            "verify",
+            str(spec_path),
+            "--depth",
+            "0",
+            "--deadlock",
+            "ignore",
+            "--from-state",
+            str(snapshot_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(proc.stdout)
+    assert proc.returncode == 1, proc.stderr
+    assert result["result"] == "violated"
+    assert result["initial_state"]["replaces_spec_init"] is True

--- a/tests/test_verify_cache.py
+++ b/tests/test_verify_cache.py
@@ -266,6 +266,7 @@ def test_verified_result_is_not_reused_across_depths(cache_dir, tmp_path):
 # key-completeness guard
 # --------------------------------------------------------------------------
 _NON_SEMANTIC_RUN_VERIFY_PARAMS = {"file", "use_cache"}
+_CACHE_BYPASSED_SEMANTIC_RUN_VERIFY_PARAMS = {"from_state"}
 
 
 def test_run_verify_signature_is_fully_classified():
@@ -280,12 +281,29 @@ def test_run_verify_signature_is_fully_classified():
     # run_verify's `requirements` (a path) becomes compute_key's
     # `requirements_sha256`; everything else must match by name.
     mapped = {"requirements": "requirements_sha256"}
-    for name in run_verify_params - _NON_SEMANTIC_RUN_VERIFY_PARAMS:
+    classified = (
+        _NON_SEMANTIC_RUN_VERIFY_PARAMS
+        | _CACHE_BYPASSED_SEMANTIC_RUN_VERIFY_PARAMS
+    )
+    for name in run_verify_params - classified:
         target = mapped.get(name, name)
         assert target in key_params or name in ("ast", "display_names", "src"), (
             f"run_verify parameter {name!r} is not threaded into verify_cache.compute_key "
             "and is not on the non-semantic allowlist -- classify it"
         )
+
+
+def test_from_state_never_reuses_normal_init_cache(cache_dir, tmp_path):
+    spec = _counter(tmp_path, bound=1)
+    normal = run_verify(str(spec), 0, "ignore")
+    assert normal["result"] == "verified"
+
+    snapshot = _write(tmp_path, "state.json", '{"x": 2}')
+    predicted = run_verify(str(spec), 0, "ignore", from_state=str(snapshot))
+
+    assert predicted["result"] == "violated"
+    assert predicted["violated_at_step"] == 0
+    assert "cache" not in predicted
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Add `fslc verify SPEC --from-state state.json` to replace the declared init with a complete Monitor/replay logical-state snapshot for bounded predictive verification.

## Why
- **Goal:** answer “can this current production state reach a violation within K steps?” without inventing a new state format.
- **Reason:** Monitor/replay already define the canonical logical JSON representation; BMC only needs a typed replacement initial constraint.
- **Alternative rejected:** adding snapshot constraints on top of `init` would reject the exact out-of-init states this feature is meant to inspect.

## What Changed
- Added complete snapshot type/shape validation for every kernel state type in `model.py`.
- Added Z3 snapshot pinning and BMC initial-constraint replacement in `bmc.py`.
- Added `verify --from-state`, BMC-only enforcement, cache bypass, concrete-identity symmetry handling, and explicit faithfulness metadata.
- Updated language/skill/design docs and regenerated the committed website references.

## Invariants
| Must stay true | Evidence | Failure symptom |
|---|---|---|
| Normal verify still starts from spec `init` | existing v1/induction/full suite | ordinary verdicts change |
| Induction never claims proof from one snapshot | explicit rejection test | snapshot run returns `proved` |
| Snapshot state is complete and typed | scalar + all-state-shapes regressions | missing/free values create false confidence |
| Cached init verdict is never reused | cache bypass regression | normal and snapshot runs share stale verdict |
| Snapshot scope is visible in JSON | exact metadata assertion | bounded result is misread as init-based verification |

## Blast Radius
- **Affected:** `verify` CLI, BMC initial constraints, logical-state JSON validation, cache classification, generated CLI/language pages.
- **Unchanged:** grammar, spec `init` semantics for normal runs, induction engine, replay format, exit-code classes.
- **Compatibility:** additive option and fields; no persisted data or migration.

## Failure Modes
- Invalid JSON → `io` error with line/column.
- Missing/extra/wrong-type/out-of-range state → `type` error before solving.
- Already-unsafe snapshot → shortest violation at step 0.
- `--engine induction --from-state` → semantics error.

## Evidence
- [x] Full suite: `.venv/bin/pytest -q` — 1294 passed, 78 skipped.
- [x] Snapshot + cache + induction focused suite — 49 passed.
- [x] Monitor/replay state-shape round trips — 11 passed.
- [x] Site/coupled-change tests — 9 passed.
- [x] Corpus snapshot — 181 passed, 1 skipped.
- [x] `git diff --check` and `compileall`.

## Rollout & Rollback
- **Rollout:** additive BMC option; snapshot runs bypass cache by construction.
- **Rollback:** revert commit `9fb2ea1`.
- **Cannot rollback if:** not applicable.

## Review Focus
- [ ] `src/fslc/model.py`: Monitor JSON compatibility and exact shape validation.
- [ ] `src/fslc/bmc.py`: array pinning, unused Seq slots, and snapshot-vs-init selection.
- [ ] `src/fslc/cli.py`: induction gate, cache bypass, and faithfulness stamp.

## Unknowns
- Partial snapshots are intentionally deferred; they need explicitly weaker existential semantics and distinct metadata.
- Snapshot caching is deferred until canonical typed snapshot content is included in the key.

Closes #175
