### PR TITLE
refactor(domain): lower resolved AST directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Changed
+- Native Rust domain lowering (issue #239) now resolves typed domain symbols,
+  enum members, `can()`, finite membership, state reads, and nested lvalues
+  structurally, then builds Kernel AST directly without generated-source
+  render/reparse or substring semantics. Resolver/type failures report original
+  domain spans; empty membership and map-state initialization are explicit;
+  characterization now records direct-lowering origins and fail-closed checks.
 - Native Rust domain parsing (issue #236) now retains defaults, ranges, guards,
   rejection conditions, assignments, invariants, stale policies, effect
   correlation/idempotency expressions, and saga guards as unresolved typed

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -73,8 +73,10 @@ Each aggregate becomes kernel state and actions:
 
 Domain enum members are namespaced during lowering (`OrderStatus_Pending`) so
 two domain enums can both contain `Pending`. Domain expressions stay in the
-short source vocabulary; the expander rewrites comparisons and `in [A, B]`
-membership according to the field type.
+short source vocabulary. The resolver selects bare enum members by expected
+logical type and lowers `in [A, B]` to a finite equality disjunction; empty
+membership lowers to `false`. A bare member with multiple candidates and no
+expected type is rejected as ambiguous.
 
 `can(Command)` is a domain-only expression helper. It lowers to that command's
 decide preconditions: all `requires` clauses and the negation of every
@@ -102,12 +104,22 @@ Effect idempotency and correlation references remain restricted to the existing
 dotted-identifier path grammar; routing those paths through the expression
 parser does not broaden the public syntax to calls, indexing, or arithmetic.
 
-Existing lowering and compatibility projections temporarily render these
-typed nodes back to source-shaped text at their boundary. That renderer is an
-adapter, not a second parser; domain expressions are never sliced and reparsed
-with repaired offsets. Consequently malformed expressions are diagnosed at
-their original domain-source coordinates while generated Kernel and CLI
-semantics remain unchanged.
+`fsl-core` builds a symbol table for domain types, aggregate state, command and
+event fields, commands, events, enum members, and lexical binders. Command/event
+fields and inner binders shadow aggregate-state reads; assignment roots always
+resolve to writable aggregate state. Resolution attaches a logical type and a
+stable generated Kernel name to each selected symbol, then recursively lowers
+`SyntaxExpr` and `SyntaxLValue` into `Expr` and `LValue`. `can(Command)` is
+resolved only against the current aggregate. Unknown or cross-aggregate
+commands, ambiguous enum members, type mismatches, invalid lvalues, and
+unsupported calls fail at the original typed node span.
+
+The executable path constructs `SurfaceSpec` directly and passes it to the
+checked Kernel lowering gate. It never renders domain source as Kernel FSL and
+parses it again. `fslc domain expand` may still render generated source as a
+debug/interop view, but that text is not semantic input. This separation also
+lets public Kernel diagnostics and origins use domain declaration/expression
+coordinates rather than generated-source coordinates.
 
 ## Effects
 

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -50,6 +50,12 @@ Unsupported or incompletely lowered structures fail export with a semantic error
 The exporter never silently omits an unknown type, predicate call, expression,
 lvalue, or non-scalar parameter domain.
 
+The Rust domain frontend reaches this boundary through typed name/type
+resolution and direct AST-to-AST lowering. Generated Kernel source from
+`fslc domain expand` is a debug representation only and is never reparsed to
+construct the checked contract. Resolver diagnostics therefore retain the
+original domain node coordinates.
+
 Compose lowering currently loses the component filename while retaining its line
 span. Public Kernel v1 therefore rejects `compose` input explicitly instead of
 fabricating a root-file source location. A future schema version may add

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -94,6 +94,11 @@ the tuple AST for every corpus file. Dialect expansion remains a pure AST-to-AST
 stage before `build_spec`, matching the current requirements, business,
 governance, compose, database, AI, and domain frontends.
 
+The native domain frontend enforces this boundary concretely: its unresolved
+typed syntax is name/type-resolved in `fsl-core` and lowered directly to Kernel
+surface AST. Generated Kernel text is available for inspection but is not an
+input to parsing, checking, runtime execution, or verification.
+
 File access is behind a `FileResolver` interface:
 
 - native CLI: filesystem-backed, with the current source-relative semantics;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -234,11 +234,19 @@ event-flag guarded actions, and effect lifecycle state to finite
 `Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` maps. Domain
 enum members are namespaced during lowering, so two domain enums may both contain
 `Pending`. Domain expressions may use `X in [A, B]` and `can(Command)`; these are
-rewritten to kernel expressions.
+resolved from the typed domain tree and lowered structurally to kernel
+expressions. Bare enum members use the expected logical type; an untyped member
+shared by multiple enums is an error. Finite membership becomes an equality
+disjunction (`X in []` is `false`). `can(Command)` resolves within the current
+aggregate and becomes the conjunction of the command's `requires` clauses and
+the negation of each rejection condition. Unknown symbols, cross-aggregate
+commands, type mismatches, and unsupported calls are reported at the original
+domain expression.
 
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
-aggregate/effect summary, `fslc domain expand` to inspect generated kernel FSL,
+aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL
+debug view,
 `fslc domain generate --target typescript|python|kotlin|swift|rust` for
 Functional DDD scaffolds, `fslc domain testgen` for adapter/conformance
 scaffolds, and `fslc domain replay --logs events.jsonl` for runtime command /

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -271,10 +271,18 @@ event-flag guarded actions, and effect lifecycle state to finite
 <code>Map&lt;CorrelationId, EffectStatus&gt;</code> / <code>Map&lt;CorrelationId, Attempt&gt;</code> maps. Domain
 enum members are namespaced during lowering, so two domain enums may both contain
 <code>Pending</code>. Domain expressions may use <code>X in [A, B]</code> and <code>can(Command)</code>; these are
-rewritten to kernel expressions.</p>
+resolved from the typed domain tree and lowered structurally to kernel
+expressions. Bare enum members use the expected logical type; an untyped member
+shared by multiple enums is an error. Finite membership becomes an equality
+disjunction (<code>X in []</code> is <code>false</code>). <code>can(Command)</code> resolves within the current
+aggregate and becomes the conjunction of the command's <code>requires</code> clauses and
+the negation of each rejection condition. Unknown symbols, cross-aggregate
+commands, type mismatches, and unsupported calls are reported at the original
+domain expression.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
-aggregate/effect summary, <code>fslc domain expand</code> to inspect generated kernel FSL,
+aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
+debug view,
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> for
 Functional DDD scaffolds, <code>fslc domain testgen</code> for adapter/conformance
 scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime command /
@@ -2044,6 +2052,10 @@ guard, and the precondition lives in an external structure — cannot be express
 in the type and remains as a runtime/verification obligation). An entity's
 <code>applicability</code> is <code>full</code> only when all transitions are derivable/branching.
 With <code>--ts</code>, it outputs a TypeScript scaffold for the derivable portion.
+The native Rust command performs this judgment from the versioned public Kernel
+JSON v1 contract, not private parser/model structures, and fails closed on an
+unsupported Kernel schema version. Its JSON report and TypeScript bytes remain
+compatible with the frozen reference output.
 → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-typestate.md"><code>DESIGN-typestate.md</code></a></p></div></details></div>
   </div>
 </section>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -271,10 +271,18 @@ event-flag guarded actions, and effect lifecycle state to finite
 <code>Map&lt;CorrelationId, EffectStatus&gt;</code> / <code>Map&lt;CorrelationId, Attempt&gt;</code> maps. Domain
 enum members are namespaced during lowering, so two domain enums may both contain
 <code>Pending</code>. Domain expressions may use <code>X in [A, B]</code> and <code>can(Command)</code>; these are
-rewritten to kernel expressions.</p>
+resolved from the typed domain tree and lowered structurally to kernel
+expressions. Bare enum members use the expected logical type; an untyped member
+shared by multiple enums is an error. Finite membership becomes an equality
+disjunction (<code>X in []</code> is <code>false</code>). <code>can(Command)</code> resolves within the current
+aggregate and becomes the conjunction of the command's <code>requires</code> clauses and
+the negation of each rejection condition. Unknown symbols, cross-aggregate
+commands, type mismatches, and unsupported calls are reported at the original
+domain expression.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
-aggregate/effect summary, <code>fslc domain expand</code> to inspect generated kernel FSL,
+aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
+debug view,
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> for
 Functional DDD scaffolds, <code>fslc domain testgen</code> for adapter/conformance
 scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime command /
@@ -2044,6 +2052,10 @@ guard, and the precondition lives in an external structure — cannot be express
 in the type and remains as a runtime/verification obligation). An entity's
 <code>applicability</code> is <code>full</code> only when all transitions are derivable/branching.
 With <code>--ts</code>, it outputs a TypeScript scaffold for the derivable portion.
