### PR TITLE
feat(origin): trace domain provenance through diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Changed
+- Native Rust domain lowering now carries a non-serialized origin chain from typed
+  domain nodes through Surface/Kernel models into validation, verification,
+  counterexamples, and `explain`. Source identity/full spans, declaration
+  paths, lowering steps, primary/secondary sources, one-to-many/many-to-one,
+  and generated-only nodes remain distinguishable; requirement traceability is
+  stored separately. Diagnostics prefer user declarations and retain generated
+  Kernel names as machine detail. Public Kernel v1 schema/version/goldens and
+  default `fslc kernel` output remain unchanged (issue #240; v2 publication is
+  tracked by #256). Rust consumers should construct parser/model values through
+  the supported parse/build APIs rather than struct literals because the
+  internal span and origin carriers add fields to those implementation types.
 - Native Rust domain lowering (issue #239) now resolves typed domain symbols,
   enum members, `can()`, finite membership, state reads, and nested lvalues
   structurally, then builds Kernel AST directly without generated-source

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -121,6 +121,15 @@ debug/interop view, but that text is not semantic input. This separation also
 lets public Kernel diagnostics and origins use domain declaration/expression
 coordinates rather than generated-source coordinates.
 
+The Rust path records those coordinates in the non-serialized origin graph described
+by [`DESIGN-origin-chain.md`](DESIGN-origin-chain.md). Checked state, action,
+guard, statement, and property targets retain source identity, full span,
+declaration path, and lowering steps. `can()` and membership expansions share
+the source expression's stable identity across generated targets; merged
+actions retain the decision as primary and the command as secondary. Synthetic
+event flags and terminal nodes are explicitly generated-only. Requirement tags
+remain a separate traceability relation.
+
 ## Effects
 
 An async `effect` declares the request event, completion events, correlation id,

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -46,6 +46,15 @@ direct spans for scalar/type/state declarations, so those declaration spans are
 explicitly `null`; their origin remains present. This is an intentional v1
 distinction, not a missing field.
 
+That v1 `origin` object is a frozen, lossy compatibility projection. The Rust
+frontend's authoritative internal provenance is the non-serialized origin chain in
+[`DESIGN-origin-chain.md`](DESIGN-origin-chain.md), where declaration/source
+origin and requirement traceability are separate types. The historical v1
+projection may still place a requirement tag in `origin.declaration` to remain
+byte-compatible; internal consumers must not infer source identity from it.
+The internal chain is absent from this closed schema and will be published only
+by Public Kernel v2 (#256).
+
 Unsupported or incompletely lowered structures fail export with a semantic error.
 The exporter never silently omits an unknown type, predicate call, expression,
 lvalue, or non-scalar parameter domain.

--- a/docs/DESIGN-origin-chain.md
+++ b/docs/DESIGN-origin-chain.md
@@ -1,0 +1,77 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Internal origin chains and diagnostic tracing
+
+Status: implemented by issue #240. Public Kernel v2 publication remains issue #256.
+
+## Contract boundary
+
+The Rust frontend carries provenance in a non-serialized `OriginRegistry`
+sidecar from
+domain lowering through `KernelSpec`, checked `KernelModel`, verification, and
+diagnostic/explain rendering. Read-only Rust accessors expose the sidecar to
+in-process diagnostic consumers, while its binding storage remains private.
+The registry is the internal source of truth. It is not serialized by
+`public_kernel_contract`, and it does not change Public
+Kernel v1, its `schema_version: "1.0.0"`, schema, golden files, or default
+`fslc kernel` output.
+
+Public Kernel v1's closed `origin` object is a deliberately lossy compatibility
+projection. Its historical `declaration` field may still be derived from a
+`MetaTag` for byte compatibility. Internal code must not treat that projection
+as the provenance model or use `MetaTag.id` as an origin identity. Publishing
+the chain requires Public Kernel v2.
+
+## Model
+
+An `OriginChain` contains a deterministic identity, known or unknown source
+file and UTF-8-safe full span, dialect, user declaration path, ordered lowering
+steps, generated flag, optional primary origin, and secondary origins.
+
+`OriginRegistry` binds chains to stable semantic targets: state declarations,
+init statements, actions, action guards/statements, properties, and terminal.
+The same identity bound to multiple targets represents one-to-many lowering.
+Secondary sites represent many-to-one lowering. `primary: None` represents a
+generated-only/source-less node; the implementation does not invent a location.
+
+Requirement traceability is stored independently in `TraceabilityRegistry`.
+It may refer to the same semantic target without becoming part of the origin
+identity.
+
+## Propagation and diagnostics
+
+Domain expressions and lvalues are matched to direct Surface AST targets by
+their preserved spans. The sidecar then moves through checked-model
+construction. Model validation attaches a target origin when it reports an
+error. Path-aware parsing attaches the root file identity to parse, name, type,
+and lowering errors. `can()`, finite membership, and legacy operator rewrites
+are recorded as lowering steps.
+
+Verifier and runtime algorithms remain name-based and solver-independent. At
+the output boundary, Rust CLI renderers resolve violated properties and trace
+actions through the checked model. The user declaration is the primary `name`;
+the generated Kernel name remains `generated_name` machine detail. JSON
+diagnostics and `explain` include the chain. Unknown/generated-only origins stay
+explicit.
+
+Compose retains its fail-closed Public Kernel v1 behavior. Complete multi-file
+compose provenance is outside issue #240.
+
+The versioned compatibility surface is Public Kernel JSON, not direct external
+construction of the Rust parser/model structs. Retaining full spans and the
+non-serialized sidecar adds internal fields to `DomainLoc`, `CoreError`,
+`ModelError`, and `KernelModel`; downstream Rust code should obtain these values
+through the parser/build APIs and read-only origin accessors rather than struct
+literals. This source-level change does not alter the versioned JSON contract.
+
+## Mechanical evidence
+
+- `rust/fsl-core/tests/origin_chain.rs` covers UTF-8 source identity, `can()`,
+  membership, legacy operators, state and nested-lvalue propagation,
+  one-to-many, many-to-one, generated-only, requirement separation, and
+  parse/type/lowering diagnostics, including duplicate state/type validation
+  with primary and secondary declarations.
+- `rust/fslc/tests/domain_origin_diagnostics.rs` covers verification,
+  counterexample, explain, and the closed Public Kernel v1 projection.
+- `rust/fslc/tests/kernel_contract.rs` continues to compare the complete v1
+  golden contract without regeneration.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -243,6 +243,15 @@ the negation of each rejection condition. Unknown symbols, cross-aggregate
 commands, type mismatches, and unsupported calls are reported at the original
 domain expression.
 
+The native Rust frontend also retains a private origin chain for domain state,
+actions, guards, statements, and properties. Verification, counterexample, and
+`explain` diagnostics use the original domain declaration as their primary
+display name and keep generated Kernel names as machine detail. The chain
+records source file/full span, declaration path, lowering steps,
+primary/secondary sources, and explicit generated-only nodes. Requirement IDs
+remain an independent traceability relation. Public Kernel v1 output is
+unchanged; publishing this chain is reserved for v2.
+
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
 aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -38,6 +38,7 @@ impl FileResolver for FsResolver {
             message: error.to_string(),
             line: 1,
             column: 1,
+            origin: None,
         })
     }
 }
@@ -65,8 +66,27 @@ pub fn parse_kernel_source(
             message: "top-level document has not reached the kernel lowering gate".to_owned(),
             line: 1,
             column: 1,
+            origin: None,
         }),
     }
+}
+
+/// Parse and lower source while attaching the caller-known root file identity
+/// to internal origins and diagnostics.
+///
+/// # Errors
+///
+/// Returns [`CoreError`] with the same language contract as
+/// [`parse_kernel_source`], enriched with the supplied source identity.
+pub fn parse_kernel_source_with_file(
+    source: &str,
+    resolver: &dyn FileResolver,
+    source_file: impl AsRef<str>,
+) -> Result<KernelSpec, CoreError> {
+    let source_file = source_file.as_ref();
+    parse_kernel_source(source, resolver)
+        .map(|kernel| kernel.with_source_file(source_file))
+        .map_err(|error| error.with_source_file(source_file))
 }
 
 #[derive(Clone)]
@@ -230,6 +250,7 @@ pub fn lower_compose(
             meta: None,
             items: static_items,
         },
+        origins: crate::OriginRegistry::default(),
     })
 }
 
@@ -242,6 +263,7 @@ fn error_at(message: impl Into<String>, span: fsl_syntax::Span) -> CoreError {
         message: message.into(),
         line: span.start.line,
         column: span.start.column,
+        origin: None,
     }
 }
 
@@ -861,6 +883,7 @@ fn sync_action(
             message: format!("unknown alias '{}'", reference.alias),
             line: action.span.start.line,
             column: action.span.start.column,
+            origin: None,
         })?;
         let source = component
             .spec
@@ -872,6 +895,7 @@ fn sync_action(
                 message: format!("unknown action '{}.{}'", reference.alias, reference.action),
                 line: action.span.start.line,
                 column: action.span.start.column,
+                origin: None,
             })?;
         let SpecItem::Action {
             params: source_params,
@@ -954,6 +978,7 @@ fn resolve_alias_qualified_name(
                 message: format!("unknown alias '{alias}'"),
                 line: 1,
                 column: 1,
+                origin: None,
             });
         }
         Ok(QualifiedName {

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -487,6 +487,7 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
         message,
         line: span.start.line,
         column: span.start.column,
+        origin: None,
     }
 }
 
@@ -1341,7 +1342,8 @@ pub fn lower_db(system: &fsl_syntax::DbSystem) -> Result<KernelSpec, CoreError> 
 ///
 /// Returns [`CoreError`] if the generated kernel catalog is invalid.
 pub fn lower_domain(domain: &fsl_syntax::DomainSpec) -> Result<KernelSpec, CoreError> {
-    lower_direct_spec(crate::domain_lowering::lower_domain_surface(domain)?)
+    let (surface, origins) = crate::domain_lowering::lower_domain_surface(domain)?;
+    crate::lower_direct_spec_with_origins(surface, origins)
 }
 
 /// Lower an AI hard-contract document to its executable catalog kernel.

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -5,12 +5,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use fsl_syntax::{
     ActionItem, Binder, DomainAggregate, DomainDecide, DomainEffect, DomainField, DomainLoc,
     DomainSaga, DomainSagaStep, DomainSpec, DomainType, Expr, LValue, MetaTag, Param, Pattern,
-    QualifiedName, SourcePos, Span, SpecItem, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr,
+    QualifiedName, Span, SpecItem, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr,
     SyntaxExprKind, SyntaxLValue, SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr,
     SyntaxTypeExprKind, TypeExpr,
 };
 
 use crate::CoreError;
+use crate::{
+    LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET, TERMINAL_TARGET,
+    action_guard_target, action_statement_target, action_target, init_statement_target,
+    property_target, state_target, type_target,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum LogicalType {
@@ -43,19 +48,30 @@ fn error_at(message: impl Into<String>, span: Span) -> CoreError {
         message: message.into(),
         line: span.start.line,
         column: span.start.column,
+        origin: Some(Box::new(OriginChain {
+            id: OriginId(format!(
+                "domain:error:{}:{}",
+                span.start.offset, span.end.offset
+            )),
+            dialect: "domain".to_owned(),
+            primary: Some(OriginSite {
+                source_file: None,
+                span: Some(span),
+                dialect: "domain".to_owned(),
+                declaration_path: Vec::new(),
+            }),
+            secondary: Vec::new(),
+            lowering_steps: vec![LoweringStep {
+                kind: "resolve_domain_expression".to_owned(),
+                detail: None,
+            }],
+            generated: false,
+        })),
     }
 }
 
 fn span_at(loc: DomainLoc) -> Span {
-    let position = SourcePos {
-        offset: 0,
-        line: loc.line,
-        column: loc.column,
-    };
-    Span {
-        start: position,
-        end: position,
-    }
+    loc.span()
 }
 
 fn safe(name: &str) -> String {
@@ -536,10 +552,25 @@ impl<'a> Resolver<'a> {
                     ));
                 };
                 if expanding_can.contains(&command.text) {
-                    return Err(error_at(
+                    let mut error = error_at(
                         format!("recursive can({}) expansion", command.text),
                         expression.span,
-                    ));
+                    );
+                    if let Some(origin) = &mut error.origin {
+                        origin.secondary.push(OriginSite {
+                            source_file: None,
+                            span: Some(span_at(decide.loc)),
+                            dialect: "domain".to_owned(),
+                            declaration_path: vec![
+                                self.domain.name.clone(),
+                                "aggregate".to_owned(),
+                                aggregate.name.clone(),
+                                "decide".to_owned(),
+                                decide.command.clone(),
+                            ],
+                        });
+                    }
+                    return Err(error);
                 }
                 expanding_can.push(command.text.clone());
                 let result = self.resolve_can(decide, scope, aggregate, expanding_can);
@@ -1973,7 +2004,9 @@ fn field_params(resolver: &Resolver<'_>, fields: &[DomainField]) -> Result<Vec<P
 
 /// Resolve a parsed domain document and lower it directly into Kernel surface AST.
 #[allow(clippy::too_many_lines)]
-pub(crate) fn lower_domain_surface(domain: &DomainSpec) -> Result<SurfaceSpec, CoreError> {
+pub(crate) fn lower_domain_surface(
+    domain: &DomainSpec,
+) -> Result<(SurfaceSpec, OriginRegistry), CoreError> {
     let resolver = Resolver::new(domain);
     resolver.validate_document_expressions()?;
     let mut items = Vec::new();
@@ -2194,14 +2227,16 @@ pub(crate) fn lower_domain_surface(domain: &DomainSpec) -> Result<SurfaceSpec, C
         span: span_at(domain.loc),
     });
 
-    Ok(SurfaceSpec {
+    let surface = SurfaceSpec {
         name: domain.name.clone(),
         meta: Some(metadata(
             "DOMAIN",
             "domain: generated from fsl-domain/fsl-effect",
         )),
         items,
-    })
+    };
+    let origins = domain_origin_registry(domain, &surface);
+    Ok((surface, origins))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2722,4 +2757,647 @@ fn lower_properties(
         });
     }
     Ok(())
