### PR TITLE
feat(parser): support literate Markdown FSL

### DIFF
--- a/.github/ci-shards/shard-1.txt
+++ b/.github/ci-shards/shard-1.txt
@@ -9,3 +9,4 @@ tests/test_self.py
 tests/test_spec_domains.py
 tests/test_trans.py
 tests/test_verify_cache.py
+tests/test_literate.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Literate Markdown FSL (issue #193): `fslc` now automatically recognizes one or
+  more standalone fenced `fsl` blocks in a Markdown source and parses them as one
+  compilation unit without a CLI flag. Prose and fence lines are blanked in place,
+  preserving original document locations for parser diagnostics, counterexamples,
+  and LSP symbols/references; imported Markdown files use their own directory for
+  relative paths. Files without an `fsl` fence retain the ordinary parse path, an
+  unclosed fence is a located parse error, and the verification cache still keys
+  the raw document bytes. See `docs/DESIGN-literate.md`.
 - Assurance classes (issue #171): a shared `fslc.assurance` classifier turns
   every command's result dict (BMC `verify`, k-induction `prove`, and the
   fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"` producers — replay,

--- a/docs/DESIGN-literate.md
+++ b/docs/DESIGN-literate.md
@@ -1,0 +1,48 @@
+# Literate FSL in Markdown
+
+Issue #193 adds Markdown as a container format for ordinary FSL compilation
+units. A file is treated as literate FSL when it contains at least one
+standalone fenced block whose opening line is `````fsl`` and whose closing line
+is ``````, with optional horizontal whitespace around either marker.
+
+## Extraction contract
+
+`src/fslc/literate.py` applies an in-place extraction before parsing:
+
+- lines inside every `fsl` fence are retained byte-for-byte;
+- prose and fence-marker lines are replaced by blank lines while retaining
+  their original newline sequence;
+- all `fsl` blocks are concatenated implicitly by their original positions and
+  parsed as one compilation unit;
+- files with no `fsl` fence, including files containing only another fence
+  language, pass through unchanged;
+- an unclosed `fsl` fence is a parse error located at its opening line.
+
+Blanking instead of copying blocks into a new buffer preserves the document's
+line and column coordinates. Parser diagnostics, declaration locations, LSP
+symbols/references, and counterexample action locations therefore point directly
+into the Markdown document.
+
+## Integration boundaries
+
+Sniffing happens at each parser entry point, including files loaded through
+`compose` and dialect imports. The existing source path remains the base path,
+so a relative import in `docs/order.md` resolves relative to `docs/`, exactly as
+it would for `docs/order.fsl`.
+
+The LSP selects a line-preserving parser adapter before dialect sniffing. The
+adapter exposes the extracted FSL to the existing index visitor without changing
+document offsets.
+
+Verification-cache identity continues to include the raw entry-file bytes in
+addition to the desugared kernel AST. A prose-only edit can therefore never
+reuse a verdict attributed to an older document revision, even when the embedded
+FSL is unchanged.
+
+## Semantic boundary
+
+Markdown is only a source container. It introduces no grammar production, AST
+node, verifier/runtime behavior, assurance class, or exit-code change. Multiple
+blocks have exactly the same meaning as the same FSL declarations in a plain
+file. Documentation traceability remains an explicit reporting concern; prose
+outside a fence is not assigned formal semantics.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -7,6 +7,15 @@ always tracks the latest implementation). The background to design decisions and
 the implementation design of each feature can be reached from
 [`README.md`](README.md) (the docs map).
 
+An FSL compilation unit may also be embedded in Markdown. Put declarations in
+one or more standalone fenced `fsl` blocks and pass the `.md` file directly to
+commands such as `fslc check` or `fslc verify`; no flag is required. All `fsl`
+blocks form one compilation unit, relative imports resolve from the Markdown
+file's directory, and diagnostics/counterexamples retain the document's original
+line and column numbers. Files without an `fsl` fence are parsed normally rather
+than being treated as empty specifications. See `docs/DESIGN-literate.md` for the
+extraction and tooling contract.
+
 ## Design principles
 
 | Principle | Existing languages (TLA+/Alloy) | FSL |

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@
 | [`DESIGN-init-if.md`](DESIGN-init-if.md) | Statement-level `if` in `init` (lowered to path-conditional initial-state constraints, same branch shape as action bodies) |
 | [`DESIGN-inline-range.md`](DESIGN-inline-range.md) | Inline anonymous range types (`x: lo..hi`) |
 | [`DESIGN-spec-domains.md`](DESIGN-spec-domains.md) | `entity` / `number` in the kernel `spec` (decoupling a domain from the verification bound) |
+| [`DESIGN-literate.md`](DESIGN-literate.md) | Literate FSL in Markdown: automatic fenced-`fsl` extraction, original document locations, imports, LSP, and cache identity |
 | [`DESIGN-precedence-policy.md`](DESIGN-precedence-policy.md) | The business-layer no-bypass precedence policy (#75) — why `business` keeps users from writing `state`/`invariant` directly |
 | [`DESIGN-ledger.md`](DESIGN-ledger.md) | `fslc ledger` (turning verifier evidence into a per-requirement-id Markdown audit ledger for PM/audit) |
 | [`DESIGN-assurance-classes.md`](DESIGN-assurance-classes.md) | Assurance-class vocabulary (`proved`/`bounded`/`replay-observed`/`statistical`/`not_run`) shared by `fslc ledger` and `fslc html`, and what each class does/does not guarantee |

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -12,6 +12,12 @@ read it before writing a spec). Within the repository, `docs/LANGUAGE.md` is the
 complete reference and `specs/*.fsl` are working examples (cart_v1 is the basic
 form, mutex_queue is Seq+leadsTo, and bank_* are refinement+compose examples).
 
+When the surrounding prose is itself the durable design artifact, it may be a
+Markdown file containing one or more fenced `fsl` blocks. Run ordinary `fslc`
+commands on that `.md` file; do not copy the blocks to a temporary `.fsl`, because
+the in-place extraction deliberately preserves diagnostics and counterexamples at
+the Markdown line numbers. Keep imports relative to the Markdown document.
+
 **What makes FSL different — connectivity, not just per-spec checking.** Classic
 formal methods describe one hard spot and verify it in isolation (the "island"
 model). FSL's distinctive value is stitching business ⊒ requirements ⊒ design

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -3,6 +3,14 @@
 Read this entire file before writing a spec. This is the full syntax and full set
 of rules as of v2.x.
 
+FSL may be the canonical executable part of a Markdown document: put declarations
+in one or more standalone fenced `fsl` blocks, then run the normal command on the
+`.md` path without a special flag. Blocks share one compilation unit; prose and
+fence lines are ignored in place so diagnostics, counterexamples, and LSP symbols
+keep the Markdown line numbers. Relative imports use the document's directory.
+An unclosed `fsl` fence is a parse error, and a document without one is not
+silently accepted as an empty spec.
+
 ## 1. Top-level structure
 
 ```fsl

--- a/src/fslc/compose.py
+++ b/src/fslc/compose.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .grammar import PARSER, Ast
 from .model import FslError
+from .literate import extract_literate_source, is_literate_source
 
 
 def _compose_err(message, kind="type", loc=None):
@@ -21,6 +22,8 @@ def _prefix(name, alias):
 
 def _parse_file(path):
     src = Path(path).read_text(encoding="utf-8")
+    if is_literate_source(src):
+        src = extract_literate_source(src)
     return Ast().transform(PARSER.parse(src))
 
 

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .compose import expand_compose
 from .grammar import Ast, PARSER
 from .model import FslError, eval_const
+from .literate import extract_literate_source, is_literate_source
 
 
 def _err(message, kind="type", loc=None, hint=None):
@@ -18,6 +19,8 @@ def _err(message, kind="type", loc=None, hint=None):
 
 def _parse_file(path, bounds_overrides=None):
     src = Path(path).read_text(encoding="utf-8")
+    if is_literate_source(src):
+        src = extract_literate_source(src)
     ast = Ast().transform(PARSER.parse(src))
     filtered = _overrides_for_declared_names(ast, bounds_overrides)
     if filtered is not None:

--- a/src/fslc/literate.py
+++ b/src/fslc/literate.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Markdown fenced-FSL sniffing and line-preserving extraction."""
+from __future__ import annotations
+
+import re
+
+from .model import FslError
+
+
+_OPEN = re.compile(r"^[ \t]*```fsl[ \t]*$")
+_CLOSE = re.compile(r"^[ \t]*```[ \t]*$")
+
+
+def is_literate_source(source):
+    return any(_OPEN.match(line) for line in source.splitlines())
+
+
+def extract_literate_source(source):
+    """Blank prose/fence lines while preserving code line and column positions."""
+    if not is_literate_source(source):
+        return source
+    output = []
+    inside = False
+    opening_line = None
+    for line_number, line in enumerate(source.splitlines(keepends=True), start=1):
+        content = line.rstrip("\r\n")
+        newline = line[len(content):]
+        if not inside and _OPEN.match(content):
+            inside = True
+            opening_line = line_number
+            output.append(newline)
+        elif inside and _CLOSE.match(content):
+            inside = False
+            opening_line = None
+            output.append(newline)
+        elif inside:
+            output.append(line)
+        else:
+            output.append(newline)
+    if inside:
+        raise FslError(
+            f"unclosed ```fsl fence opened at line {opening_line}",
+            kind="parse",
+            loc={"line": opening_line, "column": 1},
+        )
+    return "".join(output)
+
+
+class LiterateParser:
+    """Parser adapter used by LSP coverage/indexing with original positions."""
+
+    def __init__(self, parser):
+        self._parser = parser
+
+    def parse(self, source):
+        return self._parser.parse(extract_literate_source(source))

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -33,6 +33,11 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 from lark import Tree, Token
 
 from fslc.grammar import PARSER
+from fslc.literate import (
+    LiterateParser,
+    extract_literate_source,
+    is_literate_source,
+)
 from fslc.ai_parser import AI_PARSER, is_ai_source
 from fslc.ai_project import _top_blocks, is_ai_project_source
 from fslc.db_parser import DB_PARSER, is_dbsystem_source
@@ -569,6 +574,9 @@ class DocumentIndex:
 
 
 def _parser_for_source(source: str):
+    if is_literate_source(source):
+        extracted = extract_literate_source(source)
+        return LiterateParser(_parser_for_source(extracted))
     if is_dbsystem_source(source):
         return DB_PARSER
     if is_domain_source(source):

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -27,6 +27,7 @@ from .ai_expand import expand_ai_component
 from .ai_parser import is_ai_component_source, parse_ai_component
 from .domain_expand import expand_domain
 from .domain_parser import is_domain_source, parse_domain
+from .literate import extract_literate_source, is_literate_source
 
 
 def parse_src(src, base_dir=None, bounds_overrides=None):
@@ -36,6 +37,9 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
     comes from ``fslc verify --instances``/``--values`` and replaces the matching
     ``verify { ... }`` bounds before dialect desugaring runs.
     """
+    if is_literate_source(src):
+        src = extract_literate_source(src)
+
     if is_dbsystem_source(src):
         has_bounds_overrides = bool(
             bounds_overrides

--- a/tests/test_literate.py
+++ b/tests/test_literate.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Markdown-embedded literate FSL parsing (issue #193)."""
+from __future__ import annotations
+
+from fslc.cli import run_check, run_verify
+from fslc.literate import is_literate_source
+from fslc.lsp.index import build_index
+
+
+def _write(tmp_path, name, source):
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _strip_unstable(value):
+    if isinstance(value, dict):
+        return {
+            key: _strip_unstable(item)
+            for key, item in value.items()
+            if key not in ("cost", "cache")
+        }
+    if isinstance(value, list):
+        return [_strip_unstable(item) for item in value]
+    return value
+
+
+def test_syntax_error_location_is_markdown_line(tmp_path):
+    source = """# Requirement
+
+The formal rule is embedded below.
+
+```fsl
+spec BadDoc {
+  state { flag: Bool }
+  init { flag = false }
+  action stay() { flag = flag }
+  invariant Safe { flag and }
+}
+```
+"""
+    path = _write(tmp_path, "bad.md", source)
+
+    out = run_check(str(path))
+
+    assert out["result"] == "error"
+    assert out["kind"] == "parse"
+    assert out["loc"] == {"line": 10, "column": 29}
+
+
+def test_multiple_blocks_equal_one_compilation_unit(tmp_path):
+    literate = _write(tmp_path, "split.md", """# Split spec
+
+```fsl
+spec Split {
+  state { flag: Bool }
+  init { flag = false }
+  action enable() { requires not flag  flag = true }
+```
+
+The invariant stays beside its prose requirement.
+
+```fsl
+  invariant BoolFlag { flag or not flag }
+}
+```
+""")
+    plain = _write(tmp_path, "plain.fsl", """spec Split {
+  state { flag: Bool }
+  init { flag = false }
+  action enable() { requires not flag  flag = true }
+  invariant BoolFlag { flag or not flag }
+}
+""")
+
+    literate_result = run_verify(str(literate), 2, "ignore", use_cache=False)
+    plain_result = run_verify(str(plain), 2, "ignore", use_cache=False)
+
+    assert _strip_unstable(literate_result) == _strip_unstable(plain_result)
+
+
+def test_non_fsl_markdown_is_not_sniffed(tmp_path):
+    no_fence = "# prose only\n\nNothing formal here.\n"
+    python_fence = "# example\n\n```python\nprint('not fsl')\n```\n"
+
+    assert is_literate_source(no_fence) is False
+    assert is_literate_source(python_fence) is False
+    assert run_check(str(_write(tmp_path, "prose.md", no_fence)))["kind"] == "parse"
+    assert run_check(str(_write(tmp_path, "python.md", python_fence)))["kind"] == "parse"
+
+
+def test_counterexample_action_location_is_markdown_line(tmp_path):
+    path = _write(tmp_path, "violated.md", """# Safety
+
+The action below must preserve zero.
+
+```fsl
+spec ViolatedDoc {
+  type X = 0..1
+  state { x: X }
+  init { x = 0 }
+  action break_rule() { x = 1 }
+  invariant StaysZero { x == 0 }
+}
+```
+""")
+
+    out = run_verify(str(path), 1, "ignore", use_cache=False)
+
+    assert out["result"] == "violated"
+    assert out["last_action"]["name"] == "break_rule"
+    assert out["last_action"]["loc"] == {"line": 10, "column": 3}
+
+
+def test_lsp_indexes_original_markdown_positions():
+    source = """# Review
+
+```fsl
+spec IndexedDoc {
+  state { flag: Bool }
+  init { flag = false }
+  action enable() { flag = true }
+  invariant Safe { flag }
+}
+```
+"""
+
+    index = build_index(source, "indexed.md")
+    spec = next(item for item in index.symbols if item.role == "spec")
+    action = next(item for item in index.symbols if item.role == "action")
+
+    assert spec.selection_range.start.line == 3
+    assert action.selection_range.start.line == 6
+
+
+def test_lsp_dispatches_embedded_business_dialect_at_document_positions():
+    source = """# Business flow
+
+```fsl
+business ReturnHandling {
+  actor Customer, Manager
+  entity Return
+
+  process Return {
+    stages Requested, Approved
+    initial Requested
+    transition approve Requested -> Approved by Manager
+  }
+}
+verify { instances Return = 1 }
+```
+"""
+
+    index = build_index(source, "business.md")
+    business = next(item for item in index.symbols if item.name == "ReturnHandling")
+    transition = next(item for item in index.symbols if item.name == "approve")
+
+    assert business.selection_range.start.line == 3
+    assert transition.selection_range.start.line == 10
+
+
+def test_compose_import_resolves_from_markdown_directory(tmp_path):
+    _write(tmp_path, "child.fsl", """spec Child {
+  type X = 0..0
+  state { flag: Bool }
+  init { flag = false }
+  action enable(x: X) { requires not flag  flag = true }
+}
+""")
+    root = _write(tmp_path, "root.md", """# Composite
+
+```fsl
+compose Root {
+  use Child as child from "child.fsl"
+  action enable(x: child.X) = child.enable(x) { }
+  internal child.enable
+}
+```
+""")
+
+    out = run_check(str(root))
+
+    assert out["result"] == "ok"
+    assert out["spec"] == "Root"
+
+
+def test_prose_edit_changes_raw_verify_cache_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("FSLC_CACHE", "on")
+    monkeypatch.setenv("FSLC_CACHE_DIR", str(tmp_path / "cache"))
+    source = """# First prose
+
+```fsl
+spec CachedDoc {
+  state { flag: Bool }
+  init { flag = false }
+  action enable() { requires not flag  flag = true }
+  invariant Safe { flag or not flag }
+}
+```
+"""
+    path = _write(tmp_path, "cached.md", source)
+    first = run_verify(str(path), 2, "ignore")
+    second = run_verify(str(path), 2, "ignore")
+    path.write_text(source.replace("First prose", "Edited prose"), encoding="utf-8")
+    edited = run_verify(str(path), 2, "ignore")
+
+    assert "cache" not in first
+    assert second["cache"]["hit"] is True
+    assert "cache" not in edited
+
+
+def test_unclosed_fsl_fence_is_parse_error(tmp_path):
+    path = _write(tmp_path, "unclosed.md", """# Broken
+
+```fsl
+spec Broken { state { x: Bool } }
+""")
+
+    out = run_check(str(path))
+
+    assert out["result"] == "error"
+    assert out["kind"] == "parse"
+    assert out["loc"] == {"line": 3, "column": 1}


### PR DESCRIPTION
## Problem

FSLを設計文書と同じMarkdownに置く場合、従来は fenced block を一時的な `.fsl` へコピーする必要がありました。その結果、診断・反例・LSP位置が原文書とずれ、文書と実行可能仕様の二重管理が発生していました。

Closes #193

## Change contract

- standalone な fenced `fsl` block を自動検出し、複数blockを1 compilation unitとして扱います
- proseとfence行だけを同じ行位置で空白化し、FSL本文はbyte-for-byte保持します
- `check` / `verify` を含む既存コマンドは `.md` を追加flagなしで受け取ります
- parse diagnostics、counterexample action loc、LSP symbol/referenceはMarkdown原文のline/columnを返します
- 抽出後に既存dialect sniffingへ再dispatchするため、kernelだけでなくbusiness/domain/db/AI parserのLSP経路を維持します
- import/composeはMarkdown文書のdirectoryを相対path基準として維持します
- `fsl` fenceがない文書や他言語fenceはsniffせず、未閉鎖fenceはopening lineのparse errorになります
- verify cacheは引き続きraw document bytesをkeyに含め、prose-only editでも旧文書のverdictを再利用しません

## Semantic boundary

Markdownはsource containerのみです。grammar/AST、verifier/runtime semantics、assurance class、exit codeは変更しません。prose自体に形式的意味は付与しません。

## Documentation and agent guidance

- `docs/LANGUAGE.md` と `docs/DESIGN-literate.md`
- `docs/README.md` の設計map
- `skills/fsl/SKILL.md` と `skills/fsl/reference.md`
- `CHANGELOG.md`
- site reference generatorを実行し、generated HTMLに差分がないことを確認

## Evidence

- `.venv/bin/pytest -q tests/test_literate.py tests/test_lsp_index.py tests/test_coupled_change_meta.py` → 37 passed
- `.venv/bin/pytest -q tests/test_literate.py tests/test_coupled_change_meta.py tests/test_lsp_index.py tests/test_lsp_server.py tests/test_site_reference_snapshot.py` → 49 passed
- final `.venv/bin/pytest -q` → 1291 passed, 78 skipped
- `git diff --cached --check` → clean

## Review guide

1. `src/fslc/literate.py` のin-place blankingと未閉鎖fence契約
2. parser/import/LSP各入口で位置とdialect dispatchが失われないこと
3. `tests/test_literate.py` のmultiple blocks、loc、relative import、cache、non-FSL fence回帰
4. 文書がMarkdownを意味論ではなくcontainerとして説明していること