### PR TITLE
feat(ledger): add intentional undecided declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Intentional undecided declarations (issue #189): reserve the
+  `"undecided: reason"` metadata tag, including tagged `init`, and add
+  dependency-derived affected requirement IDs to new ledger and HTML undecided
+  sections. Bounded underspecification findings remain visible and now distinguish
+  exact declaration matches with additive `acknowledged` / `acknowledged_by`
+  fields. Includes native Rust integration/snapshot coverage and
+  `docs/DESIGN-undecided.md`, shared FSL skill guidance, and bilingual manual-site
+  coverage for the syntax and acknowledged-review workflow. The frozen Python
+  reference implementation is intentionally unchanged.
 - Complete the native Rust migration for issue #195: generic `check` and bounded
   `verify` now agree with the Python reference across all 181 FSL corpus files,
   database documents lower to executable compatibility kernels, collection

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -185,6 +185,10 @@ These are trend and review-priority signals for downstream tooling.
 The underspecification findings add a question-form `spec_question`,
 `evidence_basis:"bounded_bmc"`, and explicit depth/reachability metadata. See
 `DESIGN-underspecification.md` for the fixed bound, cost cap, and overlap rules.
+An exact `involved_nodes` match with an `undecided:` declaration remains in the
+output and adds `acknowledged:true` plus `acknowledged_by`; unmatched semantic
+findings retain the existing schema shape with no acknowledgement fields. This is deterministic node
+matching, not natural-language interpretation. See `DESIGN-undecided.md`.
 
 Every finding has:
 
@@ -200,6 +204,7 @@ Every finding has:
 - `candidate_repairs`
 - `do_not_assume`
 - optional `spec_question` and `evidence_basis`
+- optional `acknowledged` and `acknowledged_by` on semantic underspecification findings
 
 `progressless_cycle` is deliberately conservative in naming. It does not use
 `H1`, `Betti`, or `homology` in public output, and it does not rely on
@@ -256,6 +261,8 @@ The analysis package is in `src/fslc/analysis/`:
 - `export.py`: DOT and Mermaid formatting.
 - `findings.py`: AI-readable review findings.
 
-The implementation does not call Z3 and does not perform bounded reachability.
-If a future finding needs proof status, it should explicitly call or consume the
+Most structural projections do not call Z3. The bounded underspecification probe
+is the explicit exception: it reuses the verifier's BMC machinery at a fixed
+depth and still reports `formal_status:"not_a_violation"`. If another future
+finding needs proof status, it should explicitly call or consume the
 existing verifier/refinement/replay result and state that evidence in the JSON.

--- a/docs/DESIGN-html-report.md
+++ b/docs/DESIGN-html-report.md
@@ -59,6 +59,10 @@ the verifier's verdict on it:
   `reachable`), plus an automatic-checks table that also holds anything
   dialect-generated (type-bound checks, partial-op checks, generated actions,
   deadline invariants)
+- when present, an **Intentional Undecided Decisions** table listing each
+  `undecided:` declaration, its reason, and state-dependency-derived affected
+  requirement IDs; the section explicitly says the marker is metadata rather
+  than a verification condition
 - verification status and warnings
 - counterexample or reachable trace timeline, including relation edge summaries
   when trace state contains `relation A -> B` values