+}
+
+#[derive(Clone)]
+struct DomainSourceRecord {
+    span: Span,
+    path: Vec<String>,
+    steps: Vec<LoweringStep>,
+    secondary: Vec<OriginSite>,
+}
+
+fn source_site(path: Vec<String>, span: Span) -> OriginSite {
+    OriginSite {
+        source_file: None,
+        span: Some(span),
+        dialect: "domain".to_owned(),
+        declaration_path: path,
+    }
+}
+
+fn expression_lowering_steps(expression: &SyntaxExpr) -> Vec<LoweringStep> {
+    fn visit(expression: &SyntaxExpr, output: &mut Vec<LoweringStep>) {
+        match &expression.kind {
+            SyntaxExprKind::Call { callee, args } => {
+                if callee.text == "can" {
+                    output.push(LoweringStep {
+                        kind: "expand_can".to_owned(),
+                        detail: Some("command preconditions and rejections".to_owned()),
+                    });
+                }
+                for argument in args {
+                    visit(argument, output);
+                }
+            }
+            SyntaxExprKind::Membership { value, members } => {
+                output.push(LoweringStep {
+                    kind: "expand_membership".to_owned(),
+                    detail: Some(format!("{} equality predicate(s)", members.len())),
+                });
+                visit(value, output);
+                for member in members {
+                    visit(member, output);
+                }
+            }
+            SyntaxExprKind::Binary { op, left, right } => {
+                if op.spelling != op.canonical {
+                    output.push(LoweringStep {
+                        kind: "normalize_legacy_operator".to_owned(),
+                        detail: Some(format!("{} -> {}", op.spelling, op.canonical)),
+                    });
+                }
+                visit(left, output);
+                visit(right, output);
+            }
+            SyntaxExprKind::Some(value)
+            | SyntaxExprKind::Neg(value)
+            | SyntaxExprKind::Not(value)
+            | SyntaxExprKind::Group(value) => visit(value, output),
+            SyntaxExprKind::Set(values) | SyntaxExprKind::Seq(values) => {
+                for value in values {
+                    visit(value, output);
+                }
+            }
+            SyntaxExprKind::Struct { fields, .. } => {
+                for (_, value) in fields {
+                    visit(value, output);
+                }
+            }
+            SyntaxExprKind::Index { receiver, index } => {
+                visit(receiver, output);
+                visit(index, output);
+            }
+            SyntaxExprKind::Field { receiver, .. } => visit(receiver, output),
+            SyntaxExprKind::Method { receiver, args, .. } => {
+                visit(receiver, output);
+                for argument in args {
+                    visit(argument, output);
+                }
+            }
+            SyntaxExprKind::IfThenElse {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                visit(condition, output);
+                visit(then_expr, output);
+                visit(else_expr, output);
+            }
+            SyntaxExprKind::Is { expr, .. } => visit(expr, output),
+            SyntaxExprKind::Quantified { body, .. } => visit(body, output),
+            SyntaxExprKind::Count { condition, .. } => visit(condition, output),
+            SyntaxExprKind::Sum {
+                body, condition, ..
+            } => {
+                visit(body, output);
+                if let Some(condition) = condition {
+                    visit(condition, output);
+                }
+            }
+            SyntaxExprKind::Num(_)
+            | SyntaxExprKind::Bool(_)
+            | SyntaxExprKind::None
+            | SyntaxExprKind::Name(_)
+            | SyntaxExprKind::BinderNamed { .. } => {}
+        }
+    }
+
+    let mut output = vec![LoweringStep {
+        kind: "resolve_domain_expression".to_owned(),
+        detail: None,
+    }];
+    visit(expression, &mut output);
+    output
+}
+
+#[allow(clippy::too_many_lines)]
+fn domain_source_records(domain: &DomainSpec) -> Vec<DomainSourceRecord> {
+    let mut records = vec![DomainSourceRecord {
+        span: span_at(domain.loc),
+        path: vec![domain.name.clone()],
+        steps: Vec::new(),
+        secondary: Vec::new(),
+    }];
+    for ty in &domain.types {
+        records.push(DomainSourceRecord {
+            span: span_at(ty.loc),
+            path: vec![domain.name.clone(), "type".to_owned(), ty.name.clone()],
+            steps: Vec::new(),
+            secondary: Vec::new(),
+        });
+    }
+    for aggregate in &domain.aggregates {
+        let aggregate_path = vec![
+            domain.name.clone(),
+            "aggregate".to_owned(),
+            aggregate.name.clone(),
+        ];
+        records.push(DomainSourceRecord {
+            span: span_at(aggregate.loc),
+            path: aggregate_path.clone(),
+            steps: Vec::new(),
+            secondary: Vec::new(),
+        });
+        for field in &aggregate.state {
+            records.push(DomainSourceRecord {
+                span: field.span,
+                path: [
+                    aggregate_path.clone(),
+                    vec!["state".to_owned(), field.name.text.clone()],
+                ]
+                .concat(),
+                steps: Vec::new(),
+                secondary: Vec::new(),
+            });
+        }
+        for decide in &aggregate.decides {
+            let command = aggregate
+                .commands
+                .iter()
+                .find(|command| command.name == decide.command);
+            records.push(DomainSourceRecord {
+                span: span_at(decide.loc),
+                path: [
+                    aggregate_path.clone(),
+                    vec!["decide".to_owned(), decide.command.clone()],
+                ]
+                .concat(),
+                steps: vec![LoweringStep {
+                    kind: "lower_decision_to_action".to_owned(),
+                    detail: None,
+                }],
+                secondary: command
+                    .into_iter()
+                    .map(|command| {
+                        source_site(
+                            [
+                                aggregate_path.clone(),
+                                vec!["command".to_owned(), command.name.clone()],
+                            ]
+                            .concat(),
+                            span_at(command.loc),
+                        )
+                    })
+                    .collect(),
+            });
+            for (index, requirement) in decide.requires.iter().enumerate() {
+                records.push(DomainSourceRecord {
+                    span: requirement.span,
+                    path: [
+                        aggregate_path.clone(),
+                        vec![
+                            "decide".to_owned(),
+                            decide.command.clone(),
+                            "requires".to_owned(),
+                            index.to_string(),
+                        ],
+                    ]
+                    .concat(),
+                    steps: expression_lowering_steps(requirement),
+                    secondary: Vec::new(),
+                });
+            }
+            for reject in &decide.rejects {
+                records.push(DomainSourceRecord {
+                    span: reject.condition.span,
+                    path: [
+                        aggregate_path.clone(),
+                        vec![
+                            "decide".to_owned(),
+                            decide.command.clone(),
+                            "reject".to_owned(),
+                            reject.error.clone(),
+                        ],
+                    ]
+                    .concat(),
+                    steps: expression_lowering_steps(&reject.condition),
+                    secondary: Vec::new(),
+                });
+            }
+        }
+        for evolve in &aggregate.evolves {
+            for (index, requirement) in evolve.requires.iter().enumerate() {
+                records.push(DomainSourceRecord {
+                    span: requirement.span,
+                    path: [
+                        aggregate_path.clone(),
+                        vec![
+                            "evolve".to_owned(),
+                            evolve.event.clone(),
+                            "requires".to_owned(),
+                            index.to_string(),
+                        ],
+                    ]
+                    .concat(),
+                    steps: expression_lowering_steps(requirement),
+                    secondary: Vec::new(),
+                });
+            }
+            for assignment in &evolve.assignments {
+                records.push(DomainSourceRecord {
+                    span: assignment.span,
+                    path: [
+                        aggregate_path.clone(),
+                        vec![
+                            "evolve".to_owned(),
+                            evolve.event.clone(),
+                            assignment.target.render_source(),
+                        ],
+                    ]
+                    .concat(),
+                    steps: expression_lowering_steps(&assignment.value),
+                    secondary: Vec::new(),
+                });
+            }
+        }
+        for invariant in &aggregate.invariants {
+            let invariant_path = [
+                aggregate_path.clone(),
+                vec!["invariant".to_owned(), invariant.name.text.clone()],
+            ]
+            .concat();
+            records.push(DomainSourceRecord {
+                span: invariant.span,
+                path: invariant_path.clone(),
+                steps: Vec::new(),
+                secondary: Vec::new(),
+            });
+            records.push(DomainSourceRecord {
+                span: invariant.expr.span,
+                path: invariant_path.clone(),
+                steps: expression_lowering_steps(&invariant.expr),
+                secondary: vec![source_site(invariant_path, invariant.span)],
+            });
+        }
+    }
+    for saga in &domain.sagas {
+        for invariant in &saga.invariants {
+            let invariant_path = vec![
+                domain.name.clone(),
+                "saga".to_owned(),
+                saga.name.clone(),
+                "invariant".to_owned(),
+                invariant.name.text.clone(),
+            ];
+            records.push(DomainSourceRecord {
+                span: invariant.span,
+                path: invariant_path.clone(),
+                steps: Vec::new(),
+                secondary: Vec::new(),
+            });
+            records.push(DomainSourceRecord {
+                span: invariant.expr.span,
+                path: invariant_path.clone(),
+                steps: expression_lowering_steps(&invariant.expr),
+                secondary: vec![source_site(invariant_path, invariant.span)],
+            });
+        }
+    }
+    for effect in &domain.effects {
+        records.push(DomainSourceRecord {
+            span: span_at(effect.loc),
+            path: vec![
+                domain.name.clone(),
+                "effect".to_owned(),
+                effect.name.clone(),
+            ],
+            steps: vec![LoweringStep {
+                kind: "lower_effect_lifecycle".to_owned(),
+                detail: None,
+            }],
+            secondary: Vec::new(),
+        });
+    }
+    records
+}
+
+fn same_origin_position(left: Span, right: Span) -> bool {
+    left.start.line == right.start.line && left.start.column == right.start.column
+}
+
+fn origin_chain_for_span(
+    target: &str,
+    span: Span,
+    records: &[DomainSourceRecord],
+    generated: bool,
+) -> OriginChain {
+    let matches = records
+        .iter()
+        .filter(|record| same_origin_position(record.span, span))
+        .collect::<Vec<_>>();
+    let Some(primary) = matches.first() else {
+        return OriginChain::generated_only(format!("domain:generated:{target}"), "domain");
+    };
+    let id = format!(
+        "domain:{}:{}:{}:{}:{}",
+        primary.path.join("/"),
+        primary.span.start.offset,
+        primary.span.end.offset,
+        primary.span.start.line,
+        primary.span.start.column
+    );
+    let mut secondary = primary.secondary.clone();
+    secondary.extend(
+        matches
+            .iter()
+            .skip(1)
+            .map(|record| source_site(record.path.clone(), record.span)),
+    );
+    OriginChain {
+        id: OriginId(id),
+        dialect: "domain".to_owned(),
+        primary: Some(source_site(primary.path.clone(), primary.span)),
+        secondary,
+        lowering_steps: primary.steps.clone(),
+        generated,
+    }
+}
+
+fn statement_span(statement: &Statement) -> Span {
+    match statement {
+        Statement::Assign { span, .. }
+        | Statement::If { span, .. }
+        | Statement::ForAll { span, .. } => *span,
+    }
+}
+
+fn action_item_span(item: &ActionItem) -> Span {
+    match item {
+        ActionItem::Requires(_, span)
+        | ActionItem::Ensures(_, span)
+        | ActionItem::Let(_, _, span) => *span,
+        ActionItem::Statement(statement) => statement_span(statement),
+    }
+}
+
+fn bind_expression_tree(
+    registry: &mut OriginRegistry,
+    target: &str,
+    expression: &Expr,
+    origin: &OriginChain,
+) {
+    registry.bind(target, origin.clone());
+    let child = |suffix: &str| format!("{target}:expr:{suffix}");
+    match expression {
+        Expr::Some(value) | Expr::Neg(value) | Expr::Not(value) => {
+            bind_expression_tree(registry, &child("operand"), value, origin);
+        }
+        Expr::Set(values) | Expr::Seq(values) => {
+            for (index, value) in values.iter().enumerate() {
+                bind_expression_tree(registry, &child(&index.to_string()), value, origin);
+            }
+        }
+        Expr::Struct { fields, .. } => {
+            for (name, value) in fields {
+                bind_expression_tree(registry, &child(name), value, origin);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for (index, value) in args.iter().enumerate() {
+                bind_expression_tree(registry, &child(&index.to_string()), value, origin);
+            }
+        }
+        Expr::Index(base, index) => {
+            bind_expression_tree(registry, &child("base"), base, origin);
+            bind_expression_tree(registry, &child("index"), index, origin);
+        }
+        Expr::Field(base, _) => {
+            bind_expression_tree(registry, &child("base"), base, origin);
+        }
+        Expr::Method { receiver, args, .. } => {
+            bind_expression_tree(registry, &child("receiver"), receiver, origin);
+            for (index, value) in args.iter().enumerate() {
+                bind_expression_tree(registry, &child(&index.to_string()), value, origin);
+            }
+        }
+        Expr::Binary { left, right, .. } | Expr::BinaryNamed { left, right, .. } => {
+            bind_expression_tree(registry, &child("left"), left, origin);
+            bind_expression_tree(registry, &child("right"), right, origin);
+        }
+        Expr::IfThenElse {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            bind_expression_tree(registry, &child("condition"), condition, origin);
+            bind_expression_tree(registry, &child("then"), then_expr, origin);
+            bind_expression_tree(registry, &child("else"), else_expr, origin);
+        }
+        Expr::Is { expr, .. } | Expr::UnaryNamed { expr, .. } => {
+            bind_expression_tree(registry, &child("operand"), expr, origin);
+        }
+        Expr::Quantified { body, .. }
+        | Expr::Count {
+            condition: body, ..
+        } => {
+            bind_expression_tree(registry, &child("body"), body, origin);
+        }
+        Expr::Sum {
+            body, condition, ..
+        } => {
+            bind_expression_tree(registry, &child("body"), body, origin);
+            if let Some(condition) = condition {
+                bind_expression_tree(registry, &child("condition"), condition, origin);
+            }
+        }
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => {
+            bind_expression_tree(registry, &child("first"), first, origin);
+            bind_expression_tree(registry, &child("second"), second, origin);
+            bind_expression_tree(registry, &child("third"), third, origin);
+        }
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::BinderNamed { .. } => {}
+    }
+}
+
+fn domain_property_expression_span(domain: &DomainSpec, kind: &str, name: &str) -> Option<Span> {
+    if kind != "invariant" {
+        return None;
+    }
+    domain
+        .aggregates
+        .iter()
+        .find_map(|aggregate| {
+            aggregate.invariants.iter().find_map(|invariant| {
+                (format!("{}_{}", safe(&aggregate.name), safe(&invariant.name)) == name)
+                    .then_some(invariant.expr.span)
+            })
+        })
+        .or_else(|| {
+            domain.sagas.iter().find_map(|saga| {
+                saga.invariants.iter().find_map(|invariant| {
+                    (format!("{}_{}", safe(&saga.name), safe(&invariant.name)) == name)
+                        .then_some(invariant.expr.span)
+                })
+            })
+        })
+}
+
+#[allow(clippy::too_many_lines)]
+fn domain_origin_registry(domain: &DomainSpec, surface: &SurfaceSpec) -> OriginRegistry {
+    let records = domain_source_records(domain);
+    let mut registry = OriginRegistry::default();
+
+    registry.bind(
+        SPEC_TARGET,
+        origin_chain_for_span(SPEC_TARGET, span_at(domain.loc), &records, false),
+    );
+    for item in &surface.items {
+        let (SpecItem::Type { name, .. }
+        | SpecItem::Enum { name, .. }
+        | SpecItem::Struct { name, .. }) = item
+        else {
+            continue;
+        };
+        let target = type_target(name);
+        let matches = domain
+            .types
+            .iter()
+            .filter(|ty| ty.name == *name)
+            .collect::<Vec<_>>();
+        if matches.is_empty() {
+            registry.bind(
+                target,
+                OriginChain::generated_only(format!("domain:generated:type:{name}"), "domain"),
+            );
+        } else {
+            for ty in matches {
+                registry.bind(
+                    target.clone(),
+                    origin_chain_for_span(&target, span_at(ty.loc), &records, false),
+                );
+            }
+        }
+    }
+
+    for aggregate in &domain.aggregates {
+        for field in &aggregate.state {
+            let target = state_target(&state_name(aggregate, &field.name));
+            registry.bind(
+                target.clone(),
+                origin_chain_for_span(&target, field.span, &records, false),
+            );
+        }
+    }
+    for effect in &domain.effects {
+        for name in [status_var(effect), attempt_var(effect)] {
+            let target = state_target(&name);
+            registry.bind(
+                target.clone(),
+                origin_chain_for_span(&target, span_at(effect.loc), &records, true),
+            );
+        }
+    }
+    for aggregate in &domain.aggregates {
+        for event in &aggregate.events {
+            let target = state_target(&event_flag(&event.name));
+            registry.bind(
+                target.clone(),
+                OriginChain::generated_only(
+                    format!("domain:generated:event-flag:{}", event.name),
+                    "domain",
+                ),
+            );
+        }
+    }
+
+    let mut init_index = 0;
+    for item in &surface.items {
+        match item {
+            SpecItem::Init { statements, .. } => {
+                for statement in statements {
+                    let target = init_statement_target(init_index);
+                    registry.bind(
+                        target.clone(),
+                        origin_chain_for_span(&target, statement_span(statement), &records, true),
+                    );
+                    init_index += 1;
+                }
+            }
+            SpecItem::Action {
+                name, items, span, ..
+            } => {
+                let target = action_target(name);
+                registry.bind(
+                    target.clone(),
+                    origin_chain_for_span(&target, *span, &records, true),
+                );
+                let mut guard_index = 0;
+                let mut statement_index = 0;
+                for item in items {
+                    let target = match item {
+                        ActionItem::Requires(..) | ActionItem::Let(..) => {
+                            let target = action_guard_target(name, guard_index);
+                            guard_index += 1;
+                            target
+                        }
+                        ActionItem::Ensures(..) => {
+                            let target = format!("action:{name}:ensure:{guard_index}");
+                            guard_index += 1;
+                            target
+                        }
+                        ActionItem::Statement(..) => {
+                            let target = action_statement_target(name, statement_index);
+                            statement_index += 1;
+                            target
+                        }
+                    };
+                    let origin =
+                        origin_chain_for_span(&target, action_item_span(item), &records, true);
+                    registry.bind(target.clone(), origin.clone());
+                    match item {
+                        ActionItem::Requires(expression, _)
+                        | ActionItem::Ensures(expression, _)
+                        | ActionItem::Let(_, expression, _) => bind_expression_tree(
+                            &mut registry,
+                            &format!("{target}:expr:root"),
+                            expression,
+                            &origin,
+                        ),
+                        ActionItem::Statement(..) => {}
+                    }
+                }
+            }
+            SpecItem::Invariant {
+                name, expr, span, ..
+            } => {
+                let target = property_target("invariant", name);
+                let source_span =
+                    domain_property_expression_span(domain, "invariant", name).unwrap_or(*span);
+                let origin = origin_chain_for_span(&target, source_span, &records, false);
+                registry.bind(target.clone(), origin.clone());
+                bind_expression_tree(&mut registry, &format!("{target}:expr:root"), expr, &origin);
+            }
+            SpecItem::Trans {
+                name, expr, span, ..
+            } => {
+                let target = property_target("trans", name);
+                let origin = origin_chain_for_span(&target, *span, &records, true);
+                registry.bind(target.clone(), origin.clone());
+                bind_expression_tree(&mut registry, &format!("{target}:expr:root"), expr, &origin);
+            }
+            SpecItem::Reachable {
+                name, expr, span, ..
+            } => {
+                let target = property_target("reachable", name);
+                let origin = origin_chain_for_span(&target, *span, &records, false);
+                registry.bind(target.clone(), origin.clone());
+                bind_expression_tree(&mut registry, &format!("{target}:expr:root"), expr, &origin);
+            }
+            SpecItem::Terminal { .. } => registry.bind(
+                TERMINAL_TARGET,
+                OriginChain::generated_only(
+                    format!("domain:generated:terminal:{}", domain.name),
+                    "domain",
+                ),
+            ),
+            _ => {}
+        }
+    }
+    registry
 }

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -23,11 +23,14 @@ mod dialect;
 mod domain;
 mod domain_lowering;
 mod model;
+mod origin;
 mod public_kernel;
 mod refinement;
 mod trace;
 
-pub use compose::{FileResolver, FsResolver, lower_compose, parse_kernel_source};
+pub use compose::{
+    FileResolver, FsResolver, lower_compose, parse_kernel_source, parse_kernel_source_with_file,
+};
 pub use db::db_kernel_source;
 pub use dialect::{
     GovernanceContract, GovernanceDelegate, GovernancePreservation, RequirementsTraceCase,
@@ -39,6 +42,11 @@ pub use domain::domain_kernel_source;
 pub use model::{
     ActionDef, ActionGuard, KernelModel, LeadsToDef, ModelError, ParamDef, PropertyDef, TypeDef,
     TypeRef, Value as FslValue, build_model,
+};
+pub use origin::{
+    LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET, TERMINAL_TARGET,
+    TraceabilityRegistry, action_guard_target, action_statement_target, action_target,
+    init_statement_target, property_target, state_target, type_target,
 };
 pub use public_kernel::{
     KERNEL_SCHEMA_ID, KERNEL_SCHEMA_VERSION, PublicKernelError, public_kernel_contract,
@@ -54,15 +62,39 @@ pub struct CoreError {
     pub message: String,
     pub line: u32,
     pub column: u32,
+    pub origin: Option<Box<OriginChain>>,
+}
+
+impl CoreError {
+    #[must_use]
+    pub fn with_source_file(mut self, source_file: impl AsRef<str>) -> Self {
+        if let Some(origin) = &mut self.origin {
+            origin.set_source_file(source_file.as_ref());
+        }
+        self
+    }
 }
 
 impl fmt::Display for CoreError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "{} at {}:{}",
-            self.message, self.line, self.column
-        )
+        if let Some(source_file) = self
+            .origin
+            .as_ref()
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.source_file.as_deref())
+        {
+            write!(
+                formatter,
+                "{} at {}:{}:{}",
+                self.message, source_file, self.line, self.column
+            )
+        } else {
+            write!(
+                formatter,
+                "{} at {}:{}",
+                self.message, self.line, self.column
+            )
+        }
     }
 }
 
