### PR TITLE
fix(verifier): detect leadsTo deadlock stagnation at every depth beyond the stall step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   instead of a generated Kernel coordinate.
 
 ### Fixed
+- Bounded `leadsTo` deadlock-stagnation detection no longer requires `--depth`
+  to land exactly on the stalling step. The BMC unrolling loop permanently
+  asserted a forward transition out of every non-final step before the
+  deadlock-stagnation check ran as a single post-hoc pass, so a deadlocked
+  path below the requested depth was excluded from the solver context and the
+  spec falsely verified. The check now runs inside the per-step loop, before
+  that step's forward-transition assertion, matching the frozen Python
+  reference's existing behavior (issue #260).
 - The browser Worker now reports `leadsTo` violations. The Worker envelope
   previously ignored the bounded verifier's leadsTo verdict, so a spec whose
   `must eventually` policy is violated was reported as `verified` in the

--- a/docs/DESIGN-temporal.md
+++ b/docs/DESIGN-temporal.md
@@ -278,15 +278,22 @@ failure is a transition-progress failure.
   - `_logical_eq(spec, s1, s2)` — a helper that returns the logical equality of
     §2.3 (built using the phys_vars metadata — Option's present/value, Seq's
     data/len).
-  - The leadsTo check, after `_bmc_explore` (like verify's reachable handling),
-    runs on the shared solver per leadsTo × binding with push/pop:
-    `s.add(Or over (i,j,p) of [loop ∧ P ∧ ¬Q sequence ∧ fairness_ok])` → if sat,
-    identify (i, j, p) from the model (attach a selector Bool to each (i,j,p)
-    candidate and read it from the model) and build the trace.
+  - The lasso/fairness leadsTo check, after `_bmc_explore` (like verify's
+    reachable handling), runs on the shared solver per leadsTo × binding with
+    push/pop: `s.add(Or over (i,j,p) of [loop ∧ P ∧ ¬Q sequence ∧
+    fairness_ok])` → if sat, identify (i, j, p) from the model (attach a
+    selector Bool to each (i,j,p) candidate and read it from the model) and
+    build the trace.
   - enabled_a reuses the same `_eval_requires` conjunction as the coverage check
     (expr_cache works).
-  - The deadlock stall (§2.4) reuses the enabled expression of the existing
-    deadlock check.
+  - The deadlock stall (§2.4) is checked *inside* `_bmc_explore`, per step,
+    before that step's forward-transition assertion is added to the shared
+    solver (`_check_leadsto_stutter_at_step`, alongside the existing deadlock
+    check) — not after the loop like the lasso check above. This ordering is
+    load-bearing: the per-step BMC unrolling permanently asserts "some action
+    fires" for every non-final step, so a deadlock-stall probe issued only
+    after the full trace is built can never be satisfiable below the depth
+    horizon. Reuses the enabled expression of the existing deadlock check.
   - Symmetry reduction (§2.5.1) adds canonical row-order constraints only inside
     the lasso/stall push/pop queries. It is not asserted on the shared path
     solver, so safety/reachability behavior and finite transition construction

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -604,7 +604,7 @@ variable.
 | action coverage | Each action is enabled at least once within depth K | diagnosis of the blocking requires in `action_coverage` |
 | Deadlock | Reaching a state where all actions become disabled | warning (`violated` with `--deadlock error`) |
 | trans | Whether the two-state predicate holds across all reachable transitions | `violated` / `trans` / `trans` + trace |
-| leadsTo | A P ~> Q violation via a lasso up to depth K or via deadlock stagnation | `violated` / `leadsTo` / `bindings` + trace |
+| leadsTo | A P ~> Q violation via a lasso up to depth K or via deadlock stagnation (detected as soon as `--depth` reaches the stalling step, and at every larger depth after that, not only when it lands exactly on that step) | `violated` / `leadsTo` / `bindings` + trace |
 
 - A deadlock warning includes which state you got stuck in (e.g. `deadlock reachable at
   step 1 (state: status=ToolFault, ...)`). The full trace is also in the JSON `deadlock.trace`.

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -223,6 +223,13 @@ async fn verify_bounded_config<S: SmtSolver>(
             }
         }
 
