### PR TITLE
fix(cli): validate the explicit Rust-only CLI surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: ci
 
 # Python is a frozen reference implementation. CI validates the primary Rust
-# workspace, solver boundary, and browser/WASM distribution surfaces.
+# workspace, its compatibility contract against that reference, the solver
+# boundary, and browser/WASM distribution surfaces.
 
 on:
   push:
@@ -15,6 +16,28 @@ permissions:
   contents: read
 
 jobs:
+  rust-cli-contract:
+    name: Rust CLI contract against frozen Python reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      Z3_SYS_Z3_VERSION: "4.16.0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install frozen Python reference test dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Validate Rust CLI compatibility and Rust-only surface
+        run: python -m pytest tests/test_rust_cli_contract.py -q
+
   rust-workspace-wasm:
     name: rust workspace and WASM
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- Rust CLI contract validation (issue #220) now preserves exact compatibility
+  with the frozen Python surface while checking native-only commands and
+  options against an explicit structural allowlist. CI runs the focused
+  contract and help-parity suite, including a mutation regression that rejects
+  unlisted choice drift and runtime probes for invalid choices and help paths.
+
 ### Added
 - Explicit-state exploration engine (issue #212): native Rust
   `fslc verify --engine explicit` enumerates the concrete state space on the

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -268,6 +268,12 @@ fn print_cli_metadata() -> bool {
                     == Some(segment)
             })
         }) else {
+            if node["commands"]
+                .as_array()
+                .is_some_and(|commands| !commands.is_empty())
+            {
+                return false;
+            }
             break;
         };
         node = next;