+The native Rust command performs this judgment from the versioned public Kernel
+JSON v1 contract, not private parser/model structures, and fails closed on an
+unsupported Kernel schema version. Its JSON report and TypeScript bytes remain
+compatible with the frozen reference output.
 → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-typestate.md"><code>DESIGN-typestate.md</code></a></p></div></details></div>
   </div>
 </section>

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -1341,9 +1341,7 @@ pub fn lower_db(system: &fsl_syntax::DbSystem) -> Result<KernelSpec, CoreError> 
 ///
 /// Returns [`CoreError`] if the generated kernel catalog is invalid.
 pub fn lower_domain(domain: &fsl_syntax::DomainSpec) -> Result<KernelSpec, CoreError> {
-    let source = crate::domain_kernel_source(domain);
-    let spec = fsl_syntax::parse_surface_spec(&source)?;
-    lower_direct_spec(spec)
+    lower_direct_spec(crate::domain_lowering::lower_domain_surface(domain)?)
 }
 
 /// Lower an AI hard-contract document to its executable catalog kernel.

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -1,0 +1,2725 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_syntax::{
+    ActionItem, Binder, DomainAggregate, DomainDecide, DomainEffect, DomainField, DomainLoc,
+    DomainSaga, DomainSagaStep, DomainSpec, DomainType, Expr, LValue, MetaTag, Param, Pattern,
+    QualifiedName, SourcePos, Span, SpecItem, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr,
+    SyntaxExprKind, SyntaxLValue, SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr,
+    SyntaxTypeExprKind, TypeExpr,
+};
+
+use crate::CoreError;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum LogicalType {
+    Int,
+    Bool,
+    Named(String),
+    Map(Box<Self>, Box<Self>),
+    Set(Box<Self>),
+    Seq(Box<Self>),
+    Option(Box<Self>),
+    Unknown,
+}
+
+#[derive(Clone, Debug)]
+struct Symbol {
+    kernel_name: String,
+    ty: LogicalType,
+}
+
+type Scope = BTreeMap<String, Symbol>;
+
+#[derive(Clone, Debug)]
+struct ResolvedExpr {
+    expr: Expr,
+    ty: LogicalType,
+}
+
+fn error_at(message: impl Into<String>, span: Span) -> CoreError {
+    CoreError {
+        message: message.into(),
+        line: span.start.line,
+        column: span.start.column,
+    }
+}
+
+fn span_at(loc: DomainLoc) -> Span {
+    let position = SourcePos {
+        offset: 0,
+        line: loc.line,
+        column: loc.column,
+    };
+    Span {
+        start: position,
+        end: position,
+    }
+}
+
+fn safe(name: &str) -> String {
+    let mut value = name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if value.is_empty() {
+        value.push('x');
+    }
+    if value.starts_with(|character: char| character.is_ascii_digit()) {
+        value.insert(0, '_');
+    }
+    value
+}
+
+fn lower_name(name: &str) -> String {
+    let mut output = String::new();
+    let characters = name.chars().collect::<Vec<_>>();
+    for (index, character) in characters.iter().enumerate() {
+        let previous = index.checked_sub(1).and_then(|index| characters.get(index));
+        let next = characters.get(index + 1);
+        if character.is_ascii_uppercase()
+            && index > 0
+            && (previous.is_some_and(char::is_ascii_lowercase)
+                || previous.is_some_and(char::is_ascii_digit)
+                || next.is_some_and(char::is_ascii_lowercase))
+        {
+            output.push('_');
+        }
+        output.push(character.to_ascii_lowercase());
+    }
+    safe(&output)
+}
+
+fn state_name(aggregate: &DomainAggregate, field: &str) -> String {
+    format!("{}_{}", lower_name(&aggregate.name), safe(field))
+}
+
+fn event_flag(event: &str) -> String {
+    format!("event_{}", safe(event))
+}
+
+fn status_type(effect: &DomainEffect) -> String {
+    format!("{}EffectStatus", safe(&effect.name))
+}
+
+fn status_member(effect: &DomainEffect, member: &str) -> String {
+    format!("{}EffectStatus_{member}", safe(&effect.name))
+}
+
+fn status_var(effect: &DomainEffect) -> String {
+    format!("{}_status", lower_name(&effect.name))
+}
+
+fn attempt_type(effect: &DomainEffect) -> String {
+    format!("{}Attempt", safe(&effect.name))
+}
+
+fn attempt_var(effect: &DomainEffect) -> String {
+    format!("{}_attempts", lower_name(&effect.name))
+}
+
+fn and_all(mut values: Vec<Expr>) -> Expr {
+    if values.is_empty() {
+        return Expr::Bool(true);
+    }
+    let first = values.remove(0);
+    values.into_iter().fold(first, |left, right| Expr::Binary {
+        op: "and".to_owned(),
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn or_all(mut values: Vec<Expr>) -> Expr {
+    if values.is_empty() {
+        return Expr::Bool(false);
+    }
+    let first = values.remove(0);
+    values.into_iter().fold(first, |left, right| Expr::Binary {
+        op: "or".to_owned(),
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn qualified(name: &str) -> QualifiedName {
+    QualifiedName {
+        namespace: None,
+        name: name.to_owned(),
+    }
+}
+
+fn type_name(ty: &LogicalType) -> Option<&str> {
+    match ty {
+        LogicalType::Named(name) => Some(name),
+        _ => None,
+    }
+}
+
+fn logical_qualified_name(ty: &LogicalType, span: Span) -> Result<QualifiedName, CoreError> {
+    match ty {
+        LogicalType::Int => Ok(qualified("Int")),
+        LogicalType::Bool => Ok(qualified("Bool")),
+        LogicalType::Named(name) => Ok(qualified(name)),
+        _ => Err(error_at("map keys require a scalar or named type", span)),
+    }
+}
+
+fn needs_expected_type(expression: &SyntaxExpr) -> bool {
+    match &expression.kind {
+        SyntaxExprKind::Name(_) | SyntaxExprKind::None | SyntaxExprKind::Some(_) => true,
+        SyntaxExprKind::Set(values) | SyntaxExprKind::Seq(values) => values.is_empty(),
+        SyntaxExprKind::Group(value) => needs_expected_type(value),
+        _ => false,
+    }
+}
+
+struct Resolver<'a> {
+    domain: &'a DomainSpec,
+    types: Vec<DomainType>,
+    enums: BTreeMap<String, BTreeSet<String>>,
+    enum_candidates: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl<'a> Resolver<'a> {
+    fn compatible(&self, left: &LogicalType, right: &LogicalType) -> bool {
+        if left == right
+            || matches!(left, LogicalType::Unknown)
+            || matches!(right, LogicalType::Unknown)
+        {
+            return true;
+        }
+        let numeric = |ty: &LogicalType| match ty {
+            LogicalType::Int => true,
+            LogicalType::Named(name) => self
+                .types
+                .iter()
+                .find(|candidate| candidate.name == *name)
+                .is_some_and(|definition| matches!(definition.kind.as_str(), "range" | "external")),
+            _ => false,
+        };
+        if numeric(left) && numeric(right) {
+            return true;
+        }
+        match (left, right) {
+            (LogicalType::Map(left_key, left_value), LogicalType::Map(right_key, right_value)) => {
+                self.compatible(left_key, right_key) && self.compatible(left_value, right_value)
+            }
+            (LogicalType::Set(left), LogicalType::Set(right))
+            | (LogicalType::Seq(left), LogicalType::Seq(right))
+            | (LogicalType::Option(left), LogicalType::Option(right)) => {
+                self.compatible(left, right)
+            }
+            _ => false,
+        }
+    }
+
+    fn new(domain: &'a DomainSpec) -> Self {
+        let mut types = domain.types.clone();
+        let declared = types
+            .iter()
+            .map(|ty| ty.name.clone())
+            .collect::<BTreeSet<_>>();
+        let mut references = BTreeSet::new();
+        for aggregate in &domain.aggregates {
+            if let Some(id) = &aggregate.id_type {
+                references.insert(id.clone());
+            }
+            for field in aggregate
+                .state
+                .iter()
+                .chain(aggregate.commands.iter().flat_map(|item| &item.inputs))
+                .chain(aggregate.events.iter().flat_map(|item| &item.fields))
+            {
+                Self::collect_named_types(&field.type_name, &mut references);
+            }
+        }
+        for name in references {
+            if !declared.contains(&name) && !matches!(name.as_str(), "Int" | "Bool") {
+                types.push(DomainType {
+                    name,
+                    kind: "external".to_owned(),
+                    members: Vec::new(),
+                    lo: None,
+                    hi: None,
+                    fields: Vec::new(),
+                    invariants: Vec::new(),
+                    loc: domain.loc,
+                });
+            }
+        }
+        let mut enums = BTreeMap::<String, BTreeSet<String>>::new();
+        let mut enum_candidates = BTreeMap::<String, BTreeSet<String>>::new();
+        for ty in &types {
+            if ty.kind != "enum" {
+                continue;
+            }
+            enums.insert(ty.name.clone(), ty.members.iter().cloned().collect());
+            for member in &ty.members {
+                enum_candidates
+                    .entry(member.clone())
+                    .or_default()
+                    .insert(ty.name.clone());
+            }
+        }
+        Self {
+            domain,
+            types,
+            enums,
+            enum_candidates,
+        }
+    }
+
+    fn collect_named_types(ty: &SyntaxTypeExpr, output: &mut BTreeSet<String>) {
+        match &ty.kind {
+            SyntaxTypeExprKind::Name(name) => {
+                output.insert(name.text.clone());
+            }
+            SyntaxTypeExprKind::Apply { arguments, .. } => {
+                for argument in arguments {
+                    Self::collect_named_types(argument, output);
+                }
+            }
+        }
+    }
+
+    fn logical_type(&self, ty: &SyntaxTypeExpr) -> Result<LogicalType, CoreError> {
+        match &ty.kind {
+            SyntaxTypeExprKind::Name(name) => Ok(match name.text.as_str() {
+                "Int" => LogicalType::Int,
+                "Bool" => LogicalType::Bool,
+                other if self.types.iter().any(|ty| ty.name == other) => {
+                    LogicalType::Named(other.to_owned())
+                }
+                other => {
+                    return Err(error_at(
+                        format!("unknown domain type '{other}'"),
+                        name.span,
+                    ));
+                }
+            }),
+            SyntaxTypeExprKind::Apply {
+                constructor,
+                arguments,
+            } => match (constructor.text.as_str(), arguments.as_slice()) {
+                ("Map", [key, value]) => Ok(LogicalType::Map(
+                    Box::new(self.logical_type(key)?),
+                    Box::new(self.logical_type(value)?),
+                )),
+                ("Set", [value]) => Ok(LogicalType::Set(Box::new(self.logical_type(value)?))),
+                ("Seq", [value]) => Ok(LogicalType::Seq(Box::new(self.logical_type(value)?))),
+                ("Option", [value]) => Ok(LogicalType::Option(Box::new(self.logical_type(value)?))),
+                _ => Err(error_at(
+                    format!(
+                        "unsupported domain type constructor '{}'/{}",
+                        constructor.text,
+                        arguments.len()
+                    ),
+                    ty.span,
+                )),
+            },
+        }
+    }
+
+    fn surface_type(&self, ty: &SyntaxTypeExpr) -> Result<TypeExpr, CoreError> {
+        match &ty.kind {
+            SyntaxTypeExprKind::Name(name) => Ok(match name.text.as_str() {
+                "Int" => TypeExpr::Int,
+                "Bool" => TypeExpr::Bool,
+                other if self.types.iter().any(|ty| ty.name == other) => {
+                    TypeExpr::Name(other.to_owned())
+                }
+                other => {
+                    return Err(error_at(
+                        format!("unknown domain type '{other}'"),
+                        name.span,
+                    ));
+                }
+            }),
+            SyntaxTypeExprKind::Apply {
+                constructor,
+                arguments,
+            } => match (constructor.text.as_str(), arguments.as_slice()) {
+                ("Map", [key, value]) => Ok(TypeExpr::Map(
+                    Box::new(self.surface_type(key)?),
+                    Box::new(self.surface_type(value)?),
+                )),
+                ("Set", [value]) => Ok(TypeExpr::Set(Box::new(self.surface_type(value)?))),
+                ("Option", [value]) => Ok(TypeExpr::Option(Box::new(self.surface_type(value)?))),
+                _ => Err(error_at(
+                    format!(
+                        "unsupported domain type constructor '{}'/{}",
+                        constructor.text,
+                        arguments.len()
+                    ),
+                    ty.span,
+                )),
+            },
+        }
+    }
+
+    fn enum_value(
+        &self,
+        name: &str,
+        expected: Option<&LogicalType>,
+        span: Span,
+    ) -> Result<Option<ResolvedExpr>, CoreError> {
+        if let Some(expected_name) = expected.and_then(type_name)
+            && self
+                .enums
+                .get(expected_name)
+                .is_some_and(|members| members.contains(name))
+        {
+            return Ok(Some(ResolvedExpr {
+                expr: Expr::Var(format!("{expected_name}_{name}")),
+                ty: LogicalType::Named(expected_name.to_owned()),
+            }));
+        }
+        let Some(candidates) = self.enum_candidates.get(name) else {
+            return Ok(None);
+        };
+        if candidates.len() != 1 {
+            return Err(error_at(
+                format!(
+                    "ambiguous enum member '{name}'; expected one of {}",
+                    candidates.iter().cloned().collect::<Vec<_>>().join(", ")
+                ),
+                span,
+            ));
+        }
+        let ty = candidates.iter().next().expect("one enum candidate");
+        Ok(Some(ResolvedExpr {
+            expr: Expr::Var(format!("{ty}_{name}")),
+            ty: LogicalType::Named(ty.clone()),
+        }))
+    }
+
+    fn scope_for_aggregate(&self, aggregate: &DomainAggregate) -> Result<Scope, CoreError> {
+        aggregate
+            .state
+            .iter()
+            .map(|field| {
+                Ok((
+                    field.name.text.clone(),
+                    Symbol {
+                        kernel_name: state_name(aggregate, &field.name),
+                        ty: self.logical_type(&field.type_name)?,
+                    },
+                ))
+            })
+            .collect()
+    }
+
+    fn scope_for_fields(&self, fields: &[DomainField]) -> Result<Scope, CoreError> {
+        fields
+            .iter()
+            .map(|field| {
+                Ok((
+                    field.name.text.clone(),
+                    Symbol {
+                        kernel_name: field.name.text.clone(),
+                        ty: self.logical_type(&field.type_name)?,
+                    },
+                ))
+            })
+            .collect()
+    }
+
+    fn extend_fields(&self, scope: &mut Scope, fields: &[DomainField]) -> Result<(), CoreError> {
+        for field in fields {
+            scope.insert(
+                field.name.text.clone(),
+                Symbol {
+                    kernel_name: field.name.text.clone(),
+                    ty: self.logical_type(&field.type_name)?,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    fn resolve_name(
+        &self,
+        name: &str,
+        span: Span,
+        expected: Option<&LogicalType>,
+        scope: &Scope,
+    ) -> Result<ResolvedExpr, CoreError> {
+        if let Some(symbol) = scope.get(name) {
+            return Ok(ResolvedExpr {
+                expr: Expr::Var(symbol.kernel_name.clone()),
+                ty: symbol.ty.clone(),
+            });
+        }
+        if let Some(value) = self.enum_value(name, expected, span)? {
+            return Ok(value);
+        }
+        Err(error_at(format!("unknown domain symbol '{name}'"), span))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn resolve_expr(
+        &self,
+        expression: &SyntaxExpr,
+        expected: Option<&LogicalType>,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+        expanding_can: &mut Vec<String>,
+    ) -> Result<ResolvedExpr, CoreError> {
+        let resolved = match &expression.kind {
+            SyntaxExprKind::Num(value) => ResolvedExpr {
+                expr: Expr::Num(*value),
+                ty: LogicalType::Int,
+            },
+            SyntaxExprKind::Bool(value) => ResolvedExpr {
+                expr: Expr::Bool(*value),
+                ty: LogicalType::Bool,
+            },
+            SyntaxExprKind::None => ResolvedExpr {
+                expr: Expr::None,
+                ty: match expected {
+                    Some(expected @ LogicalType::Option(_)) => expected.clone(),
+                    Some(_) => {
+                        return Err(error_at(
+                            "none requires an Option expected type",
+                            expression.span,
+                        ));
+                    }
+                    None => LogicalType::Option(Box::new(LogicalType::Unknown)),
+                },
+            },
+            SyntaxExprKind::Name(name) => {
+                self.resolve_name(&name.text, name.span, expected, scope)?
+            }
+            SyntaxExprKind::Call { callee, args }
+                if callee.text == "can" && matches!(args.as_slice(), [SyntaxExpr { .. }]) =>
+            {
+                let [argument] = args.as_slice() else {
+                    unreachable!()
+                };
+                let SyntaxExprKind::Name(command) = &argument.kind else {
+                    return Err(error_at("can() expects a command name", argument.span));
+                };
+                let Some(aggregate) = aggregate else {
+                    return Err(error_at(
+                        "can() is only valid in an aggregate expression",
+                        expression.span,
+                    ));
+                };
+                let Some(decide) = aggregate
+                    .decides
+                    .iter()
+                    .find(|decide| decide.command == command.text)
+                else {
+                    let elsewhere = self.domain.aggregates.iter().any(|candidate| {
+                        candidate.name != aggregate.name
+                            && candidate
+                                .commands
+                                .iter()
+                                .any(|item| item.name == command.text)
+                    });
+                    let detail = if elsewhere {
+                        " belongs to another aggregate"
+                    } else {
+                        " is unknown"
+                    };
+                    return Err(error_at(
+                        format!("command '{}'{}", command.text, detail),
+                        expression.span,
+                    ));
+                };
+                if expanding_can.contains(&command.text) {
+                    return Err(error_at(
+                        format!("recursive can({}) expansion", command.text),
+                        expression.span,
+                    ));
+                }
+                expanding_can.push(command.text.clone());
+                let result = self.resolve_can(decide, scope, aggregate, expanding_can);
+                expanding_can.pop();
+                ResolvedExpr {
+                    expr: result?,
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Call { callee, .. } if callee.text == "can" => {
+                return Err(error_at(
+                    "can() expects exactly one command name",
+                    expression.span,
+                ));
+            }
+            SyntaxExprKind::Call { callee, args } => {
+                let args = args
+                    .iter()
+                    .map(|arg| self.resolve_expr(arg, None, scope, aggregate, expanding_can))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let (expr, ty) = match (callee.text.as_str(), args.as_slice()) {
+                    ("old", [value]) => (
+                        Expr::UnaryNamed {
+                            name: callee.text.clone(),
+                            expr: Box::new(value.expr.clone()),
+                            span: callee.span,
+                        },
+                        value.ty.clone(),
+                    ),
+                    ("abs", [value]) if self.compatible(&value.ty, &LogicalType::Int) => (
+                        Expr::UnaryNamed {
+                            name: callee.text.clone(),
+                            expr: Box::new(value.expr.clone()),
+                            span: callee.span,
+                        },
+                        LogicalType::Int,
+                    ),
+                    ("min" | "max", [left, right])
+                        if self.compatible(&left.ty, &LogicalType::Int)
+                            && self.compatible(&right.ty, &LogicalType::Int) =>
+                    {
+                        (
+                            Expr::BinaryNamed {
+                                name: callee.text.clone(),
+                                left: Box::new(left.expr.clone()),
+                                right: Box::new(right.expr.clone()),
+                            },
+                            LogicalType::Int,
+                        )
+                    }
+                    _ => {
+                        return Err(error_at(
+                            format!("unsupported domain call '{}'/{}", callee.text, args.len()),
+                            expression.span,
+                        ));
+                    }
+                };
+                ResolvedExpr { expr, ty }
+            }
+            SyntaxExprKind::Membership { value, members } => {
+                let value = self.resolve_expr(value, None, scope, aggregate, expanding_can)?;
+                let comparisons = members
+                    .iter()
+                    .map(|member| {
+                        let member_span = member.span;
+                        let member = self.resolve_expr(
+                            member,
+                            Some(&value.ty),
+                            scope,
+                            aggregate,
+                            expanding_can,
+                        )?;
+                        if !self.compatible(&value.ty, &member.ty) {
+                            return Err(error_at("membership member type mismatch", member_span));
+                        }
+                        Ok(Expr::Binary {
+                            op: "==".to_owned(),
+                            left: Box::new(value.expr.clone()),
+                            right: Box::new(member.expr),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, CoreError>>()?;
+                ResolvedExpr {
+                    expr: or_all(comparisons),
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Binary { op, left, right } => {
+                let left_value = self.resolve_expr(left, None, scope, aggregate, expanding_can);
+                let (left, right) = match left_value {
+                    Ok(left_value) => {
+                        let mut right_scope = scope.clone();
+                        if matches!(op.canonical.as_str(), "and" | "=>") {
+                            self.collect_pattern_bindings(
+                                left,
+                                scope,
+                                &mut right_scope,
+                                aggregate,
+                                expanding_can,
+                            )?;
+                        }
+                        let right_value = self.resolve_expr(
+                            right,
+                            needs_expected_type(right).then_some(&left_value.ty),
+                            &right_scope,
+                            aggregate,
+                            expanding_can,
+                        )?;
+                        (left_value, right_value)
+                    }
+                    Err(left_error) => {
+                        let Ok(right_value) =
+                            self.resolve_expr(right, None, scope, aggregate, expanding_can)
+                        else {
+                            return Err(left_error);
+                        };
+                        let left_value = self
+                            .resolve_expr(
+                                left,
+                                Some(&right_value.ty),
+                                scope,
+                                aggregate,
+                                expanding_can,
+                            )
+                            .map_err(|_| left_error)?;
+                        (left_value, right_value)
+                    }
+                };
+                if matches!(op.canonical.as_str(), "==" | "!=")
+                    && (matches!(left.ty, LogicalType::Option(_))
+                        || matches!(right.ty, LogicalType::Option(_)))
+                    && !matches!(&left.expr, Expr::None)
+                    && !matches!(&right.expr, Expr::None)
+                {
+                    return Err(error_at(
+                        "Option values may only compare with none; use 'is some(binding)'",
+                        op.span,
+                    ));
+                }
+                let result_type = match op.canonical.as_str() {
+                    "and" | "or" | "=>" => {
+                        if !self.compatible(&left.ty, &LogicalType::Bool)
+                            || !self.compatible(&right.ty, &LogicalType::Bool)
+                        {
+                            return Err(error_at(
+                                "logical operator requires Bool operands",
+                                op.span,
+                            ));
+                        }
+                        LogicalType::Bool
+                    }
+                    "==" | "!=" => {
+                        if !self.compatible(&left.ty, &right.ty) {
+                            return Err(error_at("comparison operand type mismatch", op.span));
+                        }
+                        LogicalType::Bool
+                    }
+                    "<" | "<=" | ">" | ">=" => {
+                        if !self.compatible(&left.ty, &LogicalType::Int)
+                            || !self.compatible(&right.ty, &LogicalType::Int)
+                        {
+                            return Err(error_at(
+                                "ordering operator requires numeric operands",
+                                op.span,
+                            ));
+                        }
+                        LogicalType::Bool
+                    }
+                    "+" | "-" | "*" | "/" | "%" => {
+                        if !self.compatible(&left.ty, &LogicalType::Int)
+                            || !self.compatible(&right.ty, &LogicalType::Int)
+                        {
+                            return Err(error_at(
+                                "arithmetic operator requires numeric operands",
+                                op.span,
+                            ));
+                        }
+                        LogicalType::Int
+                    }
+                    _ => {
+                        return Err(error_at(
+                            format!("unsupported domain operator '{}'", op.canonical),
+                            op.span,
+                        ));
+                    }
+                };
+                ResolvedExpr {
+                    expr: Expr::Binary {
+                        op: op.canonical.clone(),
+                        left: Box::new(left.expr),
+                        right: Box::new(right.expr),
+                    },
+                    ty: result_type,
+                }
+            }
+            SyntaxExprKind::Neg(value) => {
+                let value = self.resolve_expr(
+                    value,
+                    Some(&LogicalType::Int),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                ResolvedExpr {
+                    expr: Expr::Neg(Box::new(value.expr)),
+                    ty: LogicalType::Int,
+                }
+            }
+            SyntaxExprKind::Not(value) => {
+                let value = self.resolve_expr(
+                    value,
+                    Some(&LogicalType::Bool),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                ResolvedExpr {
+                    expr: Expr::Not(Box::new(value.expr)),
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Group(value) => {
+                return self.resolve_expr(value, expected, scope, aggregate, expanding_can);
+            }
+            _ => {
+                self.resolve_kernel_shape(expression, expected, scope, aggregate, expanding_can)?
+            }
+        };
+        if let Some(expected) = expected
+            && !self.compatible(&resolved.ty, expected)
+        {
+            return Err(error_at("domain expression type mismatch", expression.span));
+        }
+        Ok(resolved)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn resolve_kernel_shape(
+        &self,
+        expression: &SyntaxExpr,
+        expected: Option<&LogicalType>,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+        expanding_can: &mut Vec<String>,
+    ) -> Result<ResolvedExpr, CoreError> {
+        Ok(match &expression.kind {
+            SyntaxExprKind::Some(value) => {
+                let inner_expected = expected.and_then(|expected| match expected {
+                    LogicalType::Option(inner) => Some(inner.as_ref()),
+                    _ => None,
+                });
+                let value =
+                    self.resolve_expr(value, inner_expected, scope, aggregate, expanding_can)?;
+                ResolvedExpr {
+                    expr: Expr::Some(Box::new(value.expr)),
+                    ty: LogicalType::Option(Box::new(value.ty)),
+                }
+            }
+            SyntaxExprKind::Set(values) => {
+                let inner_expected = expected.and_then(|expected| match expected {
+                    LogicalType::Set(inner) => Some(inner.as_ref()),
+                    _ => None,
+                });
+                let values = values
+                    .iter()
+                    .map(|value| {
+                        self.resolve_expr(value, inner_expected, scope, aggregate, expanding_can)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let item_type = values.first().map_or_else(
+                    || inner_expected.cloned().unwrap_or(LogicalType::Unknown),
+                    |value| value.ty.clone(),
+                );
+                if values
+                    .iter()
+                    .any(|value| !self.compatible(&item_type, &value.ty))
+                {
+                    return Err(error_at(
+                        "Set literal element type mismatch",
+                        expression.span,
+                    ));
+                }
+                ResolvedExpr {
+                    expr: Expr::Set(values.into_iter().map(|value| value.expr).collect()),
+                    ty: LogicalType::Set(Box::new(item_type)),
+                }
+            }
+            SyntaxExprKind::Seq(values) => {
+                let inner_expected = expected.and_then(|expected| match expected {
+                    LogicalType::Seq(inner) => Some(inner.as_ref()),
+                    _ => None,
+                });
+                let values = values
+                    .iter()
+                    .map(|value| {
+                        self.resolve_expr(value, inner_expected, scope, aggregate, expanding_can)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let item_type = values.first().map_or_else(
+                    || inner_expected.cloned().unwrap_or(LogicalType::Unknown),
+                    |value| value.ty.clone(),
+                );
+                if values
+                    .iter()
+                    .any(|value| !self.compatible(&item_type, &value.ty))
+                {
+                    return Err(error_at(
+                        "Seq literal element type mismatch",
+                        expression.span,
+                    ));
+                }
+                ResolvedExpr {
+                    expr: Expr::Seq(values.into_iter().map(|value| value.expr).collect()),
+                    ty: LogicalType::Seq(Box::new(item_type)),
+                }
+            }
+            SyntaxExprKind::Struct { name, fields } => {
+                let Some(definition) = self
+                    .types
+                    .iter()
+                    .find(|ty| ty.name == name.text && ty.kind == "value_object")
+                else {
+                    return Err(error_at(
+                        format!("unknown domain value object '{}'", name.text),
+                        name.span,
+                    ));
+                };
+                let mut lowered = Vec::new();
+                let mut seen = BTreeSet::new();
+                for (field, value) in fields {
+                    if !seen.insert(field.text.clone()) {
+                        return Err(error_at(
+                            format!("duplicate field '{}.{}'", name.text, field.text),
+                            field.span,
+                        ));
+                    }
+                    let Some(field_definition) = definition
+                        .fields
+                        .iter()
+                        .find(|candidate| candidate.name.text == field.text)
+                    else {
+                        return Err(error_at(
+                            format!("unknown field '{}.{}'", name.text, field.text),
+                            field.span,
+                        ));
+                    };
+                    let expected = self.logical_type(&field_definition.type_name)?;
+                    lowered.push((
+                        field.text.clone(),
+                        self.resolve_expr(value, Some(&expected), scope, aggregate, expanding_can)?
+                            .expr,
+                    ));
+                }
+                if let Some(missing) = definition
+                    .fields
+                    .iter()
+                    .find(|field| !seen.contains(&field.name.text))
+                {
+                    return Err(error_at(
+                        format!("missing struct field '{}.{}'", name.text, missing.name.text),
+                        expression.span,
+                    ));
+                }
+                ResolvedExpr {
+                    expr: Expr::Struct {
+                        name: name.text.clone(),
+                        fields: lowered,
+                    },
+                    ty: LogicalType::Named(name.text.clone()),
+                }
+            }
+            SyntaxExprKind::Index { receiver, index } => {
+                let receiver =
+                    self.resolve_expr(receiver, None, scope, aggregate, expanding_can)?;
+                let (index_type, value_type) = match &receiver.ty {
+                    LogicalType::Map(key, value) => (key.as_ref().clone(), value.as_ref().clone()),
+                    LogicalType::Seq(value) => (LogicalType::Int, value.as_ref().clone()),
+                    _ => {
+                        return Err(error_at(
+                            "indexing requires a Map or Seq expression",
+                            expression.span,
+                        ));
+                    }
+                };
+                let index =
+                    self.resolve_expr(index, Some(&index_type), scope, aggregate, expanding_can)?;
+                ResolvedExpr {
+                    expr: Expr::Index(Box::new(receiver.expr), Box::new(index.expr)),
+                    ty: value_type,
+                }
+            }
+            SyntaxExprKind::Field { receiver, field } => {
+                let receiver =
+                    self.resolve_expr(receiver, None, scope, aggregate, expanding_can)?;
+                let Some(type_name) = type_name(&receiver.ty) else {
+                    return Err(error_at(
+                        "field access requires a value object",
+                        expression.span,
+                    ));
+                };
+                let Some(definition) = self
+                    .types
+                    .iter()
+                    .find(|ty| ty.name == type_name && ty.kind == "value_object")
+                else {
+                    return Err(error_at(
+                        format!("type '{type_name}' has no fields"),
+                        expression.span,
+                    ));
+                };
+                let Some(field_definition) = definition
+                    .fields
+                    .iter()
+                    .find(|candidate| candidate.name.text == field.text)
+                else {
+                    return Err(error_at(
+                        format!("unknown field '{type_name}.{}'", field.text),
+                        field.span,
+                    ));
+                };
+                ResolvedExpr {
+                    expr: Expr::Field(Box::new(receiver.expr), field.text.clone()),
+                    ty: self.logical_type(&field_definition.type_name)?,
+                }
+            }
+            SyntaxExprKind::Method {
+                receiver,
+                method,
+                args,
+            } => {
+                let receiver =
+                    self.resolve_expr(receiver, None, scope, aggregate, expanding_can)?;
+                let args = args
+                    .iter()
+                    .map(|value| self.resolve_expr(value, None, scope, aggregate, expanding_can))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let (result_type, expected_args): (LogicalType, Vec<LogicalType>) =
+                    match (&receiver.ty, method.text.as_str(), args.len()) {
+                        (LogicalType::Set(item) | LogicalType::Seq(item), "contains", 1) => {
+                            (LogicalType::Bool, vec![item.as_ref().clone()])
+                        }
+                        (LogicalType::Set(item), "add" | "remove", 1)
+                        | (LogicalType::Seq(item), "push", 1) => {
+                            (receiver.ty.clone(), vec![item.as_ref().clone()])
+                        }
+                        (LogicalType::Set(_) | LogicalType::Seq(_), "size", 0) => {
+                            (LogicalType::Int, Vec::new())
+                        }
+                        (LogicalType::Seq(item), "head", 0) => (item.as_ref().clone(), Vec::new()),
+                        (LogicalType::Seq(item), "at", 1) => {
+                            (item.as_ref().clone(), vec![LogicalType::Int])
+                        }
+                        (LogicalType::Set(_), name, _) => {
+                            return Err(error_at(
+                                format!("invalid Set method '{name}'/{}", args.len()),
+                                method.span,
+                            ));
+                        }
+                        (LogicalType::Seq(_), name, _) => {
+                            return Err(error_at(
+                                format!("invalid Seq method '{name}'/{}", args.len()),
+                                method.span,
+                            ));
+                        }
+                        _ => {
+                            return Err(error_at(
+                                "method receiver has no supported collection methods",
+                                expression.span,
+                            ));
+                        }
+                    };
+                for (argument, expected) in args.iter().zip(&expected_args) {
+                    if !self.compatible(&argument.ty, expected) {
+                        return Err(error_at(
+                            "collection method argument type mismatch",
+                            expression.span,
+                        ));
+                    }
+                }
+                ResolvedExpr {
+                    expr: Expr::Method {
+                        receiver: Box::new(receiver.expr),
+                        name: method.text.clone(),
+                        args: args.into_iter().map(|value| value.expr).collect(),
+                    },
+                    ty: result_type,
+                }
+            }
+            SyntaxExprKind::IfThenElse {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                let condition = self.resolve_expr(
+                    condition,
+                    Some(&LogicalType::Bool),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                let then_expr =
+                    self.resolve_expr(then_expr, expected, scope, aggregate, expanding_can)?;
+                let else_expr = self.resolve_expr(
+                    else_expr,
+                    Some(&then_expr.ty),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                ResolvedExpr {
+                    expr: Expr::IfThenElse {
+                        condition: Box::new(condition.expr),
+                        then_expr: Box::new(then_expr.expr),
+                        else_expr: Box::new(else_expr.expr),
+                    },
+                    ty: then_expr.ty,
+                }
+            }
+            SyntaxExprKind::Is { expr, pattern } => {
+                let value = self.resolve_expr(expr, None, scope, aggregate, expanding_can)?;
+                if !matches!(value.ty, LogicalType::Option(_)) {
+                    return Err(error_at(
+                        "'is none/some' requires an Option expression",
+                        expression.span,
+                    ));
+                }
+                ResolvedExpr {
+                    expr: Expr::Is {
+                        expr: Box::new(value.expr),
+                        pattern: match pattern {
+                            SyntaxPattern::None { .. } => Pattern::None,
+                            SyntaxPattern::Some { name, .. } => Pattern::Some(name.text.clone()),
+                        },
+                    },
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Quantified {
+                quantifier,
+                binder,
+                body,
+            } => {
+                let (binder, nested) =
+                    self.resolve_binder(binder, scope, aggregate, expanding_can)?;
+                let body = self.resolve_expr(
+                    body,
+                    Some(&LogicalType::Bool),
+                    &nested,
+                    aggregate,
+                    expanding_can,
+                )?;
+                ResolvedExpr {
+                    expr: Expr::Quantified {
+                        quantifier: quantifier.text.clone(),
+                        binder,
+                        body: Box::new(body.expr),
+                    },
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Count {
+                name,
+                type_name,
+                condition,
+            } => {
+                let logical = self.qualified_logical_type(type_name)?;
+                let mut nested = scope.clone();
+                nested.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: logical,
+                    },
+                );
+                let condition = self.resolve_expr(
+                    condition,
+                    Some(&LogicalType::Bool),
+                    &nested,
+                    aggregate,
+                    expanding_can,
+                )?;
+                ResolvedExpr {
+                    expr: Expr::Count {
+                        name: name.text.clone(),
+                        type_name: Self::qualified_name(type_name),
+                        condition: Box::new(condition.expr),
+                    },
+                    ty: LogicalType::Int,
+                }
+            }
+            SyntaxExprKind::Sum {
+                name,
+                type_name,
+                body,
+                condition,
+            } => {
+                let logical = self.qualified_logical_type(type_name)?;
+                let mut nested = scope.clone();
+                nested.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: logical,
+                    },
+                );
+                let body = self.resolve_expr(
+                    body,
+                    Some(&LogicalType::Int),
+                    &nested,
+                    aggregate,
+                    expanding_can,
+                )?;
+                let condition = condition
+                    .as_deref()
+                    .map(|condition| {
+                        self.resolve_expr(
+                            condition,
+                            Some(&LogicalType::Bool),
+                            &nested,
+                            aggregate,
+                            expanding_can,
+                        )
+                        .map(|value| Box::new(value.expr))
+                    })
+                    .transpose()?;
+                ResolvedExpr {
+                    expr: Expr::Sum {
+                        name: name.text.clone(),
+                        type_name: Self::qualified_name(type_name),
+                        body: Box::new(body.expr),
+                        condition,
+                    },
+                    ty: LogicalType::Int,
+                }
+            }
+            SyntaxExprKind::BinderNamed { name, binder } => {
+                let (binder, _) = self.resolve_binder(binder, scope, aggregate, expanding_can)?;
+                ResolvedExpr {
+                    expr: Expr::BinderNamed {
+                        name: if name.text == "exactlyOne" {
+                            "exactly_one".to_owned()
+                        } else {
+                            name.text.clone()
+                        },
+                        binder,
+                    },
+                    ty: LogicalType::Bool,
+                }
+            }
+            SyntaxExprKind::Num(_)
+            | SyntaxExprKind::Bool(_)
+            | SyntaxExprKind::None
+            | SyntaxExprKind::Name(_)
+            | SyntaxExprKind::Call { .. }
+            | SyntaxExprKind::Binary { .. }
+            | SyntaxExprKind::Membership { .. }
+            | SyntaxExprKind::Neg(_)
+            | SyntaxExprKind::Not(_)
+            | SyntaxExprKind::Group(_) => {
+                return Err(error_at(
+                    "internal domain lowering dispatch error",
+                    expression.span,
+                ));
+            }
+        })
+    }
+
+    fn qualified_name(name: &SyntaxQualifiedName) -> QualifiedName {
+        QualifiedName {
+            namespace: name.namespace.as_ref().map(|value| value.text.clone()),
+            name: name.name.text.clone(),
+        }
+    }
+
+    fn qualified_logical_type(&self, name: &SyntaxQualifiedName) -> Result<LogicalType, CoreError> {
+        if name.namespace.is_some() {
+            return Err(error_at(
+                "namespaced domain binder types are not supported",
+                name.span,
+            ));
+        }
+        Ok(match name.name.text.as_str() {
+            "Int" => LogicalType::Int,
+            "Bool" => LogicalType::Bool,
+            other if self.types.iter().any(|ty| ty.name == other) => {
+                LogicalType::Named(other.to_owned())
+            }
+            other => {
+                return Err(error_at(
+                    format!("unknown domain type '{other}'"),
+                    name.span,
+                ));
+            }
+        })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn resolve_binder(
+        &self,
+        binder: &SyntaxBinder,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+        expanding_can: &mut Vec<String>,
+    ) -> Result<(Binder, Scope), CoreError> {
+        match binder {
+            SyntaxBinder::Typed {
+                name,
+                type_name,
+                where_expr,
+                ..
+            } => {
+                let logical = self.qualified_logical_type(type_name)?;
+                let mut nested = scope.clone();
+                nested.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: logical,
+                    },
+                );
+                let where_expr = where_expr
+                    .as_deref()
+                    .map(|value| {
+                        self.resolve_expr(
+                            value,
+                            Some(&LogicalType::Bool),
+                            &nested,
+                            aggregate,
+                            expanding_can,
+                        )
+                        .map(|value| Box::new(value.expr))
+                    })
+                    .transpose()?;
+                Ok((
+                    Binder::Typed {
+                        name: name.text.clone(),
+                        type_name: Self::qualified_name(type_name),
+                        where_expr,
+                    },
+                    nested,
+                ))
+            }
+            SyntaxBinder::Range { name, lo, hi, .. } => {
+                let lo = self.resolve_expr(
+                    lo,
+                    Some(&LogicalType::Int),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                let hi = self.resolve_expr(
+                    hi,
+                    Some(&LogicalType::Int),
+                    scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                let mut nested = scope.clone();
+                nested.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: LogicalType::Int,
+                    },
+                );
+                Ok((
+                    Binder::Range {
+                        name: name.text.clone(),
+                        lo: Box::new(lo.expr),
+                        hi: Box::new(hi.expr),
+                    },
+                    nested,
+                ))
+            }
+            SyntaxBinder::Collection {
+                name,
+                collection,
+                where_expr,
+                ..
+            } => {
+                let collection =
+                    self.resolve_expr(collection, None, scope, aggregate, expanding_can)?;
+                let item_type = match &collection.ty {
+                    LogicalType::Set(value) | LogicalType::Seq(value) => value.as_ref().clone(),
+                    _ => {
+                        return Err(error_at(
+                            "collection binder requires a Set or Seq expression",
+                            name.span,
+                        ));
+                    }
+                };
+                let mut nested = scope.clone();
+                nested.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: item_type,
+                    },
+                );
+                let where_expr = where_expr
+                    .as_deref()
+                    .map(|value| {
+                        self.resolve_expr(
+                            value,
+                            Some(&LogicalType::Bool),
+                            &nested,
+                            aggregate,
+                            expanding_can,
+                        )
+                        .map(|value| Box::new(value.expr))
+                    })
+                    .transpose()?;
+                Ok((
+                    Binder::Collection {
+                        name: name.text.clone(),
+                        collection: Box::new(collection.expr),
+                        where_expr,
+                    },
+                    nested,
+                ))
+            }
+        }
+    }
+
+    fn resolve_can(
+        &self,
+        decide: &DomainDecide,
+        scope: &Scope,
+        aggregate: &DomainAggregate,
+        expanding_can: &mut Vec<String>,
+    ) -> Result<Expr, CoreError> {
+        let mut predicates = decide
+            .requires
+            .iter()
+            .map(|value| {
+                self.resolve_expr(
+                    value,
+                    Some(&LogicalType::Bool),
+                    scope,
+                    Some(aggregate),
+                    expanding_can,
+                )
+                .map(|value| value.expr)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        predicates.extend(
+            decide
+                .rejects
+                .iter()
+                .map(|reject| {
+                    self.resolve_expr(
+                        &reject.condition,
+                        Some(&LogicalType::Bool),
+                        scope,
+                        Some(aggregate),
+                        expanding_can,
+                    )
+                    .map(|value| Expr::Not(Box::new(value.expr)))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        Ok(and_all(predicates))
+    }
+
+    fn collect_pattern_bindings(
+        &self,
+        expression: &SyntaxExpr,
+        source_scope: &Scope,
+        target_scope: &mut Scope,
+        aggregate: Option<&DomainAggregate>,
+        expanding_can: &mut Vec<String>,
+    ) -> Result<(), CoreError> {
+        match &expression.kind {
+            SyntaxExprKind::Group(value) => self.collect_pattern_bindings(
+                value,
+                source_scope,
+                target_scope,
+                aggregate,
+                expanding_can,
+            ),
+            SyntaxExprKind::Is {
+                expr,
+                pattern: SyntaxPattern::Some { name, .. },
+            } => {
+                let value =
+                    self.resolve_expr(expr, None, source_scope, aggregate, expanding_can)?;
+                let LogicalType::Option(inner) = value.ty else {
+                    return Err(error_at(
+                        "'is some' requires an Option expression",
+                        expression.span,
+                    ));
+                };
+                target_scope.insert(
+                    name.text.clone(),
+                    Symbol {
+                        kernel_name: name.text.clone(),
+                        ty: *inner,
+                    },
+                );
+                Ok(())
+            }
+            SyntaxExprKind::Binary { op, left, right } if op.canonical == "and" => {
+                self.collect_pattern_bindings(
+                    left,
+                    source_scope,
+                    target_scope,
+                    aggregate,
+                    expanding_can,
+                )?;
+                let after_left = target_scope.clone();
+                self.collect_pattern_bindings(
+                    right,
+                    &after_left,
+                    target_scope,
+                    aggregate,
+                    expanding_can,
+                )
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn resolve_lvalue(
+        &self,
+        target: &SyntaxLValue,
+        scope: &Scope,
+        aggregate: &DomainAggregate,
+    ) -> Result<(LValue, LogicalType), CoreError> {
+        match target {
+            SyntaxLValue::Name(name) => {
+                let Some(field) = aggregate
+                    .state
+                    .iter()
+                    .find(|field| field.name.text == name.text)
+                else {
+                    return Err(error_at(
+                        format!("unknown domain lvalue '{}'", name.text),
+                        name.span,
+                    ));
+                };
+                Ok((
+                    LValue::Var(state_name(aggregate, &field.name)),
+                    self.logical_type(&field.type_name)?,
+                ))
+            }
+            SyntaxLValue::Index { base, index, span } => {
+                let (base, base_type) = self.resolve_lvalue(base, scope, aggregate)?;
+                let (name, key_type, value_type) = match (base, base_type) {
+                    (LValue::Var(name), LogicalType::Map(key, value)) => {
+                        (name, key.as_ref().clone(), value.as_ref().clone())
+                    }
+                    _ => {
+                        return Err(error_at(
+                            "Kernel lvalues only support indexing a root Map state",
+                            *span,
+                        ));
+                    }
+                };
+                let index = self.resolve_expr(
+                    index,
+                    Some(&key_type),
+                    scope,
+                    Some(aggregate),
+                    &mut Vec::new(),
+                )?;
+                Ok((LValue::Index(name, index.expr), value_type))
+            }
+            SyntaxLValue::Field { base, field, span } => {
+                let (base, base_type) = self.resolve_lvalue(base, scope, aggregate)?;
+                let Some(type_name) = type_name(&base_type) else {
+                    return Err(error_at("field lvalue requires a value object", *span));
+                };
+                let Some(definition) = self
+                    .types
+                    .iter()
+                    .find(|ty| ty.name == type_name && ty.kind == "value_object")
+                else {
+                    return Err(error_at(format!("type '{type_name}' has no fields"), *span));
+                };
+                let Some(field_definition) = definition
+                    .fields
+                    .iter()
+                    .find(|candidate| candidate.name.text == field.text)
+                else {
+                    return Err(error_at(
+                        format!("unknown field '{type_name}.{}'", field.text),
+                        field.span,
+                    ));
+                };
+                Ok((
+                    LValue::Field(Box::new(base), field.text.clone()),
+                    self.logical_type(&field_definition.type_name)?,
+                ))
+            }
+        }
+    }
+
+    fn resolve_bool(
+        &self,
+        expression: &SyntaxExpr,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+    ) -> Result<Expr, CoreError> {
+        self.resolve_expr(
+            expression,
+            Some(&LogicalType::Bool),
+            scope,
+            aggregate,
+            &mut Vec::new(),
+        )
+        .map(|value| value.expr)
+    }
+
+    fn default_value(
+        &self,
+        field: &DomainField,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+    ) -> Result<Expr, CoreError> {
+        let expected = self.logical_type(&field.type_name)?;
+        if let Some(value) = &field.default {
+            return self
+                .resolve_expr(value, Some(&expected), scope, aggregate, &mut Vec::new())
+                .map(|value| value.expr);
+        }
+        self.default_for_type(&expected, field.span, scope, aggregate)
+    }
+
+    fn default_for_type(
+        &self,
+        ty: &LogicalType,
+        span: Span,
+        scope: &Scope,
+        aggregate: Option<&DomainAggregate>,
+    ) -> Result<Expr, CoreError> {
+        Ok(match ty {
+            LogicalType::Bool => Expr::Bool(false),
+            LogicalType::Int => Expr::Num(0),
+            LogicalType::Named(name) => {
+                let Some(definition) = self.types.iter().find(|ty| ty.name == *name) else {
+                    return Err(error_at(format!("unknown domain type '{name}'"), span));
+                };
+                match definition.kind.as_str() {
+                    "enum" => {
+                        let Some(member) = definition.members.first() else {
+                            return Err(error_at(format!("enum '{name}' has no members"), span));
+                        };
+                        Expr::Var(format!("{name}_{member}"))
+                    }
+                    "range" | "external" => definition.lo.as_ref().map_or_else(
+                        || Ok(Expr::Num(0)),
+                        |value| {
+                            self.resolve_expr(
+                                value,
+                                Some(&LogicalType::Int),
+                                scope,
+                                aggregate,
+                                &mut Vec::new(),
+                            )
+                            .map(|value| value.expr)
+                        },
+                    )?,
+                    "value_object" => Expr::Struct {
+                        name: name.clone(),
+                        fields: definition
+                            .fields
+                            .iter()
+                            .map(|field| {
+                                Ok((
+                                    field.name.text.clone(),
+                                    self.default_value(field, scope, aggregate)?,
+                                ))
+                            })
+                            .collect::<Result<Vec<_>, CoreError>>()?,
+                    },
+                    other => {
+                        return Err(error_at(
+                            format!("unsupported domain type kind '{other}'"),
+                            span,
+                        ));
+                    }
+                }
+            }
+            LogicalType::Option(_) => Expr::None,
+            LogicalType::Set(_) => Expr::Set(Vec::new()),
+            LogicalType::Seq(_) => Expr::Seq(Vec::new()),
+            LogicalType::Map(_, _) => {
+                return Err(error_at(
+                    "Map state requires explicit initialization through supported semantics",
+                    span,
+                ));
+            }
+            LogicalType::Unknown => {
+                return Err(error_at(
+                    "cannot choose a default for an unknown type",
+                    span,
+                ));
+            }
+        })
+    }
+
+    fn event(
+        &self,
+        name: &str,
+        loc: DomainLoc,
+    ) -> Result<(&DomainAggregate, &fsl_syntax::DomainEvent), CoreError> {
+        self.domain
+            .aggregates
+            .iter()
+            .find_map(|aggregate| {
+                aggregate
+                    .events
+                    .iter()
+                    .find(|event| event.name == name)
+                    .map(|event| (aggregate, event))
+            })
+            .ok_or_else(|| error_at(format!("unknown domain event '{name}'"), span_at(loc)))
+    }
+
+    fn correlation(&self, effect: &DomainEffect) -> Result<(String, SyntaxTypeExpr), CoreError> {
+        let Some(expression) = &effect.correlation_id else {
+            return Err(error_at(
+                format!("effect '{}' requires correlation_id", effect.name),
+                span_at(effect.loc),
+            ));
+        };
+        let SyntaxExprKind::Field { receiver, field } = &expression.kind else {
+            return Err(error_at(
+                "effect correlation_id must be Event.field",
+                expression.span,
+            ));
+        };
+        let SyntaxExprKind::Name(event_name) = &receiver.kind else {
+            return Err(error_at(
+                "effect correlation_id must be Event.field",
+                expression.span,
+            ));
+        };
+        let (_, event) = self.event(&event_name.text, effect.loc)?;
+        let Some(definition) = event
+            .fields
+            .iter()
+            .find(|candidate| candidate.name.text == field.text)
+        else {
+            return Err(error_at(
+                format!("unknown event field '{}.{}'", event_name.text, field.text),
+                field.span,
+            ));
+        };
+        Ok((field.text.clone(), definition.type_name.clone()))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn validate_domain_path(&self, expression: &SyntaxExpr) -> Result<(), CoreError> {
+        fn collect<'a>(
+            expression: &'a SyntaxExpr,
+            output: &mut Vec<&'a fsl_syntax::SyntaxIdent>,
+        ) -> bool {
+            match &expression.kind {
+                SyntaxExprKind::Name(name) => {
+                    output.push(name);
+                    true
+                }
+                SyntaxExprKind::Field { receiver, field } => {
+                    if !collect(receiver, output) {
+                        return false;
+                    }
+                    output.push(field);
+                    true
+                }
+                _ => false,
+            }
+        }
+
+        let mut path = Vec::new();
+        if !collect(expression, &mut path) || path.len() < 2 {
+            return Err(error_at(
+                "domain effect path must be a dotted declaration path",
+                expression.span,
+            ));
+        }
+        let root = path.remove(0);
+        let first = path.remove(0);
+        let mut ty = if let Some(aggregate) = self
+            .domain
+            .aggregates
+            .iter()
+            .find(|aggregate| aggregate.name == root.text)
+        {
+            if first.text == "id" {
+                aggregate
+                    .id_type
+                    .as_ref()
+                    .map(|name| LogicalType::Named(name.clone()))
+                    .ok_or_else(|| {
+                        error_at(
+                            format!("aggregate '{}' has no id", aggregate.name),
+                            first.span,
+                        )
+                    })?
+            } else {
+                let field = aggregate
+                    .state
+                    .iter()
+                    .find(|field| field.name.text == first.text)
+                    .ok_or_else(|| {
+                        error_at(
+                            format!("unknown aggregate field '{}.{}'", root.text, first.text),
+                            first.span,
+                        )
+                    })?;
+                self.logical_type(&field.type_name)?
+            }
+        } else if let Some((_, event)) = self.domain.aggregates.iter().find_map(|aggregate| {
+            aggregate
+                .events
+                .iter()
+                .find(|event| event.name == root.text)
+                .map(|event| (aggregate, event))
+        }) {
+            let field = event
+                .fields
+                .iter()
+                .find(|field| field.name.text == first.text)
+                .ok_or_else(|| {
+                    error_at(
+                        format!("unknown event field '{}.{}'", root.text, first.text),
+                        first.span,
+                    )
+                })?;
+            self.logical_type(&field.type_name)?
+        } else {
+            return Err(error_at(
+                format!("unknown domain path root '{}'", root.text),
+                root.span,
+            ));
+        };
+        for component in path {
+            let Some(name) = type_name(&ty) else {
+                return Err(error_at(
+                    "path component requires a value object",
+                    component.span,
+                ));
+            };
+            let definition = self
+                .types
+                .iter()
+                .find(|candidate| candidate.name == name && candidate.kind == "value_object")
+                .ok_or_else(|| error_at(format!("type '{name}' has no fields"), component.span))?;
+            let field = definition
+                .fields
+                .iter()
+                .find(|field| field.name.text == component.text)
+                .ok_or_else(|| {
+                    error_at(
+                        format!("unknown field '{name}.{}'", component.text),
+                        component.span,
+                    )
+                })?;
+            ty = self.logical_type(&field.type_name)?;
+        }
+        Ok(())
+    }
+
+    fn validate_document_expressions(&self) -> Result<(), CoreError> {
+        for ty in &self.types {
+            if ty.kind != "value_object" {
+                continue;
+            }
+            let scope = self.scope_for_fields(&ty.fields)?;
+            for field in &ty.fields {
+                if let Some(default) = &field.default {
+                    let expected = self.logical_type(&field.type_name)?;
+                    let _ =
+                        self.resolve_expr(default, Some(&expected), &scope, None, &mut Vec::new())?;
+                }
+            }
+            for invariant in &ty.invariants {
+                self.resolve_bool(&invariant.expr, &scope, None)?;
+            }
+        }
+        for aggregate in &self.domain.aggregates {
+            let state_scope = self.scope_for_aggregate(aggregate)?;
+            for fields in aggregate
+                .commands
+                .iter()
+                .map(|command| command.inputs.as_slice())
+                .chain(aggregate.events.iter().map(|event| event.fields.as_slice()))
+            {
+                let mut local_scope = state_scope.clone();
+                self.extend_fields(&mut local_scope, fields)?;
+                for field in fields {
+                    if let Some(default) = &field.default {
+                        let expected = self.logical_type(&field.type_name)?;
+                        let _ = self.resolve_expr(
+                            default,
+                            Some(&expected),
+                            &local_scope,
+                            Some(aggregate),
+                            &mut Vec::new(),
+                        )?;
+                    }
+                }
+            }
+            for stale in &aggregate.stale_policies {
+                self.event(&stale.event, stale.loc)?;
+                for emitted in &stale.emits {
+                    self.event(emitted, stale.loc)?;
+                }
+                self.resolve_bool(&stale.condition, &state_scope, Some(aggregate))?;
+            }
+            for evolve in &aggregate.evolves {
+                let (_, event) = self.event(&evolve.event, evolve.loc)?;
+                let mut scope = state_scope.clone();
+                self.extend_fields(&mut scope, &event.fields)?;
+                let _ = self.evolve_items(aggregate, &evolve.event, &scope)?;
+            }
+        }
+        for effect in &self.domain.effects {
+            if let Some(idempotency_key) = &effect.idempotency_key {
+                self.validate_domain_path(idempotency_key)?;
+            }
+            let _ = self.correlation(effect)?;
+        }
+        Ok(())
+    }
+
+    fn event_assignments(
+        &self,
+        emitted: &[String],
+        span: Span,
+    ) -> Result<Vec<Statement>, CoreError> {
+        for event in emitted {
+            self.event(event, DomainLoc::from(span))?;
+        }
+        let emitted = emitted.iter().collect::<BTreeSet<_>>();
+        let mut names = self
+            .domain
+            .aggregates
+            .iter()
+            .flat_map(|aggregate| aggregate.events.iter().map(|event| event.name.as_str()))
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        Ok(names
+            .into_iter()
+            .map(|name| Statement::Assign {
+                target: LValue::Var(event_flag(name)),
+                value: Expr::Bool(emitted.contains(&name.to_owned())),
+                span,
+            })
+            .collect())
+    }
+
+    fn evolve_items(
+        &self,
+        aggregate: &DomainAggregate,
+        event_name: &str,
+        scope: &Scope,
+    ) -> Result<Vec<ActionItem>, CoreError> {
+        let Some(evolve) = aggregate
+            .evolves
+            .iter()
+            .find(|evolve| evolve.event == event_name)
+        else {
+            return Ok(Vec::new());
+        };
+        let mut items = evolve
+            .requires
+            .iter()
+            .map(|requirement| {
+                Ok(ActionItem::Requires(
+                    self.resolve_bool(requirement, scope, Some(aggregate))?,
+                    requirement.span,
+                ))
+            })
+            .collect::<Result<Vec<_>, CoreError>>()?;
+        for assignment in &evolve.assignments {
+            let (target, expected) = self.resolve_lvalue(&assignment.target, scope, aggregate)?;
+            let value = self
+                .resolve_expr(
+                    &assignment.value,
+                    Some(&expected),
+                    scope,
+                    Some(aggregate),
+                    &mut Vec::new(),
+                )?
+                .expr;
+            items.push(ActionItem::Statement(Statement::Assign {
+                target,
+                value,
+                span: assignment.span,
+            }));
+        }
+        Ok(items)
+    }
+}
+
+fn metadata(id: impl Into<String>, text: impl Into<String>) -> MetaTag {
+    MetaTag {
+        id: id.into(),
+        text: Some(text.into()),
+    }
+}
+
+fn action(name: String, params: Vec<Param>, items: Vec<ActionItem>, span: Span) -> SpecItem {
+    SpecItem::Action {
+        name,
+        params,
+        items,
+        span,
+        fair: false,
+        meta: None,
+        sync: false,
+    }
+}
+
+fn field_params(resolver: &Resolver<'_>, fields: &[DomainField]) -> Result<Vec<Param>, CoreError> {
+    fields
+        .iter()
+        .map(|field| match resolver.logical_type(&field.type_name)? {
+            LogicalType::Named(name) => Ok(Param::Typed(field.name.text.clone(), qualified(&name))),
+            LogicalType::Int => Ok(Param::Typed(field.name.text.clone(), qualified("Int"))),
+            LogicalType::Bool => Ok(Param::Typed(field.name.text.clone(), qualified("Bool"))),
+            _ => Err(error_at(
+                "domain action parameters require scalar or named types",
+                field.span,
+            )),
+        })
+        .collect()
+}
+
+/// Resolve a parsed domain document and lower it directly into Kernel surface AST.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn lower_domain_surface(domain: &DomainSpec) -> Result<SurfaceSpec, CoreError> {
+    let resolver = Resolver::new(domain);
+    resolver.validate_document_expressions()?;
+    let mut items = Vec::new();
+
+    for ty in &resolver.types {
+        match ty.kind.as_str() {
+            "enum" => items.push(SpecItem::Enum {
+                name: ty.name.clone(),
+                members: ty
+                    .members
+                    .iter()
+                    .map(|member| format!("{}_{}", ty.name, member))
+                    .collect(),
+                symmetric: false,
+            }),
+            "range" | "external" => {
+                let scope = Scope::new();
+                let lo = ty.lo.as_ref().map_or_else(
+                    || Ok(Expr::Num(0)),
+                    |value| {
+                        resolver
+                            .resolve_expr(
+                                value,
+                                Some(&LogicalType::Int),
+                                &scope,
+                                None,
+                                &mut Vec::new(),
+                            )
+                            .map(|value| value.expr)
+                    },
+                )?;
+                let hi = ty.hi.as_ref().map_or_else(
+                    || Ok(Expr::Num(1)),
+                    |value| {
+                        resolver
+                            .resolve_expr(
+                                value,
+                                Some(&LogicalType::Int),
+                                &scope,
+                                None,
+                                &mut Vec::new(),
+                            )
+                            .map(|value| value.expr)
+                    },
+                )?;
+                items.push(SpecItem::Type {
+                    name: ty.name.clone(),
+                    lo: Box::new(lo),
+                    hi: Box::new(hi),
+                    symmetric: false,
+                });
+            }
+            "value_object" => items.push(SpecItem::Struct {
+                name: ty.name.clone(),
+                fields: ty
+                    .fields
+                    .iter()
+                    .map(|field| {
+                        Ok((
+                            field.name.text.clone(),
+                            resolver.surface_type(&field.type_name)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, CoreError>>()?,
+            }),
+            other => {
+                return Err(error_at(
+                    format!("unsupported domain type kind '{other}'"),
+                    span_at(ty.loc),
+                ));
+            }
+        }
+    }
+
+    for effect in &domain.effects {
+        items.push(SpecItem::Enum {
+            name: status_type(effect),
+            members: [
+                "NotStarted",
+                "Pending",
+                "Succeeded",
+                "Failed",
+                "TimedOut",
+                "Cancelled",
+                "Compensated",
+            ]
+            .iter()
+            .map(|member| status_member(effect, member))
+            .collect(),
+            symmetric: false,
+        });
+        items.push(SpecItem::Type {
+            name: attempt_type(effect),
+            lo: Box::new(Expr::Num(0)),
+            hi: Box::new(Expr::Num(effect.retry.max_attempts.unwrap_or(1))),
+            symmetric: false,
+        });
+    }
+
+    let mut state = Vec::new();
+    let mut init = Vec::new();
+    for aggregate in &domain.aggregates {
+        let scope = resolver.scope_for_aggregate(aggregate)?;
+        for field in &aggregate.state {
+            let logical_type = resolver.logical_type(&field.type_name)?;
+            state.push((
+                state_name(aggregate, &field.name),
+                resolver.surface_type(&field.type_name)?,
+            ));
+            if let LogicalType::Map(key, value) = &logical_type {
+                if field.default.is_some() {
+                    return Err(error_at(
+                        "whole-Map domain defaults are not supported",
+                        field.span,
+                    ));
+                }
+                init.push(Statement::ForAll {
+                    binder: Binder::Typed {
+                        name: "k".to_owned(),
+                        type_name: logical_qualified_name(key, field.span)?,
+                        where_expr: None,
+                    },
+                    statements: vec![Statement::Assign {
+                        target: LValue::Index(
+                            state_name(aggregate, &field.name),
+                            Expr::Var("k".to_owned()),
+                        ),
+                        value: resolver.default_for_type(
+                            value,
+                            field.span,
+                            &scope,
+                            Some(aggregate),
+                        )?,
+                        span: field.span,
+                    }],
+                    span: field.span,
+                });
+            } else {
+                init.push(Statement::Assign {
+                    target: LValue::Var(state_name(aggregate, &field.name)),
+                    value: resolver.default_value(field, &scope, Some(aggregate))?,
+                    span: field.span,
+                });
+            }
+        }
+    }
+    let mut event_names = domain
+        .aggregates
+        .iter()
+        .flat_map(|aggregate| aggregate.events.iter().map(|event| event.name.as_str()))
+        .collect::<Vec<_>>();
+    event_names.sort_unstable();
+    for event in event_names {
+        state.push((event_flag(event), TypeExpr::Bool));
+        init.push(Statement::Assign {
+            target: LValue::Var(event_flag(event)),
+            value: Expr::Bool(false),
+            span: span_at(domain.loc),
+        });
+    }
+    for effect in &domain.effects {
+        let (_, correlation_type) = resolver.correlation(effect)?;
+        let key_type = resolver.surface_type(&correlation_type)?;
+        state.push((
+            status_var(effect),
+            TypeExpr::Map(
+                Box::new(key_type.clone()),
+                Box::new(TypeExpr::Name(status_type(effect))),
+            ),
+        ));
+        state.push((
+            attempt_var(effect),
+            TypeExpr::Map(
+                Box::new(key_type),
+                Box::new(TypeExpr::Name(attempt_type(effect))),
+            ),
+        ));
+        let span = span_at(effect.loc);
+        init.push(Statement::ForAll {
+            binder: Binder::Typed {
+                name: "k".to_owned(),
+                type_name: qualified(&correlation_type.render_source()),
+                where_expr: None,
+            },
+            statements: vec![Statement::Assign {
+                target: LValue::Index(status_var(effect), Expr::Var("k".to_owned())),
+                value: Expr::Var(status_member(effect, "NotStarted")),
+                span,
+            }],
+            span,
+        });
+        init.push(Statement::ForAll {
+            binder: Binder::Typed {
+                name: "k".to_owned(),
+                type_name: qualified(&correlation_type.render_source()),
+                where_expr: None,
+            },
+            statements: vec![Statement::Assign {
+                target: LValue::Index(attempt_var(effect), Expr::Var("k".to_owned())),
+                value: Expr::Num(0),
+                span,
+            }],
+            span,
+        });
+    }
+    items.push(SpecItem::State(state));
+    items.push(SpecItem::Init {
+        statements: init,
+        meta: None,
+    });
+
+    lower_aggregate_actions(&resolver, domain, &mut items)?;
+    lower_effect_actions(&resolver, domain, &mut items)?;
+    lower_saga_actions(&resolver, domain, &mut items)?;
+    lower_properties(&resolver, domain, &mut items)?;
+    items.push(SpecItem::Terminal {
+        expr: Box::new(Expr::Bool(false)),
+        span: span_at(domain.loc),
+    });
+
+    Ok(SurfaceSpec {
+        name: domain.name.clone(),
+        meta: Some(metadata(
+            "DOMAIN",
+            "domain: generated from fsl-domain/fsl-effect",
+        )),
+        items,
+    })
+}
+
+#[allow(clippy::too_many_lines)]
+fn lower_aggregate_actions(
+    resolver: &Resolver<'_>,
+    domain: &DomainSpec,
+    items: &mut Vec<SpecItem>,
+) -> Result<(), CoreError> {
+    let effects_by_request = domain
+        .effects
+        .iter()
+        .filter_map(|effect| {
+            effect
+                .handles
+                .as_deref()
+                .or(effect.request_event.as_deref())
+                .map(|event| (event, effect))
+        })
+        .fold(
+            BTreeMap::<&str, Vec<&DomainEffect>>::new(),
+            |mut map, (event, effect)| {
+                map.entry(event).or_default().push(effect);
+                map
+            },
+        );
+    for aggregate in &domain.aggregates {
+        for decide in &aggregate.decides {
+            let Some(command) = aggregate
+                .commands
+                .iter()
+                .find(|command| command.name == decide.command)
+            else {
+                return Err(error_at(
+                    format!(
+                        "decide references unknown command '{}.{}'",
+                        aggregate.name, decide.command
+                    ),
+                    span_at(decide.loc),
+                ));
+            };
+            let mut scope = resolver.scope_for_aggregate(aggregate)?;
+            resolver.extend_fields(&mut scope, &command.inputs)?;
+            let span = span_at(decide.loc);
+            let mut action_items = decide
+                .requires
+                .iter()
+                .map(|requirement| {
+                    Ok(ActionItem::Requires(
+                        resolver.resolve_bool(requirement, &scope, Some(aggregate))?,
+                        requirement.span,
+                    ))
+                })
+                .collect::<Result<Vec<_>, CoreError>>()?;
+            action_items.extend(
+                decide
+                    .rejects
+                    .iter()
+                    .map(|reject| {
+                        Ok(ActionItem::Requires(
+                            Expr::Not(Box::new(resolver.resolve_bool(
+                                &reject.condition,
+                                &scope,
+                                Some(aggregate),
+                            )?)),
+                            reject.condition.span,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, CoreError>>()?,
+            );
+            for event in &decide.emits {
+                resolver.event(event, decide.loc)?;
+                for effect in effects_by_request.get(event.as_str()).into_iter().flatten() {
+                    let (correlation, _) = resolver.correlation(effect)?;
+                    let Some(symbol) = scope.get(&correlation) else {
+                        return Err(error_at(
+                            format!(
+                                "effect '{}' correlation '{}' is not in command '{}' scope",
+                                effect.name, correlation, command.name
+                            ),
+                            span,
+                        ));
+                    };
+                    let current = Expr::Index(
+                        Box::new(Expr::Var(status_var(effect))),
+                        Box::new(Expr::Var(symbol.kernel_name.clone())),
+                    );
+                    for member in ["Pending", "Succeeded"] {
+                        action_items.push(ActionItem::Requires(
+                            Expr::Binary {
+                                op: "!=".to_owned(),
+                                left: Box::new(current.clone()),
+                                right: Box::new(Expr::Var(status_member(effect, member))),
+                            },
+                            span,
+                        ));
+                    }
+                }
+            }
+            action_items.extend(
+                resolver
+                    .event_assignments(&decide.emits, span)?
+                    .into_iter()
+                    .map(ActionItem::Statement),
+            );
+            for event in &decide.emits {
+                action_items.extend(resolver.evolve_items(aggregate, event, &scope)?);
+                for effect in effects_by_request.get(event.as_str()).into_iter().flatten() {
+                    let (correlation, _) = resolver.correlation(effect)?;
+                    let symbol = scope
+                        .get(&correlation)
+                        .expect("validated correlation symbol");
+                    let index = Expr::Var(symbol.kernel_name.clone());
+                    action_items.push(ActionItem::Statement(Statement::Assign {
+                        target: LValue::Index(status_var(effect), index.clone()),
+                        value: Expr::Var(status_member(effect, "Pending")),
+                        span,
+                    }));
+                    action_items.push(ActionItem::Statement(Statement::Assign {
+                        target: LValue::Index(attempt_var(effect), index),
+                        value: Expr::Num(1),
+                        span,
+                    }));
+                }
+            }
+            items.push(action(
+                format!(
+                    "{}_{}",
+                    lower_name(&aggregate.name),
+                    lower_name(&command.name)
+                ),
+                field_params(resolver, &command.inputs)?,
+                action_items,
+                span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn outcome_status(effect: &DomainEffect, event: &str) -> String {
+    let lowered = event.to_ascii_lowercase();
+    let member = if effect.timeout_event.as_deref() == Some(event)
+        || lowered.contains("timeout")
+        || lowered.contains("timedout")
+    {
+        "TimedOut"
+    } else if effect.failure_event.as_deref() == Some(event) || lowered.contains("fail") {
+        "Failed"
+    } else if lowered.contains("cancel") {
+        "Cancelled"
+    } else {
+        "Succeeded"
+    };
+    status_member(effect, member)
+}
+
+#[allow(clippy::too_many_lines)]
+fn lower_effect_actions(
+    resolver: &Resolver<'_>,
+    domain: &DomainSpec,
+    items: &mut Vec<SpecItem>,
+) -> Result<(), CoreError> {
+    for effect in &domain.effects {
+        let (correlation, correlation_type) = resolver.correlation(effect)?;
+        for event_name in &effect.outcomes {
+            let (aggregate, event) = resolver.event(event_name, effect.loc)?;
+            let span = span_at(event.loc);
+            let mut scope = resolver.scope_for_aggregate(aggregate)?;
+            resolver.extend_fields(&mut scope, &event.fields)?;
+            if !scope.contains_key(&correlation) {
+                scope.insert(
+                    correlation.clone(),
+                    Symbol {
+                        kernel_name: correlation.clone(),
+                        ty: resolver.logical_type(&correlation_type)?,
+                    },
+                );
+            }
+            let mut params = event.fields.clone();
+            if !params.iter().any(|field| field.name.text == correlation) {
+                let mut synthetic = event
+                    .fields
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| error_at("cannot synthesize correlation parameter", span))?;
+                synthetic.name.text.clone_from(&correlation);
+                synthetic.type_name = correlation_type.clone();
+                params.insert(0, synthetic);
+            }
+            let current = Expr::Index(
+                Box::new(Expr::Var(status_var(effect))),
+                Box::new(Expr::Var(correlation.clone())),
+            );
+            let mut action_items = vec![ActionItem::Requires(
+                Expr::Binary {
+                    op: "==".to_owned(),
+                    left: Box::new(current),
+                    right: Box::new(Expr::Var(status_member(effect, "Pending"))),
+                },
+                span,
+            )];
+            action_items.extend(
+                resolver
+                    .event_assignments(std::slice::from_ref(event_name), span)?
+                    .into_iter()
+                    .map(ActionItem::Statement),
+            );
+            action_items.push(ActionItem::Statement(Statement::Assign {
+                target: LValue::Index(status_var(effect), Expr::Var(correlation.clone())),
+                value: Expr::Var(outcome_status(effect, event_name)),
+                span,
+            }));
+            action_items.extend(resolver.evolve_items(aggregate, event_name, &scope)?);
+            items.push(action(
+                format!(
+                    "{}_complete_{}",
+                    lower_name(&effect.name),
+                    lower_name(event_name)
+                ),
+                field_params(resolver, &params)?,
+                action_items,
+                span,
+            ));
+        }
+        if let Some(maximum) = effect.retry.max_attempts {
+            let span = span_at(effect.loc);
+            let current_status = Expr::Index(
+                Box::new(Expr::Var(status_var(effect))),
+                Box::new(Expr::Var(correlation.clone())),
+            );
+            let status_guard = or_all(
+                ["Failed", "TimedOut"]
+                    .iter()
+                    .map(|member| Expr::Binary {
+                        op: "==".to_owned(),
+                        left: Box::new(current_status.clone()),
+                        right: Box::new(Expr::Var(status_member(effect, member))),
+                    })
+                    .collect(),
+            );
+            let current_attempts = Expr::Index(
+                Box::new(Expr::Var(attempt_var(effect))),
+                Box::new(Expr::Var(correlation.clone())),
+            );
+            let mut action_items = vec![
+                ActionItem::Requires(status_guard, span),
+                ActionItem::Requires(
+                    Expr::Binary {
+                        op: "<".to_owned(),
+                        left: Box::new(current_attempts.clone()),
+                        right: Box::new(Expr::Num(maximum)),
+                    },
+                    span,
+                ),
+            ];
+            action_items.extend(
+                resolver
+                    .event_assignments(&[], span)?
+                    .into_iter()
+                    .map(ActionItem::Statement),
+            );
+            action_items.push(ActionItem::Statement(Statement::Assign {
+                target: LValue::Index(status_var(effect), Expr::Var(correlation.clone())),
+                value: Expr::Var(status_member(effect, "Pending")),
+                span,
+            }));
+            action_items.push(ActionItem::Statement(Statement::Assign {
+                target: LValue::Index(attempt_var(effect), Expr::Var(correlation.clone())),
+                value: Expr::Binary {
+                    op: "+".to_owned(),
+                    left: Box::new(current_attempts),
+                    right: Box::new(Expr::Num(1)),
+                },
+                span,
+            }));
+            items.push(action(
+                format!("{}_retry", lower_name(&effect.name)),
+                vec![Param::Typed(
+                    correlation.clone(),
+                    qualified(&correlation_type.render_source()),
+                )],
+                action_items,
+                span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn saga_scope(resolver: &Resolver<'_>) -> Scope {
+    resolver
+        .domain
+        .aggregates
+        .iter()
+        .flat_map(|aggregate| aggregate.events.iter())
+        .map(|event| {
+            (
+                event.name.clone(),
+                Symbol {
+                    kernel_name: event_flag(&event.name),
+                    ty: LogicalType::Bool,
+                },
+            )
+        })
+        .collect()
+}
+
+fn saga_guards(
+    resolver: &Resolver<'_>,
+    saga: &DomainSaga,
+    step: &DomainSagaStep,
+    first: bool,
+) -> Result<Vec<Expr>, CoreError> {
+    let scope = saga_scope(resolver);
+    let mut guards = Vec::new();
+    if first && let Some(event) = &saga.starts_on {
+        resolver.event(event, saga.loc)?;
+        guards.push(Expr::Var(event_flag(event)));
+    }
+    guards.extend(
+        step.requires
+            .iter()
+            .map(|value| resolver.resolve_bool(value, &scope, None))
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+    if step.emits.is_empty() && !step.awaits.is_empty() {
+        for event in &step.awaits {
+            resolver.event(event, step.loc)?;
+        }
+        let events = step
+            .awaits
+            .iter()
+            .map(|event| Expr::Var(event_flag(event)))
+            .collect::<Vec<_>>();
+        guards.push(if step.awaits_mode == "all" {
+            and_all(events)
+        } else {
+            or_all(events)
+        });
+    }
+    Ok(guards)
+}
+
+fn lower_saga_actions(
+    resolver: &Resolver<'_>,
+    domain: &DomainSpec,
+    items: &mut Vec<SpecItem>,
+) -> Result<(), CoreError> {
+    for saga in &domain.sagas {
+        let mut observed = BTreeSet::new();
+        for step in &saga.steps {
+            observed.extend(step.awaits.iter().cloned());
+        }
+        for compensation in &saga.compensations {
+            observed.insert(compensation.trigger_event.clone());
+            observed.insert(compensation.after_event.clone());
+        }
+        for event_name in observed {
+            let (aggregate, event) = resolver.event(&event_name, saga.loc)?;
+            let span = span_at(event.loc);
+            let mut scope = resolver.scope_for_aggregate(aggregate)?;
+            resolver.extend_fields(&mut scope, &event.fields)?;
+            let mut action_items = resolver
+                .event_assignments(std::slice::from_ref(&event_name), span)?
+                .into_iter()
+                .map(ActionItem::Statement)
+                .collect::<Vec<_>>();
+            action_items.extend(resolver.evolve_items(aggregate, &event_name, &scope)?);
+            items.push(action(
+                format!(
+                    "saga_{}_observe_{}",
+                    lower_name(&saga.name),
+                    lower_name(&event_name)
+                ),
+                field_params(resolver, &event.fields)?,
+                action_items,
+                span,
+            ));
+        }
+        for (index, step) in saga.steps.iter().enumerate() {
+            let span = span_at(step.loc);
+            let guards = saga_guards(resolver, saga, step, index == 0)?;
+            let mut action_items = guards
+                .iter()
+                .cloned()
+                .map(|guard| ActionItem::Requires(guard, span))
+                .collect::<Vec<_>>();
+            action_items.extend(
+                resolver
+                    .event_assignments(&step.emits, span)?
+                    .into_iter()
+                    .map(ActionItem::Statement),
+            );
+            let action_name = format!("saga_{}_{}", lower_name(&saga.name), lower_name(&step.name));
+            items.push(action(action_name.clone(), Vec::new(), action_items, span));
+            if let Some(timeout) = &step.timeout_event {
+                let mut timeout_items = guards
+                    .into_iter()
+                    .map(|guard| ActionItem::Requires(guard, span))
+                    .collect::<Vec<_>>();
+                timeout_items.extend(
+                    resolver
+                        .event_assignments(std::slice::from_ref(timeout), span)?
+                        .into_iter()
+                        .map(ActionItem::Statement),
+                );
+                items.push(action(
+                    format!("{action_name}_timeout"),
+                    Vec::new(),
+                    timeout_items,
+                    span,
+                ));
+            }
+        }
+        for compensation in &saga.compensations {
+            resolver.event(&compensation.trigger_event, compensation.loc)?;
+            resolver.event(&compensation.after_event, compensation.loc)?;
+            let span = span_at(compensation.loc);
+            let mut action_items = vec![ActionItem::Requires(
+                Expr::Var(event_flag(&compensation.trigger_event)),
+                span,
+            )];
+            action_items.extend(
+                resolver
+                    .event_assignments(&compensation.emits, span)?
+                    .into_iter()
+                    .map(ActionItem::Statement),
+            );
+            items.push(action(
+                format!(
+                    "saga_{}_compensate_{}_after_{}",
+                    lower_name(&saga.name),
+                    lower_name(&compensation.trigger_event),
+                    lower_name(&compensation.after_event)
+                ),
+                Vec::new(),
+                action_items,
+                span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn lower_properties(
+    resolver: &Resolver<'_>,
+    domain: &DomainSpec,
+    items: &mut Vec<SpecItem>,
+) -> Result<(), CoreError> {
+    for aggregate in &domain.aggregates {
+        let scope = resolver.scope_for_aggregate(aggregate)?;
+        for invariant in &aggregate.invariants {
+            items.push(SpecItem::Invariant {
+                name: format!("{}_{}", safe(&aggregate.name), safe(&invariant.name)),
+                expr: Box::new(resolver.resolve_bool(&invariant.expr, &scope, Some(aggregate))?),
+                span: invariant.span,
+                meta: Some(metadata(
+                    "DOMAIN-INVARIANT",
+                    format!("{}.{}", aggregate.name, invariant.name),
+                )),
+            });
+        }
+    }
+    let scope = saga_scope(resolver);
+    for saga in &domain.sagas {
+        for invariant in &saga.invariants {
+            items.push(SpecItem::Invariant {
+                name: format!("{}_{}", safe(&saga.name), safe(&invariant.name)),
+                expr: Box::new(resolver.resolve_bool(&invariant.expr, &scope, None)?),
+                span: invariant.span,
+                meta: Some(metadata(
+                    "DOMAIN-SAGA",
+                    format!("{}.{}", saga.name, invariant.name),
+                )),
+            });
+        }
+    }
+    for effect in &domain.effects {
+        let (_, correlation_type) = resolver.correlation(effect)?;
+        let span = span_at(effect.loc);
+        let status = Expr::Index(
+            Box::new(Expr::Var(status_var(effect))),
+            Box::new(Expr::Var("k".to_owned())),
+        );
+        let succeeded = Expr::Var(status_member(effect, "Succeeded"));
+        items.push(SpecItem::Trans {
+            name: format!("{}_SuccessSticky", safe(&effect.name)),
+            expr: Box::new(Expr::Quantified {
+                quantifier: "forall".to_owned(),
+                binder: Binder::Typed {
+                    name: "k".to_owned(),
+                    type_name: qualified(&correlation_type.render_source()),
+                    where_expr: None,
+                },
+                body: Box::new(Expr::Binary {
+                    op: "=>".to_owned(),
+                    left: Box::new(Expr::Binary {
+                        op: "==".to_owned(),
+                        left: Box::new(Expr::UnaryNamed {
+                            name: "old".to_owned(),
+                            expr: Box::new(status.clone()),
+                            span,
+                        }),
+                        right: Box::new(succeeded.clone()),
+                    }),
+                    right: Box::new(Expr::Binary {
+                        op: "==".to_owned(),
+                        left: Box::new(status),
+                        right: Box::new(succeeded),
+                    }),
+                }),
+            }),
+            span,
+            meta: Some(metadata(
+                "DOMAIN-EFFECT",
+                format!("{} success is sticky", effect.name),
+            )),
+        });
+    }
+    Ok(())
+}

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -21,6 +21,7 @@ mod compose;
 mod db;
 mod dialect;
 mod domain;
+mod domain_lowering;
 mod model;
 mod public_kernel;
 mod refinement;

--- a/rust/fsl-core/tests/domain_lowering.rs
+++ b/rust/fsl-core/tests/domain_lowering.rs
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    FsResolver, KernelExpr, KernelLValue, KernelStatement, build_model, parse_kernel_source,
+};
+use fsl_syntax::{ActionItem, SpecItem};
+
+fn lower(source: &str) -> fsl_core::KernelSpec {
+    parse_kernel_source(source, &FsResolver::new(".")).expect("lower domain directly")
+}
+
+fn lowering_error(source: &str) -> fsl_core::CoreError {
+    parse_kernel_source(source, &FsResolver::new(".")).expect_err("domain lowering must fail")
+}
+
+#[test]
+fn resolves_enum_members_membership_and_can_structurally() {
+    let source = r"
+domain Orders {
+  type Status = Pending | Approved
+  aggregate Order {
+    state {
+      status: Status = Pending;
+      seen: Set<Status> = Set {};
+      current: Option<Status> = none;
+    }
+    command Approve {}
+    event Approved {}
+    decide Approve {
+      requires Pending == status
+      emits Approved
+    }
+    evolve Approved {
+      status = Approved
+      seen = Set {}
+      current = none
+    }
+    invariant enabled { can(Approve) }
+    invariant emptySet { status in [] }
+    invariant noCurrent { current == none }
+    invariant bound { current is some(x) => x == Pending }
+  }
+}
+";
+    let kernel = lower(source);
+    let model = build_model(kernel).expect("checked model");
+    let enabled = model
+        .invariants
+        .iter()
+        .find(|item| item.name == "Order_enabled")
+        .expect("enabled invariant");
+    assert_eq!(
+        enabled.expr,
+        KernelExpr::Binary {
+            op: "==".to_owned(),
+            left: Box::new(KernelExpr::Var("Status_Pending".to_owned())),
+            right: Box::new(KernelExpr::Var("order_status".to_owned())),
+        }
+    );
+    assert_eq!(
+        model
+            .invariants
+            .iter()
+            .find(|item| item.name == "Order_emptySet")
+            .expect("empty membership")
+            .expr,
+        KernelExpr::Bool(false)
+    );
+    assert!(
+        model
+            .invariants
+            .iter()
+            .any(|item| item.name == "Order_bound")
+    );
+}
+
+#[test]
+fn domain_and_kernel_expressions_lower_to_the_same_tree() {
+    let domain = lower(
+        r"
+domain Orders {
+  type Status = Pending | Approved
+  aggregate Order {
+    state { status: Status = Pending; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = Pending }
+    invariant pending { status == Pending }
+  }
+}
+",
+    );
+    let kernel = parse_kernel_source(
+        r"
+spec Orders {
+  enum Status { Status_Pending, Status_Approved }
+  state { order_status: Status }
+  init { order_status = Status_Pending }
+  action order_touch() { order_status = Status_Pending }
+  invariant Order_pending { order_status == Status_Pending }
+  terminal { false }
+}
+",
+        &FsResolver::new("."),
+    )
+    .expect("direct Kernel");
+    let domain_expr = build_model(domain).expect("domain model").invariants[0]
+        .expr
+        .clone();
+    let kernel_expr = build_model(kernel).expect("kernel model").invariants[0]
+        .expr
+        .clone();
+    assert_eq!(domain_expr, kernel_expr);
+}
+
+#[test]
+fn rejects_unknown_ambiguous_and_wrong_aggregate_symbols_at_source_spans() {
+    let ambiguous = parse_kernel_source(
+        r"
+domain Ambiguous {
+  type First = Pending | Done
+  type Second = Pending | Closed
+  aggregate Item {
+    state { ready: Bool = false; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { ready = true }
+    invariant bad { Pending == Pending }
+  }
+}
+",
+        &FsResolver::new("."),
+    )
+    .expect_err("ambiguous member");
+    assert!(
+        ambiguous
+            .message
+            .contains("ambiguous enum member 'Pending'")
+    );
+    assert_eq!((ambiguous.line, ambiguous.column), (11, 21));
+
+    let wrong_aggregate = parse_kernel_source(
+        r"
+domain Commands {
+  aggregate First {
+    state { ready: Bool = false; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { ready = true }
+    invariant bad { can(Approve) }
+  }
+  aggregate Second {
+    state { ready: Bool = false; }
+    command Approve {}
+    event Approved {}
+    decide Approve { emits Approved }
+    evolve Approved { ready = true }
+  }
+}
+",
+        &FsResolver::new("."),
+    )
+    .expect_err("cross-aggregate can");
+    assert!(
+        wrong_aggregate
+            .message
+            .contains("belongs to another aggregate")
+    );
+    assert_eq!((wrong_aggregate.line, wrong_aggregate.column), (9, 21));
+}
+
+#[test]
+fn lowers_nested_lvalues_without_rewriting_identifier_substrings() {
+    let kernel = lower(
+        r"
+domain InventoryDomain {
+  type Item = 0..1
+  type Quantity = 0..2
+  value_object Counter { value: Quantity = 0; }
+  aggregate Inventory {
+    state {
+      total: Quantity = 0;
+      counts: Map<Item, Quantity>;
+      counter: Counter;
+    }
+    command Adjust { item: Item }
+    event Adjusted { item: Item }
+    decide Adjust { emits Adjusted }
+    evolve Adjusted {
+      counts[item] = counts[item] + 1
+      counter.value = total
+    }
+  }
+}
+",
+    );
+    let surface = kernel.syntax();
+    let action = surface
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SpecItem::Action { name, items, .. } if name == "inventory_adjust" => Some(items),
+            _ => None,
+        })
+        .expect("inventory action");
+    let assignments = action.iter().filter_map(|item| match item {
+        ActionItem::Statement(KernelStatement::Assign { target, value, .. }) => {
+            Some((target, value))
+        }
+        _ => None,
+    });
+    assert!(assignments.clone().any(|(target, _)| matches!(
+        target,
+        KernelLValue::Index(name, KernelExpr::Var(index))
+            if name == "inventory_counts" && index == "item"
+    )));
+    assert!(assignments.into_iter().any(|(target, _)| matches!(
+        target,
+        KernelLValue::Field(base, field)
+            if field == "value" && matches!(base.as_ref(), KernelLValue::Var(name) if name == "inventory_counter")
+    )));
+}
+
+#[test]
+fn rejects_type_mismatch_at_the_domain_operator() {
+    let error = parse_kernel_source(
+        r"
+domain Invalid {
+  type Status = Pending | Done
+  aggregate Item {
+    state { status: Status = Pending; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = Done }
+    invariant bad { status == 1 }
+  }
+}
+",
+        &FsResolver::new("."),
+    )
+    .expect_err("type mismatch");
+    assert!(error.message.contains("comparison operand type mismatch"));
+    assert_eq!((error.line, error.column), (10, 28));
+}
+
+#[test]
+fn validates_non_executable_domain_expression_positions() {
+    let value_object = lowering_error(
+        r"
+domain InvalidValueObject {
+  value_object Counter {
+    value: Int = 0;
+    invariant bad { missing >= 0 }
+  }
+  aggregate Item {
+    state { counter: Counter; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { counter.value = 0 }
+  }
+}
+",
+    );
+    assert!(
+        value_object
+            .message
+            .contains("unknown domain symbol 'missing'")
+    );
+
+    let unused_default = lowering_error(
+        r"
+domain InvalidUnusedDefault {
+  value_object Unused { x: Int = missing; }
+  aggregate Item {
+    state { ready: Bool = false; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { ready = true }
+  }
+}
+",
+    );
+    assert!(
+        unused_default
+            .message
+            .contains("unknown domain symbol 'missing'")
+    );
+
+    let stale = lowering_error(
+        r"
+domain InvalidStale {
+  type Status = Pending | Done
+  aggregate Item {
+    state { status: Status = Pending; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = Done }
+    on_stale Touched when missing == Done { emits Touched }
+  }
+}
+",
+    );
+    assert!(stale.message.contains("unknown domain symbol 'missing'"));
+
+    let idempotency = lowering_error(
+        r"
+domain InvalidEffectPath {
+  type RequestId = 0..1
+  aggregate Item {
+    state { ready: Bool = false; }
+    command Request { id: RequestId }
+    event Requested { id: RequestId }
+    event Done { id: RequestId }
+    decide Request { emits Requested }
+    evolve Requested { ready = true }
+    evolve Done { ready = false }
+  }
+  effect Work {
+    async
+    idempotency_key Missing.id
+    correlation_id Requested.id
+    handles Requested
+    emits one_of [Done]
+  }
+}
+",
+    );
+    assert!(
+        idempotency
+            .message
+            .contains("unknown domain path root 'Missing'")
+    );
+}
+
+#[test]
+fn rejects_invalid_kernel_shaped_domain_expressions_during_check() {
+    let wrong_method_type = lowering_error(
+        r"
+domain InvalidMethodType {
+  type Status = Pending | Done
+  aggregate Item {
+    state { seen: Set<Status>; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { not seen.contains(1) }
+  }
+}
+",
+    );
+    assert!(
+        wrong_method_type
+            .message
+            .contains("collection method argument type mismatch")
+    );
+
+    let wrong_arity = lowering_error(
+        r"
+domain InvalidMethodArity {
+  type Status = Pending | Done
+  aggregate Item {
+    state { seen: Set<Status>; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { not seen.contains() }
+  }
+}
+",
+    );
+    assert!(
+        wrong_arity
+            .message
+            .contains("invalid Set method 'contains'/0")
+    );
+
+    let non_option = lowering_error(
+        r"
+domain InvalidPattern {
+  type Status = Pending | Done
+  aggregate Item {
+    state { status: Status = Pending; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { status = Done }
+    invariant bad { status is none }
+  }
+}
+",
+    );
+    assert!(non_option.message.contains("requires an Option expression"));
+
+    let missing_field = lowering_error(
+        r"
+domain InvalidStruct {
+  value_object Pair { x: Int = 0; y: Int = 0; }
+  aggregate Item {
+    state { pair: Pair; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { pair == Pair { x: 0 } }
+  }
+}
+",
+    );
+    assert!(
+        missing_field
+            .message
+            .contains("missing struct field 'Pair.y'")
+    );
+}
+
+#[test]
+fn rejects_option_comparisons_other_than_none() {
+    let some_comparison = lowering_error(
+        r"
+domain InvalidSomeComparison {
+  type Status = Pending | Done
+  aggregate Item {
+    state { current: Option<Status> = none; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched { current = none }
+    invariant bad { current == some(Pending) }
+  }
+}
+",
+    );
+    assert!(some_comparison.message.contains("use 'is some(binding)'"));
+
+    let option_comparison = lowering_error(
+        r"
+domain InvalidOptionComparison {
+  type Status = Pending | Done
+  aggregate Item {
+    state {
+      current: Option<Status> = none;
+      previous: Option<Status> = none;
+    }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { current == previous }
+  }
+}
+",
+    );
+    assert!(option_comparison.message.contains("use 'is some(binding)'"));
+
+    let option_ordering = lowering_error(
+        r"
+domain InvalidOptionOrdering {
+  type Status = Pending | Done
+  aggregate Item {
+    state { current: Option<Status> = none; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { current < none }
+  }
+}
+",
+    );
+    assert!(
+        option_ordering
+            .message
+            .contains("ordering operator requires numeric operands")
+    );
+}

--- a/rust/fslc/tests/domain_expression_characterization.rs
+++ b/rust/fslc/tests/domain_expression_characterization.rs
@@ -399,7 +399,7 @@ fn cli_snapshot(args: &[&str]) -> Value {
     json!({"exit":status,"output":output})
 }
 
-fn generated_span_note(name: &str, action_name: &str, source_declaration: &str) -> Value {
+fn direct_span_note(name: &str, action_name: &str, source_declaration: &str) -> Value {
     let contract = public_projection(name);
     let action = contract["actions"]
         .as_array()
@@ -413,7 +413,7 @@ fn generated_span_note(name: &str, action_name: &str, source_declaration: &str) 
         .unwrap_or_else(|| panic!("missing source declaration '{source_declaration}'"))
         + 1;
     json!({
-        "classification":"known_generated_kernel_coordinate_attached_to_source_file",
+        "classification":"original_domain_coordinate_preserved",
         "file":name,
         "source_declaration_line":source_line,
         "reported_public_kernel_line":action["span"]["line"],
@@ -466,9 +466,9 @@ fn baseline() -> Value {
             "expressions_valid.fsl":public_projection("expressions_valid.fsl"),
             "effect_saga_valid.fsl":public_projection("effect_saga_valid.fsl")
         },
-        "known_generated_spans":[
-            generated_span_note("expressions_valid.fsl","order_approve","decide Approve {"),
-            generated_span_note("effect_saga_valid.fsl","order_approve","decide Approve {")
+        "direct_domain_spans":[
+            direct_span_note("expressions_valid.fsl","order_approve","decide Approve {"),
+            direct_span_note("effect_saga_valid.fsl","order_approve","decide Approve {")
         ],
         "generated_kernel_source_fragments":{
             "expressions_valid.fsl":generated_fragments(&expressions,&[
@@ -522,7 +522,11 @@ fn domain_surface_lowering_public_kernel_and_diagnostics_match_baseline() {
 fn domain_monitor_and_symbolic_semantics_agree() {
     let mut total_checked = 0_usize;
     let mut rejected_changed_successor = false;
-    for name in ["expressions_valid.fsl", "effect_saga_valid.fsl"] {
+    for name in [
+        "expressions_valid.fsl",
+        "effect_saga_valid.fsl",
+        "lvalues_surface.fsl",
+    ] {
         let model = model(name);
         let initial = fsl_runtime::Monitor::new(model.clone()).expect("create Monitor");
         let mut queue = VecDeque::from([(initial, 0_usize)]);

--- a/rust/fslc/tests/fixtures/domain_characterization/ai_native_cases.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/ai_native_cases.v1.json
@@ -30,9 +30,9 @@
   ],
   "baseline": {
     "case_count": 4,
-    "initial_check_successes": 3,
-    "initial_check_success_rate": "3/4",
-    "repairs_until_check_success": [0, 1, 0, 0],
+    "initial_check_successes": 1,
+    "initial_check_success_rate": "1/4",
+    "repairs_until_check_success": [0, 1, 1, 1],
     "operator_misuse_count": 2,
     "enum_misuse_count": 1,
     "internal_generated_name_misuse_count": 1,

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -908,7 +908,7 @@
                 ">=",
                 [
                   "var",
-                  "order_quantity"
+                  "quantity"
                 ],
                 [
                   "num",
@@ -1046,7 +1046,7 @@
               ],
               [
                 "var",
-                "order_quantity"
+                "quantity"
               ],
               "<location>"
             ]
@@ -1332,22 +1332,22 @@
               "not",
               [
                 "bin",
-                "or",
+                "and",
                 [
                   "bin",
-                  "==",
+                  "or",
                   [
-                    "var",
-                    "order_status"
+                    "bin",
+                    "==",
+                    [
+                      "var",
+                      "order_status"
+                    ],
+                    [
+                      "var",
+                      "OrderStatus_Draft"
+                    ]
                   ],
-                  [
-                    "var",
-                    "OrderStatus_Draft"
-                  ]
-                ],
-                [
-                  "bin",
-                  "and",
                   [
                     "bin",
                     "==",
@@ -1359,20 +1359,20 @@
                       "var",
                       "OrderStatus_Approved"
                     ]
-                  ],
+                  ]
+                ],
+                [
+                  "not",
                   [
-                    "not",
+                    "bin",
+                    "==",
                     [
-                      "bin",
-                      "==",
-                      [
-                        "var",
-                        "order_status"
-                      ],
-                      [
-                        "var",
-                        "OrderStatus_Cancelled"
-                      ]
+                      "var",
+                      "order_status"
+                    ],
+                    [
+                      "var",
+                      "OrderStatus_Cancelled"
                     ]
                   ]
                 ]
@@ -2958,10 +2958,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 16,
-              "column": 5,
-              "end_line": 16,
-              "end_column": 17
+              "line": 19,
+              "column": 7,
+              "end_line": 19,
+              "end_column": 35
             },
             "target": {
               "kind": "var",
@@ -2971,10 +2971,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 16,
-                "column": 5,
-                "end_line": 16,
-                "end_column": 17
+                "line": 19,
+                "column": 7,
+                "end_line": 19,
+                "end_column": 35
               },
               "name": "order_status"
             },
@@ -2986,10 +2986,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 16,
-                "column": 5,
-                "end_line": 16,
-                "end_column": 17
+                "line": 19,
+                "column": 7,
+                "end_line": 19,
+                "end_column": 35
               },
               "name": "OrderStatus_Draft"
             }
@@ -3001,10 +3001,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 17,
-              "column": 5,
-              "end_line": 17,
-              "end_column": 26
+              "line": 20,
+              "column": 7,
+              "end_line": 20,
+              "end_column": 44
             },
             "target": {
               "kind": "var",
@@ -3014,10 +3014,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 17,
-                "column": 5,
-                "end_line": 17,
-                "end_column": 26
+                "line": 20,
+                "column": 7,
+                "end_line": 20,
+                "end_column": 44
               },
               "name": "order_previous_status"
             },
@@ -3029,10 +3029,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 17,
-                "column": 5,
-                "end_line": 17,
-                "end_column": 26
+                "line": 20,
+                "column": 7,
+                "end_line": 20,
+                "end_column": 44
               },
               "name": "OrderStatus_Draft"
             }
@@ -3044,10 +3044,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 18,
-              "column": 5,
-              "end_line": 18,
-              "end_column": 19
+              "line": 21,
+              "column": 7,
+              "end_line": 21,
+              "end_column": 30
             },
             "target": {
               "kind": "var",
@@ -3057,10 +3057,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 18,
-                "column": 5,
-                "end_line": 18,
-                "end_column": 19
+                "line": 21,
+                "column": 7,
+                "end_line": 21,
+                "end_column": 30
               },
               "name": "order_quantity"
             },
@@ -3073,10 +3073,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 18,
-                "column": 5,
-                "end_line": 18,
-                "end_column": 19
+                "line": 21,
+                "column": 7,
+                "end_line": 21,
+                "end_column": 30
               },
               "value": 0
             }
@@ -3088,10 +3088,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 19,
-              "column": 5,
-              "end_line": 19,
-              "end_column": 16
+              "line": 22,
+              "column": 7,
+              "end_line": 22,
+              "end_column": 25
             },
             "target": {
               "kind": "var",
@@ -3101,10 +3101,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 19,
-                "column": 5,
-                "end_line": 19,
-                "end_column": 16
+                "line": 22,
+                "column": 7,
+                "end_line": 22,
+                "end_column": 25
               },
               "name": "order_audit"
             },
@@ -3116,10 +3116,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 19,
-                "column": 5,
-                "end_line": 19,
-                "end_column": 16
+                "line": 22,
+                "column": 7,
+                "end_line": 22,
+                "end_column": 25
               },
               "name": "AuditStamp",
               "fields": {
@@ -3131,10 +3131,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 19,
-                    "column": 5,
-                    "end_line": 19,
-                    "end_column": 16
+                    "line": 22,
+                    "column": 7,
+                    "end_line": 22,
+                    "end_column": 25
                   },
                   "name": "OrderStatus_Draft"
                 },
@@ -3147,10 +3147,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 19,
-                    "column": 5,
-                    "end_line": 19,
-                    "end_column": 16
+                    "line": 22,
+                    "column": 7,
+                    "end_line": 22,
+                    "end_column": 25
                   },
                   "value": 0
                 }
@@ -3164,10 +3164,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 20,
-              "column": 5,
-              "end_line": 20,
-              "end_column": 27
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -3176,10 +3176,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 20,
-                "column": 5,
-                "end_line": 20,
-                "end_column": 27
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_ApprovalRejected"
             },
@@ -3190,10 +3190,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 20,
-                "column": 5,
-                "end_line": 20,
-                "end_column": 27
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -3205,10 +3205,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 21,
-              "column": 5,
-              "end_line": 21,
-              "end_column": 19
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -3217,10 +3217,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 21,
-                "column": 5,
-                "end_line": 21,
-                "end_column": 19
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_Approved"
             },
@@ -3231,10 +3231,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 21,
-                "column": 5,
-                "end_line": 21,
-                "end_column": 19
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -3246,10 +3246,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 22,
-              "column": 5,
-              "end_line": 22,
-              "end_column": 20
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -3258,10 +3258,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 22,
-                "column": 5,
-                "end_line": 22,
-                "end_column": 20
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_Cancelled"
             },
@@ -3272,10 +3272,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 22,
-                "column": 5,
-                "end_line": 22,
-                "end_column": 20
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -3289,10 +3289,10 @@
         },
         "span": {
           "file": "expressions_valid.fsl",
-          "line": 16,
-          "column": 5,
-          "end_line": 16,
-          "end_column": 17
+          "line": 19,
+          "column": 7,
+          "end_line": 19,
+          "end_column": 35
         }
       },
       "actions": [
@@ -3309,10 +3309,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 25,
-                  "column": 5,
-                  "end_line": 25,
-                  "end_column": 13
+                  "line": 40,
+                  "column": 16,
+                  "end_line": 40,
+                  "end_column": 61
                 },
                 "operator": "and",
                 "left": {
@@ -3322,10 +3322,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 25,
-                    "column": 5,
-                    "end_line": 25,
-                    "end_column": 13
+                    "line": 40,
+                    "column": 16,
+                    "end_line": 40,
+                    "end_column": 61
                   },
                   "operator": "==",
                   "left": {
@@ -3336,10 +3336,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 25,
-                      "column": 5,
-                      "end_line": 25,
-                      "end_column": 13
+                      "line": 40,
+                      "column": 16,
+                      "end_line": 40,
+                      "end_column": 61
                     },
                     "name": "order_status"
                   },
@@ -3351,10 +3351,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 25,
-                      "column": 5,
-                      "end_line": 25,
-                      "end_column": 13
+                      "line": 40,
+                      "column": 16,
+                      "end_line": 40,
+                      "end_column": 61
                     },
                     "name": "OrderStatus_Draft"
                   }
@@ -3366,10 +3366,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 25,
-                    "column": 5,
-                    "end_line": 25,
-                    "end_column": 13
+                    "line": 40,
+                    "column": 16,
+                    "end_line": 40,
+                    "end_column": 61
                   },
                   "operand": {
                     "kind": "binary",
@@ -3378,10 +3378,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 25,
-                      "column": 5,
-                      "end_line": 25,
-                      "end_column": 13
+                      "line": 40,
+                      "column": 16,
+                      "end_line": 40,
+                      "end_column": 61
                     },
                     "operator": "==",
                     "left": {
@@ -3392,10 +3392,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 25,
-                        "column": 5,
-                        "end_line": 25,
-                        "end_column": 13
+                        "line": 40,
+                        "column": 16,
+                        "end_line": 40,
+                        "end_column": 61
                       },
                       "name": "order_status"
                     },
@@ -3407,10 +3407,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 25,
-                        "column": 5,
-                        "end_line": 25,
-                        "end_column": 13
+                        "line": 40,
+                        "column": 16,
+                        "end_line": 40,
+                        "end_column": 61
                       },
                       "name": "OrderStatus_Cancelled"
                     }
@@ -3427,10 +3427,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 26,
-                  "column": 5,
-                  "end_line": 26,
-                  "end_column": 13
+                  "line": 41,
+                  "column": 16,
+                  "end_line": 41,
+                  "end_column": 53
                 },
                 "operator": "and",
                 "left": {
@@ -3440,10 +3440,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 26,
-                    "column": 5,
-                    "end_line": 26,
-                    "end_column": 13
+                    "line": 41,
+                    "column": 16,
+                    "end_line": 41,
+                    "end_column": 53
                   },
                   "operator": "!=",
                   "left": {
@@ -3454,10 +3454,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 26,
-                      "column": 5,
-                      "end_line": 26,
-                      "end_column": 13
+                      "line": 41,
+                      "column": 16,
+                      "end_line": 41,
+                      "end_column": 53
                     },
                     "name": "order_status"
                   },
@@ -3469,10 +3469,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 26,
-                      "column": 5,
-                      "end_line": 26,
-                      "end_column": 13
+                      "line": 41,
+                      "column": 16,
+                      "end_line": 41,
+                      "end_column": 53
                     },
                     "name": "OrderStatus_Cancelled"
                   }
@@ -3484,10 +3484,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 26,
-                    "column": 5,
-                    "end_line": 26,
-                    "end_column": 13
+                    "line": 41,
+                    "column": 16,
+                    "end_line": 41,
+                    "end_column": 53
                   },
                   "operator": ">=",
                   "left": {
@@ -3498,12 +3498,12 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 26,
-                      "column": 5,
-                      "end_line": 26,
-                      "end_column": 13
+                      "line": 41,
+                      "column": 16,
+                      "end_line": 41,
+                      "end_column": 53
                     },
-                    "name": "order_quantity"
+                    "name": "quantity"
                   },
                   "right": {
                     "kind": "num",
@@ -3512,10 +3512,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 26,
-                      "column": 5,
-                      "end_line": 26,
-                      "end_column": 13
+                      "line": 41,
+                      "column": 16,
+                      "end_line": 41,
+                      "end_column": 53
                     },
                     "value": 0
                   }
@@ -3531,10 +3531,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 27,
-                  "column": 5,
-                  "end_line": 27,
-                  "end_column": 13
+                  "line": 42,
+                  "column": 29,
+                  "end_line": 42,
+                  "end_column": 60
                 },
                 "operand": {
                   "kind": "binary",
@@ -3543,10 +3543,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 27,
-                    "column": 5,
-                    "end_line": 27,
-                    "end_column": 13
+                    "line": 42,
+                    "column": 29,
+                    "end_line": 42,
+                    "end_column": 60
                   },
                   "operator": "or",
                   "left": {
@@ -3556,10 +3556,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 27,
-                      "column": 5,
-                      "end_line": 27,
-                      "end_column": 13
+                      "line": 42,
+                      "column": 29,
+                      "end_line": 42,
+                      "end_column": 60
                     },
                     "operator": "==",
                     "left": {
@@ -3570,10 +3570,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 27,
-                        "column": 5,
-                        "end_line": 27,
-                        "end_column": 13
+                        "line": 42,
+                        "column": 29,
+                        "end_line": 42,
+                        "end_column": 60
                       },
                       "name": "order_status"
                     },
@@ -3585,10 +3585,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 27,
-                        "column": 5,
-                        "end_line": 27,
-                        "end_column": 13
+                        "line": 42,
+                        "column": 29,
+                        "end_line": 42,
+                        "end_column": 60
                       },
                       "name": "OrderStatus_Approved"
                     }
@@ -3600,10 +3600,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 27,
-                      "column": 5,
-                      "end_line": 27,
-                      "end_column": 13
+                      "line": 42,
+                      "column": 29,
+                      "end_line": 42,
+                      "end_column": 60
                     },
                     "operator": "==",
                     "left": {
@@ -3614,10 +3614,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 27,
-                        "column": 5,
-                        "end_line": 27,
-                        "end_column": 13
+                        "line": 42,
+                        "column": 29,
+                        "end_line": 42,
+                        "end_column": 60
                       },
                       "name": "order_status"
                     },
@@ -3629,10 +3629,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 27,
-                        "column": 5,
-                        "end_line": 27,
-                        "end_column": 13
+                        "line": 42,
+                        "column": 29,
+                        "end_line": 42,
+                        "end_column": 60
                       },
                       "name": "OrderStatus_Cancelled"
                     }
@@ -3649,10 +3649,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 31,
-                  "column": 5,
-                  "end_line": 31,
-                  "end_column": 13
+                  "line": 53,
+                  "column": 16,
+                  "end_line": 53,
+                  "end_column": 31
                 },
                 "operator": "==",
                 "left": {
@@ -3663,10 +3663,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 31,
-                    "column": 5,
-                    "end_line": 31,
-                    "end_column": 13
+                    "line": 53,
+                    "column": 16,
+                    "end_line": 53,
+                    "end_column": 31
                   },
                   "name": "order_status"
                 },
@@ -3678,10 +3678,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 31,
-                    "column": 5,
-                    "end_line": 31,
-                    "end_column": 13
+                    "line": 53,
+                    "column": 16,
+                    "end_line": 53,
+                    "end_column": 31
                   },
                   "name": "OrderStatus_Draft"
                 }
@@ -3696,10 +3696,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 28,
+                "line": 39,
                 "column": 5,
-                "end_line": 28,
-                "end_column": 27
+                "end_line": 39,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -3708,10 +3708,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 28,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 28,
-                  "end_column": 27
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "name": "event_ApprovalRejected"
               },
@@ -3722,10 +3722,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 28,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 28,
-                  "end_column": 27
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -3737,10 +3737,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 29,
+                "line": 39,
                 "column": 5,
-                "end_line": 29,
-                "end_column": 19
+                "end_line": 39,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -3749,10 +3749,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 29,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 29,
-                  "end_column": 19
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -3763,10 +3763,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 29,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 29,
-                  "end_column": 19
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -3778,10 +3778,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 30,
+                "line": 39,
                 "column": 5,
-                "end_line": 30,
-                "end_column": 20
+                "end_line": 39,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -3790,10 +3790,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 30,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 30,
-                  "end_column": 20
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "name": "event_Cancelled"
               },
@@ -3804,10 +3804,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 30,
+                  "line": 39,
                   "column": 5,
-                  "end_line": 30,
-                  "end_column": 20
+                  "end_line": 39,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -3819,10 +3819,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 32,
-                "column": 5,
-                "end_line": 32,
-                "end_column": 26
+                "line": 54,
+                "column": 7,
+                "end_line": 54,
+                "end_column": 31
               },
               "target": {
                 "kind": "var",
@@ -3832,10 +3832,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 32,
-                  "column": 5,
-                  "end_line": 32,
-                  "end_column": 26
+                  "line": 54,
+                  "column": 7,
+                  "end_line": 54,
+                  "end_column": 31
                 },
                 "name": "order_previous_status"
               },
@@ -3847,10 +3847,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 32,
-                  "column": 5,
-                  "end_line": 32,
-                  "end_column": 26
+                  "line": 54,
+                  "column": 7,
+                  "end_line": 54,
+                  "end_column": 31
                 },
                 "name": "order_status"
               }
@@ -3862,10 +3862,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 33,
-                "column": 5,
-                "end_line": 33,
-                "end_column": 17
+                "line": 55,
+                "column": 7,
+                "end_line": 55,
+                "end_column": 24
               },
               "target": {
                 "kind": "var",
@@ -3875,10 +3875,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 33,
-                  "column": 5,
-                  "end_line": 33,
-                  "end_column": 17
+                  "line": 55,
+                  "column": 7,
+                  "end_line": 55,
+                  "end_column": 24
                 },
                 "name": "order_status"
               },
@@ -3890,10 +3890,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 33,
-                  "column": 5,
-                  "end_line": 33,
-                  "end_column": 17
+                  "line": 55,
+                  "column": 7,
+                  "end_line": 55,
+                  "end_column": 24
                 },
                 "name": "OrderStatus_Approved"
               }
@@ -3905,10 +3905,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 34,
-                "column": 5,
-                "end_line": 34,
-                "end_column": 16
+                "line": 56,
+                "column": 7,
+                "end_line": 56,
+                "end_column": 28
               },
               "target": {
                 "kind": "field_lv",
@@ -3918,10 +3918,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 34,
-                  "column": 5,
-                  "end_line": 34,
-                  "end_column": 16
+                  "line": 56,
+                  "column": 7,
+                  "end_line": 56,
+                  "end_column": 28
                 },
                 "target": {
                   "kind": "var",
@@ -3931,10 +3931,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 34,
-                    "column": 5,
-                    "end_line": 34,
-                    "end_column": 16
+                    "line": 56,
+                    "column": 7,
+                    "end_line": 56,
+                    "end_column": 28
                   },
                   "name": "order_audit"
                 },
@@ -3948,10 +3948,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 34,
-                  "column": 5,
-                  "end_line": 34,
-                  "end_column": 16
+                  "line": 56,
+                  "column": 7,
+                  "end_line": 56,
+                  "end_column": 28
                 },
                 "name": "order_status"
               }
@@ -3963,10 +3963,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 35,
-                "column": 5,
-                "end_line": 35,
-                "end_column": 19
+                "line": 57,
+                "column": 7,
+                "end_line": 57,
+                "end_column": 26
               },
               "target": {
                 "kind": "var",
@@ -3976,10 +3976,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 35,
-                  "column": 5,
-                  "end_line": 35,
-                  "end_column": 19
+                  "line": 57,
+                  "column": 7,
+                  "end_line": 57,
+                  "end_column": 26
                 },
                 "name": "order_quantity"
               },
@@ -3991,12 +3991,12 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 35,
-                  "column": 5,
-                  "end_line": 35,
-                  "end_column": 19
+                  "line": 57,
+                  "column": 7,
+                  "end_line": 57,
+                  "end_column": 26
                 },
-                "name": "order_quantity"
+                "name": "quantity"
               }
             }
           ],
@@ -4008,10 +4008,10 @@
           },
           "span": {
             "file": "expressions_valid.fsl",
-            "line": 24,
-            "column": 3,
-            "end_line": 24,
-            "end_column": 9
+            "line": 39,
+            "column": 5,
+            "end_line": 39,
+            "end_column": 5
           }
         },
         {
@@ -4027,10 +4027,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 38,
-                  "column": 5,
-                  "end_line": 38,
-                  "end_column": 13
+                  "line": 47,
+                  "column": 16,
+                  "end_line": 47,
+                  "end_column": 53
                 },
                 "operator": "or",
                 "left": {
@@ -4040,10 +4040,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 38,
-                    "column": 5,
-                    "end_line": 38,
-                    "end_column": 13
+                    "line": 47,
+                    "column": 16,
+                    "end_line": 47,
+                    "end_column": 53
                   },
                   "operator": "==",
                   "left": {
@@ -4054,10 +4054,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 38,
-                      "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "line": 47,
+                      "column": 16,
+                      "end_line": 47,
+                      "end_column": 53
                     },
                     "name": "order_status"
                   },
@@ -4069,10 +4069,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 38,
-                      "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "line": 47,
+                      "column": 16,
+                      "end_line": 47,
+                      "end_column": 53
                     },
                     "name": "OrderStatus_Draft"
                   }
