### PR TITLE
feat(check): reconcile canonical Markdown requirements

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -9,3 +9,4 @@ tests/test_self.py
 tests/test_spec_domains.py
 tests/test_trans.py
 tests/test_verify_cache.py
+tests/test_doc_trace.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Canonical Markdown trace checks (issue #192): `check/verify --docs FILE`
+  extracts normative `## REQ-n: title` sections and reports
+  `missing_formalization`, `ghost_requirement`, and `stale_tag` with old/new
+  text evidence. `spec X "source: relative.md"` auto-discovers the doc. Exact
+  doc bytes participate in the verify-cache key, while no-doc defaults remain
+  unchanged. See `docs/DESIGN-doc-trace.md`.
 - Assurance classes (issue #171): a shared `fslc.assurance` classifier turns
   every command's result dict (BMC `verify`, k-induction `prove`, and the
   fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"` producers — replay,

--- a/docs/DESIGN-doc-trace.md
+++ b/docs/DESIGN-doc-trace.md
@@ -1,0 +1,67 @@
+# Canonical Markdown document trace
+
+Issue: #192.
+
+## Format contract
+
+Some projects must keep natural-language Markdown as the canonical contract.
+FSL supports that workflow with a deliberately strict normative-section
+format:
+
+```markdown
+# Product requirements
+
+## REQ-1: A submitted claim can be approved
+Approval requires a positive amount.
+```
+
+A normative requirement starts at exactly `## ID: title` where ID matches
+`[A-Z][A-Z0-9_-]*-\d+`, and ends at the next Markdown heading. Every normative
+statement must be inside such a section; text elsewhere is non-normative.
+Duplicate IDs are an error.
+
+The canonical tag text is the heading title plus all non-empty body lines,
+with whitespace collapsed to single spaces. The FSL declaration/scenario tag
+copies that full canonical text. This fixed normalization makes freshness
+comparison deterministic while keeping tags single-line.
+
+## CLI and diagnostics
+
+```bash
+fslc check spec.fsl --docs requirements.md
+fslc verify spec.fsl --docs requirements.md
+```
+
+Both commands append warnings:
+
+- `missing_formalization`: a doc ID has no declaration tag, acceptance, or
+  forbidden reference;
+- `ghost_requirement`: a formal ID is absent from the canonical doc;
+- `stale_tag`: a shared ID's copied tag text differs, with both `old_text` and
+  `new_text` included as review evidence.
+
+An aligned document adds no warnings. Without `--docs` and without a source
+tag, command output is unchanged.
+
+## Source auto-discovery
+
+The existing spec-level metadata tag can declare the document:
+
+```fsl
+spec Cart "source: requirements.md" { ... }
+```
+
+The path is resolved relative to the spec file. Explicit `--docs` takes
+precedence. This convention changes no grammar and remains metadata only.
+
+## Cache and meaning boundary
+
+Verify cache keys include SHA-256 of the exact Markdown bytes. Any doc edit is
+a cache miss, so trace warnings are recomputed. The bytes are key material only;
+no checksum is embedded into `.fsl` and there is no acknowledgement-hash
+ceremony.
+
+The checks establish ID existence and copied-text freshness, not semantic
+agreement between prose and formulas. The old/new pair from `stale_tag` is the
+evidence passed to a human or explicitly approved external reviewer. Core fslc
+does not call a language model or convert that judgment into a proof result.

--- a/docs/DESIGN-strict-tags.md
+++ b/docs/DESIGN-strict-tags.md
@@ -56,7 +56,9 @@ default output unchanged.
 
 ## 6. Future work / related
 
-`unknown_requirement_id` (ghost requirements, typos) and `--strict-tags error` (CI gate) are v2.
+Canonical-document `ghost_requirement`, `missing_formalization`, and copied-text
+freshness are implemented by `--docs`; see
+[`DESIGN-doc-trace.md`](DESIGN-doc-trace.md). `--strict-tags error` remains v2.
 Limited to **existence-level** reconciliation — empty formalization that is tag-only
 (**semantic level**) is handled by #6 mutate's requirement stress report
 (`empty_formalization`). Roadmap #1.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -572,7 +572,7 @@ variable.
 ## 7. The verifier `fslc`
 
 ```
-fslc check     <file.fsl>                        # syntax / names / types only (fast)
+fslc check     <file.fsl> [--docs requirements.md] # syntax / names / types + optional canonical-doc trace
 fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--deadlock warn|error|ignore]
@@ -581,6 +581,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                                                  #   invariant / trans / leadsTo / reachable (for probing)
                [--exclude-property <Name>]...    # skip named invariant/trans/leadsTo/reachable
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
+               [--docs requirements.md]          # canonical Markdown ID/freshness trace
 fslc sweep     <file.fsl> --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
@@ -1179,6 +1180,15 @@ scenarios carry `requirement: {id, text}`:
 invariant PaidLedger "REQ-3: the ledger matches the number of payments" { ... }
 action submit(c: Case, a: Amount) "REQ-1: amounts at or below the threshold are auto-approved" { ... }
 ```
+
+When Markdown must remain the canonical natural-language contract, write every
+normative section as `## REQ-n: title`, with its body continuing until the next
+heading. The canonical tag text is `title + body` with whitespace collapsed.
+`check/verify --docs FILE` reports `missing_formalization`,
+`ghost_requirement`, and `stale_tag` (including old/new text). A spec-level tag
+`spec Cart "source: requirements.md"` auto-discovers the file relative to the
+spec. Without either input, output is unchanged. See
+[`DESIGN-doc-trace.md`](DESIGN-doc-trace.md).
 
 ### 13.2 Requirements layer: `requirements` (the fsl-req dialect)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@
 | [`DESIGN-forbidden.md`](DESIGN-forbidden.md) | `forbidden` (negative acceptance criteria / must-forbid) — detecting under-constraint |
 | [`DESIGN-vacuity.md`](DESIGN-vacuity.md) | Vacuity checking (invariants whose antecedent is unreachable, leadsTo whose trigger is unreachable, always-true requires) |
 | [`DESIGN-strict-tags.md`](DESIGN-strict-tags.md) | The `--strict-tags` lint (matching untagged declarations and unreferenced requirements) |
+| [`DESIGN-doc-trace.md`](DESIGN-doc-trace.md) | Canonical Markdown normative-section format, ID/freshness diagnostics, `source:` discovery, and cache binding |
 | [`DESIGN-init-if.md`](DESIGN-init-if.md) | Statement-level `if` in `init` (lowered to path-conditional initial-state constraints, same branch shape as action bodies) |
 | [`DESIGN-inline-range.md`](DESIGN-inline-range.md) | Inline anonymous range types (`x: lo..hi`) |
 | [`DESIGN-spec-domains.md`](DESIGN-spec-domains.md) | `entity` / `number` in the kernel `spec` (decoupling a domain from the verification bound) |

--- a/docs/intro/cli.en.html
+++ b/docs/intro/cli.en.html
@@ -77,7 +77,9 @@ def _error_envelope(kind, message, loc=None, expected=None, hint=None):
     if hint:
         err[&quot;hint&quot;] = hint
     return _envelope(err)
-</pre></div></details><div class="disclosure-tree"><details><summary>fslc check</summary><div class="tree-body"><pre>usage: fslc check [-h] [--strict-tags] [--requirements REQUIREMENTS] file
+</pre></div></details><div class="disclosure-tree"><details><summary>fslc check</summary><div class="tree-body"><pre>usage: fslc check [-h] [--strict-tags] [--requirements REQUIREMENTS]
+                  [--docs DOCS]
+                  file
 
 positional arguments:
   file
@@ -86,13 +88,14 @@ options:
   -h, --help            show this help message and exit
   --strict-tags
   --requirements REQUIREMENTS
+  --docs DOCS           canonical Markdown requirements document
 </pre></div></details>
 <details><summary>fslc verify</summary><div class="tree-body"><pre>usage: fslc verify [-h] [--depth DEPTH] [--engine {bmc,induction}] [--k K_IND]
                    [--deadlock {warn,error,ignore}]
                    [--vacuity {warn,error,ignore}] [--property PROPERTY_NAME]
                    [--exclude-property EXCLUDE_PROPERTY_NAMES]
                    [--instances INSTANCES] [--values VALUES] [--strict-tags]
-                   [--requirements REQUIREMENTS] [--no-cache]
+                   [--requirements REQUIREMENTS] [--docs DOCS] [--no-cache]
                    file
 
 positional arguments:
@@ -119,6 +122,7 @@ options:
                         (NAME=LO..HI; repeatable)
   --strict-tags
   --requirements REQUIREMENTS
+  --docs DOCS           canonical Markdown requirements document
   --no-cache            skip the persistent verdict cache for this run
                         (neither reads nor writes it)
 </pre></div></details>

--- a/docs/intro/cli.ja.html
+++ b/docs/intro/cli.ja.html
@@ -77,7 +77,9 @@ def _error_envelope(kind, message, loc=None, expected=None, hint=None):
     if hint:
         err[&quot;hint&quot;] = hint
     return _envelope(err)
-</pre></div></details><div class="disclosure-tree"><details><summary>fslc check</summary><div class="tree-body"><pre>usage: fslc check [-h] [--strict-tags] [--requirements REQUIREMENTS] file
+</pre></div></details><div class="disclosure-tree"><details><summary>fslc check</summary><div class="tree-body"><pre>usage: fslc check [-h] [--strict-tags] [--requirements REQUIREMENTS]
+                  [--docs DOCS]
+                  file
 
 positional arguments:
   file
@@ -86,13 +88,14 @@ options:
   -h, --help            show this help message and exit
   --strict-tags
   --requirements REQUIREMENTS
+  --docs DOCS           canonical Markdown requirements document
 </pre></div></details>
 <details><summary>fslc verify</summary><div class="tree-body"><pre>usage: fslc verify [-h] [--depth DEPTH] [--engine {bmc,induction}] [--k K_IND]
                    [--deadlock {warn,error,ignore}]
                    [--vacuity {warn,error,ignore}] [--property PROPERTY_NAME]
                    [--exclude-property EXCLUDE_PROPERTY_NAMES]
                    [--instances INSTANCES] [--values VALUES] [--strict-tags]
-                   [--requirements REQUIREMENTS] [--no-cache]
+                   [--requirements REQUIREMENTS] [--docs DOCS] [--no-cache]
                    file
 
 positional arguments:
@@ -119,6 +122,7 @@ options:
                         (NAME=LO..HI; repeatable)
   --strict-tags
   --requirements REQUIREMENTS
+  --docs DOCS           canonical Markdown requirements document
   --no-cache            skip the persistent verdict cache for this run
                         (neither reads nor writes it)
 </pre></div></details>

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -656,7 +656,7 @@ variable.</p></div></details>
 <li>A full <code>push</code> into a Seq is also detected automatically as <code>type_bound</code>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
-<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt; [--docs requirements.md] # syntax / names / types + optional canonical-doc trace
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--deadlock warn|error|ignore]
@@ -665,6 +665,7 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
                                                  #   invariant / trans / leadsTo / reachable (for probing)
                [--exclude-property &lt;Name&gt;]...    # skip named invariant/trans/leadsTo/reachable
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
+               [--docs requirements.md]          # canonical Markdown ID/freshness trace
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
@@ -1226,6 +1227,14 @@ scenarios carry <code>requirement: {id, text}</code>:</p>
 <pre><code class="language-fsl">invariant PaidLedger &quot;REQ-3: the ledger matches the number of payments&quot; { ... }
 action submit(c: Case, a: Amount) &quot;REQ-1: amounts at or below the threshold are auto-approved&quot; { ... }
 </code></pre>
+<p>When Markdown must remain the canonical natural-language contract, write every
+normative section as <code>## REQ-n: title</code>, with its body continuing until the next
+heading. The canonical tag text is <code>title + body</code> with whitespace collapsed.
+<code>check/verify --docs FILE</code> reports <code>missing_formalization</code>,
+<code>ghost_requirement</code>, and <code>stale_tag</code> (including old/new text). A spec-level tag
+<code>spec Cart "source: requirements.md"</code> auto-discovers the file relative to the
+spec. Without either input, output is unchanged. See
+<a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-doc-trace.md"><code>DESIGN-doc-trace.md</code></a>.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -656,7 +656,7 @@ variable.</p></div></details>
 <li>A full <code>push</code> into a Seq is also detected automatically as <code>type_bound</code>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
-<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt; [--docs requirements.md] # syntax / names / types + optional canonical-doc trace
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--deadlock warn|error|ignore]
@@ -665,6 +665,7 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
                                                  #   invariant / trans / leadsTo / reachable (for probing)
                [--exclude-property &lt;Name&gt;]...    # skip named invariant/trans/leadsTo/reachable
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
+               [--docs requirements.md]          # canonical Markdown ID/freshness trace
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
 fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
