### PR TITLE
ci(wasm): wait for Chrome cleanup

### DIFF
--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -51,6 +51,7 @@ const child = spawn(chrome, [
   "--remote-debugging-port=0", `--user-data-dir=${profile}`,
   `http://127.0.0.1:${port}/`,
 ], { stdio: ["ignore", "pipe", "pipe"] });
+const childClosed = new Promise((resolve) => child.once("close", resolve));
 let stderr = "";
 child.stderr.setEncoding("utf8");
 child.stderr.on("data", (chunk) => { stderr += chunk; });
@@ -106,9 +107,12 @@ try {
   socket.close();
   if (details?.done !== "true") throw new Error(`browser probe timed out: ${stderr}`);
 } finally {
-  child.kill("SIGKILL");
-  server.close();
-  await rm(profile, { recursive: true, force: true });
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  await childClosed;
+  await new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+  await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 }
 if (details.ok !== "true") {
   throw new Error(`FSL WASM Worker smoke failed: ${details.text}\n${stderr}`);


### PR DESCRIPTION
## Summary

WASM browser smoke testの終了処理で、Chrome profile削除が`ENOTEMPTY`になるCI競合を修正します。Chromeの終了とHTTP server停止を待ってから、Node標準のretry付き`fs.rm`で一時profileを削除します。

## Root Cause

`test-browser.mjs`はChromeへ`SIGKILL`を送った直後にprofile directoryを削除していました。Chromeが`Default`配下をまだ更新している間に`rm`が走るため、GitHub Actionsで以下が再現していました。

```text
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/fsl-wasm-chrome-*/Default'
```

同じ失敗はmain runとPR #209の両方で発生しており、Issue 189の変更とは無関係です。

## What Changed

- spawn直後にChromeの`close` promiseを登録。
- 実行中の場合だけ`SIGKILL`し、`close`完了を待機。
- HTTP serverの`close` callbackを待機。
- recursive `rm`に`maxRetries: 5`と`retryDelay: 100`を設定。

テスト本体、timeout、WASM/native parity判定は変更していません。

## Evidence

- [x] Node 22 `node --check rust/fsl-wasm/test-browser.mjs`
- [x] `npm run test:browser`を修正後3回連続実行
- [x] 全実行で`ok: true`, `cancelled: true`, `nativeParity: true`
- [x] `git diff --check`

## Risk and Rollback

- リスクはcleanup終了が最大500ms延びる可能性に限定されます。
- Chromeやserverの終了に失敗した場合は従来どおりテストを失敗させ、実テスト失敗を隠しません。
- ロールバックはこの単一コミットのrevertです。

## Related

- Unblocks #209
- Failing main run: https://github.com/ymm-oss/fsl/actions/runs/29216401840
- Failing PR run: https://github.com/ymm-oss/fsl/actions/runs/29219336726
