### PR TITLE
fix(verifier): detect leadsTo within-deadline misses at every depth beyond the deadlock step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   instead of a generated Kernel coordinate.
 
 ### Fixed
+- The bounded `leadsTo ... within N` deadline check no longer misses a
+  violation when the path deadlocks after the deadline. The deadline probe ran
+  as a single post-hoc pass after the BMC unrolling loop, by which point every
+  non-final step had a permanently-asserted forward transition, so a
+  missed-deadline path that subsequently deadlocked was excluded from the
+  solver context and the spec falsely verified at any `--depth` past the
+  deadlock. The probe now runs inside the per-step loop, anchored at each
+  window's deadline step before that step's forward-transition assertion —
+  the same restructuring issue #260 applied to the stagnation check
+  (issue #266).
 - Bounded `leadsTo` deadlock-stagnation detection no longer requires `--depth`
   to land exactly on the stalling step. The BMC unrolling loop permanently
   asserted a forward transition out of every non-final step before the

--- a/docs/DESIGN-temporal.md
+++ b/docs/DESIGN-temporal.md
@@ -294,6 +294,17 @@ failure is a transition-progress failure.
     fires" for every non-final step, so a deadlock-stall probe issued only
     after the full trace is built can never be satisfiable below the depth
     horizon. Reuses the enabled expression of the existing deadlock check.
+  - The `within` deadline probe must run inline, per step, for the same
+    reason: at step `t`, the single window whose deadline lands on `t` starts
+    at `p = t - within`, and the probe `P(states[p]) ∧ ∀ q ∈ [p, t]:
+    ¬Q(states[q])` is issued before step `t`'s forward-transition assertion.
+    A missed deadline is prefix-satisfiable regardless of what follows, so
+    the inline probe subsumes a post-loop sweep — and unlike a post-loop
+    sweep it still fires when the path deadlocks after the deadline (a
+    post-loop probe misses exactly that combination once `--depth` extends
+    past the deadlock; issue #266). The native Rust verifier implements this
+    (`check_leadsto_deadlines` in `rust/fsl-verifier/src/bmc.rs`); the frozen
+    Python reference still probes post-loop and retains the known gap.
   - Symmetry reduction (§2.5.1) adds canonical row-order constraints only inside
     the lasso/stall push/pop queries. It is not asserted on the shared path
     solver, so safety/reachability behavior and finite transition construction

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -608,7 +608,7 @@ variable.
 | action coverage | Each action is enabled at least once within depth K | diagnosis of the blocking requires in `action_coverage` |
 | Deadlock | Reaching a state where all actions become disabled | warning (`violated` with `--deadlock error`) |
 | trans | Whether the two-state predicate holds across all reachable transitions | `violated` / `trans` / `trans` + trace |
-| leadsTo | A P ~> Q violation via a lasso up to depth K or via deadlock stagnation (detected as soon as `--depth` reaches the stalling step, and at every larger depth after that, not only when it lands exactly on that step) | `violated` / `leadsTo` / `bindings` + trace |
+| leadsTo | A P ~> Q violation via a missed `within` deadline, a lasso up to depth K, or deadlock stagnation (deadline misses and stagnation are detected as soon as `--depth` reaches the deadline/stalling step, and at every larger depth after that, not only when it lands exactly on that step) | `violated` / `leadsTo` / `bindings` + trace |
 
 - A deadlock warning includes which state you got stuck in (e.g. `deadlock reachable at
   step 1 (state: status=ToolFault, ...)`). The full trace is also in the JSON `deadlock.trace`.

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -687,7 +687,7 @@ variable.</p></div></details>
 </tr>
 <tr>
 <td>leadsTo</td>
-<td>A P ~&gt; Q violation via a lasso up to depth K or via deadlock stagnation (detected as soon as <code>--depth</code> reaches the stalling step, and at every larger depth after that, not only when it lands exactly on that step)</td>
+<td>A P ~&gt; Q violation via a missed <code>within</code> deadline, a lasso up to depth K, or deadlock stagnation (deadline misses and stagnation are detected as soon as <code>--depth</code> reaches the deadline/stalling step, and at every larger depth after that, not only when it lands exactly on that step)</td>
 <td><code>violated</code> / <code>leadsTo</code> / <code>bindings</code> + trace</td>
 </tr>
 </tbody>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -687,7 +687,7 @@ variable.</p></div></details>
 </tr>
 <tr>
 <td>leadsTo</td>
-<td>A P ~&gt; Q violation via a lasso up to depth K or via deadlock stagnation (detected as soon as <code>--depth</code> reaches the stalling step, and at every larger depth after that, not only when it lands exactly on that step)</td>
+<td>A P ~&gt; Q violation via a missed <code>within</code> deadline, a lasso up to depth K, or deadlock stagnation (deadline misses and stagnation are detected as soon as <code>--depth</code> reaches the deadline/stalling step, and at every larger depth after that, not only when it lands exactly on that step)</td>
 <td><code>violated</code> / <code>leadsTo</code> / <code>bindings</code> + trace</td>
 </tr>
 </tbody>

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -230,6 +230,11 @@ async fn verify_bounded_config<S: SmtSolver>(
             .await?;
         }
 
+        if result.leadsto_violation.is_none() && !model.leadstos.is_empty() {
+            result.leadsto_violation =
+                check_leadsto_deadlines(solver, model, &states, &choices, &instances, step).await?;
+        }
+
         if step == depth || instances.is_empty() {
             continue;
         }
@@ -862,6 +867,83 @@ async fn check_leadsto_stagnation<S: SmtSolver>(
     Ok(None)
 }
 
+/// Check whether a `within` deadline expires unmet at `states[step]`.
+///
+/// At step `t`, the only window whose deadline lands on `t` starts at
+/// `pending = t - within`; the probe asks whether P can hold at `pending`
+/// with Q failing on every state through `t`. Like
+/// `check_leadsto_stagnation`, this must run before the BMC unrolling loop
+/// asserts a mandatory forward transition out of `states[step]`: a path that
+/// deadlocks after a missed deadline becomes globally unsatisfiable once the
+/// deadlocked step's forced transition is committed, so a post-loop probe
+/// misses exactly the missed-deadline-then-deadlock combination (issue #266).
+async fn check_leadsto_deadlines<S: SmtSolver>(
+    solver: &mut S,
+    model: &KernelModel,
+    states: &[SymbolicState<S::Term>],
+    choices: &[S::Term],
+    instances: &[ActionInstance<S::Term>],
+    step: usize,
+) -> Result<Option<BmcViolation>, VerifyError> {
+    for property in &model.leadstos {
+        let Some(within) = property.within else {
+            continue;
+        };
+        let within = usize::try_from(within)
+            .map_err(|_| VerifyError::new("leadsTo within must be non-negative"))?;
+        let Some(pending) = step.checked_sub(within) else {
+            continue;
+        };
+        for binding in leadsto_bindings(solver, model, property)? {
+            let mut terms = vec![leadsto_condition(
+                solver,
+                model,
+                &property.before,
+                &states[pending],
+                &binding.symbolic,
+            )?];
+            for state in states.iter().take(step + 1).skip(pending) {
+                terms.push(solver.not(&leadsto_condition(
+                    solver,
+                    model,
+                    &property.after,
+                    state,
+                    &binding.symbolic,
+                )?)?);
+            }
+            let condition = solver.and(&terms)?;
+            if probe(solver, &condition).await? {
+                return Ok(Some(
+                    leadsto_violation(
+                        solver,
+                        model,
+                        property,
+                        &binding,
+                        &condition,
+                        states,
+                        choices,
+                        instances,
+                        step,
+                        LeadsToViolation {
+                            bindings: BTreeMap::new(),
+                            pending_since: pending,
+                            loop_start: None,
+                            deadline: Some(step),
+                            within: property.within,
+                            stutter: false,
+                            hint: format!(
+                                "leadsTo deadline missed: P holds at step {pending}, but Q does not hold within {within} step(s)"
+                            ),
+                        },
+                    )
+                    .await?,
+                ));
+            }
+        }
+    }
+    Ok(None)
+}
+
 #[allow(clippy::too_many_lines)]
 async fn check_leadstos<S: SmtSolver>(
     solver: &mut S,
@@ -873,61 +955,6 @@ async fn check_leadstos<S: SmtSolver>(
 ) -> Result<Option<BmcViolation>, VerifyError> {
     for property in &model.leadstos {
         for binding in leadsto_bindings(solver, model, property)? {
-            if let Some(within) = property.within {
-                let within = usize::try_from(within)
-                    .map_err(|_| VerifyError::new("leadsTo within must be non-negative"))?;
-                for pending in 0..=depth {
-                    let deadline = pending.saturating_add(within);
-                    if deadline > depth {
-                        continue;
-                    }
-                    let mut terms = vec![leadsto_condition(
-                        solver,
-                        model,
-                        &property.before,
-                        &states[pending],
-                        &binding.symbolic,
-                    )?];
-                    for state in states.iter().take(deadline + 1).skip(pending) {
-                        terms.push(solver.not(&leadsto_condition(
-                            solver,
-                            model,
-                            &property.after,
-                            state,
-                            &binding.symbolic,
-                        )?)?);
-                    }
-                    let condition = solver.and(&terms)?;
-                    if probe(solver, &condition).await? {
-                        return Ok(Some(
-                            leadsto_violation(
-                                solver,
-                                model,
-                                property,
-                                &binding,
-                                &condition,
-                                states,
-                                choices,
-                                instances,
-                                deadline,
-                                LeadsToViolation {
-                                    bindings: BTreeMap::new(),
-                                    pending_since: pending,
-                                    loop_start: None,
-                                    deadline: Some(deadline),
-                                    within: property.within,
-                                    stutter: false,
-                                    hint: format!(
-                                        "leadsTo deadline missed: P holds at step {pending}, but Q does not hold within {within} step(s)"
-                                    ),
-                                },
-                            )
-                            .await?,
-                        ));
-                    }
-                }
-            }
-
             for loop_start in 0..depth {
                 for loop_end in (loop_start + 1)..=depth {
                     let loop_equal =

--- a/rust/fsl-verifier/tests/leadsto_within_deadline.rs
+++ b/rust/fsl-verifier/tests/leadsto_within_deadline.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+// Q first holds one step after its `within` deadline, and the path then
+// deadlocks at x == 3: the deadline is missed at step 2, the deadlock is at
+// step 3 (issue #266).
+const LATE_Q: &str = r"
+spec LateQ {
+  type Count = 0..3
+  state { x: Count }
+  init { x = 0 }
+  action step() {
+    requires x < 3
+    x = x + 1
+  }
+  leadsTo Progress { x == 1 ~> within 1 x == 3 }
+}
+";
+
+#[test]
+fn within_deadline_miss_is_detected_at_every_depth_at_or_beyond_the_deadline() {
+    let kernel =
+        parse_kernel_source(LATE_Q, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+
+    for depth in [2_usize, 3, 4, 6] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth))
+            .expect("verify_bounded");
+        assert!(result.violation.is_none(), "depth {depth}: {result:?}");
+        let leadsto = result.leadsto_violation.as_ref().unwrap_or_else(|| {
+            panic!("depth {depth}: expected a leadsTo violation, got {result:?}")
+        });
+        assert_eq!(leadsto.kind, "leadsTo", "depth {depth}: {leadsto:?}");
+        let details = leadsto.leads_to.as_ref().expect("leadsTo details");
+        assert_eq!(details.pending_since, 1, "depth {depth}: {leadsto:?}");
+        assert_eq!(details.deadline, Some(2), "depth {depth}: {leadsto:?}");
+        assert!(!details.stutter, "depth {depth}: {leadsto:?}");
+    }
+}
+
+#[test]
+fn within_deadline_met_stays_verified_beyond_the_deadlock_step() {
+    // Same path, but Q (x == 3) holds exactly on the `within 2` deadline, so
+    // the property is satisfied and the trailing deadlock must not turn into
+    // a spurious deadline miss.
+    let source = LATE_Q.replace("within 1", "within 2");
+    let kernel =
+        parse_kernel_source(&source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+
+    for depth in [3_usize, 4, 6] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth))
+            .expect("verify_bounded");
+        assert!(result.violation.is_none(), "depth {depth}: {result:?}");
+        assert!(
+            result.leadsto_violation.is_none(),
+            "depth {depth}: {result:?}"
+        );
+    }
+}

--- a/rust/fsl-wasm/web/cases.mjs
+++ b/rust/fsl-wasm/web/cases.mjs
@@ -149,6 +149,30 @@ verify {
 }`,
   },
   {
+    // A `within` deadline missed one step before the path deadlocks, unrolled
+    // past the deadlock step: the deadline probe must fire inline at the
+    // deadline step, not only when --depth lands before the deadlock
+    // (issue #266).
+    id: "leadsto-within-beyond-horizon",
+    expected: "violated",
+    expect: { kind: "leadsTo", trace: true },
+    options: { depth: 4, deadlock: "ignore" },
+    source: `spec BrowserLateQ {
+  type Count = 0..3
+
+  state { x: Count }
+
+  init { x = 0 }
+
+  action step() {
+    requires x < 3
+    x = x + 1
+  }
+
+  leadsTo Progress { x == 1 ~> within 1 x == 3 }
+}`,
+  },
+  {
     // Struct-typed top-level state where one action changes only one field;
     // the Worker must not blow up rendering the trace for non-scalar state.
     id: "struct-state",

--- a/rust/fslc/tests/issue_266_leadsto_within_deadline.rs
+++ b/rust/fslc/tests/issue_266_leadsto_within_deadline.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-266-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+// The `within 1` deadline is missed at step 2 (x == 2), and the path then
+// deadlocks at x == 3. Before the fix, any --depth beyond 3 asserted a forced
+// forward transition out of the deadlocked step, making the whole branch
+// unsatisfiable for the post-loop deadline probe: depth 3 reported violated,
+// depth 4+ reported a false verified.
+const LATE_Q: &str = r"
+spec LateQ {
+  type Count = 0..3
+  state { x: Count }
+  init { x = 0 }
+  action step() {
+    requires x < 3
+    x = x + 1
+  }
+  leadsTo Progress { x == 1 ~> within 1 x == 3 }
+}
+";
+
+// The same missed deadline on a path that never deadlocks within the bound:
+// the pre-#266 post-loop probe already caught this, and the inline probe must
+// keep catching it.
+const SLOW_Q: &str = r"
+spec SlowQ {
+  type Count = 0..6
+  state { x: Count }
+  init { x = 0 }
+  action step() {
+    requires x < 6
+    x = x + 1
+  }
+  leadsTo Progress { x == 1 ~> within 1 x == 4 }
+}
+";
+
+#[test]
+fn within_deadline_miss_is_detected_at_every_depth_beyond_the_deadlock_step() {
+    let fixture = Fixture::new("late-q", LATE_Q);
+    for depth in ["2", "3", "4", "6"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["invariant"], "Progress", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 1, "depth {depth}: {value}");
+        assert_eq!(value["deadline"], 2, "depth {depth}: {value}");
+        assert_eq!(value["stutter"], false, "depth {depth}: {value}");
+        assert!(
+            value["trace"]
+                .as_array()
+                .is_some_and(|trace| !trace.is_empty()),
+            "depth {depth}: expected a non-empty trace, got {value}"
+        );
+    }
+}
+
+#[test]
+fn within_deadline_miss_without_deadlock_is_still_detected() {
+    let fixture = Fixture::new("slow-q", SLOW_Q);
+    for depth in ["2", "4", "6"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 1, "depth {depth}: {value}");
+        assert_eq!(value["deadline"], 2, "depth {depth}: {value}");
+    }
+}
+
+// One branch (sprint) satisfies Q exactly on the deadline; the other (step)
+// misses it and then deadlocks. The probe must find the violating branch,
+// not settle for the surviving one.
+const BRANCH_Q: &str = r"
+spec BranchQ {
+  type Count = 0..3
+  state { x: Count }
+  init { x = 0 }
+  action step() {
+    requires x < 3
+    x = x + 1
+  }
+  action sprint() {
+    requires x == 1
+    x = 3
+  }
+  leadsTo Progress { x == 1 ~> within 1 x == 3 }
+}
+";
+
+#[test]
+fn within_deadline_miss_on_one_branch_is_detected_despite_a_satisfying_branch() {
+    let fixture = Fixture::new("branch-q", BRANCH_Q);
+    for depth in ["2", "3", "4", "6"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 1, "depth {depth}: {value}");
+        assert_eq!(value["deadline"], 2, "depth {depth}: {value}");
+    }
+}
+
+#[test]
+fn deadlock_before_the_deadline_is_still_reported_as_stagnation() {
+    // The path deadlocks at step 1 with the obligation pending and the
+    // `within 5` deadline still in the future: the deadline probe is
+    // unsatisfiable there, and the stagnation check must report the
+    // violation (stutter) instead of letting the spec verify.
+    let source = r"
+spec StuckBeforeDeadline {
+  enum Stage { Idle, Pending, Done }
+  state { stage: Stage }
+  init { stage = Idle }
+  action submit() {
+    requires stage == Idle
+    stage = Pending
+  }
+  leadsTo Progress { stage == Pending ~> within 5 stage == Done }
+}
+";
+    let fixture = Fixture::new("stuck-before-deadline", source);
+    for depth in ["1", "2", "4"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 1, "depth {depth}: {value}");
+        assert_eq!(value["result"], "violated", "depth {depth}: {value}");
+        assert_eq!(value["violation_kind"], "leadsTo", "depth {depth}: {value}");
+        assert_eq!(value["pending_since"], 1, "depth {depth}: {value}");
+        assert_eq!(value["stutter"], true, "depth {depth}: {value}");
+    }
+}
+
+#[test]
+fn within_deadline_met_before_a_trailing_deadlock_stays_verified() {
+    let source = LATE_Q.replace("within 1", "within 2");
+    let fixture = Fixture::new("late-q-ok", &source);
+    for depth in ["3", "4", "6"] {
+        let (value, status) = run(&[
+            "verify",
+            fixture.text(),
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 0, "depth {depth}: {value}");
+        assert_eq!(value["result"], "verified", "depth {depth}: {value}");
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #266. The bounded `leadsTo ... within N` deadline check ran as a single post-hoc pass after the BMC unrolling loop (`check_leadstos`). The per-step unrolling permanently asserts a forward transition for every non-final step, so a path that missed its deadline and **then deadlocked** was globally unsatisfiable by the time the post-loop probe ran. With the issue's `LateQ` repro, `--depth 3` reported violated but `--depth 4`/`5` reported a false **verified**.

## Contract change

Bounded-verify verdict only: missed-deadline-then-deadlock paths now report `violated` / `leadsTo` at every `--depth` at or beyond the deadline step. No JSON envelope fields added; `pending_since`/`deadline`/`within`/`stutter`/`hint` and exit codes are unchanged for previously-detected violations. The browser Worker inherits the fix through the shared crate.

The `within` probe now runs inline in the per-step loop, anchored at each window's deadline step (`pending = step - within`), before that step's forward-transition assertion — the same restructuring #265 applied to the stagnation check. A missed deadline is prefix-satisfiable regardless of continuation, so the inline probe strictly subsumes the deleted post-loop sweep and needs no deadlock conjunct.

Per repository policy the frozen Python reference is untouched; it shares the old behavior (this is not a parity divergence — no parity case exercises `within`), and the retained gap is documented in `docs/DESIGN-temporal.md` §5.

## Test evidence

- `rust/fsl-verifier/tests/leadsto_within_deadline.rs`: LateQ depth sweep 2/3/4/6 → violated with `deadline=2`, `pending_since=1`, `stutter=false`; `within 2` variant (met exactly before the trailing deadlock) stays verified.
- `rust/fslc/tests/issue_266_leadsto_within_deadline.rs` (5 tests): the deadlocking miss across depths, a non-deadlocking miss (pre-existing detection path), a branching spec where one branch satisfies Q on the deadline while another misses it, deadlock-before-deadline still reported as stagnation (`stutter=true`), and the satisfied case exiting 0.
- `rust/fsl-wasm/web/cases.mjs`: new `leadsto-within-beyond-horizon` browser smoke case (depth 4, past the deadlock); `npm run test:browser` → `ok: true, nativeParity: true`.
- Full gate on the rebased head: `cargo fmt --check`, `clippy --workspace -D warnings`, `cargo test --workspace --locked` (53 suites, 0 failures).
- `fsl-soundness-reviewer`: pass — window equivalence with the deleted post-loop sweep is exact; probe ordering and per-step `leadsto_bindings` usage confirmed side-effect-free; explicit engine rejects leadsTo so no symbolic/concrete divergence surface.

## Docs

`CHANGELOG.md` [Unreleased] Fixed, `docs/DESIGN-temporal.md` §5 (inline-probe rationale + documented Python gap), `docs/LANGUAGE.md` leadsTo table row, regenerated `docs/intro/language.{en,ja}.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)