### PR TITLE
feat(verify): add explicit-state exploration engine (--engine explicit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Explicit-state exploration engine (issue #212): native Rust
+  `fslc verify --engine explicit` enumerates the concrete state space on the
+  Z3-free path (`fsl-runtime` BFS with `BTreeSet` dedup and parent-link
+  traces). Closure — no new states within `--depth` — returns `proved`
+  (`closure: true`), a complete unbounded proof that needs no lemmas even for
+  true-but-not-inductive invariants where k-induction reports `unknown_cti`;
+  depth exhaustion returns bounded `verified`; exceeding `--explicit-budget`
+  (default 1,000,000 visited states) returns the new `unknown_budget` verdict
+  (exit 1), never a silent `verified`. Violations reuse the BMC
+  shortest-counterexample trace schema, and results carry `states_explored`,
+  `max_frontier_width`, and `depth_reached`. Fail-closed rejections keep the
+  engine sound: `leadsTo` properties, nondeterministic `init`, and
+  `init forall` binder domains referencing state variables (both reference
+  engines require compile-time-constant domains). Verdict-cache keys include
+  the engine and budget. Includes corpus verdict-agreement and trace-replay
+  integration tests, `docs/DESIGN-explicit-engine.md`, shared FSL skill
+  guidance, and `tools/bench_explicit.py`; the frozen Python reference
+  implementation is intentionally unchanged.
 - Versioned normalized public Kernel contract (issue #208): native Rust
   `fslc kernel` exports checked/lowered models as typed, source-traceable JSON
   without the Python AST, while `fslc conformance` emits deterministic

--- a/docs/DESIGN-explicit-engine.md
+++ b/docs/DESIGN-explicit-engine.md
@@ -1,0 +1,209 @@
+# FSL Explicit-State Engine — Implementation Design (`--engine explicit`)
+
+This document is an implementation-level specification of `--engine explicit`
+(issue #212): a Z3-free verification engine that exhaustively enumerates the
+concrete state space of a spec. Because every FSL domain is bounded and every
+quantifier is finite-domain, breadth-first exploration of concrete states is
+*equivalent* to BMC up to depth `k`, and reaching closure (no new states) is a
+*complete proof* of all invariants — no induction, no lemmas.
+
+The engine is **Rust-native only** (`rust/`), like `fslc approval`: the frozen
+Python reference implementation is intentionally unchanged. The Python tree
+still supplies the *semantic* reference — `runtime.py Monitor` and the BFS
+oracle `tests/oracle.py` are the specification this engine productizes.
+
+## 1. Goals and non-goals
+
+- **Goals**:
+  - A verdict engine that is orders of magnitude faster than Z3-based BMC on
+    the small-state-space specs that dominate the corpus (state counts in the
+    thousands): `violated` with the shortest concrete counterexample,
+    `verified` (bounded, BMC-equivalent), and — when exploration closes —
+    `proved` (unbounded, subsumes k-induction for finite systems).
+  - A **third independent evaluator** of FSL semantics next to the symbolic
+    BMC (`bmc.py`) and the concrete step interpreter (`runtime.py Monitor`),
+    strengthening the cross-check regime rather than weakening it.
+  - Fail-closed truncation: exceeding the state budget yields an explicit
+    `unknown_budget` verdict, never a silent `verified`.
+- **Non-goals (this design)**:
+  - `--engine auto` (explicit first, fall back to symbolic on blow-up) — a
+    follow-up once explicit is trusted.
+  - Symbolic-side scaling work (symbolic action parameters, cone-of-influence
+    slicing) — the explicit engine does not replace the Z3 path; it owns the
+    small-state-space regime, the symbolic engines own the rest.
+  - SAT bit-blasting and GPU exploration — revisit only when real specs exceed
+    ~10⁹ states.
+  - Distributed/parallel exploration — the first version is single-threaded in
+    both implementations.
+
+## 2. Algorithm
+
+Standard explicit-state reachability with level-synchronous BFS:
+
+```
+frontier := canonical initial states (deduplicated)
+seen     := frontier
+for level in 0..depth:
+    check state properties on every state in frontier   # invariants, reachable, deadlock
+    if violation found: return violated (trace via parent links; BFS ⇒ shortest)
+    next := {}
+    for s in frontier, for each enabled action instance a in s:
+        s' := step(s, a)          # concrete Monitor semantics
+        check edge properties     # ensures
+        if s' not in seen: add to seen and next
+    if next is empty: return proved (closure)            # complete reachability
+    frontier := next
+if budget exceeded at any point: return unknown_budget
+return verified                                          # depth exhausted, frontier non-empty
+```
+
+Key points:
+
+- **State identity.** A state is the full concrete valuation of all state
+  variables, canonicalized the same way as `tests/oracle.py` (`state_key` /
+  `normalize`) so that dedup is semantic, not representational.
+- **Shortest counterexample.** BFS explores by depth level, so the first
+  violation found is at minimal depth; `violated_at_step` is the BFS level.
+  This matches the BMC contract (`bmc.py` returns the earliest violating
+  step of its incremental unrolling).
+- **Closure ⇒ proof.** When a level produces no unseen states, `seen` is the
+  full reachable set. Invariants checked on every member of `seen` therefore
+  hold in *every* reachable state: `result: "proved"`, the same verdict word
+  the induction engine uses, plus `closure: true` and exploration stats.
+  For specs where k-induction returns `unknown_cti` (the invariant is true but
+  not inductive), explicit closure proves it without lemmas.
+- **Deterministic init (fail closed).** The concrete interpreter requires
+  init to definitely assign every state variable
+  (`runtime.py _check_deterministic_init`); specs with underconstrained init
+  are rejected at Monitor construction (kind `semantics`, §5). Symbolic BMC
+  treats unassigned init variables as free — a strictly larger initial set —
+  so the explicit engine must never silently explore only the default-seeded
+  state: any spec it accepts has exactly one initial state, and everything
+  else is an explicit error. The Rust port must enforce the same gate.
+
+## 3. Verdict and JSON contract
+
+The result dict is shape-compatible with `bmc.verify` output so that
+`cli._envelope`, `exit_code()`, `fslc replay`, and downstream tooling work
+unchanged:
+
+| Outcome | `result` | Exit | Notes |
+|---|---|---|---|
+| Violation found | `violated` | 1 | Same trace JSON schema as BMC; `violated_at_step` = BFS depth |
+| Depth exhausted, frontier non-empty | `verified` | 0 | Bounded claim, identical strength to BMC `verified` |
+| Closure reached, no violation | `proved` | 0 | Unbounded claim; `closure: true` |
+| State budget exceeded | `unknown_budget` | 1 | Explicit truncation; never reported as verified |
+| Unsupported spec feature | `error` (kind `semantics`) | 2 | Fail closed, see §5 |
+
+Every result carries exploration stats alongside the standard
+`cost.elapsed_s`: states explored, maximum frontier width, and whether closure
+was reached. `unknown_budget` additionally reports the depth reached when the
+budget ran out.
+
+## 4. Property semantics
+
+The engine checks the same property surface as `bmc.verify`, with identical
+verdict semantics:
+
+- **Invariants** — evaluated on every visited state (including initial
+  states, level 0).
+- **`ensures`** — evaluated on every explored transition edge.
+- **`reachable`** — witnessed at the earliest level where the goal holds;
+  unreached goals are reported exactly as BMC reports them at depth
+  exhaustion. Under `proved` (closure), an unreached `reachable` is
+  *definitively* unreachable — stronger than BMC's bounded "not reached within
+  depth" — and is reported as `reachable_failed`.
+- **Deadlock** — a state with no enabled action instance, honoring
+  `deadlock_mode` (`warn`/`error`) with BMC-equivalent behavior.
+- **Vacuity/coverage** — an action never enabled anywhere explored, honoring
+  `--vacuity` the same way BMC does. Under closure this too is definitive.
+- **`leadsTo`** — not supported: the concrete runtime has no complete
+  liveness decision procedure, so specs with `leadsTo` properties are rejected
+  fail-closed (kind `semantics`) unless the property is excluded from the run;
+  the error steers the user to `--engine bmc` for the bounded lasso/stutter
+  check.
+
+## 5. Support matrix (fail closed)
+
+The engine executes concrete semantics via the ported interpreter
+(`fsl-runtime` `Monitor`). Specs using features the concrete interpreter
+cannot execute — in particular a nondeterministic init (§2) — are rejected
+with the standard JSON error envelope (kind `semantics`, exit 2) and a message
+naming the unsupported feature, mirroring the frozen Python reference's
+`runtime.py` gates (`_check_deterministic_init` and friends). The engine never
+approximates: any spec it accepts is verified under full FSL semantics, any
+spec it cannot handle is an explicit error steering the user to
+`--engine bmc`/`induction`.
+
+Beyond the definite-assignment rule, `init forall` binder *domains* must not
+reference state variables: both reference engines reject non-constant range
+bounds (`forall i in 0..n` with `n` a state variable — "ranges must be
+compile-time integers") and binders over state collections, so the explicit
+engine rejects them too. Accepting them would let the engine concretely
+evaluate a domain the symbolic engines call ill-formed, and emit verdicts for
+specs the language rejects. Constant bounds (`0..CAP` with `const CAP`) are
+resolved before the kernel AST and remain accepted.
+
+## 6. Integration
+
+- **CLI**: `fslc verify <spec> --engine explicit [--explicit-budget N]`.
+  `--explicit-budget` caps visited states (default 1,000,000).
+  `--from-state` stays BMC-only; `--lemma` stays induction-only; `--k` is
+  ignored. Other subcommands keep their `bmc`/`induction` choices for now.
+- **Verdict cache**: the persistent verify cache keys already include the
+  engine name, so explicit verdicts cache independently of BMC verdicts.
+  Cross-depth reuse of `violated` entries applies unchanged.
+- **Envelope / exit codes**: `unknown_budget` joins the exit-1 verdict list in
+  `exit_code()`; everything else reuses existing vocabulary.
+
+## 7. Soundness argument and gates
+
+The engine's claims reduce to: (a) the concrete step semantics are correct,
+and (b) the dedup key captures full state identity. (a) is the already-tested
+ported Monitor semantics (`fsl-runtime`) — the same evaluator family the
+Python BFS oracle uses to catch Z3-side false negatives. (b) uses the ordered
+`State` value itself (`BTreeSet<State>`), the same canonical identity
+`fsl_runtime::bfs` already relies on. On top of that, the repo's standing
+gates apply:
+
+- Verdict agreement on the corpus: explicit vs the Rust BMC engine (explicit
+  `proved` subsumes BMC `verified`; `violated_at_step` equal), as Rust
+  integration tests.
+- Violated traces must replay through the concrete interpreter
+  (`fsl_runtime::replay_trace`) — every counterexample is a checked concrete
+  execution.
+- The Python corpus snapshot (`tests/test_corpus_snapshot.py`) must be
+  byte-identical: the frozen Python tree is untouched.
+- The Rust/Python parity harnesses (`tools/check_rust_*_parity.py`) keep
+  passing via the established Rust-only-command pattern (as with `approval`).
+
+## 8. Placement in the Rust workspace
+
+The engine lives on the Z3-free path: the exploration core belongs with the
+concrete interpreter (`fsl-runtime`, where `bfs`, `find_boundary_violation`,
+and `replay_trace` already live), with verdict rendering wired through the
+`fslc` crate's existing envelope machinery (`verification.rs` renderers,
+`fslc_rust::trace_json`). It must not depend on `fsl-solver`, which also makes
+it the cheapest engine to ship to WASM (no Z3 worker, no COOP/COEP
+requirement — a later follow-up).
+
+## 9. Performance expectations
+
+For the current corpus (3–5 state variables, tiny domains, state spaces in the
+thousands), exploration completes in microseconds-to-milliseconds and replaces
+a Z3 session issuing hundreds of incremental `check()` calls — typically a
+10²–10⁴× wall-clock win, measured by `tools/bench_explicit.py` (explicit vs
+BMC over the corpus). The engine's cost is O(reachable states × transition
+degree) with hash-set memory; it deliberately does not try to compete beyond
+the budget cap — that regime belongs to the symbolic engines.
+
+## 10. Future work
+
+- `--engine auto`: run explicit first; on `unknown_budget`, fall back to the
+  symbolic pipeline transparently.
+- Parallel exploration (sharded frontier) if real specs approach the budget.
+- WASM exposure of the explicit engine (Z3-free verification in the browser).
+- Definitive-verdict upgrades: under closure, report unreachable `reachable`
+  goals and never-enabled actions as proofs rather than bounded observations
+  (already specified in §4; surfacing this distinction in reports/HTML is
+  follow-up polish).

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -593,6 +593,8 @@ fslc kernel    <file.fsl>                        # normalized typed Kernel JSON 
 fslc conformance <file.fsl> [--depth K]          # language-neutral Monitor vectors (default K=4)
 fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
+               [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
                [--lemma "<expr>"]...             # independently prove auxiliary candidates,
                                                  # then retry CTIs with proved lemmas only
                [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
@@ -747,8 +749,8 @@ Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant /
 mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
 typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
-`1` = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
-sweep_failed / observed_mismatch,
+`1` = violated / reachable_failed / unknown_cti / unknown_budget / nonconformant /
+refinement_failed / sweep_failed / observed_mismatch,
 `2` = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 `--vacuity error`), `3` = internal error. `observed_*` is `fslc db observe`'s
 result; `imported`/`imported_with_warnings` is `fslc db import`'s.
@@ -758,10 +760,11 @@ result; `imported`/`imported_with_warnings` is `fslc db import`'s.
 | result | Meaning | Next move |
 |---|---|---|
 | `verified` | No violation up to depth K (+ all reachable satisfied); `completeness:"bounded"` | To raise confidence, use `--engine induction` |
-| `proved` | **The invariant holds in all executions** (unbounded depth); `completeness:"unbounded"` | Done |
+| `proved` | **The invariant holds in all executions** (unbounded depth); `completeness:"unbounded"`. From `--engine induction`, or from `--engine explicit` when exploration closes (`closure:true`) | Done |
 | `violated` | A counterexample exists. Comes with `violation_kind` and the shortest trace | Read the trace and fix the spec |
 | `reachable_failed` | reachable not reached within depth K | Read each `unreached[].classification`: raise `--depth` for `insufficient_depth`, or fix the blocking constraint for `over_constrained` |
-| `unknown_cti` | The invariant is not violated but is not inductive | **Read the CTI and add an auxiliary invariant** (§8) |
+| `unknown_cti` | The invariant is not violated but is not inductive | **Read the CTI and add an auxiliary invariant** (§8), or try `--engine explicit` (closure proves without lemmas) |
+| `unknown_budget` | `--engine explicit` exceeded `--explicit-budget` before closing | Raise the budget, or use `--engine bmc`/`induction` for this spec |
 | `error` | parse / type / semantics / io | Fix per `loc` / `expected` / `hint` |
 
 `violation_kind`: `invariant` | `trans` | `ensures` | `type_bound` | `partial_op` | `deadlock` | `leadsTo`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |
+| [`DESIGN-explicit-engine.md`](DESIGN-explicit-engine.md) | `verify --engine explicit` (Rust-native): Z3-free concrete-state BFS, closure ⇒ `proved`, `unknown_budget` truncation, deterministic-init and binder-domain fail-closed gates |
 | [`DESIGN-from-state.md`](DESIGN-from-state.md) | Predictive BMC from a complete Monitor/replay logical-state snapshot (`verify --from-state`), including type validation, faithfulness metadata, cache/symmetry boundaries, and induction exclusion |
 | [`DESIGN-trans.md`](DESIGN-trans.md) | `trans` (transition invariant / two-state safety) |
 | [`DESIGN-temporal.md`](DESIGN-temporal.md) | leadsTo, weak fairness (lasso counterexamples), and respond scenarios |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -669,8 +669,12 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc kernel    &lt;file.fsl&gt;                        # normalized typed Kernel JSON for external compilers
+fslc conformance &lt;file.fsl&gt; [--depth K]          # language-neutral Monitor vectors (default K=4)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
+               [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
                [--lemma &quot;&lt;expr&gt;&quot;]...             # independently prove auxiliary candidates,
                                                  # then retry CTIs with proved lemmas only
                [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
@@ -699,7 +703,10 @@ fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   &lt;file-or-dir&gt;... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag review (§15)
 fslc html      &lt;file.fsl&gt; [--depth K] [-o report.html] # self-contained review report (§15)
-fslc ledger    &lt;file.fsl&gt; [--depth K] [--impl-log run.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc ledger    &lt;file.fsl&gt; [--depth K] [--impl-log run.json] [--approval record.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc approval create &lt;file.fsl&gt; --kind ledger|html|scenarios --artifact &lt;reviewed&gt; --approver &lt;name&gt; [-o record.json]
+fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt;       # approved | drifted
+fslc approval diff   &lt;file.fsl&gt; --record &lt;record.json&gt; [--depth K]
 fslc typestate &lt;file.fsl&gt; [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
 fslc domain analyze &lt;file.fsl&gt;                                  # aggregate/effect ownership summary
@@ -713,6 +720,18 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p>The native Rust-only <code>kernel</code> command runs after dialect lowering and semantic
+checking. Its versioned JSON contains structural types for every expression,
+source spans, requirement/lowering origin, simultaneous-update semantics, and
+explicit partial-operation failure conditions; an external compiler never needs
+the Python AST or an FSL expression parser. <code>conformance</code> emits bounded concrete
+success, disabled, and rollback-failure vectors under the companion schema.
+Nested options use tagged <code>none</code>/<code>some</code> objects so no reachable states collapse.
+Public Kernel v1 explicitly rejects <code>compose</code> export because current lowering
+does not retain truthful per-component filenames; direct and other lowered
+dialects remain supported.
+Compatibility rules, schemas, fixtures, and Rust API entry points are specified
+in <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-kernel-contract.md"><code>DESIGN-kernel-contract.md</code></a>.</p>
 <p><code>verify --from-state state.json</code> replaces the declared <code>init</code> for one bounded
 run and asks what can happen from that complete current state. The JSON shape is
 exactly <code>Monitor.state</code> / replay logical state: all variables and Map keys are
@@ -784,12 +803,23 @@ and returns <code>semantic_diff_batch</code>; supplying one spec preserves
 <code>semantic_diff</code>. Both forms include <code>vcs.materialization:
 "git_archive_full_tree"</code>. The ordinary two-path form never invokes Git and
 works outside a repository.</p>
+<p><code>approval create</code> binds a reviewed <code>ledger</code>, <code>html</code>, or <code>scenarios</code> artifact to
+the fully lowered, location-insensitive kernel digest and the current clean Git
+commit. The versioned JSON sidecar also records the normalized artifact digest,
+generator/version/options, approved requirement IDs, approver, and UTC time.
+Creation regenerates the artifact and rejects a stale review file. <code>approval
+check</code> returns <code>approved</code> only while the spec, rendering, and renderer bindings
+all match; otherwise it returns <code>drifted</code> with <code>spec_changed</code>,
+<code>rendering_changed</code>, and/or <code>renderer_changed</code>. <code>ledger --approval</code> adds the
+same status per requirement and includes the full baseline digest. <code>approval
+diff</code> materializes the approved commit and invokes the ordinary bounded semantic
+diff against the current working file. See <code>docs/DESIGN-approval.md</code>.</p>
 <p>Exit codes: <code>0</code> = verified / proved / scenarios/testgen generated / conformant / refines /
 mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
 typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
-<code>1</code> = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
-sweep_failed / observed_mismatch,
+<code>1</code> = violated / reachable_failed / unknown_cti / unknown_budget / nonconformant /
+refinement_failed / sweep_failed / observed_mismatch,
 <code>2</code> = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 <code>--vacuity error</code>), <code>3</code> = internal error. <code>observed_*</code> is <code>fslc db observe</code>'s
 result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc db import</code>'s.</p>
@@ -810,7 +840,7 @@ result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc 
 </tr>
 <tr>
 <td><code>proved</code></td>
-<td><strong>The invariant holds in all executions</strong> (unbounded depth); <code>completeness:"unbounded"</code></td>
+<td><strong>The invariant holds in all executions</strong> (unbounded depth); <code>completeness:"unbounded"</code>. From <code>--engine induction</code>, or from <code>--engine explicit</code> when exploration closes (<code>closure:true</code>)</td>
 <td>Done</td>
 </tr>
 <tr>
@@ -826,7 +856,12 @@ result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc 
 <tr>
 <td><code>unknown_cti</code></td>
 <td>The invariant is not violated but is not inductive</td>
-<td><strong>Read the CTI and add an auxiliary invariant</strong> (§8)</td>
+<td><strong>Read the CTI and add an auxiliary invariant</strong> (§8), or try <code>--engine explicit</code> (closure proves without lemmas)</td>
+</tr>
+<tr>
+<td><code>unknown_budget</code></td>
+<td><code>--engine explicit</code> exceeded <code>--explicit-budget</code> before closing</td>
+<td>Raise the budget, or use <code>--engine bmc</code>/<code>induction</code> for this spec</td>
 </tr>
 <tr>
 <td><code>error</code></td>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -669,8 +669,12 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc kernel    &lt;file.fsl&gt;                        # normalized typed Kernel JSON for external compilers
+fslc conformance &lt;file.fsl&gt; [--depth K]          # language-neutral Monitor vectors (default K=4)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
+               [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
+               [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
                [--lemma &quot;&lt;expr&gt;&quot;]...             # independently prove auxiliary candidates,
                                                  # then retry CTIs with proved lemmas only
                [--from-state state.json]         # replace init with a complete logical snapshot (BMC only)
@@ -699,7 +703,10 @@ fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   &lt;file-or-dir&gt;... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag review (§15)
 fslc html      &lt;file.fsl&gt; [--depth K] [-o report.html] # self-contained review report (§15)
-fslc ledger    &lt;file.fsl&gt; [--depth K] [--impl-log run.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc ledger    &lt;file.fsl&gt; [--depth K] [--impl-log run.json] [--approval record.json] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc approval create &lt;file.fsl&gt; --kind ledger|html|scenarios --artifact &lt;reviewed&gt; --approver &lt;name&gt; [-o record.json]
+fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt;       # approved | drifted
+fslc approval diff   &lt;file.fsl&gt; --record &lt;record.json&gt; [--depth K]
 fslc typestate &lt;file.fsl&gt; [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
 fslc domain analyze &lt;file.fsl&gt;                                  # aggregate/effect ownership summary
@@ -713,6 +720,18 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p>The native Rust-only <code>kernel</code> command runs after dialect lowering and semantic
+checking. Its versioned JSON contains structural types for every expression,
+source spans, requirement/lowering origin, simultaneous-update semantics, and
+explicit partial-operation failure conditions; an external compiler never needs
+the Python AST or an FSL expression parser. <code>conformance</code> emits bounded concrete
+success, disabled, and rollback-failure vectors under the companion schema.
+Nested options use tagged <code>none</code>/<code>some</code> objects so no reachable states collapse.
+Public Kernel v1 explicitly rejects <code>compose</code> export because current lowering
+does not retain truthful per-component filenames; direct and other lowered
+dialects remain supported.
+Compatibility rules, schemas, fixtures, and Rust API entry points are specified
+in <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-kernel-contract.md"><code>DESIGN-kernel-contract.md</code></a>.</p>
 <p><code>verify --from-state state.json</code> replaces the declared <code>init</code> for one bounded
 run and asks what can happen from that complete current state. The JSON shape is
 exactly <code>Monitor.state</code> / replay logical state: all variables and Map keys are
@@ -784,12 +803,23 @@ and returns <code>semantic_diff_batch</code>; supplying one spec preserves
 <code>semantic_diff</code>. Both forms include <code>vcs.materialization:
 "git_archive_full_tree"</code>. The ordinary two-path form never invokes Git and
 works outside a repository.</p>
+<p><code>approval create</code> binds a reviewed <code>ledger</code>, <code>html</code>, or <code>scenarios</code> artifact to
+the fully lowered, location-insensitive kernel digest and the current clean Git
+commit. The versioned JSON sidecar also records the normalized artifact digest,
+generator/version/options, approved requirement IDs, approver, and UTC time.
+Creation regenerates the artifact and rejects a stale review file. <code>approval
+check</code> returns <code>approved</code> only while the spec, rendering, and renderer bindings
+all match; otherwise it returns <code>drifted</code> with <code>spec_changed</code>,
+<code>rendering_changed</code>, and/or <code>renderer_changed</code>. <code>ledger --approval</code> adds the
+same status per requirement and includes the full baseline digest. <code>approval
+diff</code> materializes the approved commit and invokes the ordinary bounded semantic
+diff against the current working file. See <code>docs/DESIGN-approval.md</code>.</p>
 <p>Exit codes: <code>0</code> = verified / proved / scenarios/testgen generated / conformant / refines /
 mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /
 typestate / sweep_passed / observed_conformant /
 imported / imported_with_warnings,
-<code>1</code> = violated / reachable_failed / unknown_cti / nonconformant / refinement_failed /
-sweep_failed / observed_mismatch,
+<code>1</code> = violated / reachable_failed / unknown_cti / unknown_budget / nonconformant /
+refinement_failed / sweep_failed / observed_mismatch,
 <code>2</code> = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 <code>--vacuity error</code>), <code>3</code> = internal error. <code>observed_*</code> is <code>fslc db observe</code>'s
 result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc db import</code>'s.</p>
@@ -810,7 +840,7 @@ result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc 
 </tr>
 <tr>
 <td><code>proved</code></td>
-<td><strong>The invariant holds in all executions</strong> (unbounded depth); <code>completeness:"unbounded"</code></td>
+<td><strong>The invariant holds in all executions</strong> (unbounded depth); <code>completeness:"unbounded"</code>. From <code>--engine induction</code>, or from <code>--engine explicit</code> when exploration closes (<code>closure:true</code>)</td>
 <td>Done</td>
 </tr>
 <tr>
@@ -826,7 +856,12 @@ result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc 
 <tr>
 <td><code>unknown_cti</code></td>
 <td>The invariant is not violated but is not inductive</td>
-<td><strong>Read the CTI and add an auxiliary invariant</strong> (§8)</td>
+<td><strong>Read the CTI and add an auxiliary invariant</strong> (§8), or try <code>--engine explicit</code> (closure proves without lemmas)</td>
+</tr>
+<tr>
+<td><code>unknown_budget</code></td>
+<td><code>--engine explicit</code> exceeded <code>--explicit-budget</code> before closing</td>
+<td>Raise the budget, or use <code>--engine bmc</code>/<code>induction</code> for this spec</td>
 </tr>
 <tr>
 <td><code>error</code></td>

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -1,0 +1,855 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Level-synchronous explicit-state verification over concrete monitor states.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_core::{
+    FslValue as Value, KernelBinder as Binder, KernelExpr as Expr, KernelLValue as LValue,
+    KernelModel, KernelStatement as Statement, TraceAction, TraceChange, TraceStep, TypeDef,
+    TypeRef,
+};
+
+use super::{Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExplicitViolation {
+    pub violation: Violation,
+    pub trace: Vec<TraceStep>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExplicitReachableWitness {
+    pub step: usize,
+    pub trace: Vec<TraceStep>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExplicitResult {
+    pub spec: String,
+    pub depth: usize,
+    pub depth_reached: usize,
+    pub states_explored: usize,
+    pub max_frontier_width: usize,
+    pub closure: bool,
+    pub budget_exceeded: bool,
+    pub violation: Option<ExplicitViolation>,
+    pub reachables: BTreeMap<String, Option<ExplicitReachableWitness>>,
+    pub deadlock_step: Option<usize>,
+    pub deadlock_trace: Option<Vec<TraceStep>>,
+    pub action_coverage: BTreeMap<String, bool>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum InitWriteKey {
+    Root(String),
+    ConcreteIndex(String, String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ParentLink {
+    parent: State,
+    action: TraceAction,
+}
+
+/// Verify a finite kernel model using level-synchronous concrete BFS.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] when initialization is not deterministic, a
+/// concrete expression cannot be evaluated, or the model uses an unsupported
+/// explicit-engine feature.
+pub fn verify_explicit(
+    model: KernelModel,
+    depth: usize,
+    max_states: usize,
+) -> Result<ExplicitResult, RuntimeError> {
+    verify_explicit_selected(model, depth, max_states, None)
+}
+
+/// Verify with an optional set of selected implicit state-bound properties.
+///
+/// # Errors
+///
+/// Returns the same errors as [`verify_explicit`].
+#[allow(clippy::too_many_lines)]
+pub fn verify_explicit_selected(
+    model: KernelModel,
+    depth: usize,
+    max_states: usize,
+    checked_bounds: Option<&BTreeSet<String>>,
+) -> Result<ExplicitResult, RuntimeError> {
+    if max_states == 0 {
+        return Err(runtime_error("explicit state budget must be at least 1"));
+    }
+    check_deterministic_init(&model)?;
+    if !model.leadstos.is_empty() {
+        return Err(runtime_error(
+            "the explicit engine does not support leadsTo properties; use --engine bmc or exclude the leadsTo property",
+        ));
+    }
+
+    let initial = Monitor::new(model)?;
+    let initial_state = initial.state.clone();
+    let mut result = ExplicitResult {
+        spec: initial.model.name.clone(),
+        depth,
+        depth_reached: 0,
+        states_explored: 1,
+        max_frontier_width: 1,
+        closure: false,
+        budget_exceeded: false,
+        violation: None,
+        reachables: initial
+            .model
+            .reachables
+            .iter()
+            .map(|property| (property.name.clone(), None))
+            .collect(),
+        deadlock_step: None,
+        deadlock_trace: None,
+        action_coverage: initial
+            .model
+            .actions
+            .iter()
+            .map(|action| (action.name.clone(), false))
+            .collect(),
+    };
+    let mut frontier = BTreeMap::from([(initial_state.clone(), initial)]);
+    let mut seen = BTreeSet::from([initial_state.clone()]);
+    let mut parents = BTreeMap::<State, ParentLink>::new();
+
+    for level in 0..=depth {
+        result.depth_reached = level;
+        result.max_frontier_width = result.max_frontier_width.max(frontier.len());
+
+        for monitor in frontier.values() {
+            if let Some(violation) = monitor.current_violation_selected(checked_bounds)? {
+                result.violation = Some(ExplicitViolation {
+                    trace: reconstruct_trace(&initial_state, &monitor.state, &parents),
+                    violation,
+                });
+                return Ok(result);
+            }
+            record_reachables(monitor, level, &initial_state, &parents, &mut result)?;
+        }
+
+        let mut enabled_by_state = BTreeMap::new();
+        for (state, monitor) in &frontier {
+            let enabled = monitor.enabled()?;
+            for instance in &enabled {
+                result.action_coverage.insert(instance.action.clone(), true);
+            }
+            if enabled.is_empty() && result.deadlock_step.is_none() && !terminal_holds(monitor)? {
+                result.deadlock_step = Some(level);
+                result.deadlock_trace = Some(reconstruct_trace(&initial_state, state, &parents));
+            }
+            enabled_by_state.insert(state.clone(), enabled);
+        }
+
+        if level == depth {
+            break;
+        }
+
+        let mut next = BTreeMap::new();
+        for (state, monitor) in &frontier {
+            for instance in &enabled_by_state[state] {
+                let mut child = monitor.clone();
+                let stepped = child.step_selected(instance, checked_bounds)?;
+                if let Some(violation) = stepped.violation {
+                    // The Monitor rolls back on violation (`state` is the pre-step
+                    // state); the trace must show the attempted post-state.
+                    let after = stepped.attempted_state.as_ref().unwrap_or(&stepped.state);
+                    let mut trace = reconstruct_trace(&initial_state, state, &parents);
+                    trace.push(edge_trace_step(level + 1, state, instance, after));
+                    result.depth_reached = level + 1;
+                    result.violation = Some(ExplicitViolation { violation, trace });
+                    return Ok(result);
+                }
+                if seen.contains(&child.state) {
+                    continue;
+                }
+                if seen.len() >= max_states {
+                    result.states_explored = seen.len();
+                    result.budget_exceeded = true;
+                    return Ok(result);
+                }
+                let child_state = child.state.clone();
+                seen.insert(child_state.clone());
+                parents.insert(
+                    child_state.clone(),
+                    ParentLink {
+                        parent: state.clone(),
+                        action: TraceAction {
+                            name: instance.action.clone(),
+                            params: instance.params.clone(),
+                        },
+                    },
+                );
+                next.insert(child_state, child);
+            }
+        }
+        result.states_explored = seen.len();
+        if next.is_empty() {
+            result.closure = true;
+            return Ok(result);
+        }
+        frontier = next;
+    }
+
+    result.states_explored = seen.len();
+    Ok(result)
+}
+
+fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
+    let Some(terminal) = &monitor.model.terminal else {
+        return Ok(false);
+    };
+    match eval(
+        terminal,
+        &monitor.state,
+        &mut Bindings::new(),
+        &monitor.model,
+        None,
+    )? {
+        Value::Bool(value) => Ok(value),
+        _ => Err(runtime_error("terminal expression must be Boolean")),
+    }
+}
+
+fn record_reachables(
+    monitor: &Monitor,
+    level: usize,
+    initial_state: &State,
+    parents: &BTreeMap<State, ParentLink>,
+    result: &mut ExplicitResult,
+) -> Result<(), RuntimeError> {
+    for property in &monitor.model.reachables {
+        if result.reachables[&property.name].is_some() {
+            continue;
+        }
+        match eval(
+            &property.expr,
+            &monitor.state,
+            &mut Bindings::new(),
+            &monitor.model,
+            None,
+        )? {
+            Value::Bool(true) => {
+                result.reachables.insert(
+                    property.name.clone(),
+                    Some(ExplicitReachableWitness {
+                        step: level,
+                        trace: reconstruct_trace(initial_state, &monitor.state, parents),
+                    }),
+                );
+            }
+            Value::Bool(false) => {}
+            _ => return Err(runtime_error("reachable expression must be Boolean")),
+        }
+    }
+    Ok(())
+}
+
+fn reconstruct_trace(
+    initial_state: &State,
+    final_state: &State,
+    parents: &BTreeMap<State, ParentLink>,
+) -> Vec<TraceStep> {
+    let mut cursor = final_state.clone();
+    let mut reversed = Vec::<(State, TraceAction)>::new();
+    while let Some(link) = parents.get(&cursor) {
+        reversed.push((cursor, link.action.clone()));
+        cursor = link.parent.clone();
+    }
+    reversed.reverse();
+    let mut trace = vec![TraceStep {
+        step: 0,
+        state: initial_state.clone(),
+        action: None,
+        changes: BTreeMap::new(),
+    }];
+    let mut before = initial_state.clone();
+    for (index, (state, action)) in reversed.into_iter().enumerate() {
+        trace.push(TraceStep {
+            step: index + 1,
+            changes: state_changes(&before, &state),
+            state: state.clone(),
+            action: Some(action),
+        });
+        before = state;
+    }
+    trace
+}
+
+fn edge_trace_step(
+    step: usize,
+    before: &State,
+    instance: &super::EnabledAction,
+    state: &State,
+) -> TraceStep {
+    TraceStep {
+        step,
+        state: state.clone(),
+        action: Some(TraceAction {
+            name: instance.action.clone(),
+            params: instance.params.clone(),
+        }),
+        changes: state_changes(before, state),
+    }
+}
+
+fn state_changes(before: &State, after: &State) -> BTreeMap<String, TraceChange> {
+    after
+        .iter()
+        .filter_map(|(name, value)| {
+            let old = &before[name];
+            (old != value).then(|| {
+                (
+                    name.clone(),
+                    TraceChange {
+                        from: old.clone(),
+                        to: value.clone(),
+                    },
+                )
+            })
+        })
+        .collect()
+}
+
+/// Per-root definite-assignment coverage tracked at component granularity.
+///
+/// A `Map` root is fully assigned only once every concrete key in its
+/// key-type domain has been written; a `Named` struct root is fully assigned
+/// only once every declared field has been (recursively) fully assigned.
+/// Anything else stays binary (`Full` or unassigned) because there is no
+/// finer component structure to track.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Coverage {
+    Full,
+    Keys(BTreeSet<Value>),
+    Fields(BTreeMap<String, Coverage>),
+}
+
+fn check_deterministic_init(model: &KernelModel) -> Result<(), RuntimeError> {
+    let (assigned, _) = walk_init(
+        &model.init,
+        BTreeMap::new(),
+        BTreeSet::new(),
+        false,
+        &BTreeMap::new(),
+        model,
+    )?;
+    let mut missing_is_partial = false;
+    let mut missing = model
+        .state
+        .iter()
+        .filter(|(name, ty)| {
+            let coverage = assigned.get(name);
+            if coverage_is_full(coverage, ty, model) {
+                false
+            } else {
+                missing_is_partial = missing_is_partial || coverage.is_some();
+                true
+            }
+        })
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    missing.sort();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        let suffix = if missing_is_partial {
+            " (partial component initialization is rejected by the explicit engine)"
+        } else {
+            ""
+        };
+        Err(runtime_error(format!(
+            "init does not assign state variable(s): {}{suffix}",
+            missing.join(", ")
+        )))
+    }
+}
+
+/// Whether `coverage` amounts to a complete definite assignment of `ty`.
+fn coverage_is_full(coverage: Option<&Coverage>, ty: &TypeRef, model: &KernelModel) -> bool {
+    match coverage {
+        Some(Coverage::Full) => true,
+        Some(Coverage::Keys(keys)) => match ty {
+            TypeRef::Map(key_ty, _) => model
+                .map_key_values(key_ty)
+                .is_ok_and(|domain| domain.iter().all(|value| keys.contains(value))),
+            _ => false,
+        },
+        Some(Coverage::Fields(fields)) => match ty {
+            TypeRef::Named(name) => match model.types.get(name) {
+                Some(TypeDef::Struct { fields: declared }) => {
+                    declared.iter().all(|(field_name, field_ty)| {
+                        fields.get(field_name).is_some_and(|field_coverage| {
+                            coverage_is_full(Some(field_coverage), field_ty, model)
+                        })
+                    })
+                }
+                _ => false,
+            },
+            _ => false,
+        },
+        None => false,
+    }
+}
+
+/// Join the coverage contributed by one more assignment into what a root
+/// already had within the same straight-line branch. `Full` absorbs
+/// anything; same-kind coverage unions (`Keys`) or merges per-field
+/// (`Fields`); a kind mismatch keeps whatever was already recorded rather
+/// than erroring (component tracking degrades to "no worse than before").
+fn join_coverage(existing: Option<Coverage>, addition: Coverage) -> Coverage {
+    let Some(existing) = existing else {
+        return addition;
+    };
+    match (existing, addition) {
+        (Coverage::Full, _) | (_, Coverage::Full) => Coverage::Full,
+        (Coverage::Keys(mut a), Coverage::Keys(b)) => {
+            a.extend(b);
+            Coverage::Keys(a)
+        }
+        (Coverage::Fields(mut a), Coverage::Fields(b)) => {
+            for (field, addition_coverage) in b {
+                let merged = match a.remove(&field) {
+                    Some(existing_coverage) => {
+                        join_coverage(Some(existing_coverage), addition_coverage)
+                    }
+                    None => addition_coverage,
+                };
+                a.insert(field, merged);
+            }
+            Coverage::Fields(a)
+        }
+        (existing, _) => existing,
+    }
+}
+
+/// Intersect the coverage two `if` branches leave behind. `Full` yields the
+/// other side; same-kind coverage intersects (`Keys`) or meets per-field
+/// (`Fields`, dropping fields missing on either side); a kind mismatch drops
+/// the root entirely, matching the old set-intersection behavior for roots
+/// only assigned on one side.
+fn meet_coverage(a: &Coverage, b: &Coverage) -> Option<Coverage> {
+    match (a, b) {
+        (Coverage::Full, other) | (other, Coverage::Full) => Some(other.clone()),
+        (Coverage::Keys(a), Coverage::Keys(b)) => {
+            Some(Coverage::Keys(a.intersection(b).cloned().collect()))
+        }
+        (Coverage::Fields(a), Coverage::Fields(b)) => {
+            let mut merged = BTreeMap::new();
+            for (field, coverage_a) in a {
+                if let Some(coverage_b) = b.get(field)
+                    && let Some(meet) = meet_coverage(coverage_a, coverage_b)
+                {
+                    merged.insert(field.clone(), meet);
+                }
+            }
+            Some(Coverage::Fields(merged))
+        }
+        _ => None,
+    }
+}
+
+fn meet_branches(
+    then_map: BTreeMap<String, Coverage>,
+    else_map: &BTreeMap<String, Coverage>,
+) -> BTreeMap<String, Coverage> {
+    let mut merged = BTreeMap::new();
+    for (name, then_coverage) in then_map {
+        if let Some(else_coverage) = else_map.get(&name)
+            && let Some(meet) = meet_coverage(&then_coverage, else_coverage)
+        {
+            merged.insert(name, meet);
+        }
+    }
+    merged
+}
+
+/// The finite domain a `forall` binder ranges over, when it is knowable
+/// without evaluating against a concrete state — i.e. everything except a
+/// `where`-filtered domain, a `Collection` binder, or `Range` bounds that
+/// are not compile-time constants. `None` means the binder's body cannot be
+/// used to prove full coverage (a `where` filter might skip every
+/// iteration).
+fn compute_binder_values(
+    binder: &Binder,
+    model: &KernelModel,
+) -> Result<Option<Vec<Value>>, RuntimeError> {
+    match binder {
+        Binder::Typed {
+            type_name,
+            where_expr: None,
+            ..
+        } => {
+            let ty = TypeRef::Named(super::qualified_type(type_name)?);
+            Ok(Some(model.domain_values(&ty)?))
+        }
+        Binder::Range { lo, hi, .. } => {
+            match (const_int_bound(lo, model), const_int_bound(hi, model)) {
+                (Some(lo), Some(hi)) => Ok(Some((lo..=hi).map(Value::Int).collect())),
+                _ => Ok(None),
+            }
+        }
+        Binder::Typed { .. } | Binder::Collection { .. } => Ok(None),
+    }
+}
+
+fn const_int_bound(expr: &Expr, model: &KernelModel) -> Option<i64> {
+    match expr {
+        Expr::Num(value) => Some(*value),
+        Expr::Var(name) => match model.consts.get(name) {
+            Some(Value::Int(value)) => Some(*value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Resolve `name` as a member of the enum backing `key_type`, if any.
+fn resolve_enum_key(model: &KernelModel, key_type: &TypeRef, name: &str) -> Option<Value> {
+    model
+        .domain_values(key_type)
+        .ok()?
+        .into_iter()
+        .find(|value| matches!(value, Value::Enum { member, .. } if member == name))
+}
+
+/// The coverage a single assignment statement contributes to its logical
+/// root, independent of whatever the root already had. Returns `None` when
+/// the target's key/field shape carries no provable component information
+/// (an unresolved dynamic map key, or a nested lvalue).
+fn assignment_coverage(
+    target: &LValue,
+    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
+    model: &KernelModel,
+) -> Option<Coverage> {
+    match target {
+        LValue::Var(_) => Some(Coverage::Full),
+        LValue::Index(name, key_expr) => match key_expr {
+            Expr::Num(value) => Some(Coverage::Keys(BTreeSet::from([Value::Int(*value)]))),
+            Expr::Var(key) => {
+                if let Some(binder_values) = bound_names.get(key) {
+                    binder_values
+                        .clone()
+                        .map(|values| Coverage::Keys(values.into_iter().collect()))
+                } else if let Some(TypeRef::Map(key_ty, _)) = model.state_type(name) {
+                    resolve_enum_key(model, key_ty, key)
+                        .map(|value| Coverage::Keys(BTreeSet::from([value])))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        },
+        LValue::Field(base, field) => match base.as_ref() {
+            LValue::Var(_) => Some(Coverage::Fields(BTreeMap::from([(
+                field.clone(),
+                Coverage::Full,
+            )]))),
+            LValue::Index(_, _) | LValue::Field(_, _) => None,
+        },
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn walk_init(
+    statements: &[Statement],
+    mut definitely_assigned: BTreeMap<String, Coverage>,
+    mut possibly_assigned: BTreeSet<InitWriteKey>,
+    in_forall: bool,
+    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
+    model: &KernelModel,
+) -> Result<(BTreeMap<String, Coverage>, BTreeSet<InitWriteKey>), RuntimeError> {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, value, .. } => {
+                let logical = logical_var(target)
+                    .ok_or_else(|| runtime_error("invalid init assignment target"))?;
+                let key = init_write_key(target, bound_names);
+                if possibly_assigned.contains(&key) {
+                    let scope = if in_forall { "init forall" } else { "init" };
+                    return Err(runtime_error(format!(
+                        "state variable '{logical}' assigned more than once in {scope}"
+                    )));
+                }
+                if let LValue::Index(_, key_expr) = target {
+                    check_init_expr(key_expr, &definitely_assigned, model)?;
+                }
+                check_init_expr(value, &definitely_assigned, model)?;
+                if let Some(contribution) = assignment_coverage(target, bound_names, model) {
+                    let previous = definitely_assigned.remove(logical);
+                    definitely_assigned
+                        .insert(logical.to_owned(), join_coverage(previous, contribution));
+                }
+                possibly_assigned.insert(key);
+            }
+            Statement::ForAll {
+                binder, statements, ..
+            } => {
+                if in_forall {
+                    return Err(runtime_error("nested forall in init is not supported"));
+                }
+                match binder {
+                    Binder::Range { lo, hi, .. } => {
+                        let mut references = state_references(lo, model);
+                        references.extend(state_references(hi, model));
+                        if let Some(name) = references.first() {
+                            return Err(runtime_error(format!(
+                                "init forall range bounds must be compile-time constants; state variable '{name}' is not allowed"
+                            )));
+                        }
+                    }
+                    Binder::Collection { collection, .. } => {
+                        if let Some(name) = state_references(collection, model).first() {
+                            return Err(runtime_error(format!(
+                                "init forall over a state collection is not supported; state variable '{name}' is not allowed"
+                            )));
+                        }
+                    }
+                    Binder::Typed { .. } => {}
+                }
+                if let Binder::Typed { where_expr, .. } | Binder::Collection { where_expr, .. } =
+                    binder
+                    && let Some(where_expr) = where_expr
+                {
+                    check_init_expr(where_expr, &definitely_assigned, model)?;
+                }
+                let binder_values = compute_binder_values(binder, model)?;
+                let mut nested_bound = bound_names.clone();
+                nested_bound.insert(binder_name(binder).to_owned(), binder_values);
+                (definitely_assigned, possibly_assigned) = walk_init(
+                    statements,
+                    definitely_assigned,
+                    possibly_assigned,
+                    true,
+                    &nested_bound,
+                    model,
+                )?;
+            }
+            Statement::If {
+                condition,
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                check_init_expr(condition, &definitely_assigned, model)?;
+                let (then_definite, then_possible) = walk_init(
+                    then_statements,
+                    definitely_assigned.clone(),
+                    possibly_assigned.clone(),
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                let (else_definite, else_possible) = walk_init(
+                    else_statements,
+                    definitely_assigned,
+                    possibly_assigned,
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                definitely_assigned = meet_branches(then_definite, &else_definite);
+                possibly_assigned = then_possible.union(&else_possible).cloned().collect();
+            }
+        }
+    }
+    Ok((definitely_assigned, possibly_assigned))
+}
+
+fn check_init_expr(
+    expr: &Expr,
+    definitely_assigned: &BTreeMap<String, Coverage>,
+    model: &KernelModel,
+) -> Result<(), RuntimeError> {
+    let references = state_references(expr, model);
+    if let Some(name) = references.iter().find(|name| {
+        let ty = model.state_type(name.as_str());
+        !ty.is_some_and(|ty| coverage_is_full(definitely_assigned.get(name.as_str()), ty, model))
+    }) {
+        return Err(runtime_error(format!(
+            "init references state variable '{name}' before it is assigned"
+        )));
+    }
+    Ok(())
+}
+
+fn state_references(expr: &Expr, model: &KernelModel) -> BTreeSet<String> {
+    let state_names = model
+        .state
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut references = BTreeSet::new();
+    collect_state_references(expr, &state_names, &mut references);
+    references
+}
+
+fn collect_state_references(
+    expr: &Expr,
+    state_names: &BTreeSet<&str>,
+    output: &mut BTreeSet<String>,
+) {
+    match expr {
+        Expr::Var(name) => {
+            if state_names.contains(name.as_str()) {
+                output.insert(name.clone());
+            }
+        }
+        Expr::Num(_) | Expr::Bool(_) | Expr::None => {}
+        Expr::Some(value)
+        | Expr::Neg(value)
+        | Expr::Not(value)
+        | Expr::Field(value, _)
+        | Expr::UnaryNamed { expr: value, .. }
+        | Expr::Is { expr: value, .. } => {
+            collect_state_references(value, state_names, output);
+        }
+        Expr::Set(items) | Expr::Seq(items) => {
+            for item in items {
+                collect_state_references(item, state_names, output);
+            }
+        }
+        Expr::Struct { fields, .. } => {
+            for (_, value) in fields {
+                collect_state_references(value, state_names, output);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for argument in args {
+                collect_state_references(argument, state_names, output);
+            }
+        }
+        Expr::Index(base, index)
+        | Expr::Binary {
+            left: base,
+            right: index,
+            ..
+        }
+        | Expr::BinaryNamed {
+            left: base,
+            right: index,
+            ..
+        } => {
+            collect_state_references(base, state_names, output);
+            collect_state_references(index, state_names, output);
+        }
+        Expr::Method { receiver, args, .. } => {
+            collect_state_references(receiver, state_names, output);
+            for argument in args {
+                collect_state_references(argument, state_names, output);
+            }
+        }
+        Expr::IfThenElse {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_state_references(condition, state_names, output);
+            collect_state_references(then_expr, state_names, output);
+            collect_state_references(else_expr, state_names, output);
+        }
+        Expr::Quantified { binder, body, .. } => {
+            collect_binder_references(binder, state_names, output);
+            collect_state_references(body, state_names, output);
+        }
+        Expr::Count { condition, .. } => {
+            collect_state_references(condition, state_names, output);
+        }
+        Expr::Sum {
+            body, condition, ..
+        } => {
+            collect_state_references(body, state_names, output);
+            if let Some(condition) = condition {
+                collect_state_references(condition, state_names, output);
+            }
+        }
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => {
+            collect_state_references(first, state_names, output);
+            collect_state_references(second, state_names, output);
+            collect_state_references(third, state_names, output);
+        }
+        Expr::BinderNamed { binder, .. } => {
+            collect_binder_references(binder, state_names, output);
+        }
+    }
+}
+
+fn collect_binder_references(
+    binder: &Binder,
+    state_names: &BTreeSet<&str>,
+    output: &mut BTreeSet<String>,
+) {
+    match binder {
+        Binder::Typed { where_expr, .. } => {
+            if let Some(where_expr) = where_expr {
+                collect_state_references(where_expr, state_names, output);
+            }
+        }
+        Binder::Range { lo, hi, .. } => {
+            collect_state_references(lo, state_names, output);
+            collect_state_references(hi, state_names, output);
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            collect_state_references(collection, state_names, output);
+            if let Some(where_expr) = where_expr {
+                collect_state_references(where_expr, state_names, output);
+            }
+        }
+    }
+}
+
+fn logical_var(target: &LValue) -> Option<&str> {
+    match target {
+        LValue::Var(name) | LValue::Index(name, _) => Some(name),
+        LValue::Field(base, _) => match base.as_ref() {
+            LValue::Var(name) | LValue::Index(name, _) => Some(name),
+            LValue::Field(_, _) => None,
+        },
+    }
+}
+
+fn init_write_key(
+    target: &LValue,
+    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
+) -> InitWriteKey {
+    if let LValue::Index(name, index) = target {
+        match index {
+            Expr::Var(key) if !bound_names.contains_key(key) => {
+                return InitWriteKey::ConcreteIndex(name.clone(), format!("var:{key}"));
+            }
+            Expr::Num(key) => {
+                return InitWriteKey::ConcreteIndex(name.clone(), format!("num:{key}"));
+            }
+            _ => {}
+        }
+    }
+    InitWriteKey::Root(
+        logical_var(target)
+            .expect("kernel lvalue has a logical root")
+            .to_owned(),
+    )
+}
+
+fn binder_name(binder: &Binder) -> &str {
+    match binder {
+        Binder::Typed { name, .. }
+        | Binder::Range { name, .. }
+        | Binder::Collection { name, .. } => name,
+    }
+}

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -12,6 +12,13 @@ use fsl_core::{
     ModelError, ParamDef, Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef,
 };
 
+mod explicit;
+
+pub use explicit::{
+    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, verify_explicit,
+    verify_explicit_selected,
+};
+
 pub type State = BTreeMap<String, Value>;
 pub type Bindings = BTreeMap<String, Value>;
 
@@ -873,8 +880,26 @@ impl Monitor {
     ///
     /// Returns [`RuntimeError`] for stale/unknown instances, update errors, or
     /// expression/type failures.
-    #[allow(clippy::too_many_lines)]
     pub fn step(&mut self, enabled: &EnabledAction) -> Result<StepResult, RuntimeError> {
+        self.step_selected(enabled, None)
+    }
+
+    /// Execute one enabled instance while checking an optional selection of
+    /// implicit state-bound properties.
+    ///
+    /// `None` checks every implicit bound. `Some` is used by the explicit
+    /// verifier when `--property` or `--exclude-property` narrows verification.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] for stale/unknown instances, update errors, or
+    /// expression/type failures.
+    #[allow(clippy::too_many_lines)]
+    pub fn step_selected(
+        &mut self,
+        enabled: &EnabledAction,
+        checked_bounds: Option<&BTreeSet<String>>,
+    ) -> Result<StepResult, RuntimeError> {
         let action = self
             .model
             .actions
@@ -914,7 +939,13 @@ impl Monitor {
         let mut next = old_state.clone();
         next.extend(pending);
         self.step += 1;
-        let violation = match check_state(&next, Some(&old_state), &self.model, self.step) {
+        let violation = match check_state_selected(
+            &next,
+            Some(&old_state),
+            &self.model,
+            self.step,
+            checked_bounds,
+        ) {
             Ok(violation) => violation,
             Err(error) if is_partial_operation_error(&error.message) => {
                 return Ok(StepResult {
@@ -990,6 +1021,19 @@ impl Monitor {
     /// Returns [`RuntimeError`] when a property cannot be evaluated.
     pub fn current_violation(&self) -> Result<Option<Violation>, RuntimeError> {
         check_state(&self.state, None, &self.model, self.step)
+    }
+
+    /// Check the current state while honoring an optional selection of
+    /// implicit state-bound properties.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] when a property cannot be evaluated.
+    pub fn current_violation_selected(
+        &self,
+        checked_bounds: Option<&BTreeSet<String>>,
+    ) -> Result<Option<Violation>, RuntimeError> {
+        check_state_selected(&self.state, None, &self.model, self.step, checked_bounds)
     }
 }
 
@@ -2006,7 +2050,21 @@ fn check_state(
     model: &KernelModel,
     step: usize,
 ) -> Result<Option<Violation>, RuntimeError> {
+    check_state_selected(state, old_state, model, step, None)
+}
+
+fn check_state_selected(
+    state: &State,
+    old_state: Option<&State>,
+    model: &KernelModel,
+    step: usize,
+    checked_bounds: Option<&BTreeSet<String>>,
+) -> Result<Option<Violation>, RuntimeError> {
     for (name, ty) in &model.state {
+        let property_name = format!("_bounds_{name}");
+        if checked_bounds.is_some_and(|selected| !selected.contains(&property_name)) {
+            continue;
+        }
         if !value_conforms(
             state
                 .get(name)
@@ -2016,7 +2074,7 @@ fn check_state(
         )? {
             return Ok(Some(Violation {
                 kind: "type_bound".to_owned(),
-                name: format!("_bounds_{name}"),
+                name: property_name,
                 step,
             }));
         }

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    build_model(parse_kernel_source(source, &FsResolver::new(".")).expect("parse kernel"))
+        .expect("build model")
+}
+
+#[test]
+fn explicit_bfs_proves_at_state_space_closure() {
+    let model = model(
+        "spec Once { state { done: Bool } init { done = false } \
+         action finish() { requires not done done = true } \
+         invariant BooleanState { done or not done } terminal { done } }",
+    );
+    let result = fsl_runtime::verify_explicit(model, 4, 100).expect("explicit verification");
+    assert!(result.closure);
+    assert!(!result.budget_exceeded);
+    assert!(result.violation.is_none());
+    assert_eq!(result.states_explored, 2);
+    assert_eq!(result.depth_reached, 1);
+    assert_eq!(result.deadlock_step, None);
+}
+
+#[test]
+fn explicit_bfs_fails_closed_at_the_state_budget() {
+    let model = model(
+        "spec Counter { type Count = 0..2 state { count: Count } init { count = 0 } \
+         action add() { requires count < 2 count = count + 1 } }",
+    );
+    let result = fsl_runtime::verify_explicit(model, 4, 1).expect("budget verdict");
+    assert!(result.budget_exceeded);
+    assert!(!result.closure);
+    assert!(result.violation.is_none());
+    assert_eq!(result.states_explored, 1);
+    assert_eq!(result.depth_reached, 0);
+}
+
+#[test]
+fn explicit_bfs_rejects_underconstrained_or_order_dependent_init() {
+    let missing = model(
+        "spec Missing { state { x: Bool, y: Bool } init { x = false } \
+         action stay() { x = x y = y } }",
+    );
+    let error = fsl_runtime::verify_explicit(missing, 2, 100).expect_err("missing init rejected");
+    assert_eq!(error.message, "init does not assign state variable(s): y");
+
+    let read_before_write = model(
+        "spec ReadBeforeWrite { state { x: Bool, y: Bool } \
+         init { x = y y = false } action stay() { x = x y = y } }",
+    );
+    let error = fsl_runtime::verify_explicit(read_before_write, 2, 100)
+        .expect_err("order-dependent init rejected");
+    assert_eq!(
+        error.message,
+        "init references state variable 'y' before it is assigned"
+    );
+}
+
+#[test]
+fn deterministic_init_rejects_state_dependent_forall_domains() {
+    let unassigned_range = model(
+        "spec UnassignedRange { type Slot = 0..2 state { n: Slot, m: Map<Slot, Bool> } \
+         init { forall i in 0..n { m[i] = true } n = 0 } \
+         action stay() { n = n } }",
+    );
+    let error = fsl_runtime::verify_explicit(unassigned_range, 2, 100)
+        .expect_err("state-dependent init range rejected");
+    assert_eq!(
+        error.message,
+        "init forall range bounds must be compile-time constants; state variable 'n' is not allowed"
+    );
+
+    let assigned_range = model(
+        "spec AssignedRange { type Slot = 0..2 state { n: Slot, m: Map<Slot, Bool> } \
+         init { n = 2 forall i in 0..n { m[i] = true } } \
+         action stay() { n = n } }",
+    );
+    let error = fsl_runtime::verify_explicit(assigned_range, 2, 100)
+        .expect_err("assigned state still cannot bound an init range");
+    assert_eq!(
+        error.message,
+        "init forall range bounds must be compile-time constants; state variable 'n' is not allowed"
+    );
+
+    let state_collection = model(
+        "spec StateCollection { type Slot = 0..2 \
+         state { s: Set<Slot>, m: Map<Slot, Bool> } \
+         init { s = Set { 0, 1 } forall i in s { m[i] = true } } \
+         action stay() { s = s } }",
+    );
+    let error = fsl_runtime::verify_explicit(state_collection, 2, 100)
+        .expect_err("state collection init domain rejected");
+    assert_eq!(
+        error.message,
+        "init forall over a state collection is not supported; state variable 's' is not allowed"
+    );
+
+    let const_range = model(
+        "spec ConstRange { const CAP = 2 type Slot = 0..2 \
+         state { m: Map<Slot, Bool> } \
+         init { forall i in 0..CAP { m[i] = true } } \
+         action stay() { m[0] = m[0] } }",
+    );
+    let result = fsl_runtime::verify_explicit(const_range, 2, 100)
+        .expect("compile-time const init range accepted");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+}
+
+#[test]
+fn deterministic_init_tracks_branches_foralls_and_duplicate_locations() {
+    let both_branches = model(
+        "spec Branches { state { flag: Bool, value: Bool } \
+         init { flag = false if flag { value = true } else { value = false } } \
+         action stay() { flag = flag value = value } }",
+    );
+    fsl_runtime::verify_explicit(both_branches, 1, 100)
+        .expect("both init branches definitely assign value");
+
+    let one_branch = model(
+        "spec OneBranch { state { flag: Bool, value: Bool } \
+         init { flag = false if flag { value = true } } \
+         action stay() { flag = flag value = value } }",
+    );
+    let error =
+        fsl_runtime::verify_explicit(one_branch, 1, 100).expect_err("one branch is incomplete");
+    assert_eq!(
+        error.message,
+        "init does not assign state variable(s): value"
+    );
+
+    let distinct_keys = model(
+        "spec DistinctKeys { enum Key { A, B } state { values: Map<Key, Bool> } \
+         init { values[A] = false values[B] = true } \
+         action stay() { values[A] = values[A] } }",
+    );
+    fsl_runtime::verify_explicit(distinct_keys, 1, 100)
+        .expect("separate concrete map keys are not duplicate init writes");
+
+    let duplicate = model(
+        "spec Duplicate { state { value: Bool } init { value = false value = true } \
+         action stay() { value = value } }",
+    );
+    let error =
+        fsl_runtime::verify_explicit(duplicate, 1, 100).expect_err("duplicate init rejected");
+    assert_eq!(
+        error.message,
+        "state variable 'value' assigned more than once in init"
+    );
+
+    let nested_forall = model(
+        "spec Nested { const MAX = 1 state { values: Map<Int, Int> } \
+         init { forall i in 0..MAX: { forall j in 0..MAX: { values[i] = j } } } \
+         action stay() { values[0] = values[0] } }",
+    );
+    let error = fsl_runtime::verify_explicit(nested_forall, 1, 100)
+        .expect_err("nested init forall rejected");
+    assert_eq!(error.message, "nested forall in init is not supported");
+}
+
+#[test]
+fn explicit_violation_trace_replays_through_the_monitor() {
+    let model = model(
+        "spec Overflow { type Count = 0..1 state { count: Count } init { count = 0 } \
+         action add() { count = count + 1 } }",
+    );
+    let result =
+        fsl_runtime::verify_explicit(model.clone(), 3, 100).expect("explicit verification");
+    let violation = result.violation.expect("type-bound violation");
+    assert_eq!(violation.violation.kind, "type_bound");
+    assert_eq!(violation.violation.step, 2);
+    fsl_runtime::replay_trace(model, &violation.trace).expect("replay explicit trace");
+}

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -1985,7 +1985,7 @@
           "verify"
         ],
         "prog": "fslc verify",
-        "help": "usage: fslc verify [-h] [--depth DEPTH] [--engine {bmc,induction}] [--k K_IND] [--deadlock {warn,error,ignore}] [--vacuity {warn,error,ignore}] [--property PROPERTY_NAME] [--exclude-property EXCLUDE_PROPERTY_NAMES] [--instances INSTANCES] [--values VALUES] [--strict-tags] [--requirements REQUIREMENTS] [--no-cache] [--lemma LEMMAS] [--from-state FROM_STATE] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  --engine {bmc,induction}\n  --k K_IND             max induction depth (induction engine only)\n  --deadlock {warn,error,ignore}\n  --vacuity {warn,error,ignore}\n  --property PROPERTY_NAME\n                        check a single named property in isolation; resolves\n                        across invariant/trans/leadsTo/reachable declarations\n  --exclude-property EXCLUDE_PROPERTY_NAMES\n                        skip a named property; repeat to omit\n                        invariants/trans/leadsTo/reachable declarations\n  --instances INSTANCES\n                        override a verify-block 'instances NAME = N' bound\n                        (NAME=N; repeatable) — e.g. shrink to 1 entity for\n                        liveness\n  --values VALUES       override a verify-block 'values NAME = LO..HI' bound\n                        (NAME=LO..HI; repeatable)\n  --strict-tags\n  --requirements REQUIREMENTS\n  --no-cache            skip the persistent verdict cache for this run (neither\n                        reads nor writes it)\n  --lemma LEMMAS        candidate auxiliary invariant expression (induction\n                        only; repeatable)\n  --from-state FROM_STATE\n                        replace spec init with a complete Monitor/replay\n                        logical-state JSON snapshot (BMC only)\n",
+        "help": "usage: fslc verify [-h] [--depth DEPTH] [--engine {bmc,induction,explicit}] [--k K_IND] [--explicit-budget EXPLICIT_BUDGET] [--deadlock {warn,error,ignore}] [--vacuity {warn,error,ignore}] [--property PROPERTY_NAME] [--exclude-property EXCLUDE_PROPERTY_NAMES] [--instances INSTANCES] [--values VALUES] [--strict-tags] [--requirements REQUIREMENTS] [--no-cache] [--lemma LEMMAS] [--from-state FROM_STATE] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  --engine {bmc,induction,explicit}\n  --k K_IND             max induction depth (induction engine only)\n  --explicit-budget EXPLICIT_BUDGET\n                        max visited states for the explicit engine (default\n                        1000000); exceeding returns unknown_budget\n  --deadlock {warn,error,ignore}\n  --vacuity {warn,error,ignore}\n  --property PROPERTY_NAME\n                        check a single named property in isolation; resolves\n                        across invariant/trans/leadsTo/reachable declarations\n  --exclude-property EXCLUDE_PROPERTY_NAMES\n                        skip a named property; repeat to omit\n                        invariants/trans/leadsTo/reachable declarations\n  --instances INSTANCES\n                        override a verify-block 'instances NAME = N' bound\n                        (NAME=N; repeatable) — e.g. shrink to 1 entity for\n                        liveness\n  --values VALUES       override a verify-block 'values NAME = LO..HI' bound\n                        (NAME=LO..HI; repeatable)\n  --strict-tags\n  --requirements REQUIREMENTS\n  --no-cache            skip the persistent verdict cache for this run (neither\n                        reads nor writes it)\n  --lemma LEMMAS        candidate auxiliary invariant expression (induction\n                        only; repeatable)\n  --from-state FROM_STATE\n                        replace spec init with a complete Monitor/replay\n                        logical-state JSON snapshot (BMC only)\n",
         "actions": [
           {
             "dest": "help",
@@ -2020,7 +2020,8 @@
             ],
             "choices": [
               "bmc",
-              "induction"
+              "induction",
+              "explicit"
             ],
             "default": "bmc",
             "action": "store"
@@ -2032,6 +2033,15 @@
               "--k"
             ],
             "default": 1,
+            "action": "store"
+          },
+          {
+            "dest": "explicit_budget",
+            "required": false,
+            "flags": [
+              "--explicit-budget"
+            ],
+            "default": 1000000,
             "action": "store"
           },
           {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -16,11 +16,13 @@ mod approval;
 mod verification;
 
 use verification::{
-    BmcRequest, DeadlockMode, InductionRequest, ModelSelection, VerificationEngine,
-    run_bmc_filtered, run_induction_filtered, run_verify_cli,
+    BmcRequest, DeadlockMode, ExplicitRequest, InductionRequest, ModelSelection,
+    VerificationEngine, run_bmc_filtered, run_explicit_filtered, run_induction_filtered,
+    run_verify_cli,
 };
 
 const CLI_CONTRACT: &str = include_str!("../cli-contract.json");
+const DEFAULT_EXPLICIT_BUDGET: usize = 1_000_000;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ScopeBounds {
@@ -33,6 +35,7 @@ struct CliVerifyOptions {
     depth: usize,
     deadlock: String,
     engine: String,
+    explicit_budget: usize,
     k_ind: usize,
     vacuity: String,
     property: Option<String>,
@@ -51,6 +54,7 @@ impl Default for CliVerifyOptions {
             depth: 8,
             deadlock: "warn".to_owned(),
             engine: "bmc".to_owned(),
+            explicit_budget: DEFAULT_EXPLICIT_BUDGET,
             k_ind: 1,
             vacuity: "warn".to_owned(),
             property: None,
@@ -107,8 +111,16 @@ fn parse_verify_options(
             }
             "--engine" => {
                 options.engine = required_option_value(args, "--engine")?;
-                if !matches!(options.engine.as_str(), "bmc" | "induction") {
-                    return Err("--engine must be bmc or induction".to_owned());
+                if !matches!(options.engine.as_str(), "bmc" | "induction" | "explicit") {
+                    return Err("--engine must be bmc, induction, or explicit".to_owned());
+                }
+            }
+            "--explicit-budget" => {
+                options.explicit_budget = required_option_value(args, "--explicit-budget")?
+                    .parse()
+                    .map_err(|_| "--explicit-budget must be a positive integer".to_owned())?;
+                if options.explicit_budget == 0 {
+                    return Err("--explicit-budget must be a positive integer".to_owned());
                 }
             }
             "--k" => {
@@ -182,6 +194,9 @@ fn parse_specialized_verify_options(
                 engine = args
                     .next()
                     .ok_or_else(|| "--engine requires a value".to_owned())?;
+                if !matches!(engine.as_str(), "bmc" | "induction") {
+                    return Err("--engine must be bmc or induction".to_owned());
+                }
             }
             _ => return Err(format!("unknown specialized check option '{option}'")),
         }
@@ -475,6 +490,9 @@ fn command() -> Result<(Value, i32), String> {
                                 engine = args
                                     .next()
                                     .ok_or_else(|| "--engine requires a value".to_owned())?;
+                                if !matches!(engine.as_str(), "bmc" | "induction") {
+                                    return Err("--engine must be bmc or induction".to_owned());
+                                }
                             }
                             _ => return Err(format!("unknown db check option '{option}'")),
                         }
@@ -1361,6 +1379,7 @@ fn command() -> Result<(Value, i32), String> {
                 run_verify_cli(&path, &options)
             } else {
                 if options.engine != "bmc"
+                    || options.explicit_budget != DEFAULT_EXPLICIT_BUDGET
                     || options.k_ind != 1
                     || options.vacuity != "warn"
                     || options.property.is_some()
@@ -1516,6 +1535,7 @@ fn run_sweep(
                     depth,
                     deadlock: deadlock_mode.to_owned(),
                     engine: engine.to_owned(),
+                    explicit_budget: DEFAULT_EXPLICIT_BUDGET,
                     k_ind,
                     vacuity: vacuity_mode.to_owned(),
                     property: property.map(str::to_owned),
@@ -1784,6 +1804,7 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
                                 .get("deadlock")
                                 .map_or("warn", String::as_str),
                             "bmc",
+                            DEFAULT_EXPLICIT_BUDGET,
                             1,
                         );
                         (detail, status, "verify", Some(depth))
@@ -2688,7 +2709,14 @@ fn run_scenarios_mode(
         || result.leadsto_violation.is_some()
         || (!allow_unreached && result.reachables.values().any(Option::is_none))
     {
-        return run_verify(path, depth, deadlock_mode, "bmc", 1);
+        return run_verify(
+            path,
+            depth,
+            deadlock_mode,
+            "bmc",
+            DEFAULT_EXPLICIT_BUDGET,
+            1,
+        );
     }
     if let Err(error) = replay_all(&model, &result, None) {
         return (error_output("internal", &error), 2);
@@ -3464,7 +3492,8 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     let status = if result.get("result").and_then(Value::as_str) == Some("violated") {
         1
     } else {
-        let (kernel, kernel_status) = run_verify(path, depth, deadlock, engine, 1);
+        let (kernel, kernel_status) =
+            run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
         if kernel_status == 2 {
             return (kernel, kernel_status);
         }
@@ -3641,7 +3670,7 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
         }
         Err(error) => return (semantic_error_output(&error), 2),
     };
-    let (kernel, status) = run_verify(path, depth, deadlock, engine, 1);
+    let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
     if status == 2 {
         return (kernel, status);
     }
@@ -4129,7 +4158,7 @@ fn run_domain_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> 
         Ok(domain) => domain,
         Err(error) => return (semantic_error_output(&error), 2),
     };
-    let (kernel, status) = run_verify(path, depth, deadlock, engine, 1);
+    let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
     if status == 2 {
         return (kernel, status);
     }
@@ -5931,7 +5960,7 @@ fn run_mutate_legacy(
     max_mutants: usize,
     by_requirement: bool,
 ) -> (Value, i32) {
-    let (baseline, status) = run_verify(path, depth, "warn", "bmc", 1);
+    let (baseline, status) = run_verify(path, depth, "warn", "bmc", DEFAULT_EXPLICIT_BUDGET, 1);
     if status == 2
         || !matches!(
             baseline.get("result").and_then(Value::as_str),
@@ -6712,7 +6741,7 @@ fn run_mutate(
     by_requirement: bool,
     external_mutants: Option<&Path>,
 ) -> (Value, i32) {
-    let (baseline, status) = run_verify(path, depth, "warn", "bmc", 1);
+    let (baseline, status) = run_verify(path, depth, "warn", "bmc", DEFAULT_EXPLICIT_BUDGET, 1);
     if status != 0 || baseline.get("result").and_then(Value::as_str) != Some("verified") {
         return (baseline, 0);
     }
@@ -7578,7 +7607,14 @@ fn run_html_report(
         Ok(source) => source,
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
-    let (verification, _) = run_verify(path, depth, deadlock_mode, engine, 1);
+    let (verification, _) = run_verify(
+        path,
+        depth,
+        deadlock_mode,
+        engine,
+        DEFAULT_EXPLICIT_BUDGET,
+        1,
+    );
     let (mut explained, explain_status) = run_explain(path, depth, false);
     if explain_status != 0 {
         return (explained, explain_status);
@@ -7866,7 +7902,14 @@ fn run_ledger_report(
         Ok(model) => model,
         Err(error) => return (semantic_error_output(&error), 2),
     };
-    let (verification, _) = run_verify(path, depth, deadlock_mode, engine, 1);
+    let (verification, _) = run_verify(
+        path,
+        depth,
+        deadlock_mode,
+        engine,
+        DEFAULT_EXPLICIT_BUDGET,
+        1,
+    );
     let replay = impl_log.map(|trace| run_replay(path, trace).0);
     let evidence = match evidence_paths
         .iter()
@@ -12035,6 +12078,7 @@ fn run_verify(
     depth: usize,
     deadlock_mode: &str,
     engine: &str,
+    explicit_budget: usize,
     k_ind: usize,
 ) -> (Value, i32) {
     if let Ok(source) = std::fs::read_to_string(path)
@@ -12076,6 +12120,12 @@ fn run_verify(
             deadlock,
             k: k_ind,
             auxiliary: &[],
+        }),
+        Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
+            selection,
+            depth,
+            deadlock,
+            budget: explicit_budget,
         }),
         Err(error) => return (error_output("usage", &error), 2),
     };

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 pub(super) enum VerificationEngine {
     Bmc,
     Induction,
+    Explicit,
 }
 
 impl VerificationEngine {
@@ -14,7 +15,8 @@ impl VerificationEngine {
         match value {
             "bmc" => Ok(Self::Bmc),
             "induction" => Ok(Self::Induction),
-            _ => Err("--engine must be bmc or induction".to_owned()),
+            "explicit" => Ok(Self::Explicit),
+            _ => Err("--engine must be bmc, induction, or explicit".to_owned()),
         }
     }
 }
@@ -60,6 +62,14 @@ pub(super) struct InductionRequest<'a> {
     pub(super) deadlock: DeadlockMode,
     pub(super) k: usize,
     pub(super) auxiliary: &'a [(String, KernelExpr)],
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ExplicitRequest<'a> {
+    pub(super) selection: ModelSelection<'a>,
+    pub(super) depth: usize,
+    pub(super) deadlock: DeadlockMode,
+    pub(super) budget: usize,
 }
 
 type CommandResult = (Value, i32);
@@ -394,6 +404,300 @@ fn ranking_measure_text(expr: &KernelExpr) -> String {
     } else {
         text
     }
+}
+
+pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
+    let started = Instant::now();
+    let model = match load_selected_model(request.selection) {
+        Ok(model) => model,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    if model.actions.is_empty() {
+        return (semantic_error_output("spec has no actions"), 2);
+    }
+    if model
+        .actions
+        .iter()
+        .any(|action| duplicate_statement_write(&action.statements).is_some())
+    {
+        return (
+            error_output(
+                "semantics",
+                "an action may not assign the same state location more than once",
+            ),
+            2,
+        );
+    }
+    let checked_bounds = selected_implicit_bounds(
+        &model,
+        request.selection.property,
+        request.selection.excluded,
+    );
+    let result = match fsl_runtime::verify_explicit_selected(
+        model.clone(),
+        request.depth,
+        request.budget,
+        checked_bounds.as_ref(),
+    ) {
+        Ok(result) => result,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
+    render_explicit_result(
+        &model,
+        &result,
+        checked_bounds.as_ref(),
+        request.deadlock,
+        started,
+    )
+}
+
+fn explicit_as_bmc(result: &fsl_runtime::ExplicitResult) -> fsl_verifier::BmcResult {
+    fsl_verifier::BmcResult {
+        spec: result.spec.clone(),
+        depth: result.depth,
+        violation: result
+            .violation
+            .as_ref()
+            .map(|violation| fsl_verifier::BmcViolation {
+                kind: violation.violation.kind.clone(),
+                name: violation.violation.name.clone(),
+                step: violation.violation.step,
+                last_action: violation
+                    .trace
+                    .last()
+                    .and_then(|entry| entry.action.as_ref())
+                    .map(|action| action.name.clone()),
+                trace: violation.trace.clone(),
+                leads_to: None,
+            }),
+        leadsto_violation: None,
+        reachables: result
+            .reachables
+            .iter()
+            .map(|(name, witness)| {
+                (
+                    name.clone(),
+                    witness
+                        .as_ref()
+                        .map(|witness| fsl_verifier::ReachableWitness {
+                            step: witness.step,
+                            trace: witness.trace.clone(),
+                        }),
+                )
+            })
+            .collect(),
+        deadlock_step: result.deadlock_step,
+        deadlock_trace: result.deadlock_trace.clone(),
+        action_coverage: result.action_coverage.clone(),
+        frontier_progress: !result.closure && !result.budget_exceeded,
+    }
+}
+
+fn render_explicit_result(
+    model: &KernelModel,
+    result: &fsl_runtime::ExplicitResult,
+    checked_bounds: Option<&std::collections::BTreeSet<String>>,
+    deadlock: DeadlockMode,
+    started: Instant,
+) -> CommandResult {
+    let compatible = explicit_as_bmc(result);
+    if let Some(violation) = &compatible.violation {
+        let (mut output, status) = render_bmc_violation(model, violation, started);
+        add_explicit_metadata(&mut output, result);
+        return (output, status);
+    }
+
+    if deadlock == DeadlockMode::Error
+        && let Some(step) = result.deadlock_step
+    {
+        let (mut output, status) = render_deadlock_failure(model, &compatible, step, started);
+        add_explicit_metadata(&mut output, result);
+        return (output, status);
+    }
+
+    if result.budget_exceeded {
+        return render_explicit_budget(
+            model,
+            result,
+            &compatible,
+            checked_bounds,
+            deadlock,
+            started,
+        );
+    }
+
+    let unreached = compatible
+        .reachables
+        .iter()
+        .filter(|(_, witness)| witness.is_none())
+        .filter_map(|(name, _)| {
+            model
+                .reachables
+                .iter()
+                .find(|property| property.name == *name)
+        })
+        .collect::<Vec<_>>();
+    if !unreached.is_empty() {
+        let (mut output, status) = render_reachable_failure(
+            model,
+            &compatible,
+            &unreached,
+            result.depth_reached,
+            checked_bounds,
+            started,
+        );
+        if result.closure {
+            mark_reachables_definitively_unreachable(&mut output);
+        }
+        add_explicit_metadata(&mut output, result);
+        return (output, status);
+    }
+
+    render_explicit_success(
+        model,
+        result,
+        &compatible,
+        checked_bounds,
+        deadlock,
+        started,
+    )
+}
+
+fn render_explicit_budget(
+    model: &KernelModel,
+    result: &fsl_runtime::ExplicitResult,
+    compatible: &fsl_verifier::BmcResult,
+    checked_bounds: Option<&std::collections::BTreeSet<String>>,
+    deadlock: DeadlockMode,
+    started: Instant,
+) -> CommandResult {
+    let mut output = envelope();
+    output.insert("spec".to_owned(), json!(model.name));
+    output.insert("result".to_owned(), json!("unknown_budget"));
+    add_common_verification(
+        &mut output,
+        model,
+        compatible,
+        result.depth_reached,
+        checked_bounds,
+    );
+    output.insert("depth".to_owned(), json!(result.depth));
+    output.insert("completeness".to_owned(), json!("unknown"));
+    if deadlock == DeadlockMode::Ignore {
+        output.insert("deadlock".to_owned(), json!({"found": false}));
+    }
+    output.insert(
+        "hint".to_owned(),
+        json!(format!(
+            "explicit-state exploration reached its {}-state budget; increase --explicit-budget or use --engine bmc",
+            result.states_explored
+        )),
+    );
+    output.insert(
+        "cost".to_owned(),
+        json!({"elapsed_s": started.elapsed().as_secs_f64()}),
+    );
+    let mut value = Value::Object(output);
+    add_explicit_metadata(&mut value, result);
+    (value, 1)
+}
+
+fn render_explicit_success(
+    model: &KernelModel,
+    result: &fsl_runtime::ExplicitResult,
+    compatible: &fsl_verifier::BmcResult,
+    checked_bounds: Option<&std::collections::BTreeSet<String>>,
+    deadlock: DeadlockMode,
+    started: Instant,
+) -> CommandResult {
+    if !result.closure {
+        let (mut output, status) = render_bmc_success(
+            model,
+            compatible,
+            result.depth,
+            checked_bounds,
+            deadlock,
+            started,
+        );
+        add_explicit_metadata(&mut output, result);
+        return (output, status);
+    }
+
+    let mut output = envelope();
+    output.insert("spec".to_owned(), json!(model.name));
+    output.insert("result".to_owned(), json!("proved"));
+    add_common_verification(
+        &mut output,
+        model,
+        compatible,
+        result.depth_reached,
+        checked_bounds,
+    );
+    output.insert("depth".to_owned(), json!(result.depth));
+    output.insert("engine".to_owned(), json!("explicit"));
+    output.insert("completeness".to_owned(), json!("unbounded"));
+    if deadlock == DeadlockMode::Ignore {
+        output.insert("deadlock".to_owned(), json!({"found": false}));
+    }
+    output.insert(
+        "warnings".to_owned(),
+        Value::Array(verification_warnings(
+            model,
+            compatible,
+            result.depth_reached,
+            deadlock,
+        )),
+    );
+    output.insert(
+        "note".to_owned(),
+        json!(
+            "explicit-state exploration reached closure; invariants hold in every reachable state"
+        ),
+    );
+    output.insert(
+        "cost".to_owned(),
+        json!({"elapsed_s": started.elapsed().as_secs_f64()}),
+    );
+    let mut value = Value::Object(output);
+    add_explicit_metadata(&mut value, result);
+    (value, 0)
+}
+
+fn add_explicit_metadata(output: &mut Value, result: &fsl_runtime::ExplicitResult) {
+    let Some(output) = output.as_object_mut() else {
+        return;
+    };
+    output.insert("engine".to_owned(), json!("explicit"));
+    output.insert("closure".to_owned(), json!(result.closure));
+    output.insert("states_explored".to_owned(), json!(result.states_explored));
+    output.insert(
+        "max_frontier_width".to_owned(),
+        json!(result.max_frontier_width),
+    );
+    output.insert("depth_reached".to_owned(), json!(result.depth_reached));
+}
+
+fn mark_reachables_definitively_unreachable(output: &mut Value) {
+    let Some(output) = output.as_object_mut() else {
+        return;
+    };
+    if let Some(unreached) = output.get_mut("unreached").and_then(Value::as_array_mut) {
+        for item in unreached {
+            if let Value::Object(item) = item {
+                item.insert("classification".to_owned(), json!("unreachable"));
+                item.insert(
+                    "hint".to_owned(),
+                    json!(
+                        "not witnessed before explicit state-space closure; the goal is unreachable"
+                    ),
+                );
+            }
+        }
+    }
+    output.insert(
+        "hint".to_owned(),
+        json!("explicit state-space closure proves that the requested reachable goal cannot be reached"),
+    );
 }
 
 pub(super) fn run_bmc_filtered(request: BmcRequest<'_>) -> (Value, i32) {
@@ -1262,7 +1566,11 @@ fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String,
     let mut digest = Sha256::new();
     digest.update(b"fslc-rust-verify-cache-v1\0");
     digest.update(env!("CARGO_PKG_VERSION").as_bytes());
-    digest.update(b"\0backend=native-z3\0solver=4.16.0\0");
+    if options.engine == "explicit" {
+        digest.update(b"\0backend=native-explicit\0");
+    } else {
+        digest.update(b"\0backend=native-z3\0solver=4.16.0\0");
+    }
     let executable = std::env::current_exe().map_err(|error| error.to_string())?;
     digest.update(b"executable\0");
     digest.update(std::fs::read(executable).map_err(|error| error.to_string())?);
@@ -1287,6 +1595,7 @@ fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String,
         "path": canonical,
         "deadlock": options.deadlock,
         "engine": options.engine,
+        "explicit_budget": options.explicit_budget,
         "k": options.k_ind,
         "vacuity": options.vacuity,
         "property": options.property,
@@ -1348,7 +1657,14 @@ fn verify_cache_lookup(key: &str, xdepth: &str, depth: usize) -> Option<Value> {
 fn verify_cache_store(key: &str, xdepth: &str, output: &Value) {
     if !matches!(
         output.get("result").and_then(Value::as_str),
-        Some("verified" | "proved" | "violated" | "reachable_failed" | "unknown_cti")
+        Some(
+            "verified"
+                | "proved"
+                | "violated"
+                | "reachable_failed"
+                | "unknown_cti"
+                | "unknown_budget"
+        )
     ) {
         return;
     }
@@ -1362,11 +1678,12 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value) {
         return;
     }
     let temporary = parent.join(format!(".{}.{}.tmp", key, std::process::id()));
+    let explicit = output.get("engine").and_then(Value::as_str) == Some("explicit");
     let entry = json!({
         "schema": "fslc-rust-cache.v1",
         "key": key,
-        "backend": "native-z3",
-        "solver_version": "4.16.0",
+        "backend": if explicit { "native-explicit" } else { "native-z3" },
+        "solver_version": if explicit { Value::Null } else { json!("4.16.0") },
         "output": output,
     });
     if serde_json::to_vec(&entry)
@@ -1411,7 +1728,7 @@ pub(super) fn run_verify_cli(path: &Path, options: &CliVerifyOptions) -> Command
         return (
             error_output(
                 "semantics",
-                "--from-state is available only with the BMC engine; induction proves the spec init contract and cannot start from one snapshot",
+                "--from-state is available only with the BMC engine; induction and explicit verification start from the spec init contract",
             ),
             2,
         );
@@ -1547,7 +1864,7 @@ fn cached_verification(
     }
     let output = verify_cache_lookup(key, xdepth, options.depth)?;
     let status = match output.get("result").and_then(Value::as_str) {
-        Some("violated" | "reachable_failed" | "unknown_cti") => 1,
+        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
         _ => 0,
     };
     Some((output, status))
@@ -1587,6 +1904,12 @@ fn execute_cli_verification(
                 k: options.k_ind,
                 auxiliary: &[],
             }),
+            Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
+                selection,
+                depth: options.depth,
+                deadlock,
+                budget: options.explicit_budget,
+            }),
             Err(error) => (error_output("usage", &error), 2),
         };
     }
@@ -1595,6 +1918,7 @@ fn execute_cli_verification(
         options.depth,
         &options.deadlock,
         &options.engine,
+        options.explicit_budget,
         options.k_ind,
     )
 }
@@ -1749,5 +2073,23 @@ mod tests {
         assert_eq!(status, 1);
         assert_eq!(output["result"], "unknown_cti");
         assert_eq!(output["invariant"], "Sync");
+    }
+
+    #[test]
+    fn explicit_cache_keys_include_the_engine_and_state_budget() {
+        let path = repository_path("examples/gallery/valid/tiny_turnstile.fsl");
+        let bmc = CliVerifyOptions::default();
+        let mut explicit = bmc.clone();
+        explicit.engine = "explicit".to_owned();
+        let mut smaller_budget = explicit.clone();
+        smaller_budget.explicit_budget -= 1;
+
+        let bmc_keys = verify_cache_keys(&path, &bmc).expect("BMC cache keys");
+        let explicit_keys = verify_cache_keys(&path, &explicit).expect("explicit cache keys");
+        let smaller_keys =
+            verify_cache_keys(&path, &smaller_budget).expect("budget-specific cache keys");
+
+        assert_ne!(bmc_keys, explicit_keys);
+        assert_ne!(explicit_keys, smaller_keys);
     }
 }

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::json;
+
+const BUDGET: &str = "1000000";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[String]) -> (serde_json::Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn verify(path: &str, engine: &str, depth: usize, extra: &[&str]) -> (serde_json::Value, i32) {
+    let mut arguments = vec![
+        "verify".to_owned(),
+        path.to_owned(),
+        "--engine".to_owned(),
+        engine.to_owned(),
+        "--depth".to_owned(),
+        depth.to_string(),
+        "--deadlock".to_owned(),
+        "ignore".to_owned(),
+        "--no-cache".to_owned(),
+    ];
+    arguments.extend(extra.iter().map(|argument| (*argument).to_owned()));
+    run_cli(&arguments)
+}
+
+fn load_model(path: &Path) -> fsl_core::KernelModel {
+    let source = std::fs::read_to_string(path).expect("read FSL corpus file");
+    let resolver = fsl_core::FsResolver::new(path.parent().expect("spec parent"));
+    let kernel = fsl_core::parse_kernel_source(&source, &resolver).expect("lower kernel");
+    fsl_core::build_model(kernel).expect("build kernel model")
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn explicit_cli_exit_codes_cover_bounded_proved_violated_budget_and_semantics() {
+    let finite =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_finite_toggle.fsl");
+    let finite = finite.to_str().expect("UTF-8 fixture path");
+    let (bounded, status) = verify(finite, "explicit", 0, &[]);
+    assert_eq!(status, 0);
+    assert_eq!(bounded["result"], "verified");
+    assert_eq!(bounded["completeness"], "bounded");
+
+    let (proved, status) = verify(finite, "explicit", 4, &[]);
+    assert_eq!(status, 0);
+    assert_eq!(proved["result"], "proved");
+    assert_eq!(proved["engine"], "explicit");
+    assert_eq!(proved["completeness"], "unbounded");
+    assert_eq!(proved["closure"], true);
+
+    let (ignored_k, status) = verify(finite, "explicit", 4, &["--k", "99"]);
+    assert_eq!(status, 0);
+    assert_eq!(ignored_k["result"], "proved");
+
+    let (lemma_rejected, status) =
+        verify(finite, "explicit", 4, &["--lemma", "active or not active"]);
+    assert_eq!(status, 2);
+    assert_eq!(lemma_rejected["kind"], "usage");
+
+    let (snapshot_rejected, status) = verify(
+        finite,
+        "explicit",
+        4,
+        &["--from-state", "missing-state.json"],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(snapshot_rejected["kind"], "semantics");
+    assert!(
+        snapshot_rejected["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("only with the BMC engine"))
+    );
+
+    let (unsupported_liveness, status) = verify("specs/mutex_queue.fsl", "explicit", 8, &[]);
+    assert_eq!(status, 2);
+    assert_eq!(unsupported_liveness["kind"], "semantics");
+    assert!(
+        unsupported_liveness["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not support leadsTo"))
+    );
+
+    let (violated, status) = verify("specs/cart_buggy.fsl", "explicit", 8, &[]);
+    assert_eq!(status, 1);
+    assert_eq!(violated["result"], "violated");
+
+    let (budget, status) = verify(finite, "explicit", 4, &["--explicit-budget", "1"]);
+    assert_eq!(status, 1);
+    assert_eq!(budget["result"], "unknown_budget");
+    assert_eq!(budget["states_explored"], 1);
+    assert_eq!(budget["depth_reached"], 0);
+
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/explicit_nondeterministic_init.fsl");
+    let (rejected, status) = verify(
+        fixture.to_str().expect("UTF-8 fixture path"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(rejected["result"], "error");
+    assert_eq!(rejected["kind"], "semantics");
+    assert!(rejected["message"].as_str().is_some_and(|message| {
+        message.contains("init does not assign state variable(s): omitted")
+    }));
+
+    let deadlock =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_deadlock.fsl");
+    let deadlock = deadlock.to_str().expect("UTF-8 fixture path");
+    let (warning, status) = run_cli(&[
+        "verify".to_owned(),
+        deadlock.to_owned(),
+        "--engine".to_owned(),
+        "explicit".to_owned(),
+        "--depth".to_owned(),
+        "4".to_owned(),
+        "--deadlock".to_owned(),
+        "warn".to_owned(),
+        "--no-cache".to_owned(),
+    ]);
+    assert_eq!(status, 0);
+    assert!(warning["warnings"].as_array().is_some_and(|warnings| {
+        warnings.iter().any(|warning| {
+            warning["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("deadlock reachable"))
+        })
+    }));
+
+    let (deadlock_error, status) = run_cli(&[
+        "verify".to_owned(),
+        deadlock.to_owned(),
+        "--engine".to_owned(),
+        "explicit".to_owned(),
+        "--depth".to_owned(),
+        "4".to_owned(),
+        "--deadlock".to_owned(),
+        "error".to_owned(),
+        "--no-cache".to_owned(),
+    ]);
+    assert_eq!(status, 1);
+    assert_eq!(deadlock_error["violation_kind"], "deadlock");
+
+    let vacuous = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_vacuous.fsl");
+    let (vacuous_error, status) = verify(
+        vacuous.to_str().expect("UTF-8 fixture path"),
+        "explicit",
+        4,
+        &["--vacuity", "error"],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(vacuous_error["result"], "error");
+    assert_eq!(vacuous_error["kind"], "vacuous_implication");
+}
+
+#[test]
+fn explicit_init_forall_domains_match_bmc_semantics_errors() {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    for (name, expected_message) in [
+        (
+            "explicit_init_range_unassigned.fsl",
+            "init forall range bounds must be compile-time constants; state variable 'n' is not allowed",
+        ),
+        (
+            "explicit_init_range_assigned.fsl",
+            "init forall range bounds must be compile-time constants; state variable 'n' is not allowed",
+        ),
+        (
+            "explicit_init_state_collection.fsl",
+            "init forall over a state collection is not supported; state variable 's' is not allowed",
+        ),
+    ] {
+        let path = fixtures.join(name);
+        let path = path.to_str().expect("UTF-8 fixture path");
+
+        let (explicit, explicit_status) = verify(path, "explicit", 4, &[]);
+        assert_eq!(explicit_status, 2, "explicit accepted {name}");
+        assert_eq!(explicit["result"], "error", "explicit result for {name}");
+        assert_eq!(explicit["kind"], "semantics", "explicit kind for {name}");
+        assert_eq!(
+            explicit["message"], expected_message,
+            "explicit diagnostic for {name}"
+        );
+
+        let (bmc, bmc_status) = verify(path, "bmc", 4, &[]);
+        assert_eq!(bmc_status, 2, "BMC accepted {name}: {bmc:#}");
+        assert_eq!(bmc["result"], "error", "BMC result for {name}");
+        assert_eq!(bmc["kind"], "semantics", "BMC kind for {name}");
+    }
+
+    let const_bound = fixtures.join("explicit_init_const_range.fsl");
+    let const_bound = const_bound.to_str().expect("UTF-8 fixture path");
+    let (explicit, explicit_status) = verify(const_bound, "explicit", 4, &[]);
+    assert_eq!(explicit_status, 0);
+    assert_eq!(explicit["result"], "proved");
+    assert_eq!(explicit["closure"], true);
+
+    let (bmc, bmc_status) = verify(const_bound, "bmc", 4, &[]);
+    assert_eq!(bmc_status, 0);
+    assert_eq!(bmc["result"], "verified");
+}
+
+#[test]
+fn explicit_closure_proves_true_noninductive_invariant() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_noninductive.fsl");
+    let fixture = fixture.to_str().expect("UTF-8 fixture path");
+
+    let (induction, induction_status) = verify(fixture, "induction", 8, &[]);
+    assert_eq!(induction_status, 1);
+    assert_eq!(induction["result"], "unknown_cti");
+
+    let (explicit, explicit_status) = verify(fixture, "explicit", 8, &[]);
+    assert_eq!(explicit_status, 0);
+    assert_eq!(explicit["result"], "proved");
+    assert_eq!(explicit["closure"], true);
+}
+
+#[test]
+fn explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec() {
+    let root = repository_root();
+    let mut paths = std::fs::read_dir(root.join("specs"))
+        .expect("read specs corpus")
+        .map(|entry| entry.expect("corpus entry").path())
+        .filter(|path| path.extension().and_then(std::ffi::OsStr::to_str) == Some("fsl"))
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    let mut accepted = 0_usize;
+    let mut replayed = 0_usize;
+    for path in paths {
+        let relative = path
+            .strip_prefix(&root)
+            .expect("repository-relative spec")
+            .to_string_lossy()
+            .into_owned();
+        let (explicit, explicit_status) =
+            verify(&relative, "explicit", 8, &["--explicit-budget", BUDGET]);
+        if explicit_status == 2 && explicit["result"] == "error" {
+            continue;
+        }
+        accepted += 1;
+        assert_ne!(
+            explicit["result"], "unknown_budget",
+            "default budget truncated {relative}"
+        );
+
+        let (bmc, bmc_status) = verify(&relative, "bmc", 8, &[]);
+        let explicit_result = explicit["result"].as_str().expect("explicit result");
+        let normalized_explicit = if explicit_result == "proved" {
+            "verified"
+        } else {
+            explicit_result
+        };
+        assert_eq!(
+            normalized_explicit,
+            bmc["result"].as_str().expect("BMC result"),
+            "verdict mismatch for {relative}: explicit={explicit:#} bmc={bmc:#}"
+        );
+        assert_eq!(
+            explicit_status, bmc_status,
+            "exit-code mismatch for {relative}"
+        );
+
+        if explicit_result == "violated" {
+            assert_eq!(
+                explicit["violated_at_step"], bmc["violated_at_step"],
+                "violation depth mismatch for {relative}"
+            );
+            let model = load_model(&path);
+            let result = fsl_runtime::verify_explicit(model.clone(), 8, 1_000_000)
+                .expect("accepted explicit model");
+            let violation = result.violation.expect("explicit violation trace");
+            fsl_runtime::replay_trace(model, &violation.trace)
+                .unwrap_or_else(|error| panic!("trace did not replay for {relative}: {error}"));
+            replayed += 1;
+        }
+    }
+
+    assert!(accepted > 0, "explicit engine accepted no corpus specs");
+    assert!(
+        replayed > 0,
+        "corpus contained no replayed explicit violation"
+    );
+}
+
+fn fixture_path(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .to_owned()
+}
+
+#[test]
+fn explicit_rejects_partial_component_init_coverage() {
+    // A single concrete map-key write only covers that key; the rest of the
+    // map's key domain (here `B`) is left uninitialized. Root-granularity
+    // tracking would have (unsoundly) treated the whole map as assigned as
+    // soon as any one key was written.
+    let (result, status) = verify(
+        &fixture_path("explicit_partial_map_key.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(result["result"], "error");
+    assert_eq!(result["kind"], "semantics");
+    assert!(result["message"].as_str().is_some_and(|message| {
+        message.contains("init does not assign state variable(s): values")
+            && message.contains("partial component initialization is rejected")
+    }));
+
+    // A forall over a const-bounded subrange (0..1) leaves key 2 of the
+    // 0..2 domain uncovered.
+    let (result, status) = verify(
+        &fixture_path("explicit_partial_subrange.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(result["result"], "error");
+    assert_eq!(result["kind"], "semantics");
+    assert!(result["message"].as_str().is_some_and(|message| {
+        message.contains("init does not assign state variable(s): m")
+            && message.contains("partial component initialization is rejected")
+    }));
+
+    // A where-filtered forall can skip iterations at runtime, so it can
+    // never be used to prove full coverage even though every reachable
+    // binding happens to satisfy the filter here.
+    let (result, status) = verify(
+        &fixture_path("explicit_partial_where.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(result["result"], "error");
+    assert_eq!(result["kind"], "semantics");
+    assert!(
+        result["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("init does not assign state variable(s): m"))
+    );
+}
+
+#[test]
+fn explicit_accepts_map_fully_covered_by_separate_concrete_key_statements() {
+    // The fsl-db "per-column" pattern: distinct concrete-key writes that
+    // together cover the whole enum key domain must count as full coverage.
+    let (result, status) = verify(
+        &fixture_path("explicit_full_enum_keys.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 0);
+    assert!(matches!(
+        result["result"].as_str(),
+        Some("proved" | "verified")
+    ));
+}
+
+#[test]
+fn explicit_reachable_witness_step_matches_bmc() {
+    let path = fixture_path("explicit_reachable_witnessed.fsl");
+    let (explicit, explicit_status) = verify(&path, "explicit", 4, &[]);
+    assert_eq!(explicit_status, 0);
+    let (bmc, bmc_status) = verify(&path, "bmc", 4, &[]);
+    assert_eq!(bmc_status, 0);
+
+    let explicit_step = explicit["reachables"]["HitTwo"]["witnessed_at_step"].clone();
+    let bmc_step = bmc["reachables"]["HitTwo"]["witnessed_at_step"].clone();
+    assert!(!explicit_step.is_null(), "explicit did not witness HitTwo");
+    assert_eq!(
+        explicit_step, bmc_step,
+        "explicit and BMC disagree on the shortest HitTwo witness"
+    );
+}
+
+#[test]
+fn explicit_reachable_failure_classifies_unreachable_only_at_closure() {
+    let path = fixture_path("explicit_reachable_unreachable_goal.fsl");
+
+    // At a depth past the point where the finite state space closes
+    // (count saturates at 5, one step past the last `inc()`), explicit
+    // exploration proves HitSix can never happen — mark_reachables_
+    // definitively_unreachable should stamp the unreached goal and the
+    // top-level hint accordingly.
+    let (closed, closed_status) = verify(&path, "explicit", 6, &[]);
+    assert_eq!(closed_status, 1);
+    assert_eq!(closed["result"], "reachable_failed");
+    assert_eq!(closed["closure"], true);
+    let unreached = closed["unreached"].as_array().expect("unreached array");
+    assert_eq!(unreached.len(), 1);
+    assert_eq!(unreached[0]["name"], "HitSix");
+    assert_eq!(unreached[0]["classification"], "unreachable");
+    assert!(unreached[0]["hint"].as_str().is_some_and(|hint| {
+        hint.contains("not witnessed before explicit state-space closure")
+    }));
+    assert!(closed["hint"].as_str().is_some_and(|hint| {
+        hint.contains("explicit state-space closure proves that the requested reachable goal cannot be reached")
+    }));
+
+    // At a depth too small to reach closure, explicit must not claim
+    // definitive unreachability — it should classify the same way BMC
+    // does when it also cannot witness the goal within that depth.
+    let (bounded, bounded_status) = verify(&path, "explicit", 2, &[]);
+    assert_eq!(bounded_status, 1);
+    assert_eq!(bounded["result"], "reachable_failed");
+    assert_eq!(bounded["closure"], false);
+    let bounded_unreached = bounded["unreached"].as_array().expect("unreached array");
+    assert_eq!(bounded_unreached[0]["classification"], "insufficient_depth");
+
+    let (bmc_bounded, bmc_bounded_status) = verify(&path, "bmc", 2, &[]);
+    assert_eq!(bmc_bounded_status, 1);
+    assert_eq!(bmc_bounded["result"], "reachable_failed");
+    let bmc_unreached = bmc_bounded["unreached"]
+        .as_array()
+        .expect("unreached array");
+    assert_eq!(
+        bounded_unreached[0]["classification"],
+        bmc_unreached[0]["classification"]
+    );
+}
+
+#[test]
+fn explicit_excluding_a_leadsto_property_is_accepted_and_verifies_the_rest() {
+    let path = fixture_path("explicit_exclude_leadsto.fsl");
+
+    // Without exclusion, the explicit engine rejects the spec outright
+    // because it does not support leadsTo.
+    let (rejected, rejected_status) = verify(&path, "explicit", 4, &[]);
+    assert_eq!(rejected_status, 2);
+    assert_eq!(rejected["kind"], "semantics");
+
+    // Excluding the leadsTo property is accepted (no semantics error) and
+    // the remaining invariant verifies/proves.
+    let (accepted, accepted_status) = verify(
+        &path,
+        "explicit",
+        4,
+        &["--exclude-property", "FlagLeadsToDone"],
+    );
+    assert_eq!(accepted_status, 0);
+    assert!(matches!(
+        accepted["result"].as_str(),
+        Some("proved" | "verified")
+    ));
+    assert_eq!(accepted["invariants_checked"], json!(["DoneImpliesFlag"]));
+}
+
+#[test]
+fn explicit_property_narrowing_matches_bmc() {
+    let path = fixture_path("explicit_property_narrow.fsl");
+
+    // Unfiltered, NeverTrue is violated once the toggle runs.
+    let (unfiltered, unfiltered_status) = verify(&path, "explicit", 4, &[]);
+    assert_eq!(unfiltered_status, 1);
+    assert_eq!(unfiltered["result"], "violated");
+    assert_eq!(unfiltered["invariant"], "NeverTrue");
+
+    // Narrowing to the other (always-true) invariant verifies/proves on
+    // both engines.
+    let (explicit, explicit_status) =
+        verify(&path, "explicit", 4, &["--property", "AlwaysBoolean"]);
+    assert_eq!(explicit_status, 0);
+    assert!(matches!(
+        explicit["result"].as_str(),
+        Some("proved" | "verified")
+    ));
+    assert_eq!(explicit["invariants_checked"], json!(["AlwaysBoolean"]));
+
+    let (bmc, bmc_status) = verify(&path, "bmc", 4, &["--property", "AlwaysBoolean"]);
+    assert_eq!(bmc_status, 0);
+    assert_eq!(bmc["result"], "verified");
+    assert_eq!(bmc["invariants_checked"], json!(["AlwaysBoolean"]));
+}

--- a/rust/fslc/tests/fixtures/explicit_deadlock.fsl
+++ b/rust/fslc/tests/fixtures/explicit_deadlock.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitDeadlock {
+  state { done: Bool }
+  init { done = false }
+
+  action finish() {
+    requires not done
+    done = true
+  }
+}

--- a/rust/fslc/tests/fixtures/explicit_exclude_leadsto.fsl
+++ b/rust/fslc/tests/fixtures/explicit_exclude_leadsto.fsl
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitExcludeLeadsTo {
+  state { flag: Bool, done: Bool }
+  init {
+    flag = false
+    done = false
+  }
+
+  action raise() {
+    requires not flag
+    flag = true
+  }
+
+  action finish() {
+    requires flag
+    requires not done
+    done = true
+  }
+
+  invariant DoneImpliesFlag { done => flag }
+
+  leadsTo FlagLeadsToDone {
+    flag ~> done
+  }
+}

--- a/rust/fslc/tests/fixtures/explicit_finite_toggle.fsl
+++ b/rust/fslc/tests/fixtures/explicit_finite_toggle.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitFiniteToggle {
+  state { active: Bool }
+  init { active = false }
+
+  action toggle() {
+    active = not active
+  }
+
+  invariant BooleanState { active or not active }
+}

--- a/rust/fslc/tests/fixtures/explicit_full_enum_keys.fsl
+++ b/rust/fslc/tests/fixtures/explicit_full_enum_keys.fsl
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The fsl-db "per-column" pattern: a map over an enum key type initialized
+// by one statement per key rather than a single forall. Each statement only
+// covers one concrete key, but together they cover the whole key domain and
+// must be recognized as fully initialized.
+spec ExplicitFullEnumKeys {
+  enum Key { A, B }
+
+  state { values: Map<Key, Bool> }
+  init {
+    values[A] = false
+    values[B] = false
+  }
+
+  action flipA() {
+    values[A] = not values[A]
+  }
+
+  invariant AlwaysBoolean { values[A] or not values[A] }
+}

--- a/rust/fslc/tests/fixtures/explicit_init_const_range.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_const_range.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitInitConstRange {
+  const CAP = 2
+  type Slot = 0..2
+
+  state { m: Map<Slot, Bool> }
+  init { forall i in 0..CAP { m[i] = true } }
+
+  action stay() { m[0] = m[0] }
+}

--- a/rust/fslc/tests/fixtures/explicit_init_range_assigned.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_range_assigned.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitInitRangeAssigned {
+  type Slot = 0..2
+
+  state {
+    n: Slot,
+    m: Map<Slot, Bool>
+  }
+  init {
+    n = 2
+    forall i in 0..n { m[i] = true }
+  }
+
+  action stay() { n = n }
+}

--- a/rust/fslc/tests/fixtures/explicit_init_range_unassigned.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_range_unassigned.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitInitRangeUnassigned {
+  type Slot = 0..2
+
+  state {
+    n: Slot,
+    m: Map<Slot, Bool>
+  }
+  init {
+    forall i in 0..n { m[i] = true }
+    n = 0
+  }
+
+  action stay() { n = n }
+}

--- a/rust/fslc/tests/fixtures/explicit_init_state_collection.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_state_collection.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitInitStateCollection {
+  type Slot = 0..2
+
+  state {
+    s: Set<Slot>,
+    m: Map<Slot, Bool>
+  }
+  init {
+    s = Set { 0, 1 }
+    forall i in s { m[i] = true }
+  }
+
+  action stay() { s = s }
+}

--- a/rust/fslc/tests/fixtures/explicit_nondeterministic_init.fsl
+++ b/rust/fslc/tests/fixtures/explicit_nondeterministic_init.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitNondeterministicInit {
+  state { initialized: Bool, omitted: Bool }
+  init { initialized = true }
+
+  action stay() {
+    initialized = initialized
+    omitted = omitted
+  }
+}

--- a/rust/fslc/tests/fixtures/explicit_noninductive.fsl
+++ b/rust/fslc/tests/fixtures/explicit_noninductive.fsl
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// A true-but-not-inductive invariant: x steps by 2 from 0, so only even
+// values are reachable and NeverFive holds. k-induction reports unknown_cti
+// (an unreachable odd state like x = 3 satisfies the premise but steps to 5);
+// explicit closure over {0, 2, 4, 6, 8} proves it without lemmas.
+spec ExplicitNonInductive {
+  type Counter = 0..8
+
+  state { x: Counter }
+  init { x = 0 }
+
+  action step() {
+    requires x <= 6
+    x = x + 2
+  }
+
+  invariant NeverFive { x != 5 }
+}

--- a/rust/fslc/tests/fixtures/explicit_partial_map_key.fsl
+++ b/rust/fslc/tests/fixtures/explicit_partial_map_key.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitPartialMapKey {
+  enum Key { A, B }
+
+  state { values: Map<Key, Bool> }
+  init { values[A] = false }
+
+  action stay() {
+    values[A] = values[A]
+  }
+
+  invariant NotB { not values[B] }
+}

--- a/rust/fslc/tests/fixtures/explicit_partial_subrange.fsl
+++ b/rust/fslc/tests/fixtures/explicit_partial_subrange.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitPartialSubrange {
+  type Slot = 0..2
+
+  state { m: Map<Slot, Bool> }
+  init { forall i in 0..1 { m[i] = true } }
+
+  action stay() {
+    m[0] = m[0]
+  }
+}

--- a/rust/fslc/tests/fixtures/explicit_partial_where.fsl
+++ b/rust/fslc/tests/fixtures/explicit_partial_where.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitPartialWhere {
+  type Slot = 0..2
+
+  state { m: Map<Slot, Bool> }
+  init { forall k: Slot where k < 2 { m[k] = true } }
+
+  action stay() {
+    m[0] = m[0]
+  }
+}

--- a/rust/fslc/tests/fixtures/explicit_property_narrow.fsl
+++ b/rust/fslc/tests/fixtures/explicit_property_narrow.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitPropertyNarrow {
+  state { flag: Bool }
+  init { flag = false }
+
+  action toggle() {
+    flag = not flag
+  }
+
+  invariant AlwaysBoolean { flag or not flag }
+  invariant NeverTrue { not flag }
+}

--- a/rust/fslc/tests/fixtures/explicit_reachable_unreachable_goal.fsl
+++ b/rust/fslc/tests/fixtures/explicit_reachable_unreachable_goal.fsl
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// count can only ever reach 5 (the `requires count < 5` guard on inc()
+// forbids the last step past that), so HitSix is genuinely unreachable. The
+// finite state space {0,1,2,3,4,5} lets explicit-state exploration close
+// and prove that definitively, given enough depth/budget.
+spec ExplicitReachableUnreachableGoal {
+  type Count = 0..5
+
+  state { count: Count }
+  init { count = 0 }
+
+  action inc() {
+    requires count < 5
+    count = count + 1
+  }
+
+  reachable HitSix { count == 6 }
+}

--- a/rust/fslc/tests/fixtures/explicit_reachable_witnessed.fsl
+++ b/rust/fslc/tests/fixtures/explicit_reachable_witnessed.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitReachableWitnessed {
+  type Count = 0..3
+
+  state { count: Count }
+  init { count = 0 }
+
+  action inc() {
+    requires count < 3
+    count = count + 1
+  }
+
+  reachable HitTwo { count == 2 }
+}

--- a/rust/fslc/tests/fixtures/explicit_vacuous.fsl
+++ b/rust/fslc/tests/fixtures/explicit_vacuous.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitVacuous {
+  state { active: Bool }
+  init { active = false }
+
+  action stay() {
+    active = false
+  }
+
+  invariant NeverActivated { active => false }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -684,7 +684,8 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 fslc check <f>                                  # syntax / names / types only
 fslc kernel <f>                                 # normalized typed Kernel JSON for external compilers
 fslc conformance <f> [--depth K=4]              # language-neutral Monitor success/failure vectors
-fslc verify <f> [--depth K=8] [--engine bmc|induction] [--k N=1]
+fslc verify <f> [--depth K=8] [--engine bmc|induction|explicit] [--k N=1]
+               [--explicit-budget N=1000000]        # explicit only; max visited states
                [--deadlock warn|error|ignore] [--vacuity warn|error|ignore]
                [--property <Name>]                  # check one named property in isolation
                                                     #   (invariant / trans / leadsTo / reachable)
@@ -754,8 +755,11 @@ rollback conditions. Use `fslc conformance` plus
 The compatibility policy and field contract are in
 `docs/DESIGN-kernel-contract.md`.
 
-For an induction `unknown_cti`, pass candidate auxiliary invariants with
-repeatable `--lemma "EXPR"`. fslc proves each candidate independently (original
+For an induction `unknown_cti`, first try `--engine explicit` — if exploration
+closes it returns `proved` with **no lemmas at all** (the invariant being
+non-inductive is irrelevant to exhaustive search). Only when explicit is
+rejected or returns `unknown_budget`, fall back to lemma hunting: pass
+candidate auxiliary invariants with repeatable `--lemma "EXPR"`. fslc proves each candidate independently (original
 init/actions + implicit bounds, without original user invariants), rejects
 false/non-inductive/invalid candidates with their own evidence, and makes only
 `proved` candidates available to the target proof. A candidate is used only
@@ -764,6 +768,22 @@ CTI, and violated steps. On final `proved`, copy the declarations from
 `auxiliary_invariant_recommendation` into the spec and review that source edit.
 There is no flag for injecting an unverified assumption, and `--lemma` is an
 error with the BMC engine.
+
+`--engine explicit` enumerates the concrete state space (Z3-free BFS). It is
+the fastest route on small-state-space specs and, when exploration **closes**
+(no new states within `--depth`), returns `result:"proved"` with
+`closure:true` — a complete, unbounded proof that needs no lemmas, including
+for true-but-not-inductive invariants where induction returns `unknown_cti`.
+Depth exhaustion without closure returns bounded `verified` (same strength as
+BMC); exceeding `--explicit-budget` returns `unknown_budget` (exit 1) — never
+a silent `verified`. Violations return the same shortest-counterexample trace
+schema as BMC. Results carry `states_explored`, `max_frontier_width`, and
+`depth_reached`. Fail-closed rejections (kind `semantics`, exit 2): `leadsTo`
+properties, nondeterministic `init` (every state variable must be definitely
+assigned), and `init forall` binder domains that reference state variables
+(range bounds and collections must be compile-time constants) — use
+`--engine bmc` for those specs. `--from-state`, `--lemma`, and `--k` do not
+apply to this engine.
 
 `diff` uses bidirectional bounded refinement for behavior changes, implication
 between the OLD/NEW user-invariant conjunctions, and replay of OLD `forbidden`
@@ -977,7 +997,9 @@ first failed layer and later layers are marked `skipped`.
   null|value / Seq as an array / composition as `alias.var` keys). Internal names
   (`__`) do not appear.
 - `unknown_cti`: `cti.states` (k+1 states) + `violated_at`. The starting state is an
-  unreachable phantom — add an auxiliary invariant to exclude it. For invariant
+  unreachable phantom — before hunting for an auxiliary invariant, try
+  `--engine explicit` (closure proves without lemmas); if that is rejected or
+  exceeds budget, add an auxiliary invariant to exclude the phantom. For invariant
   CTIs (not `leadsTo_rank`), a monotone `Int`/`Map<K, Int>` counter whose CTI
   start lies on the unreachable side of its concrete init value gets a concrete
   candidate in `suggested_invariants: [<expr>, ...]` (also appended to `hint`) —
@@ -991,6 +1013,9 @@ first failed layer and later layers are marked `skipped`.
   `cost`, and `k_used` (the k used per invariant); reachables/coverage come from
   the base case. Ranked leadsTo entries add
   `{proved: true, completeness: "unbounded", proof: "ranking", decreases: ...}`.
+  From `--engine explicit`, `proved` instead carries `closure: true` plus
+  exploration stats (`states_explored`, `max_frontier_width`, `depth_reached`)
+  and no `k_used`; reachables/coverage are definitive (full reachable set).
 - `reachable_failed`: each `unreached[]` has `classification`:
   `insufficient_depth` (target satisfiable as a state predicate, no witness by K)
   or `over_constrained` (target unsat under type bounds/invariants, with

--- a/tools/bench_explicit.py
+++ b/tools/bench_explicit.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Explicit-state engine vs. BMC wall-time benchmark (issue #212).
+
+Not a pytest assertion -- wall-clock timing is inherently noisy across
+machines/CI runners. The mechanical guarantees (verdict agreement with the
+BMC engine, trace replay) live in the Rust integration tests; this script is
+the human-facing acceptance check for "explicit is orders of magnitude
+faster than Z3-based BMC on the small-state-space corpus".
+
+Times the *native* fslc binary end-to-end (process startup included -- that
+is what an LLM write/verify/repair loop actually pays). The verdict cache is
+pointed at a throwaway directory so every timed run is cold.
+
+Usage:
+    python tools/bench_explicit.py [spec.fsl ...] [--depth N] [--runs N]
+                                   [--fslc PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+TERMINAL = {"verified", "proved", "violated", "reachable_failed", "unknown_budget"}
+
+
+def _default_binary() -> Path:
+    for candidate in (
+        ROOT / "rust" / "target" / "release" / "fslc",
+        ROOT / "rust" / "target" / "debug" / "fslc",
+    ):
+        if candidate.exists():
+            return candidate
+    sys.exit(
+        "native fslc binary not found -- build it first:\n"
+        "    cargo build --release -p fslc --manifest-path rust/Cargo.toml"
+    )
+
+
+def _run_once(binary: Path, spec: Path, depth: int, engine: str) -> tuple[float, dict]:
+    with tempfile.TemporaryDirectory(prefix="fslc-bench-explicit-") as cache_dir:
+        env = dict(os.environ, FSLC_CACHE_DIR=cache_dir)
+        start = time.perf_counter()
+        proc = subprocess.run(
+            [str(binary), "verify", str(spec), "--depth", str(depth), "--engine", engine],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        elapsed = time.perf_counter() - start
+    try:
+        out = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.exit(f"{spec.name} ({engine}): non-JSON output:\n{proc.stdout}\n{proc.stderr}")
+    return elapsed, out
+
+
+def _time_engine(binary: Path, spec: Path, depth: int, engine: str, runs: int):
+    best = float("inf")
+    best_engine_s = float("inf")
+    result = "?"
+    for _ in range(runs):
+        elapsed, out = _run_once(binary, spec, depth, engine)
+        result = out.get("result", "?")
+        if result == "error":
+            return None, None, f"error:{out.get('kind', '?')}"
+        assert result in TERMINAL, out
+        best = min(best, elapsed)
+        engine_s = (out.get("cost") or {}).get("elapsed_s")
+        if isinstance(engine_s, (int, float)):
+            best_engine_s = min(best_engine_s, engine_s)
+    return best, best_engine_s, result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("specs", nargs="*", type=Path, default=None)
+    ap.add_argument("--depth", type=int, default=8)
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--fslc", type=Path, default=None, help="native fslc binary")
+    args = ap.parse_args()
+
+    binary = args.fslc or _default_binary()
+    specs = args.specs or sorted((ROOT / "specs").glob("*.fsl"))
+    print(
+        f"{'spec':<30} {'bmc (s)':>10} {'explicit (s)':>13} {'speedup':>9} "
+        f"{'bmc engine(s)':>14} {'expl engine(s)':>15} {'engine x':>9} "
+        f"{'bmc':>16} {'explicit':>16}"
+    )
+    for spec in specs:
+        exp_t, exp_e, exp_r = _time_engine(binary, spec, args.depth, "explicit", args.runs)
+        if exp_t is None:
+            print(f"{spec.name:<30} skipped ({exp_r})")
+            continue
+        bmc_t, bmc_e, bmc_r = _time_engine(binary, spec, args.depth, "bmc", args.runs)
+        speedup = bmc_t / exp_t if exp_t > 0 else float("inf")
+        engine_speedup = bmc_e / exp_e if exp_e > 0 else float("inf")
+        print(
+            f"{spec.name:<30} {bmc_t:>10.4f} {exp_t:>13.4f} {speedup:>8.1f}x "
+            f"{bmc_e:>14.4f} {exp_e:>15.6f} {engine_speedup:>8.1f}x "
+            f"{bmc_r:>16} {exp_r:>16}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #212.

## What

Adds a **Rust-native explicit-state exploration engine** — `fslc verify --engine explicit` — that enumerates the concrete state space on the Z3-free path (`fsl-runtime` BFS). All FSL domains are bounded, so exhaustive concrete exploration is equivalent to BMC up to `--depth`, and **closure** (no new states) is a **complete unbounded proof**:

| Outcome | `result` | Exit |
|---|---|---|
| Violation found | `violated` (shortest trace, BMC-compatible schema) | 1 |
| Depth exhausted, frontier non-empty | `verified` (bounded, BMC-equivalent) | 0 |
| Closure before depth limit | `proved` + `closure: true` + exploration stats | 0 |
| `--explicit-budget` (default 1,000,000 states) exceeded | `unknown_budget` — never a silent `verified` | 1 |
| Unsupported feature | `error` kind `semantics` (fail closed) | 2 |

The frozen Python reference is intentionally unchanged (Rust-only feature, like `approval`).

## Why

- On the small-state-space specs that dominate the corpus, engine-internal time is **8–25× faster than Z3-based BMC** (see benchmark below), and **7 corpus specs upgrade from bounded `verified` to unbounded `proved`**.
- Closure proves **true-but-not-inductive invariants without lemmas**: `explicit_noninductive.fsl` gets `unknown_cti` from `--engine induction` but `proved` from explicit (regression-tested).
- The engine is a **third independent evaluator** (beside symbolic BMC and the concrete Monitor), strengthening the cross-check regime.

## Soundness (fail-closed gates)

Rejected with kind `semantics`, steering to `--engine bmc`:

- `leadsTo` properties (no complete concrete liveness decision procedure) — unless excluded via `--exclude-property`.
- Nondeterministic `init` (every state variable must be definitely assigned). Symbolic BMC treats unassigned init vars as *free*; silently exploring only the default-seeded state would miss violations.
- **Component-partial init** (found by adversarial soundness review): a write to one map key / a subrange or `where`-filtered `forall` no longer counts as assigning the whole variable — coverage is tracked per component and must provably span the full key/field domain. Before this gate, the engine `proved` specs the frozen Python reference reports `violated` at step 0.
- `init forall` binder domains referencing state variables (both reference engines require compile-time-constant domains).

## Verification evidence

- `cargo test -p fsl-runtime -p fsl-verifier -p fslc-rust` — all green, including corpus verdict agreement (explicit vs bmc on every accepted `specs/*.fsl`, equal `violated_at_step`, traces replay through the Monitor).
- Rust/Python parity harnesses: corpus CLI 181 files / BMC 20 / full envelope 43 / CLI snapshot 151 / surface 178 — all matched.
- Python side untouched: corpus snapshot + site-reference snapshot + coupled-change metatests pass.
- Reviewed by `fsl-soundness-reviewer` (found the component-partial-init false negative → fixed + regression fixtures) and `fsl-coupled-change-reviewer` (4 gaps → all addressed: docs/README map row, LANGUAGE.md verdict vocabulary + site regen, cli-contract.json verify node, reachable/property-selection tests).

## Benchmark (`tools/bench_explicit.py`, release build, best of 3)

| spec | bmc end-to-end (s) | explicit end-to-end (s) | bmc engine (s) | explicit engine (s) | engine speedup | verdict change |
|---|---|---|---|---|---|---|
| audit_log | 0.137 | 0.127 | 0.0243 | 0.0019 | **12.6×** | verified → **proved** |
| cart_v1 | 0.150 | 0.132 | 0.0285 | 0.0015 | **19.5×** | verified → **proved** |
| cart_fixed | 0.120 | 0.111 | 0.0138 | 0.0014 | **10.1×** | verified → **proved** |
| inventory_reservation | 1.321 | 0.192 | 1.1845 | 0.0533 | **22.2×** | verified → **proved** |
| payment | 0.574 | 0.336 | 0.4291 | 0.2135 | 2.0× | verified → **proved** |
| seat_booking | 0.161 | 0.135 | 0.0387 | 0.0015 | **25.5×** | verified → **proved** |
| seat_booking_impl | 0.252 | 0.161 | 0.1071 | 0.0220 | 4.9× | verified → **proved** |
| job_pipeline | 0.400 | 0.127 | 0.2742 | 0.0150 | **18.3×** | verified |
| rate_limiter | 0.138 | 0.139 | 0.0145 | 0.0008 | **18.7×** | verified |
| cart_buggy | 0.125 | 0.132 | 0.0078 | 0.0010 | 8.2× | violated (same step & trace) |
| order_system | 4.305 | 3.460 | 4.1456 | 3.3089 | 1.3× | verified |
| order_workflow | 1.667 | 1.204 | 1.5196 | 1.0685 | 1.4× | verified |

(19 corpus specs accepted; 4 rejected: 3 refinement-mapping files rejected by every engine + 1 `leadsTo` spec, excludable via `--exclude-property`.)

End-to-end CLI time is dominated by process startup (~0.11 s) for small specs; the engine-internal column isolates solve time. Large frontiers (order_system) approach parity with BMC — that regime belongs to the symbolic engines (`--engine auto` fallback is future work, see DESIGN doc §10).

## Risk / Review Notes

- **Purely additive contract**: new `--engine explicit` choice, new `--explicit-budget` flag, new `unknown_budget` verdict (exit-1 class). The default engine, all existing verdicts, envelopes, and exit codes are unchanged — corpus CLI parity (181 files) and the Rust CLI snapshot (151 cases) pass unchanged. Verdict-cache keys include engine + budget, so explicit verdicts cannot collide with BMC entries.
- **Reviewer focus**: the soundness-critical code is `check_deterministic_init`/`walk_init` in `rust/fsl-runtime/src/explicit.rs` — the per-component coverage rules decide which specs the engine may verdict at all. The BFS core's dedup ordering (edge properties checked *before* the seen-skip) and the budget check (*before* inserting a new state) are the other two invariants worth eyeballing.
- **Boundary**: `explicit` is accepted only by `fslc verify`; sweep/html/ledger/db/ai/domain/approval still reject it. `--from-state` stays BMC-only, `--lemma` induction-only. No irreversible operations, no migrations.

## Known pre-existing issues surfaced (filed separately, out of scope)

- #220 — `tests/test_rust_cli_contract.py` already fails at HEAD: the Rust contract legitimately contains Rust-only surface (`approval`, now also `verify --engine explicit`/`--explicit-budget`) that the Python argparse export lacks, but the test demands exact equality (CI does not run it).
- #219 — Rust BMC reports an internal error ("trace initial state does not match Monitor init", exit 2) on component-partial-init specs instead of the Python reference's `violated`@0 — fails safe (red), root cause and fix direction in the issue.

## Docs

`docs/DESIGN-explicit-engine.md` (new), `docs/README.md` map row, `docs/LANGUAGE.md` §7 (+ regenerated `docs/intro/*.html`), `skills/fsl/reference.md` (including explicit-first routing on `unknown_cti`), `CHANGELOG.md`, `rust/fslc/cli-contract.json` (native `--help`).

## Follow-Up / Post-Merge

- #226 — `--engine auto` (explicit first, transparent fallback to BMC); the future default-engine candidate.
- #219 / #220 — pre-existing issues surfaced during this work (see above).
- WASM exposure of the explicit engine (Z3-free browser verification) — DESIGN doc §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
