### PR TITLE
feat(init): add inline state initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Kernel state fields now accept deterministic inline initializers and normalize
+  them to the existing `init` assignment semantics across Monitor, explicit
+  exploration, BMC, induction, and Public Kernel v1. State-reading/order-dependent
+  expressions and inline/explicit root overlap fail with source diagnostics.
+  Existing domain enum/Bool/range/external defaults and requirements number
+  lower-bound defaults now emit the edition-aware `implicit_initial_value`
+  warning with the selected value, reason, and machine-applicable insertion edit;
+  requirements Bool/enum fields remain explicitly initialized (issue #250).
 - Domain-expression characterization corpus (issue #235): Rust CI now freezes
   pre-typed-AST surface expressions and locations, normalized semantic model
   structure, representative public Kernel expression/origin output, generated

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -112,7 +112,9 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
      when `f: T` has no initializer; `f: T = <const-expr>` is an optional
      explicit initializer, const-evaluated at desugar time (out-of-bounds
      values are caught by the kernel's ordinary type-bound invariant, not by
-     a separate desugar-time bounds check).
+     a separate desugar-time bounds check). Omission emits the stable
+     `implicit_initial_value` migration warning with the selected lower bound
+     and a machine-applicable insertion edit.
    - `Bool`: **requires** an explicit initializer, `f: Bool = true` or
      `f: Bool = false`; the field-map value type is the kernel `Bool`, not a
      0/1 domain. Missing the initializer is a check-time error.

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -140,6 +140,15 @@ actions retain the decision as primary and the command as secondary. Synthetic
 event flags and terminal nodes are explicitly generated-only. Requirement tags
 remain a separate traceability relation.
 
+Aggregate state fields retain their typed explicit initializer when present. In
+the current edition, an omitted initializer keeps the established lowering
+choice for Bool (`false`), enum (first declared member), range (lower bound), or
+external placeholder (`0`) and emits `implicit_initial_value`. The warning names
+the chosen value and reason and carries a byte insertion edit. This makes the
+existing behavior migratable without treating an arbitrary default as newly
+inferred intent; the edition migrator consumes the edit contract described in
+[`DESIGN-initialization.md`](DESIGN-initialization.md).
+
 ## Effects
 
 An async `effect` declares the request event, completion events, correlation id,

--- a/docs/DESIGN-initialization.md
+++ b/docs/DESIGN-initialization.md
@@ -1,0 +1,72 @@
+# Initialization forms and migration
+
+FSL keeps three initialization forms at different abstraction levels. Kernel
+`init` describes system-wide relational initialization, requirements carried
+fields initialize one value per process entity, and domain aggregate fields
+initialize aggregate-owned state. They share checked expressions where their
+contracts overlap, but they are not one interchangeable syntax.
+
+## Kernel inline initializers
+
+A Kernel state field may carry a deterministic value expression:
+
+```fsl
+state {
+  status: Status = Pending,
+  count: Count = 0,
+  current: Option<ItemId> = none,
+  queue: Seq<JobId, 3> = Seq {},
+}
+```
+
+The surface tree retains the field span, initializer span, and inline source
+form. Before checked-model construction, each initializer is normalized to an
+ordinary assignment at the beginning of the spec's logical `init` sequence.
+The Monitor, explicit engine, BMC, induction, mutation, and Public Kernel v1
+therefore consume the same statements as the equivalent explicit `init` form.
+Public Kernel v1 does not publish a second initializer representation.
+
+An inline initializer is deliberately narrower than an `init` block:
+
+- its expression must not read any state root, including another inline field;
+- ordinary constants, enum members, constructors, and deterministic collection
+  literals are allowed and use the shared expression/type checking path;
+- statement `if`, `forall`, indexed/field targets, and relational or bulk
+  initialization remain in `init`;
+- a state root initialized inline cannot also be assigned by any explicit or
+  generated init statement; root/path overlap is a semantic error.
+
+The overlap check is a core model-construction invariant, not a backend check.
+Its diagnostic uses the inline field as the primary source and the conflicting
+init assignment as a secondary source so every execution engine fails closed in
+the same way.
+
+## Implicit-value migration
+
+The current edition preserves already-existing implicit values but reports the
+stable warning code `implicit_initial_value`. Each finding contains the field
+source span, selected value, selection reason, current/next severity, canonical
+replacement, and a machine-applicable byte insertion edit.
+
+Domain aggregate fields warn when omission selects:
+
+- `false` for `Bool`;
+- the first declared enum member;
+- the lower bound of a range;
+- `0` for an external placeholder without a declared lower bound.
+
+Requirements process fields warn only when a `number` field omits its initializer
+and therefore selects the declared `verify.values` lower bound. Requirements
+`Bool` and enum fields continue to require explicit initializers; omission remains
+a check-time error. This preserves the accepted requirements contract instead of
+inventing a new implicit value.
+
+The edit inserts ` = <selected value>` immediately after the field type. Applying
+it preserves surrounding comments/trivia and yields the value already selected by
+the current semantics. The lossless formatter (#248) and edition migrator (#249)
+own whole-source rewriting and consume this diagnostic contract; this feature does
+not introduce an incomplete formatter or migrator command.
+
+The next edition severity is reported as `error` for migration planning, but this
+design does not remove implicit-default parsing. Breaking removal remains gated by
+the edition migration policy.

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -33,7 +33,7 @@ The top-level contract contains:
 | `spec` | Logical name plus source file and original dialect. |
 | `semantics` | Simultaneous updates, pre-state reads, disabled requires, rollback failures, `old`, Euclidean integer division, terminal handling, and weak fairness. |
 | `constants`, `types`, `state` | Fully normalized declarations with structural types and lowering origin. |
-| `init` | Typed normalized statements plus requirement/origin metadata. |
+| `init` | Typed normalized statements plus requirement/origin metadata. Kernel state inline initializers appear only as equivalent root assignments. |
 | `actions` | Finite typed parameters, ordered `guards` (requires/let binding scope), compatibility projections in `requires`/`lets`, simultaneous updates, ensures, partial-operation conditions, requirement IDs, origin, and span. |
 | `properties` | Invariants, transition properties, reachability, progress, and terminal expression. |
 
@@ -41,9 +41,11 @@ Every expression has a `kind`, structural `type`, and source `span`; consumers d
 not reparse expressions or infer types. Statement and declaration origins state
 the source dialect, originating declaration or requirement ID, whether lowering
 occurred, and whether the node was generated. Action/property/statement spans
-include start and end positions. The current internal syntax tree does not retain
-direct spans for scalar/type/state declarations, so those declaration spans are
-explicitly `null`; their origin remains present. This is an intentional v1
+include start and end positions. The internal surface tree retains inline state
+field and initializer spans for diagnostics and migration, but Public Kernel v1
+does not publish the sugar as a second declaration form. Direct scalar/type/state
+declaration spans in the v1 projection remain explicitly `null`; normalized
+initializer statements carry their source span. This is an intentional v1
 distinction, not a missing field.
 
 That v1 `origin` object is a frozen, lossy compatibility projection. The Rust

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -31,7 +31,7 @@ spec <Name> ["<kind>: <intent>"] {   // optional spec-level tag → metadata bad
 
   def <name>(<p>: <type name>, ...) = <expr> // non-recursive named predicate; frontend-inlined
 
-  state { <var>: <type>, ... }
+  state { <var>: <type> [= <deterministic expr>], ... }
   init  ["undecided: reason"] { <stmt>... }
 
   [fair] action <name>(<p>: <type name>, ...) {
@@ -261,6 +261,12 @@ primary/secondary sources, and explicit generated-only nodes. Requirement IDs
 remain an independent traceability relation. Public Kernel v1 output is
 unchanged; publishing this chain is reserved for v2.
 
+When a domain aggregate state field omits its initializer, the current edition
+preserves the established Bool `false`, enum first-member, range lower-bound, or
+external-placeholder `0` choice and emits `implicit_initial_value`. The warning
+contains the selected value, reason, current/next severity, field span, and a
+machine-applicable explicit-initializer insertion.
+
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
 aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL
@@ -441,6 +447,7 @@ that `decreases` draws from.)
 | `Int` / `Bool` | `count: Int` | Unbounded integer / boolean |
 | Domain type | `type Qty = 0..5` | Bounded integer. **The range is checked automatically** (§6) |
 | Inline state domain | `state { qty: 0..5 }` | Shorthand for a named domain type in a state-variable declaration |
+| Inline state initializer | `state { qty: Qty = 0 }` | Deterministic sugar for the equivalent root assignment in `init` |
 | Entity kind | `entity Claim` / `process Claim ...` | Finite identity sort. Allowed in any layer incl. kernel `spec`; size set by `verify { instances Claim = N }`; desugars to `type Claim = 0..N-1` |
 | Number kind | `number Amount` | Finite numeric sort. Allowed in any layer incl. kernel `spec`; range set by `verify { values Amount = lo..hi }`; desugars to `type` |
 | enum | `enum St { Open, Closed }` | Members are referenced by their bare name in expressions |
@@ -454,6 +461,17 @@ that `decreases` draws from.)
 **Scalar** = Int / Bool / domain type / enum. In a `state` declaration,
 `x: lo..hi` is accepted as an anonymous domain type and is equivalent to
 declaring `type X = lo..hi` and writing `x: X`.
+
+A Kernel state field may use `name: Type = expr` for a simple deterministic
+initial value. It is normalized to an ordinary root assignment before checking,
+so Monitor, explicit exploration, BMC, induction, and Public Kernel v1 observe
+the same semantics as an equivalent `init` block. The expression may use
+constants, enum members, constructors, `none`, and deterministic collection
+literals, but it must not read any state root or another initializer. Indexed,
+field, conditional-statement, quantified, relational, and bulk initialization
+remain in `init`. Assigning the same root both inline and in `init` is a semantic
+error that reports both source locations. See
+[`DESIGN-initialization.md`](DESIGN-initialization.md).
 
 **Types legal as state variables** (anything else is rejected by `check` as a type error):
 scalar | `Option<scalar>` | struct (scalar / `Option<scalar>` fields)
@@ -1401,7 +1419,10 @@ verify {
   carried field's type `T` is a `number`, `Bool`, or an enum declared in the
   same requirements spec:
   - `number` fields default to the domain's `lo` bound; `f: T = <expr>` is an
-    optional explicit initializer (a compile-time constant expression).
+    optional explicit initializer (a compile-time constant expression). Omission
+    is retained in the current edition with the stable
+    `implicit_initial_value` warning and an insertion edit for the selected lower
+    bound.
   - `Bool` and enum fields have no invented default — `f: Bool = true/false`
     and `f: T = Member` are **required**; omitting the initializer is a
     check-time error (no silently-chosen `false` or first enum member).

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
 | [`DESIGN-vacuity.md`](DESIGN-vacuity.md) | Vacuity checking (invariants whose antecedent is unreachable, leadsTo whose trigger is unreachable, always-true requires) |
 | [`DESIGN-strict-tags.md`](DESIGN-strict-tags.md) | The `--strict-tags` lint (matching untagged declarations and unreferenced requirements) |
 | [`DESIGN-init-if.md`](DESIGN-init-if.md) | Statement-level `if` in `init` (lowered to path-conditional initial-state constraints, same branch shape as action bodies) |
+| [`DESIGN-initialization.md`](DESIGN-initialization.md) | Kernel inline state initializers, normalization to `init`, overlap diagnostics, and implicit-default migration warnings |
 | [`DESIGN-inline-range.md`](DESIGN-inline-range.md) | Inline anonymous range types (`x: lo..hi`) |
 | [`DESIGN-spec-domains.md`](DESIGN-spec-domains.md) | `entity` / `number` in the kernel `spec` (decoupling a domain from the verification bound) |
 | [`DESIGN-def.md`](DESIGN-def.md) | Non-recursive named predicate frontend sugar, expansion order, capture and diagnostic contract |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -81,7 +81,7 @@
 
   def &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) = &lt;expr&gt; // non-recursive named predicate; frontend-inlined
 
-  state { &lt;var&gt;: &lt;type&gt;, ... }
+  state { &lt;var&gt;: &lt;type&gt; [= &lt;deterministic expr&gt;], ... }
   init  [&quot;undecided: reason&quot;] { &lt;stmt&gt;... }
 
   [fair] action &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) {
@@ -295,6 +295,11 @@ records source file/full span, declaration path, lowering steps,
 primary/secondary sources, and explicit generated-only nodes. Requirement IDs
 remain an independent traceability relation. Public Kernel v1 output is
 unchanged; publishing this chain is reserved for v2.</p>
+<p>When a domain aggregate state field omits its initializer, the current edition
+preserves the established Bool <code>false</code>, enum first-member, range lower-bound, or
+external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
+contains the selected value, reason, current/next severity, field span, and a
+machine-applicable explicit-initializer insertion.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
@@ -470,6 +475,11 @@ that <code>decreases</code> draws from.)</p></div></details>
 <td>Shorthand for a named domain type in a state-variable declaration</td>
 </tr>
 <tr>
+<td>Inline state initializer</td>
+<td><code>state { qty: Qty = 0 }</code></td>
+<td>Deterministic sugar for the equivalent root assignment in <code>init</code></td>
+</tr>
+<tr>
 <td>Entity kind</td>
 <td><code>entity Claim</code> / <code>process Claim ...</code></td>
 <td>Finite identity sort. Allowed in any layer incl. kernel <code>spec</code>; size set by <code>verify { instances Claim = N }</code>; desugars to <code>type Claim = 0..N-1</code></td>
@@ -519,6 +529,16 @@ that <code>decreases</code> draws from.)</p></div></details>
 <p><strong>Scalar</strong> = Int / Bool / domain type / enum. In a <code>state</code> declaration,
 <code>x: lo..hi</code> is accepted as an anonymous domain type and is equivalent to
 declaring <code>type X = lo..hi</code> and writing <code>x: X</code>.</p>