@@ -74,6 +106,22 @@ impl From<ParseError> for CoreError {
             message: error.message,
             line: error.span.start.line,
             column: error.span.start.column,
+            origin: Some(Box::new(OriginChain {
+                id: OriginId(format!(
+                    "parse:{}:{}",
+                    error.span.start.offset, error.span.end.offset
+                )),
+                dialect: "unknown".to_owned(),
+                primary: Some(OriginSite {
+                    source_file: None,
+                    span: Some(error.span),
+                    dialect: "unknown".to_owned(),
+                    declaration_path: Vec::new(),
+                }),
+                secondary: Vec::new(),
+                lowering_steps: Vec::new(),
+                generated: false,
+            })),
         }
     }
 }
@@ -81,6 +129,7 @@ impl From<ParseError> for CoreError {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KernelSpec {
     spec: SurfaceSpec,
+    origins: OriginRegistry,
 }
 
 /// Build a checked kernel model from an already parsed surface specification.
@@ -92,7 +141,10 @@ pub struct KernelSpec {
 ///
 /// Returns [`ModelError`] when the mutated surface is not semantically valid.
 pub fn build_surface_model(spec: SurfaceSpec) -> Result<KernelModel, ModelError> {
-    build_model(KernelSpec { spec })
+    build_model(KernelSpec {
+        spec,
+        origins: OriginRegistry::default(),
+    })
 }
 
 impl KernelSpec {
@@ -109,6 +161,17 @@ impl KernelSpec {
     #[must_use]
     pub fn into_syntax(self) -> SurfaceSpec {
         self.spec
+    }
+
+    #[must_use]
+    pub fn origins(&self) -> &OriginRegistry {
+        &self.origins
+    }
+
+    #[must_use]
+    pub fn with_source_file(mut self, source_file: impl AsRef<str>) -> Self {
+        self.origins.set_source_file(source_file.as_ref());
+        self
     }
 }
 
@@ -128,6 +191,7 @@ pub fn parse_direct_kernel_spec(source: &str) -> Result<KernelSpec, CoreError> {
             message: "expected direct kernel spec".to_owned(),
             line: 1,
             column: 1,
+            origin: None,
         });
     };
     lower_direct_spec(spec)
@@ -158,6 +222,7 @@ fn validate_direct_scope_overrides(
         message,
         line: 1,
         column: 1,
+        origin: None,
     };
     if (!instances.is_empty() || !values.is_empty()) && entities.is_empty() && numbers.is_empty() {
         return Err(error(
@@ -252,6 +317,7 @@ pub fn parse_kernel_source_with_bounds(
             message: "scope overrides only support spec, business, or requirements".to_owned(),
             line: 1,
             column: 1,
+            origin: None,
         }),
     }
 }
@@ -262,9 +328,16 @@ pub fn parse_kernel_source_with_bounds(
 ///
 /// Returns [`CoreError`] when named predicate validation or expansion fails.
 pub fn lower_direct_spec(spec: SurfaceSpec) -> Result<KernelSpec, CoreError> {
+    lower_direct_spec_with_origins(spec, OriginRegistry::default())
+}
+
+fn lower_direct_spec_with_origins(
+    spec: SurfaceSpec,
+    origins: OriginRegistry,
+) -> Result<KernelSpec, CoreError> {
     let spec = PredicateExpander::new(&spec)?.expand(spec)?;
     let spec = expand_spec_domains(spec)?;
-    Ok(KernelSpec { spec })
+    Ok(KernelSpec { spec, origins })
 }
 
 #[allow(clippy::too_many_lines)]
@@ -448,6 +521,7 @@ impl PredicateExpander {
                 ),
                 line: definition.line,
                 column: definition.column,
+                origin: None,
             });
         }
         stack.push(name.to_owned());
@@ -991,6 +1065,7 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
         message,
         line: span.start.line,
         column: span.start.column,
+        origin: None,
     }
 }
 

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -8,7 +8,10 @@ use fsl_syntax::{
     ActionItem, Binder, Expr, MetaTag, Param, Span, SpecItem, Statement, SurfaceSpec, TypeExpr,
 };
 
-use crate::KernelSpec;
+use crate::{
+    KernelSpec, OriginRegistry, SPEC_TARGET, TraceabilityRegistry, action_target, property_target,
+    state_target, type_target,
+};
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Value {
@@ -131,6 +134,8 @@ pub struct KernelModel {
     pub reachables: Vec<PropertyDef>,
     pub leadstos: Vec<LeadsToDef>,
     pub terminal: Option<Expr>,
+    origins: OriginRegistry,
+    traceability: TraceabilityRegistry,
 }
 
 impl KernelModel {
@@ -237,16 +242,66 @@ impl KernelModel {
             _ => None,
         }
     }
+
+    #[must_use]
+    pub fn action_origin(&self, name: &str) -> Option<&crate::OriginChain> {
+        self.origins.primary_for(&action_target(name))
+    }
+
+    #[must_use]
+    pub fn origins(&self) -> &OriginRegistry {
+        &self.origins
+    }
+
+    #[must_use]
+    pub fn requirement_for(&self, target: &str) -> Option<&MetaTag> {
+        self.traceability.requirement_for(target)
+    }
+
+    #[must_use]
+    pub fn property_origin(&self, kind: &str, name: &str) -> Option<&crate::OriginChain> {
+        self.origins.primary_for(&property_target(kind, name))
+    }
+
+    #[must_use]
+    pub fn state_origin(&self, name: &str) -> Option<&crate::OriginChain> {
+        self.origins.primary_for(&crate::state_target(name))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelError {
     pub message: String,
+    pub origin: Option<Box<crate::OriginChain>>,
+}
+
+impl ModelError {
+    fn with_origin(mut self, origin: Option<crate::OriginChain>) -> Self {
+        self.origin = origin.map(Box::new);
+        self
+    }
 }
 
 impl fmt::Display for ModelError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.message)
+        let location = self
+            .origin
+            .as_ref()
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.span.map(|span| (site.source_file.as_deref(), span)));
+        match location {
+            Some((Some(file), span)) => write!(
+                formatter,
+                "{} at {}:{}:{}",
+                self.message, file, span.start.line, span.start.column
+            ),
+            Some((None, span)) => write!(
+                formatter,
+                "{} at {}:{}",
+                self.message, span.start.line, span.start.column
+            ),
+            None => formatter.write_str(&self.message),
+        }
     }
 }
 