@@ -4084,10 +4084,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 38,
-                    "column": 5,
-                    "end_line": 38,
-                    "end_column": 13
+                    "line": 47,
+                    "column": 16,
+                    "end_line": 47,
+                    "end_column": 53
                   },
                   "operator": "==",
                   "left": {
@@ -4098,10 +4098,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 38,
-                      "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "line": 47,
+                      "column": 16,
+                      "end_line": 47,
+                      "end_column": 53
                     },
                     "name": "order_status"
                   },
@@ -4113,10 +4113,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 38,
-                      "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "line": 47,
+                      "column": 16,
+                      "end_line": 47,
+                      "end_column": 53
                     },
                     "name": "OrderStatus_Approved"
                   }
@@ -4132,10 +4132,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 39,
-                  "column": 5,
-                  "end_line": 39,
-                  "end_column": 13
+                  "line": 48,
+                  "column": 37,
+                  "end_line": 48,
+                  "end_column": 56
                 },
                 "operand": {
                   "kind": "binary",
@@ -4144,10 +4144,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 39,
-                    "column": 5,
-                    "end_line": 39,
-                    "end_column": 13
+                    "line": 48,
+                    "column": 37,
+                    "end_line": 48,
+                    "end_column": 56
                   },
                   "operator": "==",
                   "left": {
@@ -4158,10 +4158,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 39,
-                      "column": 5,
-                      "end_line": 39,
-                      "end_column": 13
+                      "line": 48,
+                      "column": 37,
+                      "end_line": 48,
+                      "end_column": 56
                     },
                     "name": "order_status"
                   },