--- a/tests/rust_only_surface.json
+++ b/tests/rust_only_surface.json
@@ -316,26 +316,6 @@
   "action_overrides": [
     {
       "path": [
-        "refine"
-      ],
-      "index": 4,
-      "python": {
-        "dest": "rest",
-        "required": true,
-        "positional": true,
-        "nargs": "*",
-        "action": "store"
-      },
-      "rust": {
-        "dest": "rest",
-        "required": false,
-        "positional": true,
-        "nargs": "*",
-        "action": "store"
-      }
-    },
-    {
-      "path": [
         "verify"
       ],
       "index": 3,

--- a/tests/rust_only_surface.json
+++ b/tests/rust_only_surface.json
@@ -1,0 +1,392 @@
+{
+  "rust_only_nodes": [
+    {
+      "path": [
+        "approval"
+      ],
+      "parent_index": 10,
+      "prog": "fslc approval",
+      "help_sha256": "032a95ef0586ed63999c1554167f31a295a7cc64adcf3346bba9dd57bbdd1618",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        }
+      ],
+      "commands": [
+        "create",
+        "check",
+        "diff"
+      ]
+    },
+    {
+      "path": [
+        "approval",
+        "check"
+      ],
+      "parent_index": 1,
+      "prog": "fslc approval check",
+      "help_sha256": "4d6712f7502b3fa1ed3961330d467dcc5a3d07a78d05c5a92f17b84650dc013e",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "file",
+          "required": true,
+          "positional": true,
+          "action": "store"
+        },
+        {
+          "dest": "record",
+          "required": true,
+          "flags": [
+            "--record"
+          ],
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
+        "approval",
+        "create"
+      ],
+      "parent_index": 0,
+      "prog": "fslc approval create",
+      "help_sha256": "581f1401ef342238de077018d64efe62b754b57de8719fdd0cb19abea181761e",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "file",
+          "required": true,
+          "positional": true,
+          "action": "store"
+        },
+        {
+          "dest": "kind",
+          "required": true,
+          "flags": [
+            "--kind"
+          ],
+          "choices": [
+            "ledger",
+            "html",
+            "scenarios"
+          ],
+          "action": "store"
+        },
+        {
+          "dest": "artifact",
+          "required": true,
+          "flags": [
+            "--artifact"
+          ],
+          "action": "store"
+        },
+        {
+          "dest": "approver",
+          "required": true,
+          "flags": [
+            "--approver"
+          ],
+          "action": "store"
+        },
+        {
+          "dest": "requirement",
+          "required": false,
+          "flags": [
+            "--requirement"
+          ],
+          "repeatable": true,
+          "action": "store"
+        },
+        {
+          "dest": "depth",
+          "required": false,
+          "flags": [
+            "--depth"
+          ],
+          "default": 8,
+          "action": "store"
+        },
+        {
+          "dest": "deadlock",
+          "required": false,
+          "flags": [
+            "--deadlock"
+          ],
+          "choices": [
+            "warn",
+            "error",
+            "ignore"
+          ],
+          "default": "ignore",
+          "action": "store"
+        },
+        {
+          "dest": "engine",
+          "required": false,
+          "flags": [
+            "--engine"
+          ],
+          "choices": [
+            "bmc",
+            "induction"
+          ],
+          "default": "bmc",
+          "action": "store"
+        },
+        {
+          "dest": "output",
+          "required": false,
+          "flags": [
+            "-o",
+            "--output"
+          ],
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
+        "approval",
+        "diff"
+      ],
+      "parent_index": 2,
+      "prog": "fslc approval diff",
+      "help_sha256": "4168a8172ca50a3c84ac5113a6c02944e2322169716cd8c72c0af7cf3efab9f0",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "file",
+          "required": true,
+          "positional": true,
+          "action": "store"
+        },
+        {
+          "dest": "record",
+          "required": true,
+          "flags": [
+            "--record"
+          ],
+          "action": "store"
+        },
+        {
+          "dest": "depth",
+          "required": false,
+          "flags": [
+            "--depth"
+          ],
+          "default": 8,
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
+        "conformance"
+      ],
+      "parent_index": 20,
+      "prog": "fslc conformance",
+      "help_sha256": "0dc0b72607b492b1e610226d4bf0e4bb8b12567c0878bcaab08cd7170a9685fc",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "file",
+          "required": true,
+          "positional": true,
+          "action": "store"
+        },
+        {
+          "dest": "depth",
+          "required": false,
+          "flags": [
+            "--depth"
+          ],
+          "default": 4,
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
+        "kernel"
+      ],
+      "parent_index": 21,
+      "prog": "fslc kernel",
+      "help_sha256": "36be1eae907ad5f6395027d2d9fbc3a6cff9023dced823760ea878a4d8cdee70",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "file",
+          "required": true,
+          "positional": true,
+          "action": "store"
+        }
+      ],
+      "commands": []
+    }
+  ],
+  "rust_only_actions": [
+    {
+      "path": [
+        "ledger"
+      ],
+      "index": 8,
+      "action": {
+        "dest": "approval",
+        "required": false,
+        "flags": [
+          "--approval"
+        ],
+        "repeatable": true,
+        "action": "store"
+      }
+    },
+    {
+      "path": [
+        "verify"
+      ],
+      "index": 5,
+      "action": {
+        "dest": "explicit_budget",
+        "required": false,
+        "flags": [
+          "--explicit-budget"
+        ],
+        "default": 1000000,
+        "action": "store"
+      }
+    }
+  ],
+  "action_overrides": [
+    {
+      "path": [
+        "refine"
+      ],
+      "index": 4,
+      "python": {
+        "dest": "rest",
+        "required": true,
+        "positional": true,
+        "nargs": "*",
+        "action": "store"
+      },
+      "rust": {
+        "dest": "rest",
+        "required": false,
+        "positional": true,
+        "nargs": "*",
+        "action": "store"
+      }
+    },
+    {
+      "path": [
+        "verify"
+      ],
+      "index": 3,
+      "python": {
+        "dest": "engine",
+        "required": false,
+        "flags": [
+          "--engine"
+        ],
+        "choices": [
+          "bmc",
+          "induction"
+        ],
+        "default": "bmc",
+        "action": "store"
+      },
+      "rust": {
+        "dest": "engine",
+        "required": false,
+        "flags": [
+          "--engine"
+        ],
+        "choices": [
+          "bmc",
+          "induction",
+          "explicit"
+        ],
+        "default": "bmc",
+        "action": "store"
+      }
+    }
+  ],
+  "help_overrides": [
+    {
+      "path": [],
+      "python_sha256": "731a3fd77cc65de2bd63dbf5fe84d72edd9361089f618aa0998fd294bd6f4392",
+      "rust_sha256": "cc7761e0e5839fa09423b77dba131e92100dfdca3b04c9e1c1316aff5b469949"
+    },
+    {
+      "path": [
+        "ledger"
+      ],
+      "python_sha256": "9bc531a1d829f7e1da5b9deaba1e36c57005357cb54be9715f2f601582b6ed9e",
+      "rust_sha256": "ba5dc8215863e6b2c4f81ade041a09fd9413647746e67e5b6ab841d6b11b44b3"
+    },
+    {
+      "path": [
+        "verify"
+      ],
+      "python_sha256": "6616a6b36c0b9694b571449e9100c0507018b84c35aab1f2918024f8754cc948",
+      "rust_sha256": "120d39603796ab9509bddb97aa5ee23f251e344bbf0e2763524c437ecefb5981"
+    }
+  ]
+}