@@ -1226,6 +1227,14 @@ scenarios carry <code>requirement: {id, text}</code>:</p>
 <pre><code class="language-fsl">invariant PaidLedger &quot;REQ-3: the ledger matches the number of payments&quot; { ... }
 action submit(c: Case, a: Amount) &quot;REQ-1: amounts at or below the threshold are auto-approved&quot; { ... }
 </code></pre>
+<p>When Markdown must remain the canonical natural-language contract, write every
+normative section as <code>## REQ-n: title</code>, with its body continuing until the next
+heading. The canonical tag text is <code>title + body</code> with whitespace collapsed.
+<code>check/verify --docs FILE</code> reports <code>missing_formalization</code>,
+<code>ghost_requirement</code>, and <code>stale_tag</code> (including old/new text). A spec-level tag
+<code>spec Cart "source: requirements.md"</code> auto-discovers the file relative to the
+spec. Without either input, output is unchanged. See
+<a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-doc-trace.md"><code>DESIGN-doc-trace.md</code></a>.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -217,6 +217,11 @@ This way assumptions travel with the spec, are visible in PRs, and a future
 `--strict-tags` check can distinguish "intended assumptions (tagged)" from
 "unfounded fabrications (untagged)."
 
+When the user's canonical contract is Markdown rather than `.fsl`, enforce the
+`## REQ-n: title` normative-section format, copy the normalized title+body into
+the matching FSL tags, and run `check/verify --docs`. Treat stale old/new text
+as review evidence; do not claim that matching text proves formula meaning.
+
 ## Natural language → syntax mapping (from the formalization memo to the spec)
 
 Map the sentences extracted during requirement normalization (the memo above) to

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -673,7 +673,7 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 ## 7. CLI and JSON essentials
 
 ```
-fslc check <f>                                  # syntax / names / types only
+fslc check <f> [--docs requirements.md]         # syntax / names / types + optional canonical-doc trace
 fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--deadlock warn|error|ignore] [--vacuity warn|error|ignore]
                [--property <Name>]                  # check one named property in isolation
@@ -682,6 +682,7 @@ fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
                [--instances NAME=N]...              # override verify-block `instances NAME = N`
                [--values NAME=LO..HI]...            # override verify-block `values NAME = LO..HI`
                [--strict-tags] [--requirements ids.txt] [--no-cache]
+               [--docs requirements.md]
 fslc sweep <f> --instances NAME=LO..HI --depth LO..HI [--property Name]
                                                      # grid of verify runs; JSON sweep.results/minimal_counterexample
 fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emits a text review view
@@ -1053,6 +1054,13 @@ leadsTo / action:
 `invariant PaidLedger "REQ-3: ledger consistency" { ... }` →
 `requirement: {id, text}` in violated / unknown_cti / coverage diagnostic /
 scenarios / `refinement_failed` (root).
+
+If Markdown is canonical, every normative requirement must use
+`## REQ-n: title`; its body ends at the next heading. Copy the whitespace-
+normalized `title + body` into FSL tags, then run `check/verify --docs FILE`.
+`missing_formalization`, `ghost_requirement`, and `stale_tag` are trace/freshness
+warnings, not semantic-equivalence judgments. `spec X "source: relative.md"`
+auto-discovers the doc from the spec directory.
 
 ### Authoring specs as readable documentation (requirements + design)
 