@@ -4173,10 +4173,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 39,
-                      "column": 5,
-                      "end_line": 39,
-                      "end_column": 13
+                      "line": 48,
+                      "column": 37,
+                      "end_line": 48,
+                      "end_column": 56
                     },
                     "name": "OrderStatus_Cancelled"
                   }
@@ -4192,10 +4192,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 40,
+                "line": 46,
                 "column": 5,
-                "end_line": 40,
-                "end_column": 27
+                "end_line": 46,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -4204,10 +4204,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 40,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 40,
-                  "end_column": 27
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "name": "event_ApprovalRejected"
               },
@@ -4218,10 +4218,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 40,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 40,
-                  "end_column": 27
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -4233,10 +4233,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 41,
+                "line": 46,
                 "column": 5,
-                "end_line": 41,
-                "end_column": 19
+                "end_line": 46,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -4245,10 +4245,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 41,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 41,
-                  "end_column": 19
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -4259,10 +4259,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 41,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 41,
-                  "end_column": 19
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -4274,10 +4274,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 42,
+                "line": 46,
                 "column": 5,
-                "end_line": 42,
-                "end_column": 20
+                "end_line": 46,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -4286,10 +4286,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 42,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 42,
-                  "end_column": 20
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "name": "event_Cancelled"
               },
