### PR TITLE
feat(diff): add bounded semantic specification comparison

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -9,3 +9,4 @@ tests/test_self.py
 tests/test_spec_domains.py
 tests/test_trans.py
 tests/test_verify_cache.py
+tests/test_semantic_diff.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Semantic specification diff (issue #176): `fslc diff OLD.fsl NEW.fsl
+  --depth K` classifies bounded changes through bidirectional auto-refinement
+  (`behavior_added` / `behavior_removed`), SMT implication of user-invariant
+  conjunctions (`invariant_weakened` / `invariant_strengthened`), and replay of
+  OLD negative scenarios against NEW (`forbidden_relaxed`). Directional
+  differences include counterexample witnesses; incompatible names are
+  explicit `unknown` unless a one-direction `--mapping` is supplied. Changes
+  to `verify` entity/number bounds are first-class `scope_changed` findings and
+  comparisons record/use NEW's scope. Findings are analysis (exit 0); only an
+  explicit `--forbid kind,...` gate exits 1. See
+  `docs/DESIGN-semantic-diff.md`.
 - Assurance classes (issue #171): a shared `fslc.assurance` classifier turns
   every command's result dict (BMC `verify`, k-induction `prove`, and the
   fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"` producers — replay,

--- a/docs/DESIGN-semantic-diff.md
+++ b/docs/DESIGN-semantic-diff.md
@@ -1,0 +1,117 @@
+# Semantic specification diff
+
+Issue: #176
+
+## Goal and boundary
+
+`fslc diff OLD.fsl NEW.fsl --depth K` compares two specifications as state
+machines rather than comparing their source text. It answers three bounded
+review questions:
+
+1. Does NEW admit a behavior OLD did not (`behavior_added`)?
+2. Does NEW remove a behavior OLD admitted (`behavior_removed`)?
+3. Did the declared safety contract become weaker or stronger
+   (`invariant_weakened` / `invariant_strengthened`), or did an OLD
+   `forbidden` scenario become executable (`forbidden_relaxed`)?
+
+This is analysis, not an unbounded proof. Every result includes
+`bounded:{depth, completeness:"bounded"}`. A clean diff means no difference was
+found within that contract and scope; it does not prove semantic equivalence at
+all depths.
+
+## Comparison algorithm
+
+### Bidirectional refinement
+
+With identity-compatible state and action names, the command synthesizes
+`maps auto` and checks both directions:
+
+- NEW refines OLD: failure is `behavior_added`.
+- OLD refines NEW: failure is `behavior_removed`.
+
+A directional failure carries the refinement counterexample as
+`witness:{trace_type:"counterexample", trace, violation}`. This reuses the
+refinement engine's shortest bounded implementation trace and keeps its action,
+step, and mismatch evidence.
+
+Different state or action names are not guessed. That direction is `unknown`
+with the exact `only_impl` / `only_abs` names. `--mapping FILE` is the escape
+hatch: the file may map NEW→OLD or OLD→NEW and is used for that direction. The
+opposite direction still uses identity auto-mapping when possible; a mapping is
+not mechanically inverted because arbitrary state expressions and stutter do
+not have a sound general inverse.
+
+### Invariant implication
+
+When the logical and physical state schemas match, the command asks Z3 whether
+the conjunctions of user invariants imply each other, under the implicit type
+bounds:
+
+- OLD ⇒ NEW and not NEW ⇒ OLD: `invariant_weakened`.
+- NEW ⇒ OLD and not OLD ⇒ NEW: `invariant_strengthened`.
+- both implications: equivalent invariant contracts.
+- neither implication: `unknown` (`invariant_sets_are_incomparable`).
+
+A failed implication carries a concrete state witness. Implicit type-bound
+invariants constrain the query but are not themselves classified as authored
+invariant changes.
+
+### Forbidden replay
+
+Each OLD `forbidden` scenario is replayed against NEW. If NEW accepts the step
+OLD required to be rejected, the result contains `forbidden_relaxed` and the
+accepted trace. A scenario that cannot be related because its action or
+arguments no longer exist becomes `unknown`, not a false relaxation finding.
+
+## Scope changes
+
+Source-level `verify { instances ...; values ... }` bounds are recorded under
+`scope.old` and `scope.new`. A difference is a first-class `scope_changed`
+finding. Comparisons use the NEW side as the declared comparison scope: shared
+OLD entity/number bounds are overridden with NEW's values before OLD is
+desugared and built. `scope.applied_to_old` records the exact overrides, so a
+consumer never has to infer which finite universe was compared.
+
+Inline kernel `type X = lo..hi` declarations remain type contracts, not
+`verify` scope metadata. Refinement's normal domain-bound handling applies to
+them.
+
+## JSON and exit contract
+
+The stable top-level shape is:
+
+```json
+{
+  "result": "semantic_diff",
+  "bounded": {"depth": 8, "completeness": "bounded"},
+  "scope": {"old": {}, "new": {}, "comparison": "new", "applied_to_old": {}},
+  "directions": {"new_to_old": {}, "old_to_new": {}},
+  "summary": ["behavior_added"],
+  "findings": [],
+  "gate": {"forbidden": [], "violations": [], "passed": true}
+}
+```
+
+Finding kinds are `behavior_added`, `behavior_removed`,
+`invariant_weakened`, `invariant_strengthened`, `forbidden_relaxed`,
+`scope_changed`, and `unknown`. With no findings, `summary` is exactly
+`["no_semantic_change"]`.
+
+Analysis completion exits 0 even when findings exist. CI policy is explicit:
+
+```bash
+fslc diff old.fsl new.fsl --depth 8 \
+  --forbid behavior_added,invariant_weakened,forbidden_relaxed
+```
+
+Only a finding named by `--forbid` makes `gate.passed:false` and exits 1.
+Parse/type/IO errors remain exit 2 and internal failures exit 3. This separates
+an informative change report from a repository-specific compatibility gate.
+
+## Non-goals
+
+- Source/AST edit descriptions; use the VCS diff for those.
+- Unbounded language equivalence.
+- Automatic inversion of arbitrary refinement mappings.
+- Comparing non-adjacent project-chain revisions; a future project-aware layer
+  can compose mappings and call this directional core.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -587,6 +587,9 @@ fslc scenarios <file.fsl> [--depth K]            # generate integration-test sca
 fslc replay    <file.fsl> --trace <events.json>  # conformance check of an event log (§12)
 fslc testgen   <file.fsl> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    <impl> <abs> <mapping> [--depth K]# fidelity check of a detailed spec (§10)
+fslc diff      <old> <new> [--depth K] [--mapping map.fsl]
+               [--forbid behavior_added,invariant_weakened,forbidden_relaxed]
+                                                 # bounded semantic change analysis
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]  # spec mutation (§15)
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
@@ -630,8 +633,29 @@ under `sweep.minimal_counterexample`. For `--values`, the sweep fixes the lower
 bound and expands the upper bound (`lo..lo`, `lo..lo+1`, ..., `lo..hi`). A
 passing sweep means "no counterexample in this grid", not an unbounded proof.
 