--- a/src/fslc/cli.py
+++ b/src/fslc/cli.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from .diagnostics import with_faithfulness, trace_type_for
 from .parser import parse, parse_src, parse_refinement
 from .model import build_spec, check_spec, FslError, strict_tag_warnings
+from .doc_trace import check_doc_trace
 from .bmc import verify, prove, scenarios
 from . import verify_cache
 from .refine import build_refinement, refine, refine_chain
@@ -314,7 +315,7 @@ def _bounds_skip_warnings(ids, kind, bounds_overrides):
     ]
 
 
-def run_check(file, strict_tags=False, requirements=None):
+def run_check(file, strict_tags=False, requirements=None, docs=None):
     try:
         src = open(file, encoding="utf-8").read()
         if is_ai_agent_source(src) or is_ai_project_source(src):
@@ -343,6 +344,9 @@ def run_check(file, strict_tags=False, requirements=None):
             "spec": spec["name"],
             "warnings": spec["warnings"],
         }
+        doc_warnings, _doc_path, _doc_sha256 = check_doc_trace(file, spec, docs)
+        if doc_warnings:
+            out["warnings"] = list(out["warnings"]) + doc_warnings
         impl = _implements_result(spec)
         if impl:
             out["implements"] = impl
@@ -852,7 +856,7 @@ def run_sweep(
 
 def _verify_cache_lookup(ast, display_names, src, engine, depth, k_ind, deadlock_mode,
                           vacuity_mode, property_name, exclude_property_names,
-                          strict_tags, requirements, instances, values):
+                          strict_tags, requirements, instances, values, docs_sha256):
     """Best-effort cache lookup. Returns ``(cache_key, xdepth_key, hit_or_None)``;
     ``cache_key`` is ``None`` if the run is uncacheable (cache disabled, or the
     key computation itself failed) -- callers must treat that as a plain miss
@@ -868,7 +872,7 @@ def _verify_cache_lookup(ast, display_names, src, engine, depth, k_ind, deadlock
             k_ind=k_ind, deadlock_mode=deadlock_mode, vacuity_mode=vacuity_mode,
             property_name=property_name, exclude_property_names=exclude_property_names,
             strict_tags=strict_tags, requirements_sha256=requirements_sha256,
-            instances=instances, values=values,
+            instances=instances, values=values, docs_sha256=docs_sha256,
         )
         return cache_key, xdepth_key, verify_cache.lookup(cache_key, xdepth_key, depth)
     except Exception:  # noqa: BLE001 -- any cache-layer failure degrades to an uncached run
@@ -878,11 +882,13 @@ def _verify_cache_lookup(ast, display_names, src, engine, depth, k_ind, deadlock
 def run_verify(
         file, depth, deadlock_mode, engine="bmc", k_ind=1, vacuity_mode="warn",
         strict_tags=False, requirements=None, property_name=None,
-        exclude_property_names=None, instances=None, values=None, use_cache=True):
+        exclude_property_names=None, instances=None, values=None, use_cache=True,
+        docs=None):
     try:
         bounds_overrides = _build_bounds_overrides(instances, values)
         has_bounds_overrides = bool(bounds_overrides["instances"] or bounds_overrides["values"])
         spec, source_lines, ast, display_names, src = _read_spec(file, bounds_overrides)
+        doc_warnings, _doc_path, docs_sha256 = check_doc_trace(file, spec, docs)
         acc, acc_skipped = _acceptance_error(spec, skip_out_of_range=has_bounds_overrides)
         if acc:
             return _envelope(acc)
@@ -895,7 +901,7 @@ def run_verify(
             cache_key, xdepth_key, cached = _verify_cache_lookup(
                 ast, display_names, src, engine, depth, k_ind, deadlock_mode, vacuity_mode,
                 property_name, exclude_property_names, strict_tags, requirements,
-                instances, values,
+                instances, values, docs_sha256,
             )
         verify_mode = cached is not None and os.environ.get("FSLC_CACHE_VERIFY") == "1"
         if cached is not None and not verify_mode:
@@ -937,6 +943,9 @@ def run_verify(
             out = dict(out)
             out["implements"] = impl
         out = _add_strict_tag_warnings(out, spec, strict_tags, requirements)
+        if doc_warnings:
+            out = dict(out)
+            out["warnings"] = list(out.get("warnings") or []) + doc_warnings
         skip_warnings = (
             _bounds_skip_warnings(acc_skipped, "acceptance", bounds_overrides)
             + _bounds_skip_warnings(forb_skipped, "forbidden", bounds_overrides)
@@ -1789,6 +1798,8 @@ def _build_arg_parser():
     c.add_argument("file")
     c.add_argument("--strict-tags", action="store_true")
     c.add_argument("--requirements", default=None)
+    c.add_argument("--docs", default=None,
+                   help="canonical Markdown requirements document")
 
     v = sub.add_parser("verify")
     v.add_argument("file")
@@ -1813,6 +1824,8 @@ def _build_arg_parser():
                         "(NAME=LO..HI; repeatable)")
     v.add_argument("--strict-tags", action="store_true")
     v.add_argument("--requirements", default=None)
+    v.add_argument("--docs", default=None,
+                   help="canonical Markdown requirements document")
     v.add_argument("--no-cache", action="store_true",
                    help="skip the persistent verdict cache for this run (neither reads nor writes it)")
 
@@ -2023,7 +2036,7 @@ def _dispatch(args):
         print(f"fslc {__version__}")
         return 0
     if args.cmd == "check":
-        result = run_check(args.file, args.strict_tags, args.requirements)
+        result = run_check(args.file, args.strict_tags, args.requirements, args.docs)
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.cmd == "typestate":
         result = run_typestate(args.file)
@@ -2258,7 +2271,8 @@ def _dispatch(args):
                             exclude_property_names=args.exclude_property_names,
                             instances=args.instances,
                             values=args.values,
-                            use_cache=not args.no_cache)
+                            use_cache=not args.no_cache,
+                            docs=args.docs)
         print(json.dumps(result, indent=2, ensure_ascii=False))
 
     sys.exit(exit_code(result))

--- a/src/fslc/doc_trace.py
+++ b/src/fslc/doc_trace.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Canonical Markdown requirement extraction and spec-tag trace checks."""
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from .model import FslError
+
+
+_REQ_HEADING = re.compile(r"^##\s+([A-Z][A-Z0-9_-]*-\d+):\s*(.+?)\s*$")
+_ANY_HEADING = re.compile(r"^#{1,6}\s+")
+
+
+def _canonical_text(title, body_lines):
+    parts = [title.strip()]
+    parts.extend(line.strip() for line in body_lines if line.strip())
+    return " ".join(" ".join(parts).split())
+
+
+def parse_canonical_markdown(source):
+    """Extract ``REQ-ID -> canonical text`` from level-two normative sections."""
+    requirements = {}
+    current = None
+    title = None
+    body = []
+
+    def finish():
+        if current is None:
+            return
+        if current in requirements:
+            raise FslError(f"duplicate canonical requirement heading: {current}", kind="semantics")
+        requirements[current] = _canonical_text(title, body)
+
+    for line in source.splitlines():
+        match = _REQ_HEADING.match(line)
+        if match:
+            finish()
+            current, title = match.group(1), match.group(2)
+            body = []
+            continue
+        if _ANY_HEADING.match(line):
+            finish()
+            current = title = None
+            body = []
+            continue
+        if current is not None:
+            body.append(line)
+    finish()
+    return requirements
+
+
+def _formal_requirements(spec):
+    refs = {}
+
+    def add(req_id, text, element):
+        if not req_id:
+            return
+        refs.setdefault(req_id, []).append({"text": text, "element": element})
+
+    for kind, key in (
+        ("action", "actions"),
+        ("invariant", "user_invariants"),
+        ("trans", "transitions"),
+        ("leadsTo", "leadstos"),
+        ("reachable", "reachables"),
+    ):
+        for item in spec.get(key) or []:
+            meta = item.get("meta") or {}
+            add(meta.get("id"), meta.get("text"), f"{kind}:{item['name']}")
+    for kind, key in (("acceptance", "acceptance"), ("forbidden", "forbidden")):
+        for item in spec.get(key) or []:
+            add(item.get("id"), item.get("text"), f"{kind}:{item.get('id')}")
+    for req_id in spec.get("requirement_ids") or []:
+        refs.setdefault(req_id, [])
+    return refs
+
+
+def source_tag_path(spec):
+    meta = spec.get("kind")
+    if isinstance(meta, dict) and str(meta.get("id") or "").strip().lower() == "source":
+        return str(meta.get("text") or "").strip() or None
+    return None
+
+
+def resolve_docs_path(spec_path, spec, explicit=None):
+    if explicit:
+        return Path(explicit)
+    declared = source_tag_path(spec)
+    if declared:
+        return Path(spec_path).parent / declared
+    return None
+
+
+def check_doc_trace(spec_path, spec, docs_path=None):
+    """Return ``(warnings, resolved_path, bytes_sha256)``; no doc means no-op."""
+    path = resolve_docs_path(spec_path, spec, docs_path)
+    if path is None:
+        return [], None, None
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise FslError(f"cannot read canonical docs file '{path}': {exc}", kind="io") from exc
+    try:
+        source = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise FslError(f"canonical docs file must be UTF-8: {path}", kind="io") from exc
+    canonical = parse_canonical_markdown(source)
+    formal = _formal_requirements(spec)
+    warnings = []
+    for req_id in sorted(set(canonical) - set(formal)):
+        warnings.append({
+            "kind": "missing_formalization",
+            "requirement": {"id": req_id, "text": canonical[req_id]},
+            "document": str(path),
+            "message": f"canonical requirement {req_id} has no formal tag or scenario",
+        })
+    for req_id in sorted(set(formal) - set(canonical)):
+        warnings.append({
+            "kind": "ghost_requirement",
+            "requirement": {"id": req_id},
+            "document": str(path),
+            "elements": sorted(item["element"] for item in formal[req_id]),
+            "message": f"formal requirement {req_id} is absent from the canonical document",
+        })
+    for req_id in sorted(set(canonical) & set(formal)):
+        expected = canonical[req_id]
+        for item in formal[req_id]:
+            if item["text"] is None or " ".join(str(item["text"]).split()) == expected:
+                continue
+            warnings.append({
+                "kind": "stale_tag",
+                "requirement": {"id": req_id},
+                "element": item["element"],
+                "document": str(path),
+                "old_text": item["text"],
+                "new_text": expected,
+                "message": f"formal tag text for {req_id} differs from the canonical document",
+            })
+    return warnings, path, hashlib.sha256(raw).hexdigest()

