### PR TITLE
test(domain): characterize typed-expression migration baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Domain-expression characterization corpus (issue #235): Rust CI now freezes
+  pre-typed-AST surface expressions and locations, normalized semantic model
+  structure, representative public Kernel expression/origin output, generated
+  Kernel fragments, CLI diagnostics and verification traces, and concrete
+  Monitor-to-symbolic agreement. The corpus covers logical operators, enums,
+  membership, `can`, aggregate state, root/index/field lvalues, defaults,
+  invariants, stale policies, effects, sagas, invalid expressions, and a
+  deterministic AI-native prompt/spec attempt baseline. This is migration
+  evidence only and intentionally changes no language semantics.
 - Codex CLI, IDE, and desktop environment: bounded repository instructions, worktree-local
   task packets, explicit checkpoint/task-start skills, shared FSL skill discovery,
   read-only exploration and review agents, concise SessionStart context, and CI-tested

--- a/rust/fslc/tests/domain_expression_characterization.rs
+++ b/rust/fslc/tests/domain_expression_characterization.rs
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::pin;
+use std::process::Command;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{
+    FsResolver, FslValue, KernelModel, ParamDef, TypeDef, TypeRef, build_model, parse_kernel_source,
+};
+use fsl_syntax::{DomainSpec, SurfaceDocument, parse_surface_document};
+use serde_json::{Map, Value, json};
+
+const UPDATE_ENV: &str = "UPDATE_DOMAIN_CHARACTERIZATION";
+
+fn workspace() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn corpus() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/domain_characterization")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    corpus().join(name)
+}
+
+fn relative_fixture(name: &str) -> String {
+    format!("rust/fslc/tests/fixtures/domain_characterization/{name}")
+}
+
+fn source(name: &str) -> String {
+    std::fs::read_to_string(fixture(name)).expect("read characterization fixture")
+}
+
+fn domain(name: &str) -> DomainSpec {
+    let SurfaceDocument::Domain(domain) =
+        parse_surface_document(&source(name)).expect("parse domain fixture")
+    else {
+        panic!("expected domain fixture");
+    };
+    domain
+}
+
+fn surface_projection(domain: &DomainSpec) -> Value {
+    json!({
+        "name":domain.name,
+        "loc":domain.loc,
+        "types":domain.types.iter().map(|ty|json!({
+            "name":ty.name,"kind":ty.kind,"members":ty.members,"lo":ty.lo,"hi":ty.hi,
+            "fields":ty.fields.iter().map(|field|json!({"name":field.name,"type":field.type_name,"default":field.default,"loc":field.loc})).collect::<Vec<_>>(),
+            "invariants":ty.invariants.iter().map(|item|json!({"name":item.name,"expr":item.expr,"loc":item.loc})).collect::<Vec<_>>(),
+            "loc":ty.loc
+        })).collect::<Vec<_>>(),
+        "aggregates":domain.aggregates.iter().map(|aggregate|json!({
+            "name":aggregate.name,
+            "state":aggregate.state.iter().map(|field|json!({"name":field.name,"type":field.type_name,"default":field.default,"loc":field.loc})).collect::<Vec<_>>(),
+            "decides":aggregate.decides.iter().map(|item|json!({
+                "command":item.command,"requires":item.requires,
+                "rejects":item.rejects.iter().map(|reject|json!({"error":reject.error,"condition":reject.condition,"loc":reject.loc})).collect::<Vec<_>>(),
+                "emits":item.emits,"loc":item.loc
+            })).collect::<Vec<_>>(),
+            "evolves":aggregate.evolves.iter().map(|item|json!({
+                "event":item.event,"requires":item.requires,
+                "assignments":item.assignments.iter().map(|assignment|json!({"target":assignment.target,"expr":assignment.expr,"loc":assignment.loc})).collect::<Vec<_>>(),
+                "loc":item.loc
+            })).collect::<Vec<_>>(),
+            "invariants":aggregate.invariants.iter().map(|item|json!({"name":item.name,"expr":item.expr,"loc":item.loc})).collect::<Vec<_>>(),
+            "stale_policies":aggregate.stale_policies.iter().map(|item|json!({"event":item.event,"condition":item.condition,"emits":item.emits,"loc":item.loc})).collect::<Vec<_>>(),
+            "loc":aggregate.loc
+        })).collect::<Vec<_>>(),
+        "effects":domain.effects.iter().map(|effect|json!({
+            "name":effect.name,"idempotency_key":effect.idempotency_key,"correlation_id":effect.correlation_id,
+            "handles":effect.handles,"outcomes":effect.outcomes,"timeout_event":effect.timeout_event,
+            "retry_max_attempts":effect.retry.max_attempts,"loc":effect.loc
+        })).collect::<Vec<_>>(),
+        "sagas":domain.sagas.iter().map(|saga|json!({
+            "name":saga.name,"starts_on":saga.starts_on,
+            "steps":saga.steps.iter().map(|step|json!({"name":step.name,"requires":step.requires,"emits":step.emits,"awaits":step.awaits,"timeout_event":step.timeout_event,"loc":step.loc})).collect::<Vec<_>>(),
+            "invariants":saga.invariants.iter().map(|item|json!({"name":item.name,"expr":item.expr,"loc":item.loc})).collect::<Vec<_>>(),
+            "loc":saga.loc
+        })).collect::<Vec<_>>()
+    })
+}
+
+fn model(name: &str) -> KernelModel {
+    let path = fixture(name);
+    let kernel = parse_kernel_source(
+        &source(name),
+        &FsResolver::new(path.parent().expect("fixture directory")),
+    )
+    .expect("lower domain fixture");
+    build_model(kernel).expect("build domain fixture")
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn type_ref_json(ty: &TypeRef) -> Value {
+    match ty {
+        TypeRef::Int => json!({"kind":"int"}),
+        TypeRef::Bool => json!({"kind":"bool"}),
+        TypeRef::Named(name) => json!({"kind":"named","name":name}),
+        TypeRef::Range(lo, hi) => json!({"kind":"range","lo":lo,"hi":hi}),
+        TypeRef::Map(key, value) => {
+            json!({"kind":"map","key":type_ref_json(key),"value":type_ref_json(value)})
+        }
+        TypeRef::Relation(source, target) => json!({
+            "kind":"relation",
+            "source":type_ref_json(source),
+            "target":type_ref_json(target)
+        }),
+        TypeRef::Set(item) => json!({"kind":"set","item":type_ref_json(item)}),
+        TypeRef::Seq(item, capacity) => {
+            json!({"kind":"seq","item":type_ref_json(item),"capacity":capacity})
+        }
+        TypeRef::Option(item) => json!({"kind":"option","item":type_ref_json(item)}),
+    }
+}
+
+fn type_def_json(definition: &TypeDef) -> Value {
+    match definition {
+        TypeDef::Domain { lo, hi, symmetric } => {
+            json!({"kind":"domain","lo":lo,"hi":hi,"symmetric":symmetric})
+        }
+        TypeDef::Enum { members, symmetric } => {
+            json!({"kind":"enum","members":members,"symmetric":symmetric})
+        }
+        TypeDef::Struct { fields } => json!({
+            "kind":"struct",
+            "fields":fields.iter().map(|(name,ty)|json!({"name":name,"type":type_ref_json(ty)})).collect::<Vec<_>>()
+        }),
+    }
+}
+
+fn param_json(param: &ParamDef) -> Value {
+    match param {
+        ParamDef::Typed { name, ty } => {
+            json!({"kind":"typed","name":name,"type":type_ref_json(ty)})
+        }
+        ParamDef::Range { name, lo, hi } => {
+            json!({"kind":"range","name":name,"lo":lo,"hi":hi})
+        }
+    }
+}
+
+fn erase_locations(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(erase_locations).collect()),
+        Value::Object(values)
+            if values.len() == 2
+                && values.contains_key("line")
+                && values.contains_key("column") =>
+        {
+            Value::String("<location>".to_owned())
+        }
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, erase_locations(value)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn value_map(state: &BTreeMap<String, FslValue>) -> Value {
+    Value::Object(
+        state
+            .iter()
+            .map(|(name, value)| (name.clone(), fslc_rust::fsl_value_json(value)))
+            .collect(),
+    )
+}
+
+fn semantic_model(model: &KernelModel) -> Value {
+    let types = model
+        .types
+        .iter()
+        .map(|(name, definition)| (name.clone(), type_def_json(definition)))
+        .collect::<Map<_, _>>();
+    let mut state = model
+        .state
+        .iter()
+        .map(|(name, ty)| json!({"name":name,"type":type_ref_json(ty)}))
+        .collect::<Vec<_>>();
+    state.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+    let initial = fsl_runtime::Monitor::new(model.clone()).expect("construct initial Monitor");
+    let mut actions = model
+        .actions
+        .iter()
+        .map(|action| {
+            json!({
+                "name":action.name,
+                "parameters":action.params.iter().map(param_json).collect::<Vec<_>>(),
+                "requires":action.requires.iter().map(|expr|erase_locations(expr.python_ast())).collect::<Vec<_>>(),
+                "lets":action.lets.iter().map(|(name,expr)|json!([name,erase_locations(expr.python_ast())])).collect::<Vec<_>>(),
+                "updates":action.statements.iter().map(|statement|erase_locations(statement.python_ast())).collect::<Vec<_>>(),
+                "ensures":action.ensures.iter().map(|expr|erase_locations(expr.python_ast())).collect::<Vec<_>>(),
+                "fair":action.fair
+            })
+        })
+        .collect::<Vec<_>>();
+    actions.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+    let mut invariants = model
+        .invariants
+        .iter()
+        .map(|property| {
+            json!({"name":property.name,"expression":erase_locations(property.expr.python_ast())})
+        })
+        .collect::<Vec<_>>();
+    invariants.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
+    json!({
+        "name":model.name,
+        "types":types,
+        "state":state,
+        "initial_state":value_map(&initial.state),
+        "actions":actions,
+        "invariants":invariants,
+        "terminal":model.terminal.as_ref().map(|expr|erase_locations(expr.python_ast()))
+    })
+}
+
+fn normalize_files(value: &mut Value, file_name: &str) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_files(value, file_name);
+            }
+        }
+        Value::Object(values) => {
+            if values.contains_key("file") {
+                values.insert("file".to_owned(), Value::String(file_name.to_owned()));
+            }
+            for value in values.values_mut() {
+                normalize_files(value, file_name);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn property_projection(items: &Value) -> Vec<Value> {
+    items
+        .as_array()
+        .expect("properties")
+        .iter()
+        .filter(|item| {
+            !item["name"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("_bounds_")
+        })
+        .map(|item| {
+            json!({
+                "name":item["name"],
+                "source_kind":item["source_kind"],
+                "expression":item["expression"],
+                "origin":item["origin"],
+                "span":item["span"]
+            })
+        })
+        .collect()
+}
+
+fn public_projection(name: &str) -> Value {
+    let input = source(name);
+    let path = fixture(name);
+    let kernel = parse_kernel_source(
+        &input,
+        &FsResolver::new(path.parent().expect("fixture directory")),
+    )
+    .expect("lower public Kernel fixture");
+    let checked = build_model(kernel.clone()).expect("build public Kernel fixture");
+    let mut contract = fsl_core::public_kernel_contract(&kernel, &checked, name, "domain")
+        .expect("export public Kernel");
+    normalize_files(&mut contract, name);
+    let representative_actions = match name {
+        "expressions_valid.fsl" => ["order_approve", "order_cancel"].as_slice(),
+        "effect_saga_valid.fsl" => [
+            "order_approve",
+            "order_request_payment",
+            "capture_payment_complete_payment_captured",
+            "saga_payment_flow_capture",
+        ]
+        .as_slice(),
+        _ => &[],
+    };
+    let properties = &contract["properties"];
+    let init = &contract["init"];
+    json!({
+        "schema_version":contract["schema_version"],
+        "spec":contract["spec"],
+        "state":contract["state"].as_array().expect("state").iter().map(|item|json!({"name":item["name"],"type":item["type"],"origin":item["origin"]})).collect::<Vec<_>>(),
+        "init":{
+            "statements":init["statements"],
+            "origin":init["origin"],
+            "span":init["span"]
+        },
+        "actions":contract["actions"].as_array().expect("actions").iter().filter(|action|representative_actions.contains(&action["name"].as_str().unwrap_or_default())).map(|action|json!({
+            "name":action["name"],
+            "fair":action["fair"],
+            "guards":action["guards"],
+            "updates":action["updates"],
+            "origin":action["origin"],
+            "span":action["span"]
+        })).collect::<Vec<_>>(),
+        "properties":{
+            "invariants":property_projection(&properties["invariants"]),
+            "transitions":property_projection(&properties["transitions"]),
+            "terminal":properties["terminal"]
+        }
+    })
+}
+
+fn generated_fragments(domain: &DomainSpec, needles: &[&str]) -> Value {
+    let source = fsl_core::domain_kernel_source(domain);
+    Value::Array(
+        needles
+            .iter()
+            .map(|needle| {
+                source
+                    .lines()
+                    .find(|line| line.contains(needle))
+                    .unwrap_or_else(|| panic!("generated Kernel is missing '{needle}'"))
+                    .trim()
+                    .to_owned()
+                    .into()
+            })
+            .collect(),
+    )
+}
+
+fn run_cli(args: &[&str]) -> (i32, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .current_dir(workspace())
+        .args(args)
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse CLI JSON for {args:?}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (output.status.code().expect("fslc exit code"), value)
+}
+
+fn scrub_cli(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                scrub_cli(value);
+            }
+        }
+        Value::Object(values) => {
+            for key in [
+                "cache",
+                "cost",
+                "hint",
+                "note",
+                "recommended_action",
+                "warnings",
+            ] {
+                values.remove(key);
+            }
+            for value in values.values_mut() {
+                scrub_cli(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn cli_snapshot(args: &[&str]) -> Value {
+    let (status, mut output) = run_cli(args);
+    scrub_cli(&mut output);
+    json!({"exit":status,"output":output})
+}
+
+fn generated_span_note(name: &str, action_name: &str, source_declaration: &str) -> Value {
+    let contract = public_projection(name);
+    let action = contract["actions"]
+        .as_array()
+        .expect("actions")
+        .iter()
+        .find(|action| action["name"] == action_name)
+        .expect("generated action");
+    let source_line = source(name)
+        .lines()
+        .position(|line| line.trim() == source_declaration)
+        .unwrap_or_else(|| panic!("missing source declaration '{source_declaration}'"))
+        + 1;
+    json!({
+        "classification":"known_generated_kernel_coordinate_attached_to_source_file",
+        "file":name,
+        "source_declaration_line":source_line,
+        "reported_public_kernel_line":action["span"]["line"],
+        "origin":action["origin"]
+    })
+}
+
+#[allow(clippy::too_many_lines)]
+fn baseline() -> Value {
+    let expressions = domain("expressions_valid.fsl");
+    let lvalues = domain("lvalues_surface.fsl");
+    let effects = domain("effect_saga_valid.fsl");
+    let expression_model = model("expressions_valid.fsl");
+    let effect_model = model("effect_saga_valid.fsl");
+    let mut cli = Map::new();
+    for name in [
+        "expressions_valid.fsl",
+        "effect_saga_valid.fsl",
+        "lvalues_surface.fsl",
+        "legacy_logical_parse_error.fsl",
+        "invalid_unknown_name.fsl",
+        "invalid_unknown_member.fsl",
+        "invalid_type_mismatch.fsl",
+        "invalid_operator.fsl",
+        "invalid_broken_expression.fsl",
+        "ai_internal_name_misuse.fsl",
+    ] {
+        let relative = relative_fixture(name);
+        cli.insert(
+            name.to_owned(),
+            json!({
+                "check":cli_snapshot(&["check", &relative]),
+                "verify":cli_snapshot(&["verify", &relative, "--depth", "2"])
+            }),
+        );
+    }
+    json!({
+        "spdx":"Apache-2.0",
+        "schema_version":"domain-expression-characterization.v1",
+        "surface_ast":{
+            "expressions_valid.fsl":surface_projection(&expressions),
+            "lvalues_surface.fsl":surface_projection(&lvalues),
+            "effect_saga_valid.fsl":surface_projection(&effects)
+        },
+        "semantic_kernel_model":{
+            "expressions_valid.fsl":semantic_model(&expression_model),
+            "effect_saga_valid.fsl":semantic_model(&effect_model)
+        },
+        "public_kernel":{
+            "expressions_valid.fsl":public_projection("expressions_valid.fsl"),
+            "effect_saga_valid.fsl":public_projection("effect_saga_valid.fsl")
+        },
+        "known_generated_spans":[
+            generated_span_note("expressions_valid.fsl","order_approve","decide Approve {"),
+            generated_span_note("effect_saga_valid.fsl","order_approve","decide Approve {")
+        ],
+        "generated_kernel_source_fragments":{
+            "expressions_valid.fsl":generated_fragments(&expressions,&[
+                "requires order_status == OrderStatus_Draft and not",
+                "requires order_status != OrderStatus_Cancelled and order_quantity >= 0",
+                "order_audit.status = order_status",
+                "Order_legacyImplication",
+                "Order_legacyDisjunction",
+                "Order_finiteMembership"
+            ]),
+            "effect_saga_valid.fsl":generated_fragments(&effects,&[
+                "action capture_payment_complete_payment_captured",
+                "requires event_Approved and not event_PaymentFailed",
+                "PaymentFlow_terminalOutcome",
+                "CapturePayment_SuccessSticky"
+            ]),
+            "lvalues_surface.fsl":generated_fragments(&lvalues,&[
+                "inventory_total = inventory_total + 1",
+                "inventory_counts[item] = inventory_counts[item] + 1",
+                "inventory_counter.value = inventory_total"
+            ])
+        },
+        "cli":Value::Object(cli)
+    })
+}
+
+#[test]
+fn domain_surface_lowering_public_kernel_and_diagnostics_match_baseline() {
+    let actual = baseline();
+    let path = fixture("baseline.v1.json");
+    if std::env::var_os(UPDATE_ENV).is_some() {
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&actual).expect("serialize baseline")
+            ),
+        )
+        .expect("write characterization baseline");
+        return;
+    }
+    let expected: Value = serde_json::from_str(
+        &std::fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("missing {}; run with {UPDATE_ENV}=1", path.display())),
+    )
+    .expect("parse characterization baseline");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn domain_monitor_and_symbolic_semantics_agree() {
+    let mut total_checked = 0_usize;
+    let mut rejected_changed_successor = false;
+    for name in ["expressions_valid.fsl", "effect_saga_valid.fsl"] {
+        let model = model(name);
+        let initial = fsl_runtime::Monitor::new(model.clone()).expect("create Monitor");
+        let mut queue = VecDeque::from([(initial, 0_usize)]);
+        let mut seen = BTreeSet::new();
+        while let Some((monitor, depth)) = queue.pop_front() {
+            if !seen.insert(monitor.state.clone()) {
+                continue;
+            }
+            for property in &model.invariants {
+                let expected = fsl_runtime::eval(
+                    &property.expr,
+                    &monitor.state,
+                    &mut BTreeMap::new(),
+                    &model,
+                    None,
+                )
+                .expect("evaluate invariant concretely");
+                let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+                assert!(
+                    block_on(fsl_verifier::expression_matches_value(
+                        &model,
+                        &mut solver,
+                        &property.expr,
+                        &monitor.state,
+                        &expected,
+                    ))
+                    .expect("check expression agreement"),
+                    "{} disagreed in {name}",
+                    property.name
+                );
+            }
+            for enabled in monitor.enabled().expect("enumerate actions") {
+                let current = monitor.state.clone();
+                let mut successor = monitor.clone();
+                let result = successor.step(&enabled).expect("step Monitor");
+                if result.violation.is_some() {
+                    continue;
+                }
+                let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+                assert!(
+                    block_on(fsl_verifier::transition_matches_step(
+                        &model,
+                        &mut solver,
+                        &current,
+                        &enabled.action,
+                        &enabled.params,
+                        &result.state,
+                    ))
+                    .expect("check transition agreement"),
+                    "{} disagreed in {name}",
+                    enabled.action
+                );
+                total_checked += 1;
+                if !rejected_changed_successor {
+                    let mut wrong = result.state.clone();
+                    if let Some((_, FslValue::Bool(value))) = wrong
+                        .iter_mut()
+                        .find(|(_, value)| matches!(value, FslValue::Bool(_)))
+                    {
+                        *value = !*value;
+                        let mut solver =
+                            fsl_solver_z3::Z3Solver::new().expect("create rejection solver");
+                        assert!(
+                            !block_on(fsl_verifier::transition_matches_step(
+                                &model,
+                                &mut solver,
+                                &current,
+                                &enabled.action,
+                                &enabled.params,
+                                &wrong,
+                            ))
+                            .expect("reject altered successor")
+                        );
+                        rejected_changed_successor = true;
+                    }
+                }
+                if depth < 2 {
+                    queue.push_back((successor, depth + 1));
+                }
+            }
+        }
+    }
+    assert!(
+        total_checked >= 12,
+        "corpus exercised only {total_checked} transitions"
+    );
+    assert!(rejected_changed_successor);
+}
+
+#[test]
+fn ai_native_prompt_attempt_metrics_match_baseline() {
+    let manifest: Value = serde_json::from_str(&source("ai_native_cases.v1.json"))
+        .expect("parse AI-native corpus manifest");
+    let cases = manifest["cases"].as_array().expect("cases");
+    let mut initial_successes = 0_usize;
+    let mut repairs = Vec::new();
+    let mut operator_misuse = 0_i64;
+    let mut enum_misuse = 0_i64;
+    let mut internal_name_misuse = 0_i64;
+    let mut diagnostic_hits = 0_usize;
+    let mut diagnostic_total = 0_usize;
+    for case in cases {
+        let attempts = case["attempts"].as_array().expect("attempts");
+        let mut first_success = None;
+        let mut first_failure = None;
+        for (index, attempt) in attempts.iter().enumerate() {
+            let relative = relative_fixture(attempt.as_str().expect("attempt path"));
+            let (status, output) = run_cli(&["check", &relative]);
+            if index == 0 && status != 0 {
+                first_failure = Some(output);
+            }
+            if status == 0 {
+                first_success.get_or_insert(index);
+                break;
+            }
+        }
+        let repair_count = first_success.unwrap_or(attempts.len());
+        if repair_count == 0 {
+            initial_successes += 1;
+        }
+        repairs.push(repair_count);
+        operator_misuse += case["misuse"]["operator"].as_i64().expect("operator count");
+        enum_misuse += case["misuse"]["enum"].as_i64().expect("enum count");
+        internal_name_misuse += case["misuse"]["internal_generated_name"]
+            .as_i64()
+            .expect("generated-name count");
+        if let Some(line) = case
+            .get("diagnostic_expression_line")
+            .and_then(Value::as_u64)
+        {
+            diagnostic_total += 1;
+            let message = first_failure
+                .as_ref()
+                .and_then(|output| output["message"].as_str())
+                .unwrap_or_default();
+            if message.contains(&format!("at {line}:")) {
+                diagnostic_hits += 1;
+            }
+        }
+    }
+    let actual = json!({
+        "case_count":cases.len(),
+        "initial_check_successes":initial_successes,
+        "initial_check_success_rate":format!("{initial_successes}/{}",cases.len()),
+        "repairs_until_check_success":repairs,
+        "operator_misuse_count":operator_misuse,
+        "enum_misuse_count":enum_misuse,
+        "internal_generated_name_misuse_count":internal_name_misuse,
+        "diagnostic_expression_hits":diagnostic_hits,
+        "diagnostic_expression_total":diagnostic_total,
+        "diagnostic_expression_hit_rate":format!("{diagnostic_hits}/{diagnostic_total}")
+    });
+    assert_eq!(actual, manifest["baseline"]);
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/README.md
+++ b/rust/fslc/tests/fixtures/domain_characterization/README.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Domain expression characterization corpus
+
+This corpus freezes the pre-typed-expression domain frontend. It is evidence for
+the later migration, not a new language contract. Update its baselines only when
+an intentional semantic or diagnostic change has been accepted and documented.
+
+- `expressions_valid.fsl` covers canonical logical operators and legacy `->`, bare
+  enum members, finite membership, `can(Command)`, aggregate state references,
+  scalar/field assignments, defaults, invariants, and stale-policy expressions.
+- `lvalues_surface.fsl` covers root, index, and field lvalue parsing. Its current
+  Map-state lowering limitation is intentionally characterized as a failure.
+- `effect_saga_valid.fsl` covers expressions used by effect and saga lowering.
+- `on_stale` is captured in the surface projection only because current domain
+  lowering omits it; this corpus records that gap without accepting it as the
+  intended language contract.
+- `expressions_valid.fsl` records accepted legacy `||` and `->` normalization;
+  `legacy_logical_parse_error.fsl` records the current lexer rejection of `&&`.
+  The later typed-expression migration must make any change explicit.
+- `invalid_*.fsl` pins the current diagnostic kind and generated-source location
+  for unknown names/members, type mismatches, unsupported operators, and broken
+  expressions.
+- `ai_native_cases.v1.json` is a deterministic captured prompt/spec corpus. It
+  records first-pass `fslc check` success, repairs, operator/enum/generated-name
+  misuse, and whether a produced diagnostic points at the attempted expression.
+  It does not call an external model or set quality targets.
+- `known_generated_spans` labels the current public-Kernel defect where generated
+  Kernel coordinates are attached to the original domain filename. Those entries
+  are evidence of a known mismatch, not approval of the reported source spans.
+
+Regenerate a baseline only after reviewing the semantic projection, public
+Kernel expression/origin projection, verifier verdict/trace, and diagnostic span.
+Do not update goldens merely to make a refactor pass.
+
+From the repository root, regenerate the versioned baseline with:
+
+```bash
+UPDATE_DOMAIN_CHARACTERIZATION=1 cargo test --manifest-path rust/Cargo.toml \
+  -p fslc-rust --test domain_expression_characterization --locked
+```
+
+Then inspect the complete `baseline.v1.json` diff. A baseline update must be
+paired with the accepted language or diagnostic contract change that explains
+every changed projection.

--- a/rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl
@@ -1,0 +1,12 @@
+domain AiInternalNameMisuse {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = status }
+    invariant generatedName { status == Status_Draft }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/ai_native_cases.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/ai_native_cases.v1.json
@@ -1,0 +1,43 @@
+{
+  "spdx": "Apache-2.0",
+  "schema_version": "domain-ai-native-characterization.v1",
+  "cases": [
+    {
+      "id": "canonical-first-pass",
+      "prompt": "Model approval with canonical logic, finite membership, and can(Command).",
+      "attempts": ["expressions_valid.fsl"],
+      "misuse": {"operator": 0, "enum": 0, "internal_generated_name": 0}
+    },
+    {
+      "id": "legacy-operator-repair",
+      "prompt": "Model the same approval guard using familiar programming-language operators.",
+      "attempts": ["legacy_logical_parse_error.fsl", "expressions_valid.fsl"],
+      "misuse": {"operator": 2, "enum": 0, "internal_generated_name": 0},
+      "diagnostic_expression_line": 6
+    },
+    {
+      "id": "unknown-enum-member-check-gap",
+      "prompt": "Reject a state using an enum member that is not declared.",
+      "attempts": ["invalid_unknown_member.fsl"],
+      "misuse": {"operator": 0, "enum": 1, "internal_generated_name": 0}
+    },
+    {
+      "id": "generated-enum-name-check-gap",
+      "prompt": "Use the aggregate status without referring to compiler-generated names.",
+      "attempts": ["ai_internal_name_misuse.fsl"],
+      "misuse": {"operator": 0, "enum": 0, "internal_generated_name": 1}
+    }
+  ],
+  "baseline": {
+    "case_count": 4,
+    "initial_check_successes": 3,
+    "initial_check_success_rate": "3/4",
+    "repairs_until_check_success": [0, 1, 0, 0],
+    "operator_misuse_count": 2,
+    "enum_misuse_count": 1,
+    "internal_generated_name_misuse_count": 1,
+    "diagnostic_expression_hits": 1,
+    "diagnostic_expression_total": 1,
+    "diagnostic_expression_hit_rate": "1/1"
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -1,0 +1,8200 @@
+{
+  "spdx": "Apache-2.0",
+  "schema_version": "domain-expression-characterization.v1",
+  "surface_ast": {
+    "expressions_valid.fsl": {
+      "name": "DomainExpressionCharacterization",
+      "loc": {
+        "line": 1,
+        "column": 1
+      },
+      "types": [
+        {
+          "name": "OrderId",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "1",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 5,
+            "column": 3
+          }
+        },
+        {
+          "name": "Quantity",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "2",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 6,
+            "column": 3
+          }
+        },
+        {
+          "name": "OrderStatus",
+          "kind": "enum",
+          "members": [
+            "Draft",
+            "Approved",
+            "Cancelled"
+          ],
+          "lo": null,
+          "hi": null,
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 7,
+            "column": 3
+          }
+        },
+        {
+          "name": "AuditStamp",
+          "kind": "value_object",
+          "members": [],
+          "lo": null,
+          "hi": null,
+          "fields": [
+            {
+              "name": "status",
+              "type": "OrderStatus",
+              "default": "Draft",
+              "loc": {
+                "line": 10,
+                "column": 5
+              }
+            },
+            {
+              "name": "attempts",
+              "type": "Quantity",
+              "default": "0",
+              "loc": {
+                "line": 11,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [
+            {
+              "name": "nonNegative",
+              "expr": "attempts >= 0",
+              "loc": {
+                "line": 12,
+                "column": 5
+              }
+            }
+          ],
+          "loc": {
+            "line": 9,
+            "column": 3
+          }
+        }
+      ],
+      "aggregates": [
+        {
+          "name": "Order",
+          "state": [
+            {
+              "name": "status",
+              "type": "OrderStatus",
+              "default": "Draft",
+              "loc": {
+                "line": 19,
+                "column": 7
+              }
+            },
+            {
+              "name": "previous_status",
+              "type": "OrderStatus",
+              "default": "Draft",
+              "loc": {
+                "line": 20,
+                "column": 7
+              }
+            },
+            {
+              "name": "quantity",
+              "type": "Quantity",
+              "default": "0",
+              "loc": {
+                "line": 21,
+                "column": 7
+              }
+            },
+            {
+              "name": "audit",
+              "type": "AuditStamp",
+              "default": null,
+              "loc": {
+                "line": 22,
+                "column": 7
+              }
+            }
+          ],
+          "decides": [
+            {
+              "command": "Approve",
+              "requires": [
+                "status == Draft and not (status == Cancelled)",
+                "status != Cancelled and quantity >= 0"
+              ],
+              "rejects": [
+                {
+                  "error": "NotDraft",
+                  "condition": "status in [Approved, Cancelled]",
+                  "loc": {
+                    "line": 42,
+                    "column": 7
+                  }
+                }
+              ],
+              "emits": [
+                "Approved"
+              ],
+              "loc": {
+                "line": 39,
+                "column": 5
+              }
+            },
+            {
+              "command": "Cancel",
+              "requires": [
+                "status == Draft or status == Approved"
+              ],
+              "rejects": [
+                {
+                  "error": "AlreadyCancelled",
+                  "condition": "status == Cancelled",
+                  "loc": {
+                    "line": 48,
+                    "column": 7
+                  }
+                }
+              ],
+              "emits": [
+                "Cancelled"
+              ],
+              "loc": {
+                "line": 46,
+                "column": 5
+              }
+            }
+          ],
+          "evolves": [
+            {
+              "event": "Approved",
+              "requires": [
+                "status == Draft"
+              ],
+              "assignments": [
+                {
+                  "target": "previous_status",
+                  "expr": "status",
+                  "loc": {
+                    "line": 54,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "status",
+                  "expr": "Approved",
+                  "loc": {
+                    "line": 55,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "audit.status",
+                  "expr": "status",
+                  "loc": {
+                    "line": 56,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "quantity",
+                  "expr": "quantity",
+                  "loc": {
+                    "line": 57,
+                    "column": 7
+                  }
+                }
+              ],
+              "loc": {
+                "line": 52,
+                "column": 5
+              }
+            },
+            {
+              "event": "Cancelled",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "previous_status",
+                  "expr": "status",
+                  "loc": {
+                    "line": 61,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "status",
+                  "expr": "Cancelled",
+                  "loc": {
+                    "line": 62,
+                    "column": 7
+                  }
+                }
+              ],
+              "loc": {
+                "line": 60,
+                "column": 5
+              }
+            },
+            {
+              "event": "ApprovalRejected",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "previous_status",
+                  "expr": "status",
+                  "loc": {
+                    "line": 66,
+                    "column": 7
+                  }
+                }
+              ],
+              "loc": {
+                "line": 65,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [
+            {
+              "name": "canonicalImplication",
+              "expr": "status == Approved => previous_status == Draft or previous_status == Approved",
+              "loc": {
+                "line": 73,
+                "column": 5
+              }
+            },
+            {
+              "name": "legacyImplication",
+              "expr": "status == Cancelled -> not can(Cancel)",
+              "loc": {
+                "line": 77,
+                "column": 5
+              }
+            },
+            {
+              "name": "legacyDisjunction",
+              "expr": "status == Draft || status == Approved || status == Cancelled",
+              "loc": {
+                "line": 81,
+                "column": 5
+              }
+            },
+            {
+              "name": "finiteMembership",
+              "expr": "status in [Draft, Approved, Cancelled]",
+              "loc": {
+                "line": 85,
+                "column": 5
+              }
+            }
+          ],
+          "stale_policies": [
+            {
+              "event": "Approved",
+              "condition": "status == Approved and previous_status != Cancelled",
+              "emits": [
+                "ApprovalRejected"
+              ],
+              "loc": {
+                "line": 69,
+                "column": 5
+              }
+            }
+          ],
+          "loc": {
+            "line": 15,
+            "column": 3
+          }
+        }
+      ],
+      "effects": [],
+      "sagas": []
+    },
+    "lvalues_surface.fsl": {
+      "name": "DomainLvalueCharacterization",
+      "loc": {
+        "line": 1,
+        "column": 1
+      },
+      "types": [
+        {
+          "name": "ItemId",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "1",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 3,
+            "column": 3
+          }
+        },
+        {
+          "name": "Quantity",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "2",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        {
+          "name": "Counter",
+          "kind": "value_object",
+          "members": [],
+          "lo": null,
+          "hi": null,
+          "fields": [
+            {
+              "name": "value",
+              "type": "Quantity",
+              "default": "0",
+              "loc": {
+                "line": 7,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [],
+          "loc": {
+            "line": 6,
+            "column": 3
+          }
+        }
+      ],
+      "aggregates": [
+        {
+          "name": "Inventory",
+          "state": [
+            {
+              "name": "total",
+              "type": "Quantity",
+              "default": "0",
+              "loc": {
+                "line": 13,
+                "column": 7
+              }
+            },
+            {
+              "name": "counts",
+              "type": "Map<ItemId, Quantity>",
+              "default": null,
+              "loc": {
+                "line": 14,
+                "column": 7
+              }
+            },
+            {
+              "name": "counter",
+              "type": "Counter",
+              "default": null,
+              "loc": {
+                "line": 15,
+                "column": 7
+              }
+            }
+          ],
+          "decides": [
+            {
+              "command": "Adjust",
+              "requires": [],
+              "rejects": [],
+              "emits": [
+                "Adjusted"
+              ],
+              "loc": {
+                "line": 19,
+                "column": 5
+              }
+            }
+          ],
+          "evolves": [
+            {
+              "event": "Adjusted",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "total",
+                  "expr": "total + 1",
+                  "loc": {
+                    "line": 21,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "counts[item]",
+                  "expr": "counts[item] + 1",
+                  "loc": {
+                    "line": 22,
+                    "column": 7
+                  }
+                },
+                {
+                  "target": "counter.value",
+                  "expr": "total",
+                  "loc": {
+                    "line": 23,
+                    "column": 7
+                  }
+                }
+              ],
+              "loc": {
+                "line": 20,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [],
+          "stale_policies": [],
+          "loc": {
+            "line": 10,
+            "column": 3
+          }
+        }
+      ],
+      "effects": [],
+      "sagas": []
+    },
+    "effect_saga_valid.fsl": {
+      "name": "DomainEffectSagaCharacterization",
+      "loc": {
+        "line": 1,
+        "column": 1
+      },
+      "types": [
+        {
+          "name": "OrderId",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "1",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 5,
+            "column": 3
+          }
+        },
+        {
+          "name": "PaymentRequestId",
+          "kind": "range",
+          "members": [],
+          "lo": "0",
+          "hi": "1",
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 6,
+            "column": 3
+          }
+        },
+        {
+          "name": "Status",
+          "kind": "enum",
+          "members": [
+            "Draft",
+            "Approved",
+            "Paid",
+            "Failed"
+          ],
+          "lo": null,
+          "hi": null,
+          "fields": [],
+          "invariants": [],
+          "loc": {
+            "line": 7,
+            "column": 3
+          }
+        }
+      ],
+      "aggregates": [
+        {
+          "name": "Order",
+          "state": [
+            {
+              "name": "status",
+              "type": "Status",
+              "default": "Draft",
+              "loc": {
+                "line": 11,
+                "column": 13
+              }
+            }
+          ],
+          "decides": [
+            {
+              "command": "Approve",
+              "requires": [
+                "status == Draft"
+              ],
+              "rejects": [],
+              "emits": [
+                "Approved"
+              ],
+              "loc": {
+                "line": 22,
+                "column": 5
+              }
+            },
+            {
+              "command": "RequestPayment",
+              "requires": [
+                "status == Approved"
+              ],
+              "rejects": [],
+              "emits": [
+                "PaymentRequested"
+              ],
+              "loc": {
+                "line": 26,
+                "column": 5
+              }
+            }
+          ],
+          "evolves": [
+            {
+              "event": "Approved",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "status",
+                  "expr": "Approved",
+                  "loc": {
+                    "line": 31,
+                    "column": 23
+                  }
+                }
+              ],
+              "loc": {
+                "line": 31,
+                "column": 5
+              }
+            },
+            {
+              "event": "PaymentRequested",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "status",
+                  "expr": "Approved",
+                  "loc": {
+                    "line": 32,
+                    "column": 31
+                  }
+                }
+              ],
+              "loc": {
+                "line": 32,
+                "column": 5
+              }
+            },
+            {
+              "event": "PaymentCaptured",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "status",
+                  "expr": "Paid",
+                  "loc": {
+                    "line": 33,
+                    "column": 30
+                  }
+                }
+              ],
+              "loc": {
+                "line": 33,
+                "column": 5
+              }
+            },
+            {
+              "event": "PaymentFailed",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "status",
+                  "expr": "Failed",
+                  "loc": {
+                    "line": 34,
+                    "column": 28
+                  }
+                }
+              ],
+              "loc": {
+                "line": 34,
+                "column": 5
+              }
+            },
+            {
+              "event": "PaymentTimedOut",
+              "requires": [],
+              "assignments": [
+                {
+                  "target": "status",
+                  "expr": "Failed",
+                  "loc": {
+                    "line": 35,
+                    "column": 30
+                  }
+                }
+              ],
+              "loc": {
+                "line": 35,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [],
+          "stale_policies": [],
+          "loc": {
+            "line": 9,
+            "column": 3
+          }
+        }
+      ],
+      "effects": [
+        {
+          "name": "CapturePayment",
+          "idempotency_key": "Order.id",
+          "correlation_id": "PaymentRequested.payment_request_id",
+          "handles": "PaymentRequested",
+          "outcomes": [
+            "PaymentCaptured",
+            "PaymentFailed",
+            "PaymentTimedOut"
+          ],
+          "timeout_event": "PaymentTimedOut",
+          "retry_max_attempts": 2,
+          "loc": {
+            "line": 38,
+            "column": 3
+          }
+        }
+      ],
+      "sagas": [
+        {
+          "name": "PaymentFlow",
+          "starts_on": "Approved",
+          "steps": [
+            {
+              "name": "Capture",
+              "requires": [
+                "Approved and not PaymentFailed"
+              ],
+              "emits": [
+                "PaymentRequested"
+              ],
+              "awaits": [
+                "PaymentCaptured",
+                "PaymentFailed",
+                "PaymentTimedOut"
+              ],
+              "timeout_event": "PaymentTimedOut",
+              "loc": {
+                "line": 52,
+                "column": 5
+              }
+            }
+          ],
+          "invariants": [
+            {
+              "name": "terminalOutcome",
+              "expr": "PaymentCaptured or PaymentFailed or PaymentTimedOut -> not PaymentRequested",
+              "loc": {
+                "line": 59,
+                "column": 5
+              }
+            }
+          ],
+          "loc": {
+            "line": 50,
+            "column": 3
+          }
+        }
+      ]
+    }
+  },
+  "semantic_kernel_model": {
+    "expressions_valid.fsl": {
+      "name": "DomainExpressionCharacterization",
+      "types": {
+        "AuditStamp": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "status",
+              "type": {
+                "kind": "named",
+                "name": "OrderStatus"
+              }
+            },
+            {
+              "name": "attempts",
+              "type": {
+                "kind": "named",
+                "name": "Quantity"
+              }
+            }
+          ]
+        },
+        "OrderId": {
+          "kind": "domain",
+          "lo": 0,
+          "hi": 1,
+          "symmetric": false
+        },
+        "OrderStatus": {
+          "kind": "enum",
+          "members": [
+            "OrderStatus_Draft",
+            "OrderStatus_Approved",
+            "OrderStatus_Cancelled"
+          ],
+          "symmetric": false
+        },
+        "Quantity": {
+          "kind": "domain",
+          "lo": 0,
+          "hi": 2,
+          "symmetric": false
+        }
+      },
+      "state": [
+        {
+          "name": "event_ApprovalRejected",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_Approved",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_Cancelled",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "order_audit",
+          "type": {
+            "kind": "named",
+            "name": "AuditStamp"
+          }
+        },
+        {
+          "name": "order_previous_status",
+          "type": {
+            "kind": "named",
+            "name": "OrderStatus"
+          }
+        },
+        {
+          "name": "order_quantity",
+          "type": {
+            "kind": "named",
+            "name": "Quantity"
+          }
+        },
+        {
+          "name": "order_status",
+          "type": {
+            "kind": "named",
+            "name": "OrderStatus"
+          }
+        }
+      ],
+      "initial_state": {
+        "event_ApprovalRejected": false,
+        "event_Approved": false,
+        "event_Cancelled": false,
+        "order_audit": {
+          "attempts": 0,
+          "status": "OrderStatus_Draft"
+        },
+        "order_previous_status": "OrderStatus_Draft",
+        "order_quantity": 0,
+        "order_status": "OrderStatus_Draft"
+      },
+      "actions": [
+        {
+          "name": "order_approve",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "quantity",
+              "type": {
+                "kind": "named",
+                "name": "Quantity"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "and",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Draft"
+                ]
+              ],
+              [
+                "not",
+                [
+                  "bin",
+                  "==",
+                  [
+                    "var",
+                    "order_status"
+                  ],
+                  [
+                    "var",
+                    "OrderStatus_Cancelled"
+                  ]
+                ]
+              ]
+            ],
+            [
+              "bin",
+              "and",
+              [
+                "bin",
+                "!=",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Cancelled"
+                ]
+              ],
+              [
+                "bin",
+                ">=",
+                [
+                  "var",
+                  "order_quantity"
+                ],
+                [
+                  "num",
+                  0
+                ]
+              ]
+            ],
+            [
+              "not",
+              [
+                "bin",
+                "or",
+                [
+                  "bin",
+                  "==",
+                  [
+                    "var",
+                    "order_status"
+                  ],
+                  [
+                    "var",
+                    "OrderStatus_Approved"
+                  ]
+                ],
+                [
+                  "bin",
+                  "==",
+                  [
+                    "var",
+                    "order_status"
+                  ],
+                  [
+                    "var",
+                    "OrderStatus_Cancelled"
+                  ]
+                ]
+              ]
+            ],
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Draft"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_ApprovalRejected"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_Cancelled"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_previous_status"
+              ],
+              [
+                "var",
+                "order_status"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Approved"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "field_lv",
+                [
+                  "var",
+                  "order_audit"
+                ],
+                "status"
+              ],
+              [
+                "var",
+                "order_status"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_quantity"
+              ],
+              [
+                "var",
+                "order_quantity"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "order_cancel",
+          "parameters": [],
+          "requires": [
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Draft"
+                ]
+              ],
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Approved"
+                ]
+              ]
+            ],
+            [
+              "not",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Cancelled"
+                ]
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_ApprovalRejected"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_Cancelled"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_previous_status"
+              ],
+              [
+                "var",
+                "order_status"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Cancelled"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        }
+      ],
+      "invariants": [
+        {
+          "name": "Order_canonicalImplication",
+          "expression": [
+            "bin",
+            "=>",
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Approved"
+              ]
+            ],
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_previous_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Draft"
+                ]
+              ],
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_previous_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Approved"
+                ]
+              ]
+            ]
+          ]
+        },
+        {
+          "name": "Order_finiteMembership",
+          "expression": [
+            "bin",
+            "or",
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Draft"
+                ]
+              ],
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Approved"
+                ]
+              ]
+            ],
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Cancelled"
+              ]
+            ]
+          ]
+        },
+        {
+          "name": "Order_legacyDisjunction",
+          "expression": [
+            "bin",
+            "or",
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Draft"
+                ]
+              ],
+              [
+                "bin",
+                "==",
+                [
+                  "var",
+                  "order_status"
+                ],
+                [
+                  "var",
+                  "OrderStatus_Approved"
+                ]
+              ]
+            ],
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Cancelled"
+              ]
+            ]
+          ]
+        },
+        {
+          "name": "Order_legacyImplication",
+          "expression": [
+            "bin",
+            "=>",
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "OrderStatus_Cancelled"
+              ]
+            ],
+            [
+              "not",
+              [
+                "bin",
+                "or",
+                [
+                  "bin",
+                  "==",
+                  [
+                    "var",
+                    "order_status"
+                  ],
+                  [
+                    "var",
+                    "OrderStatus_Draft"
+                  ]
+                ],
+                [
+                  "bin",
+                  "and",
+                  [
+                    "bin",
+                    "==",
+                    [
+                      "var",
+                      "order_status"
+                    ],
+                    [
+                      "var",
+                      "OrderStatus_Approved"
+                    ]
+                  ],
+                  [
+                    "not",
+                    [
+                      "bin",
+                      "==",
+                      [
+                        "var",
+                        "order_status"
+                      ],
+                      [
+                        "var",
+                        "OrderStatus_Cancelled"
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        }
+      ],
+      "terminal": [
+        "bool",
+        false
+      ]
+    },
+    "effect_saga_valid.fsl": {
+      "name": "DomainEffectSagaCharacterization",
+      "types": {
+        "CapturePaymentAttempt": {
+          "kind": "domain",
+          "lo": 0,
+          "hi": 2,
+          "symmetric": false
+        },
+        "CapturePaymentEffectStatus": {
+          "kind": "enum",
+          "members": [
+            "CapturePaymentEffectStatus_NotStarted",
+            "CapturePaymentEffectStatus_Pending",
+            "CapturePaymentEffectStatus_Succeeded",
+            "CapturePaymentEffectStatus_Failed",
+            "CapturePaymentEffectStatus_TimedOut",
+            "CapturePaymentEffectStatus_Cancelled",
+            "CapturePaymentEffectStatus_Compensated"
+          ],
+          "symmetric": false
+        },
+        "OrderId": {
+          "kind": "domain",
+          "lo": 0,
+          "hi": 1,
+          "symmetric": false
+        },
+        "PaymentRequestId": {
+          "kind": "domain",
+          "lo": 0,
+          "hi": 1,
+          "symmetric": false
+        },
+        "Status": {
+          "kind": "enum",
+          "members": [
+            "Status_Draft",
+            "Status_Approved",
+            "Status_Paid",
+            "Status_Failed"
+          ],
+          "symmetric": false
+        }
+      },
+      "state": [
+        {
+          "name": "capture_payment_attempts",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "named",
+              "name": "PaymentRequestId"
+            },
+            "value": {
+              "kind": "named",
+              "name": "CapturePaymentAttempt"
+            }
+          }
+        },
+        {
+          "name": "capture_payment_status",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "named",
+              "name": "PaymentRequestId"
+            },
+            "value": {
+              "kind": "named",
+              "name": "CapturePaymentEffectStatus"
+            }
+          }
+        },
+        {
+          "name": "event_Approved",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_PaymentCaptured",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_PaymentFailed",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_PaymentRequested",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "event_PaymentTimedOut",
+          "type": {
+            "kind": "bool"
+          }
+        },
+        {
+          "name": "order_status",
+          "type": {
+            "kind": "named",
+            "name": "Status"
+          }
+        }
+      ],
+      "initial_state": {
+        "capture_payment_attempts": {
+          "0": 0,
+          "1": 0
+        },
+        "capture_payment_status": {
+          "0": "CapturePaymentEffectStatus_NotStarted",
+          "1": "CapturePaymentEffectStatus_NotStarted"
+        },
+        "event_Approved": false,
+        "event_PaymentCaptured": false,
+        "event_PaymentFailed": false,
+        "event_PaymentRequested": false,
+        "event_PaymentTimedOut": false,
+        "order_status": "Status_Draft"
+      },
+      "actions": [
+        {
+          "name": "capture_payment_complete_payment_captured",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "==",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_status"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_status",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Succeeded"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Paid"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "capture_payment_complete_payment_failed",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "==",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_status"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_status",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Failed"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Failed"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "capture_payment_complete_payment_timed_out",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "==",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_status"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_status",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_TimedOut"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Failed"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "capture_payment_retry",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "==",
+                [
+                  "index",
+                  [
+                    "var",
+                    "capture_payment_status"
+                  ],
+                  [
+                    "var",
+                    "payment_request_id"
+                  ]
+                ],
+                [
+                  "var",
+                  "CapturePaymentEffectStatus_Failed"
+                ]
+              ],
+              [
+                "bin",
+                "==",
+                [
+                  "index",
+                  [
+                    "var",
+                    "capture_payment_status"
+                  ],
+                  [
+                    "var",
+                    "payment_request_id"
+                  ]
+                ],
+                [
+                  "var",
+                  "CapturePaymentEffectStatus_TimedOut"
+                ]
+              ]
+            ],
+            [
+              "bin",
+              "<",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_attempts"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "num",
+                2
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_status",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_attempts",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "bin",
+                "+",
+                [
+                  "index",
+                  [
+                    "var",
+                    "capture_payment_attempts"
+                  ],
+                  [
+                    "var",
+                    "payment_request_id"
+                  ]
+                ],
+                [
+                  "num",
+                  1
+                ]
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "order_approve",
+          "parameters": [],
+          "requires": [
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Draft"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Approved"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "order_request_payment",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [
+            [
+              "bin",
+              "==",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Approved"
+              ]
+            ],
+            [
+              "bin",
+              "!=",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_status"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ]
+            ],
+            [
+              "bin",
+              "!=",
+              [
+                "index",
+                [
+                  "var",
+                  "capture_payment_status"
+                ],
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Succeeded"
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Approved"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_status",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "var",
+                "CapturePaymentEffectStatus_Pending"
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "index",
+                "capture_payment_attempts",
+                [
+                  "var",
+                  "payment_request_id"
+                ]
+              ],
+              [
+                "num",
+                1
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "saga_payment_flow_capture",
+          "parameters": [],
+          "requires": [
+            [
+              "var",
+              "event_Approved"
+            ],
+            [
+              "bin",
+              "and",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "not",
+                [
+                  "var",
+                  "event_PaymentFailed"
+                ]
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "saga_payment_flow_capture_timeout",
+          "parameters": [],
+          "requires": [
+            [
+              "var",
+              "event_Approved"
+            ],
+            [
+              "bin",
+              "and",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "not",
+                [
+                  "var",
+                  "event_PaymentFailed"
+                ]
+              ]
+            ]
+          ],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "saga_payment_flow_observe_payment_captured",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Paid"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "saga_payment_flow_observe_payment_failed",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Failed"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        },
+        {
+          "name": "saga_payment_flow_observe_payment_timed_out",
+          "parameters": [
+            {
+              "kind": "typed",
+              "name": "payment_request_id",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              }
+            }
+          ],
+          "requires": [],
+          "lets": [],
+          "updates": [
+            [
+              "assign",
+              [
+                "var",
+                "event_Approved"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentCaptured"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentFailed"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentRequested"
+              ],
+              [
+                "bool",
+                false
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ],
+              [
+                "bool",
+                true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Failed"
+              ],
+              "<location>"
+            ]
+          ],
+          "ensures": [],
+          "fair": false
+        }
+      ],
+      "invariants": [
+        {
+          "name": "PaymentFlow_terminalOutcome",
+          "expression": [
+            "bin",
+            "=>",
+            [
+              "bin",
+              "or",
+              [
+                "bin",
+                "or",
+                [
+                  "var",
+                  "event_PaymentCaptured"
+                ],
+                [
+                  "var",
+                  "event_PaymentFailed"
+                ]
+              ],
+              [
+                "var",
+                "event_PaymentTimedOut"
+              ]
+            ],
+            [
+              "not",
+              [
+                "var",
+                "event_PaymentRequested"
+              ]
+            ]
+          ]
+        }
+      ],
+      "terminal": [
+        "bool",
+        false
+      ]
+    }
+  },
+  "public_kernel": {
+    "expressions_valid.fsl": {
+      "schema_version": "1.0.0",
+      "spec": {
+        "name": "DomainExpressionCharacterization",
+        "source": {
+          "file": "expressions_valid.fsl",
+          "dialect": "domain"
+        }
+      },
+      "state": [
+        {
+          "name": "event_ApprovalRejected",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_ApprovalRejected",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_Approved",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_Approved",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_Cancelled",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_Cancelled",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "order_audit",
+          "type": {
+            "kind": "named",
+            "name": "AuditStamp"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_audit",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "order_previous_status",
+          "type": {
+            "kind": "named",
+            "name": "OrderStatus"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_previous_status",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "order_quantity",
+          "type": {
+            "kind": "named",
+            "name": "Quantity"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_quantity",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "order_status",
+          "type": {
+            "kind": "named",
+            "name": "OrderStatus"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_status",
+            "lowered": true,
+            "generated": false
+          }
+        }
+      ],
+      "init": {
+        "statements": [
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 16,
+              "column": 5,
+              "end_line": 16,
+              "end_column": 17
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "OrderStatus"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 16,
+                "column": 5,
+                "end_line": 16,
+                "end_column": 17
+              },
+              "name": "order_status"
+            },
+            "value": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "OrderStatus"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 16,
+                "column": 5,
+                "end_line": 16,
+                "end_column": 17
+              },
+              "name": "OrderStatus_Draft"
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 17,
+              "column": 5,
+              "end_line": 17,
+              "end_column": 26
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "OrderStatus"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 17,
+                "column": 5,
+                "end_line": 17,
+                "end_column": 26
+              },
+              "name": "order_previous_status"
+            },
+            "value": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "OrderStatus"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 17,
+                "column": 5,
+                "end_line": 17,
+                "end_column": 26
+              },
+              "name": "OrderStatus_Draft"
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 18,
+              "column": 5,
+              "end_line": 18,
+              "end_column": 19
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "Quantity"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 18,
+                "column": 5,
+                "end_line": 18,
+                "end_column": 19
+              },
+              "name": "order_quantity"
+            },
+            "value": {
+              "kind": "num",
+              "type": {
+                "kind": "domain",
+                "lo": 0,
+                "hi": 2
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 18,
+                "column": 5,
+                "end_line": 18,
+                "end_column": 19
+              },
+              "value": 0
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 19,
+              "column": 5,
+              "end_line": 19,
+              "end_column": 16
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "AuditStamp"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 19,
+                "column": 5,
+                "end_line": 19,
+                "end_column": 16
+              },
+              "name": "order_audit"
+            },
+            "value": {
+              "kind": "struct_lit",
+              "type": {
+                "kind": "named",
+                "name": "AuditStamp"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 19,
+                "column": 5,
+                "end_line": 19,
+                "end_column": 16
+              },
+              "name": "AuditStamp",
+              "fields": {
+                "status": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 19,
+                    "column": 5,
+                    "end_line": 19,
+                    "end_column": 16
+                  },
+                  "name": "OrderStatus_Draft"
+                },
+                "attempts": {
+                  "kind": "num",
+                  "type": {
+                    "kind": "domain",
+                    "lo": 0,
+                    "hi": 2
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 19,
+                    "column": 5,
+                    "end_line": 19,
+                    "end_column": 16
+                  },
+                  "value": 0
+                }
+              }
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 20,
+              "column": 5,
+              "end_line": 20,
+              "end_column": 27
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 20,
+                "column": 5,
+                "end_line": 20,
+                "end_column": 27
+              },
+              "name": "event_ApprovalRejected"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 20,
+                "column": 5,
+                "end_line": 20,
+                "end_column": 27
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 21,
+              "column": 5,
+              "end_line": 21,
+              "end_column": 19
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 21,
+                "column": 5,
+                "end_line": 21,
+                "end_column": 19
+              },
+              "name": "event_Approved"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 21,
+                "column": 5,
+                "end_line": 21,
+                "end_column": 19
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 22,
+              "column": 5,
+              "end_line": 22,
+              "end_column": 20
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 20
+              },
+              "name": "event_Cancelled"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 20
+              },
+              "value": false
+            }
+          }
+        ],
+        "origin": {
+          "dialect": "domain",
+          "declaration": "init",
+          "lowered": true,
+          "generated": false
+        },
+        "span": {
+          "file": "expressions_valid.fsl",
+          "line": 16,
+          "column": 5,
+          "end_line": 16,
+          "end_column": 17
+        }
+      },
+      "actions": [
+        {
+          "name": "order_approve",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 25,
+                  "column": 5,
+                  "end_line": 25,
+                  "end_column": 13
+                },
+                "operator": "and",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 25,
+                    "column": 5,
+                    "end_line": 25,
+                    "end_column": 13
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 25,
+                      "column": 5,
+                      "end_line": 25,
+                      "end_column": 13
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 25,
+                      "column": 5,
+                      "end_line": 25,
+                      "end_column": 13
+                    },
+                    "name": "OrderStatus_Draft"
+                  }
+                },
+                "right": {
+                  "kind": "not",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 25,
+                    "column": 5,
+                    "end_line": 25,
+                    "end_column": 13
+                  },
+                  "operand": {
+                    "kind": "binary",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 25,
+                      "column": 5,
+                      "end_line": 25,
+                      "end_column": 13
+                    },
+                    "operator": "==",
+                    "left": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 25,
+                        "column": 5,
+                        "end_line": 25,
+                        "end_column": 13
+                      },
+                      "name": "order_status"
+                    },
+                    "right": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 25,
+                        "column": 5,
+                        "end_line": 25,
+                        "end_column": 13
+                      },
+                      "name": "OrderStatus_Cancelled"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 26,
+                  "column": 5,
+                  "end_line": 26,
+                  "end_column": 13
+                },
+                "operator": "and",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 26,
+                    "column": 5,
+                    "end_line": 26,
+                    "end_column": 13
+                  },
+                  "operator": "!=",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 26,
+                      "column": 5,
+                      "end_line": 26,
+                      "end_column": 13
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 26,
+                      "column": 5,
+                      "end_line": 26,
+                      "end_column": 13
+                    },
+                    "name": "OrderStatus_Cancelled"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 26,
+                    "column": 5,
+                    "end_line": 26,
+                    "end_column": 13
+                  },
+                  "operator": ">=",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "Quantity"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 26,
+                      "column": 5,
+                      "end_line": 26,
+                      "end_column": 13
+                    },
+                    "name": "order_quantity"
+                  },
+                  "right": {
+                    "kind": "num",
+                    "type": {
+                      "kind": "int"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 26,
+                      "column": 5,
+                      "end_line": 26,
+                      "end_column": 13
+                    },
+                    "value": 0
+                  }
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "not",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 27,
+                  "column": 5,
+                  "end_line": 27,
+                  "end_column": 13
+                },
+                "operand": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 27,
+                    "column": 5,
+                    "end_line": 27,
+                    "end_column": 13
+                  },
+                  "operator": "or",
+                  "left": {
+                    "kind": "binary",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 27,
+                      "column": 5,
+                      "end_line": 27,
+                      "end_column": 13
+                    },
+                    "operator": "==",
+                    "left": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 27,
+                        "column": 5,
+                        "end_line": 27,
+                        "end_column": 13
+                      },
+                      "name": "order_status"
+                    },
+                    "right": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 27,
+                        "column": 5,
+                        "end_line": 27,
+                        "end_column": 13
+                      },
+                      "name": "OrderStatus_Approved"
+                    }
+                  },
+                  "right": {
+                    "kind": "binary",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 27,
+                      "column": 5,
+                      "end_line": 27,
+                      "end_column": 13
+                    },
+                    "operator": "==",
+                    "left": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 27,
+                        "column": 5,
+                        "end_line": 27,
+                        "end_column": 13
+                      },
+                      "name": "order_status"
+                    },
+                    "right": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 27,
+                        "column": 5,
+                        "end_line": 27,
+                        "end_column": 13
+                      },
+                      "name": "OrderStatus_Cancelled"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 31,
+                  "column": 5,
+                  "end_line": 31,
+                  "end_column": 13
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 31,
+                    "column": 5,
+                    "end_line": 31,
+                    "end_column": 13
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 31,
+                    "column": 5,
+                    "end_line": 31,
+                    "end_column": 13
+                  },
+                  "name": "OrderStatus_Draft"
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 28,
+                "column": 5,
+                "end_line": 28,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 28,
+                  "column": 5,
+                  "end_line": 28,
+                  "end_column": 27
+                },
+                "name": "event_ApprovalRejected"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 28,
+                  "column": 5,
+                  "end_line": 28,
+                  "end_column": 27
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 29,
+                "column": 5,
+                "end_line": 29,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 29,
+                  "column": 5,
+                  "end_line": 29,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 29,
+                  "column": 5,
+                  "end_line": 29,
+                  "end_column": 19
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 30,
+                "column": 5,
+                "end_line": 30,
+                "end_column": 20
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 30,
+                  "column": 5,
+                  "end_line": 30,
+                  "end_column": 20
+                },
+                "name": "event_Cancelled"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 30,
+                  "column": 5,
+                  "end_line": 30,
+                  "end_column": 20
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 32,
+                "column": 5,
+                "end_line": 32,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 32,
+                  "column": 5,
+                  "end_line": 32,
+                  "end_column": 26
+                },
+                "name": "order_previous_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 32,
+                  "column": 5,
+                  "end_line": 32,
+                  "end_column": 26
+                },
+                "name": "order_status"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 33,
+                "column": 5,
+                "end_line": 33,
+                "end_column": 17
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 33,
+                  "column": 5,
+                  "end_line": 33,
+                  "end_column": 17
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 33,
+                  "column": 5,
+                  "end_line": 33,
+                  "end_column": 17
+                },
+                "name": "OrderStatus_Approved"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 34,
+                "column": 5,
+                "end_line": 34,
+                "end_column": 16
+              },
+              "target": {
+                "kind": "field_lv",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 34,
+                  "column": 5,
+                  "end_line": 34,
+                  "end_column": 16
+                },
+                "target": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "AuditStamp"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 34,
+                    "column": 5,
+                    "end_line": 34,
+                    "end_column": 16
+                  },
+                  "name": "order_audit"
+                },
+                "field": "status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 34,
+                  "column": 5,
+                  "end_line": 34,
+                  "end_column": 16
+                },
+                "name": "order_status"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 35,
+                "column": 5,
+                "end_line": 35,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Quantity"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 35,
+                  "column": 5,
+                  "end_line": 35,
+                  "end_column": 19
+                },
+                "name": "order_quantity"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Quantity"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 35,
+                  "column": 5,
+                  "end_line": 35,
+                  "end_column": 19
+                },
+                "name": "order_quantity"
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_approve",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "expressions_valid.fsl",
+            "line": 24,
+            "column": 3,
+            "end_line": 24,
+            "end_column": 9
+          }
+        },
+        {
+          "name": "order_cancel",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 38,
+                  "column": 5,
+                  "end_line": 38,
+                  "end_column": 13
+                },
+                "operator": "or",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 38,
+                    "column": 5,
+                    "end_line": 38,
+                    "end_column": 13
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "OrderStatus_Draft"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 38,
+                    "column": 5,
+                    "end_line": 38,
+                    "end_column": 13
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "OrderStatus_Approved"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "not",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 39,
+                  "column": 5,
+                  "end_line": 39,
+                  "end_column": 13
+                },
+                "operand": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 39,
+                    "column": 5,
+                    "end_line": 39,
+                    "end_column": 13
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 39,
+                      "column": 5,
+                      "end_line": 39,
+                      "end_column": 13
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 39,
+                      "column": 5,
+                      "end_line": 39,
+                      "end_column": 13
+                    },
+                    "name": "OrderStatus_Cancelled"
+                  }
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 40,
+                "column": 5,
+                "end_line": 40,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 40,
+                  "column": 5,
+                  "end_line": 40,
+                  "end_column": 27
+                },
+                "name": "event_ApprovalRejected"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 40,
+                  "column": 5,
+                  "end_line": 40,
+                  "end_column": 27
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 41,
+                "column": 5,
+                "end_line": 41,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 41,
+                  "column": 5,
+                  "end_line": 41,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 41,
+                  "column": 5,
+                  "end_line": 41,
+                  "end_column": 19
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 42,
+                "column": 5,
+                "end_line": 42,
+                "end_column": 20
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 42,
+                  "column": 5,
+                  "end_line": 42,
+                  "end_column": 20
+                },
+                "name": "event_Cancelled"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 42,
+                  "column": 5,
+                  "end_line": 42,
+                  "end_column": 20
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 43,
+                "column": 5,
+                "end_line": 43,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 43,
+                  "column": 5,
+                  "end_line": 43,
+                  "end_column": 26
+                },
+                "name": "order_previous_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 43,
+                  "column": 5,
+                  "end_line": 43,
+                  "end_column": 26
+                },
+                "name": "order_status"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 44,
+                "column": 5,
+                "end_line": 44,
+                "end_column": 17
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 44,
+                  "column": 5,
+                  "end_line": 44,
+                  "end_column": 17
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "OrderStatus"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 44,
+                  "column": 5,
+                  "end_line": 44,
+                  "end_column": 17
+                },
+                "name": "OrderStatus_Cancelled"
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_cancel",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "expressions_valid.fsl",
+            "line": 37,
+            "column": 3,
+            "end_line": 37,
+            "end_column": 9
+          }
+        }
+      ],
+      "properties": {
+        "invariants": [
+          {
+            "name": "Order_canonicalImplication",
+            "source_kind": "invariant",
+            "expression": {
+              "kind": "binary",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 46,
+                "column": 3,
+                "end_line": 46,
+                "end_column": 12
+              },
+              "operator": "=>",
+              "left": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 46,
+                  "column": 3,
+                  "end_line": 46,
+                  "end_column": 12
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 46,
+                    "column": 3,
+                    "end_line": 46,
+                    "end_column": 12
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 46,
+                    "column": 3,
+                    "end_line": 46,
+                    "end_column": 12
+                  },
+                  "name": "OrderStatus_Approved"
+                }
+              },
+              "right": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 46,
+                  "column": 3,
+                  "end_line": 46,
+                  "end_column": 12
+                },
+                "operator": "or",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 46,
+                    "column": 3,
+                    "end_line": 46,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 46,
+                      "column": 3,
+                      "end_line": 46,
+                      "end_column": 12
+                    },
+                    "name": "order_previous_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 46,
+                      "column": 3,
+                      "end_line": 46,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Draft"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 46,
+                    "column": 3,
+                    "end_line": 46,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 46,
+                      "column": 3,
+                      "end_line": 46,
+                      "end_column": 12
+                    },
+                    "name": "order_previous_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 46,
+                      "column": 3,
+                      "end_line": 46,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Approved"
+                  }
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-INVARIANT",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 46,
+              "column": 3,
+              "end_line": 46,
+              "end_column": 12
+            }
+          },
+          {
+            "name": "Order_finiteMembership",
+            "source_kind": "invariant",
+            "expression": {
+              "kind": "binary",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 49,
+                "column": 3,
+                "end_line": 49,
+                "end_column": 12
+              },
+              "operator": "or",
+              "left": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 49,
+                  "column": 3,
+                  "end_line": 49,
+                  "end_column": 12
+                },
+                "operator": "or",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 49,
+                    "column": 3,
+                    "end_line": 49,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 49,
+                      "column": 3,
+                      "end_line": 49,
+                      "end_column": 12
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 49,
+                      "column": 3,
+                      "end_line": 49,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Draft"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 49,
+                    "column": 3,
+                    "end_line": 49,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 49,
+                      "column": 3,
+                      "end_line": 49,
+                      "end_column": 12
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 49,
+                      "column": 3,
+                      "end_line": 49,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Approved"
+                  }
+                }
+              },
+              "right": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 49,
+                  "column": 3,
+                  "end_line": 49,
+                  "end_column": 12
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 49,
+                    "column": 3,
+                    "end_line": 49,
+                    "end_column": 12
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 49,
+                    "column": 3,
+                    "end_line": 49,
+                    "end_column": 12
+                  },
+                  "name": "OrderStatus_Cancelled"
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-INVARIANT",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 49,
+              "column": 3,
+              "end_line": 49,
+              "end_column": 12
+            }
+          },
+          {
+            "name": "Order_legacyDisjunction",
+            "source_kind": "invariant",
+            "expression": {
+              "kind": "binary",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 48,
+                "column": 3,
+                "end_line": 48,
+                "end_column": 12
+              },
+              "operator": "or",
+              "left": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 48,
+                  "column": 3,
+                  "end_line": 48,
+                  "end_column": 12
+                },
+                "operator": "or",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 48,
+                    "column": 3,
+                    "end_line": 48,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 48,
+                      "column": 3,
+                      "end_line": 48,
+                      "end_column": 12
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 48,
+                      "column": 3,
+                      "end_line": 48,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Draft"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 48,
+                    "column": 3,
+                    "end_line": 48,
+                    "end_column": 12
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 48,
+                      "column": 3,
+                      "end_line": 48,
+                      "end_column": 12
+                    },
+                    "name": "order_status"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "OrderStatus"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 48,
+                      "column": 3,
+                      "end_line": 48,
+                      "end_column": 12
+                    },
+                    "name": "OrderStatus_Approved"
+                  }
+                }
+              },
+              "right": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 48,
+                  "column": 3,
+                  "end_line": 48,
+                  "end_column": 12
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 48,
+                    "column": 3,
+                    "end_line": 48,
+                    "end_column": 12
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 48,
+                    "column": 3,
+                    "end_line": 48,
+                    "end_column": 12
+                  },
+                  "name": "OrderStatus_Cancelled"
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-INVARIANT",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 48,
+              "column": 3,
+              "end_line": 48,
+              "end_column": 12
+            }
+          },
+          {
+            "name": "Order_legacyImplication",
+            "source_kind": "invariant",
+            "expression": {
+              "kind": "binary",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "expressions_valid.fsl",
+                "line": 47,
+                "column": 3,
+                "end_line": 47,
+                "end_column": 12
+              },
+              "operator": "=>",
+              "left": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 47,
+                  "column": 3,
+                  "end_line": 47,
+                  "end_column": 12
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 47,
+                    "column": 3,
+                    "end_line": 47,
+                    "end_column": 12
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "OrderStatus"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 47,
+                    "column": 3,
+                    "end_line": 47,
+                    "end_column": 12
+                  },
+                  "name": "OrderStatus_Cancelled"
+                }
+              },
+              "right": {
+                "kind": "not",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "expressions_valid.fsl",
+                  "line": 47,
+                  "column": 3,
+                  "end_line": 47,
+                  "end_column": 12
+                },
+                "operand": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "expressions_valid.fsl",
+                    "line": 47,
+                    "column": 3,
+                    "end_line": 47,
+                    "end_column": 12
+                  },
+                  "operator": "or",
+                  "left": {
+                    "kind": "binary",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 47,
+                      "column": 3,
+                      "end_line": 47,
+                      "end_column": 12
+                    },
+                    "operator": "==",
+                    "left": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 47,
+                        "column": 3,
+                        "end_line": 47,
+                        "end_column": 12
+                      },
+                      "name": "order_status"
+                    },
+                    "right": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "OrderStatus"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 47,
+                        "column": 3,
+                        "end_line": 47,
+                        "end_column": 12
+                      },
+                      "name": "OrderStatus_Draft"
+                    }
+                  },
+                  "right": {
+                    "kind": "binary",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 47,
+                      "column": 3,
+                      "end_line": 47,
+                      "end_column": 12
+                    },
+                    "operator": "and",
+                    "left": {
+                      "kind": "binary",
+                      "type": {
+                        "kind": "bool"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 47,
+                        "column": 3,
+                        "end_line": 47,
+                        "end_column": 12
+                      },
+                      "operator": "==",
+                      "left": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "OrderStatus"
+                        },
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 47,
+                          "column": 3,
+                          "end_line": 47,
+                          "end_column": 12
+                        },
+                        "name": "order_status"
+                      },
+                      "right": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "OrderStatus"
+                        },
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 47,
+                          "column": 3,
+                          "end_line": 47,
+                          "end_column": 12
+                        },
+                        "name": "OrderStatus_Approved"
+                      }
+                    },
+                    "right": {
+                      "kind": "not",
+                      "type": {
+                        "kind": "bool"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 47,
+                        "column": 3,
+                        "end_line": 47,
+                        "end_column": 12
+                      },
+                      "operand": {
+                        "kind": "binary",
+                        "type": {
+                          "kind": "bool"
+                        },
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 47,
+                          "column": 3,
+                          "end_line": 47,
+                          "end_column": 12
+                        },
+                        "operator": "==",
+                        "left": {
+                          "kind": "var",
+                          "type": {
+                            "kind": "named",
+                            "name": "OrderStatus"
+                          },
+                          "span": {
+                            "file": "expressions_valid.fsl",
+                            "line": 47,
+                            "column": 3,
+                            "end_line": 47,
+                            "end_column": 12
+                          },
+                          "name": "order_status"
+                        },
+                        "right": {
+                          "kind": "var",
+                          "type": {
+                            "kind": "named",
+                            "name": "OrderStatus"
+                          },
+                          "span": {
+                            "file": "expressions_valid.fsl",
+                            "line": 47,
+                            "column": 3,
+                            "end_line": 47,
+                            "end_column": 12
+                          },
+                          "name": "OrderStatus_Cancelled"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-INVARIANT",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 47,
+              "column": 3,
+              "end_line": 47,
+              "end_column": 12
+            }
+          }
+        ],
+        "transitions": [],
+        "terminal": {
+          "source_kind": "terminal",
+          "expression": {
+            "kind": "bool",
+            "type": {
+              "kind": "bool"
+            },
+            "span": {
+              "file": "expressions_valid.fsl",
+              "line": 50,
+              "column": 3,
+              "end_line": 50,
+              "end_column": 11
+            },
+            "value": false
+          },
+          "span": {
+            "file": "expressions_valid.fsl",
+            "line": 50,
+            "column": 3,
+            "end_line": 50,
+            "end_column": 11
+          }
+        }
+      }
+    },
+    "effect_saga_valid.fsl": {
+      "schema_version": "1.0.0",
+      "spec": {
+        "name": "DomainEffectSagaCharacterization",
+        "source": {
+          "file": "effect_saga_valid.fsl",
+          "dialect": "domain"
+        }
+      },
+      "state": [
+        {
+          "name": "capture_payment_attempts",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "named",
+              "name": "PaymentRequestId"
+            },
+            "value": {
+              "kind": "named",
+              "name": "CapturePaymentAttempt"
+            }
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "capture_payment_attempts",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "capture_payment_status",
+          "type": {
+            "kind": "map",
+            "key": {
+              "kind": "named",
+              "name": "PaymentRequestId"
+            },
+            "value": {
+              "kind": "named",
+              "name": "CapturePaymentEffectStatus"
+            }
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "capture_payment_status",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_Approved",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_Approved",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_PaymentCaptured",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_PaymentCaptured",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_PaymentFailed",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_PaymentFailed",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_PaymentRequested",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_PaymentRequested",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "event_PaymentTimedOut",
+          "type": {
+            "kind": "bool"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "event_PaymentTimedOut",
+            "lowered": true,
+            "generated": false
+          }
+        },
+        {
+          "name": "order_status",
+          "type": {
+            "kind": "named",
+            "name": "Status"
+          },
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_status",
+            "lowered": true,
+            "generated": false
+          }
+        }
+      ],
+      "init": {
+        "statements": [
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 18,
+              "column": 5,
+              "end_line": 18,
+              "end_column": 17
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "Status"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 18,
+                "column": 5,
+                "end_line": 18,
+                "end_column": 17
+              },
+              "name": "order_status"
+            },
+            "value": {
+              "kind": "var",
+              "type": {
+                "kind": "named",
+                "name": "Status"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 18,
+                "column": 5,
+                "end_line": 18,
+                "end_column": 17
+              },
+              "name": "Status_Draft"
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 19,
+              "column": 5,
+              "end_line": 19,
+              "end_column": 19
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 19,
+                "column": 5,
+                "end_line": 19,
+                "end_column": 19
+              },
+              "name": "event_Approved"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 19,
+                "column": 5,
+                "end_line": 19,
+                "end_column": 19
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 20,
+              "column": 5,
+              "end_line": 20,
+              "end_column": 26
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 20,
+                "column": 5,
+                "end_line": 20,
+                "end_column": 26
+              },
+              "name": "event_PaymentCaptured"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 20,
+                "column": 5,
+                "end_line": 20,
+                "end_column": 26
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 21,
+              "column": 5,
+              "end_line": 21,
+              "end_column": 24
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 21,
+                "column": 5,
+                "end_line": 21,
+                "end_column": 24
+              },
+              "name": "event_PaymentFailed"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 21,
+                "column": 5,
+                "end_line": 21,
+                "end_column": 24
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 22,
+              "column": 5,
+              "end_line": 22,
+              "end_column": 27
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 27
+              },
+              "name": "event_PaymentRequested"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 27
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "assign",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 23,
+              "column": 5,
+              "end_line": 23,
+              "end_column": 26
+            },
+            "target": {
+              "kind": "var",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 23,
+                "column": 5,
+                "end_line": 23,
+                "end_column": 26
+              },
+              "name": "event_PaymentTimedOut"
+            },
+            "value": {
+              "kind": "bool",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 23,
+                "column": 5,
+                "end_line": 23,
+                "end_column": 26
+              },
+              "value": false
+            }
+          },
+          {
+            "kind": "forall",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 24,
+              "column": 5,
+              "end_line": 24,
+              "end_column": 11
+            },
+            "binder": {
+              "name": "k",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              },
+              "kind": "typed"
+            },
+            "statements": [
+              {
+                "kind": "assign",
+                "type": {
+                  "kind": "statement"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 24,
+                  "column": 34,
+                  "end_line": 24,
+                  "end_column": 56
+                },
+                "target": {
+                  "kind": "index",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 24,
+                    "column": 34,
+                    "end_line": 24,
+                    "end_column": 56
+                  },
+                  "name": "capture_payment_status",
+                  "index": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "PaymentRequestId"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 24,
+                      "column": 34,
+                      "end_line": 24,
+                      "end_column": 56
+                    },
+                    "name": "k"
+                  }
+                },
+                "value": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 24,
+                    "column": 34,
+                    "end_line": 24,
+                    "end_column": 56
+                  },
+                  "name": "CapturePaymentEffectStatus_NotStarted"
+                }
+              }
+            ]
+          },
+          {
+            "kind": "forall",
+            "type": {
+              "kind": "statement"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 25,
+              "column": 5,
+              "end_line": 25,
+              "end_column": 11
+            },
+            "binder": {
+              "name": "k",
+              "type": {
+                "kind": "named",
+                "name": "PaymentRequestId"
+              },
+              "kind": "typed"
+            },
+            "statements": [
+              {
+                "kind": "assign",
+                "type": {
+                  "kind": "statement"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 25,
+                  "column": 34,
+                  "end_line": 25,
+                  "end_column": 58
+                },
+                "target": {
+                  "kind": "index",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentAttempt"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 25,
+                    "column": 34,
+                    "end_line": 25,
+                    "end_column": 58
+                  },
+                  "name": "capture_payment_attempts",
+                  "index": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "PaymentRequestId"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 25,
+                      "column": 34,
+                      "end_line": 25,
+                      "end_column": 58
+                    },
+                    "name": "k"
+                  }
+                },
+                "value": {
+                  "kind": "num",
+                  "type": {
+                    "kind": "domain",
+                    "lo": 0,
+                    "hi": 2
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 25,
+                    "column": 34,
+                    "end_line": 25,
+                    "end_column": 58
+                  },
+                  "value": 0
+                }
+              }
+            ]
+          }
+        ],
+        "origin": {
+          "dialect": "domain",
+          "declaration": "init",
+          "lowered": true,
+          "generated": false
+        },
+        "span": {
+          "file": "effect_saga_valid.fsl",
+          "line": 18,
+          "column": 5,
+          "end_line": 18,
+          "end_column": 17
+        }
+      },
+      "actions": [
+        {
+          "name": "capture_payment_complete_payment_captured",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 50,
+                  "column": 5,
+                  "end_line": 50,
+                  "end_column": 13
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "index",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 50,
+                    "column": 5,
+                    "end_line": 50,
+                    "end_column": 13
+                  },
+                  "collection": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "map",
+                      "key": {
+                        "kind": "named",
+                        "name": "PaymentRequestId"
+                      },
+                      "value": {
+                        "kind": "named",
+                        "name": "CapturePaymentEffectStatus"
+                      }
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 50,
+                      "column": 5,
+                      "end_line": 50,
+                      "end_column": 13
+                    },
+                    "name": "capture_payment_status"
+                  },
+                  "index": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "PaymentRequestId"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 50,
+                      "column": 5,
+                      "end_line": 50,
+                      "end_column": 13
+                    },
+                    "name": "payment_request_id"
+                  }
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 50,
+                    "column": 5,
+                    "end_line": 50,
+                    "end_column": 13
+                  },
+                  "name": "CapturePaymentEffectStatus_Pending"
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 51,
+                "column": 5,
+                "end_line": 51,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 51,
+                  "column": 5,
+                  "end_line": 51,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 51,
+                  "column": 5,
+                  "end_line": 51,
+                  "end_column": 19
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 52,
+                "column": 5,
+                "end_line": 52,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 52,
+                  "column": 5,
+                  "end_line": 52,
+                  "end_column": 26
+                },
+                "name": "event_PaymentCaptured"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 52,
+                  "column": 5,
+                  "end_line": 52,
+                  "end_column": 26
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 53,
+                "column": 5,
+                "end_line": 53,
+                "end_column": 24
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 53,
+                  "column": 5,
+                  "end_line": 53,
+                  "end_column": 24
+                },
+                "name": "event_PaymentFailed"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 53,
+                  "column": 5,
+                  "end_line": 53,
+                  "end_column": 24
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 54,
+                "column": 5,
+                "end_line": 54,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 54,
+                  "column": 5,
+                  "end_line": 54,
+                  "end_column": 27
+                },
+                "name": "event_PaymentRequested"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 54,
+                  "column": 5,
+                  "end_line": 54,
+                  "end_column": 27
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 55,
+                "column": 5,
+                "end_line": 55,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 55,
+                  "column": 5,
+                  "end_line": 55,
+                  "end_column": 26
+                },
+                "name": "event_PaymentTimedOut"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 55,
+                  "column": 5,
+                  "end_line": 55,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 56,
+                "column": 5,
+                "end_line": 56,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "index",
+                "type": {
+                  "kind": "named",
+                  "name": "CapturePaymentEffectStatus"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 56,
+                  "column": 5,
+                  "end_line": 56,
+                  "end_column": 27
+                },
+                "name": "capture_payment_status",
+                "index": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "PaymentRequestId"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 56,
+                    "column": 5,
+                    "end_line": 56,
+                    "end_column": 27
+                  },
+                  "name": "payment_request_id"
+                }
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "CapturePaymentEffectStatus"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 56,
+                  "column": 5,
+                  "end_line": 56,
+                  "end_column": 27
+                },
+                "name": "CapturePaymentEffectStatus_Succeeded"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 57,
+                "column": 5,
+                "end_line": 57,
+                "end_column": 17
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 57,
+                  "column": 5,
+                  "end_line": 57,
+                  "end_column": 17
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 57,
+                  "column": 5,
+                  "end_line": 57,
+                  "end_column": 17
+                },
+                "name": "Status_Paid"
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "capture_payment_complete_payment_captured",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "effect_saga_valid.fsl",
+            "line": 49,
+            "column": 3,
+            "end_line": 49,
+            "end_column": 9
+          }
+        },
+        {
+          "name": "order_approve",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 28,
+                  "column": 5,
+                  "end_line": 28,
+                  "end_column": 13
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "Status"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 28,
+                    "column": 5,
+                    "end_line": 28,
+                    "end_column": 13
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "Status"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 28,
+                    "column": 5,
+                    "end_line": 28,
+                    "end_column": 13
+                  },
+                  "name": "Status_Draft"
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 29,
+                "column": 5,
+                "end_line": 29,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 29,
+                  "column": 5,
+                  "end_line": 29,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 29,
+                  "column": 5,
+                  "end_line": 29,
+                  "end_column": 19
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 30,
+                "column": 5,
+                "end_line": 30,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 30,
+                  "column": 5,
+                  "end_line": 30,
+                  "end_column": 26
+                },
+                "name": "event_PaymentCaptured"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 30,
+                  "column": 5,
+                  "end_line": 30,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 31,
+                "column": 5,
+                "end_line": 31,
+                "end_column": 24
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 31,
+                  "column": 5,
+                  "end_line": 31,
+                  "end_column": 24
+                },
+                "name": "event_PaymentFailed"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 31,
+                  "column": 5,
+                  "end_line": 31,
+                  "end_column": 24
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 32,
+                "column": 5,
+                "end_line": 32,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 32,
+                  "column": 5,
+                  "end_line": 32,
+                  "end_column": 27
+                },
+                "name": "event_PaymentRequested"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 32,
+                  "column": 5,
+                  "end_line": 32,
+                  "end_column": 27
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 33,
+                "column": 5,
+                "end_line": 33,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 33,
+                  "column": 5,
+                  "end_line": 33,
+                  "end_column": 26
+                },
+                "name": "event_PaymentTimedOut"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 33,
+                  "column": 5,
+                  "end_line": 33,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 34,
+                "column": 5,
+                "end_line": 34,
+                "end_column": 17
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 34,
+                  "column": 5,
+                  "end_line": 34,
+                  "end_column": 17
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 34,
+                  "column": 5,
+                  "end_line": 34,
+                  "end_column": 17
+                },
+                "name": "Status_Approved"
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_approve",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "effect_saga_valid.fsl",
+            "line": 27,
+            "column": 3,
+            "end_line": 27,
+            "end_column": 9
+          }
+        },
+        {
+          "name": "order_request_payment",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 37,
+                  "column": 5,
+                  "end_line": 37,
+                  "end_column": 13
+                },
+                "operator": "==",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "Status"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 37,
+                    "column": 5,
+                    "end_line": 37,
+                    "end_column": 13
+                  },
+                  "name": "order_status"
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "Status"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 37,
+                    "column": 5,
+                    "end_line": 37,
+                    "end_column": 13
+                  },
+                  "name": "Status_Approved"
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 38,
+                  "column": 5,
+                  "end_line": 38,
+                  "end_column": 13
+                },
+                "operator": "!=",
+                "left": {
+                  "kind": "index",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 38,
+                    "column": 5,
+                    "end_line": 38,
+                    "end_column": 13
+                  },
+                  "collection": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "map",
+                      "key": {
+                        "kind": "named",
+                        "name": "PaymentRequestId"
+                      },
+                      "value": {
+                        "kind": "named",
+                        "name": "CapturePaymentEffectStatus"
+                      }
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "capture_payment_status"
+                  },
+                  "index": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "PaymentRequestId"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 38,
+                      "column": 5,
+                      "end_line": 38,
+                      "end_column": 13
+                    },
+                    "name": "payment_request_id"
+                  }
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 38,
+                    "column": 5,
+                    "end_line": 38,
+                    "end_column": 13
+                  },
+                  "name": "CapturePaymentEffectStatus_Pending"
+                }
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 39,
+                  "column": 5,
+                  "end_line": 39,
+                  "end_column": 13
+                },
+                "operator": "!=",
+                "left": {
+                  "kind": "index",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 39,
+                    "column": 5,
+                    "end_line": 39,
+                    "end_column": 13
+                  },
+                  "collection": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "map",
+                      "key": {
+                        "kind": "named",
+                        "name": "PaymentRequestId"
+                      },
+                      "value": {
+                        "kind": "named",
+                        "name": "CapturePaymentEffectStatus"
+                      }
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 39,
+                      "column": 5,
+                      "end_line": 39,
+                      "end_column": 13
+                    },
+                    "name": "capture_payment_status"
+                  },
+                  "index": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "PaymentRequestId"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 39,
+                      "column": 5,
+                      "end_line": 39,
+                      "end_column": 13
+                    },
+                    "name": "payment_request_id"
+                  }
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "CapturePaymentEffectStatus"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 39,
+                    "column": 5,
+                    "end_line": 39,
+                    "end_column": 13
+                  },
+                  "name": "CapturePaymentEffectStatus_Succeeded"
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 40,
+                "column": 5,
+                "end_line": 40,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 40,
+                  "column": 5,
+                  "end_line": 40,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 40,
+                  "column": 5,
+                  "end_line": 40,
+                  "end_column": 19
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 41,
+                "column": 5,
+                "end_line": 41,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 41,
+                  "column": 5,
+                  "end_line": 41,
+                  "end_column": 26
+                },
+                "name": "event_PaymentCaptured"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 41,
+                  "column": 5,
+                  "end_line": 41,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 42,
+                "column": 5,
+                "end_line": 42,
+                "end_column": 24
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 42,
+                  "column": 5,
+                  "end_line": 42,
+                  "end_column": 24
+                },
+                "name": "event_PaymentFailed"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 42,
+                  "column": 5,
+                  "end_line": 42,
+                  "end_column": 24
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 43,
+                "column": 5,
+                "end_line": 43,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 43,
+                  "column": 5,
+                  "end_line": 43,
+                  "end_column": 27
+                },
+                "name": "event_PaymentRequested"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 43,
+                  "column": 5,
+                  "end_line": 43,
+                  "end_column": 27
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 44,
+                "column": 5,
+                "end_line": 44,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 44,
+                  "column": 5,
+                  "end_line": 44,
+                  "end_column": 26
+                },
+                "name": "event_PaymentTimedOut"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 44,
+                  "column": 5,
+                  "end_line": 44,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 45,
+                "column": 5,
+                "end_line": 45,
+                "end_column": 17
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 45,
+                  "column": 5,
+                  "end_line": 45,
+                  "end_column": 17
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 45,
+                  "column": 5,
+                  "end_line": 45,
+                  "end_column": 17
+                },
+                "name": "Status_Approved"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 46,
+                "column": 5,
+                "end_line": 46,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "index",
+                "type": {
+                  "kind": "named",
+                  "name": "CapturePaymentEffectStatus"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 46,
+                  "column": 5,
+                  "end_line": 46,
+                  "end_column": 27
+                },
+                "name": "capture_payment_status",
+                "index": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "PaymentRequestId"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 46,
+                    "column": 5,
+                    "end_line": 46,
+                    "end_column": 27
+                  },
+                  "name": "payment_request_id"
+                }
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "CapturePaymentEffectStatus"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 46,
+                  "column": 5,
+                  "end_line": 46,
+                  "end_column": 27
+                },
+                "name": "CapturePaymentEffectStatus_Pending"
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 47,
+                "column": 5,
+                "end_line": 47,
+                "end_column": 29
+              },
+              "target": {
+                "kind": "index",
+                "type": {
+                  "kind": "named",
+                  "name": "CapturePaymentAttempt"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 47,
+                  "column": 5,
+                  "end_line": 47,
+                  "end_column": 29
+                },
+                "name": "capture_payment_attempts",
+                "index": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "named",
+                    "name": "PaymentRequestId"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 47,
+                    "column": 5,
+                    "end_line": 47,
+                    "end_column": 29
+                  },
+                  "name": "payment_request_id"
+                }
+              },
+              "value": {
+                "kind": "num",
+                "type": {
+                  "kind": "domain",
+                  "lo": 0,
+                  "hi": 2
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 47,
+                  "column": 5,
+                  "end_line": 47,
+                  "end_column": 29
+                },
+                "value": 1
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "order_request_payment",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "effect_saga_valid.fsl",
+            "line": 36,
+            "column": 3,
+            "end_line": 36,
+            "end_column": 9
+          }
+        },
+        {
+          "name": "saga_payment_flow_capture",
+          "fair": false,
+          "guards": [
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 115,
+                  "column": 5,
+                  "end_line": 115,
+                  "end_column": 13
+                },
+                "name": "event_Approved"
+              }
+            },
+            {
+              "kind": "requires",
+              "expression": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 116,
+                  "column": 5,
+                  "end_line": 116,
+                  "end_column": 13
+                },
+                "operator": "and",
+                "left": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 116,
+                    "column": 5,
+                    "end_line": 116,
+                    "end_column": 13
+                  },
+                  "name": "event_Approved"
+                },
+                "right": {
+                  "kind": "not",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 116,
+                    "column": 5,
+                    "end_line": 116,
+                    "end_column": 13
+                  },
+                  "operand": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 116,
+                      "column": 5,
+                      "end_line": 116,
+                      "end_column": 13
+                    },
+                    "name": "event_PaymentFailed"
+                  }
+                }
+              }
+            }
+          ],
+          "updates": [
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 117,
+                "column": 5,
+                "end_line": 117,
+                "end_column": 19
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 117,
+                  "column": 5,
+                  "end_line": 117,
+                  "end_column": 19
+                },
+                "name": "event_Approved"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 117,
+                  "column": 5,
+                  "end_line": 117,
+                  "end_column": 19
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 118,
+                "column": 5,
+                "end_line": 118,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 118,
+                  "column": 5,
+                  "end_line": 118,
+                  "end_column": 26
+                },
+                "name": "event_PaymentCaptured"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 118,
+                  "column": 5,
+                  "end_line": 118,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 119,
+                "column": 5,
+                "end_line": 119,
+                "end_column": 24
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 119,
+                  "column": 5,
+                  "end_line": 119,
+                  "end_column": 24
+                },
+                "name": "event_PaymentFailed"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 119,
+                  "column": 5,
+                  "end_line": 119,
+                  "end_column": 24
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 120,
+                "column": 5,
+                "end_line": 120,
+                "end_column": 27
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 120,
+                  "column": 5,
+                  "end_line": 120,
+                  "end_column": 27
+                },
+                "name": "event_PaymentRequested"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 120,
+                  "column": 5,
+                  "end_line": 120,
+                  "end_column": 27
+                },
+                "value": true
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 121,
+                "column": 5,
+                "end_line": 121,
+                "end_column": 26
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 121,
+                  "column": 5,
+                  "end_line": 121,
+                  "end_column": 26
+                },
+                "name": "event_PaymentTimedOut"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 121,
+                  "column": 5,
+                  "end_line": 121,
+                  "end_column": 26
+                },
+                "value": false
+              }
+            }
+          ],
+          "origin": {
+            "dialect": "domain",
+            "declaration": "saga_payment_flow_capture",
+            "lowered": true,
+            "generated": false
+          },
+          "span": {
+            "file": "effect_saga_valid.fsl",
+            "line": 114,
+            "column": 3,
+            "end_line": 114,
+            "end_column": 9
+          }
+        }
+      ],
+      "properties": {
+        "invariants": [
+          {
+            "name": "PaymentFlow_terminalOutcome",
+            "source_kind": "invariant",
+            "expression": {
+              "kind": "binary",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 132,
+                "column": 3,
+                "end_line": 132,
+                "end_column": 12
+              },
+              "operator": "=>",
+              "left": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 132,
+                  "column": 3,
+                  "end_line": 132,
+                  "end_column": 12
+                },
+                "operator": "or",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 132,
+                    "column": 3,
+                    "end_line": 132,
+                    "end_column": 12
+                  },
+                  "operator": "or",
+                  "left": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 132,
+                      "column": 3,
+                      "end_line": 132,
+                      "end_column": 12
+                    },
+                    "name": "event_PaymentCaptured"
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 132,
+                      "column": 3,
+                      "end_line": 132,
+                      "end_column": 12
+                    },
+                    "name": "event_PaymentFailed"
+                  }
+                },
+                "right": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 132,
+                    "column": 3,
+                    "end_line": 132,
+                    "end_column": 12
+                  },
+                  "name": "event_PaymentTimedOut"
+                }
+              },
+              "right": {
+                "kind": "not",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 132,
+                  "column": 3,
+                  "end_line": 132,
+                  "end_column": 12
+                },
+                "operand": {
+                  "kind": "var",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 132,
+                    "column": 3,
+                    "end_line": 132,
+                    "end_column": 12
+                  },
+                  "name": "event_PaymentRequested"
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-SAGA",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 132,
+              "column": 3,
+              "end_line": 132,
+              "end_column": 12
+            }
+          }
+        ],
+        "transitions": [
+          {
+            "name": "CapturePayment_SuccessSticky",
+            "source_kind": "trans",
+            "expression": {
+              "kind": "forall",
+              "type": {
+                "kind": "bool"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 133,
+                "column": 3,
+                "end_line": 133,
+                "end_column": 8
+              },
+              "quantifier": "forall",
+              "binder": {
+                "name": "k",
+                "type": {
+                  "kind": "named",
+                  "name": "PaymentRequestId"
+                },
+                "kind": "typed"
+              },
+              "body": {
+                "kind": "binary",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 133,
+                  "column": 3,
+                  "end_line": 133,
+                  "end_column": 8
+                },
+                "operator": "=>",
+                "left": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 133,
+                    "column": 3,
+                    "end_line": 133,
+                    "end_column": 8
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "old",
+                    "type": {
+                      "kind": "named",
+                      "name": "CapturePaymentEffectStatus"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 133,
+                      "column": 3,
+                      "end_line": 133,
+                      "end_column": 8
+                    },
+                    "operand": {
+                      "kind": "index",
+                      "type": {
+                        "kind": "named",
+                        "name": "CapturePaymentEffectStatus"
+                      },
+                      "span": {
+                        "file": "effect_saga_valid.fsl",
+                        "line": 133,
+                        "column": 3,
+                        "end_line": 133,
+                        "end_column": 8
+                      },
+                      "collection": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "map",
+                          "key": {
+                            "kind": "named",
+                            "name": "PaymentRequestId"
+                          },
+                          "value": {
+                            "kind": "named",
+                            "name": "CapturePaymentEffectStatus"
+                          }
+                        },
+                        "span": {
+                          "file": "effect_saga_valid.fsl",
+                          "line": 133,
+                          "column": 3,
+                          "end_line": 133,
+                          "end_column": 8
+                        },
+                        "name": "capture_payment_status"
+                      },
+                      "index": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "PaymentRequestId"
+                        },
+                        "span": {
+                          "file": "effect_saga_valid.fsl",
+                          "line": 133,
+                          "column": 3,
+                          "end_line": 133,
+                          "end_column": 8
+                        },
+                        "name": "k"
+                      }
+                    }
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "CapturePaymentEffectStatus"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 133,
+                      "column": 3,
+                      "end_line": 133,
+                      "end_column": 8
+                    },
+                    "name": "CapturePaymentEffectStatus_Succeeded"
+                  }
+                },
+                "right": {
+                  "kind": "binary",
+                  "type": {
+                    "kind": "bool"
+                  },
+                  "span": {
+                    "file": "effect_saga_valid.fsl",
+                    "line": 133,
+                    "column": 3,
+                    "end_line": 133,
+                    "end_column": 8
+                  },
+                  "operator": "==",
+                  "left": {
+                    "kind": "index",
+                    "type": {
+                      "kind": "named",
+                      "name": "CapturePaymentEffectStatus"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 133,
+                      "column": 3,
+                      "end_line": 133,
+                      "end_column": 8
+                    },
+                    "collection": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "map",
+                        "key": {
+                          "kind": "named",
+                          "name": "PaymentRequestId"
+                        },
+                        "value": {
+                          "kind": "named",
+                          "name": "CapturePaymentEffectStatus"
+                        }
+                      },
+                      "span": {
+                        "file": "effect_saga_valid.fsl",
+                        "line": 133,
+                        "column": 3,
+                        "end_line": 133,
+                        "end_column": 8
+                      },
+                      "name": "capture_payment_status"
+                    },
+                    "index": {
+                      "kind": "var",
+                      "type": {
+                        "kind": "named",
+                        "name": "PaymentRequestId"
+                      },
+                      "span": {
+                        "file": "effect_saga_valid.fsl",
+                        "line": 133,
+                        "column": 3,
+                        "end_line": 133,
+                        "end_column": 8
+                      },
+                      "name": "k"
+                    }
+                  },
+                  "right": {
+                    "kind": "var",
+                    "type": {
+                      "kind": "named",
+                      "name": "CapturePaymentEffectStatus"
+                    },
+                    "span": {
+                      "file": "effect_saga_valid.fsl",
+                      "line": 133,
+                      "column": 3,
+                      "end_line": 133,
+                      "end_column": 8
+                    },
+                    "name": "CapturePaymentEffectStatus_Succeeded"
+                  }
+                }
+              }
+            },
+            "origin": {
+              "dialect": "domain",
+              "declaration": "DOMAIN-EFFECT",
+              "lowered": true,
+              "generated": false
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 133,
+              "column": 3,
+              "end_line": 133,
+              "end_column": 8
+            }
+          }
+        ],
+        "terminal": {
+          "source_kind": "terminal",
+          "expression": {
+            "kind": "bool",
+            "type": {
+              "kind": "bool"
+            },
+            "span": {
+              "file": "effect_saga_valid.fsl",
+              "line": 134,
+              "column": 3,
+              "end_line": 134,
+              "end_column": 11
+            },
+            "value": false
+          },
+          "span": {
+            "file": "effect_saga_valid.fsl",
+            "line": 134,
+            "column": 3,
+            "end_line": 134,
+            "end_column": 11
+          }
+        }
+      }
+    }
+  },
+  "known_generated_spans": [
+    {
+      "classification": "known_generated_kernel_coordinate_attached_to_source_file",
+      "file": "expressions_valid.fsl",
+      "source_declaration_line": 39,
+      "reported_public_kernel_line": 24,
+      "origin": {
+        "dialect": "domain",
+        "declaration": "order_approve",
+        "lowered": true,
+        "generated": false
+      }
+    },
+    {
+      "classification": "known_generated_kernel_coordinate_attached_to_source_file",
+      "file": "effect_saga_valid.fsl",
+      "source_declaration_line": 22,
+      "reported_public_kernel_line": 27,
+      "origin": {
+        "dialect": "domain",
+        "declaration": "order_approve",
+        "lowered": true,
+        "generated": false
+      }
+    }
+  ],
+  "generated_kernel_source_fragments": {
+    "expressions_valid.fsl": [
+      "requires order_status == OrderStatus_Draft and not (order_status == OrderStatus_Cancelled)",
+      "requires order_status != OrderStatus_Cancelled and order_quantity >= 0",
+      "order_audit.status = order_status",
+      "invariant Order_legacyImplication \"DOMAIN-INVARIANT: Order.legacyImplication\" { order_status == OrderStatus_Cancelled => not (order_status == OrderStatus_Draft or order_status == OrderStatus_Approved and not (order_status == OrderStatus_Cancelled)) }",
+      "invariant Order_legacyDisjunction \"DOMAIN-INVARIANT: Order.legacyDisjunction\" { order_status == OrderStatus_Draft or order_status == OrderStatus_Approved or order_status == OrderStatus_Cancelled }",
+      "invariant Order_finiteMembership \"DOMAIN-INVARIANT: Order.finiteMembership\" { (order_status == OrderStatus_Draft or order_status == OrderStatus_Approved or order_status == OrderStatus_Cancelled) }"
+    ],
+    "effect_saga_valid.fsl": [
+      "action capture_payment_complete_payment_captured(payment_request_id: PaymentRequestId) {",
+      "requires event_Approved and not event_PaymentFailed",
+      "invariant PaymentFlow_terminalOutcome \"DOMAIN-SAGA: PaymentFlow.terminalOutcome\" { event_PaymentCaptured or event_PaymentFailed or event_PaymentTimedOut => not event_PaymentRequested }",
+      "trans CapturePayment_SuccessSticky \"DOMAIN-EFFECT: CapturePayment success is sticky\" { forall k: PaymentRequestId { old(capture_payment_status[k]) == CapturePaymentEffectStatus_Succeeded => capture_payment_status[k] == CapturePaymentEffectStatus_Succeeded } }"
+    ],
+    "lvalues_surface.fsl": [
+      "inventory_total = inventory_total + 1",
+      "inventory_counts[item] = inventory_counts[item] + 1",
+      "inventory_counter.value = inventory_total"
+    ]
+  },
+  "cli": {
+    "expressions_valid.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "DomainExpressionCharacterization"
+        }
+      },
+      "verify": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "spec": "DomainExpressionCharacterization",
+          "result": "verified",
+          "depth": 2,
+          "checked_to_depth": 2,
+          "completeness": "bounded",
+          "invariants_checked": [
+            "_bounds_order_status",
+            "_bounds_order_previous_status",
+            "_bounds_order_quantity",
+            "_bounds_order_audit",
+            "Order_canonicalImplication",
+            "Order_legacyImplication",
+            "Order_legacyDisjunction",
+            "Order_finiteMembership"
+          ],
+          "transitions_checked": [],
+          "reachables": {},
+          "action_coverage": {
+            "order_approve": true,
+            "order_cancel": true
+          },
+          "deadlock": {
+            "found": true,
+            "at_step": 1,
+            "trace": [
+              {
+                "step": 0,
+                "state": {
+                  "event_ApprovalRejected": false,
+                  "event_Approved": false,
+                  "event_Cancelled": false,
+                  "order_audit": {
+                    "attempts": 0,
+                    "status": "OrderStatus_Draft"
+                  },
+                  "order_previous_status": "OrderStatus_Draft",
+                  "order_quantity": 0,
+                  "order_status": "OrderStatus_Draft"
+                }
+              },
+              {
+                "step": 1,
+                "state": {
+                  "event_ApprovalRejected": false,
+                  "event_Approved": false,
+                  "event_Cancelled": true,
+                  "order_audit": {
+                    "attempts": 0,
+                    "status": "OrderStatus_Draft"
+                  },
+                  "order_previous_status": "OrderStatus_Draft",
+                  "order_quantity": 0,
+                  "order_status": "OrderStatus_Cancelled"
+                },
+                "action": {
+                  "name": "order_cancel",
+                  "params": {},
+                  "loc": {
+                    "line": 37,
+                    "column": 3
+                  }
+                },
+                "changes": {
+                  "event_Cancelled": {
+                    "from": false,
+                    "to": true
+                  },
+                  "order_status": {
+                    "from": "OrderStatus_Draft",
+                    "to": "OrderStatus_Cancelled"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "effect_saga_valid.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "DomainEffectSagaCharacterization"
+        }
+      },
+      "verify": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "spec": "DomainEffectSagaCharacterization",
+          "result": "verified",
+          "depth": 2,
+          "checked_to_depth": 2,
+          "completeness": "bounded",
+          "invariants_checked": [
+            "_bounds_order_status",
+            "_bounds_capture_payment_status",
+            "_bounds_capture_payment_attempts",
+            "PaymentFlow_terminalOutcome"
+          ],
+          "transitions_checked": [
+            "CapturePayment_SuccessSticky"
+          ],
+          "reachables": {},
+          "action_coverage": {
+            "capture_payment_complete_payment_captured": true,
+            "capture_payment_complete_payment_failed": true,
+            "capture_payment_complete_payment_timed_out": true,
+            "capture_payment_retry": {
+              "covered": false,
+              "blocking_requires": [],
+              "faithfulness_class": "intent_unexercised"
+            },
+            "order_approve": true,
+            "order_request_payment": true,
+            "saga_payment_flow_capture": true,
+            "saga_payment_flow_capture_timeout": true,
+            "saga_payment_flow_observe_payment_captured": true,
+            "saga_payment_flow_observe_payment_failed": true,
+            "saga_payment_flow_observe_payment_timed_out": true
+          },
+          "deadlock": {
+            "found": false
+          }
+        }
+      }
+    },
+    "lvalues_surface.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "DomainLvalueCharacterization"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "indexing requires a map or sequence"
+        }
+      }
+    },
+    "legacy_logical_parse_error.fsl": {
+      "check": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "parse",
+          "message": "unexpected character '&' at 6:47"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "parse",
+          "message": "unexpected character '&' at 6:47"
+        }
+      }
+    },
+    "invalid_unknown_name.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "InvalidUnknownName"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown identifier 'missing_status'"
+        }
+      }
+    },
+    "invalid_unknown_member.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "InvalidUnknownMember"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown identifier 'Cancelled'"
+        }
+      }
+    },
+    "invalid_type_mismatch.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "InvalidTypeMismatch"
+        }
+      },
+      "verify": {
+        "exit": 1,
+        "output": {
+          "fsl": "1.0",
+          "spec": "InvalidTypeMismatch",
+          "result": "violated",
+          "violation_kind": "invariant",
+          "invariant": "Order_typeMismatch",
+          "requirement": {
+            "id": "DOMAIN-INVARIANT",
+            "text": "Order.typeMismatch"
+          },
+          "loc": {
+            "line": 15,
+            "column": 3
+          },
+          "violated_at_step": 0,
+          "violating_bindings": [
+            {}
+          ],
+          "blame": {
+            "conjuncts": [
+              {
+                "index": 0,
+                "text": "order_status == 1",
+                "holds": false,
+                "violating_bindings": [
+                  {}
+                ]
+              }
+            ]
+          },
+          "last_action": null,
+          "trace": [
+            {
+              "step": 0,
+              "state": {
+                "event_Touched": false,
+                "order_status": "Status_Draft"
+              }
+            }
+          ],
+          "checked_to_depth": 0,
+          "completeness": "bounded",
+          "trace_type": "invariant"
+        }
+      }
+    },
+    "invalid_operator.fsl": {
+      "check": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "expected expression at 9:94"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "expected expression at 9:94"
+        }
+      }
+    },
+    "invalid_broken_expression.fsl": {
+      "check": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "expected expression at 9:97"
+        }
+      },
+      "verify": {
+        "exit": 2,
+        "output": {
+          "fsl": "1.0",
+          "result": "error",
+          "kind": "semantics",
+          "message": "expected expression at 9:97"
+        }
+      }
+    },
+    "ai_internal_name_misuse.fsl": {
+      "check": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "result": "ok",
+          "spec": "AiInternalNameMisuse"
+        }
+      },
+      "verify": {
+        "exit": 0,
+        "output": {
+          "fsl": "1.0",
+          "spec": "AiInternalNameMisuse",
+          "result": "verified",
+          "depth": 2,
+          "checked_to_depth": 2,
+          "completeness": "bounded",
+          "invariants_checked": [
+            "_bounds_order_status",
+            "Order_generatedName"
+          ],
+          "transitions_checked": [],
+          "reachables": {},
+          "action_coverage": {
+            "order_touch": true
+          },
+          "deadlock": {
+            "found": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl
@@ -1,0 +1,63 @@
+domain DomainEffectSagaCharacterization {
+  // SPDX-License-Identifier: Apache-2.0
+  implementation_profile functional_ddd
+
+  type OrderId = 0..1
+  type PaymentRequestId = 0..1
+  type Status = Draft | Approved | Paid | Failed
+
+  aggregate Order {
+    id OrderId
+    state { status: Status = Draft; }
+
+    command Approve {}
+    command RequestPayment { payment_request_id: PaymentRequestId }
+
+    event Approved {}
+    event PaymentRequested { payment_request_id: PaymentRequestId }
+    event PaymentCaptured { payment_request_id: PaymentRequestId }
+    event PaymentFailed { payment_request_id: PaymentRequestId }
+    event PaymentTimedOut { payment_request_id: PaymentRequestId }
+
+    decide Approve {
+      requires status == Draft
+      emits Approved
+    }
+    decide RequestPayment {
+      requires status == Approved
+      emits PaymentRequested
+    }
+
+    evolve Approved { status = Approved }
+    evolve PaymentRequested { status = Approved }
+    evolve PaymentCaptured { status = Paid }
+    evolve PaymentFailed { status = Failed }
+    evolve PaymentTimedOut { status = Failed }
+  }
+
+  effect CapturePayment {
+    async
+    irreversible
+    idempotency_key Order.id
+    correlation_id PaymentRequested.payment_request_id
+    handles PaymentRequested
+    emits one_of [PaymentCaptured, PaymentFailed, PaymentTimedOut]
+    retry { max_attempts 2 }
+    timeout after 3m emits PaymentTimedOut
+    compensation { emits PaymentFailed }
+  }
+
+  saga PaymentFlow {
+    starts_on Approved
+    step Capture {
+      async
+      requires Approved and not PaymentFailed
+      emits PaymentRequested
+      awaits one_of [PaymentCaptured, PaymentFailed, PaymentTimedOut]
+      timeout after 3m emits PaymentTimedOut
+    }
+    invariant terminalOutcome {
+      PaymentCaptured or PaymentFailed or PaymentTimedOut -> not PaymentRequested
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
@@ -1,0 +1,89 @@
+domain DomainExpressionCharacterization {
+  // SPDX-License-Identifier: Apache-2.0
+  implementation_profile functional_ddd
+
+  type OrderId = 0..1
+  type Quantity = 0..2
+  type OrderStatus = Draft | Approved | Cancelled
+
+  value_object AuditStamp {
+    status: OrderStatus = Draft;
+    attempts: Quantity = 0;
+    invariant nonNegative { attempts >= 0 }
+  }
+
+  aggregate Order {
+    id OrderId
+
+    state {
+      status: OrderStatus = Draft;
+      previous_status: OrderStatus = Draft;
+      quantity: Quantity = 0;
+      audit: AuditStamp;
+    }
+
+    command Approve {
+      quantity: Quantity
+    }
+    command Cancel {}
+
+    event Approved {
+      quantity: Quantity
+    }
+    event Cancelled {}
+    event ApprovalRejected {}
+
+    error NotDraft
+    error AlreadyCancelled
+
+    decide Approve {
+      requires status == Draft and not (status == Cancelled)
+      requires status != Cancelled and quantity >= 0
+      rejects NotDraft when status in [Approved, Cancelled]
+      emits Approved
+    }
+
+    decide Cancel {
+      requires status == Draft or status == Approved
+      rejects AlreadyCancelled when status == Cancelled
+      emits Cancelled
+    }
+
+    evolve Approved {
+      requires status == Draft
+      previous_status = status
+      status = Approved
+      audit.status = status
+      quantity = quantity
+    }
+
+    evolve Cancelled {
+      previous_status = status
+      status = Cancelled
+    }
+
+    evolve ApprovalRejected {
+      previous_status = status
+    }
+
+    on_stale Approved when status == Approved and previous_status != Cancelled {
+      emits ApprovalRejected
+    }
+
+    invariant canonicalImplication {
+      status == Approved => previous_status == Draft or previous_status == Approved
+    }
+
+    invariant legacyImplication {
+      status == Cancelled -> not can(Cancel)
+    }
+
+    invariant legacyDisjunction {
+      status == Draft || status == Approved || status == Cancelled
+    }
+
+    invariant finiteMembership {
+      status in [Draft, Approved, Cancelled]
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_broken_expression.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_broken_expression.fsl
@@ -1,0 +1,8 @@
+domain InvalidBrokenExpression {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    invariant brokenExpression { status == }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_operator.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_operator.fsl
@@ -1,0 +1,8 @@
+domain InvalidOperator {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    invariant invalidOperator { status === Draft }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl
@@ -1,0 +1,12 @@
+domain InvalidTypeMismatch {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = status }
+    invariant typeMismatch { status == 1 }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl
@@ -1,0 +1,12 @@
+domain InvalidUnknownMember {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = status }
+    invariant unknownMember { status == Cancelled }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl
@@ -1,0 +1,12 @@
+domain InvalidUnknownName {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = status }
+    invariant unknownName { missing_status == Draft }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/legacy_logical_parse_error.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/legacy_logical_parse_error.fsl
@@ -1,0 +1,8 @@
+domain LegacyLogicalParseError {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved
+  aggregate Order {
+    state { status: Status = Draft; }
+    invariant legacyLogical { status == Draft && status != Approved || status == Draft }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl
@@ -1,0 +1,26 @@
+domain DomainLvalueCharacterization {
+  // SPDX-License-Identifier: Apache-2.0
+  type ItemId = 0..1
+  type Quantity = 0..2
+
+  value_object Counter {
+    value: Quantity = 0;
+  }
+
+  aggregate Inventory {
+    id ItemId
+    state {
+      total: Quantity = 0;
+      counts: Map<ItemId, Quantity>;
+      counter: Counter;
+    }
+    command Adjust { item: ItemId }
+    event Adjusted { item: ItemId }
+    decide Adjust { emits Adjusted }
+    evolve Adjusted {
+      total = total + 1
+      counts[item] = counts[item] + 1
+      counter.value = total
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The domain frontend still stores expressions as raw strings and reparses generated Kernel source. Before the typed-expression migration, regressions in parsing, normalization, lowering, diagnostics, spans, or concrete/symbolic behavior need a deterministic Rust-CI baseline.

Closes #235.

## Contract change

- Adds a versioned domain-expression characterization corpus and generated baseline.
- Covers canonical and legacy logical syntax, enums, membership, `can()`, generated state mappings, root/index/field lvalues, defaults, invariants, stale policies, effects, sagas, and invalid expressions.
- Freezes surface locations, normalized `KernelModel`, representative public Kernel expressions/origins/nested spans, generated Kernel fragments, CLI outcomes/diagnostics/traces, and Monitor↔symbolic agreement.
- Adds deterministic AI-native prompt/spec attempt metrics without invoking an external model.
- Documents baseline regeneration and known current gaps (`on_stale` lowering, generated-coordinate public spans, Map lvalue verification) without accepting those gaps as intended language contracts.
- No language semantics, CLI surface, Rust production code, or frozen Python implementation changes.

## Evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- focused domain/expression/transition agreement tests
- `PYTHONPATH=src .../.venv/bin/python -m pytest tests/test_rust_cli_contract.py -q` — 10 passed (frozen compatibility gate only)
- independent review: merge-ready, no remaining findings

## Documentation

- Adds corpus-local update/review instructions.
- Updates `CHANGELOG.md` under `[Unreleased]`.
- No language or shared FSL skill documentation changes because this PR intentionally introduces no semantic contract.