--- a/tests/test_rust_cli_contract.py
+++ b/tests/test_rust_cli_contract.py
@@ -38,6 +38,16 @@ def _help_sha256(node: dict) -> str:
     return hashlib.sha256(node["help"].encode()).hexdigest()
 
 
+def _normalize_python_contract(contract: dict) -> dict:
+    """Remove argparse-version artifacts that do not change CLI semantics."""
+    normalized = copy.deepcopy(contract)
+    for node in _walk(normalized["root"]):
+        for action in node["actions"]:
+            if action.get("positional") and action.get("nargs") == "*":
+                action["required"] = False
+    return normalized
+
+
 def _rust_only_node(path: tuple[str, ...], nodes: dict[tuple[str, ...], dict]) -> dict:
     node = nodes[path]
     parent = nodes[path[:-1]]
@@ -57,6 +67,7 @@ def _rust_only_node(path: tuple[str, ...], nodes: dict[tuple[str, ...], dict]) -
 
 def _surface_delta(python_contract: dict, rust_contract: dict) -> dict:
     """Return the complete structural surface added or changed by Rust."""
+    python_contract = _normalize_python_contract(python_contract)
     assert set(rust_contract) == set(python_contract) == {"schema", "root"}
     assert rust_contract["schema"] == python_contract["schema"]
     python_nodes = _nodes(python_contract)
@@ -196,6 +207,18 @@ def test_unlisted_help_drift_is_rejected(rust_contract):
 
     with pytest.raises(AssertionError):
         _assert_rust_surface_is_allowed(export_contract(), mutant)
+
+
+def test_argparse_star_positional_required_artifact_is_normalized(rust_contract):
+    for required in (False, True):
+        python_contract = export_contract()
+        rest = next(
+            action
+            for action in _nodes(python_contract)[("refine",)]["actions"]
+            if action["dest"] == "rest"
+        )
+        rest["required"] = required
+        _assert_rust_surface_is_allowed(python_contract, rust_contract)
 
 
 def test_duplicate_rust_only_command_path_is_rejected(rust_contract):

