### PR TITLE
fix(ci): preserve LF for coverage golden

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+rust/fslc/tests/fixtures/conformance_coverage.v1.md text eol=lf
+rust/fslc/tests/fixtures/typestate_order.v1.json text eol=lf
+rust/fslc/tests/fixtures/typestate_order.v1.ts text eol=lf
+tests/snapshots/approval_ledger.md text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   instead of a generated Kernel coordinate.
 
 ### Fixed
+- Windows native CI now keeps the conformance coverage and approval Markdown
+  snapshots on LF and canonicalizes both the specification and repository-root
+  paths before binding approval records to Git, avoiding false snapshot drift
+  and false "outside its Git repository" errors without weakening exact checks.
 - Rust CLI contract validation (issue #220) now preserves exact compatibility
   with the frozen Python surface while checking native-only commands and
   options against an explicit structural allowlist. CI runs the focused

--- a/rust/fslc/src/approval.rs
+++ b/rust/fslc/src/approval.rs
@@ -236,7 +236,9 @@ pub fn git_location(path: &Path) -> Result<(PathBuf, String, String), String> {
     let root = PathBuf::from(git_output(
         absolute.parent().unwrap_or_else(|| Path::new(".")),
         &["rev-parse", "--show-toplevel"],
-    )?);
+    )?)
+    .canonicalize()
+    .map_err(|error| error.to_string())?;
     let relative = absolute
         .strip_prefix(&root)
         .map_err(|_| "spec is outside its Git repository".to_owned())?


### PR DESCRIPTION
## Summary

Fix the recurring Windows CI failures by canonicalizing the coverage golden's
checkout line endings and the Git paths used for approval binding.

## Why

- **Root causes:** Windows checked out `conformance_coverage.v1.md` with CRLF while the generator emits LF. Once that failure was removed, approval tests exposed a second path-representation mismatch: Rust canonicalized the spec to `\\?\C:\...`, while Git reported the same root as `C:/...`.
- **Reason:** A path-specific Git attribute preserves the exact golden comparison. Canonicalizing both filesystem operands preserves the repository-boundary check while making equivalent Windows paths comparable.
- **Alternatives:** Test-side newline normalization was rejected because it weakens byte-exact comparison. Exporting private approval internals only for an integration test was rejected because existing end-to-end tests already exercise real temporary Git repositories.

## What Changed

- Added path-specific `.gitattributes` rules for the four byte-exact text snapshots exercised by Windows: conformance coverage Markdown, approval ledger Markdown, and typestate JSON/TypeScript.
- Canonicalize the Git-reported repository root before deriving the repository-relative approval spec path.
- No test logic, golden content, solver behavior, or JSON/exit-code contract changed.

## Blast Radius and Invariants

- **Affected:** Worktree line endings for four byte-exact text snapshots and path normalization inside approval Git binding.
- **Unaffected:** Other Markdown, Rust sources, generated output, CLI/Worker contracts, and verification semantics; `git check-attr` reports their attributes as unspecified.
- **Must stay true:** The generated Markdown and checked-in golden remain byte-exact after canonical LF checkout. A violation is detected by `coverage_matrix_matches_the_v1_golden_json_and_markdown`.

## Failure Modes

- A typo in the path would leave Windows CI failing; the Windows matrix detects it.
- An overly broad pattern could affect unrelated files; all rules name exact paths and `git check-attr` confirms unrelated paths remain unspecified.
- A real golden-content drift still fails the unchanged exact assertion.
- A genuinely outside or untracked spec is still rejected by the unchanged `strip_prefix` and `git ls-files --error-unmatch` guards.

## Evidence

- Source failure: https://github.com/ymm-oss/fsl/actions/runs/29298483509/job/86977056031
- `git check-attr text eol -- rust/fslc/tests/fixtures/conformance_coverage.v1.md` → `text: set`, `eol: lf`
- `cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test conformance_coverage` → 5 passed, 0 failed
- `cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test issue_190_approval` → 3 passed, 0 failed
- `cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test kernel_contract` → 14 passed, 0 failed
- `cargo clippy --manifest-path rust/Cargo.toml --locked -p fslc-rust --all-targets -- -D warnings` → passed
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` → passed
- Final manual matrix: Windows, Ubuntu, macOS 14, Rust CLI compatibility, and workspace/WASM passed in https://github.com/ymm-oss/fsl/actions/runs/29300654137
- Independent final review found no unintended impact or missing change.

## Rollout and Rollback

- **Rollout:** Merge the attribute rule; fresh Windows checkouts materialize the fixture with LF.
- **Rollback:** Revert this commit. No data migration, record rewrite, or irreversible state exists.

## Review Focus

- Confirm the rules are restricted to the four byte-exact text snapshots.
- Confirm both spec and repository root are canonicalized before the boundary check.
- Confirm the Windows Actions job passes before merge.

## Unknowns / Merge Condition

- The final Windows native Z3 job passed all tests. The manual matrix's macOS 15 Intel job was independently classified as an external `z3-sys` download HTTP 403; macOS 14 and the same native command on Ubuntu and Windows passed.
- No documentation update is required because language or CLI contracts do not change.