@@ -4300,10 +4300,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 42,
+                  "line": 46,
                   "column": 5,
-                  "end_line": 42,
-                  "end_column": 20
+                  "end_line": 46,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -4315,10 +4315,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 43,
-                "column": 5,
-                "end_line": 43,
-                "end_column": 26
+                "line": 61,
+                "column": 7,
+                "end_line": 61,
+                "end_column": 31
               },
               "target": {
                 "kind": "var",
@@ -4328,10 +4328,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 43,
-                  "column": 5,
-                  "end_line": 43,
-                  "end_column": 26
+                  "line": 61,
+                  "column": 7,
+                  "end_line": 61,
+                  "end_column": 31
                 },
                 "name": "order_previous_status"
               },
@@ -4343,10 +4343,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 43,
-                  "column": 5,
-                  "end_line": 43,
-                  "end_column": 26
+                  "line": 61,
+                  "column": 7,
+                  "end_line": 61,
+                  "end_column": 31
                 },
                 "name": "order_status"
               }
@@ -4358,10 +4358,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 44,
-                "column": 5,
-                "end_line": 44,
-                "end_column": 17
+                "line": 62,
+                "column": 7,
+                "end_line": 62,
+                "end_column": 25
               },
               "target": {
                 "kind": "var",
@@ -4371,10 +4371,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 44,
-                  "column": 5,
-                  "end_line": 44,
-                  "end_column": 17
+                  "line": 62,
+                  "column": 7,
+                  "end_line": 62,
+                  "end_column": 25
                 },
                 "name": "order_status"
               },