@@ -259,20 +314,23 @@ impl std::error::Error for ModelError {}
 /// Returns [`ModelError`] for duplicate declarations, unresolved types,
 /// non-constant bounds, invalid capacities, or a missing state block.
 pub fn build_model(kernel: KernelSpec) -> Result<KernelModel, ModelError> {
-    ModelBuilder::new(kernel.into_syntax()).build()
+    ModelBuilder::new(kernel).build()
 }
 
 struct ModelBuilder {
     spec: SurfaceSpec,
+    origins: OriginRegistry,
     consts: BTreeMap<String, Value>,
     types: BTreeMap<String, TypeDef>,
     enum_members: BTreeMap<String, Value>,
 }
 
 impl ModelBuilder {
-    fn new(spec: SurfaceSpec) -> Self {
+    fn new(kernel: KernelSpec) -> Self {
+        let KernelSpec { spec, origins } = kernel;
         Self {
             spec,
+            origins,
             consts: BTreeMap::new(),
             types: BTreeMap::new(),
             enum_members: BTreeMap::new(),
@@ -292,14 +350,21 @@ impl ModelBuilder {
         let mut reachables = Vec::new();
         let mut leadstos = Vec::new();
         let mut terminal = None;
+        let mut traceability = TraceabilityRegistry::default();
         for item in &self.spec.items {
             match item {
                 SpecItem::State(fields) => {
                     for (name, ty) in fields {
                         if state.iter().any(|(existing, _)| existing == name) {
-                            return Err(model_error(format!("duplicate state variable '{name}'")));
+                            return Err(model_error(format!("duplicate state variable '{name}'"))
+                                .with_origin(self.origins.diagnostic_origin(&state_target(name))));
                         }
-                        state.push((name.clone(), self.resolve_type(ty)?));
+                        let origin = self.origins.diagnostic_origin(&state_target(name));
+                        state.push((
+                            name.clone(),
+                            self.resolve_type(ty)
+                                .map_err(|error| error.with_origin(origin))?,
+                        ));
                     }
                 }
                 // Dialect lowering can append generated init fragments (for
@@ -320,43 +385,67 @@ impl ModelBuilder {
                     meta,
                     span,
                     ..
-                } => actions.push(self.action(name, params, items, *span, *fair, meta.clone())?),
+                } => {
+                    if let Some(meta) = meta {
+                        traceability.bind(action_target(name), meta.clone());
+                    }
+                    let origin = self.origins.diagnostic_origin(&action_target(name));
+                    actions.push(
+                        self.action(name, params, items, *span, *fair, meta.clone())
+                            .map_err(|error| error.with_origin(origin))?,
+                    );
+                }
                 SpecItem::Invariant {
                     name,
                     expr,
                     span,
                     meta,
                     ..
-                } => invariants.push(PropertyDef {
-                    name: name.clone(),
-                    expr: expr.as_ref().clone(),
-                    span: *span,
-                    meta: meta.clone(),
-                }),
+                } => {
+                    if let Some(meta) = meta {
+                        traceability.bind(property_target("invariant", name), meta.clone());
+                    }
+                    invariants.push(PropertyDef {
+                        name: name.clone(),
+                        expr: expr.as_ref().clone(),
+                        span: *span,
+                        meta: meta.clone(),
+                    });
+                }
                 SpecItem::Trans {
                     name,
                     expr,
                     span,
                     meta,
                     ..
-                } => transitions.push(PropertyDef {
-                    name: name.clone(),
-                    expr: expr.as_ref().clone(),
-                    span: *span,
-                    meta: meta.clone(),
-                }),
+                } => {
+                    if let Some(meta) = meta {
+                        traceability.bind(property_target("trans", name), meta.clone());
+                    }
+                    transitions.push(PropertyDef {
+                        name: name.clone(),
+                        expr: expr.as_ref().clone(),
+                        span: *span,
+                        meta: meta.clone(),
+                    });
+                }
                 SpecItem::Reachable {
                     name,
                     expr,
                     span,
                     meta,
                     ..
-                } => reachables.push(PropertyDef {
-                    name: name.clone(),
-                    expr: expr.as_ref().clone(),
-                    span: *span,
-                    meta: meta.clone(),
-                }),
+                } => {
+                    if let Some(meta) = meta {
+                        traceability.bind(property_target("reachable", name), meta.clone());
+                    }
+                    reachables.push(PropertyDef {
+                        name: name.clone(),
+                        expr: expr.as_ref().clone(),
+                        span: *span,
+                        meta: meta.clone(),
+                    });
+                }
                 SpecItem::Terminal { expr, .. } => terminal = Some(expr.as_ref().clone()),
                 SpecItem::Unless {
                     name,
@@ -406,24 +495,31 @@ impl ModelBuilder {
                     decreases,
                     within,
                     ..
-                } => leadstos.push(LeadsToDef {
-                    name: name.clone(),
-                    span: *span,
-                    binders: binders.clone(),
-                    before: before.as_ref().clone(),
-                    after: after.as_ref().clone(),
-                    meta: meta.clone(),
-                    decreases: decreases.as_deref().cloned(),
-                    within: within
-                        .as_deref()
-                        .map(|expr| self.const_int(expr))
-                        .transpose()?,
-                }),
+                } => {
+                    let origin = self
+                        .origins
+                        .diagnostic_origin(&property_target("leadsTo", name));
+                    leadstos.push(LeadsToDef {
+                        name: name.clone(),
+                        span: *span,
+                        binders: binders.clone(),
+                        before: before.as_ref().clone(),
+                        after: after.as_ref().clone(),
+                        meta: meta.clone(),
+                        decreases: decreases.as_deref().cloned(),
+                        within: within
+                            .as_deref()
+                            .map(|expr| self.const_int(expr))
+                            .transpose()
+                            .map_err(|error| error.with_origin(origin))?,
+                    });
+                }
                 _ => {}
             }
         }
         if state.is_empty() {
-            return Err(model_error("spec has no state block"));
+            return Err(model_error("spec has no state block")
+                .with_origin(self.origins.diagnostic_origin(SPEC_TARGET)));
         }
         Ok(KernelModel {
             name: self.spec.name,
@@ -439,6 +535,8 @@ impl ModelBuilder {
             reachables,
             leadstos,
             terminal,
+            origins: self.origins,
+            traceability,
         })
     }
 
@@ -465,30 +563,39 @@ impl ModelBuilder {
                     hi,
                     symmetric,
                 } => {
+                    let origin = self.origins.diagnostic_origin(&type_target(name));
                     self.insert_type(
                         name,
                         TypeDef::Domain {
-                            lo: self.const_int(lo)?,
-                            hi: self.const_int(hi)?,
+                            lo: self
+                                .const_int(lo)
+                                .map_err(|error| error.with_origin(origin.clone()))?,
+                            hi: self
+                                .const_int(hi)
+                                .map_err(|error| error.with_origin(origin.clone()))?,
                             symmetric: *symmetric,
                         },
-                    )?;
+                    )
+                    .map_err(|error| error.with_origin(origin))?;
                 }
                 SpecItem::Enum {
                     name,
                     members,
                     symmetric,
                 } => {
+                    let origin = self.origins.diagnostic_origin(&type_target(name));
                     self.insert_type(
                         name,
                         TypeDef::Enum {
                             members: members.clone(),
                             symmetric: *symmetric,
                         },
-                    )?;
+                    )
+                    .map_err(|error| error.with_origin(origin.clone()))?;
                     for member in members {
                         if self.enum_members.contains_key(member) {
-                            return Err(model_error(format!("duplicate enum member '{member}'")));
+                            return Err(model_error(format!("duplicate enum member '{member}'"))
+                                .with_origin(origin));
                         }
                         self.enum_members.insert(
                             member.clone(),
@@ -504,18 +611,22 @@ impl ModelBuilder {
         }
         for item in &items {
             if let SpecItem::Struct { name, fields } = item {
+                let origin = self.origins.diagnostic_origin(&type_target(name));
                 let resolved = fields
                     .iter()
                     .map(|(field, ty)| Ok((field.clone(), self.resolve_type(ty)?)))
-                    .collect::<Result<Vec<_>, ModelError>>()?;
+                    .collect::<Result<Vec<_>, ModelError>>()
+                    .map_err(|error| error.with_origin(origin.clone()))?;
                 for (field, ty) in &resolved {
                     if !self.is_scalar_struct_field(ty) {
                         return Err(model_error(format!(
                             "struct field '{name}.{field}' has non-scalar type"
-                        )));
+                        ))
+                        .with_origin(origin));
                     }
                 }
-                self.insert_type(name, TypeDef::Struct { fields: resolved })?;
+                self.insert_type(name, TypeDef::Struct { fields: resolved })
+                    .map_err(|error| error.with_origin(origin))?;
             }
         }
         Ok(())
@@ -797,5 +908,6 @@ fn as_bool(value: &Value) -> Result<bool, ModelError> {
 fn model_error(message: impl Into<String>) -> ModelError {
     ModelError {
         message: message.into(),
+        origin: None,
     }
 }

--- a/rust/fsl-core/src/origin.rs
+++ b/rust/fsl-core/src/origin.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use fsl_syntax::{MetaTag, Span};
+
+/// Stable identity for one source node across one-to-many lowering.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct OriginId(pub String);
+
+/// The source-side location represented by an origin chain.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OriginSite {
+    pub source_file: Option<String>,
+    pub span: Option<Span>,
+    pub dialect: String,
+    pub declaration_path: Vec<String>,
+}
+
+/// One semantic rewrite performed while lowering a source node.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoweringStep {
+    pub kind: String,
+    pub detail: Option<String>,
+}
+
+/// Internal provenance carrier. This is deliberately not serialized by the
+/// public Kernel v1 exporter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OriginChain {
+    pub id: OriginId,
+    pub dialect: String,
+    pub primary: Option<OriginSite>,
+    pub secondary: Vec<OriginSite>,
+    pub lowering_steps: Vec<LoweringStep>,
+    pub generated: bool,
+}
+
+impl OriginChain {
+    #[must_use]
+    pub fn generated_only(id: impl Into<String>, dialect: impl Into<String>) -> Self {
+        Self {
+            id: OriginId(id.into()),
+            dialect: dialect.into(),
+            primary: None,
+            secondary: Vec::new(),
+            lowering_steps: vec![LoweringStep {
+                kind: "generated".to_owned(),
+                detail: None,
+            }],
+            generated: true,
+        }
+    }
+
+    pub(crate) fn set_source_file(&mut self, source_file: &str) {
+        if let Some(primary) = &mut self.primary {
+            primary.source_file = Some(source_file.to_owned());
+        }
+        for secondary in &mut self.secondary {
+            secondary.source_file = Some(source_file.to_owned());
+        }
+    }
+}
+
+/// Internal target-to-origin graph. A target can have several origins and the
+/// same origin identity can be bound to several targets.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OriginRegistry {
+    bindings: BTreeMap<String, Vec<OriginChain>>,
+}
+
+impl OriginRegistry {
+    pub fn bind(&mut self, target: impl Into<String>, origin: OriginChain) {
+        let origins = self.bindings.entry(target.into()).or_default();
+        if !origins.contains(&origin) {
+            origins.push(origin);
+        }
+    }
+
+    #[must_use]
+    pub fn origins_for(&self, target: &str) -> &[OriginChain] {
+        self.bindings.get(target).map_or(&[], Vec::as_slice)
+    }
+
+    #[must_use]
+    pub fn primary_for(&self, target: &str) -> Option<&OriginChain> {
+        self.origins_for(target).first()
+    }
+
+    #[must_use]
+    pub fn diagnostic_origin(&self, target: &str) -> Option<OriginChain> {
+        let (primary, rest) = self.origins_for(target).split_first()?;
+        let mut combined = primary.clone();
+        combined.secondary.extend(
+            rest.iter()
+                .filter_map(|origin| origin.primary.clone())
+                .chain(rest.iter().flat_map(|origin| origin.secondary.clone())),
+        );
+        Some(combined)
+    }
+
+    pub(crate) fn set_source_file(&mut self, source_file: &str) {
+        for origins in self.bindings.values_mut() {
+            for origin in origins {
+                origin.set_source_file(source_file);
+            }
+        }
+    }
+
+    pub fn targets(&self) -> impl Iterator<Item = (&str, &[OriginChain])> {
+        self.bindings
+            .iter()
+            .map(|(target, origins)| (target.as_str(), origins.as_slice()))
+    }
+}
+
+/// Requirement relations are intentionally separate from declaration/source
+/// provenance. `MetaTag.id` must never become an origin identity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TraceabilityRegistry {
+    relations: BTreeMap<String, MetaTag>,
+}
+
+impl TraceabilityRegistry {
+    pub(crate) fn bind(&mut self, target: impl Into<String>, requirement: MetaTag) {
+        self.relations.insert(target.into(), requirement);
+    }
+
+    #[must_use]
+    pub fn requirement_for(&self, target: &str) -> Option<&MetaTag> {
+        self.relations.get(target)
+    }
+}
+
+#[must_use]
+pub fn state_target(name: &str) -> String {
+    format!("state:{name}")
+}
+
+#[must_use]
+pub fn type_target(name: &str) -> String {
+    format!("type:{name}")
+}
+
+pub const SPEC_TARGET: &str = "spec";
+
+#[must_use]
+pub fn init_statement_target(index: usize) -> String {
+    format!("init:{index}")
+}
+
+#[must_use]
+pub fn action_target(name: &str) -> String {
+    format!("action:{name}")
+}
+
+#[must_use]
+pub fn action_guard_target(name: &str, index: usize) -> String {
+    format!("action:{name}:guard:{index}")
+}
+
+#[must_use]
+pub fn action_statement_target(name: &str, index: usize) -> String {
+    format!("action:{name}:statement:{index}")
+}
+
+#[must_use]
+pub fn property_target(kind: &str, name: &str) -> String {
+    format!("property:{kind}:{name}")
+}
+
+pub const TERMINAL_TARGET: &str = "terminal";