+`diff` compares state-machine meaning instead of source text. It runs bounded
+refinement in both directions: NEW→OLD failure is `behavior_added`, while
+OLD→NEW failure is `behavior_removed`. It separately checks implication between
+the conjunctions of user invariants (`invariant_weakened` /
+`invariant_strengthened`) and replays OLD `forbidden` scenarios against NEW
+(`forbidden_relaxed`). Directional failures include counterexample witnesses.
+Same-named compatible state/actions are mapped automatically; name mismatches
+are `unknown` unless `--mapping` supplies that direction. An arbitrary mapping
+is never inverted automatically.
+
+The JSON result is `semantic_diff` with `bounded`, `scope`, `directions`,
+`summary`, `findings`, and `gate`. A changed `verify { instances/values }`
+scope is reported as `scope_changed`, and shared OLD bounds are rebuilt under
+the NEW scope recorded by `scope.comparison:"new"` and
+`scope.applied_to_old`. With no findings, `summary` is
+`["no_semantic_change"]`. Findings are analysis output and therefore exit 0 by
+default. Only findings explicitly listed by comma-separated `--forbid` make
+the gate fail and exit 1. All comparisons remain bounded to `--depth`; clean
+output is not an unbounded equivalence proof.
+
 Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant / refines /
-mutated / explained / analyzed / typestate / sweep_passed / observed_conformant /
+mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
+typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
 `1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
 sweep_failed / observed_mismatch,

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 | [`DESIGN-trans.md`](DESIGN-trans.md) | `trans` (transition invariant / two-state safety) |
 | [`DESIGN-temporal.md`](DESIGN-temporal.md) | leadsTo, weak fairness (lasso counterexamples), and respond scenarios |
 | [`DESIGN-refinement.md`](DESIGN-refinement.md) | Refinement checking (mapping files, conditional expressions, preserve progress) |
+| [`DESIGN-semantic-diff.md`](DESIGN-semantic-diff.md) | `fslc diff` bounded semantic comparison (bidirectional refinement, invariant implication, forbidden replay, scope and gate contract) |
 | [`DESIGN-compose.md`](DESIGN-compose.md) | Spec composition (namespaces, synchronized actions, internal) |
 | [`DESIGN-bridge.md`](DESIGN-bridge.md) | Implementation bridge (runtime Monitor / replay / testgen) |
 | [`DESIGN-scenarios.md`](DESIGN-scenarios.md) | scenarios and the unsat-core diagnostics for coverage |

--- a/docs/intro/cli.en.html
+++ b/docs/intro/cli.en.html
@@ -32,6 +32,8 @@
     </div>
     <details open><summary>Exit codes &amp; JSON envelope <span class="tree-blurb">— exit_code() / _envelope() / _error_envelope(), from src/fslc/cli.py</span></summary><div class="tree-body"><p>Every command prints one JSON object to stdout and maps its <code>result</code> field to a process exit code through this function — verbatim from the source, so this table cannot drift from the actual contract:</p><pre>def exit_code(result):
     r = result.get(&quot;result&quot;)
+    if r == &quot;semantic_diff&quot;:
+        return 0 if result.get(&quot;gate&quot;, {}).get(&quot;passed&quot;, True) else 1
     if r in (&quot;verified&quot;, &quot;proved&quot;, &quot;scenarios&quot;, &quot;conformant&quot;, &quot;generated&quot;,
              &quot;refines&quot;, &quot;typestate&quot;, &quot;mutated&quot;, &quot;explained&quot;, &quot;analyzed&quot;,
              &quot;verified_under_assumptions&quot;, &quot;agent_analyzed&quot;, &quot;replay_conformant&quot;,
@@ -257,6 +259,19 @@ positional arguments:
 options:
   -h, --help     show this help message and exit
   --depth DEPTH
+</pre></div></details>
+<details><summary>fslc diff</summary><div class="tree-body"><pre>usage: fslc diff [-h] [--depth DEPTH] [--mapping MAPPING] [--forbid FORBID]
+                 old new
+
+positional arguments:
+  old
+  new
+
+options:
+  -h, --help         show this help message and exit
+  --depth DEPTH
+  --mapping MAPPING  optional refinement mapping for one comparison direction
+  --forbid FORBID    comma-separated finding kinds that should fail the gate
 </pre></div></details>
 <details><summary>fslc chain</summary><div class="tree-body"><pre>usage: fslc chain [-h] [--keep-going] [path]
 

--- a/docs/intro/cli.ja.html
+++ b/docs/intro/cli.ja.html
@@ -32,6 +32,8 @@
     </div>
     <details open><summary>Exit codes &amp; JSON envelope <span class="tree-blurb">— exit_code() / _envelope() / _error_envelope(), from src/fslc/cli.py</span></summary><div class="tree-body"><p>Every command prints one JSON object to stdout and maps its <code>result</code> field to a process exit code through this function — verbatim from the source, so this table cannot drift from the actual contract:</p><pre>def exit_code(result):
     r = result.get(&quot;result&quot;)
+    if r == &quot;semantic_diff&quot;:
+        return 0 if result.get(&quot;gate&quot;, {}).get(&quot;passed&quot;, True) else 1
     if r in (&quot;verified&quot;, &quot;proved&quot;, &quot;scenarios&quot;, &quot;conformant&quot;, &quot;generated&quot;,
              &quot;refines&quot;, &quot;typestate&quot;, &quot;mutated&quot;, &quot;explained&quot;, &quot;analyzed&quot;,
              &quot;verified_under_assumptions&quot;, &quot;agent_analyzed&quot;, &quot;replay_conformant&quot;,
@@ -257,6 +259,19 @@ positional arguments:
 options:
   -h, --help     show this help message and exit
   --depth DEPTH
+</pre></div></details>
+<details><summary>fslc diff</summary><div class="tree-body"><pre>usage: fslc diff [-h] [--depth DEPTH] [--mapping MAPPING] [--forbid FORBID]
+                 old new
+
+positional arguments:
+  old
+  new
+
+options:
+  -h, --help         show this help message and exit
+  --depth DEPTH
+  --mapping MAPPING  optional refinement mapping for one comparison direction
+  --forbid FORBID    comma-separated finding kinds that should fail the gate
 </pre></div></details>
 <details><summary>fslc chain</summary><div class="tree-body"><pre>usage: fslc chain [-h] [--keep-going] [path]
 

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -671,6 +671,9 @@ fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-te
 fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # conformance check of an event log (§12)
 fslc testgen   &lt;file.fsl&gt; [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    &lt;impl&gt; &lt;abs&gt; &lt;mapping&gt; [--depth K]# fidelity check of a detailed spec (§10)
+fslc diff      &lt;old&gt; &lt;new&gt; [--depth K] [--mapping map.fsl]
+               [--forbid behavior_added,invariant_weakened,forbidden_relaxed]
+                                                 # bounded semantic change analysis
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]  # spec mutation (§15)
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
@@ -710,8 +713,27 @@ verification result under <code>sweep.results</code>, and returns the first fail
 under <code>sweep.minimal_counterexample</code>. For <code>--values</code>, the sweep fixes the lower
 bound and expands the upper bound (<code>lo..lo</code>, <code>lo..lo+1</code>, ..., <code>lo..hi</code>). A
 passing sweep means "no counterexample in this grid", not an unbounded proof.</p>
+<p><code>diff</code> compares state-machine meaning instead of source text. It runs bounded
+refinement in both directions: NEW→OLD failure is <code>behavior_added</code>, while
+OLD→NEW failure is <code>behavior_removed</code>. It separately checks implication between
+the conjunctions of user invariants (<code>invariant_weakened</code> /
+<code>invariant_strengthened</code>) and replays OLD <code>forbidden</code> scenarios against NEW
+(<code>forbidden_relaxed</code>). Directional failures include counterexample witnesses.
+Same-named compatible state/actions are mapped automatically; name mismatches
+are <code>unknown</code> unless <code>--mapping</code> supplies that direction. An arbitrary mapping
+is never inverted automatically.</p>
+<p>The JSON result is <code>semantic_diff</code> with <code>bounded</code>, <code>scope</code>, <code>directions</code>,
+<code>summary</code>, <code>findings</code>, and <code>gate</code>. A changed <code>verify { instances/values }</code>
+scope is reported as <code>scope_changed</code>, and shared OLD bounds are rebuilt under
+the NEW scope recorded by <code>scope.comparison:"new"</code> and
+<code>scope.applied_to_old</code>. With no findings, <code>summary</code> is
+<code>["no_semantic_change"]</code>. Findings are analysis output and therefore exit 0 by
+default. Only findings explicitly listed by comma-separated <code>--forbid</code> make
+the gate fail and exit 1. All comparisons remain bounded to <code>--depth</code>; clean
+output is not an unbounded equivalence proof.</p>
 <p>Exit codes: <code>0</code> = verified / proved / scenarios/testgen generated / conformant / refines /
-mutated / explained / analyzed / typestate / sweep_passed / observed_conformant /
+mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
+typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
 <code>1</code> = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
 sweep_failed / observed_mismatch,

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -671,6 +671,9 @@ fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-te
 fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # conformance check of an event log (§12)
 fslc testgen   &lt;file.fsl&gt; [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # implementation-conformance test scaffold (§12)
 fslc refine    &lt;impl&gt; &lt;abs&gt; &lt;mapping&gt; [--depth K]# fidelity check of a detailed spec (§10)
+fslc diff      &lt;old&gt; &lt;new&gt; [--depth K] [--mapping map.fsl]
+               [--forbid behavior_added,invariant_weakened,forbidden_relaxed]
+                                                 # bounded semantic change analysis
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
 fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]  # spec mutation (§15)
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
@@ -710,8 +713,27 @@ verification result under <code>sweep.results</code>, and returns the first fail
 under <code>sweep.minimal_counterexample</code>. For <code>--values</code>, the sweep fixes the lower
 bound and expands the upper bound (<code>lo..lo</code>, <code>lo..lo+1</code>, ..., <code>lo..hi</code>). A
 passing sweep means "no counterexample in this grid", not an unbounded proof.</p>
+<p><code>diff</code> compares state-machine meaning instead of source text. It runs bounded
+refinement in both directions: NEW→OLD failure is <code>behavior_added</code>, while
+OLD→NEW failure is <code>behavior_removed</code>. It separately checks implication between
+the conjunctions of user invariants (<code>invariant_weakened</code> /
+<code>invariant_strengthened</code>) and replays OLD <code>forbidden</code> scenarios against NEW
+(<code>forbidden_relaxed</code>). Directional failures include counterexample witnesses.
+Same-named compatible state/actions are mapped automatically; name mismatches
+are <code>unknown</code> unless <code>--mapping</code> supplies that direction. An arbitrary mapping
+is never inverted automatically.</p>
+<p>The JSON result is <code>semantic_diff</code> with <code>bounded</code>, <code>scope</code>, <code>directions</code>,
+<code>summary</code>, <code>findings</code>, and <code>gate</code>. A changed <code>verify { instances/values }</code>
+scope is reported as <code>scope_changed</code>, and shared OLD bounds are rebuilt under
+the NEW scope recorded by <code>scope.comparison:"new"</code> and
+<code>scope.applied_to_old</code>. With no findings, <code>summary</code> is
+<code>["no_semantic_change"]</code>. Findings are analysis output and therefore exit 0 by
+default. Only findings explicitly listed by comma-separated <code>--forbid</code> make
+the gate fail and exit 1. All comparisons remain bounded to <code>--depth</code>; clean
+output is not an unbounded equivalence proof.</p>
 <p>Exit codes: <code>0</code> = verified / proved / scenarios/testgen generated / conformant / refines /
-mutated / explained / analyzed / typestate / sweep_passed / observed_conformant /
+mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
+typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
 <code>1</code> = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
 sweep_failed / observed_mismatch,

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -287,7 +287,10 @@ the formalization memo.**
    `fslc testgen -o test_x.py`
    (implementation-conformance pytest skeleton), `fslc replay --trace events.json`
    (log conformance), `fslc refine impl.fsl abs.fsl mapping.fsl` (faithfulness check
-   of a detailed spec).
+   of a detailed spec), and `fslc diff old.fsl new.fsl --depth 8` (bounded
+   semantic change analysis with behavior/invariant/forbidden witnesses). Diff
+   findings are informational by default; add an explicit comma-separated
+   `--forbid` policy to make selected kinds fail CI.
    For AI tool-boundary contracts, use `fslc ai check file.fsl` on
    `ai_component` specs and `fslc ai replay file.fsl --logs events.jsonl` for
    runtime event evidence. For recursive fsl-ai agent composition, use

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -690,6 +690,9 @@ fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* 
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
 fslc testgen <f> [--depth K] [--strict] [--target pytest|vitest|swift|kotlin|dart|phpunit] [-o out]  # Adapter skeleton + conformance tests (pytest default / Vitest / Swift Testing / kotlin.test / package:test / PHPUnit)
 fslc refine <impl> <abs> <mapping> [--depth K]  # refines | refinement_failed
+fslc diff <old> <new> [--depth K] [--mapping <mapping>]
+          [--forbid behavior_added,invariant_weakened,forbidden_relaxed]
+                                                  # bounded semantic change report
 fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> req -> design -> impl table + JSON
 fslc analyze <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--format json|dot|mermaid]  # structural review
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
@@ -719,6 +722,17 @@ fslc ai drift <f> --logs events.jsonl [--baseline-logs p] [--window N] [--baseli
 fslc ai compat <f> [--environment <env>]                # emit a dbsystem artifact capability profile for AI compat
 fslc compat check <f> [--include-ai]                    # dbsystem compatibility check, optionally folding in AI capability profiles
 ```