@@ -4386,10 +4386,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 44,
-                  "column": 5,
-                  "end_line": 44,
-                  "end_column": 17
+                  "line": 62,
+                  "column": 7,
+                  "end_line": 62,
+                  "end_column": 25
                 },
                 "name": "OrderStatus_Cancelled"
               }
@@ -4403,10 +4403,10 @@
           },
           "span": {
             "file": "expressions_valid.fsl",
-            "line": 37,
-            "column": 3,
-            "end_line": 37,
-            "end_column": 9
+            "line": 46,
+            "column": 5,
+            "end_line": 46,
+            "end_column": 5
           }
         }
       ],
@@ -4422,10 +4422,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 46,
-                "column": 3,
-                "end_line": 46,
-                "end_column": 12
+                "line": 73,
+                "column": 5,
+                "end_line": 75,
+                "end_column": 6
               },
               "operator": "=>",
               "left": {
@@ -4435,10 +4435,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 46,
-                  "column": 3,
-                  "end_line": 46,
-                  "end_column": 12
+                  "line": 73,
+                  "column": 5,
+                  "end_line": 75,
+                  "end_column": 6
                 },
                 "operator": "==",
                 "left": {
@@ -4449,10 +4449,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 46,
-                    "column": 3,
-                    "end_line": 46,
-                    "end_column": 12
+                    "line": 73,
+                    "column": 5,
+                    "end_line": 75,
+                    "end_column": 6
                   },
                   "name": "order_status"
                 },
@@ -4464,10 +4464,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 46,
-                    "column": 3,
-                    "end_line": 46,
-                    "end_column": 12
+                    "line": 73,
+                    "column": 5,
+                    "end_line": 75,
+                    "end_column": 6
                   },
                   "name": "OrderStatus_Approved"
                 }
@@ -4479,10 +4479,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 46,
-                  "column": 3,
-                  "end_line": 46,
-                  "end_column": 12
+                  "line": 73,
+                  "column": 5,
+                  "end_line": 75,
+                  "end_column": 6
                 },
                 "operator": "or",
                 "left": {
@@ -4492,10 +4492,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 46,
-                    "column": 3,
-                    "end_line": 46,
-                    "end_column": 12
+                    "line": 73,
+                    "column": 5,
+                    "end_line": 75,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4506,10 +4506,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 46,
-                      "column": 3,
-                      "end_line": 46,
-                      "end_column": 12
+                      "line": 73,
+                      "column": 5,
+                      "end_line": 75,
+                      "end_column": 6
                     },
                     "name": "order_previous_status"
                   },
@@ -4521,10 +4521,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 46,
-                      "column": 3,
-                      "end_line": 46,
-                      "end_column": 12
+                      "line": 73,
+                      "column": 5,
+                      "end_line": 75,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Draft"
                   }
@@ -4536,10 +4536,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 46,
-                    "column": 3,
-                    "end_line": 46,
-                    "end_column": 12
+                    "line": 73,
+                    "column": 5,
+                    "end_line": 75,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4550,10 +4550,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 46,
-                      "column": 3,
-                      "end_line": 46,
-                      "end_column": 12
+                      "line": 73,
+                      "column": 5,
+                      "end_line": 75,
+                      "end_column": 6
                     },
                     "name": "order_previous_status"
                   },
@@ -4565,10 +4565,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 46,
-                      "column": 3,
-                      "end_line": 46,
-                      "end_column": 12
+                      "line": 73,
+                      "column": 5,
+                      "end_line": 75,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Approved"
                   }
@@ -4583,10 +4583,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 46,
-              "column": 3,
-              "end_line": 46,
-              "end_column": 12
+              "line": 73,
+              "column": 5,
+              "end_line": 75,
+              "end_column": 6
             }
           },
           {
@@ -4599,10 +4599,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 49,
-                "column": 3,
-                "end_line": 49,
-                "end_column": 12
+                "line": 85,
+                "column": 5,
+                "end_line": 87,
+                "end_column": 6
               },
               "operator": "or",
               "left": {
@@ -4612,10 +4612,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 49,
-                  "column": 3,
-                  "end_line": 49,
-                  "end_column": 12
+                  "line": 85,
+                  "column": 5,
+                  "end_line": 87,
+                  "end_column": 6
                 },
                 "operator": "or",
                 "left": {
@@ -4625,10 +4625,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 49,
-                    "column": 3,
-                    "end_line": 49,
-                    "end_column": 12
+                    "line": 85,
+                    "column": 5,
+                    "end_line": 87,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4639,10 +4639,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 49,
-                      "column": 3,
-                      "end_line": 49,
-                      "end_column": 12
+                      "line": 85,
+                      "column": 5,
+                      "end_line": 87,
+                      "end_column": 6
                     },
                     "name": "order_status"
                   },
@@ -4654,10 +4654,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 49,
-                      "column": 3,
-                      "end_line": 49,
-                      "end_column": 12
+                      "line": 85,
+                      "column": 5,
+                      "end_line": 87,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Draft"
                   }
@@ -4669,10 +4669,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 49,
-                    "column": 3,
-                    "end_line": 49,
-                    "end_column": 12
+                    "line": 85,
+                    "column": 5,
+                    "end_line": 87,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4683,10 +4683,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 49,
-                      "column": 3,
-                      "end_line": 49,
-                      "end_column": 12
+                      "line": 85,
+                      "column": 5,
+                      "end_line": 87,
+                      "end_column": 6
                     },
                     "name": "order_status"
                   },
@@ -4698,10 +4698,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 49,
-                      "column": 3,
-                      "end_line": 49,
-                      "end_column": 12
+                      "line": 85,
+                      "column": 5,
+                      "end_line": 87,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Approved"
                   }
@@ -4714,10 +4714,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 49,
-                  "column": 3,
-                  "end_line": 49,
-                  "end_column": 12
+                  "line": 85,
+                  "column": 5,
+                  "end_line": 87,
+                  "end_column": 6
                 },
                 "operator": "==",
                 "left": {
@@ -4728,10 +4728,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 49,
-                    "column": 3,
-                    "end_line": 49,
-                    "end_column": 12
+                    "line": 85,
+                    "column": 5,
+                    "end_line": 87,
+                    "end_column": 6
                   },
                   "name": "order_status"
                 },
@@ -4743,10 +4743,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 49,
-                    "column": 3,
-                    "end_line": 49,
-                    "end_column": 12
+                    "line": 85,
+                    "column": 5,
+                    "end_line": 87,
+                    "end_column": 6
                   },
                   "name": "OrderStatus_Cancelled"
                 }
@@ -4760,10 +4760,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 49,
-              "column": 3,
-              "end_line": 49,
-              "end_column": 12
+              "line": 85,
+              "column": 5,
+              "end_line": 87,
+              "end_column": 6
             }
           },
           {
@@ -4776,10 +4776,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 48,
-                "column": 3,
-                "end_line": 48,
-                "end_column": 12
+                "line": 81,
+                "column": 5,
+                "end_line": 83,
+                "end_column": 6
               },
               "operator": "or",
               "left": {
@@ -4789,10 +4789,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 48,
-                  "column": 3,
-                  "end_line": 48,
-                  "end_column": 12
+                  "line": 81,
+                  "column": 5,
+                  "end_line": 83,
+                  "end_column": 6
                 },
                 "operator": "or",
                 "left": {
@@ -4802,10 +4802,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 48,
-                    "column": 3,
-                    "end_line": 48,
-                    "end_column": 12
+                    "line": 81,
+                    "column": 5,
+                    "end_line": 83,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4816,10 +4816,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 48,
-                      "column": 3,
-                      "end_line": 48,
-                      "end_column": 12
+                      "line": 81,
+                      "column": 5,
+                      "end_line": 83,
+                      "end_column": 6
                     },
                     "name": "order_status"
                   },
@@ -4831,10 +4831,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 48,
-                      "column": 3,
-                      "end_line": 48,
-                      "end_column": 12
+                      "line": 81,
+                      "column": 5,
+                      "end_line": 83,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Draft"
                   }
@@ -4846,10 +4846,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 48,
-                    "column": 3,
-                    "end_line": 48,
-                    "end_column": 12
+                    "line": 81,
+                    "column": 5,
+                    "end_line": 83,
+                    "end_column": 6
                   },
                   "operator": "==",
                   "left": {
@@ -4860,10 +4860,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 48,
-                      "column": 3,
-                      "end_line": 48,
-                      "end_column": 12
+                      "line": 81,
+                      "column": 5,
+                      "end_line": 83,
+                      "end_column": 6
                     },
                     "name": "order_status"
                   },
@@ -4875,10 +4875,10 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 48,
-                      "column": 3,
-                      "end_line": 48,
-                      "end_column": 12
+                      "line": 81,
+                      "column": 5,
+                      "end_line": 83,
+                      "end_column": 6
                     },
                     "name": "OrderStatus_Approved"
                   }
@@ -4891,10 +4891,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 48,
-                  "column": 3,
-                  "end_line": 48,
-                  "end_column": 12
+                  "line": 81,
+                  "column": 5,
+                  "end_line": 83,
+                  "end_column": 6
                 },
                 "operator": "==",
                 "left": {
@@ -4905,10 +4905,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 48,
-                    "column": 3,
-                    "end_line": 48,
-                    "end_column": 12
+                    "line": 81,
+                    "column": 5,
+                    "end_line": 83,
+                    "end_column": 6
                   },
                   "name": "order_status"
                 },
@@ -4920,10 +4920,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 48,
-                    "column": 3,
-                    "end_line": 48,
-                    "end_column": 12
+                    "line": 81,
+                    "column": 5,
+                    "end_line": 83,
+                    "end_column": 6
                   },
                   "name": "OrderStatus_Cancelled"
                 }
@@ -4937,10 +4937,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 48,
-              "column": 3,
-              "end_line": 48,
-              "end_column": 12
+              "line": 81,
+              "column": 5,
+              "end_line": 83,
+              "end_column": 6
             }
           },
           {
@@ -4953,10 +4953,10 @@
               },
               "span": {
                 "file": "expressions_valid.fsl",
-                "line": 47,
-                "column": 3,
-                "end_line": 47,
-                "end_column": 12
+                "line": 77,
+                "column": 5,
+                "end_line": 79,
+                "end_column": 6
               },
               "operator": "=>",
               "left": {
@@ -4966,10 +4966,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 47,
-                  "column": 3,
-                  "end_line": 47,
-                  "end_column": 12
+                  "line": 77,
+                  "column": 5,
+                  "end_line": 79,
+                  "end_column": 6
                 },
                 "operator": "==",
                 "left": {
@@ -4980,10 +4980,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 47,
-                    "column": 3,
-                    "end_line": 47,
-                    "end_column": 12
+                    "line": 77,
+                    "column": 5,
+                    "end_line": 79,
+                    "end_column": 6
                   },
                   "name": "order_status"
                 },