--- a/rust/fsl-core/tests/origin_chain.rs
+++ b/rust/fsl-core/tests/origin_chain.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    FsResolver, TERMINAL_TARGET, action_guard_target, action_statement_target, action_target,
+    build_model, property_target, state_target,
+};
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    let kernel = fsl_core::parse_kernel_source(source, &FsResolver::new("."))
+        .expect("lower domain")
+        .with_source_file("fixtures/orders-多言語.fsl");
+    build_model(kernel).expect("build checked model")
+}
+
+#[test]
+fn carries_domain_origins_across_surface_model_and_expression_expansion() {
+    let source = r"
+domain Orders {
+  type Status = Pending | Approved
+  aggregate Order {
+    state { status: Status = Pending; }
+
+    // 多言語 comment keeps byte offsets and source columns distinct.
+    command Approve {}
+    event Approved {}
+    decide Approve {
+      requires status == Pending
+      emits Approved
+    }
+    evolve Approved { status = Approved }
+    invariant allowed { can(Approve) }
+    invariant listed { status in [Pending, Approved] }
+    invariant legacy { status == Pending || status == Approved }
+  }
+}
+";
+    let model = model(source);
+
+    let allowed = model
+        .property_origin("invariant", "Order_allowed")
+        .expect("allowed origin");
+    let allowed_site = allowed.primary.as_ref().expect("user source");
+    assert_eq!(
+        allowed_site.source_file.as_deref(),
+        Some("fixtures/orders-多言語.fsl")
+    );
+    assert_eq!(allowed_site.span.expect("span").start.line, 15);
+    let allowed_span = allowed_site.span.expect("span");
+    assert!(allowed_span.start.offset > 0);
+    assert!(allowed_span.end.offset > allowed_span.start.offset);
+    assert_eq!(
+        &source[allowed_span.start.offset..allowed_span.end.offset],
+        "can(Approve)"
+    );
+    assert_eq!(
+        allowed_site.declaration_path,
+        ["Orders", "aggregate", "Order", "invariant", "allowed"]
+    );
+    assert!(
+        allowed
+            .lowering_steps
+            .iter()
+            .any(|step| step.kind == "expand_can")
+    );
+
+    let listed = model
+        .property_origin("invariant", "Order_listed")
+        .expect("membership origin");
+    assert!(listed.lowering_steps.iter().any(|step| {
+        step.kind == "expand_membership"
+            && step.detail.as_deref() == Some("2 equality predicate(s)")
+    }));
+    let listed_span = listed
+        .primary
+        .as_ref()
+        .and_then(|site| site.span)
+        .expect("membership span");
+    assert_eq!(
+        &source[listed_span.start.offset..listed_span.end.offset],
+        "status in [Pending, Approved]"
+    );
+    let listed_expression_targets = model
+        .origins()
+        .targets()
+        .filter(|(target, _)| target.starts_with("property:invariant:Order_listed:expr:root"))
+        .collect::<Vec<_>>();
+    assert!(listed_expression_targets.len() >= 7);
+    assert!(
+        listed_expression_targets
+            .iter()
+            .all(|(_, origins)| { origins.first().is_some_and(|origin| origin.id == listed.id) })
+    );
+    let allowed_expression_targets = model
+        .origins()
+        .targets()
+        .filter(|(target, _)| target.starts_with("property:invariant:Order_allowed:expr:root"))
+        .collect::<Vec<_>>();
+    assert!(allowed_expression_targets.len() >= 3);
+    assert!(allowed_expression_targets.iter().all(|(_, origins)| {
+        origins
+            .first()
+            .is_some_and(|origin| origin.id == allowed.id)
+    }));
+    let legacy = model
+        .property_origin("invariant", "Order_legacy")
+        .expect("legacy origin");
+    assert!(
+        legacy
+            .lowering_steps
+            .iter()
+            .any(|step| step.kind == "normalize_legacy_operator")
+    );
+
+    let requirement = model
+        .requirement_for(&property_target("invariant", "Order_allowed"))
+        .expect("separate requirement relation");
+    assert_eq!(requirement.id, "DOMAIN-INVARIANT");
+    assert_ne!(allowed.id.0, requirement.id);
+}
+
+#[test]
+fn represents_one_to_many_many_to_one_and_generated_only_nodes() {
+    let source = r"
+domain Orders {
+  type Status = Pending | Approved
+  aggregate Order {
+    state { status: Status = Pending; }
+    command Approve {}
+    event Approved {}
+    decide Approve {
+      requires status == Pending
+      emits Approved
+    }
+    evolve Approved { status = Approved }
+    invariant safe { status == Pending || status == Approved }
+  }
+}
+";
+    let model = model(source);
+    let action = model
+        .origins()
+        .primary_for(&action_target("order_approve"))
+        .expect("action origin");
+    assert!(action.generated);
+    let action_span = action
+        .primary
+        .as_ref()
+        .and_then(|site| site.span)
+        .expect("decision source span");
+    assert!(action_span.start.offset > 0);
+    assert!(action_span.end.offset > action_span.start.offset);
+    assert!(action.secondary.iter().any(|site| {
+        site.declaration_path == ["Orders", "aggregate", "Order", "command", "Approve"]
+    }));
+
+    let generated_statement = model
+        .origins()
+        .primary_for(&action_statement_target("order_approve", 0))
+        .expect("generated event assignment");
+    assert_eq!(action.id, generated_statement.id);
+    assert!(
+        model
+            .origins()
+            .primary_for(&action_guard_target("order_approve", 0))
+            .is_some()
+    );
+
+    let event_flag = model
+        .origins()
+        .primary_for(&state_target("event_Approved"))
+        .expect("event flag origin");
+    assert!(event_flag.generated);
+    assert!(event_flag.primary.is_none());
+    let terminal = model
+        .origins()
+        .primary_for(TERMINAL_TARGET)
+        .expect("terminal origin");
+    assert!(terminal.generated);
+    assert!(terminal.primary.is_none());
+}
+
+#[test]
+fn checked_model_validation_combines_colliding_domain_origins() {
+    let kernel = fsl_core::parse_kernel_source_with_file(
+        r"
+domain Collision {
+  aggregate FooBar { state { value: Int = 0; } }
+  aggregate foo_bar { state { value: Int = 0; } }
+}
+",
+        &FsResolver::new("."),
+        "collision.fsl",
+    )
+    .expect("lower collision");
+    let error = build_model(kernel).expect_err("generated state names collide");
+    assert!(error.message.contains("duplicate state variable"));
+    let origin = error.origin.expect("validation origin");
+    assert_eq!(
+        origin
+            .primary
+            .as_ref()
+            .and_then(|site| site.source_file.as_deref()),
+        Some("collision.fsl")
+    );
+    assert!(origin.secondary.iter().any(|site| {
+        site.source_file.as_deref() == Some("collision.fsl")
+            && site.declaration_path.iter().any(|part| part == "foo_bar")
+    }));
+}
+
+#[test]
+fn checked_type_validation_keeps_all_duplicate_declaration_origins() {
+    let kernel = fsl_core::parse_kernel_source_with_file(
+        r"
+domain DuplicateType {
+  type Count = 0..1
+  type Count = 0..2
+  aggregate Item { state { count: Count = 0; } }
+}
+",
+        &FsResolver::new("."),
+        "duplicate-type.fsl",
+    )
+    .expect("lower duplicate types");
+    let error = build_model(kernel).expect_err("duplicate type rejected");
+    assert!(error.message.contains("duplicate type"));
+    let origin = error.origin.expect("type validation origin");
+    let primary = origin.primary.as_ref().expect("first declaration");
+    assert_eq!(primary.source_file.as_deref(), Some("duplicate-type.fsl"));
+    assert_eq!(primary.span.expect("first type span").start.line, 3);
+    assert!(origin.secondary.iter().any(|site| {
+        site.source_file.as_deref() == Some("duplicate-type.fsl")
+            && site.span.is_some_and(|span| span.start.line == 4)
+    }));
+}
+
+#[test]
+fn nested_lvalue_statement_keeps_the_original_assignment_span() {
+    let source = r"
+domain Nested {
+  type Quantity = 0..2
+  value_object Counter { value: Quantity = 0; }
+  aggregate Item {
+    state { counter: Counter; }
+    command Put { value: Quantity; }
+    event PutDone { value: Quantity; }
+    decide Put { emits PutDone }
+    evolve PutDone { counter.value = value }
+    invariant nonnegative { counter.value >= 0 }
+  }
+}
+";
+    let model = model(source);
+    let action = model
+        .actions
+        .iter()
+        .find(|action| action.name == "item_put")
+        .expect("put action");
+    let statement_index = action
+        .statements
+        .iter()
+        .rposition(|statement| matches!(statement, fsl_core::KernelStatement::Assign { .. }))
+        .expect("nested assignment");
+    let origin = model
+        .origins()
+        .primary_for(&action_statement_target("item_put", statement_index))
+        .expect("assignment origin");
+    let site = origin.primary.as_ref().expect("source assignment");
+    assert!(site.declaration_path.join(".").contains("counter.value"));
+    assert!(site.span.expect("assignment span").start.line > 0);
+}
+
+#[test]
+fn parse_type_and_lowering_errors_keep_primary_and_secondary_source_origins() {
+    let parse_error = fsl_core::parse_kernel_source_with_file(
+        "domain Broken { aggregate Item { invariant bad { true ",
+        &FsResolver::new("."),
+        "broken.fsl",
+    )
+    .expect_err("parse error");
+    let parse_primary = parse_error
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .expect("parse primary origin");
+    assert_eq!(parse_primary.source_file.as_deref(), Some("broken.fsl"));
+    assert!(parse_primary.span.is_some());
+
+    let type_error = fsl_core::parse_kernel_source_with_file(
+        r"
+domain Broken {
+  aggregate Item {
+    state { count: Int = 0; }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+    invariant bad { missing == 0 }
+  }
+}
+",
+        &FsResolver::new("."),
+        "broken.fsl",
+    )
+    .expect_err("name/type error");
+    let type_primary = type_error
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .expect("type primary origin");
+    assert_eq!(type_primary.source_file.as_deref(), Some("broken.fsl"));
+    assert_eq!(type_primary.span.expect("type span").start.line, 9);
+
+    let lowering_error = fsl_core::parse_kernel_source_with_file(
+        r"
+domain Recursive {
+  aggregate Item {
+    state { ready: Bool = true; }
+    command Touch {}
+    event Touched {}
+    decide Touch { requires can(Touch) emits Touched }
+    evolve Touched {}
+    invariant enabled { can(Touch) }
+  }
+}
+",
+        &FsResolver::new("."),
+        "recursive.fsl",
+    )
+    .expect_err("recursive lowering error");
+    let lowering = lowering_error.origin.expect("lowering origin");
+    assert_eq!(
+        lowering
+            .primary
+            .as_ref()
+            .and_then(|site| site.source_file.as_deref()),
+        Some("recursive.fsl")
+    );
+    assert!(lowering.secondary.iter().any(|site| {
+        site.source_file.as_deref() == Some("recursive.fsl")
+            && site
+                .declaration_path
+                .last()
+                .is_some_and(|item| item == "Touch")
+    }));
+}

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -14,6 +14,8 @@ use crate::{ParseError, Span, Token, TokenKind, lex};
 pub struct DomainLoc {
     pub line: u32,
     pub column: u32,
+    #[serde(skip)]
+    span: Span,
 }
 
 impl From<Span> for DomainLoc {
@@ -21,7 +23,15 @@ impl From<Span> for DomainLoc {
         Self {
             line: span.start.line,
             column: span.start.column,
+            span,
         }
+    }
+}
+
+impl DomainLoc {
+    #[must_use]
+    pub fn span(self) -> Span {
+        self.span
     }
 }
 

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -54,6 +54,7 @@ impl FileResolver for MemoryResolver {
             message: format!("file not found: {path}"),
             line: 1,
             column: 1,
+            origin: None,
         })
     }
 }

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -15,6 +15,53 @@ pub fn display_name(name: &str) -> String {
     name.replacen("__", ".", 1).replace("QqDbSepqQ", "__")
 }
 
