### PR TITLE
refactor(typestate): consume public Kernel JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Public-Kernel-backed native typestate generation (issue #215): Rust
+  `fslc typestate` now performs applicability analysis and TypeScript scaffold
+  generation from versioned public Kernel JSON v1 instead of private
+  `KernelModel` structures. The adapter validates schema identity/version,
+  restores declaration order from public spans, and preserves existing report
+  and `--ts` bytes with golden tests. The old private-model adapter is retired
+  from the native CLI path; the frozen Python reference remains unchanged.
 - Explicit-state exploration engine (issue #212): native Rust
   `fslc verify --engine explicit` enumerates the concrete state space on the
   Z3-free path (`fsl-runtime` BFS with `BTreeSet` dedup and parent-link

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -151,6 +151,9 @@ the golden failure vectors, and this guide. Target-specific generators remain
 supported, but their next versions
 should consume public Kernel JSON rather than internal model/AST shapes. Their
 migration/deprecation is intentionally tracked as separate follow-up issues:
-domain scaffolds [#213](https://github.com/ymm-oss/fsl/issues/213), general test
-generators [#214](https://github.com/ymm-oss/fsl/issues/214), and typestate
-TypeScript output [#215](https://github.com/ymm-oss/fsl/issues/215).
+domain scaffolds [#213](https://github.com/ymm-oss/fsl/issues/213) and general
+test generators [#214](https://github.com/ymm-oss/fsl/issues/214). Native Rust
+typestate analysis and TypeScript output completed this migration in
+[#215](https://github.com/ymm-oss/fsl/issues/215): the CLI now feeds public
+Kernel JSON v1 to the generator, rejects incompatible schema versions, and no
+longer uses the private-model adapter. The frozen Python reference is unchanged.

--- a/docs/DESIGN-typestate.md
+++ b/docs/DESIGN-typestate.md
@@ -38,17 +38,27 @@ dropping a transition it could not understand** (it errs on the sound side). If 
 
 ## 5. Ripple / implementation
 
-- New `src/fslc/typestate.py`. Spec-dict traversal only, **verification engine and Z3
-  unmodified**. The enum form is judged by the pair `_enum_guard_states` / `_enum_assignments`
-  / `_enum_is_status_only`, the Option form by the `_opt_*` pair, and `_classify` produces the
-  three-way classification and per-entity applicability. Reserved-word collisions for TS
-  identifiers are avoided with `RESERVED_TS`.
-- cli.py: the `typestate` subcommand (`run_typestate`). Add `"typestate"` to the success set of
-  `exit_code`.
+- The frozen Python reference remains in `src/fslc/typestate.py`; it is not the
+  implementation path for native Rust releases.
+- The native Rust CLI parses and checks the source once, projects it through
+  `fsl_core::public_kernel_contract`, and passes only public Kernel JSON v1 to
+  `fsl_tools::analyze_typestate`. The adapter validates `$schema` and
+  `schema_version` before constructing the small typestate-specific view.
+- The old native adapter that accepted `KernelModel` directly is deprecated and
+  retired from the CLI path. Rust callers should export public Kernel JSON and
+  call the JSON adapter; private AST/model shapes are not a generator contract.
+- Public Kernel actions are normalized by name. Typestate restores declaration
+  order from public source spans so the report and `--ts` output remain byte
+  compatible with the established CLI contract.
+- The verification engine and solver are unmodified. Reserved-word collisions
+  for TypeScript identifiers remain escaped by the existing emitter.
 
 ## 6. Tests / related
 
-tests/test_typestate.py. Originates from a separate PR (#10 phantom-gen-experiment). In bridging
-formal specs to the implementation side's type system it is the same family as DESIGN-bridge
-(testgen / Monitor) — whereas bridge emits "behavioral conformance tests," typestate judges
-"the promotability of state premises into **types**."
+The frozen reference behavior remains covered by `tests/test_typestate.py`.
+Native coverage additionally checks the public-Kernel adapter, rejects unknown
+schema versions, and compares both JSON and `--ts` bytes with v1 golden files.
+In bridging formal specs to the implementation side's type system it is the same
+family as DESIGN-bridge (testgen / Monitor) — whereas bridge emits "behavioral
+conformance tests," typestate judges "the promotability of state premises into
+**types**."

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2057,4 +2057,8 @@ guard, and the precondition lives in an external structure — cannot be express
 in the type and remains as a runtime/verification obligation). An entity's
 `applicability` is `full` only when all transitions are derivable/branching.
 With `--ts`, it outputs a TypeScript scaffold for the derivable portion.
+The native Rust command performs this judgment from the versioned public Kernel
+JSON v1 contract, not private parser/model structures, and fails closed on an
+unsupported Kernel schema version. Its JSON report and TypeScript bytes remain
+compatible with the frozen reference output.
 → [`DESIGN-typestate.md`](DESIGN-typestate.md)

--- a/rust/fsl-tools/src/typestate.rs
+++ b/rust/fsl-tools/src/typestate.rs
@@ -1,19 +1,112 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Typestate derivation from the typed FSL kernel.
+//! Typestate derivation from the versioned public FSL Kernel JSON.
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use fsl_core::{
-    KernelExpr as Expr, KernelLValue as LValue, KernelModel, KernelStatement as Statement,
-    ParamDef, Pattern, TypeDef, TypeRef,
-};
+use fsl_core::{KERNEL_SCHEMA_ID, KERNEL_SCHEMA_VERSION};
 use serde_json::{Map, Value, json};
 
 const EMPTY: &str = "Empty";
 const FILLED: &str = "Filled";
 
 type StateMap = BTreeMap<String, BTreeSet<String>>;
+
+#[derive(Clone)]
+enum TypeRef {
+    Int,
+    Bool,
+    Range,
+    Named(String),
+    Option(Box<Self>),
+    Set(Box<Self>),
+    Map(Box<Self>),
+    Other,
+}
+
+#[derive(Clone)]
+enum TypeDef {
+    Domain,
+    Enum { members: Vec<String> },
+    Struct { fields: Vec<(String, TypeRef)> },
+}
+
+#[derive(Clone)]
+enum Pattern {
+    None,
+    Some,
+}
+
+#[derive(Clone)]
+enum Expr {
+    Var(String),
+    Num(i64),
+    Bool(bool),
+    None,
+    Binary {
+        op: String,
+        left: Box<Self>,
+        right: Box<Self>,
+    },
+    Not(Box<Self>),
+    Neg(Box<Self>),
+    Field(Box<Self>, String),
+    Index(Box<Self>, Box<Self>),
+    Method {
+        receiver: Box<Self>,
+        name: String,
+    },
+    Some(Box<Self>),
+    Is {
+        expr: Box<Self>,
+        pattern: Pattern,
+    },
+    Set,
+    Seq,
+    Struct {
+        fields: Vec<(String, Self)>,
+    },
+    Placeholder(String),
+}
+
+#[derive(Clone)]
+enum LValue {
+    Var(String),
+    Index(String, Expr),
+    Field(Box<Self>, String),
+}
+
+#[derive(Clone)]
+enum Statement {
+    Assign {
+        target: LValue,
+        value: Expr,
+    },
+    If {
+        condition: Expr,
+        then_statements: Vec<Self>,
+        else_statements: Vec<Self>,
+    },
+    ForAll {
+        statements: Vec<Self>,
+    },
+}
+
+struct Action {
+    name: String,
+    params: Vec<String>,
+    requires: Vec<Expr>,
+    statements: Vec<Statement>,
+    requirement: Option<Value>,
+    source_order: (String, u64, u64),
+}
+
+struct PublicKernelView {
+    name: String,
+    types: BTreeMap<String, TypeDef>,
+    state: Vec<(String, TypeRef)>,
+    actions: Vec<Action>,
+}
 
 #[derive(Clone, Copy)]
 enum EnumLocation<'a> {
@@ -40,6 +133,401 @@ struct Entity {
     data_fields: Vec<(String, TypeRef)>,
 }
 
+fn required_object<'a>(value: &'a Value, context: &str) -> Result<&'a Map<String, Value>, String> {
+    value
+        .as_object()
+        .ok_or_else(|| format!("public Kernel {context} must be an object"))
+}
+
+fn required_array<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    context: &str,
+) -> Result<&'a [Value], String> {
+    object
+        .get(key)
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| format!("public Kernel {context}.{key} must be an array"))
+}
+
+fn required_str<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    context: &str,
+) -> Result<&'a str, String> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("public Kernel {context}.{key} must be a string"))
+}
+
+fn parse_type(value: &Value, context: &str) -> Result<TypeRef, String> {
+    let object = required_object(value, context)?;
+    let kind = required_str(object, "kind", context)?;
+    match kind {
+        "int" => Ok(TypeRef::Int),
+        "bool" => Ok(TypeRef::Bool),
+        "domain" => Ok(TypeRef::Range),
+        "named" => Ok(TypeRef::Named(
+            required_str(object, "name", context)?.to_owned(),
+        )),
+        "option" => Ok(TypeRef::Option(Box::new(parse_type(
+            object
+                .get("item")
+                .ok_or_else(|| format!("public Kernel {context}.item is required"))?,
+            &format!("{context}.item"),
+        )?))),
+        "set" => Ok(TypeRef::Set(Box::new(parse_type(
+            object
+                .get("item")
+                .ok_or_else(|| format!("public Kernel {context}.item is required"))?,
+            &format!("{context}.item"),
+        )?))),
+        "map" => {
+            parse_type(
+                object
+                    .get("key")
+                    .ok_or_else(|| format!("public Kernel {context}.key is required"))?,
+                &format!("{context}.key"),
+            )?;
+            Ok(TypeRef::Map(Box::new(parse_type(
+                object
+                    .get("value")
+                    .ok_or_else(|| format!("public Kernel {context}.value is required"))?,
+                &format!("{context}.value"),
+            )?)))
+        }
+        _ => Ok(TypeRef::Other),
+    }
+}
+
+fn parse_expr(value: &Value, context: &str) -> Result<Expr, String> {
+    let object = required_object(value, context)?;
+    let kind = required_str(object, "kind", context)?;
+    let child = |key: &str| -> Result<Expr, String> {
+        parse_expr(
+            object
+                .get(key)
+                .ok_or_else(|| format!("public Kernel {context}.{key} is required"))?,
+            &format!("{context}.{key}"),
+        )
+    };
+    match kind {
+        "var" => Ok(Expr::Var(required_str(object, "name", context)?.to_owned())),
+        "num" => Ok(Expr::Num(
+            object
+                .get("value")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| format!("public Kernel {context}.value must be an integer"))?,
+        )),
+        "bool" => Ok(Expr::Bool(
+            object
+                .get("value")
+                .and_then(Value::as_bool)
+                .ok_or_else(|| format!("public Kernel {context}.value must be a boolean"))?,
+        )),
+        "none" => Ok(Expr::None),
+        "binary" => Ok(Expr::Binary {
+            op: required_str(object, "operator", context)?.to_owned(),
+            left: Box::new(child("left")?),
+            right: Box::new(child("right")?),
+        }),
+        "not" => Ok(Expr::Not(Box::new(child("operand")?))),
+        "neg" => Ok(Expr::Neg(Box::new(child("operand")?))),
+        "field" => Ok(Expr::Field(
+            Box::new(child("value")?),
+            required_str(object, "field", context)?.to_owned(),
+        )),
+        "index" => Ok(Expr::Index(
+            Box::new(child("collection")?),
+            Box::new(child("index")?),
+        )),
+        "method" => Ok(Expr::Method {
+            receiver: Box::new(child("receiver")?),
+            name: required_str(object, "method", context)?.to_owned(),
+        }),
+        "some" => Ok(Expr::Some(Box::new(child("operand")?))),
+        "is" => {
+            let pattern = required_object(
+                object
+                    .get("pattern")
+                    .ok_or_else(|| format!("public Kernel {context}.pattern is required"))?,
+                &format!("{context}.pattern"),
+            )?;
+            Ok(Expr::Is {
+                expr: Box::new(child("operand")?),
+                pattern: if required_str(pattern, "kind", &format!("{context}.pattern"))? == "none"
+                {
+                    Pattern::None
+                } else {
+                    Pattern::Some
+                },
+            })
+        }
+        "set_lit" => Ok(Expr::Set),
+        "seq_lit" => Ok(Expr::Seq),
+        "struct_lit" => {
+            let fields = required_object(
+                object
+                    .get("fields")
+                    .ok_or_else(|| format!("public Kernel {context}.fields is required"))?,
+                &format!("{context}.fields"),
+            )?
+            .iter()
+            .map(|(name, value)| {
+                Ok((
+                    name.clone(),
+                    parse_expr(value, &format!("{context}.fields.{name}"))?,
+                ))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+            Ok(Expr::Struct { fields })
+        }
+        "ite" => Ok(Expr::Placeholder("if_expr".to_owned())),
+        "forall" | "exists" => Ok(Expr::Placeholder("quant".to_owned())),
+        _ => Ok(Expr::Placeholder(kind.to_owned())),
+    }
+}
+
+fn parse_lvalue(value: &Value, context: &str) -> Result<LValue, String> {
+    let object = required_object(value, context)?;
+    match required_str(object, "kind", context)? {
+        "var" => Ok(LValue::Var(
+            required_str(object, "name", context)?.to_owned(),
+        )),
+        "index" => Ok(LValue::Index(
+            required_str(object, "name", context)?.to_owned(),
+            parse_expr(
+                object
+                    .get("index")
+                    .ok_or_else(|| format!("public Kernel {context}.index is required"))?,
+                &format!("{context}.index"),
+            )?,
+        )),
+        "field_lv" => Ok(LValue::Field(
+            Box::new(parse_lvalue(
+                object
+                    .get("target")
+                    .ok_or_else(|| format!("public Kernel {context}.target is required"))?,
+                &format!("{context}.target"),
+            )?),
+            required_str(object, "field", context)?.to_owned(),
+        )),
+        kind => Err(format!(
+            "unsupported public Kernel lvalue kind '{kind}' at {context}"
+        )),
+    }
+}
+
+fn parse_statement(value: &Value, context: &str) -> Result<Statement, String> {
+    let object = required_object(value, context)?;
+    match required_str(object, "kind", context)? {
+        "assign" => Ok(Statement::Assign {
+            target: parse_lvalue(
+                object
+                    .get("target")
+                    .ok_or_else(|| format!("public Kernel {context}.target is required"))?,
+                &format!("{context}.target"),
+            )?,
+            value: parse_expr(
+                object
+                    .get("value")
+                    .ok_or_else(|| format!("public Kernel {context}.value is required"))?,
+                &format!("{context}.value"),
+            )?,
+        }),
+        "if" => Ok(Statement::If {
+            condition: parse_expr(
+                object
+                    .get("condition")
+                    .ok_or_else(|| format!("public Kernel {context}.condition is required"))?,
+                &format!("{context}.condition"),
+            )?,
+            then_statements: parse_statements(object, "then", context)?,
+            else_statements: parse_statements(object, "else", context)?,
+        }),
+        "forall" => Ok(Statement::ForAll {
+            statements: parse_statements(object, "statements", context)?,
+        }),
+        kind => Err(format!(
+            "unsupported public Kernel statement kind '{kind}' at {context}"
+        )),
+    }
+}
+
+fn parse_statements(
+    object: &Map<String, Value>,
+    key: &str,
+    context: &str,
+) -> Result<Vec<Statement>, String> {
+    required_array(object, key, context)?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| parse_statement(value, &format!("{context}.{key}[{index}]")))
+        .collect()
+}
+
+fn action_source_order(object: &Map<String, Value>) -> (String, u64, u64) {
+    object.get("span").and_then(Value::as_object).map_or_else(
+        || (String::new(), u64::MAX, u64::MAX),
+        |span| {
+            (
+                span.get("file")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+                span.get("line").and_then(Value::as_u64).unwrap_or(u64::MAX),
+                span.get("column")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(u64::MAX),
+            )
+        },
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+fn adapt_public_kernel(kernel: &Value) -> Result<PublicKernelView, String> {
+    let root = required_object(kernel, "root")?;
+    let schema = required_str(root, "$schema", "root")?;
+    if schema != KERNEL_SCHEMA_ID {
+        return Err(format!(
+            "unsupported public Kernel $schema '{schema}'; expected '{KERNEL_SCHEMA_ID}'"
+        ));
+    }
+    let version = required_str(root, "schema_version", "root")?;
+    if version != KERNEL_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported public Kernel schema_version '{version}'; expected '{KERNEL_SCHEMA_VERSION}'"
+        ));
+    }
+    let spec = required_object(
+        root.get("spec")
+            .ok_or_else(|| "public Kernel root.spec is required".to_owned())?,
+        "root.spec",
+    )?;
+
+    let mut types = BTreeMap::new();
+    for (index, value) in required_array(root, "types", "root")?.iter().enumerate() {
+        let context = format!("root.types[{index}]");
+        let object = required_object(value, &context)?;
+        let name = required_str(object, "name", &context)?.to_owned();
+        let definition = required_object(
+            object
+                .get("definition")
+                .ok_or_else(|| format!("public Kernel {context}.definition is required"))?,
+            &format!("{context}.definition"),
+        )?;
+        let definition_context = format!("{context}.definition");
+        let definition = match required_str(definition, "kind", &definition_context)? {
+            "domain" => TypeDef::Domain,
+            "enum" => TypeDef::Enum {
+                members: required_array(definition, "members", &definition_context)?
+                    .iter()
+                    .map(|member| {
+                        member.as_str().map(str::to_owned).ok_or_else(|| {
+                            format!("public Kernel {definition_context}.members must be strings")
+                        })
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+            },
+            "struct" => TypeDef::Struct {
+                fields: required_array(definition, "fields", &definition_context)?
+                    .iter()
+                    .enumerate()
+                    .map(|(field_index, field)| {
+                        let field_context = format!("{definition_context}.fields[{field_index}]");
+                        let field = required_object(field, &field_context)?;
+                        Ok((
+                            required_str(field, "name", &field_context)?.to_owned(),
+                            parse_type(
+                                field.get("type").ok_or_else(|| {
+                                    format!("public Kernel {field_context}.type is required")
+                                })?,
+                                &format!("{field_context}.type"),
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+            },
+            kind => {
+                return Err(format!(
+                    "unsupported public Kernel type definition kind '{kind}' at {definition_context}"
+                ));
+            }
+        };
+        types.insert(name, definition);
+    }
+
+    let state = required_array(root, "state", "root")?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let context = format!("root.state[{index}]");
+            let object = required_object(value, &context)?;
+            Ok((
+                required_str(object, "name", &context)?.to_owned(),
+                parse_type(
+                    object
+                        .get("type")
+                        .ok_or_else(|| format!("public Kernel {context}.type is required"))?,
+                    &format!("{context}.type"),
+                )?,
+            ))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    let mut actions = required_array(root, "actions", "root")?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let context = format!("root.actions[{index}]");
+            let object = required_object(value, &context)?;
+            Ok(Action {
+                name: required_str(object, "name", &context)?.to_owned(),
+                params: required_array(object, "parameters", &context)?
+                    .iter()
+                    .enumerate()
+                    .map(|(parameter_index, parameter)| {
+                        let parameter_context = format!("{context}.parameters[{parameter_index}]");
+                        required_str(
+                            required_object(parameter, &parameter_context)?,
+                            "name",
+                            &parameter_context,
+                        )
+                        .map(str::to_owned)
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+                requires: required_array(object, "requires", &context)?
+                    .iter()
+                    .enumerate()
+                    .map(|(require_index, expression)| {
+                        parse_expr(expression, &format!("{context}.requires[{require_index}]"))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+                statements: parse_statements(object, "updates", &context)?,
+                requirement: object
+                    .get("requirement")
+                    .filter(|value| !value.is_null())
+                    .cloned(),
+                source_order: action_source_order(object),
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    actions.sort_by(|left, right| {
+        left.source_order
+            .cmp(&right.source_order)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    Ok(PublicKernelView {
+        name: required_str(spec, "name", "root.spec")?.to_owned(),
+        types,
+        state,
+        actions,
+    })
+}
+
 fn display_name(name: &str) -> String {
     name.replacen("__", ".", 1)
 }
@@ -57,28 +545,20 @@ fn expr_source(expr: &Expr) -> String {
         Expr::Neg(value) => format!("-{}", expr_source(value)),
         Expr::Field(base, field) => format!("{}.{field}", expr_source(base)),
         Expr::Index(base, index) => format!("{}[{}]", expr_source(base), expr_source(index)),
-        Expr::Method { receiver, name, .. } => format!("{}.{name}(...)", expr_source(receiver)),
+        Expr::Method { receiver, name } => format!("{}.{name}(...)", expr_source(receiver)),
         Expr::Some(value) => format!("some({})", expr_source(value)),
         Expr::Is { expr, pattern } => format!(
             "{} is {}",
             expr_source(expr),
             match pattern {
                 Pattern::None => "none",
-                Pattern::Some(_) => "some(...)",
+                Pattern::Some => "some(...)",
             }
         ),
-        Expr::Set(_) => "set_lit".to_owned(),
-        Expr::Seq(_) => "seq_lit".to_owned(),
+        Expr::Set => "set_lit".to_owned(),
+        Expr::Seq => "seq_lit".to_owned(),
         Expr::Struct { .. } => "struct_lit".to_owned(),
-        Expr::Call { .. } => "call".to_owned(),
-        Expr::IfThenElse { .. } => "if_expr".to_owned(),
-        Expr::Quantified { .. } => "quant".to_owned(),
-        Expr::Count { .. } => "count".to_owned(),
-        Expr::Sum { .. } => "sum".to_owned(),
-        Expr::UnaryNamed { name, .. }
-        | Expr::BinaryNamed { name, .. }
-        | Expr::TernaryNamed { name, .. }
-        | Expr::BinderNamed { name, .. } => name.clone(),
+        Expr::Placeholder(name) => name.clone(),
     }
 }
 
@@ -400,15 +880,12 @@ fn option_assignments(statements: &[Statement], var: &str) -> Vec<Assignment> {
     output
 }
 
-fn requirement(action: &fsl_core::ActionDef) -> Option<Value> {
-    action
-        .meta
-        .as_ref()
-        .map(|meta| json!({"id": meta.id, "text": meta.text}))
+fn requirement(action: &Action) -> Option<Value> {
+    action.requirement.clone()
 }
 
 fn classify_action(
-    action: &fsl_core::ActionDef,
+    action: &Action,
     guard_states: impl Fn(&Expr) -> StateMap,
     assignments: Vec<Assignment>,
     is_state_only: impl Fn(&Expr) -> bool,
@@ -461,10 +938,7 @@ fn classify_action(
     let mut output = Map::new();
     output.insert("action".to_owned(), json!(display_name(&action.name)));
     output.insert("verdict".to_owned(), json!(verdict));
-    output.insert(
-        "params".to_owned(),
-        json!(action.params.iter().map(ParamDef::name).collect::<Vec<_>>()),
-    );
+    output.insert("params".to_owned(), json!(action.params));
     output.insert("transitions".to_owned(), Value::Array(transitions));
     output.insert(
         "value_preconditions".to_owned(),
@@ -486,12 +960,12 @@ fn classify_action(
     Some(Value::Object(output))
 }
 
-fn ts_type(model: &KernelModel, ty: &TypeRef) -> String {
+fn ts_type(model: &PublicKernelView, ty: &TypeRef) -> String {
     match ty {
-        TypeRef::Int | TypeRef::Range(_, _) => "number".to_owned(),
+        TypeRef::Int | TypeRef::Range => "number".to_owned(),
         TypeRef::Bool => "boolean".to_owned(),
         TypeRef::Named(name) => match model.types.get(name) {
-            Some(TypeDef::Domain { .. }) => "number".to_owned(),
+            Some(TypeDef::Domain) => "number".to_owned(),
             Some(TypeDef::Enum { .. } | TypeDef::Struct { .. }) => display_name(name),
             None => "unknown".to_owned(),
         },
@@ -502,7 +976,12 @@ fn ts_type(model: &KernelModel, ty: &TypeRef) -> String {
 }
 
 #[allow(clippy::too_many_lines)]
-fn emit_typescript(model: &KernelModel, entity: &Entity, actions: &[Value], note: &str) -> String {
+fn emit_typescript(
+    model: &PublicKernelView,
+    entity: &Entity,
+    actions: &[Value],
+    note: &str,
+) -> String {
     let state_type = format!("{}State", entity.type_name);
     let mut lines = vec![
         format!(
@@ -641,7 +1120,7 @@ fn camel(name: &str) -> String {
         .collect()
 }
 
-fn discover_entities(model: &KernelModel) -> Vec<Entity> {
+fn discover_entities(model: &PublicKernelView) -> Vec<Entity> {
     let mut entities = Vec::new();
     for (type_name, definition) in &model.types {
         let TypeDef::Struct { fields } = definition else {
@@ -651,7 +1130,7 @@ fn discover_entities(model: &KernelModel) -> Vec<Entity> {
             let TypeRef::Named(enum_name) = ty else {
                 continue;
             };
-            let Some(TypeDef::Enum { members, .. }) = model.types.get(enum_name) else {
+            let Some(TypeDef::Enum { members }) = model.types.get(enum_name) else {
                 continue;
             };
             entities.push(Entity {
@@ -675,7 +1154,7 @@ fn discover_entities(model: &KernelModel) -> Vec<Entity> {
             TypeRef::Named(name) if matches!(model.types.get(name), Some(TypeDef::Enum { .. })) => {
                 Some(name)
             }
-            TypeRef::Map(_, value) => match value.as_ref() {
+            TypeRef::Map(value) => match value.as_ref() {
                 TypeRef::Named(name)
                     if matches!(model.types.get(name), Some(TypeDef::Enum { .. })) =>
                 {
@@ -686,7 +1165,7 @@ fn discover_entities(model: &KernelModel) -> Vec<Entity> {
             _ => None,
         };
         if let Some(enum_name) = enum_name
-            && let Some(TypeDef::Enum { members, .. }) = model.types.get(enum_name)
+            && let Some(TypeDef::Enum { members }) = model.types.get(enum_name)
         {
             entities.push(Entity {
                 kind: "enum",
@@ -703,7 +1182,7 @@ fn discover_entities(model: &KernelModel) -> Vec<Entity> {
     for (var, ty) in &model.state {
         let inner = match ty {
             TypeRef::Option(inner) => Some(inner.as_ref()),
-            TypeRef::Map(_, value) => match value.as_ref() {
+            TypeRef::Map(value) => match value.as_ref() {
                 TypeRef::Option(inner) => Some(inner.as_ref()),
                 _ => None,
             },
@@ -729,12 +1208,17 @@ fn discover_entities(model: &KernelModel) -> Vec<Entity> {
     entities
 }
 
-/// Derive sound host-language typestate slices from a checked FSL model.
-#[must_use]
+/// Derive sound host-language typestate slices from public Kernel JSON v1.
+///
+/// # Errors
+///
+/// Returns an error when the input is not the supported public Kernel schema or
+/// when a required normalized field cannot be decoded.
 #[allow(clippy::too_many_lines)]
-pub fn analyze_typestate(model: &KernelModel) -> Value {
+pub fn analyze_typestate(kernel: &Value) -> Result<Value, String> {
+    let model = adapt_public_kernel(kernel)?;
     let mut report_entities = Vec::new();
-    for entity in discover_entities(model) {
+    for entity in discover_entities(&model) {
         let (actions, key, note) = if entity.kind == "enum" {
             let location = entity.field.as_deref().map_or_else(
                 || EnumLocation::Var(entity.var.as_deref().unwrap_or_default()),
@@ -815,7 +1299,7 @@ pub fn analyze_typestate(model: &KernelModel) -> Value {
         } else {
             "partial"
         };
-        let typescript = emit_typescript(model, &entity, &actions, &note);
+        let typescript = emit_typescript(&model, &entity, &actions, &note);
         report_entities.push(json!({
             "entity": key,
             "kind": entity.kind,
@@ -853,5 +1337,5 @@ pub fn analyze_typestate(model: &KernelModel) -> Value {
             json!("no enum-field or Option state machine found — nothing to derive."),
         );
     }
-    Value::Object(report)
+    Ok(Value::Object(report))
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3227,13 +3227,21 @@ fn run_check(path: &Path) -> (Value, i32) {
 fn run_kernel_contract(path: &Path) -> (Value, i32) {
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
-        Err(error) => return (error_output("io", &error.to_string()), 2),
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
     };
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
     let kernel = match fsl_core::parse_kernel_source(&source, &resolver) {
         Ok(kernel) => kernel,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            let message =
+                if error.message == "top-level document has not reached the kernel lowering gate" {
+                    "spec has no state block".to_owned()
+                } else {
+                    error.to_string()
+                };
+            return (semantic_error_output(&message), 2);
+        }
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
@@ -7029,12 +7037,36 @@ fn run_mutate(
 }
 
 fn run_typestate(path: &Path) -> (Value, i32) {
-    let model = match load_model(path) {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) => return (error_output("io", &error.to_string()), 2),
+    };
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let resolver = fsl_core::FsResolver::new(base);
+    let kernel = match fsl_core::parse_kernel_source(&source, &resolver) {
+        Ok(kernel) => kernel,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
+    let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
+    let path_text = path.to_string_lossy();
+    let contract = match fsl_core::public_kernel_contract(
+        &kernel,
+        &model,
+        &path_text,
+        source_dialect(&source),
+    ) {
+        Ok(contract) => contract,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
+    let report = match fsl_tools::analyze_typestate(&contract) {
+        Ok(report) => report,
         Err(error) => return (semantic_error_output(&error), 2),
     };
     let mut output = envelope();
-    if let Value::Object(report) = fsl_tools::analyze_typestate(&model) {
+    if let Value::Object(report) = report {
         output.extend(report);
     }
     (Value::Object(output), 0)

--- a/rust/fslc/tests/fixtures/typestate_order.v1.json
+++ b/rust/fslc/tests/fixtures/typestate_order.v1.json
@@ -1,0 +1,105 @@
+{
+  "fsl": "1.0",
+  "result": "typestate",
+  "spec": "OrderWorkflow",
+  "entities": [
+    {
+      "entity": "Order.status",
+      "kind": "enum",
+      "enum": "Status",
+      "states": [
+        "Draft",
+        "Placed",
+        "Paid",
+        "Shipped",
+        "Cancelled"
+      ],
+      "applicability": "full",
+      "actions": [
+        {
+          "action": "place",
+          "verdict": "derivable",
+          "params": [
+            "o",
+            "q"
+          ],
+          "transitions": [
+            {
+              "entity": "orders[o]",
+              "from": [
+                "Draft"
+              ],
+              "to": "Placed",
+              "conditional": false
+            }
+          ],
+          "value_preconditions": [
+            "(q > 0)"
+          ]
+        },
+        {
+          "action": "pay",
+          "verdict": "derivable",
+          "params": [
+            "o"
+          ],
+          "transitions": [
+            {
+              "entity": "orders[o]",
+              "from": [
+                "Placed"
+              ],
+              "to": "Paid",
+              "conditional": false
+            }
+          ],
+          "value_preconditions": []
+        },
+        {
+          "action": "ship",
+          "verdict": "derivable",
+          "params": [
+            "o"
+          ],
+          "transitions": [
+            {
+              "entity": "orders[o]",
+              "from": [
+                "Paid"
+              ],
+              "to": "Shipped",
+              "conditional": false
+            }
+          ],
+          "value_preconditions": []
+        },
+        {
+          "action": "cancel",
+          "verdict": "derivable",
+          "params": [
+            "o"
+          ],
+          "transitions": [
+            {
+              "entity": "orders[o]",
+              "from": [
+                "Paid",
+                "Placed"
+              ],
+              "to": "Cancelled",
+              "conditional": false
+            }
+          ],
+          "value_preconditions": []
+        }
+      ],
+      "typescript": "// Typestate skeleton for `Order` from spec `OrderWorkflow`.\n// FSL holds these in a collection; phantom types track one entity, so each becomes an independently-typed handle.\n// Only transitions with a LOCAL from-state guard are typed; the rest stay dynamic.\n\nexport type OrderState = \"Draft\" | \"Placed\" | \"Paid\" | \"Shipped\" | \"Cancelled\";\n\ndeclare const __state: unique symbol;\nexport interface Order<S extends OrderState> {\n  qty: number;\n  readonly [__state]: S;\n}\n\n  // runtime precondition (not in type): (q > 0)\nexport function place(self: Order<\"Draft\">, o: number, q: number): Order<\"Placed\">;\nexport function pay(self: Order<\"Placed\">, o: number): Order<\"Paid\">;\nexport function ship(self: Order<\"Paid\">, o: number): Order<\"Shipped\">;\nexport function cancel(self: Order<\"Paid\" | \"Placed\">, o: number): Order<\"Cancelled\">;"
+    }
+  ],
+  "summary": {
+    "entities": 1,
+    "full": 1,
+    "partial": 0,
+    "none": 0
+  }
+}

--- a/rust/fslc/tests/fixtures/typestate_order.v1.ts
+++ b/rust/fslc/tests/fixtures/typestate_order.v1.ts
@@ -1,0 +1,17 @@
+// Typestate skeleton for `Order` from spec `OrderWorkflow`.
+// FSL holds these in a collection; phantom types track one entity, so each becomes an independently-typed handle.
+// Only transitions with a LOCAL from-state guard are typed; the rest stay dynamic.
+
+export type OrderState = "Draft" | "Placed" | "Paid" | "Shipped" | "Cancelled";
+
+declare const __state: unique symbol;
+export interface Order<S extends OrderState> {
+  qty: number;
+  readonly [__state]: S;
+}
+
+  // runtime precondition (not in type): (q > 0)
+export function place(self: Order<"Draft">, o: number, q: number): Order<"Placed">;
+export function pay(self: Order<"Placed">, o: number): Order<"Paid">;
+export function ship(self: Order<"Paid">, o: number): Order<"Shipped">;
+export function cancel(self: Order<"Paid" | "Placed">, o: number): Order<"Cancelled">;

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -95,6 +95,75 @@ spec Binding {
 }
 
 #[test]
+fn typestate_consumes_the_versioned_public_kernel_contract() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root");
+    let path = workspace.join("specs/order_workflow.fsl");
+    let (kernel, model) = load(&path);
+    let contract = fsl_core::public_kernel_contract(
+        &kernel,
+        &model,
+        path.to_str().expect("UTF-8 path"),
+        "kernel",
+    )
+    .expect("export public Kernel");
+
+    let report = fsl_tools::analyze_typestate(&contract).expect("analyze public Kernel");
+
+    assert_eq!(report["result"], "typestate");
+    assert_eq!(report["spec"], "OrderWorkflow");
+    assert_eq!(report["summary"]["full"], 1);
+    assert_eq!(report["entities"][0]["actions"][0]["action"], "place");
+    assert_eq!(report["entities"][0]["actions"][3]["action"], "cancel");
+}
+
+#[test]
+fn typestate_rejects_an_incompatible_public_kernel_version() {
+    let path = fixture("kernel_contract.fsl");
+    let (kernel, model) = load(&path);
+    let mut contract = fsl_core::public_kernel_contract(&kernel, &model, "fixture.fsl", "kernel")
+        .expect("export public Kernel");
+    contract["schema_version"] = Value::String("2.0.0".to_owned());
+
+    let error = fsl_tools::analyze_typestate(&contract)
+        .expect_err("unknown public Kernel versions must fail closed");
+
+    assert!(error.contains("unsupported public Kernel schema_version"));
+}
+
+#[test]
+fn native_cli_typestate_outputs_match_the_v1_golden_files() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root");
+    let binary = env!("CARGO_BIN_EXE_fslc");
+
+    for (extra, expected) in [
+        (
+            Vec::<&str>::new(),
+            include_bytes!("fixtures/typestate_order.v1.json").as_slice(),
+        ),
+        (
+            vec!["--ts"],
+            include_bytes!("fixtures/typestate_order.v1.ts").as_slice(),
+        ),
+    ] {
+        let output = Command::new(binary)
+            .current_dir(workspace)
+            .args(["typestate", "specs/order_workflow.fsl"])
+            .args(extra)
+            .output()
+            .expect("run native typestate CLI");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, expected);
+    }
+}
+
+#[test]
 fn conformance_distinguishes_nested_options_and_guard_partials() {
     let source = r"
 spec NestedOption {

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -992,6 +992,9 @@ first failed layer and later layers are marked `skipped`.
   An entity's `applicability` is `full` only when all transitions are
   derivable/branching. `relational` ones carry a reason (diagnostics) and a
   requirement ID. `--ts` outputs only the TypeScript for the derivable portion.
+  The native Rust path consumes public Kernel JSON v1 and rejects unsupported
+  schema versions; private Rust AST/model shapes are not a generator API. The
+  Python reference implementation remains frozen.
 - Counterexample trace: `[{step, state, action{name,params,loc}, changes{path:{from,to}}}]`.
   Shortest guaranteed. State is the logical representation (enum name / Option as
   null|value / Seq as an array / composition as `alias.var` keys). Internal names


### PR DESCRIPTION
## Summary

Move the native Rust `fslc typestate` applicability analysis and TypeScript emitter from private `KernelModel` access to versioned public Kernel JSON v1. Existing JSON and `--ts` bytes remain unchanged; the frozen Python reference is untouched.

Closes #215.

## Why

- **Goal:** make typestate a downstream consumer of the public compiler contract introduced in #208.
- **Reason:** private AST/model shapes are not versioned generator APIs; the public Kernel carries the typed expressions, updates, requirements, and spans typestate needs.
- **Alternatives:** retaining a `KernelModel` adapter would preserve the coupling; reparsing source in `fsl-tools` would duplicate lowering semantics. Both were rejected.

## What changed

- Added a fail-closed public Kernel v1 adapter in `fsl-tools` and changed `analyze_typestate` to accept JSON.
- Routed the Rust CLI through `public_kernel_contract` before analysis.
- Restored source declaration order from public spans because Kernel actions are name-normalized.
- Added adapter/version tests plus byte-for-byte JSON and TypeScript golden fixtures.
- Documented retirement of the private-model path in the language, design, shared skill reference, and changelog.

## Blast radius and invariants

- **Affected:** Rust typestate library API and native `typestate` CLI execution path.
- **Not changed:** Python implementation, grammar, verifier, runtime, solver, CLI flags, report schema, or generated TypeScript format.
- **Must stay true:** incompatible Kernel schemas fail closed; action classification/order and output bytes match the established contract; other Rust crates remain solver-boundary compatible.

## Failure modes

| Risk | Detection |
|---|---|
| JSON field mapping changes a verdict | public-Kernel adapter test and Python↔Rust CLI contract suite |
| normalized action order changes output | v1 JSON/TS golden byte tests |
| unsupported schema is silently accepted | incompatible-version regression test |

## Evidence

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo build --workspace --locked` plus solver dependency-boundary checks
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py -q` — 10 passed
- `.venv/bin/python -m pytest tests/test_coupled_change_meta.py -q` — 7 passed
- Existing five typestate JSON cases and `--ts` output retained their pre-change SHA-256 hashes.

Evidence level: L2/E1 (unit, integration, golden, and differential coverage; changed-lines coverage was not measured).

## Rollout, rollback, and review focus

- **Rollout:** ordinary Rust release; no migration or data change.
- **Rollback:** revert commit `ef25a0d`; no persisted state is involved.
- **Review focus:** JSON-to-typestate mapping and fail-closed behavior in `rust/fsl-tools/src/typestate.rs`; CLI boundary in `rust/fslc/src/main.rs`; exact compatibility assertions in `rust/fslc/tests/kernel_contract.rs`.

## Unknowns

- None currently identified. GitHub-hosted Rust CLI contract and Rust workspace/WASM checks are green.