--- a/docs/DESIGN-ledger.md
+++ b/docs/DESIGN-ledger.md
@@ -45,13 +45,16 @@ fslc ledger spec.fsl --depth 8 --impl-log run.json -o ledger.md
 1. **Header** — the guarantee limit in positive form ("BMC: depth N までの全実行を
    網羅" / "k帰納法で全実行を証明") + the honesty line ("保証するのは内部整合;
    intent fidelity is borne by the per-row 判断").
-2. **リスク一覧** — one row per requirement id: 業務目的 / 状態 (🔴 要確認 / 🟢
+2. **未決定一覧** — when `undecided:` metadata exists, declaration / reason /
+   state-dependency-derived affected requirement IDs. The marker is explicitly
+   identified as metadata, not a verification condition.
+3. **リスク一覧** — one row per requirement id: 業務目的 / 状態 (🔴 要確認 / 🟢
    確認済) / 検出種別 (`trace_type`) / リスク (`control.severity`) / 判断者
    (`control.owner`) / 次アクション.
-3. **要件ID別詳細** — per requirement: the raw counterexample **translated into a
+4. **要件ID別詳細** — per requirement: the raw counterexample **translated into a
    business sentence** (dispatched on `trace_type`), the next action, and a
    decision line (☐承認 ☐差戻し ☐リスク受容 / 判断者 / 期限).
-4. **付録** — the raw JSON findings, collapsed (`<details>`), demoted off page 1.
+5. **付録** — the raw JSON findings, collapsed (`<details>`), demoted off page 1.
 
 ## Column → source map
 

--- a/docs/DESIGN-undecided.md
+++ b/docs/DESIGN-undecided.md
@@ -1,0 +1,86 @@
+# Intentional undecided declarations
+
+Issue: #189
+
+## Goal
+
+FSL represents deferred decisions as nondeterminism, but nondeterminism alone
+does not say whether the freedom is intentional. The reserved declaration tag
+`"undecided: reason"` records that a specification owner has reviewed a choice
+and deliberately left it open. The tag is metadata: it does not add a guard,
+property, assumption, or verification obligation.
+
+## Syntax and scope
+
+`undecided` uses the existing single declaration-tag slot. The canonical spelling
+is lower-case and the parser recognizes it case-insensitively. It is available on
+kernel declarations that accept metadata tags, plus `init`:
+
+```fsl
+init "undecided: initial operating mode will be selected later" { ... }
+action route() "undecided: routing policy is pending" { ... }
+trans Routing "undecided: cross-step routing constraint is pending" { ... }
+```
+
+The same slot cannot simultaneously carry a requirement tag. Therefore
+`undecided` is never treated as a requirement ID. A declaration's affected
+requirement IDs are derived from the model dependency graph instead.
+
+The authoritative implementation is the native Rust CLI. The Python
+implementation is frozen as a compatibility reference and is intentionally not
+changed for this feature; tests and snapshots for this contract live on the
+Rust CLI side.
+
+## Affected-requirement calculation
+
+Each declaration receives a deterministic state footprint:
+
+- `init`: assignment targets, right-hand sides, branch conditions, and binders;
+- `action`: guards, lets, assignment targets/values, branch conditions, and
+  ensures clauses;
+- properties: every referenced state root in the property expression (and both
+  sides/decreases for `leadsTo`).
+
+A requirement ID is affected when one of its tagged declarations has a
+non-empty footprint intersection with the undecided declaration. Output is
+deterministic (IDs lexicographically, declarations in model order); the
+dependency comparison itself uses sets. An empty result is rendered as `—`,
+not guessed from prose.
+
+## Report surfaces
+
+`fslc ledger` adds `## 未決定一覧`; `fslc html` adds
+`Intentional Undecided Decisions`. Both list the declaration, reason, and
+affected requirement IDs, and both state that the marker is metadata rather
+than a verification condition. Reports omit the section when no marker exists.
+
+## Underspecification acknowledgement
+
+`analyze --profile ai-review` continues to emit every `divergent_choice` and
+`unconstrained_effect` finding. It does not suppress reviewed freedom. A finding
+whose `involved_nodes` contains an `undecided` declaration gains:
+
+```json
+{
+  "acknowledged": true,
+  "acknowledged_by": [
+    {"declaration": "action route", "reason": "routing policy is pending"}
+  ]
+}
+```
+
+An unmatched semantic finding carries no acknowledgement fields and remains an
+unresolved finding. The fields are additive in `analysis-findings.v0`;
+`formal_status` remains
+`not_a_violation`. Acknowledgement is exact declaration-node matching, never a
+natural-language similarity judgment.
+
+## Non-goals and limits
+
+- Proving that an undecided declaration is safe; ordinary verification still
+  checks every allowed resolution.
+- Suppressing findings or lowering their evidence strength.
+- Inferring product decisions from the tag reason.
+- Supporting more than one metadata tag on a declaration.
+- Treating requirements-process `covers` as an undecided marker; `covers`
+  remains the transition-to-requirement traceability contract.

--- a/docs/DESIGN-underspecification.md
+++ b/docs/DESIGN-underspecification.md
@@ -114,6 +114,11 @@ Other findings are not duplicates. For example, `progressless_cycle` asks about
 eventual progress, while `divergent_choice` asks which immediate contract
 outcome is intended.
 
+An exact involved-node match with an `undecided:` declaration is retained and
+adds `acknowledged:true` plus `acknowledged_by`; an unmatched semantic finding
+has no acknowledgement fields. Acknowledgement never suppresses the finding. See
+`DESIGN-undecided.md`.
+
 ## Non-goals
 
 - Proving determinism or completeness at all depths.

--- a/docs/GUIDE-analyze.ja.md
+++ b/docs/GUIDE-analyze.ja.md
@@ -182,6 +182,13 @@ findings は**決定的なヒューリスティック**で、すべて `severity
 BMC witness がある場合、同じ state/action の `unread_state` / `unguarded_action` は
 二重表示せず、強い意味論所見へ一本化する。
 
+さらに、所見の `involved_nodes` が `"undecided: 理由"` タグ付き宣言と一致すると、
+所見は抑制されず `acknowledged: true` と `acknowledged_by`（宣言名・理由）を持つ。
+一致しない所見には acknowledgement フィールドを追加しない。前者は
+「意図的に先送り済み」、フィールドのない後者は「未処理」としてレビューキューを分ける。
+`undecided:` は検証条件ではなく、通常の `verify` は引き続き全ての解決に対して
+安全性を検査する。設計詳細は `DESIGN-undecided.md` を参照。
+
 ### 6.1 実例
 
 デモ仕様 `OrderReview`（`submit()` に guard なし、`audit_ready` を誰も書かない）を

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -32,7 +32,7 @@ spec <Name> ["<kind>: <intent>"] {   // optional spec-level tag → metadata bad
   def <name>(<p>: <type name>, ...) = <expr> // non-recursive named predicate; frontend-inlined
 
   state { <var>: <type>, ... }
-  init  { <stmt>... }
+  init  ["undecided: reason"] { <stmt>... }
 
   [fair] action <name>(<p>: <type name>, ...) {
     requires <expr>                     // guard. multiple allowed (conjunction)
@@ -1282,6 +1282,23 @@ invariant PaidLedger "REQ-3: the ledger matches the number of payments" { ... }
 action submit(c: Case, a: Amount) "REQ-1: amounts at or below the threshold are auto-approved" { ... }
 ```
 
+The reserved `"undecided: reason"` tag marks a reviewed, intentionally deferred
+decision. It is metadata and is never verified as a property. It may be attached
+to `init`, `action`, `invariant`, `trans`, `reachable`, or `leadsTo`; for example:
+
+```fsl
+init "undecided: initial operating mode is pending" { mode = Manual }
+action route() "undecided: routing policy is pending" { ... }
+```
+
+`fslc ledger` and `fslc html` list these declarations and the requirement IDs
+whose state dependencies overlap them. `analyze --profile ai-review` keeps an
+underspecification finding but marks an exact declaration match as
+`acknowledged:true`. Because the declaration-tag slot is singular, an
+`undecided` declaration does not also carry an `ID: text` tag. See
+`DESIGN-undecided.md`. This feature is implemented by the authoritative native
+Rust CLI and is not backported to the frozen Python reference implementation.
+
 ### 13.2 Requirements layer: `requirements` (the fsl-req dialect)
 
 ```fsl
@@ -1968,7 +1985,9 @@ DESIGN-*.md).
   `divergent_choice`, and `unconstrained_effect`. The last two use a fixed
   depth-4 BMC probe: they include `evidence_basis:"bounded_bmc"`, the reachable
   branch witness, and a question-form `spec_question` asking which outcome is
-  intended. A BMC-backed `unconstrained_effect` suppresses the same state's
+  intended. Exact matches with `undecided:` declarations remain visible with
+  `acknowledged:true` and `acknowledged_by`; unmatched semantic findings carry
+  no acknowledgement fields. A BMC-backed `unconstrained_effect` suppresses the same state's
   structural `unread_state`; semantic action witnesses similarly suppress a
   duplicate `unguarded_action`. Absence is not proof of determinism beyond the
   bound. See [`DESIGN-underspecification.md`](DESIGN-underspecification.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@
 | [`DESIGN-analysis.md`](DESIGN-analysis.md) | `fslc analyze` (Typed Semantic Graph, graph projections, focus impact slices, action dependency/conflict graphs, structural metrics, batch mode, refinement/project traceability graphs, DOT/Mermaid exports, schemas, AI-readable structural review findings/candidates) |
 | [`DESIGN-tag-drift.md`](DESIGN-tag-drift.md) | Deterministic declaration-tag identifier drift findings and `tag-review.v0` external review export contract |
 | [`DESIGN-underspecification.md`](DESIGN-underspecification.md) | bounded `divergent_choice` / `unconstrained_effect` AI-review findings and question-form output |
+| [`DESIGN-undecided.md`](DESIGN-undecided.md) | reserved `undecided:` declaration metadata, affected-requirement projection, ledger/HTML display, and acknowledged underspecification findings |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
 | [`DESIGN-domain.md`](DESIGN-domain.md) | fsl-domain (`domain`) Functional DDD / async effect dialect: aggregate ownership, command/event decide/evolve lowering, saga/process-manager actions, effect lifecycle state, findings, multi-target scaffolds, and runtime replay |
 | [`DESIGN-effect.md`](DESIGN-effect.md) | fsl-effect lifecycle semantics used by fsl-domain: correlation, retry, timeout, idempotency, and guarantee boundary |

--- a/docs/intro/analysis.en.html
+++ b/docs/intro/analysis.en.html
@@ -162,15 +162,15 @@ fslc analyze spec.fsl --projection action_state_graph --format mermaid</code></p
       </div>
       <div class="card">
         <h3><code>divergent_choice</code></h3>
-        <p>A depth-4 BMC witness shows two actions enabled in one reachable state and splitting an invariant or acceptance outcome. The finding asks which outcome is intended.</p>
+        <p>A depth-4 BMC witness shows two actions enabled in one reachable state and splitting an invariant or acceptance outcome. The finding asks which outcome is intended and remains visible even when acknowledged.</p>
       </div>
       <div class="card">
         <h3><code>unconstrained_effect</code></h3>
-        <p>A depth-4 BMC witness shows two actions writing different next values to state outside the contract-observation graph. It supersedes the duplicate <code>unread_state</code> signal.</p>
+        <p>A depth-4 BMC witness shows two actions writing different next values to state outside the contract-observation graph. It supersedes the duplicate <code>unread_state</code> signal, but is never suppressed by acknowledgement.</p>
       </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
-      <p style="margin:0">The cycle finding does not inspect English keywords in names. The underspecification findings are bounded review evidence, not proof of determinism: absence means only “not witnessed within depth 4.”</p>
+      <p style="margin:0">The cycle finding does not inspect English keywords in names. The underspecification findings are bounded review evidence, not proof of determinism: absence means only “not witnessed within depth 4.” An exact match with an <code>undecided:</code> declaration adds <code>acknowledged:true</code> and <code>acknowledged_by</code>; unmatched findings have no acknowledgement fields and remain unresolved. The tag records intentional deferral and is not a verification condition. See <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-undecided.md">DESIGN-undecided.md</a>.</p>
     </div>
   </div>
 </section>

--- a/docs/intro/analysis.ja.html
+++ b/docs/intro/analysis.ja.html
@@ -162,15 +162,15 @@ fslc analyze spec.fsl --projection action_state_graph --format mermaid</code></p
       </div>
       <div class="card">
         <h3><code>divergent_choice</code></h3>
-        <p>深さ4のBMC witness が、同じ到達状態で2操作が有効になり、invariant または acceptance の結果が分かれることを示します。どちらが意図かを質問します。</p>
+        <p>深さ4のBMC witness が、同じ到達状態で2操作が有効になり、invariant または acceptance の結果が分かれることを示します。どちらが意図かを質問し、acknowledged 後も所見を残します。</p>
       </div>
       <div class="card">
         <h3><code>unconstrained_effect</code></h3>
-        <p>深さ4のBMC witness が、契約の観測グラフ外の状態へ2操作が異なる次値を書けることを示します。重複する <code>unread_state</code> は抑制します。</p>
+        <p>深さ4のBMC witness が、契約の観測グラフ外の状態へ2操作が異なる次値を書けることを示します。重複する <code>unread_state</code> は抑制しますが、acknowledgement によってこの所見自体を消すことはありません。</p>
       </div>
     </div>
     <div class="callout reveal" style="margin-top:24px">
-      <p style="margin:0">cycle 所見は名前の英単語を見ません。未決定領域の所見は有界レビュー証拠であり、決定性の証明ではありません。所見がないことは「深さ4以内では witness がない」という意味だけです。</p>
+      <p style="margin:0">cycle 所見は名前の英単語を見ません。未決定領域の所見は有界レビュー証拠であり、決定性の証明ではありません。所見がないことは「深さ4以内では witness がない」という意味だけです。<code>undecided:</code> 宣言との完全一致は <code>acknowledged:true</code> と <code>acknowledged_by</code> を追加し、一致しない所見には acknowledgement フィールドを追加せず、未処理のまま残します。このタグは意図的な先送りを記録するメタデータで、検証条件ではありません。詳細は <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-undecided.md">DESIGN-undecided.md</a>。</p>
     </div>
   </div>
 </section>

--- a/docs/intro/design-notes.en.html
+++ b/docs/intro/design-notes.en.html
@@ -57,6 +57,7 @@
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ledger.md">DESIGN-ledger.md</a></td><td><code>fslc ledger</code> (turning verifier evidence into a per-requirement Markdown audit ledger)</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-nfr.md">DESIGN-nfr.md</a></td><td>Non-functional requirements (the mapping table, discrete-time SLA: time/urgent/age/deadline)</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md">DESIGN-analysis.md</a></td><td><code>fslc analyze</code> (the Typed Semantic Graph, graph projections, AI-review findings)</td></tr>
+      <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-undecided.md">DESIGN-undecided.md</a></td><td><code>undecided:</code> declaration metadata, affected-requirement projection, report surfaces, and acknowledged underspecification findings</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-docs-site.md">DESIGN-docs-site.md</a></td><td>The IA, navigation, and generated-reference template decisions for this manual site (produced with Relational Design)</td></tr>
     </table>
   </div>

--- a/docs/intro/design-notes.ja.html
+++ b/docs/intro/design-notes.ja.html
@@ -57,6 +57,7 @@
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-ledger.md">DESIGN-ledger.md</a></td><td><code>fslc ledger</code>（検証根拠を要件ID別の監査台帳Markdownに変換）</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-nfr.md">DESIGN-nfr.md</a></td><td>非機能要件（対応表、離散時間SLA：time/urgent/age/deadline）</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md">DESIGN-analysis.md</a></td><td><code>fslc analyze</code>（Typed Semantic Graph、グラフ投影、AIレビュー所見）</td></tr>
+      <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-undecided.md">DESIGN-undecided.md</a></td><td><code>undecided:</code> 宣言メタデータ、影響要件の投影、レポート表示、未決定領域所見の acknowledged 表示</td></tr>
       <tr><td><a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-docs-site.md">DESIGN-docs-site.md</a></td><td>このマニュアルサイトのIA・ナビ・生成リファレンステンプレートの設計判断（Relational Designで作成）</td></tr>
     </table>
   </div>

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -82,7 +82,7 @@
   def &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) = &lt;expr&gt; // non-recursive named predicate; frontend-inlined
 
   state { &lt;var&gt;: &lt;type&gt;, ... }
-  init  { &lt;stmt&gt;... }
+  init  [&quot;undecided: reason&quot;] { &lt;stmt&gt;... }
 
   [fair] action &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) {
     requires &lt;expr&gt;                     // guard. multiple allowed (conjunction)
@@ -1317,6 +1317,19 @@ scenarios carry <code>requirement: {id, text}</code>:</p>
 <pre><code class="language-fsl">invariant PaidLedger &quot;REQ-3: the ledger matches the number of payments&quot; { ... }
 action submit(c: Case, a: Amount) &quot;REQ-1: amounts at or below the threshold are auto-approved&quot; { ... }
 </code></pre>
+<p>The reserved <code>"undecided: reason"</code> tag marks a reviewed, intentionally deferred
+decision. It is metadata and is never verified as a property. It may be attached
+to <code>init</code>, <code>action</code>, <code>invariant</code>, <code>trans</code>, <code>reachable</code>, or <code>leadsTo</code>; for example:</p>
+<pre><code class="language-fsl">init &quot;undecided: initial operating mode is pending&quot; { mode = Manual }
+action route() &quot;undecided: routing policy is pending&quot; { ... }
+</code></pre>
+<p><code>fslc ledger</code> and <code>fslc html</code> list these declarations and the requirement IDs
+whose state dependencies overlap them. <code>analyze --profile ai-review</code> keeps an
+underspecification finding but marks an exact declaration match as
+<code>acknowledged:true</code>. Because the declaration-tag slot is singular, an
+<code>undecided</code> declaration does not also carry an <code>ID: text</code> tag. See
+<code>DESIGN-undecided.md</code>. This feature is implemented by the authoritative native
+Rust CLI and is not backported to the frozen Python reference implementation.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }
@@ -1960,7 +1973,9 @@ DESIGN-*.md).</p>
   <code>divergent_choice</code>, and <code>unconstrained_effect</code>. The last two use a fixed
   depth-4 BMC probe: they include <code>evidence_basis:"bounded_bmc"</code>, the reachable
   branch witness, and a question-form <code>spec_question</code> asking which outcome is
-  intended. A BMC-backed <code>unconstrained_effect</code> suppresses the same state's
+  intended. Exact matches with <code>undecided:</code> declarations remain visible with
+  <code>acknowledged:true</code> and <code>acknowledged_by</code>; unmatched semantic findings carry
+  no acknowledgement fields. A BMC-backed <code>unconstrained_effect</code> suppresses the same state's
   structural <code>unread_state</code>; semantic action witnesses similarly suppress a
   duplicate <code>unguarded_action</code>. Absence is not proof of determinism beyond the
   bound. See <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-underspecification.md"><code>DESIGN-underspecification.md</code></a>.

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -82,7 +82,7 @@
   def &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) = &lt;expr&gt; // non-recursive named predicate; frontend-inlined
 
   state { &lt;var&gt;: &lt;type&gt;, ... }
-  init  { &lt;stmt&gt;... }
+  init  [&quot;undecided: reason&quot;] { &lt;stmt&gt;... }
 
   [fair] action &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) {
     requires &lt;expr&gt;                     // guard. multiple allowed (conjunction)
@@ -1317,6 +1317,19 @@ scenarios carry <code>requirement: {id, text}</code>:</p>
 <pre><code class="language-fsl">invariant PaidLedger &quot;REQ-3: the ledger matches the number of payments&quot; { ... }
 action submit(c: Case, a: Amount) &quot;REQ-1: amounts at or below the threshold are auto-approved&quot; { ... }
 </code></pre>
+<p>The reserved <code>"undecided: reason"</code> tag marks a reviewed, intentionally deferred
+decision. It is metadata and is never verified as a property. It may be attached
+to <code>init</code>, <code>action</code>, <code>invariant</code>, <code>trans</code>, <code>reachable</code>, or <code>leadsTo</code>; for example:</p>
+<pre><code class="language-fsl">init &quot;undecided: initial operating mode is pending&quot; { mode = Manual }
+action route() &quot;undecided: routing policy is pending&quot; { ... }
+</code></pre>
+<p><code>fslc ledger</code> and <code>fslc html</code> list these declarations and the requirement IDs
+whose state dependencies overlap them. <code>analyze --profile ai-review</code> keeps an
+underspecification finding but marks an exact declaration match as
+<code>acknowledged:true</code>. Because the declaration-tag slot is singular, an
+<code>undecided</code> declaration does not also carry an <code>ID: text</code> tag. See
+<code>DESIGN-undecided.md</code>. This feature is implemented by the authoritative native
+Rust CLI and is not backported to the frozen Python reference implementation.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }
@@ -1960,7 +1973,9 @@ DESIGN-*.md).</p>
   <code>divergent_choice</code>, and <code>unconstrained_effect</code>. The last two use a fixed
   depth-4 BMC probe: they include <code>evidence_basis:"bounded_bmc"</code>, the reachable
   branch witness, and a question-form <code>spec_question</code> asking which outcome is
-  intended. A BMC-backed <code>unconstrained_effect</code> suppresses the same state's
+  intended. Exact matches with <code>undecided:</code> declarations remain visible with
+  <code>acknowledged:true</code> and <code>acknowledged_by</code>; unmatched semantic findings carry
+  no acknowledgement fields. A BMC-backed <code>unconstrained_effect</code> suppresses the same state's
   structural <code>unread_state</code>; semantic action witnesses similarly suppress a
   duplicate <code>unguarded_action</code>. Absence is not proof of determinism beyond the
   bound. See <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-underspecification.md"><code>DESIGN-underspecification.md</code></a>.

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -173,16 +173,22 @@ pub fn lower_compose(
 
     let mut static_items = Vec::new();
     let mut init = Vec::new();
+    let mut init_meta = None;
     let mut actions = Vec::new();
     for alias in &order {
         let component = &components[alias];
         for item in &component.spec.items {
             match item {
-                SpecItem::Init(statements) => init.extend(rewrite_statements(
-                    statements.clone(),
-                    component,
-                    &HashSet::new(),
-                )),
+                SpecItem::Init { statements, meta } => {
+                    init.extend(rewrite_statements(
+                        statements.clone(),
+                        component,
+                        &HashSet::new(),
+                    ));
+                    if init_meta.is_none() {
+                        init_meta.clone_from(meta);
+                    }
+                }
                 SpecItem::Action { name, .. } => {
                     if !internal.contains(&(alias.clone(), name.clone())) {
                         actions.push(rewrite_component_item(item.clone(), component));
@@ -198,8 +204,11 @@ pub fn lower_compose(
             ComposeItem::Common(SpecItem::State(fields)) => {
                 static_items.push(SpecItem::State(fields.clone()));
             }
-            ComposeItem::Common(SpecItem::Init(statements)) => {
+            ComposeItem::Common(SpecItem::Init { statements, meta }) => {
                 init.extend(rewrite_compose_statements(statements.clone(), &components));
+                if init_meta.is_none() {
+                    init_meta.clone_from(meta);
+                }
             }
             ComposeItem::Common(item) => {
                 static_items.push(rewrite_compose_item(item.clone(), &components)?);
@@ -210,7 +219,10 @@ pub fn lower_compose(
             ComposeItem::Use { .. } | ComposeItem::Internal { .. } => {}
         }
     }
-    static_items.push(SpecItem::Init(init));
+    static_items.push(SpecItem::Init {
+        statements: init,
+        meta: init_meta,
+    });
     static_items.extend(actions);
     Ok(KernelSpec {
         spec: SurfaceSpec {
@@ -274,9 +286,10 @@ fn rewrite_component_item(item: SpecItem, component: &Component) -> SpecItem {
                 .map(|(name, ty)| (prefix(alias, &name), rewrite_type(ty, component)))
                 .collect(),
         ),
-        SpecItem::Init(statements) => {
-            SpecItem::Init(rewrite_statements(statements, component, &HashSet::new()))
-        }
+        SpecItem::Init { statements, meta } => SpecItem::Init {
+            statements: rewrite_statements(statements, component, &HashSet::new()),
+            meta,
+        },
         SpecItem::Action {
             name,
             params,

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -291,8 +291,8 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
                 })
                 .collect(),
         ));
-        items.push(SpecItem::Init(
-            processes
+        items.push(SpecItem::Init {
+            statements: processes
                 .iter()
                 .map(|process| Statement::ForAll {
                     binder: typed_binder("c", &process.name),
@@ -307,7 +307,8 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
                     span: process.span,
                 })
                 .collect(),
-        ));
+            meta: None,
+        });
     }
     for process in &processes {
         for transition in &process.transitions {
@@ -887,7 +888,10 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
     }
     if !state.is_empty() {
         items.push(SpecItem::State(state));
-        items.push(SpecItem::Init(init));
+        items.push(SpecItem::Init {
+            statements: init,
+            meta: None,
+        });
     }
     for process in &processes {
         let replacements = process
@@ -1100,7 +1104,10 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
                 ),
             };
             items.push(SpecItem::State(vec![(name.clone(), state_type)]));
-            items.push(SpecItem::Init(vec![init_statement]));
+            items.push(SpecItem::Init {
+                statements: vec![init_statement],
+                meta: None,
+            });
             age_info.insert(
                 name,
                 (binder, condition, span, cap, reference, target, type_name),
@@ -1240,11 +1247,14 @@ pub fn lower_governance(governance: SurfaceGovernance) -> Result<KernelSpec, Cor
                 symmetric: false,
             },
             SpecItem::State(vec![("_governance_ok".to_owned(), TypeExpr::Bool)]),
-            SpecItem::Init(vec![Statement::Assign {
-                target: LValue::Var("_governance_ok".to_owned()),
-                value: Expr::Bool(true),
-                span,
-            }]),
+            SpecItem::Init {
+                statements: vec![Statement::Assign {
+                    target: LValue::Var("_governance_ok".to_owned()),
+                    value: Expr::Bool(true),
+                    span,
+                }],
+                meta: None,
+            },
             SpecItem::Action {
                 name: "_governance_noop".to_owned(),
                 params: Vec::new(),
@@ -1283,11 +1293,14 @@ fn lower_catalog_sentinel(name: String, prefix: &str, id: &str) -> Result<Kernel
         meta: None,
         items: vec![
             SpecItem::State(vec![(state_name.clone(), TypeExpr::Bool)]),
-            SpecItem::Init(vec![Statement::Assign {
-                target: LValue::Var(state_name.clone()),
-                value: Expr::Bool(true),
-                span,
-            }]),
+            SpecItem::Init {
+                statements: vec![Statement::Assign {
+                    target: LValue::Var(state_name.clone()),
+                    value: Expr::Bool(true),
+                    span,
+                }],
+                meta: None,
+            },
             SpecItem::Action {
                 name: action_name,
                 params: Vec::new(),

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -517,9 +517,10 @@ impl PredicateExpander {
                     .map(|(name, ty)| Ok((name, self.expand_type(ty)?)))
                     .collect::<Result<_, CoreError>>()?,
             ),
-            SpecItem::Init(statements) => {
-                SpecItem::Init(self.expand_statements(statements, &mut Vec::new())?)
-            }
+            SpecItem::Init { statements, meta } => SpecItem::Init {
+                statements: self.expand_statements(statements, &mut Vec::new())?,
+                meta,
+            },
             SpecItem::Action {
                 name,
                 params,

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -124,6 +124,7 @@ pub struct KernelModel {
     pub enum_members: BTreeMap<String, Value>,
     pub state: Vec<(String, TypeRef)>,
     pub init: Vec<Statement>,
+    pub init_meta: Option<MetaTag>,
     pub actions: Vec<ActionDef>,
     pub invariants: Vec<PropertyDef>,
     pub transitions: Vec<PropertyDef>,
@@ -284,6 +285,7 @@ impl ModelBuilder {
         self.collect_types()?;
         let mut state = Vec::new();
         let mut init = Vec::new();
+        let mut init_meta = None;
         let mut actions = Vec::new();
         let mut invariants = Vec::new();
         let mut transitions = Vec::new();
@@ -304,7 +306,12 @@ impl ModelBuilder {
                 // example an NFR age counter) after the user's init block.
                 // Every fragment is part of the same logical initialization;
                 // replacing the earlier fragment leaves user state unconstrained.
-                SpecItem::Init(statements) => init.extend(statements.clone()),
+                SpecItem::Init { statements, meta } => {
+                    init.extend(statements.clone());
+                    if init_meta.is_none() {
+                        init_meta.clone_from(meta);
+                    }
+                }
                 SpecItem::Action {
                     name,
                     params,
@@ -425,6 +432,7 @@ impl ModelBuilder {
             enum_members: self.enum_members,
             state,
             init,
+            init_meta,
             actions,
             invariants,
             transitions,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1299,8 +1299,12 @@ impl Parser {
         }
         if self.peek_ident("init") {
             self.bump();
+            let meta = self.take_meta();
             self.expect_symbol("{")?;
-            return Ok(SpecItem::Init(self.statement_list()?));
+            return Ok(SpecItem::Init {
+                statements: self.statement_list()?,
+                meta,
+            });
         }
         if self.peek_ident("fair") || self.peek_ident("action") {
             return self.action_item();

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -108,7 +108,10 @@ pub enum SpecItem {
     Entity(String, Span),
     Number(String, Span),
     State(Vec<(String, TypeExpr)>),
-    Init(Vec<Statement>),
+    Init {
+        statements: Vec<Statement>,
+        meta: Option<MetaTag>,
+    },
     Action {
         name: String,
         params: Vec<Param>,
@@ -783,7 +786,13 @@ impl SpecItem {
                     .map(|(name, ty)| json!(["decl", name, ty.python_ast()]))
                     .collect::<Vec<_>>()
             ]),
-            Self::Init(statements) => json!(["init", statements_ast(statements)]),
+            Self::Init { statements, meta } => {
+                let mut values = vec![json!("init"), Value::Array(statements_ast(statements))];
+                if let Some(meta) = meta {
+                    values.push(meta.python_ast());
+                }
+                Value::Array(values)
+            }
             Self::Action {
                 name,
                 params,

--- a/rust/fsl-tools/src/html.rs
+++ b/rust/fsl-tools/src/html.rs
@@ -739,6 +739,48 @@ fn status_section(verification: &Value) -> String {
     )
 }
 
+fn undecided_section(items: &[Value]) -> String {
+    if items.is_empty() {
+        return String::new();
+    }
+    let rows = items
+        .iter()
+        .map(|item| {
+            let ids = item["requirement_ids"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "<tr><td><code>{}</code></td><td>{}</td><td>{}</td></tr>",
+                escape(item["declaration"].as_str().unwrap_or_default()),
+                escape(item["reason"].as_str().unwrap_or_default()),
+                if ids.is_empty() {
+                    "—".to_owned()
+                } else {
+                    escape(&ids)
+                },
+            )
+        })
+        .collect::<String>();
+    format!(
+        r#"
+      <section class="section" id="undecided">
+        <div class="section-head"><div>
+          <h2>Intentional Undecided Decisions</h2>
+          <p><code>undecided:</code> declarations are review metadata and are not verification conditions.</p>
+        </div></div>
+        <div class="panel table-wrap"><table>
+          <thead><tr><th>Declaration</th><th>Reason</th><th>Affected requirement IDs</th></tr></thead>
+          <tbody>{rows}</tbody>
+        </table></div>
+      </section>
+"#
+    )
+}
+
 fn params(params: &Value) -> String {
     let Some(params) = params.as_object() else {
         return String::new();
@@ -1054,6 +1096,7 @@ pub fn render_html_report(
     source: &str,
     explained: &Value,
     verification: &Value,
+    undecided: &[Value],
 ) -> String {
     let skeleton = &explained["skeleton"];
     let spec = explained["spec"]
@@ -1086,7 +1129,7 @@ pub fn render_html_report(
     );
     let status = verification["result"].as_str().unwrap_or("unknown");
     let warnings = verification["warnings"].as_array().map_or(0, Vec::len);
-    let body = [
+    let mut sections = vec![
         hero(
             spec,
             file,
@@ -1111,6 +1154,11 @@ pub fn render_html_report(
         ),
         actions_section(&actions, coverage),
         properties_section(&properties, &checks, verification),
+    ];
+    if !undecided.is_empty() {
+        sections.push(undecided_section(undecided));
+    }
+    sections.extend([
         status_section(verification),
         String::new(),
         trace_section(verification),
@@ -1122,8 +1170,8 @@ pub fn render_html_report(
         ),
         source_section(source),
         raw_section(explained, verification),
-    ]
-    .join("\n");
+    ]);
+    let body = sections.join("\n");
     [
         "<!doctype html>".to_owned(),
         "<html lang=\"en\">".to_owned(),

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -10,6 +10,8 @@ use fsl_core::KernelModel;
 use fsl_syntax::MetaTag;
 use serde_json::Value;
 
+use crate::undecided_declarations;
+
 #[derive(Clone, Default)]
 struct RequirementEntry {
     text: Option<String>,
@@ -35,6 +37,9 @@ fn add_requirement(
     metadata: Option<&MetaTag>,
 ) {
     let Some(metadata) = metadata else { return };
+    if metadata.id.eq_ignore_ascii_case("undecided") {
+        return;
+    }
     if !registry.contains_key(&metadata.id) {
         order.push(metadata.id.clone());
     }
@@ -98,6 +103,13 @@ fn requirement_registry(model: &KernelModel) -> (Vec<String>, BTreeMap<String, R
 
 fn requirement(value: &Value) -> (Option<String>, Option<String>) {
     let requirement = value.get("requirement").and_then(Value::as_object);
+    if requirement
+        .and_then(|item| item.get("id"))
+        .and_then(Value::as_str)
+        .is_some_and(|id| id.eq_ignore_ascii_case("undecided"))
+    {
+        return (None, None);
+    }
     (
         requirement
             .and_then(|item| item.get("id"))
@@ -111,7 +123,7 @@ fn requirement(value: &Value) -> (Option<String>, Option<String>) {
 }
 
 fn metadata_for<'a>(model: &'a KernelModel, group: &str, name: &str) -> Option<&'a MetaTag> {
-    match group {
+    let metadata = match group {
         "invariants" => model
             .invariants
             .iter()
@@ -138,7 +150,8 @@ fn metadata_for<'a>(model: &'a KernelModel, group: &str, name: &str) -> Option<&
             .find(|action| action.name == name)
             .and_then(|action| action.meta.as_ref()),
         _ => None,
-    }
+    };
+    metadata.filter(|metadata| !metadata.id.eq_ignore_ascii_case("undecided"))
 }
 
 fn finding_requirement(
@@ -611,6 +624,7 @@ pub fn render_ledger(
     evidence: &[(String, Value)],
 ) -> String {
     let (mut requirement_order, registry) = requirement_registry(model);
+    let undecided = undecided_declarations(model);
     let findings = collect_findings(model, verification);
     let mut by_requirement: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
     let mut spec_level = Vec::new();
@@ -689,6 +703,31 @@ pub fn render_ledger(
                 );
             }
             _ => {}
+        }
+    }
+    if !undecided.is_empty() {
+        output.push_str(
+            "\n## 未決定一覧\n\n`undecided:` は意図的な未決定を記録するメタデータであり、検証条件には含まれません。\n\n| 宣言 | 未決定の理由 | 影響する要件ID |\n|---|---|---|\n",
+        );
+        for item in &undecided {
+            let ids = item["requirement_ids"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = writeln!(
+                output,
+                "| `{}` | {} | {} |",
+                escape(item["declaration"].as_str().unwrap_or_default()),
+                escape(item["reason"].as_str().unwrap_or_default()),
+                if ids.is_empty() {
+                    "—".to_owned()
+                } else {
+                    escape(&ids)
+                },
+            );
         }
     }
     output.push_str(

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -16,6 +16,7 @@ mod mutate;
 mod refinement_analysis;
 mod testgen;
 mod typestate;
+mod undecided;
 
 pub use ai::{check_ai, replay_ai};
 pub use analysis::{analyze_model, build_tsg};
@@ -31,6 +32,7 @@ pub use mutate::{BuiltinMutant, enumerate_builtin_mutants};
 pub use refinement_analysis::analyze_refinement;
 pub use testgen::{emit_dart, emit_kotlin, emit_phpunit, emit_swift, emit_vitest};
 pub use typestate::analyze_typestate;
+pub use undecided::undecided_declarations;
 
 /// Complete a deterministic graph envelope from already normalized nodes and edges.
 #[must_use]

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -761,10 +761,13 @@ pub fn enumerate_builtin_mutants(spec: &SurfaceSpec) -> Vec<BuiltinMutant> {
                     });
                 }
             }
-            SpecItem::Init(statements) => {
+            SpecItem::Init { statements, meta } => {
                 for mutation in statement_mutations(statements, &enums, "init") {
                     let mut mutated = spec.clone();
-                    mutated.items[item_index] = SpecItem::Init(mutation.statements);
+                    mutated.items[item_index] = SpecItem::Init {
+                        statements: mutation.statements,
+                        meta: meta.clone(),
+                    };
                     output.push(BuiltinMutant {
                         op: mutation.op.to_owned(),
                         spec: mutated,

--- a/rust/fsl-tools/src/undecided.rs
+++ b/rust/fsl-tools/src/undecided.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Intentional-undecided metadata extraction (issue #189).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_core::{ActionDef, KernelBinder, KernelExpr, KernelLValue, KernelModel, KernelStatement};
+use fsl_syntax::MetaTag;
+use serde_json::{Value, json};
+
+fn is_undecided(meta: Option<&MetaTag>) -> bool {
+    meta.is_some_and(|meta| meta.id.eq_ignore_ascii_case("undecided"))
+}
+
+fn reason(meta: &MetaTag) -> String {
+    meta.text.clone().unwrap_or_default()
+}
+
+fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> {
+    fn collect(expr: &KernelExpr, roots: &mut BTreeSet<String>) {
+        match expr {
+            KernelExpr::Var(name) => {
+                roots.insert(name.clone());
+            }
+            KernelExpr::Some(value)
+            | KernelExpr::Neg(value)
+            | KernelExpr::Not(value)
+            | KernelExpr::Field(value, _)
+            | KernelExpr::UnaryNamed { expr: value, .. } => collect(value, roots),
+            KernelExpr::Index(left, right)
+            | KernelExpr::Binary { left, right, .. }
+            | KernelExpr::BinaryNamed { left, right, .. } => {
+                collect(left, roots);
+                collect(right, roots);
+            }
+            KernelExpr::IfThenElse {
+                condition,
+                then_expr,
+                else_expr,
+            }
+            | KernelExpr::TernaryNamed {
+                first: condition,
+                second: then_expr,
+                third: else_expr,
+                ..
+            } => {
+                collect(condition, roots);
+                collect(then_expr, roots);
+                collect(else_expr, roots);
+            }
+            KernelExpr::Set(items) | KernelExpr::Seq(items) => {
+                for item in items {
+                    collect(item, roots);
+                }
+            }
+            KernelExpr::Struct { fields, .. } => {
+                for (_, value) in fields {
+                    collect(value, roots);
+                }
+            }
+            KernelExpr::Call { args, .. } | KernelExpr::Method { args, .. } => {
+                if let KernelExpr::Method { receiver, .. } = expr {
+                    collect(receiver, roots);
+                }
+                for arg in args {
+                    collect(arg, roots);
+                }
+            }
+            KernelExpr::Is { expr, .. } => collect(expr, roots),
+            KernelExpr::Quantified { binder, body, .. } => {
+                collect_binder(binder, roots);
+                collect(body, roots);
+            }
+            KernelExpr::Count { condition, .. } => collect(condition, roots),
+            KernelExpr::Sum {
+                body, condition, ..
+            } => {
+                collect(body, roots);
+                if let Some(condition) = condition {
+                    collect(condition, roots);
+                }
+            }
+            KernelExpr::BinderNamed { binder, .. } => collect_binder(binder, roots),
+            KernelExpr::Num(_) | KernelExpr::Bool(_) | KernelExpr::None => {}
+        }
+    }
+
+    fn collect_binder(binder: &KernelBinder, roots: &mut BTreeSet<String>) {
+        match binder {
+            KernelBinder::Typed { where_expr, .. } => {
+                if let Some(expr) = where_expr {
+                    collect(expr, roots);
+                }
+            }
+            KernelBinder::Range { lo, hi, .. } => {
+                collect(lo, roots);
+                collect(hi, roots);
+            }
+            KernelBinder::Collection {
+                collection,
+                where_expr,
+                ..
+            } => {
+                collect(collection, roots);
+                if let Some(expr) = where_expr {
+                    collect(expr, roots);
+                }
+            }
+        }
+    }
+
+    let state = model
+        .state
+        .iter()
+        .map(|(name, _)| name)
+        .collect::<BTreeSet<_>>();
+    let mut roots = BTreeSet::new();
+    collect(expr, &mut roots);
+    roots.retain(|name| state.contains(name));
+    roots
+}
+
+fn lvalue_roots(model: &KernelModel, target: &KernelLValue) -> BTreeSet<String> {
+    match target {
+        KernelLValue::Var(name) => BTreeSet::from([name.clone()]),
+        KernelLValue::Index(name, index) => {
+            let mut roots = BTreeSet::from([name.clone()]);
+            roots.extend(expression_roots(model, index));
+            roots
+        }
+        KernelLValue::Field(base, _) => lvalue_roots(model, base),
+    }
+}
+
+fn statement_roots(model: &KernelModel, statements: &[KernelStatement]) -> BTreeSet<String> {
+    let mut roots = BTreeSet::new();
+    for statement in statements {
+        match statement {
+            KernelStatement::Assign { target, value, .. } => {
+                roots.extend(lvalue_roots(model, target));
+                roots.extend(expression_roots(model, value));
+            }
+            KernelStatement::If {
+                condition,
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                roots.extend(expression_roots(model, condition));
+                roots.extend(statement_roots(model, then_statements));
+                roots.extend(statement_roots(model, else_statements));
+            }
+            KernelStatement::ForAll {
+                binder, statements, ..
+            } => {
+                let binder_expr = KernelExpr::BinderNamed {
+                    name: "forall".to_owned(),
+                    binder: binder.clone(),
+                };
+                roots.extend(expression_roots(model, &binder_expr));
+                roots.extend(statement_roots(model, statements));
+            }
+        }
+    }
+    roots
+}
+
+fn action_roots(model: &KernelModel, action: &ActionDef) -> BTreeSet<String> {
+    let mut roots = statement_roots(model, &action.statements);
+    for expr in action
+        .requires
+        .iter()
+        .chain(action.lets.iter().map(|(_, expr)| expr))
+        .chain(action.ensures.iter())
+    {
+        roots.extend(expression_roots(model, expr));
+    }
+    roots
+}
+
+fn requirement_roots(model: &KernelModel) -> BTreeMap<String, BTreeSet<String>> {
+    let mut output = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut add = |meta: Option<&MetaTag>, roots: BTreeSet<String>| {
+        if let Some(meta) = meta.filter(|meta| !is_undecided(Some(meta))) {
+            output.entry(meta.id.clone()).or_default().extend(roots);
+        }
+    };
+    for action in &model.actions {
+        add(action.meta.as_ref(), action_roots(model, action));
+    }
+    for property in model
+        .invariants
+        .iter()
+        .chain(&model.transitions)
+        .chain(&model.reachables)
+    {
+        add(
+            property.meta.as_ref(),
+            expression_roots(model, &property.expr),
+        );
+    }
+    for property in &model.leadstos {
+        let mut roots = expression_roots(model, &property.before);
+        roots.extend(expression_roots(model, &property.after));
+        if let Some(decreases) = &property.decreases {
+            roots.extend(expression_roots(model, decreases));
+        }
+        add(property.meta.as_ref(), roots);
+    }
+    output
+}
+
+fn record(
+    declaration: &str,
+    node: &str,
+    meta: &MetaTag,
+    roots: &BTreeSet<String>,
+    requirements: &BTreeMap<String, BTreeSet<String>>,
+) -> Value {
+    let requirement_ids = requirements
+        .iter()
+        .filter(|(_, requirement_roots)| !roots.is_disjoint(requirement_roots))
+        .map(|(id, _)| id)
+        .collect::<Vec<_>>();
+    json!({
+        "declaration": declaration,
+        "node": node,
+        "reason": reason(meta),
+        "requirement_ids": requirement_ids,
+    })
+}
+
+/// Return every declaration tagged with the reserved `undecided:` marker.
+#[must_use]
+pub fn undecided_declarations(model: &KernelModel) -> Vec<Value> {
+    let requirements = requirement_roots(model);
+    let mut output = Vec::new();
+    if let Some(meta) = model
+        .init_meta
+        .as_ref()
+        .filter(|meta| is_undecided(Some(meta)))
+    {
+        let roots = statement_roots(model, &model.init);
+        output.push(record("init", "init", meta, &roots, &requirements));
+    }
+    for action in &model.actions {
+        if let Some(meta) = action.meta.as_ref().filter(|meta| is_undecided(Some(meta))) {
+            output.push(record(
+                &format!("action {}", action.name),
+                &format!("action:{}", action.name),
+                meta,
+                &action_roots(model, action),
+                &requirements,
+            ));
+        }
+    }
+    for (kind, properties) in [
+        ("invariant", &model.invariants),
+        ("trans", &model.transitions),
+        ("reachable", &model.reachables),
+    ] {
+        for property in properties {
+            if let Some(meta) = property
+                .meta
+                .as_ref()
+                .filter(|meta| is_undecided(Some(meta)))
+            {
+                output.push(record(
+                    &format!("{kind} {}", property.name),
+                    &format!("{kind}:{}", property.name),
+                    meta,
+                    &expression_roots(model, &property.expr),
+                    &requirements,
+                ));
+            }
+        }
+    }
+    for property in &model.leadstos {
+        if let Some(meta) = property
+            .meta
+            .as_ref()
+            .filter(|meta| is_undecided(Some(meta)))
+        {
+            let mut roots = expression_roots(model, &property.before);
+            roots.extend(expression_roots(model, &property.after));
+            output.push(record(
+                &format!("leadsTo {}", property.name),
+                &format!("leadsTo:{}", property.name),
+                meta,
+                &roots,
+                &requirements,
+            ));
+        }
+    }
+    output
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -4713,10 +4713,13 @@ fn weakening_candidates(spec: &fsl_syntax::SurfaceSpec) -> Vec<WeakeningCandidat
     let mut candidates = Vec::new();
     for (item_index, item) in spec.items.iter().enumerate() {
         match item {
-            fsl_syntax::SpecItem::Init(statements) => {
+            fsl_syntax::SpecItem::Init { statements, meta } => {
                 for (replacement, span) in statement_removals(statements) {
                     let mut mutated = spec.clone();
-                    mutated.items[item_index] = fsl_syntax::SpecItem::Init(replacement);
+                    mutated.items[item_index] = fsl_syntax::SpecItem::Init {
+                        statements: replacement,
+                        meta: meta.clone(),
+                    };
                     candidates.push(WeakeningCandidate {
                         spec: mutated,
                         op: "assignment-removal",
@@ -5682,7 +5685,7 @@ fn builtin_mutant_count(spec: &fsl_syntax::SurfaceSpec) -> usize {
             fsl_syntax::SpecItem::Const { value, .. } => {
                 expression_mutant_count(value, &enum_siblings)
             }
-            fsl_syntax::SpecItem::Init(statements) => statements
+            fsl_syntax::SpecItem::Init { statements, .. } => statements
                 .iter()
                 .map(|statement| statement_mutant_count(statement, &enum_siblings))
                 .sum(),
@@ -6108,7 +6111,7 @@ fn init_assignment_roots(
 ) -> std::collections::BTreeMap<String, usize> {
     let mut roots = std::collections::BTreeMap::new();
     for item in &spec.items {
-        if let fsl_syntax::SpecItem::Init(statements) = item {
+        if let fsl_syntax::SpecItem::Init { statements, .. } = item {
             collect_assignment_roots(statements, &mut roots);
         }
     }
@@ -7384,6 +7387,7 @@ fn run_html_report(
         &source,
         &explained,
         &verification,
+        &fsl_tools::undecided_declarations(&model),
     );
     generated_content_result(
         "html_report",
@@ -8786,6 +8790,45 @@ fn semantic_review_findings(review: &SemanticReview) -> Vec<Value> {
     findings
 }
 
+fn acknowledge_undecided_findings(model: &KernelModel, findings: &mut [Value]) {
+    let undecided = fsl_tools::undecided_declarations(model);
+    for finding in findings {
+        if !matches!(
+            finding["finding_type"].as_str(),
+            Some("divergent_choice" | "unconstrained_effect")
+        ) {
+            continue;
+        }
+        let involved = finding["involved_nodes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .collect::<std::collections::BTreeSet<_>>();
+        let acknowledged_by = undecided
+            .iter()
+            .filter(|declaration| {
+                declaration["node"]
+                    .as_str()
+                    .is_some_and(|node| involved.contains(node))
+            })
+            .map(|declaration| {
+                json!({
+                    "declaration": declaration["declaration"],
+                    "reason": declaration["reason"],
+                })
+            })
+            .collect::<Vec<_>>();
+        if acknowledged_by.is_empty() {
+            continue;
+        }
+        if let Value::Object(object) = finding {
+            object.insert("acknowledged".to_owned(), json!(true));
+            object.insert("acknowledged_by".to_owned(), json!(acknowledged_by));
+        }
+    }
+}
+
 fn ai_review_output(model: &KernelModel, acceptance: &[(String, KernelExpr)]) -> Value {
     let tsg = fsl_tools::build_tsg(model);
     let mut findings = ai_structural_findings(&tsg);
@@ -8835,6 +8878,7 @@ fn ai_review_output(model: &KernelModel, acceptance: &[(String, KernelExpr)]) ->
         ));
     }
     findings.extend(semantic_review_findings(&semantic));
+    acknowledge_undecided_findings(model, &mut findings);
     findings.sort_by_key(|finding| {
         (
             finding["finding_type"]

--- a/rust/fslc/tests/issue_189_undecided.rs
+++ b/rust/fslc/tests/issue_189_undecided.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::{Value, json};
+
+fn repository_file(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn run(arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_file(""))
+        .output()
+        .expect("run native fslc")
+}
+
+fn divergent_finding(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("analysis JSON");
+    envelope["findings"]
+        .as_array()
+        .expect("findings")
+        .iter()
+        .find(|finding| finding["finding_type"] == "divergent_choice")
+        .expect("divergent_choice")
+        .clone()
+}
+
+#[test]
+fn undecided_declarations_surface_in_reports_and_acknowledge_without_suppression() {
+    let spec = repository_file("tests/fixtures/undecided.fsl");
+    let spec = spec.to_str().expect("UTF-8 fixture path");
+
+    let ledger = run(&["ledger", spec]);
+    assert!(
+        ledger.status.success(),
+        "{}",
+        String::from_utf8_lossy(&ledger.stderr)
+    );
+    let ledger = String::from_utf8(ledger.stdout).expect("ledger UTF-8");
+    for expected in [
+        "## 未決定一覧",
+        "`init`",
+        "`action approve`",
+        "REQ-1",
+        "approval versus rejection policy is pending",
+    ] {
+        assert!(
+            ledger.contains(expected),
+            "missing {expected:?} from ledger"
+        );
+    }
+    assert!(!ledger.contains("| undecided |"));
+
+    let html = run(&["html", spec]);
+    assert!(
+        html.status.success(),
+        "{}",
+        String::from_utf8_lossy(&html.stderr)
+    );
+    let html = String::from_utf8(html.stdout).expect("HTML UTF-8");
+    for expected in [
+        "Intentional Undecided Decisions",
+        "action approve",
+        "REQ-1",
+        "approval versus rejection policy is pending",
+    ] {
+        assert!(html.contains(expected), "missing {expected:?} from HTML");
+    }
+
+    let finding = divergent_finding(&run(&["analyze", spec, "--profile", "ai-review"]));
+    assert_eq!(finding["formal_status"], "not_a_violation");
+    assert_eq!(finding["acknowledged"], true);
+    assert_eq!(
+        finding["acknowledged_by"],
+        json!([{
+            "declaration": "action approve",
+            "reason": "approval versus rejection policy is pending",
+        }])
+    );
+
+    let snapshot: Value = serde_json::from_slice(
+        &std::fs::read(repository_file("tests/snapshots/undecided_report.json"))
+            .expect("read snapshot"),
+    )
+    .expect("snapshot JSON");
+    let ledger_section = ledger
+        .split_once("## 未決定一覧")
+        .expect("undecided section")
+        .1
+        .split_once("## リスク一覧")
+        .expect("risk section")
+        .0;
+    assert_eq!(
+        format!("## 未決定一覧{}", ledger_section.trim_end()),
+        snapshot["ledger_section"]
+    );
+    assert_eq!(
+        json!({
+            "finding_type": finding["finding_type"],
+            "formal_status": finding["formal_status"],
+            "acknowledged": finding["acknowledged"],
+            "acknowledged_by": finding["acknowledged_by"],
+        }),
+        snapshot["finding"]
+    );
+}
+
+#[test]
+fn unmarked_underspecification_remains_unacknowledged() {
+    let source = r#"
+spec ReviewChoice {
+  state { ready: Bool, approved: Bool }
+  init { ready = true  approved = false }
+  action approve() {
+    requires ready
+    ready = false
+    approved = true
+  }
+  action reject() {
+    requires ready
+    ready = false
+    approved = false
+  }
+  invariant ApprovedWhenDone "REQ-1: a completed review is approved" {
+    ready or approved
+  }
+}
+"#;
+    let path = std::env::temp_dir().join(format!(
+        "fsl-issue-189-unacknowledged-{}.fsl",
+        std::process::id()
+    ));
+    std::fs::write(&path, source).expect("write temporary spec");
+    let path_text = path.to_str().expect("UTF-8 temporary path");
+    let finding = divergent_finding(&run(&["analyze", path_text, "--profile", "ai-review"]));
+    std::fs::remove_file(path).expect("remove temporary spec");
+
+    assert!(finding.get("acknowledged").is_none());
+    assert!(finding.get("acknowledged_by").is_none());
+}

--- a/schemas/fslc/analysis/analysis-findings.v0.schema.json
+++ b/schemas/fslc/analysis/analysis-findings.v0.schema.json
@@ -56,6 +56,19 @@
         "do_not_assume": { "type": "array", "items": { "type": "string" } },
         "spec_question": { "type": "string", "pattern": "\\?$" },
         "evidence_basis": { "enum": ["structural", "bounded_bmc"] },
+        "acknowledged": { "type": "boolean" },
+        "acknowledged_by": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["declaration", "reason"],
+            "properties": {
+              "declaration": { "type": "string" },
+              "reason": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
         "loc": { "$ref": "#/$defs/loc" }
       },
       "additionalProperties": true

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -136,17 +136,21 @@ why weakening the upper layer to make a lower one pass defeats the point.
 ## Prerequisite: the fslc verifier
 
 This skill only supplies language knowledge; verification is done by the `fslc`
-CLI. If it is not installed, run `pip install -e .` from the FSL repository (the
-root containing `pyproject.toml`) — the only dependencies are lark and z3-solver,
-and no native build is required. In environments where `fslc` is not on PATH,
-`python -m fslc ...` works identically.
+CLI. If it is not installed, run `bash install.sh` from the FSL repository (or
+`bash ~/.fsl/install.sh` after cloning there). The installer places the
+checksummed native Rust binary on the public `fslc` path; Python is optional and
+used only for the frozen reference/LSP development surface.
 
 ## How to run
 
 ```bash
-fslc <subcommand> ...            # if installed as editable
-python -m fslc <subcommand> ...  # or via the venv python
+fslc <subcommand> ...            # authoritative native Rust CLI
 ```
+
+The Python implementation is a frozen compatibility reference and optional LSP
+support surface. New language/CLI features are not backported to it. In
+particular, use the native `fslc` binary for `undecided:` syntax and its
+ledger/HTML/analyze output; do not route new work through `python -m fslc`.
 
 Output is always a single JSON document on stdout. exit: 0=success
 (verified/proved/generated/analyzed), 1=property not satisfied
@@ -217,6 +221,37 @@ This way assumptions travel with the spec, are visible in PRs, and a future
 `--strict-tags` check can distinguish "intended assumptions (tagged)" from
 "unfounded fabrications (untagged)."
 
+### Preserve intentionally deferred decisions with `undecided:`
+
+When the specification owner has explicitly decided to leave a choice open,
+record that review decision on the declaration instead of inventing a guard or
+property:
+
+```fsl
+init "undecided: initial operating mode will be selected at rollout" {
+  mode = Manual
+}
+action route() "undecided: routing policy is pending owner approval" {
+  ...
+}
+```
+
+`undecided:` is metadata, not a verification condition. Verification still
+checks every behavior allowed by the spec. `fslc ledger` and `fslc html` list
+the declaration, reason, and state-dependency-derived affected requirement IDs.
+`analyze --profile ai-review` keeps matching `divergent_choice` /
+`unconstrained_effect` findings visible and marks them `acknowledged:true` with
+`acknowledged_by`; an unmatched finding has no acknowledgement fields and stays
+in the unresolved review queue.
+
+Use this marker only after a human owner deliberately accepts the deferral. Do
+not use it to hide an agent's uncertainty, a missing source requirement, or a
+failed formalization guess. The declaration has one tag slot, so an
+`undecided:` declaration cannot simultaneously carry an `ID: text` tag; reports
+derive affected IDs from state dependencies. Full syntax and limits are in
+`reference.md` and `docs/DESIGN-undecided.md`. This feature belongs to the
+native Rust CLI and is intentionally not added to the frozen Python reference.
+
 ## Natural language → syntax mapping (from the formalization memo to the spec)
 
 Map the sentences extracted during requirement normalization (the memo above) to
@@ -280,7 +315,9 @@ the formalization memo.**
    unwritten state, and unguarded actions, plus depth-4 BMC-backed
    `divergent_choice` / `unconstrained_effect` questions. Present
    `spec_question` to the specification owner instead of choosing a branch or
-   inventing a constraint. `analyze` also supports batch
+   inventing a constraint. If `acknowledged:true`, retain the finding and show
+   its `acknowledged_by` declaration/reason as an intentional deferral; if
+   the fields are absent, keep it in the unresolved review queue. `analyze` also supports batch
    file/directory review, standalone `refinement_graph`, project
    `traceability_graph`, DOT/Mermaid graph exports, and JSON schemas under
    `schemas/fslc/analysis/`. These are review signals with

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -16,7 +16,7 @@ spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadat
   def <name>(<p>: <type name>, ...) = <expr> // non-recursive predicate, frontend-inlined
 
   state { <var>: <type>, ... }
-  init  { <stmt>... }                     // assign exactly once per variable/Map-key (deterministic)
+  init  ["undecided: reason"] { <stmt>... } // assign exactly once per variable/Map-key (deterministic)
 
   [fair] action <name>(<p>: <type name>, ...) {
     requires <expr>                        // 0 or more. conjunction. enabled condition
@@ -1136,6 +1136,15 @@ leadsTo / action:
 `invariant PaidLedger "REQ-3: ledger consistency" { ... }` →
 `requirement: {id, text}` in violated / unknown_cti / coverage diagnostic /
 scenarios / `refinement_failed` (root).
+
+Reserved intentional-undecided metadata uses the same single tag slot:
+`init "undecided: initial mode pending" { ... }` or
+`action choose() "undecided: selection policy pending" { ... }`. It is not a
+verification condition or requirement ID. `ledger` / `html` list the marker and
+state-dependency-derived affected requirement IDs; `analyze --profile ai-review`
+retains matching underspecification findings with `acknowledged:true`. See
+`docs/DESIGN-undecided.md`. This syntax and its report surfaces are native Rust
+CLI features; the frozen Python reference is not extended.
 
 ### Authoring specs as readable documentation (requirements + design)
 

--- a/tests/fixtures/undecided.fsl
+++ b/tests/fixtures/undecided.fsl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+spec ReviewChoice {
+  state { ready: Bool, approved: Bool }
+  init "undecided: initial review mode is pending" {
+    ready = true
+    approved = false
+  }
+  action approve() "undecided: approval versus rejection policy is pending" {
+    requires ready
+    ready = false
+    approved = true
+  }
+  action reject() {
+    requires ready
+    ready = false
+    approved = false
+  }
+  invariant ApprovedWhenDone "REQ-1: a completed review is approved" {
+    ready or approved
+  }
+}

--- a/tests/snapshots/undecided_report.json
+++ b/tests/snapshots/undecided_report.json
@@ -1,0 +1,14 @@
+{
+  "ledger_section": "## 未決定一覧\n\n`undecided:` は意図的な未決定を記録するメタデータであり、検証条件には含まれません。\n\n| 宣言 | 未決定の理由 | 影響する要件ID |\n|---|---|---|\n| `init` | initial review mode is pending | REQ-1 |\n| `action approve` | approval versus rejection policy is pending | REQ-1 |",
+  "finding": {
+    "finding_type": "divergent_choice",
+    "formal_status": "not_a_violation",
+    "acknowledged": true,
+    "acknowledged_by": [
+      {
+        "declaration": "action approve",
+        "reason": "approval versus rejection policy is pending"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes #189.

Native Rust FSLに、意図的な未決定を記録する `undecided:` 宣言メタデータを追加します。宣言はledger/HTMLの未決定一覧とAI review findingのacknowledgementに反映されますが、形式検証の条件や結果は変更しません。

## Why

- **Goal**: 意図的に先送りした判断と、意図せず残ったunderspecificationを区別できるようにする。
- **Reason**: 未決定事項を仕様内の正典メタデータとして保持し、影響するrequirement IDとともにレビュー可能にする。
- **Alternative**: findingを抑制する方式は、未決定の存在と検証証拠を隠すため採用していません。

## What Changed

- action/transition/initを対象にした `undecided:` 宣言をnative Rust parser/modelへ追加。
- `fslc ledger` と `fslc html` に未決定一覧と影響requirement IDを表示。
- 対応するAI review findingへ `acknowledged: true` と `acknowledged_by` を付与。finding自体は保持。
- 分析JSON schema、fixture、snapshot、Rust integration testを追加。
- language/design/guide/skill/Webサイトの英日ドキュメントを同期。
- frozen Python実装には変更を加えていません。

## Blast Radius

- **Affected**: native Rustのsyntax/core/tools/CLI、分析JSON schema、ledger/HTML出力、公開ドキュメントとFSL skill。
- **Compatibility**: 既存仕様はそのまま受理されます。acknowledgement fieldsは該当findingだけに追加され、未宣言findingの従来JSON shapeは維持されます。

## Invariants

| 条件 | 根拠 | 破ったときの症状 |
|---|---|---|
| `undecided:` は検証を弱めない | verifyの手動確認・integration test | 本来のinvariant違反が消える |
| findingを抑制しない | issue 189 integration test | acknowledged findingが分析結果から欠落する |
| 未宣言findingの出力shapeを維持する | `unmarked_underspecification_remains_unacknowledged` | Python/native parityやconsumerが壊れる |

## Evidence

- [x] `Z3_SYS_Z3_VERSION=4.16.0 cargo test -p fslc-rust --test issue_189_undecided` — 2 passed
- [x] `Z3_SYS_Z3_VERSION=4.16.0 cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `.venv/bin/pytest tests/test_site_reference_snapshot.py -q` — 3 passed
- [x] `.venv/bin/python tools/check_rust_phase3_commands.py` — 107/107
- [x] native CLI manual smoke: `check`, `verify`, `ledger`, `html`, `analyze`
- [x] `git diff --check`

Known unrelated baseline: the full Python pytest suite still has the pre-existing `test_rust_cli_contract.py` fixture mismatch (`rest.required false` vs `true`). This PR does not modify Python source or Python tests.

## Failure Modes and Detection

| パターン | 検知手段 |
|---|---|
| 宣言とfindingの対応付けが過剰 | 未宣言fixtureのintegration test |
| requirement IDの影響計算漏れ | ledger/HTML snapshotと手動smoke |
| メタデータが意味論へ混入 | invariant違反が継続するverify test |

## Rollout & Rollback

- **Rollout**: additive language metadataとしてnative Rust releaseへ含めます。移行作業は不要です。
- **Rollback**: このコミットをrevertし、schema/docs/generated siteを同時に戻します。永続データ移行はありません。

## Review Focus

- `rust/fsl-tools/src/undecided.rs`: 宣言とrequirement/findingの対応付け
- `rust/fslc/src/main.rs`: acknowledged fieldsの付与条件
- `rust/fsl-tools/src/ledger.rs` / `html.rs`: 一覧の表示と非抑制
- `docs/DESIGN-undecided.md`: メタデータ境界と運用契約

## Related

- Closes #189
- Related: #179, #171