+
+`diff` uses bidirectional bounded refinement for behavior changes, implication
+between the OLD/NEW user-invariant conjunctions, and replay of OLD `forbidden`
+scenarios against NEW. Its stable finding kinds are `behavior_added`,
+`behavior_removed`, `invariant_weakened`, `invariant_strengthened`,
+`forbidden_relaxed`, `scope_changed`, and `unknown`; an empty report uses
+`no_semantic_change`. A changed `verify` scope is explicit and comparison uses
+NEW's shared entity/number bounds. Findings exit 0 because the command is an
+analysis; use `--forbid` to turn selected kinds into an exit-1 CI gate. Every
+verdict is bounded by `--depth`, and a mapping only resolves the direction
+declared in its `impl`/`abs` fields (it is never inverted).
 
 `verify` is backed by a persistent verdict cache (issue #169) keyed on every
 input that can affect its output (the post-desugaring kernel AST, the raw

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -20,6 +20,7 @@ from .model import build_spec, check_spec, FslError, strict_tag_warnings
 from .bmc import verify, prove, scenarios
 from . import verify_cache
 from .refine import build_refinement, refine, refine_chain
+from .semantic_diff import semantic_diff
 from .runtime import Monitor
 from .acceptance import validate_acceptance, validate_forbidden
 from .testgen import TestgenScenarioError, generate_test_bundle, default_output_name
@@ -1748,8 +1749,36 @@ def run_domain_replay(file, logs):
         return _envelope({"result": "error", "kind": "internal", "message": str(e)})
 
 
+def run_diff(old, new, depth=8, mapping=None, forbid=None):
+    """Run a bounded semantic comparison and return the standard JSON envelope."""
+    try:
+        if isinstance(forbid, str):
+            forbid = [item.strip() for item in forbid.split(",") if item.strip()]
+        return _envelope(semantic_diff(old, new, depth, mapping, forbid))
+    except UnexpectedInput as e:
+        return _parse_error_result(e)
+    except VisitError as e:
+        orig = e.orig_exc
+        return _error_envelope(
+            getattr(orig, "kind", "semantics"),
+            str(orig),
+            _loc_from_exc(orig),
+            getattr(orig, "expected", None),
+            getattr(orig, "hint", None),
+        )
+    except FslError as e:
+        return _error_envelope(e.kind, str(e), _loc_from_exc(e),
+                               getattr(e, "expected", None), getattr(e, "hint", None))
+    except FileNotFoundError as e:
+        return _envelope({"result": "error", "kind": "io", "message": str(e)})
+    except Exception as e:
+        return _envelope({"result": "error", "kind": "internal", "message": str(e)})
+
+
 def exit_code(result):
     r = result.get("result")
+    if r == "semantic_diff":
+        return 0 if result.get("gate", {}).get("passed", True) else 1
     if r in ("verified", "proved", "scenarios", "conformant", "generated",
              "refines", "typestate", "mutated", "explained", "analyzed",
              "verified_under_assumptions", "agent_analyzed", "replay_conformant",
@@ -1894,6 +1923,15 @@ def _build_arg_parser():
     rf.add_argument("rest", nargs="*",
                     help="chain check: appending more (abs map) pairs runs an end-to-end composed check")
     rf.add_argument("--depth", type=int, default=8)
+
+    df = sub.add_parser("diff", help="compare OLD and NEW specification semantics")
+    df.add_argument("old")
+    df.add_argument("new")
+    df.add_argument("--depth", type=int, default=8)
+    df.add_argument("--mapping", default=None,
+                    help="optional refinement mapping for one comparison direction")
+    df.add_argument("--forbid", default="",
+                    help="comma-separated finding kinds that should fail the gate")
 
     ch = sub.add_parser("chain", help="run a project manifest across business, requirements, design, and impl")
     ch.add_argument("path", nargs="?", default="fsl-project.toml")
@@ -2051,6 +2089,9 @@ def _dispatch(args):
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "refine":
         result = run_refine(args.impl, args.abs, args.mapping, args.depth, rest=args.rest)
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif args.cmd == "diff":
+        result = run_diff(args.old, args.new, args.depth, args.mapping, args.forbid)
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "chain":
         from .chain import format_chain_table, run_chain

--- a/src/fslc/semantic_diff.py
+++ b/src/fslc/semantic_diff.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Bounded semantic comparison of two FSL specifications."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import z3
+from lark.exceptions import UnexpectedInput
+
+from .acceptance import replay_forbidden
+from .bmc import (
+    _eval_cache_scope,
+    _implicit_inv_constraints,
+    eval_expr,
+    logical_state_values,
+    make_state,
+)
+from .grammar import Ast, PARSER
+from .model import FslError, build_spec
+from .parser import parse_refinement, parse_src
+from .refine import build_refinement, refine
+
+
+FINDING_KINDS = (
+    "behavior_added",
+    "behavior_removed",
+    "invariant_weakened",
+    "invariant_strengthened",
+    "forbidden_relaxed",
+    "scope_changed",
+    "unknown",
+)
+
+
+def _declared_scope(source):
+    """Return source-level verify bounds before dialect desugaring removes them."""
+    try:
+        tree = PARSER.parse(source)
+        ast = Ast().transform(tree)
+    except (UnexpectedInput, FslError):
+        return {"instances": {}, "values": {}}
+    if not isinstance(ast, tuple) or len(ast) < 3:
+        return {"instances": {}, "values": {}}
+    instances = {}
+    values = {}
+    for item in ast[2]:
+        if item[0] != "verify_bounds":
+            continue
+        for bound in item[1]:
+            if bound[0] == "verify_instances":
+                instances[bound[1]] = bound[2]
+            elif bound[0] == "verify_values":
+                values[bound[1]] = (bound[2], bound[3])
+    return {"instances": instances, "values": values}
+
+
+def _public_scope(scope):
+    return {
+        "instances": dict(sorted(scope["instances"].items())),
+        "values": {
+            name: [bounds[0], bounds[1]]
+            for name, bounds in sorted(scope["values"].items())
+        },
+    }
+
+
+def _load_spec(path, source, bounds_overrides=None):
+    ast, display_names = parse_src(
+        source,
+        str(Path(path).parent),
+        bounds_overrides=bounds_overrides,
+    )
+    return build_spec(ast, display_names)
+
+
+def _auto_mapping(impl_spec, abs_spec):
+    tree = (
+        "refinement",
+        f"{impl_spec['name']}SemanticDiff{abs_spec['name']}",
+        [
+            ("impl", impl_spec["name"]),
+            ("abs", abs_spec["name"]),
+            ("maps_auto", None),
+        ],
+    )
+    return build_refinement(tree, impl_spec, abs_spec)
+
+
+def _identity_shape_mismatch(impl_spec, abs_spec):
+    impl_state = set(impl_spec["state"])
+    abs_state = set(abs_spec["state"])
+    impl_actions = {action["name"] for action in impl_spec["actions"]}
+    abs_actions = {action["name"] for action in abs_spec["actions"]}
+    if impl_state == abs_state and impl_actions == abs_actions:
+        return None
+    return {
+        "state": {
+            "only_impl": sorted(impl_state - abs_state),
+            "only_abs": sorted(abs_state - impl_state),
+        },
+        "actions": {
+            "only_impl": sorted(impl_actions - abs_actions),
+            "only_abs": sorted(abs_actions - impl_actions),
+        },
+    }
+
+
+def _direction(impl_spec, abs_spec, depth, explicit_ast=None):
+    automatic = explicit_ast is None
+    if explicit_ast is None:
+        mismatch = _identity_shape_mismatch(impl_spec, abs_spec)
+        if mismatch:
+            return {
+                "result": "unknown",
+                "reason": "state_or_action_names_differ",
+                "mismatch": mismatch,
+            }, None
+        try:
+            mapping = _auto_mapping(impl_spec, abs_spec)
+        except FslError as exc:
+            return {
+                "result": "unknown",
+                "reason": "automatic_mapping_failed",
+                "message": str(exc),
+            }, None
+    else:
+        mapping = build_refinement(explicit_ast, impl_spec, abs_spec)
+
+    try:
+        result = refine(impl_spec, abs_spec, mapping, depth)
+    except FslError as exc:
+        if not automatic:
+            raise
+        return {
+            "result": "unknown",
+            "reason": "automatic_mapping_failed",
+            "message": str(exc),
+        }, None
+    public = {
+        "result": result.get("result"),
+        "checked_to_depth": depth,
+    }
+    if result.get("result") == "refinement_failed":
+        public["kind"] = result.get("kind")
+        public["violated_at_step"] = result.get("violated_at_step")
+    elif result.get("result") != "refines":
+        public = {
+            "result": "unknown",
+            "reason": "refinement_input_not_verifiable",
+            "detail": result,
+        }
+    return public, result
+
+
+def _counterexample_witness(result):
+    return {
+        "trace_type": "counterexample",
+        "trace": result.get("impl_trace", []),
+        "violation": {
+            key: result[key]
+            for key in ("kind", "violated_at_step", "impl_action", "mismatch")
+            if key in result
+        },
+    }
+
+
+def _same_state_schema(old_spec, new_spec):
+    if old_spec["state"] != new_spec["state"]:
+        return False
+    return {p["phys"] for p in old_spec["phys_vars"]} == {
+        p["phys"] for p in new_spec["phys_vars"]
+    }
+
+
+def _invariant_implication(antecedent_spec, consequent_spec, state_spec, label):
+    state = make_state(state_spec, f"semantic_diff_{label}")
+    solver = z3.Solver()
+    cache = {}
+    solver.add(*_implicit_inv_constraints(state_spec, state, cache))
+    with _eval_cache_scope(cache, id(state)):
+        antecedent = [
+            eval_expr(inv["expr"], state, {}, antecedent_spec)
+            for inv in antecedent_spec.get("user_invariants", [])
+        ]
+        consequent = [
+            eval_expr(inv["expr"], state, {}, consequent_spec)
+            for inv in consequent_spec.get("user_invariants", [])
+        ]
+    solver.add(z3.And(*antecedent) if antecedent else z3.BoolVal(True))
+    solver.add(z3.Not(z3.And(*consequent) if consequent else z3.BoolVal(True)))
+    status = solver.check()
+    if status == z3.unsat:
+        return {"implies": True}
+    if status == z3.sat:
+        model = solver.model()
+        return {
+            "implies": False,
+            "state": logical_state_values(model, state, state_spec),
+        }
+    return {"implies": None, "reason": solver.reason_unknown()}
+
+
+def _compare_invariants(old_spec, new_spec):
+    if not _same_state_schema(old_spec, new_spec):
+        return None, None
+    try:
+        old_to_new = _invariant_implication(old_spec, new_spec, new_spec, "old_new")
+        new_to_old = _invariant_implication(new_spec, old_spec, new_spec, "new_old")
+    except (FslError, KeyError, z3.Z3Exception) as exc:
+        return None, {"reason": "invariant_implication_failed", "message": str(exc)}
+    return (old_to_new, new_to_old), None
+
+
+def _forbidden_findings(old_spec, new_spec):
+    findings = []
+    unknown = []
+    for forbidden in old_spec.get("forbidden") or []:
+        try:
+            replay = replay_forbidden(new_spec, forbidden)
+        except FslError as exc:
+            unknown.append({
+                "kind": "unknown",
+                "subject": "forbidden",
+                "id": forbidden["id"],
+                "reason": str(exc),
+            })
+            continue
+        if not replay.get("ok") and replay.get("kind") == "forbidden":
+            findings.append({
+                "kind": "forbidden_relaxed",
+                "id": forbidden["id"],
+                "witness": {
+                    "trace_type": "counterexample",
+                    "trace": replay.get("accepted_trace", []),
+                    "accepted_step": replay.get("accepted_step"),
+                    "state": replay.get("state"),
+                },
+            })
+    return findings + unknown
+
+
+def semantic_diff(old_path, new_path, depth=8, mapping_path=None, forbid=None):
+    """Compare OLD and NEW under NEW's declared verify scope."""
+    old_source = Path(old_path).read_text(encoding="utf-8")
+    new_source = Path(new_path).read_text(encoding="utf-8")
+    old_scope = _declared_scope(old_source)
+    new_scope = _declared_scope(new_source)
+    scope_changed = old_scope != new_scope
+
+    overrides = {
+        "instances": {
+            name: value
+            for name, value in new_scope["instances"].items()
+            if name in old_scope["instances"]
+        },
+        "values": {
+            name: value
+            for name, value in new_scope["values"].items()
+            if name in old_scope["values"]
+        },
+    }
+    old_spec = _load_spec(
+        old_path,
+        old_source,
+        bounds_overrides=overrides if scope_changed else None,
+    )
+    new_spec = _load_spec(new_path, new_source)
+
+    explicit_ast = None
+    explicit_direction = None
+    if mapping_path:
+        explicit_ast = parse_refinement(Path(mapping_path).read_text(encoding="utf-8"))
+        items = explicit_ast[2]
+        impl = next((item[1] for item in items if item[0] == "impl"), None)
+        abs_name = next((item[1] for item in items if item[0] == "abs"), None)
+        if (impl, abs_name) == (new_spec["name"], old_spec["name"]):
+            explicit_direction = "new_to_old"
+        elif (impl, abs_name) == (old_spec["name"], new_spec["name"]):
+            explicit_direction = "old_to_new"
+        else:
+            raise FslError(
+                "diff mapping must map NEW to OLD or OLD to NEW",
+                kind="type",
+            )
+
+    new_public, new_raw = _direction(
+        new_spec,
+        old_spec,
+        depth,
+        explicit_ast if explicit_direction == "new_to_old" else None,
+    )
+    old_public, old_raw = _direction(
+        old_spec,
+        new_spec,
+        depth,
+        explicit_ast if explicit_direction == "old_to_new" else None,
+    )
+
+    findings = []
+    if new_public["result"] == "refinement_failed":
+        findings.append({
+            "kind": "behavior_added",
+            "direction": "new_to_old",
+            "witness": _counterexample_witness(new_raw),
+        })
+    elif new_public["result"] == "unknown":
+        findings.append({
+            "kind": "unknown",
+            "direction": "new_to_old",
+            "reason": new_public.get("reason"),
+            "detail": (
+                new_public.get("mismatch")
+                or new_public.get("detail")
+                or new_public.get("message")
+            ),
+        })
+    if old_public["result"] == "refinement_failed":
+        findings.append({
+            "kind": "behavior_removed",
+            "direction": "old_to_new",
+            "witness": _counterexample_witness(old_raw),
+        })
+    elif old_public["result"] == "unknown":
+        findings.append({
+            "kind": "unknown",
+            "direction": "old_to_new",
+            "reason": old_public.get("reason"),
+            "detail": (
+                old_public.get("mismatch")
+                or old_public.get("detail")
+                or old_public.get("message")
+            ),
+        })
+
+    implication, implication_error = _compare_invariants(old_spec, new_spec)
+    if implication is not None:
+        old_to_new, new_to_old = implication
+        if old_to_new["implies"] is True and new_to_old["implies"] is False:
+            findings.append({
+                "kind": "invariant_weakened",
+                "witness": {
+                    "trace_type": "state_counterexample",
+                    "state": new_to_old["state"],
+                },
+            })
+        elif new_to_old["implies"] is True and old_to_new["implies"] is False:
+            findings.append({
+                "kind": "invariant_strengthened",
+                "witness": {
+                    "trace_type": "state_counterexample",
+                    "state": old_to_new["state"],
+                },
+            })
+        elif old_to_new["implies"] is not True or new_to_old["implies"] is not True:
+            findings.append({
+                "kind": "unknown",
+                "subject": "invariants",
+                "reason": "invariant_sets_are_incomparable",
+                "old_to_new": old_to_new,
+                "new_to_old": new_to_old,
+            })
+    elif implication_error is not None:
+        findings.append({"kind": "unknown", "subject": "invariants", **implication_error})
+
+    findings.extend(_forbidden_findings(old_spec, new_spec))
+    if scope_changed:
+        findings.append({
+            "kind": "scope_changed",
+            "old": _public_scope(old_scope),
+            "new": _public_scope(new_scope),
+            "comparison": "new",
+        })
+
+    present = {finding["kind"] for finding in findings}
+    summary = [kind for kind in FINDING_KINDS if kind in present]
+    if not summary:
+        summary = ["no_semantic_change"]
+    forbidden = sorted(set(forbid or []))
+    unknown_forbid = sorted(set(forbidden) - set(FINDING_KINDS))
+    if unknown_forbid:
+        raise FslError(
+            f"unknown --forbid finding kind(s): {', '.join(unknown_forbid)}",
+            kind="semantics",
+        )
+    violations = [kind for kind in forbidden if kind in present]
+
+    return {
+        "result": "semantic_diff",
+        "old": {"file": str(old_path), "spec": old_spec["name"]},
+        "new": {"file": str(new_path), "spec": new_spec["name"]},
+        "bounded": {"depth": depth, "completeness": "bounded"},
+        "scope": {
+            "old": _public_scope(old_scope),
+            "new": _public_scope(new_scope),
+            "comparison": "new",
+            "applied_to_old": _public_scope(overrides),
+        },
+        "directions": {
+            "new_to_old": new_public,
+            "old_to_new": old_public,
+        },
+        "summary": summary,
+        "findings": findings,
+        "gate": {
+            "forbidden": forbidden,
+            "violations": violations,
+            "passed": not violations,
+        },
+    }

--- a/tests/snapshots/semantic_diff_behavior_added.json
+++ b/tests/snapshots/semantic_diff_behavior_added.json
@@ -1,0 +1,75 @@
+{
+  "bounded": {
+    "completeness": "bounded",
+    "depth": 3
+  },
+  "directions": {
+    "new_to_old": {
+      "checked_to_depth": 3,
+      "kind": "abs_requires_failed",
+      "result": "refinement_failed",
+      "violated_at_step": 2
+    },
+    "old_to_new": {
+      "checked_to_depth": 3,
+      "result": "refines"
+    }
+  },
+  "findings": [
+    {
+      "direction": "new_to_old",
+      "kind": "behavior_added",
+      "witness": {
+        "trace": [
+          {
+            "state": {"flag": false},
+            "step": 0
+          },
+          {
+            "action": {
+              "loc": {"column": 55, "line": 1},
+              "name": "enable",
+              "params": {}
+            },
+            "changes": {"flag": {"from": false, "to": true}},
+            "state": {"flag": true},
+            "step": 1
+          },
+          {
+            "action": {
+              "loc": {"column": 55, "line": 1},
+              "name": "enable",
+              "params": {}
+            },
+            "changes": {},
+            "state": {"flag": true},
+            "step": 2
+          }
+        ],
+        "trace_type": "counterexample",
+        "violation": {
+          "impl_action": {
+            "loc": {"column": 55, "line": 1},
+            "name": "enable",
+            "params": {}
+          },
+          "kind": "abs_requires_failed",
+          "mismatch": [],
+          "violated_at_step": 2
+        }
+      }
+    }
+  ],
+  "fsl": "1.0",
+  "gate": {"forbidden": [], "passed": true, "violations": []},
+  "new": {"file": "new.fsl", "spec": "New"},
+  "old": {"file": "old.fsl", "spec": "Old"},
+  "result": "semantic_diff",
+  "scope": {
+    "applied_to_old": {"instances": {}, "values": {}},
+    "comparison": "new",
+    "new": {"instances": {}, "values": {}},
+    "old": {"instances": {}, "values": {}}
+  },
+  "summary": ["behavior_added"]
+}

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -208,6 +208,7 @@ COMMAND_DESIGN_DOCS = {
     "html": ("DESIGN-html-report.md",),
     "ledger": ("DESIGN-ledger.md",),
     "refine": ("DESIGN-refinement.md",),
+    "diff": ("DESIGN-semantic-diff.md",),
     "chain": ("DESIGN-layers.md",),
     "typestate": ("DESIGN-typestate.md",),
     "analyze": ("DESIGN-analysis.md",),

--- a/tests/test_semantic_diff.py
+++ b/tests/test_semantic_diff.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Semantic specification diff (issue #176)."""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from fslc.cli import _build_arg_parser, exit_code, run_diff
+
+
+SNAPSHOT = Path(__file__).parent / "snapshots" / "semantic_diff_behavior_added.json"
+
+
+def _write(tmp_path, name, source):
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return str(path)
+
+
+def _flag_spec(name, requires="requires not flag", invariant=""):
+    return f"""
+    spec {name} {{
+      state {{ flag: Bool }}
+      init {{ flag = false }}
+      action enable() {{
+        {requires}
+        flag = true
+      }}
+      {invariant}
+    }}
+    """
+
+
+def test_weakened_guard_is_behavior_added_with_witness(tmp_path):
+    old = _write(tmp_path, "old.fsl", _flag_spec("Old"))
+    new = _write(tmp_path, "new.fsl", _flag_spec("New", requires=""))
+
+    out = run_diff(old, new, depth=3)
+
+    assert out["result"] == "semantic_diff"
+    assert "behavior_added" in out["summary"]
+    finding = next(item for item in out["findings"] if item["kind"] == "behavior_added")
+    assert finding["direction"] == "new_to_old"
+    assert finding["witness"]["trace_type"] == "counterexample"
+    assert finding["witness"]["trace"]
+    assert out["bounded"] == {"depth": 3, "completeness": "bounded"}
+    assert exit_code(out) == 0
+
+
+def test_behavior_added_json_snapshot(tmp_path):
+    old = _write(
+        tmp_path,
+        "old.fsl",
+        "spec Old { state { flag: Bool } init { flag = false } "
+        "action enable() { requires not flag flag = true } }",
+    )
+    new = _write(
+        tmp_path,
+        "new.fsl",
+        "spec New { state { flag: Bool } init { flag = false } "
+        "action enable() { flag = true } }",
+    )
+
+    out = run_diff(old, new, depth=3)
+    out["old"]["file"] = "old.fsl"
+    out["new"]["file"] = "new.fsl"
+
+    assert out == json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+def test_removed_invariant_conjunct_is_invariant_weakened(tmp_path):
+    old = _write(
+        tmp_path,
+        "old.fsl",
+        """
+        spec Old {
+          type X = 0..2
+          state { x: X }
+          init { x = 0 }
+          action advance() { requires x == 0  x = 1 }
+          invariant Limit { x >= 0 and x <= 1 }
+        }
+        """,
+    )
+    new = _write(
+        tmp_path,
+        "new.fsl",
+        """
+        spec New {
+          type X = 0..2
+          state { x: X }
+          init { x = 0 }
+          action advance() { requires x == 0  x = 1 }
+          invariant Limit { x >= 0 }
+        }
+        """,
+    )
+
+    out = run_diff(old, new, depth=2)
+
+    assert "invariant_weakened" in out["summary"]
+    finding = next(item for item in out["findings"] if item["kind"] == "invariant_weakened")
+    assert finding["witness"]["state"]["x"] == 2
+
+
+def test_identical_semantics_report_no_semantic_change(tmp_path):
+    old = _write(tmp_path, "old.fsl", _flag_spec("Old"))
+    new = _write(tmp_path, "new.fsl", _flag_spec("New"))
+
+    out = run_diff(old, new, depth=2)
+
+    assert out["summary"] == ["no_semantic_change"]
+    assert out["findings"] == []
+    assert out["directions"]["new_to_old"]["result"] == "refines"
+    assert out["directions"]["old_to_new"]["result"] == "refines"
+
+
+def test_name_mismatch_is_unknown_without_mapping(tmp_path):
+    old = _write(tmp_path, "old.fsl", _flag_spec("Old"))
+    new = _write(
+        tmp_path,
+        "new.fsl",
+        _flag_spec("New").replace("flag", "enabled"),
+    )
+
+    out = run_diff(old, new, depth=2)
+
+    assert "unknown" in out["summary"]
+    assert out["directions"]["new_to_old"]["result"] == "unknown"
+    assert out["directions"]["old_to_new"]["result"] == "unknown"
+
+
+def test_mapping_resolves_its_declared_direction_only(tmp_path):
+    old = _write(tmp_path, "old.fsl", _flag_spec("Old"))
+    new = _write(
+        tmp_path,
+        "new.fsl",
+        _flag_spec("New").replace("enable()", "turn_on()").replace("flag", "enabled"),
+    )
+    mapping = _write(
+        tmp_path,
+        "mapping.fsl",
+        """
+        refinement NewRefinesOld {
+          impl New
+          abs Old
+          map flag = enabled
+          action turn_on() -> enable()
+        }
+        """,
+    )
+
+    out = run_diff(old, new, depth=2, mapping=mapping)
+
+    assert out["directions"]["new_to_old"]["result"] == "refines"
+    assert out["directions"]["old_to_new"]["result"] == "unknown"
+
+
+def test_scope_change_uses_new_side_bounds(tmp_path):
+    old = _write(
+        tmp_path,
+        "old.fsl",
+        """
+        spec Old {
+          entity E
+          state { current: E }
+          init { current = 0 }
+          action stay() { current = current }
+        }
+        verify { instances E = 1 }
+        """,
+    )
+    new = _write(
+        tmp_path,
+        "new.fsl",
+        """
+        spec New {
+          entity E
+          state { current: E }
+          init { current = 0 }
+          action stay() { current = current }
+        }
+        verify { instances E = 2 }
+        """,
+    )
+
+    out = run_diff(old, new, depth=1)
+
+    assert "scope_changed" in out["summary"]
+    assert out["scope"]["comparison"] == "new"
+    assert out["scope"]["old"]["instances"] == {"E": 1}
+    assert out["scope"]["new"]["instances"] == {"E": 2}
+    assert out["scope"]["applied_to_old"]["instances"] == {"E": 2}
+
+
+def test_old_forbidden_accepted_by_new_is_forbidden_relaxed(tmp_path):
+    old_source = """
+    requirements Old {
+      type OrderId = 0..1
+      enum OSt { Cart, Paid, Shipped, Cancelled }
+      state { order: Map<OrderId, OSt> }
+      init { forall o: OrderId { order[o] = Cart } }
+      requirement REQ-1 "lifecycle" {
+        action pay(o: OrderId) { requires order[o] == Cart  order[o] = Paid }
+        action ship(o: OrderId) { requires order[o] == Paid  order[o] = Shipped }
+        action cancel(o: OrderId) { requires order[o] == Paid  order[o] = Cancelled }
+      }
+      forbidden FB-1 "post-shipment cancellation is rejected" {
+        pay(0) ship(0) cancel(0)
+        expect rejected
+      }
+    }
+    """
+    new_source = old_source.replace("requirements Old", "requirements New").replace(
+        "requires order[o] == Paid  order[o] = Cancelled",
+        "requires order[o] == Paid or order[o] == Shipped  order[o] = Cancelled",
+    )
+    old = _write(tmp_path, "old.fsl", old_source)
+    new = _write(tmp_path, "new.fsl", new_source)
+
+    out = run_diff(old, new, depth=4)
+
+    assert "forbidden_relaxed" in out["summary"]
+    finding = next(item for item in out["findings"] if item["kind"] == "forbidden_relaxed")
+    assert finding["id"] == "FB-1"
+    assert finding["witness"]["trace"][-1]["action"] == "cancel"
+
+
+def test_forbid_is_the_only_semantic_diff_exit_one(tmp_path):
+    old = _write(tmp_path, "old.fsl", _flag_spec("Old"))
+    new = _write(tmp_path, "new.fsl", _flag_spec("New", requires=""))
+
+    analysis = run_diff(old, new, depth=2)
+    gated = run_diff(old, new, depth=2, forbid=["behavior_added"])
+
+    assert exit_code(analysis) == 0
+    assert gated["gate"] == {
+        "forbidden": ["behavior_added"],
+        "violations": ["behavior_added"],
+        "passed": False,
+    }
+    assert exit_code(gated) == 1
+
+
+def test_diff_cli_contract():
+    args = _build_arg_parser().parse_args([
+        "diff", "old.fsl", "new.fsl", "--depth", "5",
+        "--forbid", "behavior_added,invariant_weakened",
+    ])
+
+    assert args.old == "old.fsl"
+    assert args.new == "new.fsl"
+    assert args.depth == 5
+    assert args.forbid == "behavior_added,invariant_weakened"


### PR DESCRIPTION
## Summary

Adds `fslc diff OLD.fsl NEW.fsl --depth K`, a bounded semantic comparison command that classifies behavioral and safety-contract changes rather than only showing a source diff.

Closes #176.

## Why

Reviewers currently have to infer whether an FSL edit adds/removes behavior or weakens a safety rule. This command makes those judgments mechanical where the existing refinement, invariant, and forbidden-scenario semantics can support them, while keeping uncertainty and boundedness explicit.

## What changed

- Runs refinement in both directions:
  - NEW → OLD failure: `behavior_added`
  - OLD → NEW failure: `behavior_removed`
- Uses Z3 implication over the conjunctions of user invariants to classify `invariant_weakened` and `invariant_strengthened`.
- Replays OLD `forbidden` scenarios against NEW to detect `forbidden_relaxed`.
- Emits counterexample traces or state witnesses for directional findings.
- Reports `scope_changed` and rebuilds shared OLD `verify { instances/values }` bounds under the NEW-side scope, recorded in JSON.
- Reports name/schema correspondence gaps as `unknown`; `--mapping` can resolve one declared direction without unsoundly inverting arbitrary mappings.
- Keeps findings informational (exit 0) unless selected by an explicit comma-separated `--forbid` gate (exit 1).
- Updates `docs/LANGUAGE.md`, the semantic-diff design contract, FSL skill/reference, changelog, CLI/design coupled-change map, and generated JA/EN website references.

## Invariants and boundaries

- All conclusions are bounded by `--depth`; `bounded.completeness` is always `bounded`.
- A clean report is not an unbounded equivalence proof.
- Implicit type bounds constrain invariant implication but are not classified as authored invariant edits.
- State/action names are never guessed.
- An explicit mapping applies only in its declared `impl` → `abs` direction.
- `--forbid` is policy layered over analysis; findings alone do not fail the command.

## Blast radius

- New leaf module: `src/fslc/semantic_diff.py`.
- Additive top-level CLI command and exit-code handling in `src/fslc/cli.py`.
- No grammar or existing verify/refine semantics changed.
- Generated site reference pages changed because the CLI and language references changed.

## Failure modes

- Non-corresponding state/action schemas produce `unknown`, not a false semantic verdict.
- Invalid explicit mappings remain ordinary type/semantic errors (exit 2).
- If an input cannot be verified enough for refinement, that direction is `unknown` with the underlying detail.
- Different `verify` scopes are visible and compared at the NEW-side shared scope; the exact applied overrides are emitted.

## Evidence

- `pytest -q` → `1292 passed, 78 skipped` (13:01)
- Focused semantic diff / coupled-change / generated-site checks → `19 passed`
- JSON snapshot covers a weakened guard with a directional counterexample witness.
- Regression cases cover identical semantics, weakened invariant conjunct, explicit mapping, scope changes, forbidden relaxation, and explicit gate exit behavior.

## Rollout and rollback

This is additive and opt-in. Rollback is a revert of this commit; no persisted data or migration is involved.

## Review focus

1. Is NEW-side scope the right explicit comparison convention for `verify` bound changes?
2. Is the split between informational findings and explicit `--forbid` policy suitable for CI consumers?
3. Are the witness and `unknown` shapes sufficient for downstream review tooling?

## Unknowns / follow-ups

- Project-chain / non-adjacent semantic diff is intentionally deferred.
- Arbitrary refinement mappings do not have a sound general inverse; two renamed directions may require separate future mapping inputs.