+<p>A Kernel state field may use <code>name: Type = expr</code> for a simple deterministic
+initial value. It is normalized to an ordinary root assignment before checking,
+so Monitor, explicit exploration, BMC, induction, and Public Kernel v1 observe
+the same semantics as an equivalent <code>init</code> block. The expression may use
+constants, enum members, constructors, <code>none</code>, and deterministic collection
+literals, but it must not read any state root or another initializer. Indexed,
+field, conditional-statement, quantified, relational, and bulk initialization
+remain in <code>init</code>. Assigning the same root both inline and in <code>init</code> is a semantic
+error that reports both source locations. See
+<a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-initialization.md"><code>DESIGN-initialization.md</code></a>.</p>
 <p><strong>Types legal as state variables</strong> (anything else is rejected by <code>check</code> as a type error):
 scalar | <code>Option&lt;scalar&gt;</code> | struct (scalar / <code>Option&lt;scalar&gt;</code> fields)
 | <code>Map&lt;bounded scalar, scalar | Option&lt;scalar&gt; | struct&gt;</code>
@@ -1430,7 +1450,10 @@ verify {
   carried field's type <code>T</code> is a <code>number</code>, <code>Bool</code>, or an enum declared in the
   same requirements spec:</li>
 <li><code>number</code> fields default to the domain's <code>lo</code> bound; <code>f: T = &lt;expr&gt;</code> is an
-    optional explicit initializer (a compile-time constant expression).</li>
+    optional explicit initializer (a compile-time constant expression). Omission
+    is retained in the current edition with the stable
+    <code>implicit_initial_value</code> warning and an insertion edit for the selected lower
+    bound.</li>
 <li><code>Bool</code> and enum fields have no invented default — <code>f: Bool = true/false</code>
     and <code>f: T = Member</code> are <strong>required</strong>; omitting the initializer is a
     check-time error (no silently-chosen <code>false</code> or first enum member).</li>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -81,7 +81,7 @@
 
   def &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) = &lt;expr&gt; // non-recursive named predicate; frontend-inlined
 
-  state { &lt;var&gt;: &lt;type&gt;, ... }
+  state { &lt;var&gt;: &lt;type&gt; [= &lt;deterministic expr&gt;], ... }
   init  [&quot;undecided: reason&quot;] { &lt;stmt&gt;... }
 
   [fair] action &lt;name&gt;(&lt;p&gt;: &lt;type name&gt;, ...) {
@@ -295,6 +295,11 @@ records source file/full span, declaration path, lowering steps,
 primary/secondary sources, and explicit generated-only nodes. Requirement IDs
 remain an independent traceability relation. Public Kernel v1 output is
 unchanged; publishing this chain is reserved for v2.</p>
+<p>When a domain aggregate state field omits its initializer, the current edition
+preserves the established Bool <code>false</code>, enum first-member, range lower-bound, or
+external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
+contains the selected value, reason, current/next severity, field span, and a
+machine-applicable explicit-initializer insertion.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
@@ -470,6 +475,11 @@ that <code>decreases</code> draws from.)</p></div></details>
 <td>Shorthand for a named domain type in a state-variable declaration</td>
 </tr>
 <tr>
+<td>Inline state initializer</td>
+<td><code>state { qty: Qty = 0 }</code></td>
+<td>Deterministic sugar for the equivalent root assignment in <code>init</code></td>
+</tr>
+<tr>
 <td>Entity kind</td>
 <td><code>entity Claim</code> / <code>process Claim ...</code></td>
 <td>Finite identity sort. Allowed in any layer incl. kernel <code>spec</code>; size set by <code>verify { instances Claim = N }</code>; desugars to <code>type Claim = 0..N-1</code></td>
@@ -519,6 +529,16 @@ that <code>decreases</code> draws from.)</p></div></details>
 <p><strong>Scalar</strong> = Int / Bool / domain type / enum. In a <code>state</code> declaration,
 <code>x: lo..hi</code> is accepted as an anonymous domain type and is equivalent to
 declaring <code>type X = lo..hi</code> and writing <code>x: X</code>.</p>
+<p>A Kernel state field may use <code>name: Type = expr</code> for a simple deterministic
+initial value. It is normalized to an ordinary root assignment before checking,
+so Monitor, explicit exploration, BMC, induction, and Public Kernel v1 observe
+the same semantics as an equivalent <code>init</code> block. The expression may use
+constants, enum members, constructors, <code>none</code>, and deterministic collection
+literals, but it must not read any state root or another initializer. Indexed,
+field, conditional-statement, quantified, relational, and bulk initialization
+remain in <code>init</code>. Assigning the same root both inline and in <code>init</code> is a semantic
+error that reports both source locations. See
+<a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-initialization.md"><code>DESIGN-initialization.md</code></a>.</p>
 <p><strong>Types legal as state variables</strong> (anything else is rejected by <code>check</code> as a type error):
 scalar | <code>Option&lt;scalar&gt;</code> | struct (scalar / <code>Option&lt;scalar&gt;</code> fields)
 | <code>Map&lt;bounded scalar, scalar | Option&lt;scalar&gt; | struct&gt;</code>
