### PR TITLE
fix(bmc): replay partially initialized witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   enveloped result tree reserves `kind` for the diagnostic discriminator.)
 
 ### Fixed
+- Rust BMC witness replay now starts from the solver-projected step-zero state,
+  so partially initialized aggregate components remain legitimately free and
+  invariant counterexamples return `violated` instead of an internal Monitor
+  init mismatch. Explicit `--from-state` snapshots remain authoritative, and
+  top-level `kind: "internal"` envelopes now consistently exit 3 per the CLI
+  contract. The frozen Python reference is unchanged. (#219)
 - **CI**: `tests/test_site_reference_snapshot.py` (added with the doc-site
   rebuild) was missing from every `.github/ci-shards/shard-*.txt`, so
   `pr-shard-coverage` was failing on any PR touching the test suite. Added it

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -212,10 +212,11 @@ fn main() {
     if print_cli_metadata() {
         return;
     }
-    let (output, status) = match command() {
+    let (output, reported_status) = match command() {
         Ok(result) => result,
         Err(error) => (error_output("usage", &error), 2),
     };
+    let status = normalized_exit_status(&output, reported_status);
     println!(
         "{}",
         serde_json::to_string_pretty(&output).expect("serialize CLI output")
@@ -2119,7 +2120,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         };
         let enabled = match monitor.enabled() {
             Ok(enabled) => enabled,
-            Err(error) => return (error_output("internal", &error.to_string()), 2),
+            Err(error) => return (error_output("internal", &error.to_string()), 3),
         };
         let Some(instance) = enabled
             .iter()
@@ -2138,7 +2139,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         };
         let stepped = match monitor.step(instance) {
             Ok(stepped) => stepped,
-            Err(error) => return (error_output("internal", &error.to_string()), 2),
+            Err(error) => return (error_output("internal", &error.to_string()), 3),
         };
         if let Some(violation) = stepped.violation {
             return replay_failure(
@@ -2678,7 +2679,7 @@ fn run_scenarios_mode(
     }
     let mut solver = match fsl_solver_z3::Z3Solver::new() {
         Ok(solver) => solver,
-        Err(error) => return (error_output("internal", &error.to_string()), 2),
+        Err(error) => return (error_output("internal", &error.to_string()), 3),
     };
     let result = match block_on_native(fsl_verifier::verify_bounded(&model, &mut solver, depth)) {
         Ok(result) => result,
@@ -2691,11 +2692,11 @@ fn run_scenarios_mode(
         return run_verify(path, depth, deadlock_mode, "bmc", 1);
     }
     if let Err(error) = replay_all(&model, &result, None) {
-        return (error_output("internal", &error), 2);
+        return (error_output("internal", &error), 3);
     }
     let covers = match fsl_runtime::action_cover_traces(model.clone(), depth) {
         Ok(covers) => covers,
-        Err(error) => return (error_output("internal", &error.to_string()), 2),
+        Err(error) => return (error_output("internal", &error.to_string()), 3),
     };
     let mut scenario_warnings = result
         .reachables
@@ -2743,7 +2744,7 @@ fn run_scenarios_mode(
     }
     let responses = match fsl_runtime::leadsto_response_traces(&model, depth) {
         Ok(responses) => responses,
-        Err(error) => return (error_output("internal", &error.to_string()), 2),
+        Err(error) => return (error_output("internal", &error.to_string()), 3),
     };
     let response_names = responses
         .iter()
@@ -3458,7 +3459,7 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     };
     let mut result = match fsl_tools::check_db(&system) {
         Ok(Value::Object(result)) => result,
-        Ok(_) => return (error_output("internal", "invalid database result"), 2),
+        Ok(_) => return (error_output("internal", "invalid database result"), 3),
         Err(error) => return (semantic_error_output(&error.to_string()), 2),
     };
     let status = if result.get("result").and_then(Value::as_str) == Some("violated") {
@@ -3519,7 +3520,7 @@ fn run_db_observe(path: &Path, trace: &Path) -> (Value, i32) {
         }
         Ok(_) => (
             error_output("internal", "invalid database observation result"),
-            2,
+            3,
         ),
         Err(error) => (semantic_error_output(&error.to_string()), 2),
     }
@@ -3604,7 +3605,7 @@ fn stable_kernel_projection(kernel: Value) -> Value {
 
 fn wrap_specialized(result: Value) -> (Value, i32) {
     let Value::Object(mut result) = result else {
-        return (error_output("internal", "invalid specialized result"), 2);
+        return (error_output("internal", "invalid specialized result"), 3);
     };
     result.retain(|_, value| !value.is_null());
     let status = match result.get("result").and_then(Value::as_str) {
@@ -4192,7 +4193,7 @@ fn run_domain_generate(
     };
     if let Some(output_path) = output_path {
         let Value::Object(object) = &mut result else {
-            return (error_output("internal", "invalid scaffold result"), 2);
+            return (error_output("internal", "invalid scaffold result"), 3);
         };
         if let Err(error) = std::fs::create_dir_all(output_path) {
             return (error_output("io", &error.to_string()), 2);
@@ -11493,7 +11494,7 @@ fn run_refine(
     let progress = if checked.failure.is_none() && !mapping.progress.is_empty() {
         let mut solver = match fsl_solver_z3::Z3Solver::new() {
             Ok(solver) => solver,
-            Err(error) => return (error_output("internal", &error.to_string()), 2),
+            Err(error) => return (error_output("internal", &error.to_string()), 3),
         };
         match block_on_native(fsl_verifier::check_refinement_progress(
             &implementation,
@@ -11577,11 +11578,11 @@ fn run_refine(
         let Some(details) = &violation.leads_to else {
             return (
                 error_output("internal", "missing refinement progress diagnostics"),
-                2,
+                3,
             );
         };
         if let Err(error) = fsl_runtime::replay_trace(implementation.clone(), &violation.trace) {
-            return (error_output("internal", &error.to_string()), 2);
+            return (error_output("internal", &error.to_string()), 3);
         }
         let declaration = mapping
             .progress
@@ -12658,10 +12659,15 @@ fn replay_all(
     initial_state: Option<&std::collections::BTreeMap<String, FslValue>>,
 ) -> Result<(), String> {
     let replay = |trace: &[fsl_core::TraceStep]| {
-        initial_state.map_or_else(
-            || fsl_runtime::replay_trace(model.clone(), trace),
-            |state| fsl_runtime::replay_trace_from_state(model.clone(), trace, state),
-        )
+        // Symbolic init may leave individual state components unconstrained.
+        // The witness state is the concrete seed for that chosen model;
+        // Monitor::new uses defaults and cannot reproduce those free values.
+        initial_state
+            .or_else(|| trace.first().map(|entry| &entry.state))
+            .map_or_else(
+                || fsl_runtime::replay_trace(model.clone(), trace),
+                |state| fsl_runtime::replay_trace_from_state(model.clone(), trace, state),
+            )
     };
     if let Some(violation) = &result.violation {
         replay(&violation.trace).map_err(|error| error.to_string())?;
@@ -12690,6 +12696,16 @@ fn error_output(kind: &str, message: &str) -> Value {
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message));
     Value::Object(output)
+}
+
+fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {
+    if output.get("result").and_then(Value::as_str) == Some("error")
+        && output.get("kind").and_then(Value::as_str) == Some("internal")
+    {
+        3
+    } else {
+        reported_status
+    }
 }
 
 fn semantic_error_output(message: &str) -> Value {
@@ -12736,5 +12752,22 @@ fn block_on_native<F: Future>(future: F) -> F::Output {
     match future.as_mut().poll(&mut context) {
         Poll::Ready(result) => result,
         Poll::Pending => panic!("native Z3 backend unexpectedly yielded Pending"),
+    }
+}
+
+#[cfg(test)]
+mod exit_status_tests {
+    use super::*;
+
+    #[test]
+    fn internal_error_envelopes_always_exit_three() {
+        assert_eq!(
+            normalized_exit_status(&error_output("internal", "fault"), 2),
+            3
+        );
+        assert_eq!(
+            normalized_exit_status(&error_output("semantics", "bad spec"), 2),
+            2
+        );
     }
 }

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -100,7 +100,7 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
     let Value::Object(base) = &base_value else {
         return (
             error_output("internal", "BMC returned a non-object envelope"),
-            2,
+            3,
         );
     };
     if base.get("result").and_then(Value::as_str) != Some("verified") {
@@ -113,7 +113,7 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
     };
     let mut solver = match fsl_solver_z3::Z3Solver::new() {
         Ok(solver) => solver,
-        Err(error) => return (error_output("internal", &error.to_string()), 2),
+        Err(error) => return (error_output("internal", &error.to_string()), 3),
     };
     let induction = match block_on_native(fsl_verifier::prove_induction(&model, &mut solver, k)) {
         Ok(result) => result,
@@ -453,7 +453,7 @@ fn solve_bmc(
 ) -> Result<fsl_verifier::BmcResult, CommandResult> {
     let mut solver = match fsl_solver_z3::Z3Solver::new() {
         Ok(solver) => solver,
-        Err(error) => return Err((error_output("internal", &error.to_string()), 2)),
+        Err(error) => return Err((error_output("internal", &error.to_string()), 3)),
     };
     let verification = if let Some(initial_state) = request.initial_state {
         block_on_native(fsl_verifier::verify_bounded_from_state(
@@ -476,7 +476,7 @@ fn solve_bmc(
         Err(error) => return Err((semantic_error_output(&error.to_string()), 2)),
     };
     if let Err(error) = replay_all(&prepared.model, &result, request.initial_state) {
-        return Err((error_output("internal", &error), 2));
+        return Err((error_output("internal", &error), 3));
     }
     Ok(result)
 }
@@ -705,7 +705,7 @@ fn render_leadsto_failure(
     started: Instant,
 ) -> (Value, i32) {
     let Some(details) = &violation.leads_to else {
-        return (error_output("internal", "missing leadsTo diagnostics"), 2);
+        return (error_output("internal", "missing leadsTo diagnostics"), 3);
     };
     let property = model
         .leadstos

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -61,6 +61,28 @@ fn native_cli_preserves_bmc_outcomes() {
 }
 
 #[test]
+fn native_cli_replays_witnesses_from_partially_initialized_state() {
+    let (violated, status) = run_cli(&[
+        "verify",
+        "tests/fixtures/rust_port/partial_map_init.fsl",
+        "--depth",
+        "4",
+        "--engine",
+        "bmc",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1);
+    assert_eq!(violated["result"], "violated");
+    assert_eq!(violated["violation_kind"], "invariant");
+    assert_eq!(violated["invariant"], "NotB");
+    assert_eq!(violated["violated_at_step"], 0);
+    assert_eq!(violated["trace"][0]["state"]["values"]["A"], false);
+    assert_eq!(violated["trace"][0]["state"]["values"]["B"], true);
+}
+
+#[test]
 fn native_cli_preserves_induction_outcomes() {
     let (proved, status) = run_cli(&[
         "verify",

--- a/tests/fixtures/rust_port/partial_map_init.fsl
+++ b/tests/fixtures/rust_port/partial_map_init.fsl
@@ -1,0 +1,19 @@
+spec ProbePartialMap {
+  enum Key { A, B }
+
+  state {
+    values: Map<Key, Bool>
+  }
+
+  init {
+    values[A] = false
+  }
+
+  action noop() {
+    values[A] = values[A]
+  }
+
+  invariant NotB {
+    not values[B]
+  }
+}


### PR DESCRIPTION
## Summary

Fix Rust BMC witness replay for specs whose `init` leaves aggregate components unconstrained. Counterexamples now replay from the solver-projected step-zero state and return the expected `violated` result instead of an internal Monitor init mismatch.

The frozen Python reference is unchanged.

## Root cause

The symbolic BMC correctly leaves unassigned components free, but concrete replay previously started from `Monitor::new`, which seeds deterministic default values. A valid symbolic witness could therefore disagree with the Monitor only at step zero and be misclassified as an internal error.

## Changes

- Seed symbolic witness replay from each trace's projected step-zero state unless an explicit `--from-state` snapshot was supplied.
- Preserve concrete checks for enabled actions, successor states, and change sets after step zero.
- Normalize top-level `kind: "internal"` envelopes to exit code 3 per the public CLI contract.
- Add a partial-Map-init fixture and native CLI regression test.
- Document the fix under `[Unreleased]`.

## Predict-Light

- Level: P1
- Risk surface: verifier soundness and public CLI exit-code contract
- Public API, dependency, persistence, auth, and billing boundaries are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- Direct Rust CLI reproduction: `violated`, exit 1, `violated_at_step: 0`, witness `values.B: true`
- AdvisoryGraphen micro review: 4/4 claims evidence-referenced, 0 obstructions, no full-workflow escalation

Closes #219