+fn origin_site_json(site: &fsl_core::OriginSite) -> Value {
+    let span = site.span.map(|span| {
+        json!({
+            "start": {
+                "offset": span.start.offset,
+                "line": span.start.line,
+                "column": span.start.column,
+            },
+            "end": {
+                "offset": span.end.offset,
+                "line": span.end.line,
+                "column": span.end.column,
+            },
+        })
+    });
+    json!({
+        "source_file": site.source_file,
+        "span": span,
+        "dialect": site.dialect,
+        "declaration_path": site.declaration_path,
+    })
+}
+
+#[must_use]
+pub fn internal_origin_json(origin: &fsl_core::OriginChain) -> Value {
+    json!({
+        "identity": origin.id.0,
+        "dialect": origin.dialect,
+        "primary": origin.primary.as_ref().map(origin_site_json),
+        "secondary": origin.secondary.iter().map(origin_site_json).collect::<Vec<_>>(),
+        "lowering_steps": origin.lowering_steps.iter().map(|step| json!({
+            "kind": step.kind,
+            "detail": step.detail,
+        })).collect::<Vec<_>>(),
+        "generated": origin.generated,
+    })
+}
+
+#[must_use]
+pub fn origin_display_name(origin: &fsl_core::OriginChain) -> Option<&str> {
+    origin
+        .primary
+        .as_ref()
+        .and_then(|site| site.declaration_path.last())
+        .map(String::as_str)
+}
+
 #[must_use]
 pub fn trace_json(model: &KernelModel, trace: &[TraceStep]) -> Value {
     Value::Array(
@@ -26,7 +73,22 @@ pub fn trace_json(model: &KernelModel, trace: &[TraceStep]) -> Value {
                 value.insert("state".to_owned(), state_json(&entry.state));
                 if let Some(action) = &entry.action {
                     let mut action_json = serde_json::Map::new();
-                    action_json.insert("name".to_owned(), json!(display_name(&action.name)));
+                    let origin = model.action_origin(&action.name);
+                    action_json.insert(
+                        "name".to_owned(),
+                        json!(
+                            origin
+                                .and_then(origin_display_name)
+                                .map_or_else(|| display_name(&action.name), str::to_owned)
+                        ),
+                    );
+                    if let Some(origin) = origin {
+                        action_json.insert(
+                            "generated_name".to_owned(),
+                            json!(display_name(&action.name)),
+                        );
+                        action_json.insert("origin".to_owned(), internal_origin_json(origin));
+                    }
                     action_json.insert(
                         "params".to_owned(),
                         Value::Object(

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3455,7 +3455,15 @@ fn run_check_with_tags(
 
 fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, String> {
     let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    fsl_syntax::parse_surface_document(&source).map_err(|error| error.to_string())
+    fsl_syntax::parse_surface_document(&source).map_err(|error| {
+        format!(
+            "{} at {}:{}:{}",
+            error.message,
+            path.display(),
+            error.span.start.line,
+            error.span.start.column
+        )
+    })
 }
 
 fn validate_specialized_document(path: &Path) -> Result<(), String> {
@@ -4644,13 +4652,18 @@ fn model_stage_flows(model: &KernelModel) -> Vec<Value> {
     flows
 }
 
+#[allow(clippy::too_many_lines)]
 fn model_skeleton(model: &KernelModel) -> Value {
     let actions = model
         .actions
         .iter()
         .map(|action| {
+            let origin = model.action_origin(&action.name);
             let mut value = json!({
-                "name": fslc_rust::display_name(&action.name),
+                "name": origin
+                    .and_then(|origin| origin.primary.as_ref())
+                    .and_then(|site| site.declaration_path.last())
+                    .map_or_else(|| fslc_rust::display_name(&action.name), String::clone),
                 "params": action.params.iter().map(|param|param_skeleton(model,param)).collect::<Vec<_>>(),
                 "requires_text": action.requires.iter().map(|expr|format!("requires {}",fslc_rust::expr_text(expr))).collect::<Vec<_>>(),
                 "ensures_text": action.ensures.iter().map(|expr|format!("ensures {}",fslc_rust::expr_text(expr))).collect::<Vec<_>>(),
@@ -4660,6 +4673,18 @@ fn model_skeleton(model: &KernelModel) -> Value {
                 && let Value::Object(value) = &mut value
             {
                 value.insert("fair".to_owned(), json!(true));
+            }
+            if let Some(origin) = origin
+                && let Value::Object(value) = &mut value
+            {
+                value.insert(
+                    "generated_name".to_owned(),
+                    json!(fslc_rust::display_name(&action.name)),
+                );
+                value.insert(
+                    "origin".to_owned(),
+                    fslc_rust::internal_origin_json(origin),
+                );
             }
             value
         })
@@ -4671,7 +4696,26 @@ fn model_skeleton(model: &KernelModel) -> Value {
         ("reachable", &model.reachables),
     ] {
         properties.extend(items.iter().map(|property| {
-            json!({"name":fslc_rust::display_name(&property.name),"kind":kind,"body_text":fslc_rust::expr_text(&property.expr),"requirement":metadata(property.meta.as_ref())})
+            let origin = model.property_origin(kind, &property.name);
+            let mut value = json!({
+                "name": origin
+                    .and_then(|origin| origin.primary.as_ref())
+                    .and_then(|site| site.declaration_path.last())
+                    .map_or_else(|| fslc_rust::display_name(&property.name), String::clone),
+                "kind":kind,
+                "body_text":fslc_rust::expr_text(&property.expr),
+                "requirement":metadata(property.meta.as_ref())
+            });
+            if let Some(origin) = origin
+                && let Value::Object(value) = &mut value
+            {
+                value.insert(
+                    "generated_name".to_owned(),
+                    json!(fslc_rust::display_name(&property.name)),
+                );
+                value.insert("origin".to_owned(), fslc_rust::internal_origin_json(origin));
+            }
+            value
         }));
     }
     for property in &model.leadstos {
@@ -5471,21 +5515,52 @@ fn invariant_violation_explanation(
                 .actions
                 .iter()
                 .find(|definition| definition.name == action.name);
-            json!({
-                "name": display(&action.name),
+            let origin = model.action_origin(&action.name);
+            let mut value = json!({
+                "name": origin
+                    .and_then(fslc_rust::origin_display_name)
+                    .map_or_else(|| display(&action.name), str::to_owned),
                 "params": action.params.iter().map(|(name, value)| (
                     name.clone(), fslc_rust::fsl_value_json(value)
                 )).collect::<Map<_, _>>(),
                 "loc": definition.map(|definition| definition.span.python_loc()),
-            })
+            });
+            if let Some(origin) = origin
+                && let Value::Object(value) = &mut value
+            {
+                value.insert("generated_name".to_owned(), json!(display(&action.name)));
+                value.insert("origin".to_owned(), fslc_rust::internal_origin_json(origin));
+                if let Some(span) = origin.primary.as_ref().and_then(|site| site.span) {
+                    value.insert("loc".to_owned(), span.python_loc());
+                }
+            }
+            value
         });
     let mut explanation = Map::new();
     explanation.insert("violation_kind".to_owned(), json!(violation.kind));
-    explanation.insert("invariant".to_owned(), json!(display(&violation.name)));
+    let origin = model.property_origin("invariant", &violation.name);
+    explanation.insert(
+        "invariant".to_owned(),
+        json!(
+            origin
+                .and_then(fslc_rust::origin_display_name)
+                .map_or_else(|| display(&violation.name), str::to_owned)
+        ),
+    );
     explanation.insert(
         "loc".to_owned(),
-        property.map_or(Value::Null, |property| property.span.python_loc()),
+        origin
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.span)
+            .map_or_else(
+                || property.map_or(Value::Null, |property| property.span.python_loc()),
+                fsl_syntax::Span::python_loc,
+            ),
     );
+    if let Some(origin) = origin {
+        explanation.insert("generated_name".to_owned(), json!(display(&violation.name)));
+        explanation.insert("origin".to_owned(), fslc_rust::internal_origin_json(origin));
+    }
     explanation.insert("violated_at_step".to_owned(), json!(violation.step));
     explanation.insert("violating_bindings".to_owned(), violating.clone());
     explanation.insert(
@@ -11925,6 +12000,7 @@ fn statement_location(statements: &[fsl_core::KernelStatement]) -> Value {
     })
 }
 
+#[allow(clippy::too_many_lines)]
 fn concrete_boundary_output(
     model: &KernelModel,
     violation: &fsl_runtime::Violation,
@@ -11935,7 +12011,6 @@ fn concrete_boundary_output(
     output.insert("result".to_owned(), json!("violated"));
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("violation_kind".to_owned(), json!(violation.kind));
-    output.insert("invariant".to_owned(), json!(display(&violation.name)));
     let action = trace.last().and_then(|entry| entry.action.as_ref());
     let definition = action.and_then(|action| {
         model
@@ -11943,13 +12018,43 @@ fn concrete_boundary_output(
             .iter()
             .find(|definition| definition.name == action.name)
     });
+    let origin = match violation.kind.as_str() {
+        "invariant" => model.property_origin("invariant", &violation.name),
+        "trans" => model.property_origin("trans", &violation.name),
+        "type_bound" => violation
+            .name
+            .strip_prefix("_bounds_")
+            .and_then(|name| model.state_origin(name)),
+        _ => action.and_then(|action| model.action_origin(&action.name)),
+    };
+    output.insert(
+        "invariant".to_owned(),
+        json!(
+            origin
+                .and_then(fslc_rust::origin_display_name)
+                .map_or_else(|| display(&violation.name), str::to_owned)
+        ),
+    );
+    if let Some(origin) = origin {
+        output.insert("generated_name".to_owned(), json!(display(&violation.name)));
+        output.insert("origin".to_owned(), fslc_rust::internal_origin_json(origin));
+    }
     output.insert(
         "loc".to_owned(),
-        if violation.kind == "partial_op" {
-            definition.map_or(Value::Null, |action| statement_location(&action.statements))
-        } else {
-            Value::Null
-        },
+        origin
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.span)
+            .map_or_else(
+                || {
+                    if violation.kind == "partial_op" {
+                        definition
+                            .map_or(Value::Null, |action| statement_location(&action.statements))
+                    } else {
+                        Value::Null
+                    }
+                },
+                fsl_syntax::Span::python_loc,
+            ),
     );
     if violation.kind == "partial_op" {
         output.insert(
@@ -11984,13 +12089,23 @@ fn concrete_boundary_output(
     output.insert(
         "last_action".to_owned(),
         action.map_or(Value::Null, |action| {
-            json!({
-                "name": display(&action.name),
+            let action_origin = model.action_origin(&action.name);
+            let mut value = json!({
+                "name": action_origin
+                    .and_then(fslc_rust::origin_display_name)
+                    .map_or_else(|| display(&action.name), str::to_owned),
                 "params": action.params.iter().map(|(name, value)| (
                     name.clone(), fslc_rust::fsl_value_json(value)
                 )).collect::<Map<_, _>>(),
                 "loc": definition.map(|definition| definition.span.python_loc()),
-            })
+            });
+            if let Some(origin) = action_origin
+                && let Value::Object(value) = &mut value
+            {
+                value.insert("generated_name".to_owned(), json!(display(&action.name)));
+                value.insert("origin".to_owned(), fslc_rust::internal_origin_json(origin));
+            }
+            value
         }),
     );
     let mut rendered_trace = fslc_rust::trace_json(model, trace);
@@ -12493,13 +12608,15 @@ fn load_model(path: &Path) -> Result<KernelModel, String> {
     let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
-    let kernel = fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| {
-        if error.message == "top-level document has not reached the kernel lowering gate" {
-            "spec has no state block".to_owned()
-        } else {
-            error.to_string()
-        }
-    })?;
+    let kernel =
+        fsl_core::parse_kernel_source_with_file(&source, &resolver, path.to_string_lossy())
+            .map_err(|error| {
+                if error.message == "top-level document has not reached the kernel lowering gate" {
+                    "spec has no state block".to_owned()
+                } else {
+                    error.to_string()
+                }
+            })?;
     fsl_core::build_model(kernel).map_err(|error| error.to_string())
 }
 

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -74,6 +74,50 @@ pub(super) struct ExplicitRequest<'a> {
 
 type CommandResult = (Value, i32);
 
+fn origin_aware_property_name(
+    output: &mut Map<String, Value>,
+    model: &KernelModel,
+    kind: &str,
+    name: &str,
+) -> String {
+    let Some(origin) = model.property_origin(kind, name) else {
+        return display(name);
+    };
+    output.insert("generated_name".to_owned(), json!(display(name)));
+    output.insert(
+        "origin".to_owned(),
+        ::fslc_rust::internal_origin_json(origin),
+    );
+    if let Some(span) = origin.primary.as_ref().and_then(|site| site.span) {
+        output.insert("loc".to_owned(), span.python_loc());
+    }
+    ::fslc_rust::origin_display_name(origin).map_or_else(|| display(name), str::to_owned)
+}
+
+fn origin_aware_action_json(
+    model: &KernelModel,
+    name: &str,
+    params: &Map<String, Value>,
+    fallback_loc: Value,
+) -> Value {
+    let Some(origin) = model.action_origin(name) else {
+        return json!({"name": display(name), "params": params, "loc": fallback_loc});
+    };
+    let loc = origin
+        .primary
+        .as_ref()
+        .and_then(|site| site.span)
+        .map_or(fallback_loc, fsl_syntax::Span::python_loc);
+    json!({
+        "name": ::fslc_rust::origin_display_name(origin)
+            .map_or_else(|| display(name), str::to_owned),
+        "generated_name": display(name),
+        "params": params,
+        "loc": loc,
+        "origin": ::fslc_rust::internal_origin_json(origin),
+    })
+}
+
 struct PreparedBmc {
     model: KernelModel,
     checked_bounds: Option<std::collections::BTreeSet<String>>,
@@ -170,10 +214,16 @@ fn render_induction_cti(
     let mut output = envelope();
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("unknown_cti"));
+    let property_kind = if cti.kind == "trans" {
+        "trans"
+    } else {
+        "invariant"
+    };
+    let name = origin_aware_property_name(&mut output, model, property_kind, &cti.name);
     if cti.kind == "trans" {
-        output.insert("trans".to_owned(), json!(display(&cti.name)));
+        output.insert("trans".to_owned(), json!(name));
     }
-    output.insert("invariant".to_owned(), json!(display(&cti.name)));
+    output.insert("invariant".to_owned(), json!(name));
     output.insert("k".to_owned(), json!(cti.k));
     output.insert("checked_to_depth".to_owned(), json!(depth));
     output.insert("completeness".to_owned(), json!("bounded"));
@@ -231,11 +281,11 @@ fn render_rank_failure(
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("unknown_cti"));
     output.insert("violation_kind".to_owned(), json!("leadsTo_rank"));
-    output.insert("invariant".to_owned(), json!(display(&failure.name)));
-    output.insert(
-        "loc".to_owned(),
-        property.map_or(Value::Null, |property| property.span.python_loc()),
-    );
+    let name = origin_aware_property_name(&mut output, model, "leadsTo", &failure.name);
+    output.insert("invariant".to_owned(), json!(name));
+    output
+        .entry("loc".to_owned())
+        .or_insert_with(|| property.map_or(Value::Null, |property| property.span.python_loc()));
     output.insert(
         "bindings".to_owned(),
         Value::Object(
@@ -266,15 +316,23 @@ fn render_rank_failure(
             .actions
             .iter()
             .find(|definition| definition.name == *action_name);
+        let params = action
+            .map(|action| {
+                action
+                    .params
+                    .iter()
+                    .map(|(name, value)| (name.clone(), ::fslc_rust::fsl_value_json(value)))
+                    .collect::<Map<_, _>>()
+            })
+            .unwrap_or_default();
         output.insert(
             "last_action".to_owned(),
-            json!({
-                "name": display(action_name),
-                "params": action.map(|action| action.params.iter().map(|(name, value)| (
-                    name.clone(), ::fslc_rust::fsl_value_json(value)
-                )).collect::<Map<_, _>>()).unwrap_or_default(),
-                "loc": definition.map(|definition| definition.span.python_loc()),
-            }),
+            origin_aware_action_json(
+                model,
+                action_name,
+                &params,
+                definition.map_or(Value::Null, |definition| definition.span.python_loc()),
+            ),
         );
     }
     output.insert(
@@ -837,6 +895,7 @@ fn render_bmc_result(
     )
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_bmc_violation(
     model: &KernelModel,
     violation: &fsl_verifier::BmcViolation,
@@ -846,14 +905,39 @@ fn render_bmc_violation(
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("violated"));
     output.insert("violation_kind".to_owned(), json!(violation.kind));
+    let (property_kind, property) = if violation.kind == "trans" {
+        (
+            "trans",
+            model
+                .transitions
+                .iter()
+                .find(|property| property.name == violation.name),
+        )
+    } else {
+        (
+            "invariant",
+            model
+                .invariants
+                .iter()
+                .find(|property| property.name == violation.name),
+        )
+    };
+    let origin = model.property_origin(property_kind, &violation.name);
+    let display_name = origin
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.declaration_path.last())
+        .map_or_else(|| display(&violation.name), String::clone);
     if violation.kind == "trans" {
-        output.insert("trans".to_owned(), json!(display(&violation.name)));
+        output.insert("trans".to_owned(), json!(display_name));
     }
-    output.insert("invariant".to_owned(), json!(display(&violation.name)));
-    let property = model
-        .invariants
-        .iter()
-        .find(|property| property.name == violation.name);
+    output.insert("invariant".to_owned(), json!(display_name));
+    if let Some(origin) = origin {
+        output.insert("generated_name".to_owned(), json!(display(&violation.name)));
+        output.insert(
+            "origin".to_owned(),
+            ::fslc_rust::internal_origin_json(origin),
+        );
+    }
     if let Some(meta) = property.and_then(|property| property.meta.as_ref()) {
         output.insert("requirement".to_owned(), metadata(Some(meta)));
     }
@@ -891,13 +975,27 @@ fn render_bmc_violation(
                     .actions
                     .iter()
                     .find(|definition| definition.name == action.name);
-                json!({
-                    "name": display(&action.name),
+                let origin = model.action_origin(&action.name);
+                let mut rendered = json!({
+                    "name": origin
+                        .and_then(|origin| origin.primary.as_ref())
+                        .and_then(|site| site.declaration_path.last())
+                        .map_or_else(|| display(&action.name), String::clone),
                     "params": action.params.iter().map(|(name, value)| (
                         name.clone(), ::fslc_rust::fsl_value_json(value)
                     )).collect::<Map<_, _>>(),
                     "loc": definition.map(|definition| definition.span.python_loc()),
-                })
+                });
+                if let Some(origin) = origin
+                    && let Value::Object(rendered) = &mut rendered
+                {
+                    rendered.insert("generated_name".to_owned(), json!(display(&action.name)));
+                    rendered.insert(
+                        "origin".to_owned(),
+                        ::fslc_rust::internal_origin_json(origin),
+                    );
+                }
+                rendered
             }),
     );
     let mut trace = ::fslc_rust::trace_json(model, &violation.trace);
@@ -938,8 +1036,12 @@ fn render_reachable_failure(
             unreached
                 .iter()
                 .map(|property| {
+                    let origin = model.property_origin("reachable", &property.name);
                     let mut item = json!({
-                        "name": display(&property.name),
+                        "name": origin
+                            .and_then(|origin| origin.primary.as_ref())
+                            .and_then(|site| site.declaration_path.last())
+                            .map_or_else(|| display(&property.name), String::clone),
                         "loc": property.span.python_loc(),
                         "classification": "insufficient_depth",
                         "hint": format!("not witnessed within depth {depth}; try a larger --depth"),
@@ -950,6 +1052,15 @@ fn render_reachable_failure(
                         && let Value::Object(item) = &mut item
                     {
                         item.insert("requirement".to_owned(), metadata(Some(meta)));
+                    }
+                    if let Some(origin) = origin
+                        && let Value::Object(item) = &mut item
+                    {
+                        item.insert("generated_name".to_owned(), json!(display(&property.name)));
+                        item.insert(
+                            "origin".to_owned(),
+                            ::fslc_rust::internal_origin_json(origin),
+                        );
                     }
                     item
                 })
@@ -1019,11 +1130,11 @@ fn render_leadsto_failure(
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("violated"));
     output.insert("violation_kind".to_owned(), json!("leadsTo"));
-    output.insert("invariant".to_owned(), json!(display(&violation.name)));
-    output.insert(
-        "loc".to_owned(),
-        property.map_or(Value::Null, |property| property.span.python_loc()),
-    );
+    let name = origin_aware_property_name(&mut output, model, "leadsTo", &violation.name);
+    output.insert("invariant".to_owned(), json!(name));
+    output
+        .entry("loc".to_owned())
+        .or_insert_with(|| property.map_or(Value::Null, |property| property.span.python_loc()));
     output.insert(
         "bindings".to_owned(),
         Value::Object(
@@ -2073,6 +2184,24 @@ mod tests {
         assert_eq!(status, 1);
         assert_eq!(output["result"], "unknown_cti");
         assert_eq!(output["invariant"], "Sync");
+    }
+
+    #[test]
+    fn induction_counterexample_renderer_uses_domain_origin() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/domain_origin_violation.fsl");
+        let model = load_model(&path).expect("domain model");
+        let cti = fsl_verifier::InductionCti {
+            kind: "invariant".to_owned(),
+            name: "Order_mustBeApproved".to_owned(),
+            k: 1,
+            trace: Vec::new(),
+        };
+        let (output, status) = render_induction_cti(&model, &cti, 1, Instant::now());
+        assert_eq!(status, 1);
+        assert_eq!(output["invariant"], "mustBeApproved");
+        assert_eq!(output["generated_name"], "Order_mustBeApproved");
+        assert_eq!(output["origin"]["dialect"], "domain");
     }
 
     #[test]

--- a/rust/fslc/tests/domain_origin_diagnostics.rs
+++ b/rust/fslc/tests/domain_origin_diagnostics.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/domain_origin_violation.fsl")
+}
+
+fn run(arguments: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid CLI JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+#[test]
+fn verify_and_counterexample_trace_use_domain_declarations_as_primary_names() {
+    let path = fixture();
+    let (output, status) = run(&[
+        "verify".to_owned(),
+        path.to_string_lossy().into_owned(),
+        "--depth".to_owned(),
+        "1".to_owned(),
+        "--deadlock".to_owned(),
+        "ignore".to_owned(),
+        "--no-cache".to_owned(),
+    ]);
+    assert_eq!(status, 1);
+    assert_eq!(output["result"], "violated");
+    assert_eq!(output["invariant"], "mustBeApproved");
+    assert_eq!(output["generated_name"], "Order_mustBeApproved");
+    assert_eq!(
+        output["origin"]["primary"]["source_file"],
+        path.to_string_lossy().as_ref()
+    );
+    assert_eq!(output["origin"]["primary"]["span"]["start"]["line"], 15);
+    assert_eq!(
+        output["origin"]["primary"]["declaration_path"],
+        serde_json::json!([
+            "Orders",
+            "aggregate",
+            "Order",
+            "invariant",
+            "mustBeApproved"
+        ])
+    );
+    assert_eq!(output["trace"][0]["step"], 0);
+}
+
+#[test]
+fn explain_surfaces_origin_without_promoting_generated_names() {
+    let path = fixture();
+    let (output, status) = run(&[
+        "explain".to_owned(),
+        path.to_string_lossy().into_owned(),
+        "--depth".to_owned(),
+        "1".to_owned(),
+    ]);
+    assert_eq!(status, 0);
+    let property = output["skeleton"]["properties"]
+        .as_array()
+        .expect("properties")
+        .iter()
+        .find(|property| property["name"] == "mustBeApproved")
+        .expect("domain invariant");
+    assert_eq!(property["generated_name"], "Order_mustBeApproved");
+    assert_eq!(property["origin"]["dialect"], "domain");
+    assert_eq!(
+        property["requirement"]["id"], "DOMAIN-INVARIANT",
+        "requirement traceability remains a separate field"
+    );
+    assert_ne!(
+        property["origin"]["identity"],
+        property["requirement"]["id"]
+    );
+}
+
+#[test]
+fn public_kernel_v1_remains_closed_and_does_not_emit_internal_chain_fields() {
+    let path = fixture();
+    let (output, status) = run(&["kernel".to_owned(), path.to_string_lossy().into_owned()]);
+    assert_eq!(status, 0);
+    assert_eq!(output["schema_version"], "1.0.0");
+    let origin = output["properties"]["invariants"][0]["origin"]
+        .as_object()
+        .expect("public v1 origin");
+    assert_eq!(
+        origin
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>(),
+        ["declaration", "dialect", "generated", "lowered"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    );
+    for internal in ["identity", "primary", "secondary", "lowering_steps"] {
+        assert!(!origin.contains_key(internal));
+    }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -3167,7 +3167,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -3179,7 +3179,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_ApprovalRejected"
             },
@@ -3193,7 +3193,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -3208,7 +3208,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -3220,7 +3220,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_Approved"
             },
@@ -3234,7 +3234,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -3249,7 +3249,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -3261,7 +3261,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_Cancelled"
             },
@@ -3275,7 +3275,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -3699,7 +3699,7 @@
                 "line": 39,
                 "column": 5,
                 "end_line": 39,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -3711,7 +3711,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_ApprovalRejected"
               },
@@ -3725,7 +3725,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -3740,7 +3740,7 @@
                 "line": 39,
                 "column": 5,
                 "end_line": 39,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -3752,7 +3752,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Approved"
               },
@@ -3766,7 +3766,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": true
               }
@@ -3781,7 +3781,7 @@
                 "line": 39,
                 "column": 5,
                 "end_line": 39,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -3793,7 +3793,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Cancelled"
               },
@@ -3807,7 +3807,7 @@
                   "line": 39,
                   "column": 5,
                   "end_line": 39,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -4011,7 +4011,7 @@
             "line": 39,
             "column": 5,
             "end_line": 39,
-            "end_column": 5
+            "end_column": 11
           }
         },
         {
@@ -4195,7 +4195,7 @@
                 "line": 46,
                 "column": 5,
                 "end_line": 46,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -4207,7 +4207,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_ApprovalRejected"
               },
@@ -4221,7 +4221,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -4236,7 +4236,7 @@
                 "line": 46,
                 "column": 5,
                 "end_line": 46,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -4248,7 +4248,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Approved"
               },
@@ -4262,7 +4262,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -4277,7 +4277,7 @@
                 "line": 46,
                 "column": 5,
                 "end_line": 46,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -4289,7 +4289,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Cancelled"
               },
@@ -4303,7 +4303,7 @@
                   "line": 46,
                   "column": 5,
                   "end_line": 46,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": true
               }
@@ -4406,7 +4406,7 @@
             "line": 46,
             "column": 5,
             "end_line": 46,
-            "end_column": 5
+            "end_column": 11
           }
         }
       ],
@@ -5218,7 +5218,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "value": false
           },
@@ -5227,7 +5227,7 @@
             "line": 1,
             "column": 1,
             "end_line": 1,
-            "end_column": 1
+            "end_column": 7
           }
         }
       }
@@ -5411,7 +5411,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -5423,7 +5423,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_Approved"
             },
@@ -5437,7 +5437,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -5452,7 +5452,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -5464,7 +5464,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_PaymentCaptured"
             },
@@ -5478,7 +5478,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -5493,7 +5493,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -5505,7 +5505,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_PaymentFailed"
             },
@@ -5519,7 +5519,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -5534,7 +5534,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -5546,7 +5546,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_PaymentRequested"
             },