@@ -4995,10 +4995,10 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 47,
-                    "column": 3,
-                    "end_line": 47,
-                    "end_column": 12
+                    "line": 77,
+                    "column": 5,
+                    "end_line": 79,
+                    "end_column": 6
                   },
                   "name": "OrderStatus_Cancelled"
                 }
@@ -5010,10 +5010,10 @@
                 },
                 "span": {
                   "file": "expressions_valid.fsl",
-                  "line": 47,
-                  "column": 3,
-                  "end_line": 47,
-                  "end_column": 12
+                  "line": 77,
+                  "column": 5,
+                  "end_line": 79,
+                  "end_column": 6
                 },
                 "operand": {
                   "kind": "binary",
@@ -5022,12 +5022,12 @@
                   },
                   "span": {
                     "file": "expressions_valid.fsl",
-                    "line": 47,
-                    "column": 3,
-                    "end_line": 47,
-                    "end_column": 12
+                    "line": 77,
+                    "column": 5,
+                    "end_line": 79,
+                    "end_column": 6
                   },
-                  "operator": "or",
+                  "operator": "and",
                   "left": {
                     "kind": "binary",
                     "type": {
@@ -5035,56 +5035,12 @@
                     },
                     "span": {
                       "file": "expressions_valid.fsl",
-                      "line": 47,
-                      "column": 3,
-                      "end_line": 47,
-                      "end_column": 12
+                      "line": 77,
+                      "column": 5,
+                      "end_line": 79,
+                      "end_column": 6
                     },
-                    "operator": "==",
-                    "left": {
-                      "kind": "var",
-                      "type": {
-                        "kind": "named",
-                        "name": "OrderStatus"
-                      },
-                      "span": {
-                        "file": "expressions_valid.fsl",
-                        "line": 47,
-                        "column": 3,
-                        "end_line": 47,
-                        "end_column": 12
-                      },
-                      "name": "order_status"
-                    },
-                    "right": {
-                      "kind": "var",
-                      "type": {
-                        "kind": "named",
-                        "name": "OrderStatus"
-                      },
-                      "span": {
-                        "file": "expressions_valid.fsl",
-                        "line": 47,
-                        "column": 3,
-                        "end_line": 47,
-                        "end_column": 12
-                      },
-                      "name": "OrderStatus_Draft"
-                    }
-                  },
-                  "right": {
-                    "kind": "binary",
-                    "type": {
-                      "kind": "bool"
-                    },
-                    "span": {
-                      "file": "expressions_valid.fsl",
-                      "line": 47,
-                      "column": 3,
-                      "end_line": 47,
-                      "end_column": 12
-                    },
-                    "operator": "and",
+                    "operator": "or",
                     "left": {
                       "kind": "binary",
                       "type": {
@@ -5092,10 +5048,10 @@
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 47,
-                        "column": 3,
-                        "end_line": 47,
-                        "end_column": 12
+                        "line": 77,
+                        "column": 5,
+                        "end_line": 79,
+                        "end_column": 6
                       },
                       "operator": "==",
                       "left": {
@@ -5106,10 +5062,10 @@
                         },
                         "span": {
                           "file": "expressions_valid.fsl",
-                          "line": 47,
-                          "column": 3,
-                          "end_line": 47,
-                          "end_column": 12
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
                         },
                         "name": "order_status"
                       },
@@ -5121,69 +5077,113 @@
                         },
                         "span": {
                           "file": "expressions_valid.fsl",
-                          "line": 47,
-                          "column": 3,
-                          "end_line": 47,
-                          "end_column": 12
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
                         },
-                        "name": "OrderStatus_Approved"
+                        "name": "OrderStatus_Draft"
                       }
                     },
                     "right": {
-                      "kind": "not",
+                      "kind": "binary",
                       "type": {
                         "kind": "bool"
                       },
                       "span": {
                         "file": "expressions_valid.fsl",
-                        "line": 47,
-                        "column": 3,
-                        "end_line": 47,
-                        "end_column": 12
+                        "line": 77,
+                        "column": 5,
+                        "end_line": 79,
+                        "end_column": 6
                       },
-                      "operand": {
-                        "kind": "binary",
+                      "operator": "==",
+                      "left": {
+                        "kind": "var",
                         "type": {
-                          "kind": "bool"
+                          "kind": "named",
+                          "name": "OrderStatus"
                         },
                         "span": {
                           "file": "expressions_valid.fsl",
-                          "line": 47,
-                          "column": 3,
-                          "end_line": 47,
-                          "end_column": 12
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
                         },
-                        "operator": "==",
-                        "left": {
-                          "kind": "var",
-                          "type": {
-                            "kind": "named",
-                            "name": "OrderStatus"
-                          },
-                          "span": {
-                            "file": "expressions_valid.fsl",
-                            "line": 47,
-                            "column": 3,
-                            "end_line": 47,
-                            "end_column": 12
-                          },
-                          "name": "order_status"
+                        "name": "order_status"
+                      },
+                      "right": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "OrderStatus"
                         },
-                        "right": {
-                          "kind": "var",
-                          "type": {
-                            "kind": "named",
-                            "name": "OrderStatus"
-                          },
-                          "span": {
-                            "file": "expressions_valid.fsl",
-                            "line": 47,
-                            "column": 3,
-                            "end_line": 47,
-                            "end_column": 12
-                          },
-                          "name": "OrderStatus_Cancelled"
-                        }
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
+                        },
+                        "name": "OrderStatus_Approved"
+                      }
+                    }
+                  },
+                  "right": {
+                    "kind": "not",
+                    "type": {
+                      "kind": "bool"
+                    },
+                    "span": {
+                      "file": "expressions_valid.fsl",
+                      "line": 77,
+                      "column": 5,
+                      "end_line": 79,
+                      "end_column": 6
+                    },
+                    "operand": {
+                      "kind": "binary",
+                      "type": {
+                        "kind": "bool"
+                      },
+                      "span": {
+                        "file": "expressions_valid.fsl",
+                        "line": 77,
+                        "column": 5,
+                        "end_line": 79,
+                        "end_column": 6
+                      },
+                      "operator": "==",
+                      "left": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "OrderStatus"
+                        },
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
+                        },
+                        "name": "order_status"
+                      },
+                      "right": {
+                        "kind": "var",
+                        "type": {
+                          "kind": "named",
+                          "name": "OrderStatus"
+                        },
+                        "span": {
+                          "file": "expressions_valid.fsl",
+                          "line": 77,
+                          "column": 5,
+                          "end_line": 79,
+                          "end_column": 6
+                        },
+                        "name": "OrderStatus_Cancelled"
                       }
                     }
                   }
@@ -5198,10 +5198,10 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 47,
-              "column": 3,
-              "end_line": 47,
-              "end_column": 12
+              "line": 77,
+              "column": 5,
+              "end_line": 79,
+              "end_column": 6
             }
           }
         ],
@@ -5215,19 +5215,19 @@
             },
             "span": {
               "file": "expressions_valid.fsl",
-              "line": 50,
-              "column": 3,
-              "end_line": 50,
-              "end_column": 11
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "value": false
           },
           "span": {
             "file": "expressions_valid.fsl",
-            "line": 50,
-            "column": 3,
-            "end_line": 50,
-            "end_column": 11
+            "line": 1,
+            "column": 1,
+            "end_line": 1,
+            "end_column": 1
           }
         }
       }
@@ -5365,10 +5365,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 18,
-              "column": 5,
-              "end_line": 18,
-              "end_column": 17
+              "line": 11,
+              "column": 13,
+              "end_line": 11,
+              "end_column": 36
             },
             "target": {
               "kind": "var",
@@ -5378,10 +5378,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 18,
-                "column": 5,
-                "end_line": 18,
-                "end_column": 17
+                "line": 11,
+                "column": 13,
+                "end_line": 11,
+                "end_column": 36
               },
               "name": "order_status"
             },
@@ -5393,10 +5393,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 18,
-                "column": 5,
-                "end_line": 18,
-                "end_column": 17
+                "line": 11,
+                "column": 13,
+                "end_line": 11,
+                "end_column": 36
               },
               "name": "Status_Draft"
             }
@@ -5408,10 +5408,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 19,
-              "column": 5,
-              "end_line": 19,
-              "end_column": 19
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -5420,10 +5420,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 19,
-                "column": 5,
-                "end_line": 19,
-                "end_column": 19
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_Approved"
             },
@@ -5434,10 +5434,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 19,
-                "column": 5,
-                "end_line": 19,
-                "end_column": 19
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -5449,10 +5449,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 20,
-              "column": 5,
-              "end_line": 20,
-              "end_column": 26
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -5461,10 +5461,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 20,
-                "column": 5,
-                "end_line": 20,
-                "end_column": 26
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_PaymentCaptured"
             },
@@ -5475,10 +5475,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 20,
-                "column": 5,
-                "end_line": 20,
-                "end_column": 26
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -5490,10 +5490,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 21,
-              "column": 5,
-              "end_line": 21,
-              "end_column": 24
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -5502,10 +5502,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 21,
-                "column": 5,
-                "end_line": 21,
-                "end_column": 24
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_PaymentFailed"
             },
@@ -5516,10 +5516,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 21,
-                "column": 5,
-                "end_line": 21,
-                "end_column": 24
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -5531,10 +5531,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 22,
-              "column": 5,
-              "end_line": 22,
-              "end_column": 27
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -5543,10 +5543,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 22,
-                "column": 5,
-                "end_line": 22,
-                "end_column": 27
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_PaymentRequested"
             },
@@ -5557,10 +5557,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 22,
-                "column": 5,
-                "end_line": 22,
-                "end_column": 27
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -5572,10 +5572,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 23,
-              "column": 5,
-              "end_line": 23,
-              "end_column": 26
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "target": {
               "kind": "var",
@@ -5584,10 +5584,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 23,
-                "column": 5,
-                "end_line": 23,
-                "end_column": 26
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "name": "event_PaymentTimedOut"
             },
@@ -5598,10 +5598,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 23,
-                "column": 5,
-                "end_line": 23,
-                "end_column": 26
+                "line": 1,
+                "column": 1,
+                "end_line": 1,
+                "end_column": 1
               },
               "value": false
             }
@@ -5613,10 +5613,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 24,
-              "column": 5,
-              "end_line": 24,
-              "end_column": 11
+              "line": 38,
+              "column": 3,
+              "end_line": 38,
+              "end_column": 3
             },
             "binder": {
               "name": "k",
@@ -5634,10 +5634,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 24,
-                  "column": 34,
-                  "end_line": 24,
-                  "end_column": 56
+                  "line": 38,
+                  "column": 3,
+                  "end_line": 38,
+                  "end_column": 3
                 },
                 "target": {
                   "kind": "index",
@@ -5647,10 +5647,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 24,
-                    "column": 34,
-                    "end_line": 24,
-                    "end_column": 56
+                    "line": 38,
+                    "column": 3,
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "name": "capture_payment_status",
                   "index": {
@@ -5661,10 +5661,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 24,
-                      "column": 34,
-                      "end_line": 24,
-                      "end_column": 56
+                      "line": 38,
+                      "column": 3,
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "name": "k"
                   }
@@ -5677,10 +5677,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 24,
-                    "column": 34,
-                    "end_line": 24,
-                    "end_column": 56
+                    "line": 38,
+                    "column": 3,
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "name": "CapturePaymentEffectStatus_NotStarted"
                 }
@@ -5694,10 +5694,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 25,
-              "column": 5,
-              "end_line": 25,
-              "end_column": 11
+              "line": 38,
+              "column": 3,
+              "end_line": 38,
+              "end_column": 3
             },
             "binder": {
               "name": "k",
@@ -5715,10 +5715,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 25,
-                  "column": 34,
-                  "end_line": 25,
-                  "end_column": 58
+                  "line": 38,
+                  "column": 3,
+                  "end_line": 38,
+                  "end_column": 3
                 },
                 "target": {
                   "kind": "index",
@@ -5728,10 +5728,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 25,
-                    "column": 34,
-                    "end_line": 25,
-                    "end_column": 58
+                    "line": 38,
+                    "column": 3,
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "name": "capture_payment_attempts",
                   "index": {
@@ -5742,10 +5742,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 25,
-                      "column": 34,
-                      "end_line": 25,
-                      "end_column": 58
+                      "line": 38,
+                      "column": 3,
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "name": "k"
                   }
@@ -5759,10 +5759,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 25,
-                    "column": 34,
-                    "end_line": 25,
-                    "end_column": 58
+                    "line": 38,
+                    "column": 3,
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "value": 0
                 }
@@ -5778,10 +5778,10 @@
         },
         "span": {
           "file": "effect_saga_valid.fsl",
-          "line": 18,
-          "column": 5,
-          "end_line": 18,
-          "end_column": 17
+          "line": 11,
+          "column": 13,
+          "end_line": 11,
+          "end_column": 36
         }
       },
       "actions": [
@@ -5798,10 +5798,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 50,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 50,
-                  "end_column": 13
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "operator": "==",
                 "left": {
@@ -5812,10 +5812,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 50,
+                    "line": 18,
                     "column": 5,
-                    "end_line": 50,
-                    "end_column": 13
+                    "end_line": 18,
+                    "end_column": 5
                   },
                   "collection": {
                     "kind": "var",
@@ -5832,10 +5832,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 50,
+                      "line": 18,
                       "column": 5,
-                      "end_line": 50,
-                      "end_column": 13
+                      "end_line": 18,
+                      "end_column": 5
                     },
                     "name": "capture_payment_status"
                   },
@@ -5847,10 +5847,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 50,
+                      "line": 18,
                       "column": 5,
-                      "end_line": 50,
-                      "end_column": 13
+                      "end_line": 18,
+                      "end_column": 5
                     },
                     "name": "payment_request_id"
                   }
@@ -5863,10 +5863,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 50,
+                    "line": 18,
                     "column": 5,
-                    "end_line": 50,
-                    "end_column": 13
+                    "end_line": 18,
+                    "end_column": 5
                   },
                   "name": "CapturePaymentEffectStatus_Pending"
                 }
@@ -5881,10 +5881,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 51,
+                "line": 18,
                 "column": 5,
-                "end_line": 51,
-                "end_column": 19
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -5893,10 +5893,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 51,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 51,
-                  "end_column": 19
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -5907,10 +5907,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 51,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 51,
-                  "end_column": 19
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -5922,10 +5922,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 52,
+                "line": 18,
                 "column": 5,
-                "end_line": 52,
-                "end_column": 26
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -5934,10 +5934,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 52,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 52,
-                  "end_column": 26
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -5948,10 +5948,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 52,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 52,
-                  "end_column": 26
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -5963,10 +5963,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 53,
+                "line": 18,
                 "column": 5,
-                "end_line": 53,
-                "end_column": 24
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -5975,10 +5975,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 53,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 53,
-                  "end_column": 24
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "event_PaymentFailed"
               },
@@ -5989,10 +5989,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 53,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 53,
-                  "end_column": 24
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6004,10 +6004,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 54,
+                "line": 18,
                 "column": 5,
-                "end_line": 54,
-                "end_column": 27
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6016,10 +6016,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 54,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 54,
-                  "end_column": 27
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "event_PaymentRequested"
               },
@@ -6030,10 +6030,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 54,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 54,
-                  "end_column": 27
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6045,10 +6045,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 55,
+                "line": 18,
                 "column": 5,
-                "end_line": 55,
-                "end_column": 26
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6057,10 +6057,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 55,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 55,
-                  "end_column": 26
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -6071,10 +6071,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 55,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 55,
-                  "end_column": 26
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6086,10 +6086,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 56,
+                "line": 18,
                 "column": 5,
-                "end_line": 56,
-                "end_column": 27
+                "end_line": 18,
+                "end_column": 5
               },
               "target": {
                 "kind": "index",
@@ -6099,10 +6099,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 56,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 56,
-                  "end_column": 27
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "capture_payment_status",
                 "index": {
@@ -6113,10 +6113,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 56,
+                    "line": 18,
                     "column": 5,
-                    "end_line": 56,
-                    "end_column": 27
+                    "end_line": 18,
+                    "end_column": 5
                   },
                   "name": "payment_request_id"
                 }
@@ -6129,10 +6129,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 56,
+                  "line": 18,
                   "column": 5,
-                  "end_line": 56,
-                  "end_column": 27
+                  "end_line": 18,
+                  "end_column": 5
                 },
                 "name": "CapturePaymentEffectStatus_Succeeded"
               }
@@ -6144,10 +6144,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 57,
-                "column": 5,
-                "end_line": 57,
-                "end_column": 17
+                "line": 33,
+                "column": 30,
+                "end_line": 33,
+                "end_column": 43
               },
               "target": {
                 "kind": "var",
@@ -6157,10 +6157,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 57,
-                  "column": 5,
-                  "end_line": 57,
-                  "end_column": 17
+                  "line": 33,
+                  "column": 30,
+                  "end_line": 33,
+                  "end_column": 43
                 },
                 "name": "order_status"
               },
@@ -6172,10 +6172,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 57,
-                  "column": 5,
-                  "end_line": 57,
-                  "end_column": 17
+                  "line": 33,
+                  "column": 30,
+                  "end_line": 33,
+                  "end_column": 43
                 },
                 "name": "Status_Paid"
               }
@@ -6189,10 +6189,10 @@
           },
           "span": {
             "file": "effect_saga_valid.fsl",
-            "line": 49,
-            "column": 3,
-            "end_line": 49,
-            "end_column": 9
+            "line": 18,
+            "column": 5,
+            "end_line": 18,
+            "end_column": 5
           }
         },
         {
@@ -6208,10 +6208,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 28,
-                  "column": 5,
-                  "end_line": 28,
-                  "end_column": 13
+                  "line": 23,
+                  "column": 16,
+                  "end_line": 23,
+                  "end_column": 31
                 },
                 "operator": "==",
                 "left": {
@@ -6222,10 +6222,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 28,
-                    "column": 5,
-                    "end_line": 28,
-                    "end_column": 13
+                    "line": 23,
+                    "column": 16,
+                    "end_line": 23,
+                    "end_column": 31
                   },
                   "name": "order_status"
                 },
@@ -6237,10 +6237,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 28,
-                    "column": 5,
-                    "end_line": 28,
-                    "end_column": 13
+                    "line": 23,
+                    "column": 16,
+                    "end_line": 23,
+                    "end_column": 31
                   },
                   "name": "Status_Draft"
                 }
@@ -6255,10 +6255,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 29,
+                "line": 22,
                 "column": 5,
-                "end_line": 29,
-                "end_column": 19
+                "end_line": 22,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6267,10 +6267,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 29,
+                  "line": 22,
                   "column": 5,
-                  "end_line": 29,
-                  "end_column": 19
+                  "end_line": 22,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -6281,10 +6281,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 29,
+                  "line": 22,
                   "column": 5,
-                  "end_line": 29,
-                  "end_column": 19
+                  "end_line": 22,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -6296,10 +6296,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 30,
+                "line": 22,
                 "column": 5,
-                "end_line": 30,
-                "end_column": 26
+                "end_line": 22,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6308,10 +6308,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 30,
+                  "line": 22,
                   "column": 5,
-                  "end_line": 30,
-                  "end_column": 26
+                  "end_line": 22,
+                  "end_column": 5
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -6322,10 +6322,133 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 30,
+                  "line": 22,
                   "column": 5,
-                  "end_line": 30,
-                  "end_column": 26
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 5
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "name": "event_PaymentFailed"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 5
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "name": "event_PaymentRequested"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "value": false
+              }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 22,
+                "column": 5,
+                "end_line": 22,
+                "end_column": 5
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
+                },
+                "name": "event_PaymentTimedOut"
+              },
+              "value": {
+                "kind": "bool",
+                "type": {
+                  "kind": "bool"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 22,
+                  "column": 5,
+                  "end_line": 22,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6338,132 +6461,9 @@
               "span": {
                 "file": "effect_saga_valid.fsl",
                 "line": 31,
-                "column": 5,
+                "column": 23,
                 "end_line": 31,
-                "end_column": 24
-              },
-              "target": {
-                "kind": "var",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 31,
-                  "column": 5,
-                  "end_line": 31,
-                  "end_column": 24
-                },
-                "name": "event_PaymentFailed"
-              },
-              "value": {
-                "kind": "bool",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 31,
-                  "column": 5,
-                  "end_line": 31,
-                  "end_column": 24
-                },
-                "value": false
-              }
-            },
-            {
-              "kind": "assign",
-              "type": {
-                "kind": "statement"
-              },
-              "span": {
-                "file": "effect_saga_valid.fsl",
-                "line": 32,
-                "column": 5,
-                "end_line": 32,
-                "end_column": 27
-              },
-              "target": {
-                "kind": "var",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 32,
-                  "column": 5,
-                  "end_line": 32,
-                  "end_column": 27
-                },
-                "name": "event_PaymentRequested"
-              },
-              "value": {
-                "kind": "bool",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 32,
-                  "column": 5,
-                  "end_line": 32,
-                  "end_column": 27
-                },
-                "value": false
-              }
-            },
-            {
-              "kind": "assign",
-              "type": {
-                "kind": "statement"
-              },
-              "span": {
-                "file": "effect_saga_valid.fsl",
-                "line": 33,
-                "column": 5,
-                "end_line": 33,
-                "end_column": 26
-              },
-              "target": {
-                "kind": "var",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 33,
-                  "column": 5,
-                  "end_line": 33,
-                  "end_column": 26
-                },
-                "name": "event_PaymentTimedOut"
-              },
-              "value": {
-                "kind": "bool",
-                "type": {
-                  "kind": "bool"
-                },
-                "span": {
-                  "file": "effect_saga_valid.fsl",
-                  "line": 33,
-                  "column": 5,
-                  "end_line": 33,
-                  "end_column": 26
-                },
-                "value": false
-              }
-            },
-            {
-              "kind": "assign",
-              "type": {
-                "kind": "statement"
-              },
-              "span": {
-                "file": "effect_saga_valid.fsl",
-                "line": 34,
-                "column": 5,
-                "end_line": 34,
-                "end_column": 17
+                "end_column": 40
               },
               "target": {
                 "kind": "var",
@@ -6473,10 +6473,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 34,
-                  "column": 5,
-                  "end_line": 34,
-                  "end_column": 17
+                  "line": 31,
+                  "column": 23,
+                  "end_line": 31,
+                  "end_column": 40
                 },
                 "name": "order_status"
               },
@@ -6488,10 +6488,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 34,
-                  "column": 5,
-                  "end_line": 34,
-                  "end_column": 17
+                  "line": 31,
+                  "column": 23,
+                  "end_line": 31,
+                  "end_column": 40
                 },
                 "name": "Status_Approved"
               }
@@ -6505,10 +6505,10 @@
           },
           "span": {
             "file": "effect_saga_valid.fsl",
-            "line": 27,
-            "column": 3,
-            "end_line": 27,
-            "end_column": 9
+            "line": 22,
+            "column": 5,
+            "end_line": 22,
+            "end_column": 5
           }
         },
         {
@@ -6524,10 +6524,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 37,
-                  "column": 5,
-                  "end_line": 37,
-                  "end_column": 13
+                  "line": 27,
+                  "column": 16,
+                  "end_line": 27,
+                  "end_column": 34
                 },
                 "operator": "==",
                 "left": {
@@ -6538,10 +6538,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 37,
-                    "column": 5,
-                    "end_line": 37,
-                    "end_column": 13
+                    "line": 27,
+                    "column": 16,
+                    "end_line": 27,
+                    "end_column": 34
                   },
                   "name": "order_status"
                 },
@@ -6553,10 +6553,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 37,
-                    "column": 5,
-                    "end_line": 37,
-                    "end_column": 13
+                    "line": 27,
+                    "column": 16,
+                    "end_line": 27,
+                    "end_column": 34
                   },
                   "name": "Status_Approved"
                 }