@@ -1430,7 +1450,10 @@ verify {
   carried field's type <code>T</code> is a <code>number</code>, <code>Bool</code>, or an enum declared in the
   same requirements spec:</li>
 <li><code>number</code> fields default to the domain's <code>lo</code> bound; <code>f: T = &lt;expr&gt;</code> is an
-    optional explicit initializer (a compile-time constant expression).</li>
+    optional explicit initializer (a compile-time constant expression). Omission
+    is retained in the current edition with the stable
+    <code>implicit_initial_value</code> warning and an insertion edit for the selected lower
+    bound.</li>
 <li><code>Bool</code> and enum fields have no invented default — <code>f: Bool = true/false</code>
     and <code>f: T = Member</code> are <strong>required</strong>; omitting the initializer is a
     check-time error (no silently-chosen <code>false</code> or first enum member).</li>

--- a/examples/kernel_inline_initializer.fsl
+++ b/examples/kernel_inline_initializer.fsl
@@ -1,0 +1,23 @@
+spec KernelInlineInitializer {
+  enum Status { Pending, Done }
+  type Count = 0..2
+  type ItemId = 0..1
+  type JobId = 0..1
+
+  state {
+    status: Status = Pending,
+    count: Count = 0,
+    current: Option<ItemId> = none,
+    queue: Seq<JobId, 3> = Seq {},
+  }
+
+  action finish() {
+    requires count < 2
+    status = Done
+    count = count + 1
+  }
+
+  invariant ProgressCoupled "REQ-INIT-1: completion records positive progress" {
+    status == Done => count > 0
+  }
+}

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -121,7 +121,7 @@ impl ComponentNames {
                 SpecItem::State(fields) => {
                     names
                         .state
-                        .extend(fields.iter().map(|(name, _)| name.clone()));
+                        .extend(fields.iter().map(|field| field.name.clone()));
                 }
                 SpecItem::Action { name, .. } => {
                     names.actions.insert(name.clone());
@@ -305,7 +305,15 @@ fn rewrite_component_item(item: SpecItem, component: &Component) -> SpecItem {
         SpecItem::State(fields) => SpecItem::State(
             fields
                 .into_iter()
-                .map(|(name, ty)| (prefix(alias, &name), rewrite_type(ty, component)))
+                .map(|field| fsl_syntax::StateField {
+                    name: prefix(alias, &field.name),
+                    ty: rewrite_type(field.ty, component),
+                    initializer: field
+                        .initializer
+                        .map(|expr| rewrite_expr(expr, component, &HashSet::new())),
+                    span: field.span,
+                    initializer_span: field.initializer_span,
+                })
                 .collect(),
         ),
         SpecItem::Init { statements, meta } => SpecItem::Init {

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -7,8 +7,8 @@ use fsl_syntax::{
     GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem, LValue, MetaTag, Param,
     PreservationItem, ProcessField, ProcessItem, ProcessTransition, QualifiedName,
     RequirementAction, RequirementActionItem, RequirementBlockItem, RequirementsItem, SpecItem,
-    Statement, SurfaceBusiness, SurfaceDocument, SurfaceGovernance, SurfaceRequirements,
-    SurfaceSpec, TimeItem, TypeExpr, VerifyItem,
+    StateField, Statement, SurfaceBusiness, SurfaceDocument, SurfaceGovernance,
+    SurfaceRequirements, SurfaceSpec, TimeItem, TypeExpr, VerifyItem,
 };
 
 use crate::{CoreError, KernelSpec, lower_direct_spec, substitute_expr};
@@ -281,12 +281,13 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             processes
                 .iter()
                 .map(|process| {
-                    (
+                    StateField::generated(
                         process_state(&process.name),
                         TypeExpr::Map(
                             Box::new(TypeExpr::Name(process.name.clone())),
                             Box::new(TypeExpr::Name(process_enum(&process.name))),
                         ),
+                        process.span,
                     )
                 })
                 .collect(),
@@ -842,12 +843,13 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
     let mut init = Vec::new();
     for process in &processes {
         let process_name = &process.process.name;
-        state.push((
+        state.push(StateField::generated(
             process_state(process_name),
             TypeExpr::Map(
                 Box::new(TypeExpr::Name(process_name.clone())),
                 Box::new(TypeExpr::Name(process_enum(process_name))),
             ),
+            process.process.span,
         ));
         let mut init_body = vec![Statement::Assign {
             target: LValue::Index(process_state(process_name), Expr::Var("c".to_owned())),
@@ -860,12 +862,13 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
             } else {
                 TypeExpr::Name(field.type_name.name.clone())
             };
-            state.push((
+            state.push(StateField::generated(
                 process_field_state(process_name, &field.name),
                 TypeExpr::Map(
                     Box::new(TypeExpr::Name(process_name.clone())),
                     Box::new(field_ty),
                 ),
+                process.process.span,
             ));
             let initial = field.initial.clone().unwrap_or_else(|| {
                 value_bounds
@@ -1104,7 +1107,11 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
                     LValue::Var(name.clone()),
                 ),
             };
-            items.push(SpecItem::State(vec![(name.clone(), state_type)]));
+            items.push(SpecItem::State(vec![StateField::generated(
+                name.clone(),
+                state_type,
+                span,
+            )]));
             items.push(SpecItem::Init {
                 statements: vec![init_statement],
                 meta: None,
@@ -1247,7 +1254,11 @@ pub fn lower_governance(governance: SurfaceGovernance) -> Result<KernelSpec, Cor
                 hi: Box::new(Expr::Num(0)),
                 symmetric: false,
             },
-            SpecItem::State(vec![("_governance_ok".to_owned(), TypeExpr::Bool)]),
+            SpecItem::State(vec![StateField::generated(
+                "_governance_ok",
+                TypeExpr::Bool,
+                span,
+            )]),
             SpecItem::Init {
                 statements: vec![Statement::Assign {
                     target: LValue::Var("_governance_ok".to_owned()),
@@ -1293,7 +1304,11 @@ fn lower_catalog_sentinel(name: String, prefix: &str, id: &str) -> Result<Kernel
         name,
         meta: None,
         items: vec![
-            SpecItem::State(vec![(state_name.clone(), TypeExpr::Bool)]),
+            SpecItem::State(vec![StateField::generated(
+                state_name.clone(),
+                TypeExpr::Bool,
+                span,
+            )]),
             SpecItem::Init {
                 statements: vec![Statement::Assign {
                     target: LValue::Var(state_name.clone()),

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -5,9 +5,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use fsl_syntax::{
     ActionItem, Binder, DomainAggregate, DomainDecide, DomainEffect, DomainField, DomainLoc,
     DomainSaga, DomainSagaStep, DomainSpec, DomainType, DomainTypeSourceForm, Expr, LValue,
-    MetaTag, Param, Pattern, QualifiedName, Span, SpecItem, Statement, SurfaceSpec, SyntaxBinder,
-    SyntaxExpr, SyntaxExprKind, SyntaxLValue, SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr,
-    SyntaxTypeExprKind, TypeExpr,
+    MetaTag, Param, Pattern, QualifiedName, Span, SpecItem, StateField, Statement, SurfaceSpec,
+    SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxLValue, SyntaxPattern, SyntaxQualifiedName,
+    SyntaxTypeExpr, SyntaxTypeExprKind, TypeExpr,
 };
 
 use crate::CoreError;
@@ -2135,9 +2135,10 @@ pub(crate) fn lower_domain_surface(
         let scope = resolver.scope_for_aggregate(aggregate)?;
         for field in &aggregate.state {
             let logical_type = resolver.logical_type(&field.type_name)?;
-            state.push((
+            state.push(StateField::generated(
                 state_name(aggregate, &field.name),
                 resolver.surface_type(&field.type_name)?,
+                field.span,
             ));
             if let LogicalType::Map(key, value) = &logical_type {
                 if field.default.is_some() {
@@ -2183,7 +2184,11 @@ pub(crate) fn lower_domain_surface(
         .collect::<Vec<_>>();
     event_names.sort_unstable();
     for event in event_names {
-        state.push((event_flag(event), TypeExpr::Bool));
+        state.push(StateField::generated(
+            event_flag(event),
+            TypeExpr::Bool,
+            span_at(domain.loc),
+        ));
         init.push(Statement::Assign {
             target: LValue::Var(event_flag(event)),
             value: Expr::Bool(false),
@@ -2193,19 +2198,21 @@ pub(crate) fn lower_domain_surface(
     for effect in &domain.effects {
         let (_, correlation_type) = resolver.correlation(effect)?;
         let key_type = resolver.surface_type(&correlation_type)?;
-        state.push((
+        state.push(StateField::generated(
             status_var(effect),
             TypeExpr::Map(
                 Box::new(key_type.clone()),
                 Box::new(TypeExpr::Name(status_type(effect))),
             ),
+            span_at(effect.loc),
         ));
-        state.push((
+        state.push(StateField::generated(
             attempt_var(effect),
             TypeExpr::Map(
                 Box::new(key_type),
                 Box::new(TypeExpr::Name(attempt_type(effect))),
             ),
+            span_at(effect.loc),
         ));
         let span = span_at(effect.loc);
         init.push(Statement::ForAll {

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -8,7 +8,8 @@ use std::fmt;
 
 use fsl_syntax::{
     ActionItem, Binder, BusinessItem, Expr, LValue, Param, ParseError, RequirementsItem, SpecItem,
-    Statement, SurfaceDocument, SurfaceSpec, TypeExpr, VerifyItem, parse_surface_document,
+    StateField, Statement, SurfaceDocument, SurfaceSpec, TypeExpr, VerifyItem,
+    parse_surface_document,
 };
 use serde_json::Value;
 
@@ -593,7 +594,18 @@ impl PredicateExpander {
             SpecItem::State(fields) => SpecItem::State(
                 fields
                     .into_iter()
-                    .map(|(name, ty)| Ok((name, self.expand_type(ty)?)))
+                    .map(|field| {
+                        Ok(StateField {
+                            name: field.name,
+                            ty: self.expand_type(field.ty)?,
+                            initializer: field
+                                .initializer
+                                .map(|expr| self.expand_expr(expr, &mut Vec::new()))
+                                .transpose()?,
+                            span: field.span,
+                            initializer_span: field.initializer_span,
+                        })
+                    })
                     .collect::<Result<_, CoreError>>()?,
             ),
             SpecItem::Init { statements, meta } => SpecItem::Init {

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -5,12 +5,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use fsl_syntax::{
-    ActionItem, Binder, Expr, MetaTag, Param, Span, SpecItem, Statement, SurfaceSpec, TypeExpr,
+    ActionItem, Binder, Expr, LValue, MetaTag, Param, Span, SpecItem, Statement, SurfaceSpec,
+    TypeExpr,
 };
 
 use crate::{
-    KernelSpec, OriginRegistry, SPEC_TARGET, TraceabilityRegistry, action_target, property_target,
-    state_target, type_target,
+    KernelSpec, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET,
+    TraceabilityRegistry, action_target, property_target, state_target, type_target,
 };
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -301,7 +302,27 @@ impl fmt::Display for ModelError {
                 self.message, span.start.line, span.start.column
             ),
             None => formatter.write_str(&self.message),
+        }?;
+        if let Some(secondary) = self
+            .origin
+            .as_ref()
+            .and_then(|origin| origin.secondary.first())
+            .and_then(|site| site.span.map(|span| (site.source_file.as_deref(), span)))
+        {
+            match secondary {
+                (Some(file), span) => write!(
+                    formatter,
+                    "; conflicting assignment at {}:{}:{}",
+                    file, span.start.line, span.start.column
+                ),
+                (None, span) => write!(
+                    formatter,
+                    "; conflicting assignment at {}:{}",
+                    span.start.line, span.start.column
+                ),
+            }?;
         }
+        Ok(())
     }
 }
 
@@ -341,8 +362,30 @@ impl ModelBuilder {
     fn build(mut self) -> Result<KernelModel, ModelError> {
         self.collect_consts()?;
         self.collect_types()?;
+        let state_names = self
+            .spec
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                SpecItem::State(fields) => Some(fields.iter().map(|field| field.name.clone())),
+                _ => None,
+            })
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        let explicit_init_writes = self
+            .spec
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                SpecItem::Init { statements, .. } => Some(statements),
+                _ => None,
+            })
+            .flat_map(|statements| statement_root_spans(statements))
+            .collect::<BTreeMap<_, _>>();
         let mut state = Vec::new();
+        let mut inline_init = Vec::new();
         let mut init = Vec::new();
+        let mut inline_initializers = Vec::new();
         let mut init_meta = None;
         let mut actions = Vec::new();
         let mut invariants = Vec::new();
@@ -354,15 +397,66 @@ impl ModelBuilder {
         for item in &self.spec.items {
             match item {
                 SpecItem::State(fields) => {
-                    for (name, ty) in fields {
-                        if state.iter().any(|(existing, _)| existing == name) {
-                            return Err(model_error(format!("duplicate state variable '{name}'"))
-                                .with_origin(self.origins.diagnostic_origin(&state_target(name))));
+                    for field in fields {
+                        if state.iter().any(|(existing, _)| existing == &field.name) {
+                            return Err(model_error(format!(
+                                "duplicate state variable '{}'",
+                                field.name
+                            ))
+                            .with_origin(
+                                self.origins.diagnostic_origin(&state_target(&field.name)),
+                            ));
                         }
-                        let origin = self.origins.diagnostic_origin(&state_target(name));
+                        if let Some(initializer) = &field.initializer {
+                            if let Some(form) = unsupported_inline_form(initializer) {
+                                return Err(model_error(format!(
+                                    "inline initializer for '{}' does not allow {form}; use init",
+                                    field.name
+                                ))
+                                .with_origin(Some(source_origin(
+                                    &field.name,
+                                    field.initializer_span.unwrap_or(field.span),
+                                    None,
+                                ))));
+                            }
+                            if let Some(name) = first_state_reference(initializer, &state_names) {
+                                return Err(model_error(format!(
+                                    "inline initializer for '{}' must not read state root '{name}'",
+                                    field.name
+                                ))
+                                .with_origin(Some(source_origin(
+                                    &field.name,
+                                    field.initializer_span.unwrap_or(field.span),
+                                    None,
+                                ))));
+                            }
+                            if let Some(conflict_span) = explicit_init_writes.get(&field.name) {
+                                return Err(model_error(format!(
+                                    "state root '{}' is assigned by both an inline initializer and init",
+                                    field.name
+                                ))
+                                .with_origin(Some(source_origin(
+                                    &field.name,
+                                    field.span,
+                                    Some(*conflict_span),
+                                ))));
+                            }
+                            let initializer_span = field.initializer_span.unwrap_or(field.span);
+                            inline_initializers.push((
+                                inline_init.len(),
+                                field.name.clone(),
+                                initializer_span,
+                            ));
+                            inline_init.push(Statement::Assign {
+                                target: LValue::Var(field.name.clone()),
+                                value: initializer.clone(),
+                                span: initializer_span,
+                            });
+                        }
+                        let origin = self.origins.diagnostic_origin(&state_target(&field.name));
                         state.push((
-                            name.clone(),
-                            self.resolve_type(ty)
+                            field.name.clone(),
+                            self.resolve_type(&field.ty)
                                 .map_err(|error| error.with_origin(origin))?,
                         ));
                     }
@@ -521,7 +615,9 @@ impl ModelBuilder {
             return Err(model_error("spec has no state block")
                 .with_origin(self.origins.diagnostic_origin(SPEC_TARGET)));
         }
-        Ok(KernelModel {
+        inline_init.extend(init);
+        let init = inline_init;
+        let model = KernelModel {
             name: self.spec.name,
             consts: self.consts,
             types: self.types,
@@ -537,7 +633,25 @@ impl ModelBuilder {
             terminal,
             origins: self.origins,
             traceability,
-        })
+        };
+        let inline_initializers = inline_initializers
+            .into_iter()
+            .map(|(index, name, span)| (index, (name, span)))
+            .collect::<BTreeMap<_, _>>();
+        for (index, statement) in model.init.iter().enumerate() {
+            crate::public_kernel::validate_statement_types(statement, &model).map_err(|error| {
+                if let Some((name, span)) = inline_initializers.get(&index) {
+                    model_error(format!(
+                        "invalid inline initializer for '{name}': {}",
+                        error.message
+                    ))
+                    .with_origin(Some(source_origin(name, *span, None)))
+                } else {
+                    model_error(format!("invalid init statement: {}", error.message))
+                }
+            })?;
+        }
+        Ok(model)
     }
 
     fn collect_consts(&mut self) -> Result<(), ModelError> {
@@ -759,6 +873,157 @@ impl ModelBuilder {
             Value::Int(value) => Ok(value),
             _ => Err(model_error("constant expression must be an integer")),
         }
+    }
+}
+
+fn source_origin(name: &str, primary: Span, secondary: Option<Span>) -> OriginChain {
+    OriginChain {
+        id: OriginId(format!(
+            "kernel:inline-initializer:{name}:{}:{}",
+            primary.start.offset, primary.end.offset
+        )),
+        dialect: "kernel".to_owned(),
+        primary: Some(OriginSite {
+            source_file: None,
+            span: Some(primary),
+            dialect: "kernel".to_owned(),
+            declaration_path: vec!["state".to_owned(), name.to_owned()],
+        }),
+        secondary: secondary
+            .map(|span| OriginSite {
+                source_file: None,
+                span: Some(span),
+                dialect: "kernel".to_owned(),
+                declaration_path: vec!["init".to_owned(), name.to_owned()],
+            })
+            .into_iter()
+            .collect(),
+        lowering_steps: vec![LoweringStep {
+            kind: "inline_initializer".to_owned(),
+            detail: Some("normalized to init assignment".to_owned()),
+        }],
+        generated: false,
+    }
+}
+
+fn lvalue_root(target: &LValue) -> &str {
+    match target {
+        LValue::Var(name) | LValue::Index(name, _) => name,
+        LValue::Field(base, _) => lvalue_root(base),
+    }
+}
+
+fn statement_root_spans(statements: &[Statement]) -> Vec<(String, Span)> {
+    let mut roots = Vec::new();
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, span, .. } => {
+                roots.push((lvalue_root(target).to_owned(), *span));
+            }
+            Statement::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                roots.extend(statement_root_spans(then_statements));
+                roots.extend(statement_root_spans(else_statements));
+            }
+            Statement::ForAll { statements, .. } => {
+                roots.extend(statement_root_spans(statements));
+            }
+        }
+    }
+    roots
+}
+
+fn first_state_reference(expr: &Expr, state_names: &BTreeSet<String>) -> Option<String> {
+    if let Expr::Var(name) = expr
+        && state_names.contains(name)
+    {
+        return Some(name.clone());
+    }
+    expr_children(expr)
+        .into_iter()
+        .find_map(|child| first_state_reference(child, state_names))
+}
+
+fn unsupported_inline_form(expr: &Expr) -> Option<&'static str> {
+    let unsupported = match expr {
+        Expr::Quantified { .. } => Some("a quantified expression"),
+        Expr::Count { .. } | Expr::Sum { .. } | Expr::BinderNamed { .. } => {
+            Some("a binder or aggregate expression")
+        }
+        Expr::UnaryNamed { name, .. }
+            if name == "old" || name == "stage" || name.starts_with("rel_") =>
+        {
+            Some("a temporal or relational expression")
+        }
+        Expr::TernaryNamed { name, .. } if name.starts_with("rel_") => {
+            Some("a relational expression")
+        }
+        _ => None,
+    };
+    unsupported.or_else(|| {
+        expr_children(expr)
+            .into_iter()
+            .find_map(unsupported_inline_form)
+    })
+}
+
+fn expr_children(expr: &Expr) -> Vec<&Expr> {
+    match expr {
+        Expr::Some(expr)
+        | Expr::Neg(expr)
+        | Expr::Not(expr)
+        | Expr::UnaryNamed { expr, .. }
+        | Expr::Is { expr, .. }
+        | Expr::Field(expr, _) => vec![expr],
+        Expr::Set(items) | Expr::Seq(items) => items.iter().collect(),
+        Expr::Struct { fields, .. } => fields.iter().map(|(_, expr)| expr).collect(),
+        Expr::Call { args, .. } => args.iter().collect(),
+        Expr::Index(left, right)
+        | Expr::Binary { left, right, .. }
+        | Expr::BinaryNamed { left, right, .. } => vec![left, right],
+        Expr::Method { receiver, args, .. } => std::iter::once(receiver.as_ref())
+            .chain(args.iter())
+            .collect(),
+        Expr::IfThenElse {
+            condition,
+            then_expr,
+            else_expr,
+        } => vec![condition, then_expr, else_expr],
+        Expr::Quantified { binder, body, .. } => binder_exprs(binder)
+            .into_iter()
+            .chain(std::iter::once(body.as_ref()))
+            .collect(),
+        Expr::Count { condition, .. } => vec![condition],
+        Expr::Sum {
+            body, condition, ..
+        } => std::iter::once(body.as_ref())
+            .chain(condition.as_deref())
+            .collect(),
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => vec![first, second, third],
+        Expr::BinderNamed { binder, .. } => binder_exprs(binder),
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => Vec::new(),
+    }
+}
+
+fn binder_exprs(binder: &Binder) -> Vec<&Expr> {
+    match binder {
+        Binder::Typed { where_expr, .. } => where_expr.iter().map(AsRef::as_ref).collect(),
+        Binder::Range { lo, hi, .. } => vec![lo, hi],
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => std::iter::once(collection.as_ref())
+            .chain(where_expr.iter().map(AsRef::as_ref))
+            .collect(),
     }
 }
 

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -90,12 +90,13 @@ fn base_env(model: &KernelModel) -> TypeEnv {
             crate::FslValue::Bool(_) => TypeRef::Bool,
             _ => TypeRef::Int,
         };
-        env.insert(name.clone(), ty);
+        env.entry(name.clone()).or_insert(ty);
     }
     for (type_name, definition) in &model.types {
         if let TypeDef::Enum { members, .. } = definition {
             for member in members {
-                env.insert(member.clone(), TypeRef::Named(type_name.clone()));
+                env.entry(member.clone())
+                    .or_insert_with(|| TypeRef::Named(type_name.clone()));
             }
         }
     }
@@ -262,6 +263,77 @@ fn infer_type(
     }
 }
 
+fn types_compatible(
+    actual: &TypeRef,
+    expected: &TypeRef,
+    model: &KernelModel,
+) -> Result<bool, PublicKernelError> {
+    let actual = resolve(model, actual)?;
+    let expected = resolve(model, expected)?;
+    Ok(match (&actual, &expected) {
+        (TypeRef::Int | TypeRef::Range(_, _), TypeRef::Int | TypeRef::Range(_, _))
+        | (TypeRef::Bool, TypeRef::Bool) => true,
+        (TypeRef::Named(actual), TypeRef::Named(expected)) => actual == expected,
+        (TypeRef::Set(actual), TypeRef::Set(expected))
+        | (TypeRef::Option(actual), TypeRef::Option(expected))
+        | (TypeRef::Seq(actual, _), TypeRef::Seq(expected, _)) => {
+            types_compatible(actual, expected, model)?
+        }
+        (TypeRef::Map(actual_key, actual_value), TypeRef::Map(expected_key, expected_value))
+        | (
+            TypeRef::Relation(actual_key, actual_value),
+            TypeRef::Relation(expected_key, expected_value),
+        ) => {
+            types_compatible(actual_key, expected_key, model)?
+                && types_compatible(actual_value, expected_value, model)?
+        }
+        _ => false,
+    })
+}
+
+fn ensure_assignable(
+    expr: &Expr,
+    expected: &TypeRef,
+    env: &TypeEnv,
+    model: &KernelModel,
+) -> Result<(), PublicKernelError> {
+    let resolved = resolve(model, expected)?;
+    match (expr, &resolved) {
+        (Expr::None, TypeRef::Option(_)) => return Ok(()),
+        (Expr::Some(item), TypeRef::Option(expected_item)) => {
+            return ensure_assignable(item, expected_item, env, model);
+        }
+        (Expr::Set(items), TypeRef::Set(expected_item))
+        | (Expr::Seq(items), TypeRef::Seq(expected_item, _)) => {
+            for item in items {
+                ensure_assignable(item, expected_item, env, model)?;
+            }
+            return Ok(());
+        }
+        (
+            Expr::IfThenElse {
+                then_expr,
+                else_expr,
+                ..
+            },
+            _,
+        ) => {
+            ensure_assignable(then_expr, expected, env, model)?;
+            ensure_assignable(else_expr, expected, env, model)?;
+            return Ok(());
+        }
+        _ => {}
+    }
+    let actual = infer_type(expr, env, model, None)?;
+    if types_compatible(&actual, expected, model)? {
+        Ok(())
+    } else {
+        Err(error(format!(
+            "expression of type {actual:?} is not assignable to {expected:?}"
+        )))
+    }
+}
+
 fn extend_pattern_binding(
     expression: &Expr,
     env: &mut TypeEnv,
@@ -361,6 +433,13 @@ fn expr_json(
     expected: Option<&TypeRef>,
 ) -> Result<Value, PublicKernelError> {
     let ty = infer_type(expr, env, model, expected)?;
+    if let Some(expected) = expected
+        && !types_compatible(&ty, expected, model)?
+    {
+        return Err(error(format!(
+            "expression of type {ty:?} is not assignable to {expected:?}"
+        )));
+    }
     let mut output = Map::from_iter([
         ("kind".to_owned(), Value::String("unknown".to_owned())),
         ("type".to_owned(), type_json(&ty)),
@@ -747,6 +826,7 @@ fn statement_json(
             span,
         } => {
             let ty = lvalue_type(target, env, model)?;
+            ensure_assignable(value, &ty, env, model)?;
             Ok(json!({
                 "kind":"assign","type":{"kind":"statement"},"span":span_json(path,*span),
                 "target":lvalue_json(target,env,model,path,*span)?,
@@ -782,6 +862,60 @@ fn statement_json(
                 "binder":binder_json(binder,env,model,path,*span)?,
                 "statements":statements.iter().map(|item|statement_json(item,&local,model,path)).collect::<Result<Vec<_>,_>>()?
             }))
+        }
+    }
+}
+
+/// Run the public Kernel expression/type checker for one normalized statement.
+///
+/// Inline state initializers lower to ordinary assignments, so keeping this
+/// entry point beside `statement_json` prevents their validation rules from
+/// drifting away from the existing normalized Kernel contract.
+pub(crate) fn validate_statement_types(
+    statement: &Statement,
+    model: &KernelModel,
+) -> Result<(), PublicKernelError> {
+    validate_statement_assignments(statement, &base_env(model), model)
+}
+
+fn validate_statement_assignments(
+    statement: &Statement,
+    env: &TypeEnv,
+    model: &KernelModel,
+) -> Result<(), PublicKernelError> {
+    match statement {
+        Statement::Assign { .. } => statement_json(statement, env, model, "").map(|_| ()),
+        Statement::If {
+            then_statements,
+            else_statements,
+            ..
+        } => then_statements
+            .iter()
+            .chain(else_statements)
+            .try_for_each(|item| validate_statement_assignments(item, env, model)),
+        Statement::ForAll {
+            binder, statements, ..
+        } => {
+            let (name, ty) = match binder {
+                Binder::Typed {
+                    name, type_name, ..
+                } => (name, TypeRef::Named(qualified_name(type_name)?)),
+                Binder::Range { name, .. } => (name, TypeRef::Int),
+                Binder::Collection {
+                    name, collection, ..
+                } => {
+                    let collection_ty = resolve(model, &infer_type(collection, env, model, None)?)?;
+                    let (TypeRef::Set(item) | TypeRef::Seq(item, _)) = collection_ty else {
+                        return Err(error("collection binder requires Set or Seq"));
+                    };
+                    (name, *item)
+                }
+            };
+            let mut local = env.clone();
+            local.insert(name.clone(), ty);
+            statements
+                .iter()
+                .try_for_each(|item| validate_statement_assignments(item, &local, model))
         }
     }
 }

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -39,9 +39,9 @@ pub use surface::{
     GovernanceDelegateItem, GovernanceItem, HelpfulAction, LValue, MapsClause, MetaTag, Param,
     PreservationItem, ProcessField, ProcessFields, ProcessItem, ProcessTransition, RefinementItem,
     RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
-    RequirementBranch, RequirementsItem, SpecItem, Statement, SurfaceBusiness, SurfaceCompose,
-    SurfaceDocument, SurfaceGovernance, SurfaceRefinement, SurfaceRequirements, SurfaceSpec,
-    SyncAction, SyncRef, TimeItem, TypeExpr, VerifyItem,
+    RequirementBranch, RequirementsItem, SpecItem, StateField, Statement, SurfaceBusiness,
+    SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement, SurfaceRequirements,
+    SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr, VerifyItem,
 };
 pub use syntax_expr::{
     SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxIdent, SyntaxLValue, SyntaxOperator,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -16,6 +16,13 @@ use crate::{
     VerifyItem, lex,
 };
 
+fn join_span(start: Span, end: Span) -> Span {
+    Span {
+        start: start.start,
+        end: end.end,
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParseError {
     pub message: String,
@@ -837,9 +844,12 @@ impl Parser {
             let fields_span = self.bump().span;
             let mut fields = Vec::new();
             loop {
+                let field_start = self.peek().span;
                 let field_name = self.expect_ident()?;
                 self.expect_symbol(":")?;
+                let type_start = self.peek().span;
                 let type_name = self.qualified_name()?;
+                let type_span = join_span(type_start, self.last_span());
                 let initial = if self.eat_symbol("=") {
                     Some(self.expression(0)?)
                 } else {
@@ -849,6 +859,8 @@ impl Parser {
                     name: field_name,
                     type_name,
                     initial,
+                    span: join_span(field_start, self.last_span()),
+                    type_span,
                 });
                 if !self.eat_symbol(",") {
                     break;
@@ -1295,7 +1307,7 @@ impl Parser {
         if self.peek_ident("state") {
             self.bump();
             self.expect_symbol("{")?;
-            let declarations = self.field_list()?;
+            let declarations = self.state_field_list()?;
             return Ok(SpecItem::State(declarations));
         }
         if self.peek_ident("init") {
@@ -1382,6 +1394,44 @@ impl Parser {
         }
     }
 
+    fn state_field_list(&mut self) -> Result<Vec<crate::StateField>, ParseError> {
+        let mut fields = Vec::new();
+        if self.eat_symbol("}") {
+            return Ok(fields);
+        }
+        loop {
+            let start = self.peek().span;
+            let name = self.expect_ident()?;
+            self.expect_symbol(":")?;
+            let ty = self.type_expr()?;
+            let (initializer, initializer_span) = if self.eat_symbol("=") {
+                let initializer_start = self.peek().span;
+                let initializer = self.expression(0)?;
+                let initializer_end = self.last_span();
+                (
+                    Some(initializer),
+                    Some(join_span(initializer_start, initializer_end)),
+                )
+            } else {
+                (None, None)
+            };
+            fields.push(crate::StateField {
+                name,
+                ty,
+                initializer,
+                span: join_span(start, self.last_span()),
+                initializer_span,
+            });
+            if self.eat_symbol("}") {
+                return Ok(fields);
+            }
+            self.expect_symbol(",")?;
+            if self.eat_symbol("}") {
+                return Ok(fields);
+            }
+        }
+    }
+
     fn type_expr(&mut self) -> Result<TypeExpr, ParseError> {
         if self.eat_ident("Int") {
             return Ok(TypeExpr::Int);
@@ -1438,7 +1488,7 @@ impl Parser {
     fn next_is_type_delimiter(&self) -> bool {
         matches!(
             &self.peek_n(1).kind,
-            TokenKind::Symbol(symbol) if matches!(symbol.as_str(), "," | ">" | "}" | "->")
+            TokenKind::Symbol(symbol) if matches!(symbol.as_str(), "," | ">" | "}" | "->" | "=")
         )
     }
 
@@ -1880,6 +1930,10 @@ impl Parser {
 
     fn peek(&self) -> &Token {
         &self.tokens[self.cursor]
+    }
+
+    fn last_span(&self) -> Span {
+        self.tokens[self.cursor.saturating_sub(1)].span
     }
 
     fn peek_n(&self, offset: usize) -> &Token {

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -72,6 +72,29 @@ pub struct HelpfulAction {
     pub span: Span,
 }
 
+/// One Kernel state declaration, retaining optional inline-initializer syntax.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StateField {
+    pub name: String,
+    pub ty: TypeExpr,
+    pub initializer: Option<Expr>,
+    pub span: Span,
+    pub initializer_span: Option<Span>,
+}
+
+impl StateField {
+    #[must_use]
+    pub fn generated(name: impl Into<String>, ty: TypeExpr, span: Span) -> Self {
+        Self {
+            name: name.into(),
+            ty,
+            initializer: None,
+            span,
+            initializer_span: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VerifyItem {
     Instances(String, i64, Span),
@@ -107,7 +130,7 @@ pub enum SpecItem {
     },
     Entity(String, Span),
     Number(String, Span),
-    State(Vec<(String, TypeExpr)>),
+    State(Vec<StateField>),
     Init {
         statements: Vec<Statement>,
         meta: Option<MetaTag>,
@@ -227,6 +250,8 @@ pub struct ProcessField {
     pub name: String,
     pub type_name: QualifiedName,
     pub initial: Option<Expr>,
+    pub span: Span,
+    pub type_span: Span,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -783,7 +808,15 @@ impl SpecItem {
                 "state",
                 declarations
                     .iter()
-                    .map(|(name, ty)| json!(["decl", name, ty.python_ast()]))
+                    .map(|field| {
+                        let mut declaration =
+                            vec![json!("decl"), json!(field.name), field.ty.python_ast()];
+                        if let Some(initializer) = &field.initializer {
+                            declaration.push(initializer.python_ast());
+                            declaration.push(json!(field.initializer_span.map(Span::python_loc)));
+                        }
+                        Value::Array(declaration)
+                    })
                     .collect::<Vec<_>>()
             ]),
             Self::Init { statements, meta } => {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3513,14 +3513,182 @@ fn domain_enum_union_warnings(path: &Path) -> Vec<Value> {
         .collect()
 }
 
+fn implicit_initial_value_warnings(path: &Path) -> Vec<Value> {
+    let Ok(document) = parse_surface_document(path) else {
+        return Vec::new();
+    };
+    match document {
+        fsl_syntax::SurfaceDocument::Domain(domain) => domain_implicit_warnings(path, &domain),
+        fsl_syntax::SurfaceDocument::Requirements(requirements) => {
+            requirements_implicit_warnings(path, &requirements)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn domain_implicit_warnings(path: &Path, domain: &fsl_syntax::DomainSpec) -> Vec<Value> {
+    let declared = domain
+        .types
+        .iter()
+        .map(|ty| (ty.name.as_str(), ty))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    domain
+        .aggregates
+        .iter()
+        .flat_map(|aggregate| {
+            aggregate.state.iter().filter_map(|field| {
+                let type_name = field.type_name.render_source();
+                let selected = omitted_domain_value(&type_name, field.default.as_ref(), &declared)?;
+                Some(implicit_initial_value_warning(
+                    path,
+                    &format!("{}.{}", aggregate.name, field.name.text),
+                    field.span,
+                    field.type_name.span.end.offset,
+                    &selected.0,
+                    &selected.1,
+                ))
+            })
+        })
+        .collect()
+}
+
+fn omitted_domain_value(
+    type_name: &str,
+    default: Option<&fsl_syntax::SyntaxExpr>,
+    declared: &std::collections::BTreeMap<&str, &fsl_syntax::DomainType>,
+) -> Option<(String, String)> {
+    if default.is_some() {
+        return None;
+    }
+    if type_name == "Bool" {
+        return Some(("false".to_owned(), "Bool defaults to false".to_owned()));
+    }
+    if type_name == "Int" {
+        return None;
+    }
+    if let Some(definition) = declared.get(type_name) {
+        return match definition.kind.as_str() {
+            "enum" => definition.members.first().map(|member| {
+                (
+                    member.clone(),
+                    format!(
+                        "the first declared member of enum '{}' is selected",
+                        definition.name
+                    ),
+                )
+            }),
+            "range" => definition.lo.as_ref().map(|lo| {
+                (
+                    lo.render_source(),
+                    format!("the lower bound of range '{}' is selected", definition.name),
+                )
+            }),
+            _ => None,
+        };
+    }
+    (!type_name.contains('<')).then(|| {
+        (
+            "0".to_owned(),
+            format!("external placeholder type '{type_name}' defaults to 0"),
+        )
+    })
+}
+
+fn requirements_implicit_warnings(
+    path: &Path,
+    requirements: &fsl_syntax::SurfaceRequirements,
+) -> Vec<Value> {
+    let mut lower_bounds = std::collections::BTreeMap::new();
+    for item in &requirements.items {
+        if let fsl_syntax::RequirementsItem::Common(fsl_syntax::SpecItem::VerifyBounds {
+            items,
+            ..
+        }) = item
+        {
+            for bound in items {
+                if let fsl_syntax::VerifyItem::Values(name, lo, _, _) = bound {
+                    lower_bounds.insert(name.as_str(), fslc_rust::expr_text(lo));
+                }
+            }
+        }
+    }
+    requirements
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            fsl_syntax::RequirementsItem::Process(fsl_syntax::BusinessItem::Process {
+                name,
+                fields: Some(fields),
+                ..
+            }) => Some((name, fields)),
+            _ => None,
+        })
+        .flat_map(|(process, fields)| {
+            let lower_bounds = &lower_bounds;
+            fields.fields.iter().filter_map(move |field| {
+                if field.initial.is_some() {
+                    return None;
+                }
+                let selected = lower_bounds.get(field.type_name.name.as_str())?;
+                Some(implicit_initial_value_warning(
+                    path,
+                    &format!("{process}.{}", field.name),
+                    field.span,
+                    field.type_span.end.offset,
+                    selected,
+                    &format!(
+                        "the lower bound of number '{}' is selected",
+                        field.type_name.name
+                    ),
+                ))
+            })
+        })
+        .collect()
+}
+
+fn implicit_initial_value_warning(
+    path: &Path,
+    field: &str,
+    span: fsl_syntax::Span,
+    insertion_offset: usize,
+    selected: &str,
+    reason: &str,
+) -> Value {
+    let replacement = format!(" = {selected}");
+    json!({
+        "kind": "implicit_initial_value",
+        "code": "implicit_initial_value",
+        "severity": "warning",
+        "edition_severity": {"current": "warning", "next": "error"},
+        "message": format!("field '{field}' implicitly selects {selected}; add an explicit initializer"),
+        "field": field,
+        "selected_value": selected,
+        "reason": reason,
+        "loc": {
+            "file": path,
+            "line": span.start.line,
+            "column": span.start.column,
+            "end_line": span.end.line,
+            "end_column": span.end.column,
+        },
+        "canonical_replacement": replacement,
+        "suggestion": {
+            "kind": "insert",
+            "replacement": replacement,
+            "span": {"start": insertion_offset, "end": insertion_offset},
+            "machine_applicable": true,
+        },
+    })
+}
+
 fn apply_domain_edition(
     (mut output, status): (Value, i32),
     path: &Path,
     edition: &str,
 ) -> (Value, i32) {
-    let mut additions = domain_enum_union_warnings(path);
-    if edition == "next" && !additions.is_empty() {
-        for finding in &mut additions {
+    let mut legacy_additions = domain_enum_union_warnings(path);
+    if edition == "next" && !legacy_additions.is_empty() {
+        for finding in &mut legacy_additions {
             finding["severity"] = json!("error");
             finding["message"] = json!(format!(
                 "{}; legacy domain enum unions are not accepted in the next edition",
@@ -3533,9 +3701,11 @@ fn apply_domain_edition(
         error.insert("result".to_owned(), json!("error"));
         error.insert("kind".to_owned(), json!("deprecated_domain_enum_union"));
         error.insert("edition".to_owned(), json!(edition));
-        error.insert("findings".to_owned(), Value::Array(additions));
+        error.insert("findings".to_owned(), Value::Array(legacy_additions));
         return (Value::Object(error), 2);
     }
+    let mut additions = legacy_additions;
+    additions.extend(implicit_initial_value_warnings(path));
     if !additions.is_empty()
         && let Value::Object(envelope) = &mut output
     {

--- a/rust/fslc/tests/issue_250_initialization.rs
+++ b/rust/fslc/tests/issue_250_initialization.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-250-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+
+    fn replace(&self, source: &str) {
+        std::fs::write(&self.0, source).expect("replace fixture");
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn without_spans(mut value: Value) -> Value {
+    match &mut value {
+        Value::Object(object) => {
+            object.remove("span");
+            for child in object.values_mut() {
+                *child = without_spans(std::mem::take(child));
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                *item = without_spans(std::mem::take(item));
+            }
+        }
+        _ => {}
+    }
+    value
+}
+
+const INLINE: &str = r"spec InlineInit {
+  const ZERO = 0
+  enum Status { Pending, Done }
+  type Count = 0..2
+  type ItemId = 0..1
+  type JobId = 0..1
+  state {
+    status: Status = Pending,
+    count: Count = ZERO,
+    current: Option<ItemId> = none,
+    queue: Seq<JobId, 3> = Seq {},
+  }
+  action finish() { status = Done }
+  invariant CountStartsAtZero { count >= 0 }
+}
+";
+
+const EXPLICIT: &str = r"spec InlineInit {
+  const ZERO = 0
+  enum Status { Pending, Done }
+  type Count = 0..2
+  type ItemId = 0..1
+  type JobId = 0..1
+  state {
+    status: Status,
+    count: Count,
+    current: Option<ItemId>,
+    queue: Seq<JobId, 3>,
+  }
+  init {
+    status = Pending
+    count = ZERO
+    current = none
+    queue = Seq {}
+  }
+  action finish() { status = Done }
+  invariant CountStartsAtZero { count >= 0 }
+}
+";
+
+#[test]
+fn inline_and_explicit_forms_share_checked_init_and_verdicts() {
+    let inline = Fixture::new("inline", INLINE);
+    let explicit = Fixture::new("explicit", EXPLICIT);
+
+    let (inline_kernel, inline_status) = run(&["kernel", inline.text()]);
+    let (explicit_kernel, explicit_status) = run(&["kernel", explicit.text()]);
+    assert_eq!(inline_status, 0, "{inline_kernel}");
+    assert_eq!(explicit_status, 0, "{explicit_kernel}");
+    assert!(inline_kernel["init"]["statements"].is_array());
+    assert_eq!(
+        without_spans(inline_kernel["init"]["statements"].clone()),
+        without_spans(explicit_kernel["init"]["statements"].clone())
+    );
+
+    for engine in ["bmc", "induction", "explicit"] {
+        let (inline_result, inline_status) = run(&[
+            "verify",
+            inline.text(),
+            "--depth",
+            "2",
+            "--engine",
+            engine,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        let (explicit_result, explicit_status) = run(&[
+            "verify",
+            explicit.text(),
+            "--depth",
+            "2",
+            "--engine",
+            engine,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(inline_status, explicit_status, "{engine}: {inline_result}");
+        assert_eq!(inline_result["result"], explicit_result["result"]);
+        assert_eq!(
+            inline_result["completeness"],
+            explicit_result["completeness"]
+        );
+    }
+}
+
+#[test]
+fn inline_assignments_precede_the_logical_init_regardless_of_source_order() {
+    let fixture = Fixture::new(
+        "source-order",
+        r"spec SourceOrder {
+  type N = 0..2
+  init { second = 1 }
+  state { first: N = 0, second: N }
+  action stay() { second = second }
+  invariant InRange { first >= 0 }
+}
+",
+    );
+    let (kernel, status) = run(&["kernel", fixture.text()]);
+    assert_eq!(status, 0, "{kernel}");
+    let statements = kernel["init"]["statements"]
+        .as_array()
+        .expect("init statements");
+    assert_eq!(statements[0]["target"]["name"], "first");
+    assert_eq!(statements[1]["target"]["name"], "second");
+}
+
+#[test]
+fn inline_initializer_must_not_read_any_state_root() {
+    for source in [
+        "spec Bad { type N = 0..2 state { a: N = 0, b: N = a } action stay() { b = b } }",
+        "spec Bad { type N = 0..2 state { a: N = a } action stay() { a = a } }",
+    ] {
+        let fixture = Fixture::new("state-read", source);
+        let (output, status) = run(&["check", fixture.text()]);
+        assert_eq!(status, 2, "{output}");
+        assert_eq!(output["kind"], "semantics");
+        assert!(
+            output["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("must not read state"))
+        );
+    }
+}
+
+#[test]
+fn inline_values_use_the_existing_name_and_type_checker() {
+    for (inline, explicit) in [
+        (
+            "spec Bad { state { flag: Bool = 0 } action stay() { } }",
+            "spec Bad { state { flag: Bool } init { flag = 0 } action stay() { } }",
+        ),
+        (
+            "spec Bad { enum Status { Pending } state { status: Status = Missing } action stay() { } }",
+            "spec Bad { enum Status { Pending } state { status: Status } init { status = Missing } action stay() { } }",
+        ),
+        (
+            "spec Bad { state { count: Int = 1 + Missing } action stay() { } }",
+            "spec Bad { state { count: Int } init { count = 1 + Missing } action stay() { } }",
+        ),
+    ] {
+        for source in [inline, explicit] {
+            let fixture = Fixture::new("invalid-value", source);
+            let (output, status) = run(&["check", fixture.text()]);
+            assert_eq!(status, 2, "{output}");
+            assert!(
+                matches!(output["kind"].as_str(), Some("type" | "semantics")),
+                "{output}"
+            );
+        }
+    }
+}
+
+#[test]
+fn shared_init_checker_uses_runtime_state_name_precedence() {
+    let fixture = Fixture::new(
+        "name-precedence",
+        r"spec NamePrecedence {
+  const source = 0
+  state { source: Bool, target: Bool }
+  init { source = false target = source }
+  action stay() { target = target }
+  invariant Typed { target == true or target == false }
+}
+",
+    );
+    let (output, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 0, "{output}");
+}
+
+#[test]
+fn inline_and_explicit_assignment_to_the_same_root_reports_both_spans() {
+    let fixture = Fixture::new(
+        "overlap",
+        r"spec Bad {
+  type N = 0..2
+  state { count: N = 0 }
+  init { count = 1 }
+  action stay() { count = count }
+}
+",
+    );
+    let (output, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["kind"], "semantics");
+    let message = output["message"].as_str().expect("semantic message");
+    assert!(message.contains("at 3:"), "{message}");
+    assert!(
+        message.contains("conflicting assignment at 4:"),
+        "{message}"
+    );
+}
+
+#[test]
+fn relational_and_bulk_initialization_remain_init_only() {
+    for declaration in [
+        "values: Map<N, N> = forall n: N { values[n] = 0 }",
+        "value: N = if true { value = 0 } else { value = 1 }",
+    ] {
+        let source =
+            format!("spec Bad {{ type N = 0..1 state {{ {declaration} }} action stay() {{ }} }}");
+        let fixture = Fixture::new("statement-form", &source);
+        let (output, status) = run(&["check", fixture.text()]);
+        assert_eq!(status, 2, "{output}");
+        assert_eq!(output["kind"], "parse");
+    }
+}
+
+#[test]
+fn quantified_expression_initializers_are_rejected_semantically() {
+    let fixture = Fixture::new(
+        "quantified-expression",
+        r"spec Quantified {
+  type N = 0..1
+  state { n: N, flag: Bool = forall x: N: x == x }
+  init { n = 0 }
+  action stay() { n = n }
+}
+",
+    );
+    let (output, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["kind"], "semantics");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("quantified expression")),
+        "{output}"
+    );
+}
+
+#[test]
+fn domain_implicit_values_warn_with_selected_values_and_insertions() {
+    let source = r"domain Defaults {
+  implementation_profile functional_ddd
+  enum Status { Pending, Done }
+  type Count = 2..3
+  aggregate Order {
+    id OrderId
+    state {
+      status: Status;
+      active: Bool;
+      count: Count;
+      owner: OwnerId; // keep this comment
+    }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+  }
+}
+";
+    let fixture = Fixture::new("domain-defaults", source);
+    let (output, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 0, "{output}");
+    let warnings = output["warnings"].as_array().expect("warnings array");
+    let implicit = warnings
+        .iter()
+        .filter(|warning| warning["code"] == "implicit_initial_value")
+        .collect::<Vec<_>>();
+    assert_eq!(implicit.len(), 4, "{output}");
+    let selected = implicit
+        .iter()
+        .map(|warning| {
+            (
+                warning["field"].as_str().expect("field"),
+                warning["selected_value"].as_str().expect("selected value"),
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(selected["Order.status"], "Pending");
+    assert_eq!(selected["Order.active"], "false");
+    assert_eq!(selected["Order.count"], "2");
+    assert_eq!(selected["Order.owner"], "0");
+    for warning in implicit {
+        assert_eq!(warning["edition_severity"]["current"], "warning");
+        assert_eq!(warning["edition_severity"]["next"], "error");
+        assert_eq!(warning["suggestion"]["kind"], "insert");
+        assert_eq!(warning["suggestion"]["machine_applicable"], true);
+        assert_eq!(
+            warning["suggestion"]["span"]["start"],
+            warning["suggestion"]["span"]["end"]
+        );
+    }
+}
+
+#[test]
+fn requirements_number_default_warning_edit_preserves_comment_and_verdict() {
+    let source = r"requirements Amounts {
+  number Amount
+  process Claim with amount: Amount // keep
+  {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by System
+  }
+}
+verify {
+  instances Claim = 1
+  values Amount = 2..4
+}
+";
+    let fixture = Fixture::new("requirements-default", source);
+    let (before, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 0, "{before}");
+    let warning = before["warnings"]
+        .as_array()
+        .and_then(|warnings| {
+            warnings
+                .iter()
+                .find(|warning| warning["code"] == "implicit_initial_value")
+        })
+        .unwrap_or_else(|| panic!("missing implicit warning: {before}"));
+    assert_eq!(warning["field"], "Claim.amount");
+    assert_eq!(warning["selected_value"], "2");
+
+    let mut migrated = source.to_owned();
+    let start = usize::try_from(
+        warning["suggestion"]["span"]["start"]
+            .as_u64()
+            .expect("byte offset"),
+    )
+    .expect("offset fits usize");
+    migrated.insert_str(
+        start,
+        warning["suggestion"]["replacement"]
+            .as_str()
+            .expect("replacement"),
+    );
+    assert!(migrated.contains("amount: Amount = 2 // keep"));
+    fixture.replace(&migrated);
+
+    let (after, status) = run(&["check", fixture.text()]);
+    assert_eq!(status, 0, "{after}");
+    assert!(!after["warnings"].as_array().is_some_and(|warnings| {
+        warnings
+            .iter()
+            .any(|warning| warning["code"] == "implicit_initial_value")
+    }));
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -15,7 +15,7 @@ spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadat
   struct <Name> { <field>: <type>, ... }  // field: scalar | Option<scalar>
   def <name>(<p>: <type name>, ...) = <expr> // non-recursive predicate, frontend-inlined
 
-  state { <var>: <type>, ... }
+  state { <var>: <type> [= <deterministic expr>], ... }
   init  ["undecided: reason"] { <stmt>... } // assign exactly once per variable/Map-key (deterministic)
 
   [fair] action <name>(<p>: <type name>, ...) {
@@ -258,6 +258,11 @@ source-less nodes as generated-only. Requirement tags are a separate
 traceability relation, not origin identities. Public Kernel v1 remains
 byte-compatible and does not expose the internal chain; publication belongs to
 v2 (#256).
+
+Omitted domain aggregate initializers retain the current Bool `false`, enum
+first-member, range lower-bound, or external-placeholder `0` behavior while
+emitting `implicit_initial_value`. The warning carries the selected value,
+reason, edition severities, source span, and a machine-applicable insertion.
 
 AI hard-contract dialect (expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):
@@ -549,6 +554,7 @@ still caught as `map_out_of_bounds`/`abs_state_mismatch`.
 | Int / Bool | `n: Int` | Int is unbounded |
 | Domain type | `type Qty = 0..5` | **automatic bound check** (violated/type_bound) |
 | Inline state domain | `state { qty: 0..5 }` | Shorthand for a named domain type in a state-variable declaration |
+| Inline state initializer | `state { qty: Qty = 0 }` | Deterministic sugar for the equivalent root assignment in `init`; may not read state |
 | symmetric domain | `symmetric type TaskId = 0..2` | Same as a domain type, plus liveness symmetry reduction |
 | entity kind (dialects) | `entity Claim` / `process Claim ...` | Finite identity sort for business/requirements; bound by `verify { instances Claim = N }` |
 | number kind (dialects) | `number Amount` | Finite numeric sort for business/requirements; bound by `verify { values Amount = lo..hi }` |
@@ -569,6 +575,14 @@ Map<bounded scalar, scalar|Option|struct> | Set<bounded scalar> | Seq<scalar, N>
 relation bounded-scalar -> bounded-scalar.
 Anything else (nested structs, Set/Map/Seq as a Map value, etc.) is rejected by
 check as a type error.
+
+Kernel `state` fields may carry deterministic inline initializers. They normalize
+to ordinary root assignments before checking and therefore share Monitor/BMC/
+induction/explicit/Public-Kernel semantics with `init`. Constants, enum members,
+constructors, `none`, and deterministic collection literals are allowed. State
+reads, references to another initializer, indexed/field targets, statement `if`,
+`forall`, and bulk/relational initialization remain invalid inline. The same root
+cannot be assigned both inline and in `init`.
 
 ## 3. Expression catalog
 
@@ -1369,7 +1383,9 @@ verify {
   field updates (`set f = expr`), and traceability (`covers REQ-n "text"`). A
   carried field's type `T` is a `number`, `Bool`, or an enum declared in the
   same requirements spec. Numbers default to the domain's `lo` bound and may
-  take an optional explicit `f: T = <const-expr>` initializer; `Bool` and enum
+  take an optional explicit `f: T = <const-expr>` initializer; omission emits
+  `implicit_initial_value` with the selected lower bound and an insertion edit.
+  `Bool` and enum
   fields have no invented default and **require** an explicit initializer
   (`f: Bool = true/false`, `f: T = Member`) — omitting it is a check-time error.
 - `kpi NAME = count ENTITY in STAGE` is a declarative projection in both

--- a/src/fslc/compose.py
+++ b/src/fslc/compose.py
@@ -33,7 +33,7 @@ def _collect_component_names(items):
         elif tag in ("type", "enum", "struct"):
             types.add(it[1])
         elif tag == "state":
-            for _, n, _ in it[1]:
+            for _, n, *_ in it[1]:
                 state.add(n)
         elif tag == "action":
             actions.add(it[1])
@@ -316,10 +316,17 @@ def _prefix_component_items(items, alias, display_names):
             out.append(("struct", pn, fields))
         elif tag == "state":
             decls = []
-            for _, n, ty_ast in it[1]:
+            for declaration in it[1]:
+                _, n, ty_ast, *initializer = declaration
                 pn = _prefix(n, alias)
                 display_names[pn] = _display_logical(alias, n)
-                decls.append(("decl", pn, _rewrite_type(ty_ast, {alias}, types, consts)))
+                rewritten = ("decl", pn, _rewrite_type(ty_ast, {alias}, types, consts))
+                if initializer:
+                    rewritten += (
+                        _rewrite_expr(initializer[0], {alias}, state, types, consts),
+                        initializer[1],
+                    )
+                decls.append(rewritten)
             out.append(("state", decls))
         elif tag == "init":
             out.append(("init", [_rewrite_stmt(s, {alias}, state, types, consts) for s in it[1]]))
@@ -518,8 +525,15 @@ def _rewrite_compose_items(compose_rest, action_by_name, compose_aliases, merged
             merged.append(("action", aname, _rewrite_params(params, compose_aliases), new_body, loc, fair, meta))
         elif tag == "state":
             decls = []
-            for _, n, ty_ast in it[1]:
-                decls.append(("decl", n, _rewrite_type(ty_ast, compose_aliases)))
+            for declaration in it[1]:
+                _, n, ty_ast, *initializer = declaration
+                rewritten = ("decl", n, _rewrite_type(ty_ast, compose_aliases))
+                if initializer:
+                    rewritten += (
+                        _rewrite_expr(initializer[0], compose_aliases, empty_comp, set(), set()),
+                        initializer[1],
+                    )
+                decls.append(rewritten)
             merged.append(("state", decls))
         elif tag == "init":
             merged.append(("init", [_rewrite_stmt(s, compose_aliases, empty_comp, set(), set()) for s in it[1]]))

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -68,7 +68,7 @@ entity_def: "entity" NAME
 number_def: "number" NAME
 
 state_def: "state" "{" var_decl ("," var_decl)* ","? "}"
-var_decl: NAME ":" type
+var_decl: NAME ":" type ["=" expr]
 ?type: "Int"  -> t_int
      | "Bool" -> t_bool
      | "relation" type "->" type -> t_relation
@@ -599,8 +599,10 @@ class Ast(Transformer):
     def t_name(self, meta, n):
         return ("name", n)
 
-    def var_decl(self, meta, n, ty):
-        return ("decl", n, ty)
+    def var_decl(self, meta, n, ty, initializer=None):
+        if initializer is None:
+            return ("decl", n, ty)
+        return ("decl", n, ty, initializer, _loc(meta))
 
     def entity_def(self, meta, name):
         return ("entity", name, _loc(meta))

--- a/src/fslc/model.py
+++ b/src/fslc/model.py
@@ -1269,6 +1269,7 @@ def build_spec(tree, display_names=None, semantic_check=True):
 
     state = {}
     init = []
+    inline_init = []
     actions = []
     invariants = []
     transitions = []
@@ -1281,12 +1282,17 @@ def build_spec(tree, display_names=None, semantic_check=True):
     for it in items:
         tag = it[0]
         if tag == "state":
-            for _, n, ty_ast in it[1]:
+            for declaration in it[1]:
+                _, n, ty_ast, *initializer = declaration
                 _check_reserved(n, "state variable")
                 if n in state:
                     _err(f"duplicate state variable '{n}'", kind="name")
                 state[n] = resolve_type(ty_ast, types_meta, consts)
                 state_type_refs[n] = resolve_type_ref(ty_ast, types_meta, consts)
+                if initializer:
+                    inline_init.append(
+                        ("assign", ("var", n), initializer[0], initializer[1])
+                    )
         elif tag == "init":
             init = it[1]
         elif tag == "action":
@@ -1373,6 +1379,8 @@ def build_spec(tree, display_names=None, semantic_check=True):
                 _err("duplicate terminal block", kind="semantics")
             terminal = it[1]
             terminal_loc = it[2] if len(it) > 2 else None
+
+    init = inline_init + init
 
     if not state:
         _err("spec has no state block", kind="semantics")

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -1045,6 +1045,12 @@
       "warnings": []
     }
   },
+  "examples/kernel_inline_initializer.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/layers/return_impl.fsl": {
     "check": {
       "result": "ok",

--- a/tests/test_inline_initializer_compat.py
+++ b/tests/test_inline_initializer_compat.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen Python/LSP compatibility for native Kernel inline initializers."""
+
+from fslc.model import build_spec
+from fslc.parser import parse_src
+
+
+def _build(source: str):
+    tree, display_names = parse_src(source)
+    return build_spec(tree, display_names)
+
+
+def test_inline_initializer_projects_to_the_existing_python_init_shape():
+    inline = _build(
+        """
+spec Compat {
+  enum Status { Pending, Done }
+  state { status: Status = Pending, active: Bool = false }
+  action stay() { status = status }
+}
+"""
+    )
+    explicit = _build(
+        """
+spec Compat {
+  enum Status { Pending, Done }
+  state { status: Status, active: Bool }
+  init { status = Pending active = false }
+  action stay() { status = status }
+}
+"""
+    )
+
+    assert [statement[:3] for statement in inline["init"]] == [
+        statement[:3] for statement in explicit["init"]
+    ]


### PR DESCRIPTION
## Problem

Kernel state declarations could not express simple deterministic initial values inline, while domain and requirements lowering retained implicit defaults without a stable migration diagnostic.

## Contract change

- Add optional deterministic Kernel state initializers and normalize them to the existing logical init assignments.
- Reject state reads, initializer-order dependencies, quantified/relational/bulk forms, and inline plus explicit assignment overlap with both source locations.
- Reuse one assignment name/type validation path for inline and explicit init statements while preserving runtime name-resolution precedence.
- Emit stable implicit_initial_value warnings for retained domain defaults and requirements numeric lower-bound defaults, including selected value, reason, current/next edition severity, source location, and a machine-applicable insertion edit.
- Keep Public Kernel v1 normalized and schema-stable; no second initializer representation is published.
- Preserve the accepted requirements contract: omitted Bool and enum carried fields remain errors.

The frozen Python surface only gains the parser/LSP and normalized-init compatibility needed by the repository parity gates; Rust remains authoritative.

## Evidence

- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --workspace --locked
- cargo build --manifest-path rust/Cargo.toml --workspace --locked
- Issue-focused Rust integration: 10 passed
- Public Kernel contract tests: 14 passed, v1 goldens unchanged
- Python Rust CLI contract: 10 passed
- Full Python suite: 1411 passed, 81 skipped
- Independent final review: no blocking findings after fixing quantified initializer rejection and name-resolution precedence

Documentation, generated language references, skill reference, example, changelog, and the intentionally regenerated corpus snapshot are included.

Closes #250