@@ -5560,7 +5560,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -5575,7 +5575,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "target": {
               "kind": "var",
@@ -5587,7 +5587,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "name": "event_PaymentTimedOut"
             },
@@ -5601,7 +5601,7 @@
                 "line": 1,
                 "column": 1,
                 "end_line": 1,
-                "end_column": 1
+                "end_column": 7
               },
               "value": false
             }
@@ -5616,7 +5616,7 @@
               "line": 38,
               "column": 3,
               "end_line": 38,
-              "end_column": 3
+              "end_column": 9
             },
             "binder": {
               "name": "k",
@@ -5637,7 +5637,7 @@
                   "line": 38,
                   "column": 3,
                   "end_line": 38,
-                  "end_column": 3
+                  "end_column": 9
                 },
                 "target": {
                   "kind": "index",
@@ -5650,7 +5650,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "name": "capture_payment_status",
                   "index": {
@@ -5664,7 +5664,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "name": "k"
                   }
@@ -5680,7 +5680,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "name": "CapturePaymentEffectStatus_NotStarted"
                 }
@@ -5697,7 +5697,7 @@
               "line": 38,
               "column": 3,
               "end_line": 38,
-              "end_column": 3
+              "end_column": 9
             },
             "binder": {
               "name": "k",
@@ -5718,7 +5718,7 @@
                   "line": 38,
                   "column": 3,
                   "end_line": 38,
-                  "end_column": 3
+                  "end_column": 9
                 },
                 "target": {
                   "kind": "index",
@@ -5731,7 +5731,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "name": "capture_payment_attempts",
                   "index": {
@@ -5745,7 +5745,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "name": "k"
                   }
@@ -5762,7 +5762,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "value": 0
                 }
@@ -5801,7 +5801,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "operator": "==",
                 "left": {
@@ -5815,7 +5815,7 @@
                     "line": 18,
                     "column": 5,
                     "end_line": 18,
-                    "end_column": 5
+                    "end_column": 10
                   },
                   "collection": {
                     "kind": "var",
@@ -5835,7 +5835,7 @@
                       "line": 18,
                       "column": 5,
                       "end_line": 18,
-                      "end_column": 5
+                      "end_column": 10
                     },
                     "name": "capture_payment_status"
                   },
@@ -5850,7 +5850,7 @@
                       "line": 18,
                       "column": 5,
                       "end_line": 18,
-                      "end_column": 5
+                      "end_column": 10
                     },
                     "name": "payment_request_id"
                   }
@@ -5866,7 +5866,7 @@
                     "line": 18,
                     "column": 5,
                     "end_line": 18,
-                    "end_column": 5
+                    "end_column": 10
                   },
                   "name": "CapturePaymentEffectStatus_Pending"
                 }
@@ -5884,7 +5884,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "var",
@@ -5896,7 +5896,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "event_Approved"
               },
@@ -5910,7 +5910,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "value": false
               }
@@ -5925,7 +5925,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "var",
@@ -5937,7 +5937,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -5951,7 +5951,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "value": true
               }
@@ -5966,7 +5966,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "var",
@@ -5978,7 +5978,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "event_PaymentFailed"
               },
@@ -5992,7 +5992,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "value": false
               }
@@ -6007,7 +6007,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "var",
@@ -6019,7 +6019,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "event_PaymentRequested"
               },
@@ -6033,7 +6033,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "value": false
               }
@@ -6048,7 +6048,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "var",
@@ -6060,7 +6060,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -6074,7 +6074,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "value": false
               }
@@ -6089,7 +6089,7 @@
                 "line": 18,
                 "column": 5,
                 "end_line": 18,
-                "end_column": 5
+                "end_column": 10
               },
               "target": {
                 "kind": "index",
@@ -6102,7 +6102,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "capture_payment_status",
                 "index": {
@@ -6116,7 +6116,7 @@
                     "line": 18,
                     "column": 5,
                     "end_line": 18,
-                    "end_column": 5
+                    "end_column": 10
                   },
                   "name": "payment_request_id"
                 }
@@ -6132,7 +6132,7 @@
                   "line": 18,
                   "column": 5,
                   "end_line": 18,
-                  "end_column": 5
+                  "end_column": 10
                 },
                 "name": "CapturePaymentEffectStatus_Succeeded"
               }
@@ -6192,7 +6192,7 @@
             "line": 18,
             "column": 5,
             "end_line": 18,
-            "end_column": 5
+            "end_column": 10
           }
         },
         {
@@ -6258,7 +6258,7 @@
                 "line": 22,
                 "column": 5,
                 "end_line": 22,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6270,7 +6270,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Approved"
               },
@@ -6284,7 +6284,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": true
               }
@@ -6299,7 +6299,7 @@
                 "line": 22,
                 "column": 5,
                 "end_line": 22,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6311,7 +6311,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -6325,7 +6325,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6340,7 +6340,7 @@
                 "line": 22,
                 "column": 5,
                 "end_line": 22,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6352,7 +6352,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentFailed"
               },
@@ -6366,7 +6366,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6381,7 +6381,7 @@
                 "line": 22,
                 "column": 5,
                 "end_line": 22,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6393,7 +6393,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentRequested"
               },