@@ -6571,10 +6571,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 38,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 38,
-                  "end_column": 13
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "operator": "!=",
                 "left": {
@@ -6585,10 +6585,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 38,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 38,
-                    "end_column": 13
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "collection": {
                     "kind": "var",
@@ -6605,10 +6605,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 38,
+                      "line": 26,
                       "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "end_line": 26,
+                      "end_column": 5
                     },
                     "name": "capture_payment_status"
                   },
@@ -6620,10 +6620,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 38,
+                      "line": 26,
                       "column": 5,
-                      "end_line": 38,
-                      "end_column": 13
+                      "end_line": 26,
+                      "end_column": 5
                     },
                     "name": "payment_request_id"
                   }
@@ -6636,10 +6636,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 38,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 38,
-                    "end_column": 13
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "name": "CapturePaymentEffectStatus_Pending"
                 }
@@ -6654,10 +6654,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 39,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 39,
-                  "end_column": 13
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "operator": "!=",
                 "left": {
@@ -6668,10 +6668,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 39,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 39,
-                    "end_column": 13
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "collection": {
                     "kind": "var",
@@ -6688,10 +6688,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 39,
+                      "line": 26,
                       "column": 5,
-                      "end_line": 39,
-                      "end_column": 13
+                      "end_line": 26,
+                      "end_column": 5
                     },
                     "name": "capture_payment_status"
                   },
@@ -6703,10 +6703,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 39,
+                      "line": 26,
                       "column": 5,
-                      "end_line": 39,
-                      "end_column": 13
+                      "end_line": 26,
+                      "end_column": 5
                     },
                     "name": "payment_request_id"
                   }
@@ -6719,10 +6719,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 39,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 39,
-                    "end_column": 13
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "name": "CapturePaymentEffectStatus_Succeeded"
                 }
@@ -6737,10 +6737,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 40,
+                "line": 26,
                 "column": 5,
-                "end_line": 40,
-                "end_column": 19
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6749,10 +6749,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 40,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 40,
-                  "end_column": 19
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -6763,10 +6763,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 40,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 40,
-                  "end_column": 19
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6778,10 +6778,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 41,
+                "line": 26,
                 "column": 5,
-                "end_line": 41,
-                "end_column": 26
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6790,10 +6790,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 41,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 41,
-                  "end_column": 26
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -6804,10 +6804,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 41,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 41,
-                  "end_column": 26
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6819,10 +6819,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 42,
+                "line": 26,
                 "column": 5,
-                "end_line": 42,
-                "end_column": 24
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6831,10 +6831,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 42,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 42,
-                  "end_column": 24
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "event_PaymentFailed"
               },
@@ -6845,10 +6845,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 42,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 42,
-                  "end_column": 24
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6860,10 +6860,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 43,
+                "line": 26,
                 "column": 5,
-                "end_line": 43,
-                "end_column": 27
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6872,10 +6872,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 43,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 43,
-                  "end_column": 27
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "event_PaymentRequested"
               },
@@ -6886,10 +6886,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 43,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 43,
-                  "end_column": 27
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -6901,10 +6901,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 44,
+                "line": 26,
                 "column": 5,
-                "end_line": 44,
-                "end_column": 26
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -6913,10 +6913,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 44,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 44,
-                  "end_column": 26
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -6927,10 +6927,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 44,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 44,
-                  "end_column": 26
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -6942,10 +6942,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 45,
-                "column": 5,
-                "end_line": 45,
-                "end_column": 17
+                "line": 32,
+                "column": 31,
+                "end_line": 32,
+                "end_column": 48
               },
               "target": {
                 "kind": "var",
@@ -6955,10 +6955,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 45,
-                  "column": 5,
-                  "end_line": 45,
-                  "end_column": 17
+                  "line": 32,
+                  "column": 31,
+                  "end_line": 32,
+                  "end_column": 48
                 },
                 "name": "order_status"
               },
@@ -6970,10 +6970,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 45,
-                  "column": 5,
-                  "end_line": 45,
-                  "end_column": 17
+                  "line": 32,
+                  "column": 31,
+                  "end_line": 32,
+                  "end_column": 48
                 },
                 "name": "Status_Approved"
               }
@@ -6985,10 +6985,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 46,
+                "line": 26,
                 "column": 5,
-                "end_line": 46,
-                "end_column": 27
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "index",
@@ -6998,10 +6998,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 46,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 46,
-                  "end_column": 27
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "capture_payment_status",
                 "index": {
@@ -7012,10 +7012,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 46,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 46,
-                    "end_column": 27
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "name": "payment_request_id"
                 }
@@ -7028,10 +7028,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 46,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 46,
-                  "end_column": 27
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "CapturePaymentEffectStatus_Pending"
               }
@@ -7043,10 +7043,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 47,
+                "line": 26,
                 "column": 5,
-                "end_line": 47,
-                "end_column": 29
+                "end_line": 26,
+                "end_column": 5
               },
               "target": {
                 "kind": "index",
@@ -7056,10 +7056,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 47,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 47,
-                  "end_column": 29
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "name": "capture_payment_attempts",
                 "index": {
@@ -7070,10 +7070,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 47,
+                    "line": 26,
                     "column": 5,
-                    "end_line": 47,
-                    "end_column": 29
+                    "end_line": 26,
+                    "end_column": 5
                   },
                   "name": "payment_request_id"
                 }
@@ -7087,10 +7087,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 47,
+                  "line": 26,
                   "column": 5,
-                  "end_line": 47,
-                  "end_column": 29
+                  "end_line": 26,
+                  "end_column": 5
                 },
                 "value": 1
               }
@@ -7104,10 +7104,10 @@
           },
           "span": {
             "file": "effect_saga_valid.fsl",
-            "line": 36,
-            "column": 3,
-            "end_line": 36,
-            "end_column": 9
+            "line": 26,
+            "column": 5,
+            "end_line": 26,
+            "end_column": 5
           }
         },
         {
@@ -7123,10 +7123,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 115,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 115,
-                  "end_column": 13
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               }
@@ -7140,10 +7140,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 116,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 116,
-                  "end_column": 13
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "operator": "and",
                 "left": {
@@ -7153,10 +7153,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 116,
+                    "line": 52,
                     "column": 5,
-                    "end_line": 116,
-                    "end_column": 13
+                    "end_line": 52,
+                    "end_column": 5
                   },
                   "name": "event_Approved"
                 },
@@ -7167,10 +7167,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 116,
+                    "line": 52,
                     "column": 5,
-                    "end_line": 116,
-                    "end_column": 13
+                    "end_line": 52,
+                    "end_column": 5
                   },
                   "operand": {
                     "kind": "var",
@@ -7179,10 +7179,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 116,
+                      "line": 52,
                       "column": 5,
-                      "end_line": 116,
-                      "end_column": 13
+                      "end_line": 52,
+                      "end_column": 5
                     },
                     "name": "event_PaymentFailed"
                   }
@@ -7198,10 +7198,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 117,
+                "line": 52,
                 "column": 5,
-                "end_line": 117,
-                "end_column": 19
+                "end_line": 52,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -7210,10 +7210,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 117,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 117,
-                  "end_column": 19
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_Approved"
               },
@@ -7224,10 +7224,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 117,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 117,
-                  "end_column": 19
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -7239,10 +7239,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 118,
+                "line": 52,
                 "column": 5,
-                "end_line": 118,
-                "end_column": 26
+                "end_line": 52,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -7251,10 +7251,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 118,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 118,
-                  "end_column": 26
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -7265,10 +7265,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 118,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 118,
-                  "end_column": 26
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -7280,10 +7280,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 119,
+                "line": 52,
                 "column": 5,
-                "end_line": 119,
-                "end_column": 24
+                "end_line": 52,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -7292,10 +7292,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 119,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 119,
-                  "end_column": 24
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_PaymentFailed"
               },
@@ -7306,10 +7306,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 119,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 119,
-                  "end_column": 24
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -7321,10 +7321,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 120,
+                "line": 52,
                 "column": 5,
-                "end_line": 120,
-                "end_column": 27
+                "end_line": 52,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -7333,10 +7333,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 120,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 120,
-                  "end_column": 27
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_PaymentRequested"
               },
@@ -7347,10 +7347,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 120,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 120,
-                  "end_column": 27
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "value": true
               }
@@ -7362,10 +7362,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 121,
+                "line": 52,
                 "column": 5,
-                "end_line": 121,
-                "end_column": 26
+                "end_line": 52,
+                "end_column": 5
               },
               "target": {
                 "kind": "var",
@@ -7374,10 +7374,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 121,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 121,
-                  "end_column": 26
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -7388,10 +7388,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 121,
+                  "line": 52,
                   "column": 5,
-                  "end_line": 121,
-                  "end_column": 26
+                  "end_line": 52,
+                  "end_column": 5
                 },
                 "value": false
               }
@@ -7405,10 +7405,10 @@
           },
           "span": {
             "file": "effect_saga_valid.fsl",
-            "line": 114,
-            "column": 3,
-            "end_line": 114,
-            "end_column": 9
+            "line": 52,
+            "column": 5,
+            "end_line": 52,
+            "end_column": 5
           }
         }
       ],
@@ -7424,10 +7424,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 132,
-                "column": 3,
-                "end_line": 132,
-                "end_column": 12
+                "line": 59,
+                "column": 5,
+                "end_line": 61,
+                "end_column": 6
               },
               "operator": "=>",
               "left": {
@@ -7437,10 +7437,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 132,
-                  "column": 3,
-                  "end_line": 132,
-                  "end_column": 12
+                  "line": 59,
+                  "column": 5,
+                  "end_line": 61,
+                  "end_column": 6
                 },
                 "operator": "or",
                 "left": {
@@ -7450,10 +7450,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 132,
-                    "column": 3,
-                    "end_line": 132,
-                    "end_column": 12
+                    "line": 59,
+                    "column": 5,
+                    "end_line": 61,
+                    "end_column": 6
                   },
                   "operator": "or",
                   "left": {
@@ -7463,10 +7463,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 132,
-                      "column": 3,
-                      "end_line": 132,
-                      "end_column": 12
+                      "line": 59,
+                      "column": 5,
+                      "end_line": 61,
+                      "end_column": 6
                     },
                     "name": "event_PaymentCaptured"
                   },
@@ -7477,10 +7477,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 132,
-                      "column": 3,
-                      "end_line": 132,
-                      "end_column": 12
+                      "line": 59,
+                      "column": 5,
+                      "end_line": 61,
+                      "end_column": 6
                     },
                     "name": "event_PaymentFailed"
                   }
@@ -7492,10 +7492,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 132,
-                    "column": 3,
-                    "end_line": 132,
-                    "end_column": 12
+                    "line": 59,
+                    "column": 5,
+                    "end_line": 61,
+                    "end_column": 6
                   },
                   "name": "event_PaymentTimedOut"
                 }
@@ -7507,10 +7507,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 132,
-                  "column": 3,
-                  "end_line": 132,
-                  "end_column": 12
+                  "line": 59,
+                  "column": 5,
+                  "end_line": 61,
+                  "end_column": 6
                 },
                 "operand": {
                   "kind": "var",
@@ -7519,10 +7519,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 132,
-                    "column": 3,
-                    "end_line": 132,
-                    "end_column": 12
+                    "line": 59,
+                    "column": 5,
+                    "end_line": 61,
+                    "end_column": 6
                   },
                   "name": "event_PaymentRequested"
                 }
@@ -7536,10 +7536,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 132,
-              "column": 3,
-              "end_line": 132,
-              "end_column": 12
+              "line": 59,
+              "column": 5,
+              "end_line": 61,
+              "end_column": 6
             }
           }
         ],
@@ -7554,10 +7554,10 @@
               },
               "span": {
                 "file": "effect_saga_valid.fsl",
-                "line": 133,
+                "line": 38,
                 "column": 3,
-                "end_line": 133,
-                "end_column": 8
+                "end_line": 38,
+                "end_column": 3
               },
               "quantifier": "forall",
               "binder": {
@@ -7575,10 +7575,10 @@
                 },
                 "span": {
                   "file": "effect_saga_valid.fsl",
-                  "line": 133,
+                  "line": 38,
                   "column": 3,
-                  "end_line": 133,
-                  "end_column": 8
+                  "end_line": 38,
+                  "end_column": 3
                 },
                 "operator": "=>",
                 "left": {
@@ -7588,10 +7588,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 133,
+                    "line": 38,
                     "column": 3,
-                    "end_line": 133,
-                    "end_column": 8
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "operator": "==",
                   "left": {
@@ -7602,10 +7602,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 133,
+                      "line": 38,
                       "column": 3,
-                      "end_line": 133,
-                      "end_column": 8
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "operand": {
                       "kind": "index",
@@ -7615,10 +7615,10 @@
                       },
                       "span": {
                         "file": "effect_saga_valid.fsl",
-                        "line": 133,
+                        "line": 38,
                         "column": 3,
-                        "end_line": 133,
-                        "end_column": 8
+                        "end_line": 38,
+                        "end_column": 3
                       },
                       "collection": {
                         "kind": "var",
@@ -7635,10 +7635,10 @@
                         },
                         "span": {
                           "file": "effect_saga_valid.fsl",
-                          "line": 133,
+                          "line": 38,
                           "column": 3,
-                          "end_line": 133,
-                          "end_column": 8
+                          "end_line": 38,
+                          "end_column": 3
                         },
                         "name": "capture_payment_status"
                       },
@@ -7650,10 +7650,10 @@
                         },
                         "span": {
                           "file": "effect_saga_valid.fsl",
-                          "line": 133,
+                          "line": 38,
                           "column": 3,
-                          "end_line": 133,
-                          "end_column": 8
+                          "end_line": 38,
+                          "end_column": 3
                         },
                         "name": "k"
                       }
@@ -7667,10 +7667,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 133,
+                      "line": 38,
                       "column": 3,
-                      "end_line": 133,
-                      "end_column": 8
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "name": "CapturePaymentEffectStatus_Succeeded"
                   }
@@ -7682,10 +7682,10 @@
                   },
                   "span": {
                     "file": "effect_saga_valid.fsl",
-                    "line": 133,
+                    "line": 38,
                     "column": 3,
-                    "end_line": 133,
-                    "end_column": 8
+                    "end_line": 38,
+                    "end_column": 3
                   },
                   "operator": "==",
                   "left": {
@@ -7696,10 +7696,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 133,
+                      "line": 38,
                       "column": 3,
-                      "end_line": 133,
-                      "end_column": 8
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "collection": {
                       "kind": "var",
@@ -7716,10 +7716,10 @@
                       },
                       "span": {
                         "file": "effect_saga_valid.fsl",
-                        "line": 133,
+                        "line": 38,
                         "column": 3,
-                        "end_line": 133,
-                        "end_column": 8
+                        "end_line": 38,
+                        "end_column": 3
                       },
                       "name": "capture_payment_status"
                     },
@@ -7731,10 +7731,10 @@
                       },
                       "span": {
                         "file": "effect_saga_valid.fsl",
-                        "line": 133,
+                        "line": 38,
                         "column": 3,
-                        "end_line": 133,
-                        "end_column": 8
+                        "end_line": 38,
+                        "end_column": 3
                       },
                       "name": "k"
                     }
@@ -7747,10 +7747,10 @@
                     },
                     "span": {
                       "file": "effect_saga_valid.fsl",
-                      "line": 133,
+                      "line": 38,
                       "column": 3,
-                      "end_line": 133,
-                      "end_column": 8
+                      "end_line": 38,
+                      "end_column": 3
                     },
                     "name": "CapturePaymentEffectStatus_Succeeded"
                   }
@@ -7765,10 +7765,10 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 133,
+              "line": 38,
               "column": 3,
-              "end_line": 133,
-              "end_column": 8
+              "end_line": 38,
+              "end_column": 3
             }
           }
         ],
@@ -7781,30 +7781,30 @@
             },
             "span": {
               "file": "effect_saga_valid.fsl",
-              "line": 134,
-              "column": 3,
-              "end_line": 134,
-              "end_column": 11
+              "line": 1,
+              "column": 1,
+              "end_line": 1,
+              "end_column": 1
             },
             "value": false
           },
           "span": {
             "file": "effect_saga_valid.fsl",
-            "line": 134,
-            "column": 3,
-            "end_line": 134,
-            "end_column": 11
+            "line": 1,
+            "column": 1,
+            "end_line": 1,
+            "end_column": 1
           }
         }
       }
     }
   },
-  "known_generated_spans": [
+  "direct_domain_spans": [
     {
-      "classification": "known_generated_kernel_coordinate_attached_to_source_file",
+      "classification": "original_domain_coordinate_preserved",
       "file": "expressions_valid.fsl",
       "source_declaration_line": 39,
-      "reported_public_kernel_line": 24,
+      "reported_public_kernel_line": 39,
       "origin": {
         "dialect": "domain",
         "declaration": "order_approve",
@@ -7813,10 +7813,10 @@
       }
     },
     {
-      "classification": "known_generated_kernel_coordinate_attached_to_source_file",
+      "classification": "original_domain_coordinate_preserved",
       "file": "effect_saga_valid.fsl",
       "source_declaration_line": 22,
-      "reported_public_kernel_line": 27,
+      "reported_public_kernel_line": 22,
       "origin": {
         "dialect": "domain",
         "declaration": "order_approve",
@@ -7918,8 +7918,8 @@
                   "name": "order_cancel",
                   "params": {},
                   "loc": {
-                    "line": 37,
-                    "column": 3
+                    "line": 46,
+                    "column": 5
                   }
                 },
                 "changes": {
@@ -7999,12 +7999,27 @@
         }
       },
       "verify": {
-        "exit": 2,
+        "exit": 0,
         "output": {
           "fsl": "1.0",
-          "result": "error",
-          "kind": "semantics",
-          "message": "indexing requires a map or sequence"
+          "spec": "DomainLvalueCharacterization",
+          "result": "verified",
+          "depth": 2,
+          "checked_to_depth": 2,
+          "completeness": "bounded",
+          "invariants_checked": [
+            "_bounds_inventory_total",
+            "_bounds_inventory_counts",
+            "_bounds_inventory_counter"
+          ],
+          "transitions_checked": [],
+          "reachables": {},
+          "action_coverage": {
+            "inventory_adjust": true
+          },
+          "deadlock": {
+            "found": false
+          }
         }
       }
     },
@@ -8030,11 +8045,12 @@
     },
     "invalid_unknown_name.fsl": {
       "check": {
-        "exit": 0,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "result": "ok",
-          "spec": "InvalidUnknownName"
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown domain symbol 'missing_status' at 10:29"
         }
       },
       "verify": {
@@ -8043,17 +8059,18 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown identifier 'missing_status'"
+          "message": "unknown domain symbol 'missing_status' at 10:29"
         }
       }
     },
     "invalid_unknown_member.fsl": {
       "check": {
-        "exit": 0,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "result": "ok",
-          "spec": "InvalidUnknownMember"
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown domain symbol 'Cancelled' at 10:41"
         }
       },
       "verify": {
@@ -8062,64 +8079,27 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown identifier 'Cancelled'"
+          "message": "unknown domain symbol 'Cancelled' at 10:41"
         }
       }
     },
     "invalid_type_mismatch.fsl": {
       "check": {
-        "exit": 0,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "result": "ok",
-          "spec": "InvalidTypeMismatch"
+          "result": "error",
+          "kind": "semantics",
+          "message": "comparison operand type mismatch at 10:37"
         }
       },
       "verify": {
-        "exit": 1,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "spec": "InvalidTypeMismatch",
-          "result": "violated",
-          "violation_kind": "invariant",
-          "invariant": "Order_typeMismatch",
-          "requirement": {
-            "id": "DOMAIN-INVARIANT",
-            "text": "Order.typeMismatch"
-          },
-          "loc": {
-            "line": 15,
-            "column": 3
-          },
-          "violated_at_step": 0,
-          "violating_bindings": [
-            {}
-          ],
-          "blame": {
-            "conjuncts": [
-              {
-                "index": 0,
-                "text": "order_status == 1",
-                "holds": false,
-                "violating_bindings": [
-                  {}
-                ]
-              }
-            ]
-          },
-          "last_action": null,
-          "trace": [
-            {
-              "step": 0,
-              "state": {
-                "event_Touched": false,
-                "order_status": "Status_Draft"
-              }
-            }
-          ],
-          "checked_to_depth": 0,
-          "completeness": "bounded",
-          "trace_type": "invariant"
+          "result": "error",
+          "kind": "semantics",
+          "message": "comparison operand type mismatch at 10:37"
         }
       }
     },
@@ -8165,34 +8145,21 @@
     },
     "ai_internal_name_misuse.fsl": {
       "check": {
-        "exit": 0,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "result": "ok",
-          "spec": "AiInternalNameMisuse"
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown domain symbol 'Status_Draft' at 10:41"
         }
       },
       "verify": {
-        "exit": 0,
+        "exit": 2,
         "output": {
           "fsl": "1.0",
-          "spec": "AiInternalNameMisuse",
-          "result": "verified",
-          "depth": 2,
-          "checked_to_depth": 2,
-          "completeness": "bounded",
-          "invariants_checked": [
-            "_bounds_order_status",
-            "Order_generatedName"
-          ],
-          "transitions_checked": [],
-          "reachables": {},
-          "action_coverage": {
-            "order_touch": true
-          },
-          "deadlock": {
-            "found": false
-          }
+          "result": "error",
+          "kind": "semantics",
+          "message": "unknown domain symbol 'Status_Draft' at 10:41"
         }
       }
     }

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -227,8 +227,12 @@ errors, pure `decide`/`evolve`, async effect lifecycles, and saga/process-manage
 coordination. It lowers to kernel actions/state/invariants plus finite effect
 status/attempt maps. Domain enum members are namespaced during lowering, so
 separate enums may reuse words like `Pending`. Domain expressions may use `X in
-[A, B]` and `can(Command)`.
-Use `fslc domain check` for `verified_under_assumptions` plus fsl-domain
+[A, B]` and `can(Command)`. Rust resolves these constructs structurally: bare
+enum members use the expected field type, membership becomes a finite equality
+disjunction, and `can()` expands the selected current-aggregate command's
+preconditions. Unknown/ambiguous symbols and type mismatches point to the
+original domain expression. Use `fslc domain check` for
+`verified_under_assumptions` plus fsl-domain
 findings, `fslc domain expand` to inspect the generated kernel, and
 `fslc domain generate --target typescript|python|kotlin|swift|rust` /
 `fslc domain testgen` for Functional DDD and adapter scaffolds. Use


### PR DESCRIPTION
## Problem

The Rust domain pipeline still rendered generated Kernel source and reparsed it, while expression normalization depended on string rewriting. That made symbol resolution ambiguous, lost original source locations, and allowed invalid domain expressions to fail late.

## Contract change

- Resolve domain symbols and logical types directly from the typed domain AST.
- Lower expressions, membership, `can(...)`, state reads/writes, nested lvalues, actions, effects, and sagas directly into Kernel surface AST.
- Preserve original domain spans in diagnostics.
- Fail closed for unknown/ambiguous symbols, invalid methods/structs/patterns, Option misuse, and nonnumeric ordering.
- Keep `domain expand` generated Kernel text as a debug/interoperability view only; it is no longer semantic input.
- Preserve Monitor/symbolic agreement and update the #235 characterization baseline for intentional direct-origin behavior.

Rust is the authoritative implementation; the frozen Python product behavior is unchanged.

## Evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py -q` (10 passed)
- `.venv/bin/python -m pytest tests/test_site_reference_snapshot.py -q` (3 passed)
- Independent final review: clean, no actionable findings

Documentation, generated language reference pages, skill reference, characterization fixtures, and changelog are updated.

Closes #239