--- a/tests/test_rust_cli_contract.py
+++ b/tests/test_rust_cli_contract.py
@@ -1,19 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Complete Python-to-Rust public CLI surface contract."""
+"""Frozen Python CLI compatibility plus an explicit Rust-only surface."""
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from tools.export_cli_contract import export_contract
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUST = ROOT / "rust" / "target" / "debug" / "fslc"
+RUST_ONLY_SURFACE = ROOT / "tests" / "rust_only_surface.json"
 
 
 def _walk(node: dict):
@@ -22,17 +27,129 @@ def _walk(node: dict):
         yield from _walk(child)
 
 
-def test_cli_contract_export_is_deterministic_and_complete():
-    first = export_contract()
-    second = export_contract()
-    assert first == second
-    paths = {tuple(node["path"]) for node in _walk(first["root"])}
-    assert ("verify",) in paths
-    assert ("ai", "replay") in paths
-    assert ("domain", "generate") in paths
+def _nodes(contract: dict) -> dict[tuple[str, ...], dict]:
+    walked = list(_walk(contract["root"]))
+    nodes = {tuple(node["path"]): node for node in walked}
+    assert len(nodes) == len(walked), "CLI contract paths must be unique"
+    return nodes
 
 
-def test_rust_embeds_the_current_python_cli_contract():
+def _help_sha256(node: dict) -> str:
+    return hashlib.sha256(node["help"].encode()).hexdigest()
+
+
+def _rust_only_node(path: tuple[str, ...], nodes: dict[tuple[str, ...], dict]) -> dict:
+    node = nodes[path]
+    parent = nodes[path[:-1]]
+    return {
+        "path": list(path),
+        "parent_index": next(
+            index
+            for index, child in enumerate(parent["commands"])
+            if tuple(child["path"]) == path
+        ),
+        "prog": node["prog"],
+        "help_sha256": _help_sha256(node),
+        "actions": node["actions"],
+        "commands": [child["path"][-1] for child in node["commands"]],
+    }
+
+
+def _surface_delta(python_contract: dict, rust_contract: dict) -> dict:
+    """Return the complete structural surface added or changed by Rust."""
+    assert set(rust_contract) == set(python_contract) == {"schema", "root"}
+    assert rust_contract["schema"] == python_contract["schema"]
+    python_nodes = _nodes(python_contract)
+    rust_nodes = _nodes(rust_contract)
+    expected_node_fields = {"path", "prog", "help", "actions", "commands"}
+    assert all(set(node) == expected_node_fields for node in rust_nodes.values())
+
+    missing_nodes = sorted(set(python_nodes) - set(rust_nodes))
+    assert not missing_nodes, f"Rust is missing Python CLI nodes: {missing_nodes}"
+
+    rust_only_nodes = [
+        _rust_only_node(path, rust_nodes)
+        for path in sorted(set(rust_nodes) - set(python_nodes))
+    ]
+    rust_only_actions = []
+    action_overrides = []
+
+    for path in sorted(python_nodes):
+        python_node = python_nodes[path]
+        rust_node = rust_nodes[path]
+        assert rust_node["path"] == python_node["path"]
+        assert rust_node["prog"] == python_node["prog"]
+
+        python_children = [tuple(child["path"]) for child in python_node["commands"]]
+        rust_children = [tuple(child["path"]) for child in rust_node["commands"]]
+        assert [child for child in rust_children if child in python_nodes] == python_children
+
+        python_actions = {action["dest"]: action for action in python_node["actions"]}
+        rust_actions = {action["dest"]: action for action in rust_node["actions"]}
+        missing_actions = [dest for dest in python_actions if dest not in rust_actions]
+        assert not missing_actions, (
+            f"Rust node {path} is missing Python actions: {missing_actions}"
+        )
+        assert [
+            action["dest"]
+            for action in rust_node["actions"]
+            if action["dest"] in python_actions
+        ] == list(python_actions)
+
+        for index, action in enumerate(rust_node["actions"]):
+            dest = action["dest"]
+            if dest not in python_actions:
+                rust_only_actions.append(
+                    {"path": list(path), "index": index, "action": action}
+                )
+            elif action != python_actions[dest]:
+                action_overrides.append(
+                    {
+                        "path": list(path),
+                        "index": index,
+                        "python": python_actions[dest],
+                        "rust": action,
+                    }
+                )
+
+    return {
+        "rust_only_nodes": rust_only_nodes,
+        "rust_only_actions": rust_only_actions,
+        "action_overrides": action_overrides,
+    }
+
+
+def _assert_rust_surface_is_allowed(python_contract: dict, rust_contract: dict) -> None:
+    policy = json.loads(RUST_ONLY_SURFACE.read_text(encoding="utf-8"))
+    assert set(policy) == {
+        "rust_only_nodes",
+        "rust_only_actions",
+        "action_overrides",
+        "help_overrides",
+    }
+    assert _surface_delta(python_contract, rust_contract) == {
+        key: policy[key]
+        for key in ("rust_only_nodes", "rust_only_actions", "action_overrides")
+    }
+
+    python_nodes = _nodes(python_contract)
+    rust_nodes = _nodes(rust_contract)
+    actual_help_overrides = [
+        {
+            "path": list(path),
+            "python_sha256": _help_sha256(python_node),
+            "rust_sha256": _help_sha256(rust_nodes[path]),
+        }
+        for path, python_node in python_nodes.items()
+        if rust_nodes[path]["help"] != python_node["help"]
+    ]
+    assert sorted(actual_help_overrides, key=lambda item: item["path"]) == policy[
+        "help_overrides"
+    ]
+
+
+@pytest.fixture(scope="module")
+def rust_contract() -> dict:
     subprocess.run(
         ["cargo", "build", "--quiet", "--locked", "-p", "fslc-rust"],
         cwd=ROOT / "rust",
@@ -46,12 +163,87 @@ def test_rust_embeds_the_current_python_cli_contract():
         check=False,
     )
     assert proc.returncode == 0, proc.stderr
-    assert json.loads(proc.stdout) == export_contract()
+    return json.loads(proc.stdout)
 
 
-def test_rust_help_matches_argparse_at_every_command_path():
-    contract = export_contract()
-    for node in _walk(contract["root"]):
+def test_cli_contract_export_is_deterministic_and_complete():
+    first = export_contract()
+    second = export_contract()
+    assert first == second
+    paths = {tuple(node["path"]) for node in _walk(first["root"])}
+    assert ("verify",) in paths
+    assert ("ai", "replay") in paths
+    assert ("domain", "generate") in paths
+
+
+def test_rust_surface_extends_frozen_python_contract_only_by_policy(rust_contract):
+    _assert_rust_surface_is_allowed(export_contract(), rust_contract)
+
+
+def test_unlisted_choice_mismatch_is_rejected(rust_contract):
+    mutant = copy.deepcopy(rust_contract)
+    verify = _nodes(mutant)[("verify",)]
+    engine = next(action for action in verify["actions"] if action["dest"] == "engine")
+    engine["choices"][-1] = "explict"
+
+    with pytest.raises(AssertionError):
+        _assert_rust_surface_is_allowed(export_contract(), mutant)
+
+
+def test_unlisted_help_drift_is_rejected(rust_contract):
+    mutant = copy.deepcopy(rust_contract)
+    _nodes(mutant)[()]["help"] = "arbitrary help drift\n"
+
+    with pytest.raises(AssertionError):
+        _assert_rust_surface_is_allowed(export_contract(), mutant)
+
+
+def test_duplicate_rust_only_command_path_is_rejected(rust_contract):
+    mutant = copy.deepcopy(rust_contract)
+    approval = copy.deepcopy(_nodes(mutant)[("approval",)])
+    mutant["root"]["commands"].append(approval)
+
+    with pytest.raises(AssertionError, match="paths must be unique"):
+        _assert_rust_surface_is_allowed(export_contract(), mutant)
+
+
+def test_rust_parser_rejects_unlisted_engine_choice(rust_contract):
+    proc = subprocess.run(
+        [str(RUST), "verify", "specs/cart_v1.fsl", "--engine", "explict"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "--engine must be bmc, induction, or explicit" in proc.stdout
+
+
+def test_unknown_help_path_is_rejected(rust_contract):
+    proc = subprocess.run(
+        [str(RUST), "not-a-command", "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+
+
+def test_help_after_leaf_command_arguments_uses_that_command(rust_contract):
+    proc = subprocess.run(
+        [str(RUST), "verify", "specs/cart_v1.fsl", "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == _nodes(rust_contract)[("verify",)]["help"]
+
+
+def test_rust_help_matches_embedded_contract_at_every_command_path(rust_contract):
+    for node in _walk(rust_contract["root"]):
         proc = subprocess.run(
             [str(RUST), *node["path"], "--help"],
             cwd=ROOT,


### PR DESCRIPTION
## Summary

- replace exact Python↔Rust CLI equality with an explicit structural allowlist for native-only Rust commands and options
- pin Rust-only help text and allowed common-node help differences by SHA-256, while rejecting missing, reordered, duplicated, or unlisted contract surface
- normalize the Python `argparse` representation of `nargs="*"` positionals so the semantic contract is stable across supported Python versions
- add runtime probes for invalid engine choices, unknown help paths, and help after leaf-command arguments
- run the focused Rust CLI contract suite in CI without changing the frozen Python implementation

## Root cause

The contract test required the embedded Rust CLI contract to equal the frozen Python argparse export byte-for-byte. Native Rust features such as `approval`, `kernel`, `conformance`, `verify --engine explicit`, and `--explicit-budget` are intentional, so the equality invariant had become permanently false while CI no longer ran the test.

## Validation

- `.venv/bin/pytest tests/test_rust_cli_contract.py -q` — 10 passed
- `.venv/bin/pytest -q` — 1398 passed, 78 skipped
- `cargo test --workspace --locked`
- `cargo test --locked -p fslc-rust`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --workspace --locked`
- `git diff --check`

Closes #220