@@ -6407,7 +6407,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6422,7 +6422,7 @@
                 "line": 22,
                 "column": 5,
                 "end_line": 22,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6434,7 +6434,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -6448,7 +6448,7 @@
                   "line": 22,
                   "column": 5,
                   "end_line": 22,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6508,7 +6508,7 @@
             "line": 22,
             "column": 5,
             "end_line": 22,
-            "end_column": 5
+            "end_column": 11
           }
         },
         {
@@ -6574,7 +6574,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "operator": "!=",
                 "left": {
@@ -6588,7 +6588,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "collection": {
                     "kind": "var",
@@ -6608,7 +6608,7 @@
                       "line": 26,
                       "column": 5,
                       "end_line": 26,
-                      "end_column": 5
+                      "end_column": 11
                     },
                     "name": "capture_payment_status"
                   },
@@ -6623,7 +6623,7 @@
                       "line": 26,
                       "column": 5,
                       "end_line": 26,
-                      "end_column": 5
+                      "end_column": 11
                     },
                     "name": "payment_request_id"
                   }
@@ -6639,7 +6639,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "name": "CapturePaymentEffectStatus_Pending"
                 }
@@ -6657,7 +6657,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "operator": "!=",
                 "left": {
@@ -6671,7 +6671,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "collection": {
                     "kind": "var",
@@ -6691,7 +6691,7 @@
                       "line": 26,
                       "column": 5,
                       "end_line": 26,
-                      "end_column": 5
+                      "end_column": 11
                     },
                     "name": "capture_payment_status"
                   },
@@ -6706,7 +6706,7 @@
                       "line": 26,
                       "column": 5,
                       "end_line": 26,
-                      "end_column": 5
+                      "end_column": 11
                     },
                     "name": "payment_request_id"
                   }
@@ -6722,7 +6722,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "name": "CapturePaymentEffectStatus_Succeeded"
                 }
@@ -6740,7 +6740,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6752,7 +6752,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_Approved"
               },
@@ -6766,7 +6766,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6781,7 +6781,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6793,7 +6793,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -6807,7 +6807,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6822,7 +6822,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6834,7 +6834,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentFailed"
               },
@@ -6848,7 +6848,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6863,7 +6863,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6875,7 +6875,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentRequested"
               },
@@ -6889,7 +6889,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": true
               }
@@ -6904,7 +6904,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "var",
@@ -6916,7 +6916,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -6930,7 +6930,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": false
               }
@@ -6988,7 +6988,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "index",
@@ -7001,7 +7001,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "capture_payment_status",
                 "index": {
@@ -7015,7 +7015,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "name": "payment_request_id"
                 }
@@ -7031,7 +7031,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "CapturePaymentEffectStatus_Pending"
               }
@@ -7046,7 +7046,7 @@
                 "line": 26,
                 "column": 5,
                 "end_line": 26,
-                "end_column": 5
+                "end_column": 11
               },
               "target": {
                 "kind": "index",
@@ -7059,7 +7059,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "name": "capture_payment_attempts",
                 "index": {
@@ -7073,7 +7073,7 @@
                     "line": 26,
                     "column": 5,
                     "end_line": 26,
-                    "end_column": 5
+                    "end_column": 11
                   },
                   "name": "payment_request_id"
                 }
@@ -7090,7 +7090,7 @@
                   "line": 26,
                   "column": 5,
                   "end_line": 26,
-                  "end_column": 5
+                  "end_column": 11
                 },
                 "value": 1
               }
@@ -7107,7 +7107,7 @@
             "line": 26,
             "column": 5,
             "end_line": 26,
-            "end_column": 5
+            "end_column": 11
           }
         },
         {
@@ -7126,7 +7126,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_Approved"
               }
@@ -7143,7 +7143,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "operator": "and",
                 "left": {
@@ -7156,7 +7156,7 @@
                     "line": 52,
                     "column": 5,
                     "end_line": 52,
-                    "end_column": 5
+                    "end_column": 9
                   },
                   "name": "event_Approved"
                 },
@@ -7170,7 +7170,7 @@
                     "line": 52,
                     "column": 5,
                     "end_line": 52,
-                    "end_column": 5
+                    "end_column": 9
                   },
                   "operand": {
                     "kind": "var",
@@ -7182,7 +7182,7 @@
                       "line": 52,
                       "column": 5,
                       "end_line": 52,
-                      "end_column": 5
+                      "end_column": 9
                     },
                     "name": "event_PaymentFailed"
                   }
@@ -7201,7 +7201,7 @@
                 "line": 52,
                 "column": 5,
                 "end_line": 52,
-                "end_column": 5
+                "end_column": 9
               },
               "target": {
                 "kind": "var",
@@ -7213,7 +7213,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_Approved"
               },
@@ -7227,7 +7227,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "value": false
               }
@@ -7242,7 +7242,7 @@
                 "line": 52,
                 "column": 5,
                 "end_line": 52,
-                "end_column": 5
+                "end_column": 9
               },
               "target": {
                 "kind": "var",
@@ -7254,7 +7254,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_PaymentCaptured"
               },
@@ -7268,7 +7268,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "value": false
               }
@@ -7283,7 +7283,7 @@
                 "line": 52,
                 "column": 5,
                 "end_line": 52,
-                "end_column": 5
+                "end_column": 9
               },
               "target": {
                 "kind": "var",
@@ -7295,7 +7295,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_PaymentFailed"
               },
@@ -7309,7 +7309,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "value": false
               }
@@ -7324,7 +7324,7 @@
                 "line": 52,
                 "column": 5,
                 "end_line": 52,
-                "end_column": 5
+                "end_column": 9
               },
               "target": {
                 "kind": "var",
@@ -7336,7 +7336,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_PaymentRequested"
               },
@@ -7350,7 +7350,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "value": true
               }
@@ -7365,7 +7365,7 @@
                 "line": 52,
                 "column": 5,
                 "end_line": 52,
-                "end_column": 5
+                "end_column": 9
               },
               "target": {
                 "kind": "var",
@@ -7377,7 +7377,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "name": "event_PaymentTimedOut"
               },
@@ -7391,7 +7391,7 @@
                   "line": 52,
                   "column": 5,
                   "end_line": 52,
-                  "end_column": 5
+                  "end_column": 9
                 },
                 "value": false
               }
@@ -7408,7 +7408,7 @@
             "line": 52,
             "column": 5,
             "end_line": 52,
-            "end_column": 5
+            "end_column": 9
           }
         }
       ],
@@ -7557,7 +7557,7 @@
                 "line": 38,
                 "column": 3,
                 "end_line": 38,
-                "end_column": 3
+                "end_column": 9
               },
               "quantifier": "forall",
               "binder": {
@@ -7578,7 +7578,7 @@
                   "line": 38,
                   "column": 3,
                   "end_line": 38,
-                  "end_column": 3
+                  "end_column": 9
                 },
                 "operator": "=>",
                 "left": {
@@ -7591,7 +7591,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "operator": "==",
                   "left": {
@@ -7605,7 +7605,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "operand": {
                       "kind": "index",
@@ -7618,7 +7618,7 @@
                         "line": 38,
                         "column": 3,
                         "end_line": 38,
-                        "end_column": 3
+                        "end_column": 9
                       },
                       "collection": {
                         "kind": "var",
@@ -7638,7 +7638,7 @@
                           "line": 38,
                           "column": 3,
                           "end_line": 38,
-                          "end_column": 3
+                          "end_column": 9
                         },
                         "name": "capture_payment_status"
                       },
@@ -7653,7 +7653,7 @@
                           "line": 38,
                           "column": 3,
                           "end_line": 38,
-                          "end_column": 3
+                          "end_column": 9
                         },
                         "name": "k"
                       }
@@ -7670,7 +7670,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "name": "CapturePaymentEffectStatus_Succeeded"
                   }
@@ -7685,7 +7685,7 @@
                     "line": 38,
                     "column": 3,
                     "end_line": 38,
-                    "end_column": 3
+                    "end_column": 9
                   },
                   "operator": "==",
                   "left": {
@@ -7699,7 +7699,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "collection": {
                       "kind": "var",
@@ -7719,7 +7719,7 @@
                         "line": 38,
                         "column": 3,
                         "end_line": 38,
-                        "end_column": 3
+                        "end_column": 9
                       },
                       "name": "capture_payment_status"
                     },
@@ -7734,7 +7734,7 @@
                         "line": 38,
                         "column": 3,
                         "end_line": 38,
-                        "end_column": 3
+                        "end_column": 9
                       },
                       "name": "k"
                     }
@@ -7750,7 +7750,7 @@
                       "line": 38,
                       "column": 3,
                       "end_line": 38,
-                      "end_column": 3
+                      "end_column": 9
                     },
                     "name": "CapturePaymentEffectStatus_Succeeded"
                   }
@@ -7768,7 +7768,7 @@
               "line": 38,
               "column": 3,
               "end_line": 38,
-              "end_column": 3
+              "end_column": 9
             }
           }
         ],
@@ -7784,7 +7784,7 @@
               "line": 1,
               "column": 1,
               "end_line": 1,
-              "end_column": 1
+              "end_column": 7
             },
             "value": false
           },
@@ -7793,7 +7793,7 @@
             "line": 1,
             "column": 1,
             "end_line": 1,
-            "end_column": 1
+            "end_column": 7
           }
         }
       }
@@ -7915,7 +7915,67 @@
                   "order_status": "OrderStatus_Cancelled"
                 },
                 "action": {
-                  "name": "order_cancel",
+                  "name": "Cancel",
+                  "generated_name": "order_cancel",
+                  "origin": {
+                    "identity": "domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5",
+                    "dialect": "domain",
+                    "primary": {
+                      "source_file": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
+                      "span": {
+                        "start": {
+                          "offset": 1003,
+                          "line": 46,
+                          "column": 5
+                        },
+                        "end": {
+                          "offset": 1009,
+                          "line": 46,
+                          "column": 11
+                        }
+                      },
+                      "dialect": "domain",
+                      "declaration_path": [
+                        "DomainExpressionCharacterization",
+                        "aggregate",
+                        "Order",
+                        "decide",
+                        "Cancel"
+                      ]
+                    },
+                    "secondary": [
+                      {
+                        "source_file": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
+                        "span": {
+                          "start": {
+                            "offset": 604,
+                            "line": 28,
+                            "column": 5
+                          },
+                          "end": {
+                            "offset": 611,
+                            "line": 28,
+                            "column": 12
+                          }
+                        },
+                        "dialect": "domain",
+                        "declaration_path": [
+                          "DomainExpressionCharacterization",
+                          "aggregate",
+                          "Order",
+                          "command",
+                          "Cancel"
+                        ]
+                      }
+                    ],
+                    "lowering_steps": [
+                      {
+                        "kind": "lower_decision_to_action",
+                        "detail": null
+                      }
+                    ],
+                    "generated": true
+                  },
                   "params": {},
                   "loc": {
                     "line": 46,
@@ -8050,7 +8110,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'missing_status' at 10:29"
+          "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29"
         }
       },
       "verify": {
@@ -8059,7 +8119,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'missing_status' at 10:29"
+          "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29"
         }
       }
     },
@@ -8070,7 +8130,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'Cancelled' at 10:41"
+          "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41"
         }
       },
       "verify": {
@@ -8079,7 +8139,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'Cancelled' at 10:41"
+          "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41"
         }
       }
     },
@@ -8090,7 +8150,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "comparison operand type mismatch at 10:37"
+          "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37"
         }
       },
       "verify": {
@@ -8099,7 +8159,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "comparison operand type mismatch at 10:37"
+          "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37"
         }
       }
     },
@@ -8150,7 +8210,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'Status_Draft' at 10:41"
+          "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41"
         }
       },
       "verify": {
@@ -8159,7 +8219,7 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "semantics",
-          "message": "unknown domain symbol 'Status_Draft' at 10:41"
+          "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41"
         }
       }
     }

--- a/rust/fslc/tests/fixtures/domain_origin_violation.fsl
+++ b/rust/fslc/tests/fixtures/domain_origin_violation.fsl
@@ -1,0 +1,17 @@
+domain Orders { // SPDX-License-Identifier: Apache-2.0
+  type Status = Pending | Approved
+  aggregate Order {
+    state { status: Status = Pending; }
+
+    // 多言語のコメント and a blank line exercise UTF-8 source tracking.
+    command Approve {}
+    event Approved {}
+    decide Approve {
+      requires status == Pending
+      emits Approved
+    }
+    evolve Approved { status = Approved }
+
+    invariant mustBeApproved { status == Approved }
+  }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -242,6 +242,16 @@ findings, `fslc domain expand` to inspect the generated kernel, and
 real gateway behavior, queue delivery, wall-clock timeouts, or production
 exactly-once semantics.
 
+The Rust frontend keeps an internal origin chain across direct domain lowering,
+checked-model construction, verification, counterexamples, and `explain`.
+Diagnostics prefer the original domain declaration/expression, expose generated
+Kernel names only as machine detail, preserve primary/secondary origins and
+expansion steps (`can()`, membership, legacy operators), and represent
+source-less nodes as generated-only. Requirement tags are a separate
+traceability relation, not origin identities. Public Kernel v1 remains
+byte-compatible and does not expose the internal chain; publication belongs to
+v2 (#256).
+
 AI hard-contract dialect (expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):
 


### PR DESCRIPTION
## Problem

Domain lowering preserved only enclosing spans and metadata, so provenance was lost across one-to-many rewrites, generated nodes, checked-model validation, verifier evidence, and user-facing diagnostics.

## Contract change

- add a non-serialized Rust origin registry with stable identity, source file/full UTF-8 span, dialect, declaration path, lowering steps, primary/secondary sites, and explicit generated-only nodes
- propagate origins from typed DomainSpec nodes through Surface/Kernel models into validation, BMC/induction/liveness evidence, counterexamples, concrete diagnostics, and explain
- keep requirement traceability in a separate registry; MetaTag.id is not an origin identity
- prefer original domain declaration names while retaining lowered names as generated_name machine detail
- preserve the closed Public Kernel v1 schema, schema_version 1.0.0, golden files, and default kernel output; publication remains #256

## Evidence

- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --workspace --locked
- cargo build --manifest-path rust/Cargo.toml --workspace --locked
- .venv/bin/python -m pytest tests/test_rust_cli_contract.py -q (10 passed)
- independent review completed with no merge blockers

Focused regressions cover multibyte source offsets and exact expression slices, can and membership expansion, legacy operators, nested lvalues, one-to-many/many-to-one/generated-only mappings, duplicate state/type validation with primary and secondary origins, parse/type/lowering errors, BMC and induction rendering, explain/counterexample output, requirement separation, and Public Kernel v1 closure.

Closes #240
