### PR TITLE
feat(approval): bind approval records to spec digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Digest-bound approval records (issue #190): add native Rust `fslc approval
+  create|check|diff` for reviewed ledger, HTML, and scenario artifacts. Versioned
+  sidecars bind a location-insensitive lowered-kernel digest, normalized rendered
+  artifact digest, generation inputs, requirement IDs, approver, timestamp, and
+  reconstructable Git baseline. `fslc ledger --approval` now shows per-requirement
+  `approved` / `drifted` state with the complete baseline digest and a direct
+  semantic-diff command. Includes JSON Schema, snapshot/integration coverage, and
+  `docs/DESIGN-approval.md`; the frozen Python reference remains unchanged.
 - Intentional undecided declarations (issue #189): reserve the
   `"undecided: reason"` metadata tag, including tagged `init`, and add
   dependency-derived affected requirement IDs to new ledger and HTML undecided

--- a/docs/DESIGN-approval.md
+++ b/docs/DESIGN-approval.md
@@ -1,0 +1,160 @@
+# Digest-bound approval records
+
+Issue: #190
+
+## Goal
+
+Stakeholders often approve a rendered ledger, HTML report, or concrete scenario
+set rather than reading the FSL source. `fslc approval` binds that reviewed
+artifact to the normalized specification that produced it. A later check can
+therefore distinguish an unchanged approval from specification, rendering, or
+renderer drift without treating a checkbox in generated Markdown as evidence.
+
+The implementation is native Rust. The frozen Python reference is intentionally
+unchanged.
+
+## Workflow
+
+Approval creation requires a tracked specification and a clean Git worktree.
+This makes the recorded commit a reconstructable semantic-diff baseline. First
+generate and review an artifact using the same inputs that will be recorded:
+
+```bash
+fslc ledger specs/order.fsl --depth 8 -o order-ledger.md
+fslc approval create specs/order.fsl \
+  --kind ledger \
+  --artifact order-ledger.md \
+  --approver alice \
+  --depth 8 \
+  -o order.approval.json
+```
+
+`approval create` regenerates the target before writing the record. A stale or
+wrong artifact is rejected rather than approved. Omitting `--requirement`
+approves every requirement ID found in the lowered model; the option is
+repeatable when a decision covers only selected requirements. A specification
+without requirement IDs is rejected because it cannot produce a meaningful
+per-requirement ledger decision.
+
+Check a record directly or include it in a ledger:
+
+```bash
+fslc approval check specs/order.fsl --record order.approval.json
+fslc ledger specs/order.fsl --approval order.approval.json
+```
+
+The direct result is `approval_check` with `status:"approved"` or
+`status:"drifted"`. Drift remains an analysis result and exits 0. A malformed,
+unsupported, wrong-spec, or locally unavailable Git-baseline record is an error
+and exits 2. Unknown sidecar fields are rejected so schema changes cannot be
+silently ignored.
+
+When drift is reported, compare the approved commit to the current working tree
+(including uncommitted edits) without manually materializing the baseline:
+
+```bash
+fslc approval diff specs/order.fsl --record order.approval.json --depth 8
+```
+
+The result is the ordinary bounded `semantic_diff` envelope plus `approval`
+baseline metadata. Before comparison, the materialized specification is hashed
+again and must match the record's baseline digest.
+
+## Record contract
+
+The committed sidecar follows
+[`schemas/fslc/approval/approval-record.v1.schema.json`](../schemas/fslc/approval/approval-record.v1.schema.json):
+
+```json
+{
+  "schema": "fslc.approval.v1",
+  "spec": {
+    "path": "specs/order.fsl",
+    "digest_algorithm": "fsl-kernel-ast-v1+sha256",
+    "digest": "sha256:<64 hex>",
+    "git_commit": "<full commit>"
+  },
+  "target": {
+    "kind": "ledger",
+    "path": "order-ledger.md",
+    "digest_algorithm": "fsl-rendered-artifact-v1+sha256",
+    "digest": "sha256:<64 hex>",
+    "generator": "fslc",
+    "generator_version": "2.7.0",
+    "inputs": {"depth": 8, "deadlock": "ignore", "engine": "bmc"}
+  },
+  "approval": {
+    "approver": "alice",
+    "approved_at": "2026-07-13T04:00:00Z",
+    "requirements": ["REQ-1"]
+  }
+}
+```
+
+Supported target kinds are `ledger`, `html`, and `scenarios`.
+
+## Digest contracts
+
+### Specification digest
+
+`fsl-kernel-ast-v1+sha256` hashes the fully lowered kernel AST. Compose/use and
+dialect dependencies are expanded before hashing, so a referenced-spec change
+moves the digest. Source-location objects are removed; comments, whitespace,
+line movement, and path spelling therefore do not create false specification
+drift. Requirement metadata remains in the AST and is covered.
+
+The digest is deliberately separate from the verification cache key. Cache keys
+include source text, implementation versions, and verification options to avoid
+stale diagnostics; those inputs would make a long-lived human approval unstable.
+
+v1 uses one conservative whole-spec digest plus a list of approved requirement
+IDs. Any semantic change marks every requirement in that record `drifted`.
+Requirement-local hashing is deferred until a sound dependency slice can account
+for shared state, actions, and cross-cutting properties.
+
+### Rendered artifact digest
+
+`fsl-rendered-artifact-v1+sha256` binds the reviewed presentation while removing
+execution-only noise. Scenario JSON omits only top-level execution metadata
+(`cost` and `cache`) before canonical serialization, preserving same-named
+fields inside reviewed domain state. HTML normalizes embedded `elapsed_s` values. Ledger
+Markdown is hashed as rendered. This preserves review-visible content while
+preventing solver timing from producing false drift.
+
+The approval overlay itself is not part of a ledger target digest. The base
+ledger is rendered and hashed first, then approval status is added. This avoids
+a recursive artifact hash.
+
+## Status and failure reasons
+
+An approval is `approved` only when all three bindings match:
+
+- normalized specification digest;
+- normalized rendered-artifact digest;
+- renderer version.
+
+Otherwise it is `drifted` with one or more machine reasons:
+`spec_changed`, `rendering_changed`, or `renderer_changed`. Ledger output shows
+the complete baseline digest and an executable `fslc approval diff` command for
+every drifted requirement. Repeatable `--approval` records are applied in CLI
+order; a later record replaces an earlier decision for the same requirement ID.
+
+## Trust boundary
+
+The `approver` string is attribution, not a cryptographic identity. Authenticity
+and authorization remain repository controls: signed commits where required,
+CODEOWNERS/review policy, branch protection, and audit-log retention. Editing the
+sidecar is equivalent to editing other governed repository evidence. A future
+schema version may add detached signatures without changing v1 verification.
+
+## Tests
+
+Native integration coverage proves:
+
+- create then check produces `approved`;
+- comments do not move the spec or artifact digest;
+- a semantic edit produces `drifted` with the baseline digest;
+- rendering digest changes are classified separately;
+- `approval diff` materializes the approved commit and reports semantic change;
+- ledger output matches the approval snapshot;
+- ledger, HTML, and scenarios are valid review targets.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -619,7 +619,10 @@ fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag review (§15)
 fslc html      <file.fsl> [--depth K] [-o report.html] # self-contained review report (§15)
-fslc ledger    <file.fsl> [--depth K] [--impl-log run.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc ledger    <file.fsl> [--depth K] [--impl-log run.json] [--approval record.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc approval create <file.fsl> --kind ledger|html|scenarios --artifact <reviewed> --approver <name> [-o record.json]
+fslc approval check  <file.fsl> --record <record.json>       # approved | drifted
+fslc approval diff   <file.fsl> --record <record.json> [--depth K]
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check <file.fsl> [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
 fslc domain analyze <file.fsl>                                  # aggregate/effect ownership summary
@@ -712,6 +715,18 @@ and returns `semantic_diff_batch`; supplying one spec preserves
 `semantic_diff`. Both forms include `vcs.materialization:
 "git_archive_full_tree"`. The ordinary two-path form never invokes Git and
 works outside a repository.
+
+`approval create` binds a reviewed `ledger`, `html`, or `scenarios` artifact to
+the fully lowered, location-insensitive kernel digest and the current clean Git
+commit. The versioned JSON sidecar also records the normalized artifact digest,
+generator/version/options, approved requirement IDs, approver, and UTC time.
+Creation regenerates the artifact and rejects a stale review file. `approval
+check` returns `approved` only while the spec, rendering, and renderer bindings
+all match; otherwise it returns `drifted` with `spec_changed`,
+`rendering_changed`, and/or `renderer_changed`. `ledger --approval` adds the
+same status per requirement and includes the full baseline digest. `approval
+diff` materializes the approved commit and invokes the ordinary bounded semantic
+diff against the current working file. See `docs/DESIGN-approval.md`.
 
 Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant / refines /
 mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 | [`DESIGN-refinement.md`](DESIGN-refinement.md) | Refinement checking (mapping files, conditional expressions, preserve progress) |
 | [`DESIGN-semantic-diff.md`](DESIGN-semantic-diff.md) | `fslc diff` bounded semantic comparison (bidirectional refinement, invariant implication, forbidden replay, scope and gate contract) |
 | [`DESIGN-diff-git.md`](DESIGN-diff-git.md) | Git/CI adapter for revision-consistent full-tree materialization and changed-spec batch semantic diff |
+| [`DESIGN-approval.md`](DESIGN-approval.md) | Digest-bound human approval records, rendering drift checks, and approved-baseline semantic diff |
 | [`DESIGN-compose.md`](DESIGN-compose.md) | Spec composition (namespaces, synchronized actions, internal) |
 | [`DESIGN-bridge.md`](DESIGN-bridge.md) | Implementation bridge (runtime Monitor / replay / testgen) |
 | [`DESIGN-log-replay.md`](DESIGN-log-replay.md) | Production JSONL replay through refinement mapping syntax: record contract, complete-observation boundary, first-divergence JSON, and Monitor execution |

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -612,9 +612,30 @@ fn guarantee_line(verification: &Value) -> String {
     )
 }
 
+fn approval_entry<'a>(approvals: Option<&'a Value>, requirement_id: &str) -> Option<&'a Value> {
+    approvals?.get("requirements")?.get(requirement_id)
+}
+
+fn approval_cell(approvals: Option<&Value>, requirement_id: &str) -> String {
+    let Some(entry) = approval_entry(approvals, requirement_id) else {
+        return "— unapproved".to_owned();
+    };
+    match entry.get("status").and_then(Value::as_str) {
+        Some("approved") => "✅ approved".to_owned(),
+        Some("drifted") => format!(
+            "⚠ drifted (since {})",
+            entry
+                .get("baseline_digest")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+        ),
+        Some(status) => format!("❌ {status}"),
+        None => "❌ invalid".to_owned(),
+    }
+}
+
 /// Render the complete requirement-oriented Markdown audit ledger.
 #[must_use]
-#[allow(clippy::too_many_lines)]
 pub fn render_ledger(
     file: &str,
     model: &KernelModel,
@@ -622,6 +643,21 @@ pub fn render_ledger(
     scenarios: &Value,
     replay: Option<&Value>,
     evidence: &[(String, Value)],
+) -> String {
+    render_ledger_with_approvals(file, model, verification, scenarios, replay, evidence, None)
+}
+
+/// Render the audit ledger with optional digest-bound approval decisions.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn render_ledger_with_approvals(
+    file: &str,
+    model: &KernelModel,
+    verification: &Value,
+    scenarios: &Value,
+    replay: Option<&Value>,
+    evidence: &[(String, Value)],
+    approvals: Option<&Value>,
 ) -> String {
     let (mut requirement_order, registry) = requirement_registry(model);
     let undecided = undecided_declarations(model);
@@ -639,6 +675,16 @@ pub fn render_ledger(
             }
         } else {
             spec_level.push(finding);
+        }
+    }
+    if let Some(approved_requirements) = approvals
+        .and_then(|value| value.get("requirements"))
+        .and_then(Value::as_object)
+    {
+        for requirement_id in approved_requirements.keys() {
+            if !requirement_order.contains(requirement_id) {
+                requirement_order.push(requirement_id.clone());
+            }
         }
     }
     let mut confirmed = BTreeSet::new();
@@ -705,6 +751,11 @@ pub fn render_ledger(
             _ => {}
         }
     }
+    if approvals.is_some() {
+        output.push_str(
+            "- 承認照合: versioned approval record の spec/rendering digest を照合済み。\n",
+        );
+    }
     if !undecided.is_empty() {
         output.push_str(
             "\n## 未決定一覧\n\n`undecided:` は意図的な未決定を記録するメタデータであり、検証条件には含まれません。\n\n| 宣言 | 未決定の理由 | 影響する要件ID |\n|---|---|---|\n",
@@ -730,9 +781,15 @@ pub fn render_ledger(
             );
         }
     }
-    output.push_str(
-        "\n## リスク一覧（要件ID別）\n\n| 要件ID | 業務目的 | 状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |\n|---|---|---|---|---|---|---|---|\n",
-    );
+    if approvals.is_some() {
+        output.push_str(
+            "\n## リスク一覧（要件ID別）\n\n| 要件ID | 業務目的 | 状態 | 承認状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |\n|---|---|---|---|---|---|---|---|---|\n",
+        );
+    } else {
+        output.push_str(
+            "\n## リスク一覧（要件ID別）\n\n| 要件ID | 業務目的 | 状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |\n|---|---|---|---|---|---|---|---|\n",
+        );
+    }
     for requirement_id in &requirement_order {
         let entry = registry.get(requirement_id);
         let requirement_findings = by_requirement
@@ -745,7 +802,18 @@ pub fn render_ledger(
         let purpose = entry
             .and_then(|entry| entry.text.as_deref())
             .unwrap_or(fallback_text);
-        let (status, types, risk, owner, action) = if requirement_findings.is_empty() {
+        let (status, types, risk, owner, action) = if requirement_findings.is_empty()
+            && entry.is_none()
+            && approval_entry(approvals, requirement_id).is_some()
+        {
+            (
+                "🟡 現行仕様に要件IDなし",
+                "—".to_owned(),
+                "要確認",
+                "____",
+                "要件IDの削除または変更を確認".to_owned(),
+            )
+        } else if requirement_findings.is_empty() {
             (
                 if confirmed.contains(requirement_id) {
                     "🟢 確認済（承認可）"
@@ -774,20 +842,38 @@ pub fn render_ledger(
                 .join(" / ");
             ("🔴 要確認", types, "要確認", "____", action)
         };
-        let _ = writeln!(
-            output,
-            "| {} | {} | {status} | {} | {} | {risk} | {owner} | {} |",
-            escape(requirement_id),
-            escape(purpose),
-            escape(&assurance_cell(
-                requirement_id,
-                &registry,
-                verification,
-                evidence
-            )),
-            escape(&types),
-            escape(&action),
-        );
+        if approvals.is_some() {
+            let _ = writeln!(
+                output,
+                "| {} | {} | {status} | {} | {} | {} | {risk} | {owner} | {} |",
+                escape(requirement_id),
+                escape(purpose),
+                escape(&approval_cell(approvals, requirement_id)),
+                escape(&assurance_cell(
+                    requirement_id,
+                    &registry,
+                    verification,
+                    evidence
+                )),
+                escape(&types),
+                escape(&action),
+            );
+        } else {
+            let _ = writeln!(
+                output,
+                "| {} | {} | {status} | {} | {} | {risk} | {owner} | {} |",
+                escape(requirement_id),
+                escape(purpose),
+                escape(&assurance_cell(
+                    requirement_id,
+                    &registry,
+                    verification,
+                    evidence
+                )),
+                escape(&types),
+                escape(&action),
+            );
+        }
     }
     if !spec_level.is_empty() {
         let types = spec_level
@@ -798,12 +884,21 @@ pub fn render_ledger(
             .collect::<Vec<_>>()
             .join(", ");
         let depth = verification.get("checked_to_depth").and_then(Value::as_u64);
-        let _ = writeln!(
-            output,
-            "| （仕様全体） | 要件ID未付与の検出 | 🔴 要確認 | {} | {} | 要確認 | ____ | 下記詳細 |",
-            escape(&assurance_label(assurance_token(verification), depth)),
-            escape(&types)
-        );
+        if approvals.is_some() {
+            let _ = writeln!(
+                output,
+                "| （仕様全体） | 要件ID未付与の検出 | 🔴 要確認 | — unapproved | {} | {} | 要確認 | ____ | 下記詳細 |",
+                escape(&assurance_label(assurance_token(verification), depth)),
+                escape(&types)
+            );
+        } else {
+            let _ = writeln!(
+                output,
+                "| （仕様全体） | 要件ID未付与の検出 | 🔴 要確認 | {} | {} | 要確認 | ____ | 下記詳細 |",
+                escape(&assurance_label(assurance_token(verification), depth)),
+                escape(&types)
+            );
+        }
     }
     output.push_str("\n## 要件ID別詳細\n\n");
     let mut detail_ids = requirement_order
@@ -859,6 +954,46 @@ pub fn render_ledger(
             );
         }
         output.push_str("- 判断: ☐ 承認　☐ 差戻し　☐ リスク受容　／　判断者: ____　期限: ____\n\n");
+    }
+    if let Some(approvals) = approvals {
+        output.push_str(
+            "## 承認照合\n\n| 要件ID | 承認状態 | 承認基準 digest | 承認対象 | drift理由 | semantic diff |\n|---|---|---|---|---|---|\n",
+        );
+        for requirement_id in &requirement_order {
+            let entry = approval_entry(Some(approvals), requirement_id);
+            let baseline = entry
+                .and_then(|item| item.get("baseline_digest"))
+                .and_then(Value::as_str)
+                .unwrap_or("—");
+            let target = entry
+                .and_then(|item| item.get("target_kind"))
+                .and_then(Value::as_str)
+                .unwrap_or("—");
+            let reasons = entry
+                .and_then(|item| item.get("reasons"))
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let command = entry
+                .filter(|item| item.get("status").and_then(Value::as_str) == Some("drifted"))
+                .and_then(|item| item.get("semantic_diff_command"))
+                .and_then(Value::as_str)
+                .unwrap_or("—");
+            let _ = writeln!(
+                output,
+                "| {} | {} | `{}` | {} | {} | `{}` |",
+                escape(requirement_id),
+                escape(&approval_cell(Some(approvals), requirement_id)),
+                escape(baseline),
+                escape(target),
+                escape(if reasons.is_empty() { "—" } else { &reasons }),
+                escape(command),
+            );
+        }
+        output.push('\n');
     }
     if !evidence.is_empty() {
         output.push_str(

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -27,7 +27,7 @@ pub use domain::{
     analyze_domain, check_domain, domain_adapter_files, domain_kernel_source, domain_scaffold,
 };
 pub use html::render_html_report;
-pub use ledger::render_ledger;
+pub use ledger::{render_ledger, render_ledger_with_approvals};
 pub use mutate::{BuiltinMutant, enumerate_builtin_mutants};
 pub use refinement_analysis::analyze_refinement;
 pub use testgen::{emit_dart, emit_kotlin, emit_phpunit, emit_swift, emit_vitest};

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -3,7 +3,7 @@
   "root": {
     "path": [],
     "prog": "fslc",
-    "help": "usage: fslc [-h] [-V] {version,check,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
+    "help": "usage: fslc [-h] [-V] {version,check,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
     "actions": [
       {
         "dest": "help",
@@ -1361,10 +1361,69 @@
       },
       {
         "path": [
+          "approval"
+        ],
+        "prog": "fslc approval",
+        "help": "usage: fslc approval [-h] {create,check,diff}\n\npositional arguments:\n  {create,check,diff}\n    create              bind a reviewed artifact to the normalized spec digest\n    check               compare a spec and regenerated artifact to an approval record\n    diff                run semantic diff from the approved Git baseline\n\noptions:\n  -h, --help            show this help message and exit\n",
+        "actions": [
+          {
+            "dest": "help",
+            "required": false,
+            "flags": ["-h", "--help"],
+            "nargs": 0,
+            "action": "store"
+          }
+        ],
+        "commands": [
+          {
+            "path": ["approval", "create"],
+            "prog": "fslc approval create",
+            "help": "usage: fslc approval create [-h] --kind {ledger,html,scenarios} --artifact ARTIFACT --approver APPROVER [--requirement ID] [--depth DEPTH] [--deadlock {warn,error,ignore}] [--engine {bmc,induction}] [-o OUTPUT] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --kind {ledger,html,scenarios}\n  --artifact ARTIFACT   reviewed artifact generated with the recorded inputs\n  --approver APPROVER\n  --requirement ID      requirement ID to approve; repeatable, defaults to all\n  --depth DEPTH\n  --deadlock {warn,error,ignore}\n  --engine {bmc,induction}\n  -o, --output OUTPUT\n",
+            "actions": [
+              {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
+              {"dest":"file","required":true,"positional":true,"action":"store"},
+              {"dest":"kind","required":true,"flags":["--kind"],"choices":["ledger","html","scenarios"],"action":"store"},
+              {"dest":"artifact","required":true,"flags":["--artifact"],"action":"store"},
+              {"dest":"approver","required":true,"flags":["--approver"],"action":"store"},
+              {"dest":"requirement","required":false,"flags":["--requirement"],"repeatable":true,"action":"store"},
+              {"dest":"depth","required":false,"flags":["--depth"],"default":8,"action":"store"},
+              {"dest":"deadlock","required":false,"flags":["--deadlock"],"choices":["warn","error","ignore"],"default":"ignore","action":"store"},
+              {"dest":"engine","required":false,"flags":["--engine"],"choices":["bmc","induction"],"default":"bmc","action":"store"},
+              {"dest":"output","required":false,"flags":["-o","--output"],"action":"store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["approval", "check"],
+            "prog": "fslc approval check",
+            "help": "usage: fslc approval check [-h] --record RECORD file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help       show this help message and exit\n  --record RECORD\n",
+            "actions": [
+              {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
+              {"dest":"file","required":true,"positional":true,"action":"store"},
+              {"dest":"record","required":true,"flags":["--record"],"action":"store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["approval", "diff"],
+            "prog": "fslc approval diff",
+            "help": "usage: fslc approval diff [-h] --record RECORD [--depth DEPTH] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help       show this help message and exit\n  --record RECORD\n  --depth DEPTH\n",
+            "actions": [
+              {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
+              {"dest":"file","required":true,"positional":true,"action":"store"},
+              {"dest":"record","required":true,"flags":["--record"],"action":"store"},
+              {"dest":"depth","required":false,"flags":["--depth"],"default":8,"action":"store"}
+            ],
+            "commands": []
+          }
+        ]
+      },
+      {
+        "path": [
           "ledger"
         ],
         "prog": "fslc ledger",
-        "help": "usage: fslc ledger [-h] [--depth DEPTH] [-o OUTPUT] [--deadlock {warn,error,ignore}] [--impl-log IMPL_LOG] [--engine {bmc,induction}] [--evidence EVIDENCE] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  -o, --output OUTPUT\n  --deadlock {warn,error,ignore}\n  --impl-log IMPL_LOG   optional implementation trace JSON to score conformance\n                        (fslc replay)\n  --engine {bmc,induction}\n                        use k-induction so a requirement's assurance class can\n                        reach 'proved' (#171)\n  --evidence EVIDENCE   path to a saved stdout envelope (JSON) from an external-\n                        evidence producer (fslc ai eval/replay/drift, fslc db\n                        observe, fslc domain replay, ...); repeatable\n",
+        "help": "usage: fslc ledger [-h] [--depth DEPTH] [-o OUTPUT] [--deadlock {warn,error,ignore}] [--impl-log IMPL_LOG] [--engine {bmc,induction}] [--evidence EVIDENCE] [--approval RECORD] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  -o, --output OUTPUT\n  --deadlock {warn,error,ignore}\n  --impl-log IMPL_LOG   optional implementation trace JSON to score conformance\n                        (fslc replay)\n  --engine {bmc,induction}\n                        use k-induction so a requirement's assurance class can\n                        reach 'proved' (#171)\n  --evidence EVIDENCE   path to a saved stdout envelope (JSON) from an external-\n                        evidence producer (fslc ai eval/replay/drift, fslc db\n                        observe, fslc domain replay, ...); repeatable\n  --approval RECORD     digest-bound approval record to check; repeatable\n",
         "actions": [
           {
             "dest": "help",
@@ -1440,6 +1499,15 @@
             "required": false,
             "flags": [
               "--evidence"
+            ],
+            "repeatable": true,
+            "action": "store"
+          },
+          {
+            "dest": "approval",
+            "required": false,
+            "flags": [
+              "--approval"
             ],
             "repeatable": true,
             "action": "store"

--- a/rust/fslc/src/approval.rs
+++ b/rust/fslc/src/approval.rs
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Versioned approval records that bind reviewed artifacts to normalized FSL.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fsl_core::KernelModel;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+pub const APPROVAL_SCHEMA: &str = "fslc.approval.v1";
+pub const SPEC_DIGEST_ALGORITHM: &str = "fsl-kernel-ast-v1+sha256";
+pub const ARTIFACT_DIGEST_ALGORITHM: &str = "fsl-rendered-artifact-v1+sha256";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationInputs {
+    pub depth: usize,
+    pub deadlock: String,
+    pub engine: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecBinding {
+    pub path: String,
+    pub digest_algorithm: String,
+    pub digest: String,
+    pub git_commit: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TargetBinding {
+    pub kind: String,
+    pub path: String,
+    pub digest_algorithm: String,
+    pub digest: String,
+    pub generator: String,
+    pub generator_version: String,
+    pub inputs: GenerationInputs,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalMetadata {
+    pub approver: String,
+    pub approved_at: String,
+    pub requirements: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalRecord {
+    pub schema: String,
+    pub spec: SpecBinding,
+    pub target: TargetBinding,
+    pub approval: ApprovalMetadata,
+}
+
+fn is_location(value: &Map<String, Value>) -> bool {
+    value.len() == 2
+        && value.get("line").is_some_and(Value::is_number)
+        && value.get("column").is_some_and(Value::is_number)
+}
+
+fn normalized_ast(value: &Value) -> Option<Value> {
+    match value {
+        Value::Array(items) => Some(Value::Array(
+            items.iter().filter_map(normalized_ast).collect(),
+        )),
+        Value::Object(items) if is_location(items) => None,
+        Value::Object(items) => {
+            let mut keys = items.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let mut normalized = Map::new();
+            for key in keys {
+                if let Some(value) = normalized_ast(&items[key]) {
+                    normalized.insert(key.clone(), value);
+                }
+            }
+            Some(Value::Object(normalized))
+        }
+        _ => Some(value.clone()),
+    }
+}
+
+#[must_use]
+pub fn sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn stable_json(value: &Value, strip_execution_metadata: bool) -> Value {
+    match value {
+        Value::Array(items) => {
+            Value::Array(items.iter().map(|item| stable_json(item, false)).collect())
+        }
+        Value::Object(items) => {
+            let mut keys = items
+                .keys()
+                .filter(|key| {
+                    !strip_execution_metadata || !matches!(key.as_str(), "cost" | "cache")
+                })
+                .collect::<Vec<_>>();
+            keys.sort_unstable();
+            Value::Object(
+                keys.into_iter()
+                    .map(|key| (key.clone(), stable_json(&items[key], false)))
+                    .collect(),
+            )
+        }
+        _ => value.clone(),
+    }
+}
+
+/// Remove execution-only noise before binding a human-facing artifact.
+pub fn normalized_artifact(kind: &str, bytes: &[u8]) -> Result<Vec<u8>, String> {
+    if kind == "scenarios" {
+        let value: Value = serde_json::from_slice(bytes)
+            .map_err(|error| format!("scenario artifact is not valid JSON: {error}"))?;
+        return serde_json::to_vec(&stable_json(&value, true)).map_err(|error| error.to_string());
+    }
+    if kind == "html" {
+        let source = std::str::from_utf8(bytes)
+            .map_err(|error| format!("HTML artifact is not UTF-8: {error}"))?;
+        let mut normalized = String::new();
+        for line in source.split_inclusive('\n') {
+            if let Some(normalized_line) =
+                normalize_elapsed(line, "&quot;elapsed_s&quot;:", "&lt;elapsed&gt;")
+            {
+                normalized.push_str(&normalized_line);
+            } else if let Some(normalized_line) =
+                normalize_elapsed(line, "\"elapsed_s\":", "\"<elapsed>\"")
+            {
+                normalized.push_str(&normalized_line);
+            } else {
+                normalized.push_str(line);
+            }
+        }
+        return Ok(normalized.into_bytes());
+    }
+    Ok(bytes.to_vec())
+}
+
+fn normalize_elapsed(line: &str, marker: &str, replacement: &str) -> Option<String> {
+    let marker_start = line.find(marker)?;
+    let value_start = marker_start
+        + marker.len()
+        + line[marker_start + marker.len()..]
+            .len()
+            .saturating_sub(line[marker_start + marker.len()..].trim_start().len());
+    let value_len = line[value_start..]
+        .bytes()
+        .take_while(|byte| matches!(byte, b'0'..=b'9' | b'.' | b'-' | b'+' | b'e' | b'E'))
+        .count();
+    if value_len == 0 {
+        return None;
+    }
+    Some(format!(
+        "{}{}{}",
+        &line[..value_start],
+        replacement,
+        &line[value_start + value_len..]
+    ))
+}
+
+/// Hash the fully lowered kernel AST while ignoring source locations.
+///
+/// Comments, whitespace, source paths, and line movement do not invalidate an
+/// approval. Imported/composed specifications are covered because the resolver
+/// expands them before `python_ast` is projected.
+pub fn spec_digest(path: &Path) -> Result<String, String> {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
+    let kernel =
+        fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| error.to_string())?;
+    let ast = normalized_ast(&kernel.python_ast())
+        .ok_or_else(|| "normalized kernel AST is empty".to_owned())?;
+    let encoded = serde_json::to_vec(&ast).map_err(|error| error.to_string())?;
+    let mut framed = SPEC_DIGEST_ALGORITHM.as_bytes().to_vec();
+    framed.push(0);
+    framed.extend(encoded);
+    Ok(sha256_bytes(&framed))
+}
+
+#[must_use]
+pub fn requirement_ids(model: &KernelModel) -> Vec<String> {
+    let mut ids = BTreeSet::new();
+    let mut add = |metadata: Option<&fsl_syntax::MetaTag>| {
+        if let Some(metadata) = metadata
+            && !metadata.id.eq_ignore_ascii_case("undecided")
+        {
+            ids.insert(metadata.id.clone());
+        }
+    };
+    for action in &model.actions {
+        add(action.meta.as_ref());
+    }
+    for property in &model.invariants {
+        add(property.meta.as_ref());
+    }
+    for property in &model.transitions {
+        add(property.meta.as_ref());
+    }
+    for property in &model.reachables {
+        add(property.meta.as_ref());
+    }
+    for property in &model.leadstos {
+        add(property.meta.as_ref());
+    }
+    ids.into_iter().collect()
+}
+
+fn git_output(cwd: &Path, arguments: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| error.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_owned());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+/// Return `(repository root, repository-relative spec path, HEAD commit)`.
+pub fn git_location(path: &Path) -> Result<(PathBuf, String, String), String> {
+    let absolute = path.canonicalize().map_err(|error| error.to_string())?;
+    let root = PathBuf::from(git_output(
+        absolute.parent().unwrap_or_else(|| Path::new(".")),
+        &["rev-parse", "--show-toplevel"],
+    )?);
+    let relative = absolute
+        .strip_prefix(&root)
+        .map_err(|_| "spec is outside its Git repository".to_owned())?
+        .to_string_lossy()
+        .replace('\\', "/");
+    git_output(&root, &["ls-files", "--error-unmatch", "--", &relative])?;
+    let commit = git_output(&root, &["rev-parse", "HEAD"])?;
+    Ok((root, relative, commit))
+}
+
+/// Resolve the Git baseline and require all tracked content to match it.
+pub fn git_binding(path: &Path) -> Result<(PathBuf, String, String), String> {
+    let (root, relative, commit) = git_location(path)?;
+    let status = Command::new("git")
+        .args(["diff", "--quiet", "HEAD", "--"])
+        .current_dir(&root)
+        .status()
+        .map_err(|error| error.to_string())?;
+    if !status.success() {
+        return Err(
+            "approval creation requires a clean tracked worktree so the baseline can be reconstructed"
+                .to_owned(),
+        );
+    }
+    Ok((root, relative, commit))
+}
+
+/// Require the recorded commit and its specification path to exist locally.
+pub fn verify_git_baseline(repo: &Path, relative_path: &str, commit: &str) -> Result<(), String> {
+    let commit_object = format!("{commit}^{{commit}}");
+    git_output(repo, &["cat-file", "-e", &commit_object])?;
+    let spec_object = format!("{commit}:{relative_path}");
+    git_output(repo, &["cat-file", "-e", &spec_object])?;
+    Ok(())
+}
+
+pub fn read_record(path: &Path) -> Result<ApprovalRecord, String> {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let record: ApprovalRecord = serde_json::from_str(&source)
+        .map_err(|error| format!("invalid approval record: {error}"))?;
+    validate_record(&record)?;
+    Ok(record)
+}
+
+pub fn validate_record(record: &ApprovalRecord) -> Result<(), String> {
+    if record.schema != APPROVAL_SCHEMA {
+        return Err(format!("unsupported approval schema '{}'", record.schema));
+    }
+    if record.spec.digest_algorithm != SPEC_DIGEST_ALGORITHM {
+        return Err(format!(
+            "unsupported spec digest algorithm '{}'",
+            record.spec.digest_algorithm
+        ));
+    }
+    if record.target.digest_algorithm != ARTIFACT_DIGEST_ALGORITHM {
+        return Err(format!(
+            "unsupported artifact digest algorithm '{}'",
+            record.target.digest_algorithm
+        ));
+    }
+    if !matches!(record.target.kind.as_str(), "ledger" | "html" | "scenarios") {
+        return Err(format!(
+            "unsupported approval target '{}'",
+            record.target.kind
+        ));
+    }
+    if record.spec.path.trim().is_empty() || record.target.path.trim().is_empty() {
+        return Err("approval record paths must not be empty".to_owned());
+    }
+    if !is_sha256(&record.spec.digest) || !is_sha256(&record.target.digest) {
+        return Err("approval record contains an invalid SHA-256 digest".to_owned());
+    }
+    if !matches!(record.spec.git_commit.len(), 40 | 64)
+        || !record
+            .spec
+            .git_commit
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err("approval record contains an invalid Git commit".to_owned());
+    }
+    if record.target.generator != "fslc" || record.target.generator_version.trim().is_empty() {
+        return Err("approval record contains an unsupported generator".to_owned());
+    }
+    if !matches!(
+        record.target.inputs.deadlock.as_str(),
+        "warn" | "error" | "ignore"
+    ) || !matches!(record.target.inputs.engine.as_str(), "bmc" | "induction")
+    {
+        return Err("approval record contains invalid generation inputs".to_owned());
+    }
+    if record.approval.approver.trim().is_empty() {
+        return Err("approval record requires a non-empty approver".to_owned());
+    }
+    if !is_canonical_utc_timestamp(&record.approval.approved_at) {
+        return Err("approval record requires a canonical UTC approval timestamp".to_owned());
+    }
+    if record.approval.requirements.is_empty() {
+        return Err("approval record requires at least one requirement ID".to_owned());
+    }
+    let mut requirements = BTreeSet::new();
+    if record
+        .approval
+        .requirements
+        .iter()
+        .any(|requirement| requirement.trim().is_empty() || !requirements.insert(requirement))
+    {
+        return Err("approval record requirement IDs must be non-empty and unique".to_owned());
+    }
+    Ok(())
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 71
+        && value.starts_with("sha256:")
+        && value[7..]
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn is_canonical_utc_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 20
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+        || bytes[19] != b'Z'
+    {
+        return false;
+    }
+    let number = |start: usize, end: usize| {
+        bytes[start..end].iter().try_fold(0_u32, |value, byte| {
+            byte.is_ascii_digit()
+                .then_some(value * 10 + u32::from(*byte - b'0'))
+        })
+    };
+    let (Some(year), Some(month), Some(day), Some(hour), Some(minute), Some(second)) = (
+        number(0, 4),
+        number(5, 7),
+        number(8, 10),
+        number(11, 13),
+        number(14, 16),
+        number(17, 19),
+    ) else {
+        return false;
+    };
+    let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let days = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if leap => 29,
+        2 => 28,
+        _ => return false,
+    };
+    (1..=days).contains(&day) && hour < 24 && minute < 60 && second < 60
+}
+
+pub fn write_record(path: &Path, record: &ApprovalRecord) -> Result<(), String> {
+    let mut encoded = serde_json::to_string_pretty(record).map_err(|error| error.to_string())?;
+    encoded.push('\n');
+    std::fs::write(path, encoded).map_err(|error| error.to_string())
+}
+
+#[must_use]
+pub fn evaluate(
+    record: &ApprovalRecord,
+    record_path: &Path,
+    current_spec_digest: &str,
+    current_artifact_digest: &str,
+    current_generator_version: &str,
+) -> Value {
+    let mut reasons = Vec::new();
+    if record.spec.digest != current_spec_digest {
+        reasons.push("spec_changed");
+    }
+    if record.target.digest != current_artifact_digest {
+        reasons.push("rendering_changed");
+    }
+    if record.target.generator_version != current_generator_version {
+        reasons.push("renderer_changed");
+    }
+    let status = if reasons.is_empty() {
+        "approved"
+    } else {
+        "drifted"
+    };
+    json!({
+        "status": status,
+        "reasons": reasons,
+        "record": record_path.display().to_string(),
+        "target_kind": record.target.kind,
+        "approver": record.approval.approver,
+        "approved_at": record.approval.approved_at,
+        "requirements": record.approval.requirements,
+        "baseline_digest": record.spec.digest,
+        "current_digest": current_spec_digest,
+        "artifact_digest": record.target.digest,
+        "current_artifact_digest": current_artifact_digest,
+        "diff_base": record.spec.git_commit,
+        "semantic_diff_command": format!(
+            "fslc approval diff {} --record {}",
+            shell_word(&record.spec.path),
+            shell_word(&record_path.display().to_string())
+        ),
+    })
+}
+
+fn shell_word(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'_' | b'-' | b'.'))
+    {
+        return value.to_owned();
+    }
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[must_use]
+pub fn now_rfc3339() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs());
+    let days = i64::try_from(seconds / 86_400).unwrap_or_default();
+    let day_seconds = seconds % 86_400;
+    let hour = day_seconds / 3_600;
+    let minute = (day_seconds % 3_600) / 60;
+    let second = day_seconds % 60;
+
+    // Howard Hinnant's civil-from-days transform, with day zero at Unix epoch.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        is_canonical_utc_timestamp, normalized_artifact, normalized_ast, now_rfc3339, sha256_bytes,
+        shell_word,
+    };
+    use serde_json::{Value, json};
+
+    #[test]
+    fn normalized_ast_removes_locations_but_preserves_metadata() {
+        let value = json!([
+            "action",
+            {"line": 4, "column": 2},
+            {"id": "REQ-1", "text": "approved"},
+            ["call", "next", [], {"line": 8, "column": 7}],
+        ]);
+        assert_eq!(
+            normalized_ast(&value),
+            Some(json!([
+                "action",
+                {"id": "REQ-1", "text": "approved"},
+                ["call", "next", []],
+            ]))
+        );
+    }
+
+    #[test]
+    fn digest_is_prefixed_and_timestamp_is_utc() {
+        assert_eq!(
+            sha256_bytes(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        let now = now_rfc3339();
+        assert!(now.ends_with('Z'));
+        assert_eq!(now.len(), 20);
+        assert!(is_canonical_utc_timestamp(&now));
+        assert!(!is_canonical_utc_timestamp("2026-02-30T12:00:00Z"));
+    }
+
+    #[test]
+    fn scenario_normalization_keeps_domain_cost_and_shell_quotes_paths() {
+        let artifact = json!({
+            "fsl": "1.0",
+            "cost": {"elapsed_s": 0.25},
+            "cache": {"hit": true},
+            "scenarios": [{"initial_state": {"cost": 7, "cache": false}}],
+        });
+        let normalized = normalized_artifact(
+            "scenarios",
+            &serde_json::to_vec(&artifact).expect("serialize scenario"),
+        )
+        .expect("normalize scenario");
+        let normalized: Value = serde_json::from_slice(&normalized).expect("normalized JSON");
+        assert!(normalized.get("cost").is_none());
+        assert!(normalized.get("cache").is_none());
+        assert_eq!(normalized["scenarios"][0]["initial_state"]["cost"], 7);
+        assert_eq!(normalized["scenarios"][0]["initial_state"]["cache"], false);
+        assert_eq!(shell_word("specs/order.fsl"), "specs/order.fsl");
+        assert_eq!(
+            shell_word("review specs/order.fsl"),
+            "'review specs/order.fsl'"
+        );
+    }
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -12,6 +12,7 @@ use fsl_core::{
 };
 use serde_json::{Map, Value, json};
 
+mod approval;
 mod verification;
 
 use verification::{
@@ -294,6 +295,125 @@ fn command() -> Result<(Value, i32), String> {
                 strict_tags,
                 requirements.as_deref(),
             ))
+        }
+        "approval" => {
+            let subcommand = args.next().ok_or_else(|| {
+                "usage: fslc approval <create|check|diff> SPEC [options]".to_owned()
+            })?;
+            let path = PathBuf::from(
+                args.next()
+                    .ok_or_else(|| format!("fslc approval {subcommand} requires a spec"))?,
+            );
+            match subcommand.as_str() {
+                "create" => {
+                    let mut kind = None;
+                    let mut artifact = None;
+                    let mut approver = None;
+                    let mut requirements = Vec::new();
+                    let mut depth = 8_usize;
+                    let mut deadlock = "ignore".to_owned();
+                    let mut engine = "bmc".to_owned();
+                    let mut output = None;
+                    while let Some(option) = args.next() {
+                        match option.as_str() {
+                            "--kind" => kind = Some(required_option_value(&mut args, "--kind")?),
+                            "--artifact" => {
+                                artifact = Some(PathBuf::from(required_option_value(
+                                    &mut args,
+                                    "--artifact",
+                                )?));
+                            }
+                            "--approver" => {
+                                approver = Some(required_option_value(&mut args, "--approver")?);
+                            }
+                            "--requirement" => requirements
+                                .push(required_option_value(&mut args, "--requirement")?),
+                            "--depth" => {
+                                depth = required_option_value(&mut args, "--depth")?
+                                    .parse()
+                                    .map_err(|_| {
+                                        "--depth must be a non-negative integer".to_owned()
+                                    })?;
+                            }
+                            "--deadlock" => {
+                                deadlock = required_option_value(&mut args, "--deadlock")?;
+                                if !matches!(deadlock.as_str(), "warn" | "error" | "ignore") {
+                                    return Err(
+                                        "--deadlock must be warn, error, or ignore".to_owned()
+                                    );
+                                }
+                            }
+                            "--engine" => {
+                                engine = required_option_value(&mut args, "--engine")?;
+                                if !matches!(engine.as_str(), "bmc" | "induction") {
+                                    return Err("--engine must be bmc or induction".to_owned());
+                                }
+                            }
+                            "-o" | "--output" => {
+                                output = Some(PathBuf::from(required_option_value(
+                                    &mut args, "--output",
+                                )?));
+                            }
+                            _ => return Err(format!("unknown approval create option '{option}'")),
+                        }
+                    }
+                    Ok(run_approval_create(
+                        &path,
+                        &kind.ok_or_else(|| "approval create requires --kind".to_owned())?,
+                        &artifact
+                            .ok_or_else(|| "approval create requires --artifact".to_owned())?,
+                        &approver
+                            .ok_or_else(|| "approval create requires --approver".to_owned())?,
+                        &requirements,
+                        &approval::GenerationInputs {
+                            depth,
+                            deadlock,
+                            engine,
+                        },
+                        output.as_deref(),
+                    ))
+                }
+                "check" => {
+                    if args.next().as_deref() != Some("--record") {
+                        return Err("approval check requires --record RECORD.json".to_owned());
+                    }
+                    let record = PathBuf::from(
+                        args.next()
+                            .ok_or_else(|| "--record requires a path".to_owned())?,
+                    );
+                    if args.next().is_some() {
+                        return Err("unexpected approval check argument".to_owned());
+                    }
+                    Ok(run_approval_check(&path, &record))
+                }
+                "diff" => {
+                    let mut record = None;
+                    let mut depth = 8_usize;
+                    while let Some(option) = args.next() {
+                        match option.as_str() {
+                            "--record" => {
+                                record = Some(PathBuf::from(required_option_value(
+                                    &mut args, "--record",
+                                )?));
+                            }
+                            "--depth" => {
+                                depth = required_option_value(&mut args, "--depth")?
+                                    .parse()
+                                    .map_err(|_| {
+                                        "--depth must be a non-negative integer".to_owned()
+                                    })?;
+                            }
+                            _ => return Err(format!("unknown approval diff option '{option}'")),
+                        }
+                    }
+                    Ok(run_approval_diff(
+                        &path,
+                        &record.ok_or_else(|| "approval diff requires --record".to_owned())?,
+                        depth,
+                    ))
+                }
+                _ => Err(format!("unknown approval subcommand '{subcommand}'")),
+            }
         }
         "db" => {
             let subcommand = args
@@ -776,6 +896,7 @@ fn command() -> Result<(Value, i32), String> {
             let mut engine = "bmc".to_owned();
             let mut impl_log = None;
             let mut evidence = Vec::new();
+            let mut approval_records = Vec::new();
             let mut deadlock = if command == "ledger" {
                 "ignore".to_owned()
             } else {
@@ -827,6 +948,9 @@ fn command() -> Result<(Value, i32), String> {
                     "--evidence" if command == "ledger" => evidence.push(PathBuf::from(
                         required_option_value(&mut args, "--evidence")?,
                     )),
+                    "--approval" if command == "ledger" => approval_records.push(PathBuf::from(
+                        required_option_value(&mut args, "--approval")?,
+                    )),
                     "--strict" => strict = true,
                     _ => return Err(format!("unknown {command} option '{option}'")),
                 }
@@ -843,6 +967,7 @@ fn command() -> Result<(Value, i32), String> {
                     &engine,
                     impl_log.as_deref(),
                     &evidence,
+                    &approval_records,
                     output.as_deref(),
                 ),
                 _ => unreachable!(),
@@ -7403,6 +7528,243 @@ fn run_html_report(
     )
 }
 
+fn approval_artifact(
+    path: &Path,
+    kind: &str,
+    inputs: &approval::GenerationInputs,
+) -> Result<Vec<u8>, Value> {
+    let (result, status) = match kind {
+        "ledger" => run_ledger_report(
+            path,
+            inputs.depth,
+            &inputs.deadlock,
+            &inputs.engine,
+            None,
+            &[],
+            &[],
+            None,
+        ),
+        "html" => run_html_report(path, inputs.depth, &inputs.deadlock, &inputs.engine, None),
+        "scenarios" => run_scenarios(path, inputs.depth, &inputs.deadlock),
+        _ => {
+            return Err(error_output(
+                "usage",
+                &format!("unsupported approval target '{kind}'"),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(result);
+    }
+    if matches!(kind, "ledger" | "html") {
+        result
+            .get("content")
+            .and_then(Value::as_str)
+            .map(|content| content.as_bytes().to_vec())
+            .ok_or_else(|| error_output("internal", "generated artifact has no content"))
+    } else {
+        let mut encoded = serde_json::to_vec_pretty(&result)
+            .map_err(|error| error_output("internal", &error.to_string()))?;
+        encoded.push(b'\n');
+        Ok(encoded)
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn run_approval_create(
+    path: &Path,
+    kind: &str,
+    artifact_path: &Path,
+    approver: &str,
+    selected_requirements: &[String],
+    inputs: &approval::GenerationInputs,
+    output_path: Option<&Path>,
+) -> (Value, i32) {
+    if !matches!(kind, "ledger" | "html" | "scenarios") {
+        return (
+            error_output("usage", "--kind must be ledger, html, or scenarios"),
+            2,
+        );
+    }
+    if approver.trim().is_empty() {
+        return (error_output("usage", "--approver must not be empty"), 2);
+    }
+    let model = match load_model(path) {
+        Ok(model) => model,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let (_repo, relative_path, git_commit) = match approval::git_binding(path) {
+        Ok(binding) => binding,
+        Err(error) => return (error_output("io", &error), 2),
+    };
+    let digest = match approval::spec_digest(path) {
+        Ok(digest) => digest,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let expected_artifact = match approval_artifact(path, kind, inputs) {
+        Ok(artifact) => artifact,
+        Err(error) => return (error, 2),
+    };
+    let reviewed_artifact = match std::fs::read(artifact_path) {
+        Ok(artifact) => artifact,
+        Err(error) => return (error_output("io", &error.to_string()), 2),
+    };
+    let normalized_reviewed = match approval::normalized_artifact(kind, &reviewed_artifact) {
+        Ok(artifact) => artifact,
+        Err(error) => return (error_output("semantics", &error), 2),
+    };
+    let normalized_expected = match approval::normalized_artifact(kind, &expected_artifact) {
+        Ok(artifact) => artifact,
+        Err(error) => return (error_output("internal", &error), 3),
+    };
+    if normalized_reviewed != normalized_expected {
+        return (
+            error_output(
+                "semantics",
+                "reviewed artifact does not match a fresh rendering with the recorded inputs",
+            ),
+            2,
+        );
+    }
+    let available = approval::requirement_ids(&model);
+    if available.is_empty() {
+        return (
+            error_output(
+                "semantics",
+                "approval creation requires at least one requirement ID in the specification",
+            ),
+            2,
+        );
+    }
+    let mut requirements = if selected_requirements.is_empty() {
+        available.clone()
+    } else {
+        selected_requirements.to_vec()
+    };
+    requirements.sort();
+    requirements.dedup();
+    if let Some(unknown) = requirements
+        .iter()
+        .find(|requirement| !available.contains(*requirement))
+    {
+        return (
+            error_output(
+                "semantics",
+                &format!("approval references unknown requirement '{unknown}'"),
+            ),
+            2,
+        );
+    }
+    let record = approval::ApprovalRecord {
+        schema: approval::APPROVAL_SCHEMA.to_owned(),
+        spec: approval::SpecBinding {
+            path: relative_path,
+            digest_algorithm: approval::SPEC_DIGEST_ALGORITHM.to_owned(),
+            digest,
+            git_commit,
+        },
+        target: approval::TargetBinding {
+            kind: kind.to_owned(),
+            path: artifact_path.display().to_string(),
+            digest_algorithm: approval::ARTIFACT_DIGEST_ALGORITHM.to_owned(),
+            digest: approval::sha256_bytes(&normalized_reviewed),
+            generator: "fslc".to_owned(),
+            generator_version: env!("CARGO_PKG_VERSION").to_owned(),
+            inputs: inputs.clone(),
+        },
+        approval: approval::ApprovalMetadata {
+            approver: approver.to_owned(),
+            approved_at: approval::now_rfc3339(),
+            requirements,
+        },
+    };
+    let destination = output_path.map_or_else(
+        || {
+            let stem = path
+                .file_stem()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or("spec");
+            path.with_file_name(format!("{stem}.approval.json"))
+        },
+        Path::to_path_buf,
+    );
+    if let Err(error) = approval::write_record(&destination, &record) {
+        return (error_output("io", &error), 2);
+    }
+    let mut output = envelope();
+    output.insert("result".to_owned(), json!("created"));
+    output.insert("kind".to_owned(), json!("approval_record"));
+    output.insert("output".to_owned(), json!(destination));
+    output.insert(
+        "record".to_owned(),
+        serde_json::to_value(record).unwrap_or(Value::Null),
+    );
+    (Value::Object(output), 0)
+}
+
+fn approval_evaluation(path: &Path, record_path: &Path) -> Result<Value, Value> {
+    let record = approval::read_record(record_path).map_err(|error| error_output("io", &error))?;
+    let (repo, relative_path, _head) =
+        approval::git_location(path).map_err(|error| error_output("io", &error))?;
+    if record.spec.path != relative_path {
+        return Err(error_output(
+            "semantics",
+            &format!(
+                "approval record targets '{}' but current spec is '{relative_path}'",
+                record.spec.path
+            ),
+        ));
+    }
+    approval::verify_git_baseline(&repo, &relative_path, &record.spec.git_commit)
+        .map_err(|error| error_output("io", &error))?;
+    let current_spec_digest =
+        approval::spec_digest(path).map_err(|error| semantic_error_output(&error))?;
+    let artifact = approval_artifact(path, &record.target.kind, &record.target.inputs)?;
+    let normalized_artifact = approval::normalized_artifact(&record.target.kind, &artifact)
+        .map_err(|error| error_output("internal", &error))?;
+    let current_artifact_digest = approval::sha256_bytes(&normalized_artifact);
+    Ok(approval::evaluate(
+        &record,
+        record_path,
+        &current_spec_digest,
+        &current_artifact_digest,
+        env!("CARGO_PKG_VERSION"),
+    ))
+}
+
+fn run_approval_check(path: &Path, record_path: &Path) -> (Value, i32) {
+    let evaluation = match approval_evaluation(path, record_path) {
+        Ok(evaluation) => evaluation,
+        Err(error) => return (error, 2),
+    };
+    let mut output = envelope();
+    output.insert("result".to_owned(), json!("approval_check"));
+    if let Some(fields) = evaluation.as_object() {
+        output.extend(fields.clone());
+    }
+    (Value::Object(output), 0)
+}
+
+fn approval_overlay(path: &Path, record_paths: &[PathBuf]) -> Result<Value, Value> {
+    let mut requirements = Map::new();
+    let mut records = Vec::new();
+    for record_path in record_paths {
+        let evaluation = approval_evaluation(path, record_path)?;
+        for requirement in evaluation
+            .get("requirements")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            requirements.insert(requirement.to_owned(), evaluation.clone());
+        }
+        records.push(evaluation);
+    }
+    Ok(json!({"requirements": requirements, "records": records}))
+}
+
+#[allow(clippy::too_many_arguments)]
 fn run_ledger_report(
     path: &Path,
     depth: usize,
@@ -7410,6 +7772,7 @@ fn run_ledger_report(
     engine: &str,
     impl_log: Option<&Path>,
     evidence_paths: &[PathBuf],
+    approval_paths: &[PathBuf],
     output_path: Option<&Path>,
 ) -> (Value, i32) {
     let model = match load_model(path) {
@@ -7443,13 +7806,22 @@ fn run_ledger_report(
         .into_iter()
         .map(|(source, value)| (source.display().to_string(), value))
         .collect::<Vec<_>>();
-    let content = fsl_tools::render_ledger(
+    let approvals = if approval_paths.is_empty() {
+        None
+    } else {
+        match approval_overlay(path, approval_paths) {
+            Ok(approvals) => Some(approvals),
+            Err(error) => return (error, 2),
+        }
+    };
+    let content = fsl_tools::render_ledger_with_approvals(
         &path.display().to_string(),
         &model,
         &verification,
         &scenarios,
         replay.as_ref(),
         &evidence,
+        approvals.as_ref(),
     );
     generated_content_result(
         "audit_ledger",
@@ -10356,6 +10728,89 @@ fn materialize_git_tree(repo: &Path, revision: &str, destination: &Path) -> Resu
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_owned());
     }
     Ok(())
+}
+
+fn run_approval_diff(path: &Path, record_path: &Path, depth: usize) -> (Value, i32) {
+    let record = match approval::read_record(record_path) {
+        Ok(record) => record,
+        Err(error) => return (error_output("io", &error), 2),
+    };
+    let (repo, relative_path, _head) = match approval::git_location(path) {
+        Ok(location) => location,
+        Err(error) => return (error_output("io", &error), 2),
+    };
+    if relative_path != record.spec.path {
+        return (
+            error_output(
+                "semantics",
+                &format!(
+                    "approval record targets '{}' but current spec is '{relative_path}'",
+                    record.spec.path
+                ),
+            ),
+            2,
+        );
+    }
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let root =
+        std::env::temp_dir().join(format!("fslc-approval-diff-{}-{nonce}", std::process::id()));
+    let base_tree = root.join("base");
+    if let Err(error) = materialize_git_tree(&repo, &record.spec.git_commit, &base_tree) {
+        let _ = std::fs::remove_dir_all(&root);
+        return (error_output("io", &error), 2);
+    }
+    let old = base_tree.join(&record.spec.path);
+    if !old.is_file() {
+        let _ = std::fs::remove_dir_all(&root);
+        return (
+            error_output(
+                "io",
+                &format!(
+                    "approved spec '{}' is missing from baseline {}",
+                    record.spec.path, record.spec.git_commit
+                ),
+            ),
+            2,
+        );
+    }
+    let materialized_digest = match approval::spec_digest(&old) {
+        Ok(digest) => digest,
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&root);
+            return (semantic_error_output(&error), 2);
+        }
+    };
+    if materialized_digest != record.spec.digest {
+        let _ = std::fs::remove_dir_all(&root);
+        return (
+            error_output(
+                "semantics",
+                "approval baseline commit does not match the recorded specification digest",
+            ),
+            2,
+        );
+    }
+    let (mut result, status) = run_diff(&old, path, depth, None, &[]);
+    if let Value::Object(output) = &mut result {
+        if let Some(Value::Object(old)) = output.get_mut("old") {
+            old.insert(
+                "file".to_owned(),
+                json!(format!("{}:{}", record.spec.git_commit, record.spec.path)),
+            );
+        }
+        output.insert(
+            "approval".to_owned(),
+            json!({
+                "record": record_path.display().to_string(),
+                "baseline_digest": record.spec.digest,
+                "baseline_commit": record.spec.git_commit,
+            }),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&root);
+    (result, status)
 }
 
 #[allow(clippy::too_many_lines)]

--- a/rust/fslc/tests/issue_190_approval.rs
+++ b/rust/fslc/tests/issue_190_approval.rs
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
+
+fn repository_file(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn run(cwd: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run native fslc")
+}
+
+fn successful(cwd: &Path, arguments: &[&str]) -> Output {
+    let output = run(cwd, arguments);
+    assert!(
+        output.status.success(),
+        "command {arguments:?} failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn failed(cwd: &Path, arguments: &[&str]) -> Value {
+    let output = run(cwd, arguments);
+    assert!(
+        !output.status.success(),
+        "command {arguments:?} unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    json_output(&output)
+}
+
+fn json_output(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("JSON command output")
+}
+
+fn git(cwd: &Path, arguments: &[&str]) {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {arguments:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_stdout(cwd: &Path, arguments: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(output.status.success(), "git {arguments:?} failed");
+    String::from_utf8(output.stdout)
+        .expect("Git output is UTF-8")
+        .trim()
+        .to_owned()
+}
+
+fn approval_repo() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let root = std::env::temp_dir().join(format!(
+        "fslc-issue-190-{}-{nonce}-{}",
+        std::process::id(),
+        NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed),
+    ));
+    if root.exists() {
+        std::fs::remove_dir_all(&root).expect("remove stale temporary repository");
+    }
+    std::fs::create_dir_all(&root).expect("create temporary repository");
+    std::fs::copy(
+        repository_file("tests/fixtures/approval.fsl"),
+        root.join("spec.fsl"),
+    )
+    .expect("copy approval fixture");
+    git(&root, &["init", "-q"]);
+    git(
+        &root,
+        &["config", "user.email", "approval-test@example.com"],
+    );
+    git(&root, &["config", "user.name", "Approval Test"]);
+    git(&root, &["add", "spec.fsl"]);
+    git(&root, &["commit", "-qm", "approval baseline"]);
+    root
+}
+
+fn normalize_digests(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut output = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index..].starts_with(b"sha256:")
+            && index + 71 <= bytes.len()
+            && bytes[index + 7..index + 71]
+                .iter()
+                .all(u8::is_ascii_hexdigit)
+        {
+            output.extend_from_slice(b"sha256:<digest>");
+            index += 71;
+        } else {
+            output.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(output).expect("normalized ledger remains UTF-8")
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn approval_record_reports_approved_then_drifted_and_drives_semantic_diff() {
+    let root = approval_repo();
+    successful(
+        &root,
+        &["ledger", "spec.fsl", "--depth", "2", "-o", "review.md"],
+    );
+    let created = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--depth",
+            "2",
+            "-o",
+            "approval.json",
+        ],
+    ));
+    let baseline = created["record"]["spec"]["digest"]
+        .as_str()
+        .expect("baseline digest")
+        .to_owned();
+    assert_eq!(
+        created["record"]["approval"]["requirements"],
+        json!(["REQ-190"])
+    );
+
+    let approved = json_output(&successful(
+        &root,
+        &["approval", "check", "spec.fsl", "--record", "approval.json"],
+    ));
+    assert_eq!(approved["status"], "approved");
+    assert_eq!(approved["reasons"], json!([]));
+
+    let mut invalid_record: Value = serde_json::from_slice(
+        &std::fs::read(root.join("approval.json")).expect("read approval record"),
+    )
+    .expect("approval record JSON");
+    invalid_record["schema"] = json!("fslc.approval.v999");
+    std::fs::write(
+        root.join("unsupported.json"),
+        serde_json::to_vec_pretty(&invalid_record).expect("serialize unsupported record"),
+    )
+    .expect("write unsupported record");
+    let unsupported = failed(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "unsupported.json",
+        ],
+    );
+    assert_eq!(unsupported["kind"], "io");
+
+    invalid_record["schema"] = json!("fslc.approval.v1");
+    invalid_record["spec"]["digest"] = json!("sha256:not-a-digest");
+    std::fs::write(
+        root.join("malformed.json"),
+        serde_json::to_vec_pretty(&invalid_record).expect("serialize malformed record"),
+    )
+    .expect("write malformed record");
+    let malformed = failed(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "malformed.json",
+        ],
+    );
+    assert_eq!(malformed["kind"], "io");
+
+    let mut unknown_field = created["record"].clone();
+    unknown_field["unexpected"] = json!(true);
+    std::fs::write(
+        root.join("unknown-field.json"),
+        serde_json::to_vec_pretty(&unknown_field).expect("serialize unknown-field record"),
+    )
+    .expect("write unknown-field record");
+    let unknown_field = failed(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "unknown-field.json",
+        ],
+    );
+    assert_eq!(unknown_field["kind"], "io");
+
+    let mut missing_baseline = created["record"].clone();
+    missing_baseline["spec"]["git_commit"] = json!("0".repeat(40));
+    std::fs::write(
+        root.join("missing-baseline.json"),
+        serde_json::to_vec_pretty(&missing_baseline).expect("serialize missing baseline"),
+    )
+    .expect("write missing-baseline record");
+    let missing_baseline = failed(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "missing-baseline.json",
+        ],
+    );
+    assert_eq!(missing_baseline["kind"], "io");
+
+    successful(
+        &root,
+        &[
+            "ledger",
+            "spec.fsl",
+            "--depth",
+            "2",
+            "--approval",
+            "approval.json",
+            "-o",
+            "approved.md",
+        ],
+    );
+    let ledger = std::fs::read_to_string(root.join("approved.md")).expect("approved ledger");
+    let risk = ledger
+        .split_once("## リスク一覧（要件ID別）")
+        .expect("risk table")
+        .1
+        .split_once("## 要件ID別詳細")
+        .expect("risk table end")
+        .0;
+    let approval = ledger
+        .split_once("## 承認照合")
+        .expect("approval section")
+        .1
+        .split_once("## 付録")
+        .expect("approval section end")
+        .0;
+    let snapshot = format!("## リスク一覧（要件ID別）{risk}## 承認照合{approval}");
+    assert_eq!(
+        normalize_digests(&snapshot).trim(),
+        include_str!("../../../tests/snapshots/approval_ledger.md").trim()
+    );
+
+    let original = std::fs::read_to_string(root.join("spec.fsl")).expect("read fixture");
+    std::fs::write(
+        root.join("spec.fsl"),
+        format!("{original}\n// review-only comment\n"),
+    )
+    .expect("append non-semantic comment");
+    let comment_only = json_output(&successful(
+        &root,
+        &["approval", "check", "spec.fsl", "--record", "approval.json"],
+    ));
+    assert_eq!(comment_only["status"], "approved");
+
+    let mut renderer_record: Value = serde_json::from_slice(
+        &std::fs::read(root.join("approval.json")).expect("read approval record"),
+    )
+    .expect("approval record JSON");
+    renderer_record["target"]["digest"] = json!(format!("sha256:{}", "0".repeat(64)));
+    std::fs::write(
+        root.join("renderer-drift.json"),
+        serde_json::to_vec_pretty(&renderer_record).expect("serialize drift record"),
+    )
+    .expect("write drift record");
+    let renderer_drift = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "renderer-drift.json",
+        ],
+    ));
+    assert_eq!(renderer_drift["status"], "drifted");
+    assert_eq!(renderer_drift["reasons"], json!(["rendering_changed"]));
+
+    let changed = original.replace("approved = true", "approved = false");
+    std::fs::write(root.join("spec.fsl"), &changed).expect("write semantic change");
+    let drifted = json_output(&successful(
+        &root,
+        &["approval", "check", "spec.fsl", "--record", "approval.json"],
+    ));
+    assert_eq!(drifted["status"], "drifted");
+    assert!(
+        drifted["reasons"]
+            .as_array()
+            .expect("drift reasons")
+            .contains(&json!("spec_changed"))
+    );
+    assert_eq!(drifted["baseline_digest"], baseline);
+
+    let diff = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "diff",
+            "spec.fsl",
+            "--record",
+            "approval.json",
+            "--depth",
+            "2",
+        ],
+    ));
+    assert_eq!(diff["result"], "semantic_diff");
+    assert_eq!(diff["approval"]["baseline_digest"], baseline);
+    assert_ne!(diff["summary"], json!(["no_semantic_change"]));
+
+    git(&root, &["add", "spec.fsl"]);
+    git(&root, &["commit", "-qm", "semantic change"]);
+    let mut mismatched_baseline: Value = serde_json::from_slice(
+        &std::fs::read(root.join("approval.json")).expect("read approval record"),
+    )
+    .expect("approval record JSON");
+    mismatched_baseline["spec"]["git_commit"] = json!(git_stdout(&root, &["rev-parse", "HEAD"]));
+    std::fs::write(
+        root.join("mismatched-baseline.json"),
+        serde_json::to_vec_pretty(&mismatched_baseline).expect("serialize mismatched baseline"),
+    )
+    .expect("write mismatched baseline record");
+    let mismatch = failed(
+        &root,
+        &[
+            "approval",
+            "diff",
+            "spec.fsl",
+            "--record",
+            "mismatched-baseline.json",
+            "--depth",
+            "2",
+        ],
+    );
+    assert_eq!(mismatch["kind"], "semantics");
+
+    let without_requirement_ids = changed
+        .replace(" \"REQ-190: a pending review can be approved\"", "")
+        .replace(" \"REQ-190: an approved review remains approved\"", "");
+    std::fs::write(root.join("spec.fsl"), without_requirement_ids)
+        .expect("remove requirement IDs from current spec");
+    successful(
+        &root,
+        &[
+            "ledger",
+            "spec.fsl",
+            "--depth",
+            "2",
+            "--approval",
+            "approval.json",
+            "-o",
+            "removed-requirement.md",
+        ],
+    );
+    let removed = std::fs::read_to_string(root.join("removed-requirement.md"))
+        .expect("removed requirement ledger");
+    assert!(removed.contains("REQ-190"));
+    assert!(removed.contains("現行仕様に要件IDなし"));
+    assert!(removed.contains("drifted"));
+
+    std::fs::remove_dir_all(root).expect("remove temporary repository");
+}
+
+#[test]
+fn html_and_scenarios_are_supported_review_targets() {
+    let root = approval_repo();
+    for (kind, artifact, render_arguments) in [
+        (
+            "html",
+            "review.html",
+            vec![
+                "html",
+                "spec.fsl",
+                "--depth",
+                "2",
+                "--deadlock",
+                "ignore",
+                "-o",
+                "review.html",
+            ],
+        ),
+        (
+            "scenarios",
+            "scenarios.json",
+            vec![
+                "scenarios",
+                "spec.fsl",
+                "--depth",
+                "2",
+                "--deadlock",
+                "ignore",
+            ],
+        ),
+    ] {
+        let rendered = successful(&root, &render_arguments);
+        if kind == "scenarios" {
+            std::fs::write(root.join(artifact), &rendered.stdout)
+                .expect("write scenarios artifact");
+        }
+        let record = format!("{kind}.approval.json");
+        successful(
+            &root,
+            &[
+                "approval",
+                "create",
+                "spec.fsl",
+                "--kind",
+                kind,
+                "--artifact",
+                artifact,
+                "--approver",
+                "alice",
+                "--depth",
+                "2",
+                "--deadlock",
+                "ignore",
+                "-o",
+                &record,
+            ],
+        );
+        let checked = json_output(&successful(
+            &root,
+            &["approval", "check", "spec.fsl", "--record", &record],
+        ));
+        assert_eq!(checked["status"], "approved", "target {kind}");
+    }
+    std::fs::remove_dir_all(root).expect("remove temporary repository");
+}
+
+#[test]
+fn approval_creation_rejects_stale_unknown_dirty_and_unidentified_inputs() {
+    let root = approval_repo();
+    successful(
+        &root,
+        &["ledger", "spec.fsl", "--depth", "2", "-o", "review.md"],
+    );
+
+    std::fs::write(root.join("review.md"), "stale review\n").expect("write stale review");
+    let stale = failed(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--depth",
+            "2",
+        ],
+    );
+    assert_eq!(stale["kind"], "semantics");
+
+    successful(
+        &root,
+        &["ledger", "spec.fsl", "--depth", "2", "-o", "review.md"],
+    );
+    let unknown = failed(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--requirement",
+            "REQ-UNKNOWN",
+            "--depth",
+            "2",
+        ],
+    );
+    assert_eq!(unknown["kind"], "semantics");
+
+    let source = std::fs::read_to_string(root.join("spec.fsl")).expect("read spec");
+    std::fs::write(root.join("spec.fsl"), format!("{source}\n// dirty\n"))
+        .expect("dirty tracked spec");
+    let dirty = failed(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--depth",
+            "2",
+        ],
+    );
+    assert_eq!(dirty["kind"], "io");
+
+    std::fs::write(
+        root.join("spec.fsl"),
+        source
+            .replace(" \"REQ-190: a pending review can be approved\"", "")
+            .replace(" \"REQ-190: an approved review remains approved\"", ""),
+    )
+    .expect("remove requirement IDs");
+    git(&root, &["add", "spec.fsl"]);
+    git(&root, &["commit", "-qm", "remove requirement IDs"]);
+    successful(
+        &root,
+        &["ledger", "spec.fsl", "--depth", "2", "-o", "review.md"],
+    );
+    let unidentified = failed(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--depth",
+            "2",
+        ],
+    );
+    assert_eq!(unidentified["kind"], "semantics");
+
+    std::fs::remove_dir_all(root).expect("remove temporary repository");
+}

--- a/schemas/fslc/approval/approval-record.v1.schema.json
+++ b/schemas/fslc/approval/approval-record.v1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fsl.dev/schemas/fslc/approval/approval-record.v1.schema.json",
+  "title": "FSL approval record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "spec", "target", "approval"],
+  "properties": {
+    "schema": { "const": "fslc.approval.v1" },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "digest_algorithm", "digest", "git_commit"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "digest_algorithm": { "const": "fsl-kernel-ast-v1+sha256" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "git_commit": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "path",
+        "digest_algorithm",
+        "digest",
+        "generator",
+        "generator_version",
+        "inputs"
+      ],
+      "properties": {
+        "kind": { "enum": ["ledger", "html", "scenarios"] },
+        "path": { "type": "string", "minLength": 1 },
+        "digest_algorithm": { "const": "fsl-rendered-artifact-v1+sha256" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "generator": { "const": "fslc" },
+        "generator_version": { "type": "string", "minLength": 1 },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["depth", "deadlock", "engine"],
+          "properties": {
+            "depth": { "type": "integer", "minimum": 0 },
+            "deadlock": { "enum": ["warn", "error", "ignore"] },
+            "engine": { "enum": ["bmc", "induction"] }
+          }
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approver", "approved_at", "requirements"],
+      "properties": {
+        "approver": { "type": "string", "minLength": 1 },
+        "approved_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -712,8 +712,13 @@ fslc chain [fsl-project.toml] [--keep-going]     # manifest-driven business -> r
 fslc analyze <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag review
 fslc typestate <f> [--ts]                       # state machine -> ghost-type applicability + TS skeleton
 fslc html <f> [--depth K] [-o report.html] [--engine bmc|induction]  # self-contained HTML review report (dev audience)
-fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md] [--engine bmc|induction] [--evidence result.json]...
+fslc ledger <f> [--depth K] [--impl-log run.json] [-o ledger.md] [--engine bmc|induction] [--evidence result.json]... [--approval record.json]...
                                                         # business audit ledger by requirement id (PM/audit)
+fslc approval create <f> --kind ledger|html|scenarios --artifact <reviewed> --approver <name> [--requirement ID]... [-o record.json]
+                                                        # bind the reviewed artifact to normalized spec + Git baseline
+fslc approval check <f> --record <record.json>          # approved | drifted with machine reasons
+fslc approval diff <f> --record <record.json> [--depth K]
+                                                        # semantic diff from approved commit to current working spec
 fslc domain check <f> [--depth K] [--engine bmc|induction]  # Functional DDD / effect findings
 fslc domain analyze <f>                                      # aggregate/effect ownership summary
 fslc domain expand <f> [-o out.fsl]                          # generated kernel FSL
@@ -848,6 +853,19 @@ business translation, governance columns (risk/decider) come from `control`
 metadata when present (fill-in otherwise), and the guarantee limit is stated in
 positive form. Raw JSON is demoted to a collapsed appendix. See
 `docs/DESIGN-ledger.md`.
+
+Digest-bound approvals (issue #190) are separate from assurance class and from
+the ledger's empty human-decision checkbox. `approval create` must be run from a
+clean tracked Git baseline and only accepts a reviewed artifact that matches a
+fresh rendering under the recorded inputs. The sidecar uses a lowered-kernel
+digest that ignores source locations plus a normalized artifact digest for
+`ledger`, `html`, or `scenarios`. `approval check` and `ledger --approval`
+report `approved` or `drifted`; drift reasons distinguish spec, rendering, and
+renderer changes. A drifted row carries the complete baseline digest and an
+`approval diff` command, which compares the approved commit to the current
+working spec. Treat `approver` as attribution; authenticity comes from the
+repository's signed-commit/review/branch-protection policy. See
+`docs/DESIGN-approval.md`.
 
 Every requirement id in the ledger (and every property row in `fslc html`)
 carries an **assurance class** (issue #171): `proved(induction)` (k-induction,

--- a/tests/fixtures/approval.fsl
+++ b/tests/fixtures/approval.fsl
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Approval-record regression fixture for issue #190.
+
+spec ApprovalReview {
+  state { approved: Bool, ever_approved: Bool }
+
+  init {
+    approved = false
+    ever_approved = false
+  }
+
+  action approve() "REQ-190: a pending review can be approved" {
+    requires not approved
+    approved = true
+    ever_approved = true
+  }
+
+  invariant ApprovalPersists "REQ-190: an approved review remains approved" {
+    ever_approved => approved
+  }
+}

--- a/tests/snapshots/approval_ledger.md
+++ b/tests/snapshots/approval_ledger.md
@@ -1,0 +1,11 @@
+## リスク一覧（要件ID別）
+
+| 要件ID | 業務目的 | 状態 | 承認状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |
+|---|---|---|---|---|---|---|---|---|
+| REQ-190 | an approved review remains approved | 🟢 反例なし | ✅ approved | bounded(BMC depth 2) | — | — | — | — |
+
+## 承認照合
+
+| 要件ID | 承認状態 | 承認基準 digest | 承認対象 | drift理由 | semantic diff |
+|---|---|---|---|---|---|
+| REQ-190 | ✅ approved | `sha256:<digest>` | ledger | — | `—` |


### PR DESCRIPTION
## Summary

- add native Rust `fslc approval create|check|diff` commands with a versioned JSON sidecar and schema
- bind reviewed ledger, HTML, or scenario artifacts to a location-insensitive lowered-kernel digest, rendering digest, generator inputs, approver, timestamp, and reconstructable Git baseline
- add `fslc ledger --approval` with per-requirement `approved` / `drifted` state, full baseline digest, drift reasons, and an executable semantic-diff command
- preserve removed requirement IDs as drifted ledger rows and fail closed for malformed records, unavailable/mismatched baselines, stale artifacts, and dirty approval creation
- document the design and update the native CLI contract/FSL skill reference

The Python reference implementation remains frozen and unchanged.

## Why

Stakeholders approve rendered review artifacts, but those approvals need to become invalid when either the normalized specification or its reviewed rendering changes. The recorded Git commit also makes the approved baseline directly usable by the existing semantic-diff flow.

Closes #190.

## Validation

- `cargo fmt --all -- --check`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo test --workspace --locked`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo build --workspace --locked`
- `cargo audit --no-fetch`
- runtime and WASM dependency-boundary inspection
- JSON validation for the CLI contract and approval-record schema