--- a/src/fslc/verify_cache.py
+++ b/src/fslc/verify_cache.py
@@ -142,6 +142,7 @@ def compute_key(
     exclude_property_names: Optional[list],
     strict_tags: bool,
     requirements_sha256: Optional[str],
+    docs_sha256: Optional[str],
     instances: Optional[list],
     values: Optional[list],
 ) -> tuple:
@@ -163,6 +164,7 @@ def compute_key(
         "exclude_property_names": sorted(exclude_property_names or []),
         "strict_tags": strict_tags,
         "requirements_sha256": requirements_sha256,
+        "docs_sha256": docs_sha256,
         "instances": sorted(instances or []),
         "values": sorted(values or []),
     }

--- a/tests/snapshots/doc_trace_warnings.json
+++ b/tests/snapshots/doc_trace_warnings.json
@@ -1,0 +1,44 @@
+[
+  {
+    "kind": "missing_formalization",
+    "requirement": {
+      "id": "REQ-2",
+      "text": "audit is retained Audit history remains available."
+    },
+    "document": "requirements.md",
+    "message": "canonical requirement REQ-2 has no formal tag or scenario"
+  },
+  {
+    "kind": "ghost_requirement",
+    "requirement": {
+      "id": "REQ-3"
+    },
+    "document": "requirements.md",
+    "elements": [
+      "invariant:Ghost"
+    ],
+    "message": "formal requirement REQ-3 is absent from the canonical document"
+  },
+  {
+    "kind": "stale_tag",
+    "requirement": {
+      "id": "REQ-1"
+    },
+    "element": "action:enable",
+    "document": "requirements.md",
+    "old_text": "old flag wording",
+    "new_text": "flag can be enabled The flag moves from false to true.",
+    "message": "formal tag text for REQ-1 differs from the canonical document"
+  },
+  {
+    "kind": "stale_tag",
+    "requirement": {
+      "id": "REQ-1"
+    },
+    "element": "invariant:BoolFlag",
+    "document": "requirements.md",
+    "old_text": "old flag wording",
+    "new_text": "flag can be enabled The flag moves from false to true.",
+    "message": "formal tag text for REQ-1 differs from the canonical document"
+  }
+]

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -197,8 +197,8 @@ TOP_DEF_DESIGN_DOCS = {
 # command -> tuple of required docs, or a str waiver reason.
 COMMAND_DESIGN_DOCS = {
     "version": "CLI plumbing, no design doc of its own",
-    "check": ("DESIGN-v1.md",),
-    "verify": ("DESIGN-v1.md", "DESIGN-induction.md"),
+    "check": ("DESIGN-v1.md", "DESIGN-doc-trace.md"),
+    "verify": ("DESIGN-v1.md", "DESIGN-induction.md", "DESIGN-doc-trace.md"),
     "sweep": "scope-grid driver over verify; no standalone semantics (documented in LANGUAGE.md)",
     "scenarios": ("DESIGN-scenarios.md",),
     "replay": ("DESIGN-bridge.md",),

--- a/tests/test_doc_trace.py
+++ b/tests/test_doc_trace.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Canonical Markdown document trace checks (issue #192)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fslc.cli import _build_arg_parser, run_check, run_verify
+
+
+SNAPSHOT = Path(__file__).parent / "snapshots" / "doc_trace_warnings.json"
+REQ1 = "flag can be enabled The flag moves from false to true."
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _spec(source_tag="", tag_text=REQ1, extra=""):
+    meta = f' "source: requirements.md"' if source_tag else ""
+    return f"""
+spec DocTrace{meta} {{
+  state {{ flag: Bool }}
+  init {{ flag = false }}
+  action enable() "REQ-1: {tag_text}" {{
+    requires not flag
+    flag = true
+  }}
+  invariant BoolFlag "REQ-1: {tag_text}" {{ flag or not flag }}
+  {extra}
+}}
+"""
+
+
+def _docs(extra=""):
+    # Tests below use explicit text where needed; this helper preserves the
+    # canonical title+body normalization contract.
+    return f"""# Product requirements
+
+## REQ-1: flag can be enabled
+The flag moves from false to true.
+
+{extra}
+"""
+
+
+def _doc_warnings(out):
+    return [
+        item for item in out.get("warnings", [])
+        if item.get("kind") in {"missing_formalization", "ghost_requirement", "stale_tag"}
+    ]
+
+
+def test_consistent_canonical_doc_has_no_trace_warnings(tmp_path):
+    spec = _write(tmp_path, "spec.fsl", _spec())
+    docs = _write(tmp_path, "requirements.md", _docs())
+
+    checked = run_check(str(spec), docs=str(docs))
+    verified = run_verify(str(spec), 2, "ignore", docs=str(docs), use_cache=False)
+
+    assert checked["result"] == "ok"
+    assert verified["result"] == "verified"
+    assert _doc_warnings(checked) == []
+    assert _doc_warnings(verified) == []
+
+
+def test_bidirectional_id_and_freshness_warnings_include_evidence(tmp_path):
+    spec = _write(
+        tmp_path,
+        "spec.fsl",
+        _spec(
+            tag_text="old flag wording",
+            extra='invariant Ghost "REQ-3: removed requirement" { true }',
+        ),
+    )
+    docs = _write(tmp_path, "requirements.md", _docs(extra="""
+## REQ-2: audit is retained
+Audit history remains available.
+"""))
+
+    out = run_check(str(spec), docs=str(docs))
+    warnings = _doc_warnings(out)
+
+    assert [item["kind"] for item in warnings] == [
+        "missing_formalization", "ghost_requirement", "stale_tag", "stale_tag",
+    ]
+    stale = [item for item in warnings if item["kind"] == "stale_tag"]
+    assert all(item["old_text"] == "old flag wording" for item in stale)
+    assert all(item["new_text"] == REQ1 for item in stale)
+    normalized = json.loads(json.dumps(warnings))
+    for item in normalized:
+        item["document"] = "requirements.md"
+    assert normalized == json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+def test_source_tag_auto_discovers_doc_relative_to_spec(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    spec = _write(nested, "spec.fsl", _spec(source_tag=True))
+    _write(nested, "requirements.md", _docs())
+
+    out = run_check(str(spec))
+
+    assert out["result"] == "ok"
+    assert _doc_warnings(out) == []
+
+
+def test_doc_bytes_participate_in_verify_cache_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("FSLC_CACHE", "on")
+    monkeypatch.setenv("FSLC_CACHE_DIR", str(tmp_path / "cache"))
+    spec = _write(tmp_path, "spec.fsl", _spec())
+    docs = _write(tmp_path, "requirements.md", _docs())
+
+    first = run_verify(str(spec), 2, "ignore", docs=str(docs))
+    second = run_verify(str(spec), 2, "ignore", docs=str(docs))
+    docs.write_text(_docs().replace("false to true", "off to on"), encoding="utf-8")
+    after_doc_edit = run_verify(str(spec), 2, "ignore", docs=str(docs))
+
+    assert "cache" not in first
+    assert second["cache"]["hit"] is True
+    assert "cache" not in after_doc_edit
+    assert any(item["kind"] == "stale_tag" for item in after_doc_edit["warnings"])
+
+
+def test_default_without_docs_or_source_tag_is_unchanged(tmp_path):
+    spec = _write(tmp_path, "spec.fsl", _spec())
+
+    implicit = run_check(str(spec))
+    explicit_none = run_check(str(spec), docs=None)
+
+    assert implicit == explicit_none
+    assert _doc_warnings(implicit) == []
+
+
+def test_docs_cli_contract():
+    check = _build_arg_parser().parse_args([
+        "check", "spec.fsl", "--docs", "requirements.md",
+    ])
+    verify = _build_arg_parser().parse_args([
+        "verify", "spec.fsl", "--docs", "requirements.md",
+    ])
+
+    assert check.docs == "requirements.md"
+    assert verify.docs == "requirements.md"

--- a/tests/test_verify_cache.py
+++ b/tests/test_verify_cache.py
@@ -279,7 +279,10 @@ def test_run_verify_signature_is_fully_classified():
     key_params = set(inspect.signature(verify_cache.compute_key).parameters)
     # run_verify's `requirements` (a path) becomes compute_key's
     # `requirements_sha256`; everything else must match by name.
-    mapped = {"requirements": "requirements_sha256"}
+    mapped = {
+        "requirements": "requirements_sha256",
+        "docs": "docs_sha256",
+    }
     for name in run_verify_params - _NON_SEMANTIC_RUN_VERIFY_PARAMS:
         target = mapped.get(name, name)
         assert target in key_params or name in ("ast", "display_names", "src"), (


### PR DESCRIPTION
## Summary

Adds deterministic trace/freshness checks between canonical Markdown requirements and FSL tags/scenarios.

Closes #192.

## What changed

- Defines canonical normative sections as `## REQ-n: title` through the next heading.
- Normalizes canonical tag text as title + non-empty body lines with collapsed whitespace.
- Adds `check/verify --docs FILE`.
- Emits `missing_formalization`, `ghost_requirement`, and `stale_tag`; stale findings carry both old and new text.
- Adds `spec X "source: relative.md"` auto-discovery relative to the spec.
- Adds exact Markdown bytes to the verify cache key, so doc-only edits force a cache miss and re-check.
- Updates strict-tags design, language docs, FSL skill/reference, changelog, and generated website references.

## Responsibility boundary

- The checks establish ID existence and copied-text freshness, not natural-language/formula semantic equivalence.
- Text outside an ID section is explicitly non-normative; this format contract is what makes omission detection complete.
- No checksum is embedded into `.fsl`; doc edits produce actionable old/new evidence rather than an acknowledgement-hash ceremony.
- Explicit `--docs` wins over `source:`. Without either, existing output is unchanged.

## Evidence

- Full suite: **1288 passed, 78 skipped** in 12m07s
- Doc/cache/strict-tags/coupled-change/site suite: **52 passed**
- Focused canonical-doc and cache-key completeness suite: **7 passed**
- Snapshot fixes all three warning shapes including old/new text.
- `git diff --check`: clean

## Review focus

- Markdown section termination and canonical whitespace normalization.
- Formal reference collection across tags/acceptance/forbidden.
- Doc-byte cache-key threading and no-doc byte compatibility.