+        if result.leadsto_violation.is_none() && !model.leadstos.is_empty() {
+            result.leadsto_violation = check_leadsto_stagnation(
+                solver, model, &states, &choices, &instances, step, &enabled,
+            )
+            .await?;
+        }
+
         if step == depth || instances.is_empty() {
             continue;
         }
@@ -238,8 +245,10 @@ async fn verify_bounded_config<S: SmtSolver>(
         states.push(next);
         choices.push(choice);
     }
-    result.leadsto_violation =
-        check_leadstos(solver, model, &states, &choices, &instances, depth).await?;
+    if result.leadsto_violation.is_none() {
+        result.leadsto_violation =
+            check_leadstos(solver, model, &states, &choices, &instances, depth).await?;
+    }
     Ok(result)
 }
 
@@ -777,6 +786,82 @@ async fn leadsto_violation<S: SmtSolver>(
     })
 }
 
+/// Check whether `states[step]` is a deadlock with a pending leadsTo obligation.
+///
+/// Must run before the BMC unrolling loop asserts a mandatory forward
+/// transition out of `states[step]` (see `verify_bounded_config`); once that
+/// assertion is committed, a deadlock at `step` becomes globally unsatisfiable
+/// for any later query in the same solver session, regardless of whether the
+/// deadlock is actually reachable. Running this inline, per step, mirrors the
+/// timing of the general deadlock probe in the same loop and the frozen
+/// Python reference's `_check_leadsto_stutter_at_step`.
+#[allow(clippy::too_many_arguments)]
+async fn check_leadsto_stagnation<S: SmtSolver>(
+    solver: &mut S,
+    model: &KernelModel,
+    states: &[SymbolicState<S::Term>],
+    choices: &[S::Term],
+    instances: &[ActionInstance<S::Term>],
+    step: usize,
+    enabled: &[S::Term],
+) -> Result<Option<BmcViolation>, VerifyError> {
+    let deadlock = solver.not(&solver.or(enabled)?)?;
+    for property in &model.leadstos {
+        for binding in leadsto_bindings(solver, model, property)? {
+            for pending in 0..=step {
+                let mut terms = vec![
+                    deadlock.clone(),
+                    leadsto_condition(
+                        solver,
+                        model,
+                        &property.before,
+                        &states[pending],
+                        &binding.symbolic,
+                    )?,
+                ];
+                for state in states.iter().take(step + 1).skip(pending) {
+                    terms.push(solver.not(&leadsto_condition(
+                        solver,
+                        model,
+                        &property.after,
+                        state,
+                        &binding.symbolic,
+                    )?)?);
+                }
+                let condition = solver.and(&terms)?;
+                if probe(solver, &condition).await? {
+                    return Ok(Some(
+                        leadsto_violation(
+                            solver,
+                            model,
+                            property,
+                            &binding,
+                            &condition,
+                            states,
+                            choices,
+                            instances,
+                            step,
+                            LeadsToViolation {
+                                bindings: BTreeMap::new(),
+                                pending_since: pending,
+                                loop_start: None,
+                                deadline: None,
+                                within: property.within,
+                                stutter: true,
+                                hint: format!(
+                                    "P held at step {pending} but execution deadlocks at step {step} without Q"
+                                ),
+                            },
+                        )
+                        .await?,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
 #[allow(clippy::too_many_lines)]
 async fn check_leadstos<S: SmtSolver>(
     solver: &mut S,
@@ -786,64 +871,6 @@ async fn check_leadstos<S: SmtSolver>(
     instances: &[ActionInstance<S::Term>],
     depth: usize,
 ) -> Result<Option<BmcViolation>, VerifyError> {
-    for step in 0..=depth {
-        let enabled = enabled_terms(solver, model, instances, &states[step])?;
-        let deadlock = solver.not(&solver.or(&enabled)?)?;
-        for property in &model.leadstos {
-            for binding in leadsto_bindings(solver, model, property)? {
-                for pending in 0..=step {
-                    let mut terms = vec![
-                        deadlock.clone(),
-                        leadsto_condition(
-                            solver,
-                            model,
-                            &property.before,
-                            &states[pending],
-                            &binding.symbolic,
-                        )?,
-                    ];
-                    for state in states.iter().take(step + 1).skip(pending) {
-                        terms.push(solver.not(&leadsto_condition(
-                            solver,
-                            model,
-                            &property.after,
-                            state,
-                            &binding.symbolic,
-                        )?)?);
-                    }
-                    let condition = solver.and(&terms)?;
-                    if probe(solver, &condition).await? {
-                        return Ok(Some(
-                            leadsto_violation(
-                                solver,
-                                model,
-                                property,
-                                &binding,
-                                &condition,
-                                states,
-                                choices,
-                                instances,
-                                step,
-                                LeadsToViolation {
-                                    bindings: BTreeMap::new(),
-                                    pending_since: pending,
-                                    loop_start: None,
-                                    deadline: None,
-                                    within: property.within,
-                                    stutter: true,
-                                    hint: format!(
-                                        "P held at step {pending} but execution deadlocks at step {step} without Q"
-                                    ),
-                                },
-                            )
-                            .await?,
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
     for property in &model.leadstos {
         for binding in leadsto_bindings(solver, model, property)? {
             if let Some(within) = property.within {

--- a/rust/fsl-verifier/tests/leadsto_stagnation.rs
+++ b/rust/fsl-verifier/tests/leadsto_stagnation.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+const STUCK_EARLY: &str = r"
+spec StuckEarly {
+  enum Stage { Idle, Pending, Done }
+  state { stage: Stage }
+  init { stage = Idle }
+  action submit() {
+    requires stage == Idle
+    stage = Pending
+  }
+  leadsTo Progress { stage == Pending ~> stage == Done }
+}
+";
+
+#[test]
+fn leadsto_stagnation_is_detected_at_every_depth_at_or_beyond_the_deadlock_step() {
+    let kernel =
+        parse_kernel_source(STUCK_EARLY, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+
+    for depth in [1_usize, 2, 6] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth))
+            .expect("verify_bounded");
+        assert!(result.violation.is_none(), "depth {depth}: {result:?}");
+        let leadsto = result.leadsto_violation.as_ref().unwrap_or_else(|| {
+            panic!("depth {depth}: expected a leadsTo violation, got {result:?}")
+        });
+        assert_eq!(leadsto.kind, "leadsTo", "depth {depth}: {leadsto:?}");
+        assert_eq!(
+            leadsto.leads_to.as_ref().map(|leads_to| leads_to.stutter),
+            Some(true),
+            "depth {depth}: {leadsto:?}"
+        );
+    }
+}

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -172,9 +172,9 @@ fn render_verify(model: &KernelModel, options: &Options, result: fsl_verifier::B
         return Value::Object(output);
     }
     // Native CLI (rust/fslc/src/verification.rs render_bmc_result) checks
-    // deadlock-as-error before leadsto_violation: both can legitimately be
-    // `Some` at once (deadlock_step is set inside the per-step loop,
-    // leadsto_violation only after it ends), so this order is the contract.
+    // deadlock-as-error before leadsto_violation: both are populated inside
+    // the same per-step loop and can legitimately be `Some` at once, so this
+    // order is the contract.
     if options.deadlock == "error"
         && let Some(step) = result.deadlock_step
     {

--- a/rust/fsl-wasm/web/cases.mjs
+++ b/rust/fsl-wasm/web/cases.mjs
@@ -96,6 +96,35 @@ verify {
 }`,
   },
   {
+    // Same spec as "business-leadsto" but unrolled past the deadlock step:
+    // the leadsTo-via-deadlock-stagnation violation must still be reported,
+    // not only when --depth lands exactly on the stalling step (issue #260).
+    id: "business-leadsto-beyond-horizon",
+    expected: "violated",
+    expect: { kind: "leadsTo", trace: true },
+    options: { depth: 4, deadlock: "ignore" },
+    source: `business BrowserLeak {
+  actor System
+  entity Job
+
+  process Job {
+    stages Idle, Pending, Done, Dropped
+    initial Idle
+
+    transition submit Idle    -> Pending by System
+    transition finish Pending -> Done    by System
+    transition drop   Pending -> Dropped by System
+  }
+
+  policy POL-DONE "every submitted job must eventually complete"
+    every Job in Pending must eventually be Done
+}
+
+verify {
+  instances Job = 1
+}`,
+  },
+  {
     // A `must eventually` obligation whose only path deadlocks: both
     // `deadlock_step` and `leadsto_violation` are set on the same BmcResult,
     // and with --deadlock error the Worker must report "deadlock" (matching

--- a/rust/fslc/tests/issue_260_leadsto_stagnation.rs
+++ b/rust/fslc/tests/issue_260_leadsto_stagnation.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-260-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+const BROWSER_LEAK: &str = r#"
+business BrowserLeak {
+  actor System
+  entity Job
+  process Job {
+    stages Idle, Pending, Done, Dropped
+    initial Idle
+    transition submit Idle    -> Pending by System
+    transition finish Pending -> Done    by System
+    transition drop   Pending -> Dropped by System
+  }
+  policy POL-DONE "every submitted job must eventually complete"
+    every Job in Pending must eventually be Done
+}
+verify { instances Job = 1 }
+"#;
+
+const STUCK_KERNEL: &str = r"
+spec BrowserStuckKernel {
+  enum Stage { Idle, Pending, Done }
+  state { stage: Stage }
+  init { stage = Idle }
+  action submit() {
+    requires stage == Idle
+    stage = Pending
+  }
+  leadsTo Progress { stage == Pending ~> stage == Done }
+}
+";
+
+#[test]
+fn leadsto_deadlock_stagnation_is_detected_beyond_the_deadlock_step() {
+    let fixture = Fixture::new("business", BROWSER_LEAK);
+    for depth in ["2", "3", "4", "6"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["invariant"], "POL-DONE", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 1, "depth {depth}: {value}");
+        assert_eq!(value["stutter"], true, "depth {depth}: {value}");
+        assert!(
+            value["trace"]
+                .as_array()
+                .is_some_and(|trace| !trace.is_empty()),
+            "depth {depth}: expected a non-empty trace, got {value}"
+        );
+    }
+}
+
+#[test]
+fn leadsto_deadlock_stagnation_is_detected_beyond_the_deadlock_step_for_plain_kernel_spec() {
+    let fixture = Fixture::new("kernel", STUCK_KERNEL);
+    for depth in ["1", "2", "4"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["invariant"], "Progress", "depth {depth}: {value}");
+        assert_eq!(value["stutter"], true, "depth {depth}: {value}");
+    }
+}
+
+#[test]
+fn deadlock_error_still_wins_over_leadsto_beyond_the_deadlock_step() {
+    let fixture = Fixture::new("kernel-error", STUCK_KERNEL);
+    let (value, status) = run(&[
+        "verify",
+        fixture.text(),
+        "--depth",
+        "3",
+        "--deadlock",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated", "{value}");
+    assert_eq!(value["violation_kind"], "deadlock", "{value}");
+}
+
+#[test]
+fn leadsto_stagnation_is_detected_when_the_deadlock_is_the_initial_state() {
+    let source = r"
+spec StuckAtInit {
+  enum Stage { Idle, Done }
+  state { stage: Stage }
+  init { stage = Idle }
+  action unreachable() {
+    requires stage == Done
+    stage = Done
+  }
+  leadsTo Progress { stage == Idle ~> stage == Done }
+}
+";
+    let fixture = Fixture::new("stuck-at-init", source);
+    for depth in ["0", "1", "3"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 0, "depth {depth}: {value}");
+        assert_eq!(value["stutter"], true, "depth {depth}: {value}");
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #260: bounded `leadsTo` deadlock-stagnation detection only fired when `--depth` landed exactly on the stalling step. Any larger depth silently reported a false `verified` for the same underlying violation.

## Root cause
`check_leadstos`'s deadlock-stagnation probe ran as a single post-hoc pass after the entire BMC per-step unrolling loop finished (`rust/fsl-verifier/src/bmc.rs`). By the time it ran, every step strictly below `--depth` already had a permanently-asserted forward transition ("some action fires") committed to the shared solver session — so the deadlock hypothesis being probed was already globally unsatisfiable for any step short of the final one. Only `step == depth` (which has no forced continuation) could ever be found.

The frozen Python reference (`src/fslc/bmc.py`, `_check_leadsto_stutter_at_step`) never had this bug: it runs the equivalent check inline, per step, before that step's transition is committed.

## Changes
- `rust/fsl-verifier/src/bmc.rs`: extracted the stagnation-check body into `check_leadsto_stagnation` and call it inline in the per-step loop, immediately after the existing general deadlock probe and before that step's forward-transition assertion — mirroring the Python reference's timing. The remaining post-loop `check_leadstos` now only handles the (unaffected) `within`-deadline and lasso/fairness branches. Both call sites are guarded so the first stagnation hit short-circuits, preserving the existing "first violation wins" contract.
- `rust/fsl-verifier/tests/leadsto_stagnation.rs` (new): crate-level `verify_bounded` regression across depths 1/2/6.
- `rust/fslc/tests/issue_260_leadsto_stagnation.rs` (new): CLI-level regression — a business-dialect spec and a plain kernel spec across multiple depths beyond the stall step, a `--deadlock error` priority-preservation case, and a deadlock-at-`step==0` boundary case.
- `rust/fsl-wasm/web/cases.mjs`: added `business-leadsto-beyond-horizon`, a depth-4 companion to the existing depth-2 `business-leadsto` case, so the browser Worker gate also covers the regression.
- `rust/fsl-wasm/src/lib.rs`: corrected a comment that claimed `leadsto_violation` is only populated after the per-step loop ends (no longer true).
- `docs/LANGUAGE.md`: clarified the leadsTo contract row in the "Automatic checks" table to state deadlock-stagnation is depth-independent once the horizon reaches the stalling step.
- `docs/DESIGN-temporal.md`: corrected a stale architecture note that conflated the deadlock-stall check's timing with the lasso/fairness check's timing (the stall check has always run inline in both the Python reference and now Rust; only the lasso check runs post-loop).
- `CHANGELOG.md`: added a `[Unreleased] / Fixed` entry.

## Verification
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — clean
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked` — all pass, including the new regressions
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked` — clean
- Manual native CLI repro: the issue's `BrowserLeak` spec now correctly reports `violated`/`leadsTo` at `--depth 2, 3, 4, 6` (previously only 2); `--deadlock error` priority over `leadsTo` confirmed unchanged at depth beyond the stall step.
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py tests/test_temporal.py -q` — all pass (Python reference already correct; parity preserved)
- `rust/fsl-wasm`: `npm ci && node build.mjs && npm run test:browser` — `{"ok": true, "nativeParity": true}`
- Independent review: `fsl-soundness-reviewer` (verdict: sound, no new false negative/positive; suggested extra edge-case tests, since incorporated — multi-property/quantified-binding coverage remains a nice-to-have, not blocking) and `fsl-coupled-change-reviewer` (confirmed no other duplicate post-hoc-check logic elsewhere in the workspace, no snapshot/golden regeneration needed, SPDX headers present; flagged the `docs/DESIGN-temporal.md` staleness fixed in this PR).

## Risk / Review Notes
- Pure bug fix to existing symbolic-verification semantics; no new grammar, CLI flag, or public Kernel field. `BmcResult`'s shape is unchanged.
- Strictly more sound: previously-missed violations are now correctly reported. Any spec that previously (incorrectly) verified due to this bug at a depth beyond its true deadlock step will now correctly report a `leadsTo` violation instead. No corpus/golden snapshot was found to embed this exact shape (checked by the coupled-change reviewer), so no regeneration is needed.
- `fsl-runtime` (solver-independent BFS/Monitor) is untouched — it already rejects any spec with `leadsTo` properties outright, so there is no concrete-engine parity surface for this change to affect.

## Follow-Up / Post-Merge Checks
- A related, separate gap was found during investigation: the `within`-deadline leadsTo check has an analogous forced-continuation blind spot for paths where `Q` first holds after its deadline and the path then deadlocks — reproduced identically in both Rust and the frozen Python reference (so it's not a parity divergence, and out of scope for this issue). Will file as a new issue for a follow-up fix.