### PR TITLE
feat(syntax): add token-based dialect registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Native dialect selection now lexes each document once and dispatches through a
+  duplicate-checked keyword registry shared by Kernel, CLI, WASM, and mirrored
+  Python/LSP entrypoints. Leading BOM/comments/whitespace and typed top-level
+  annotations are handled before selection without mistaking annotation arguments
+  for dialects; specialized frontends consume the original token stream. Add
+  exact empty/unknown diagnostic codes, spans, and supported-keyword lists, an
+  evidence-only `agent` surface, and span-retaining multi-segment `SymbolPath`
+  values (issue #247).
 - Native Rust now carries ordered, typed `Requirement`, `Undecided`, `Kind`,
   and namespaced `Custom` annotations through a common target-keyed IR. Legacy
   declaration strings, spec badges, requirement blocks, process `covers`, and

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -19,6 +19,11 @@ values. `SymbolPath` rejects empty namespace segments. Every annotation retains
 its own source span; declaration provenance remains in `OriginRegistry` and never
 uses a requirement ID as source identity.
 
+Issue #247 subsequently added the document-level `@...` subset needed by
+token-based dialect dispatch. `DESIGN-dialect-dispatch.md` is authoritative for
+annotations immediately before a top-level document; issue #241 retains ownership
+of annotation placement on declarations inside that document.
+
 ## Carrier and declaration coverage
 
 `Annotations` preserves source order for formatter/comment fidelity while its
@@ -99,7 +104,9 @@ suppression, and exact declaration matching—remain unchanged.
 
 ## Non-goals
 
-- `@requirement`, `@kind`, or arbitrary `@namespace` parser syntax;
+- `@requirement`, `@kind`, or arbitrary `@namespace` syntax on declarations
+  inside a document (document-level syntax is defined by
+  `DESIGN-dialect-dispatch.md`);
 - formatter or source migrator behavior;
 - macro execution or verifier semantics selected by an annotation;
 - publishing annotations by mutating Public Kernel v1/v2.

--- a/docs/DESIGN-dialect-dispatch.md
+++ b/docs/DESIGN-dialect-dispatch.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Token-based dialect dispatch
+
+Status: accepted. Implemented by issue #247.
+
+## Decision
+
+The native syntax library lexes each document once and selects its frontend from
+one keyword registry. The registry keys are `spec`, `refinement`, `compose`,
+`business`, `governance`, `requirements`, `domain`, `dbsystem`, `ai_component`,
+and `agent`. Registration validates keyword uniqueness before the first parse;
+adding a frontend changes the one registry declaration and its tests.
+
+`parse_document(SourceFile)` is the canonical library entrypoint. It returns a
+`ParsedDocument` containing the selected keyword, document-level annotations,
+and typed `SurfaceDocument`. Every frontend receives the original `SourceFile`,
+the same owned token vector, and the cursor of the declaration keyword. The
+specialized DB, domain, and AI adapters may still be called directly, but the
+canonical path does not ask them to lex again. `parse_surface_document(&str)` is
+the surface-only adapter over this entrypoint.
+
+The native CLI, Kernel lowering, and WASM path use this dispatch through
+`fsl-syntax`/`fsl-core`. The retained Python parser and LSP cannot consume Rust
+tokens in-process, so their single `dialect_registry` adapter mirrors the same
+significant-token and registry-key contract and masks dispatch-only prefixes
+without changing source coordinates. The Rust registry remains authoritative.
+
+## Significant declaration rule
+
+Processing order is:
+
+1. read the original source (there is currently no Markdown/literate extractor);
+2. lex while skipping one leading UTF-8 BOM, whitespace, and `//` comments;
+3. parse and retain consecutive document-level annotations;
+4. select the frontend from the next identifier token;
+5. pass the untouched token stream, declaration cursor, and source to that
+   frontend.
+
+Annotation arguments are consumed as a group, so a keyword such as `spec` inside
+`@acme.route(spec)` cannot select the frontend. Comments and blank lines do not
+break attachment. Document-level annotations use the typed IR and the canonical
+forms `@requirement(id, text?)`, `@undecided(reason)`, `@kind(id, text?)`, or a
+multi-segment custom namespace with string, integer, Boolean, or symbol-path
+arguments. Kernel lowering binds them to the stable `spec` target.
+
+This document supersedes `DESIGN-annotations.md` only for annotations immediately
+before the top-level document. Issue #241 continues to own annotation placement
+on declarations inside a document, legacy-source migration, and formatter policy.
+
+## Diagnostics
+
+An empty/comment-only document returns `FSL-DIALECT-EMPTY` at EOF. An annotation
+without a target returns `FSL-DIALECT-ANNOTATION-TARGET`. An unknown first token
+returns `FSL-DIALECT-UNKNOWN` at that exact token and lists registry keywords in
+deterministic registration order. The CLI check/verify envelopes expose the code
+and `loc`; other syntax errors retain `FSL-PARSE` unless a narrower annotation
+code applies.
+
+The BOM contributes its Unicode-scalar column and UTF-8 byte offset to following
+spans. It is trivia only at byte offset zero.
+
+## Boundaries
+
+- `agent` is an evidence-only surface document for generic `fslc check`: this
+  dispatch frontend validates the declaration header, balanced outer envelope,
+  and trailing EOF, but deliberately leaves the body opaque. Structural agent
+  grammar/graph analysis remains the `fslc ai check` surface. Kernel
+  verification rejects the evidence-only document, as before.
+- AI project/statistical block detection remains an AI-frontend feature scan;
+  its first significant identifier must belong to the known AI project block
+  set, but those evidence blocks are not dialect registry entries.
+- Public Kernel v1/v2 JSON schemas do not gain annotation fields or a new dialect
+  field. Existing normalized dialect strings are derived from the registry key.
+- `SymbolPath` stores its segments and complete span structurally. Display joins
+  segments only at the presentation boundary, and equality compares segments.
+
+## Verification obligations
+
+- every registered dialect selects after BOM/comments/annotations;
+- specialized frontends parse the registry-provided token stream;
+- duplicate keys fail registry validation;
+- annotation argument keywords never affect selection;
+- empty/unknown codes, spans, and supported-keyword order are stable;
+- CLI, library, Kernel lowering, LSP indexing, and the dialect corpus retain
+  their existing successful outcomes.

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -99,6 +99,10 @@ typed syntax is name/type-resolved in `fsl-core` and lowered directly to Kernel
 surface AST. Generated Kernel text is available for inspection but is not an
 input to parsing, checking, runtime execution, or verification.
 
+Issue #247 replaced raw-prefix selection with the accepted token registry in
+`DESIGN-dialect-dispatch.md`: one shared lex produces the token stream consumed
+by the selected frontend, and Kernel/CLI/WASM callers share that library entrypoint.
+
 File access is behind a `FileResolver` interface:
 
 - native CLI: filesystem-backed, with the current source-relative semantics;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1392,6 +1392,24 @@ compatibility projection. See `DESIGN-undecided.md` and
 `DESIGN-annotations.md`. This is implemented by the authoritative native Rust
 CLI and is not backported to the frozen Python reference implementation.
 
+A document itself may now carry typed annotations before its dialect keyword:
+
+```fsl
+@requirement("REQ-DOC", "this document owns the checkout contract")
+@acme.review(owner.platform, 2, true)
+spec Checkout { ... }
+```
+
+The shared lexer skips a leading BOM, whitespace, and `//` comments before
+these annotations, retains their order and spans, then selects the dialect from
+the following declaration keyword. Keywords inside annotation arguments do not
+participate in dispatch. This document-level subset supports `@requirement`,
+`@undecided`, `@kind`, and custom multi-segment namespaces; annotation placement
+on declarations inside the document remains tracked by issue #241. Empty and
+unknown documents report `FSL-DIALECT-EMPTY` / `FSL-DIALECT-UNKNOWN` with exact
+locations and the deterministic supported-keyword list. See
+`DESIGN-dialect-dispatch.md`.
+
 ### 13.2 Requirements layer: `requirements` (the fsl-req dialect)
 
 ```fsl

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 |---|---|
 | [`DESIGN-layers.md`](DESIGN-layers.md) | **Shared kernel + three dialects** (consulting / requirements / design): overall concept and validation |
 | [`DESIGN-dialects.md`](DESIGN-dialects.md) | Implementation spec for the dialects (declaration tags, fsl-req, fsl-biz) |
+| [`DESIGN-dialect-dispatch.md`](DESIGN-dialect-dispatch.md) | Shared-lexer dialect registry, significant-token rules, document annotations, diagnostics, and frontend contract |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -5,8 +5,9 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use fsl_syntax::{
-    ActionItem, Binder, ComposeItem, Expr, LValue, Param, QualifiedName, SpecItem, Statement,
-    SurfaceCompose, SurfaceDocument, SurfaceSpec, SyncAction, TypeExpr, parse_surface_document,
+    ActionItem, Annotations, Binder, ComposeItem, Expr, LValue, Param, QualifiedName, SourceFile,
+    SpecItem, Statement, SurfaceCompose, SurfaceDocument, SurfaceSpec, SyncAction, TypeExpr,
+    parse_document,
 };
 
 use crate::{CoreError, KernelSpec, PredicateExpander, expand_spec_domains, substitute};
@@ -53,7 +54,8 @@ pub fn parse_kernel_source(
     source: &str,
     resolver: &dyn FileResolver,
 ) -> Result<KernelSpec, CoreError> {
-    match parse_surface_document(source)? {
+    let parsed = parse_document(SourceFile::new(source))?;
+    let mut kernel = match parsed.surface {
         SurfaceDocument::Spec(spec) => crate::lower_direct_spec(spec),
         SurfaceDocument::Business(business) => crate::lower_business(business),
         SurfaceDocument::Requirements(requirements) => crate::lower_requirements(requirements),
@@ -62,13 +64,17 @@ pub fn parse_kernel_source(
         SurfaceDocument::Domain(domain) => crate::lower_domain(&domain),
         SurfaceDocument::AiComponent(component) => crate::lower_ai_component(component),
         SurfaceDocument::Compose(compose) => lower_compose(compose, resolver),
-        SurfaceDocument::Refinement(_) => Err(CoreError {
+        SurfaceDocument::Refinement(_) | SurfaceDocument::Agent(_) => Err(CoreError {
             message: "top-level document has not reached the kernel lowering gate".to_owned(),
             line: 1,
             column: 1,
             origin: None,
         }),
-    }
+    }?;
+    kernel
+        .annotations
+        .extend(crate::SPEC_TARGET, parsed.annotations);
+    Ok(kernel)
 }
 
 /// Parse and lower source while attaching the caller-known root file identity
@@ -141,6 +147,32 @@ impl ComponentNames {
     }
 }
 
+fn parse_component(
+    source: &str,
+    use_span: fsl_syntax::Span,
+) -> Result<(SurfaceSpec, Annotations), CoreError> {
+    let parsed = parse_document(SourceFile::new(source))?;
+    let SurfaceDocument::Spec(spec) = parsed.surface else {
+        return Err(error_at("compose use must reference a spec", use_span));
+    };
+    let spec = PredicateExpander::new(&spec)?.expand(spec)?;
+    Ok((expand_spec_domains(spec)?, parsed.annotations))
+}
+
+fn composed_kernel(name: String, items: Vec<SpecItem>, annotations: Annotations) -> KernelSpec {
+    let mut kernel = KernelSpec {
+        spec: SurfaceSpec {
+            name,
+            meta: None,
+            items,
+        },
+        origins: crate::OriginRegistry::default(),
+        annotations: fsl_syntax::AnnotationRegistry::default(),
+    };
+    kernel.annotations.extend(crate::SPEC_TARGET, annotations);
+    kernel
+}
+
 /// Lower one compose document using source-relative component resolution.
 ///
 /// # Errors
@@ -152,6 +184,7 @@ pub fn lower_compose(
     resolver: &dyn FileResolver,
 ) -> Result<KernelSpec, CoreError> {
     let mut components = BTreeMap::new();
+    let mut component_annotations = Annotations::default();
     let mut order = Vec::new();
     for item in &compose.items {
         let ComposeItem::Use {
@@ -167,11 +200,8 @@ pub fn lower_compose(
             return Err(error_at(format!("duplicate alias '{alias}'"), *span));
         }
         let source = resolver.read(path)?;
-        let SurfaceDocument::Spec(spec) = parse_surface_document(&source)? else {
-            return Err(error_at("compose use must reference a spec", *span));
-        };
-        let spec = PredicateExpander::new(&spec)?.expand(spec)?;
-        let spec = expand_spec_domains(spec)?;
+        let (spec, annotations) = parse_component(&source, *span)?;
+        component_annotations.extend(annotations.source_order().iter().cloned());
         order.push(alias.clone());
         components.insert(
             alias.clone(),
@@ -244,15 +274,11 @@ pub fn lower_compose(
         meta: init_meta,
     });
     static_items.extend(actions);
-    Ok(KernelSpec {
-        spec: SurfaceSpec {
-            name: compose.name,
-            meta: None,
-            items: static_items,
-        },
-        origins: crate::OriginRegistry::default(),
-        annotations: fsl_syntax::AnnotationRegistry::default(),
-    })
+    Ok(composed_kernel(
+        compose.name,
+        static_items,
+        component_annotations,
+    ))
 }
 
 fn prefix(alias: &str, name: &str) -> String {

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -8,8 +8,8 @@ use std::fmt;
 
 use fsl_syntax::{
     ActionItem, AnnotationRegistry, Binder, BusinessItem, Expr, LValue, Param, ParseError,
-    RequirementsItem, SpecItem, StateField, Statement, SurfaceDocument, SurfaceSpec, TypeExpr,
-    VerifyItem, parse_surface_document,
+    RequirementsItem, SourceFile, SpecItem, StateField, Statement, SurfaceDocument, SurfaceSpec,
+    TypeExpr, VerifyItem, parse_document,
 };
 use serde_json::Value;
 
@@ -206,7 +206,8 @@ impl KernelSpec {
 /// Returns [`CoreError`] for parse failures, non-`spec` documents, invalid
 /// predicate definitions, recursion, arity mismatches, or variable capture.
 pub fn parse_direct_kernel_spec(source: &str) -> Result<KernelSpec, CoreError> {
-    let SurfaceDocument::Spec(spec) = parse_surface_document(source)? else {
+    let parsed = parse_document(SourceFile::new(source))?;
+    let SurfaceDocument::Spec(spec) = parsed.surface else {
         return Err(CoreError {
             message: "expected direct kernel spec".to_owned(),
             line: 1,
@@ -214,7 +215,9 @@ pub fn parse_direct_kernel_spec(source: &str) -> Result<KernelSpec, CoreError> {
             origin: None,
         });
     };
-    lower_direct_spec(spec)
+    let mut kernel = lower_direct_spec(spec)?;
+    kernel.annotations.extend(SPEC_TARGET, parsed.annotations);
+    Ok(kernel)
 }
 
 fn validate_direct_scope_overrides(
@@ -309,7 +312,8 @@ pub fn parse_kernel_source_with_bounds(
         }
     }
 
-    match parse_surface_document(source)? {
+    let parsed = parse_document(SourceFile::new(source))?;
+    let mut kernel = match parsed.surface {
         SurfaceDocument::Spec(mut spec) => {
             validate_direct_scope_overrides(&spec, instances, values)?;
             for item in &mut spec.items {
@@ -339,7 +343,9 @@ pub fn parse_kernel_source_with_bounds(
             column: 1,
             origin: None,
         }),
-    }
+    }?;
+    kernel.annotations.extend(SPEC_TARGET, parsed.annotations);
+    Ok(kernel)
 }
 
 /// Lower a parsed direct `spec` into the kernel representation.

--- a/rust/fsl-core/tests/typed_annotations.rs
+++ b/rust/fsl-core/tests/typed_annotations.rs
@@ -2,8 +2,8 @@
 // Copyright 2026 Ryoichi Izumita
 
 use fsl_core::{
-    Annotation, AnnotationValue, FsResolver, SymbolPath, action_target, build_model,
-    parse_kernel_source, requirements_trace_contract,
+    Annotation, AnnotationValue, FileResolver, FsResolver, SPEC_TARGET, SymbolPath, action_target,
+    build_model, parse_kernel_source, parse_kernel_source_with_bounds, requirements_trace_contract,
 };
 use fsl_syntax::{SourcePos, Span};
 
@@ -49,6 +49,10 @@ fn keeps_multiple_typed_annotations_and_legacy_projection_on_one_declaration() {
             span: span(20),
         },
     );
+    let custom = SymbolPath::new(["acme".to_owned(), "review".to_owned()], span(24))
+        .expect("valid namespace");
+    assert_eq!(custom.segments(), ["acme", "review"]);
+    assert_eq!(custom.span(), span(24));
     kernel.bind_annotation(
         target.clone(),
         Annotation::Undecided {
@@ -98,6 +102,77 @@ fn keeps_multiple_typed_annotations_and_legacy_projection_on_one_declaration() {
         "review owner is pending"
     );
     assert_eq!(action.meta.as_ref().expect("legacy projection").id, "REQ-1");
+}
+
+#[test]
+fn top_level_annotations_flow_from_dispatch_into_the_checked_spec() {
+    let kernel = parse_kernel_source(
+        r#"
+@requirement("REQ-TOP", "the document owns this contract")
+@acme.review(owner.team, 2, true)
+spec TopLevelAnnotations {
+  state { ready: Bool }
+  init { ready = false }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated document");
+
+    let annotations = kernel.annotations().annotations_for(SPEC_TARGET);
+    assert_eq!(annotations.source_order().len(), 2);
+    assert_eq!(annotations.requirements().unwrap()[0].id, "REQ-TOP");
+    let Annotation::Custom { namespace, .. } = &annotations.source_order()[1] else {
+        panic!("expected custom annotation")
+    };
+    assert_eq!(namespace.to_string(), "acme.review");
+    assert_eq!(namespace.span().start.line, 3);
+}
+
+#[test]
+fn scoped_parse_preserves_top_level_annotations() {
+    let kernel = parse_kernel_source_with_bounds(
+        "@requirement(\"REQ-TOP\")\nspec Annotated { state { ready: Bool } init { ready = false } }",
+        &std::collections::BTreeMap::new(),
+        &std::collections::BTreeMap::new(),
+    )
+    .expect("parse annotated scoped document");
+
+    assert_eq!(
+        kernel
+            .annotations()
+            .annotations_for(SPEC_TARGET)
+            .requirements()
+            .unwrap()[0]
+            .id,
+        "REQ-TOP"
+    );
+}
+
+#[test]
+fn compose_preserves_component_document_annotations() {
+    struct Resolver;
+    impl FileResolver for Resolver {
+        fn read(&self, _path: &str) -> Result<String, fsl_core::CoreError> {
+            Ok("@requirement(\"REQ-COMPONENT\")\nspec Child { state { ready: Bool } init { ready = false } }".to_owned())
+        }
+    }
+
+    let kernel = parse_kernel_source(
+        "compose Parent { use Child as child from \"child.fsl\" }",
+        &Resolver,
+    )
+    .expect("parse annotated component");
+
+    assert_eq!(
+        kernel
+            .annotations()
+            .annotations_for(SPEC_TARGET)
+            .requirements()
+            .unwrap()[0]
+            .id,
+        "REQ-COMPONENT"
+    );
 }
 
 #[test]

--- a/rust/fsl-syntax/src/ai.rs
+++ b/rust/fsl-syntax/src/ai.rs
@@ -128,14 +128,19 @@ impl AiHardCheck {
 ///
 /// Returns [`ParseError`] when lexical or syntactic analysis fails.
 pub fn parse_ai_component(source: &str) -> Result<AiComponent, ParseError> {
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
+    let tokens = lex(source).map_err(ParseError::from)?;
+    parse_ai_component_tokens(source, tokens, 0)
+}
+
+pub(crate) fn parse_ai_component_tokens(
+    source: &str,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<AiComponent, ParseError> {
     let mut parser = AiParser {
         source,
         tokens,
-        cursor: 0,
+        cursor,
     };
     let component = parser.component()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
@@ -335,10 +340,7 @@ impl AiParser<'_> {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Ident(value) | TokenKind::String(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected name or string".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected name or string", token.span)),
         }
     }
 
@@ -405,10 +407,7 @@ impl AiParser<'_> {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Ident(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected identifier", token.span)),
         }
     }
 
@@ -429,9 +428,6 @@ impl AiParser<'_> {
     }
 
     fn error(&self, message: &str) -> ParseError {
-        ParseError {
-            message: message.to_owned(),
-            span: self.peek().span,
-        }
+        ParseError::new(message, self.peek().span)
     }
 }

--- a/rust/fsl-syntax/src/annotation.rs
+++ b/rust/fsl-syntax/src/annotation.rs
@@ -9,8 +9,11 @@ use std::fmt;
 use crate::Span;
 
 /// A namespaced symbol such as `acme.review.owner`.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SymbolPath(Vec<String>);
+#[derive(Clone, Debug)]
+pub struct SymbolPath {
+    segments: Vec<String>,
+    span: Span,
+}
 
 impl SymbolPath {
     /// Construct a validated symbol path.
@@ -29,18 +32,43 @@ impl SymbolPath {
                 span,
             ));
         }
-        Ok(Self(segments))
+        Ok(Self { segments, span })
     }
 
     #[must_use]
     pub fn segments(&self) -> &[String] {
-        &self.0
+        &self.segments
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl PartialEq for SymbolPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.segments == other.segments
+    }
+}
+
+impl Eq for SymbolPath {}
+
+impl PartialOrd for SymbolPath {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SymbolPath {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.segments.cmp(&other.segments)
     }
 }
 
 impl fmt::Display for SymbolPath {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0.join("."))
+        formatter.write_str(&self.segments.join("."))
     }
 }
 

--- a/rust/fsl-syntax/src/db.rs
+++ b/rust/fsl-syntax/src/db.rs
@@ -263,11 +263,15 @@ enum DbItem {
 ///
 /// Returns [`ParseError`] when lexical, syntactic, or structural analysis fails.
 pub fn parse_db_system(source: &str) -> Result<DbSystem, ParseError> {
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
-    let mut parser = DbParser { tokens, cursor: 0 };
+    let tokens = lex(source).map_err(ParseError::from)?;
+    parse_db_system_tokens(tokens, 0)
+}
+
+pub(crate) fn parse_db_system_tokens(
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<DbSystem, ParseError> {
+    let mut parser = DbParser { tokens, cursor };
     let system = parser.system()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after dbsystem"));
@@ -712,10 +716,7 @@ impl DbParser {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Ident(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected identifier", token.span)),
         }
     }
 
@@ -731,10 +732,7 @@ impl DbParser {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Int(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected integer".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected integer", token.span)),
         }
     }
 
@@ -747,9 +745,6 @@ impl DbParser {
     }
 
     fn error(&self, message: &str) -> ParseError {
-        ParseError {
-            message: message.to_owned(),
-            span: self.peek().span,
-        }
+        ParseError::new(message, self.peek().span)
     }
 }

--- a/rust/fsl-syntax/src/dispatch.rs
+++ b/rust/fsl-syntax/src/dispatch.rs
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
+
+use crate::lexer::lex_declaration_prefix;
+use crate::{
+    Annotation, AnnotationValue, Annotations, ParseError, Span, SurfaceAgent, SurfaceDocument,
+    SymbolPath, Token, TokenKind, lex,
+};
+
+/// Original source passed beside the shared token stream to a dialect frontend.
+#[derive(Clone, Copy, Debug)]
+pub struct SourceFile<'a> {
+    source: &'a str,
+}
+
+impl<'a> SourceFile<'a> {
+    #[must_use]
+    pub const fn new(source: &'a str) -> Self {
+        Self { source }
+    }
+
+    #[must_use]
+    pub const fn source(self) -> &'a str {
+        self.source
+    }
+}
+
+/// One parsed surface document plus annotations attached before its declaration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParsedDocument {
+    pub keyword: &'static str,
+    pub annotations: Annotations,
+    pub surface: SurfaceDocument,
+}
+
+type Frontend =
+    for<'a> fn(SourceFile<'a>, Vec<Token>, usize) -> Result<SurfaceDocument, ParseError>;
+
+#[derive(Clone, Copy)]
+struct FrontendRegistration {
+    keyword: &'static str,
+    parse: Frontend,
+}
+
+macro_rules! frontends {
+    ($($keyword:literal => $parse:path),+ $(,)?) => {
+        pub const DIALECT_KEYWORDS: &[&str] = &[$($keyword),+];
+        const FRONTENDS: &[FrontendRegistration] = &[
+            $(FrontendRegistration { keyword: $keyword, parse: $parse }),+
+        ];
+    };
+}
+
+frontends! {
+    "spec" => parse_shared,
+    "refinement" => parse_shared,
+    "compose" => parse_shared,
+    "business" => parse_shared,
+    "governance" => parse_shared,
+    "requirements" => parse_shared,
+    "domain" => parse_domain,
+    "dbsystem" => parse_db,
+    "ai_component" => parse_ai,
+    "agent" => parse_agent,
+}
+
+static VALID_REGISTRY: LazyLock<()> = LazyLock::new(|| {
+    validate_registry(FRONTENDS).expect("duplicate FSL dialect registry keyword");
+});
+
+/// Validate that every registered top-level keyword is unique.
+///
+/// # Errors
+///
+/// Returns the duplicated keyword when registry construction is invalid.
+pub fn validate_frontend_registry() -> Result<(), String> {
+    validate_registry(FRONTENDS)
+}
+
+fn validate_registry(registry: &[FrontendRegistration]) -> Result<(), String> {
+    let mut seen = BTreeSet::new();
+    for registration in registry {
+        if !seen.insert(registration.keyword) {
+            return Err(format!(
+                "duplicate FSL dialect registry keyword '{}'",
+                registration.keyword
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return the declaration keyword selected by the shared lexer and annotation scanner.
+///
+/// # Errors
+///
+/// Returns a coded parse error for empty, annotation-only, or unknown documents.
+pub fn dialect_keyword(source: &str) -> Result<&'static str, ParseError> {
+    let tokens = lex(source).map_err(ParseError::from)?;
+    let (_, cursor) = leading_annotations(&tokens)?;
+    select_frontend(&tokens, cursor).map(|registration| registration.keyword)
+}
+
+/// Return the first significant declaration identifier, including identifiers
+/// owned by feature-level parsers rather than the dialect registry.
+///
+/// # Errors
+///
+/// Returns a coded parse error when the document has no declaration identifier.
+pub fn declaration_keyword(source: &str) -> Result<String, ParseError> {
+    let tokens = lex_declaration_prefix(source).map_err(ParseError::from)?;
+    let (_, cursor) = leading_annotations(&tokens)?;
+    declaration_identifier(&tokens, cursor).map(str::to_owned)
+}
+
+/// Lex once, select a registered frontend, and parse using that same token stream.
+///
+/// # Errors
+///
+/// Returns lexical, annotation, dispatch, or frontend syntax errors.
+pub fn parse_document(source: SourceFile<'_>) -> Result<ParsedDocument, ParseError> {
+    LazyLock::force(&VALID_REGISTRY);
+    let tokens = lex(source.source()).map_err(ParseError::from)?;
+    let (annotations, cursor) = leading_annotations(&tokens)?;
+    let registration = select_frontend(&tokens, cursor)?;
+    let surface = (registration.parse)(source, tokens, cursor)?;
+    Ok(ParsedDocument {
+        keyword: registration.keyword,
+        annotations,
+        surface,
+    })
+}
+
+fn select_frontend(
+    tokens: &[Token],
+    cursor: usize,
+) -> Result<&'static FrontendRegistration, ParseError> {
+    let token = &tokens[cursor];
+    let keyword = declaration_identifier(tokens, cursor)?;
+    FRONTENDS
+        .iter()
+        .find(|registration| registration.keyword == keyword)
+        .ok_or_else(|| unknown_dialect(token))
+}
+
+fn declaration_identifier(tokens: &[Token], cursor: usize) -> Result<&str, ParseError> {
+    let token = &tokens[cursor];
+    match &token.kind {
+        TokenKind::Eof => Err(ParseError::coded(
+            if cursor == 0 {
+                "FSL-DIALECT-EMPTY"
+            } else {
+                "FSL-DIALECT-ANNOTATION-TARGET"
+            },
+            if cursor == 0 {
+                format!(
+                    "empty or comment-only FSL document; supported dialect keywords: {}",
+                    DIALECT_KEYWORDS.join(", ")
+                )
+            } else {
+                "top-level annotation must be followed by a declaration".to_owned()
+            },
+            token.span,
+        )),
+        TokenKind::Ident(keyword) => Ok(keyword),
+        _ => Err(unknown_dialect(token)),
+    }
+}
+
+fn unknown_dialect(token: &Token) -> ParseError {
+    let found = match &token.kind {
+        TokenKind::Ident(value) | TokenKind::String(value) | TokenKind::Symbol(value) => {
+            value.clone()
+        }
+        TokenKind::Int(value) => value.to_string(),
+        TokenKind::Eof => "end of file".to_owned(),
+    };
+    ParseError::coded(
+        "FSL-DIALECT-UNKNOWN",
+        format!(
+            "unsupported top-level declaration '{found}'; supported dialect keywords: {}",
+            DIALECT_KEYWORDS.join(", ")
+        ),
+        token.span,
+    )
+}
+
+fn parse_shared(
+    _source: SourceFile<'_>,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    crate::parser::parse_shared_tokens(tokens, cursor)
+}
+
+fn parse_db(
+    _source: SourceFile<'_>,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    crate::db::parse_db_system_tokens(tokens, cursor).map(SurfaceDocument::Db)
+}
+
+fn parse_domain(
+    _source: SourceFile<'_>,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    crate::domain::parse_domain_tokens(tokens, cursor).map(SurfaceDocument::Domain)
+}
+
+fn parse_ai(
+    source: SourceFile<'_>,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    crate::ai::parse_ai_component_tokens(source.source(), tokens, cursor)
+        .map(SurfaceDocument::AiComponent)
+}
+
+fn parse_agent(
+    _source: SourceFile<'_>,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    let mut tokens = tokens.into_iter().skip(cursor);
+    let start = tokens.next().expect("dispatch selected agent token").span;
+    let name = match tokens.next() {
+        Some(Token {
+            kind: TokenKind::Ident(name),
+            ..
+        }) => name,
+        Some(token) => {
+            return Err(ParseError::coded(
+                "FSL-PARSE",
+                "expected agent name",
+                token.span,
+            ));
+        }
+        None => unreachable!("lexer always appends EOF"),
+    };
+    let open = tokens.next().expect("lexer appends EOF");
+    if !matches!(&open.kind, TokenKind::Symbol(symbol) if symbol == "{") {
+        return Err(ParseError::new("expected '{' after agent name", open.span));
+    }
+    let mut depth = 1_usize;
+    let end = loop {
+        let token = tokens.next().expect("lexer appends EOF");
+        match &token.kind {
+            TokenKind::Symbol(symbol) if symbol == "{" => {
+                depth += 1;
+            }
+            TokenKind::Symbol(symbol) if symbol == "}" => {
+                depth -= 1;
+                if depth == 0 {
+                    break token.span;
+                }
+            }
+            TokenKind::Eof => {
+                return Err(ParseError::new(
+                    "agent declaration must contain balanced braces",
+                    token.span,
+                ));
+            }
+            _ => {}
+        }
+    };
+    let trailing = tokens.next().expect("lexer appends EOF");
+    if !matches!(trailing.kind, TokenKind::Eof) {
+        return Err(ParseError::new(
+            "unexpected token after agent",
+            trailing.span,
+        ));
+    }
+    Ok(SurfaceDocument::Agent(SurfaceAgent {
+        name,
+        span: Span {
+            start: start.start,
+            end: end.end,
+        },
+    }))
+}
+
+fn leading_annotations(tokens: &[Token]) -> Result<(Annotations, usize), ParseError> {
+    let mut cursor = 0;
+    let mut annotations = Vec::new();
+    while symbol(tokens, cursor, "@") {
+        annotations.push(annotation(tokens, &mut cursor)?);
+    }
+    let annotations = Annotations::new(annotations);
+    annotations
+        .validate()
+        .map_err(|error| ParseError::coded("FSL-ANNOTATION-INVALID", error.message, error.span))?;
+    Ok((annotations, cursor))
+}
+
+fn annotation(tokens: &[Token], cursor: &mut usize) -> Result<Annotation, ParseError> {
+    let start = tokens[*cursor].span;
+    *cursor += 1;
+    let (path, _) = symbol_path(tokens, cursor)?;
+    expect_symbol(tokens, cursor, "(")?;
+    let mut arguments = Vec::new();
+    if !symbol(tokens, *cursor, ")") {
+        loop {
+            arguments.push(annotation_value(tokens, cursor)?);
+            if symbol(tokens, *cursor, ")") {
+                break;
+            }
+            expect_symbol(tokens, cursor, ",")?;
+        }
+    }
+    let end = tokens[*cursor].span;
+    *cursor += 1;
+    let span = Span {
+        start: start.start,
+        end: end.end,
+    };
+    match path.segments() {
+        [name] if name == "requirement" => match arguments.as_slice() {
+            [AnnotationValue::String(id)] => Ok(Annotation::Requirement {
+                id: id.clone(),
+                text: None,
+                span,
+            }),
+            [AnnotationValue::String(id), AnnotationValue::String(text)] => {
+                Ok(Annotation::Requirement {
+                    id: id.clone(),
+                    text: Some(text.clone()),
+                    span,
+                })
+            }
+            _ => Err(annotation_shape(
+                "requirement",
+                "one or two string arguments",
+                span,
+            )),
+        },
+        [name] if name == "undecided" => match arguments.as_slice() {
+            [AnnotationValue::String(reason)] => Ok(Annotation::Undecided {
+                reason: reason.clone(),
+                span,
+            }),
+            _ => Err(annotation_shape("undecided", "one string argument", span)),
+        },
+        [name] if name == "kind" => match arguments.as_slice() {
+            [AnnotationValue::String(id)] => Ok(Annotation::Kind {
+                id: id.clone(),
+                text: None,
+                span,
+            }),
+            [AnnotationValue::String(id), AnnotationValue::String(text)] => Ok(Annotation::Kind {
+                id: id.clone(),
+                text: Some(text.clone()),
+                span,
+            }),
+            _ => Err(annotation_shape(
+                "kind",
+                "one or two string arguments",
+                span,
+            )),
+        },
+        _ => Ok(Annotation::Custom {
+            namespace: path,
+            arguments,
+            span,
+        }),
+    }
+}
+
+fn annotation_shape(name: &str, expected: &str, span: Span) -> ParseError {
+    ParseError::coded(
+        "FSL-ANNOTATION-ARGUMENTS",
+        format!("@{name} expects {expected}"),
+        span,
+    )
+}
+
+fn annotation_value(tokens: &[Token], cursor: &mut usize) -> Result<AnnotationValue, ParseError> {
+    let token = &tokens[*cursor];
+    match &token.kind {
+        TokenKind::String(value) => {
+            *cursor += 1;
+            Ok(AnnotationValue::String(value.clone()))
+        }
+        TokenKind::Int(value) => {
+            *cursor += 1;
+            Ok(AnnotationValue::Integer(*value))
+        }
+        TokenKind::Ident(value) if value == "true" || value == "false" => {
+            *cursor += 1;
+            Ok(AnnotationValue::Boolean(value == "true"))
+        }
+        TokenKind::Ident(_) => {
+            symbol_path(tokens, cursor).map(|(path, _)| AnnotationValue::Symbol(path))
+        }
+        _ => Err(ParseError::coded(
+            "FSL-ANNOTATION-ARGUMENTS",
+            "annotation argument must be a string, integer, Boolean, or symbol path",
+            token.span,
+        )),
+    }
+}
+
+fn symbol_path(tokens: &[Token], cursor: &mut usize) -> Result<(SymbolPath, Span), ParseError> {
+    let start = tokens[*cursor].span;
+    let mut segments = Vec::new();
+    loop {
+        match &tokens[*cursor].kind {
+            TokenKind::Ident(segment) => {
+                segments.push(segment.clone());
+                *cursor += 1;
+            }
+            _ => {
+                return Err(ParseError::coded(
+                    "FSL-ANNOTATION-PATH",
+                    "expected annotation symbol path segment",
+                    tokens[*cursor].span,
+                ));
+            }
+        }
+        if !symbol(tokens, *cursor, ".") {
+            break;
+        }
+        *cursor += 1;
+    }
+    let end = tokens[*cursor - 1].span;
+    let span = Span {
+        start: start.start,
+        end: end.end,
+    };
+    SymbolPath::new(segments, span)
+        .map(|path| (path, span))
+        .map_err(|error| ParseError::coded("FSL-ANNOTATION-PATH", error.message, error.span))
+}
+
+fn expect_symbol(tokens: &[Token], cursor: &mut usize, expected: &str) -> Result<(), ParseError> {
+    if symbol(tokens, *cursor, expected) {
+        *cursor += 1;
+        Ok(())
+    } else {
+        Err(ParseError::coded(
+            "FSL-ANNOTATION-SYNTAX",
+            format!("expected '{expected}' in annotation"),
+            tokens[*cursor].span,
+        ))
+    }
+}
+
+fn symbol(tokens: &[Token], cursor: usize, expected: &str) -> bool {
+    matches!(tokens.get(cursor).map(|token| &token.kind), Some(TokenKind::Symbol(value)) if value == expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_rejects_duplicate_keywords() {
+        let duplicate = [
+            FrontendRegistration {
+                keyword: "spec",
+                parse: parse_shared,
+            },
+            FrontendRegistration {
+                keyword: "spec",
+                parse: parse_agent,
+            },
+        ];
+        assert_eq!(
+            validate_registry(&duplicate).unwrap_err(),
+            "duplicate FSL dialect registry keyword 'spec'"
+        );
+    }
+
+    #[test]
+    fn every_registered_dialect_uses_the_significant_keyword_rule() {
+        validate_frontend_registry().unwrap();
+        for keyword in DIALECT_KEYWORDS {
+            let source = format!(
+                "\u{feff}// leading comment\n@acme.route(spec, requirements)\n{keyword} Name {{}}"
+            );
+            assert_eq!(dialect_keyword(&source).unwrap(), *keyword);
+        }
+    }
+
+    #[test]
+    fn annotation_keyword_arguments_do_not_drive_dispatch() {
+        let parsed = parse_document(SourceFile::new(
+            "\u{feff}@acme.route(spec, requirements)\n// target follows\ndomain Orders {}",
+        ))
+        .unwrap();
+        assert_eq!(parsed.keyword, "domain");
+        assert_eq!(parsed.annotations.source_order().len(), 1);
+        assert_eq!(
+            declaration_keyword("@acme.route(spec)\ndataset Eval {}"),
+            Ok("dataset".to_owned())
+        );
+        assert_eq!(
+            declaration_keyword("ai_action Draft { arbitrary & opaque ? text }"),
+            Ok("ai_action".to_owned())
+        );
+    }
+
+    #[test]
+    fn specialized_frontends_parse_after_leading_trivia() {
+        let db = parse_document(SourceFile::new(
+            "// comment\ndbsystem Demo { database app { schema 0 table users { column id: Int present not_null; } } }",
+        ))
+        .unwrap();
+        let ai = parse_document(SourceFile::new(
+            "\u{feff}// comment\nai_component Demo { tool Search { schema SearchV1; } authority { may_execute Search; } }",
+        ))
+        .unwrap();
+        assert!(matches!(db.surface, SurfaceDocument::Db(_)));
+        assert!(matches!(ai.surface, SurfaceDocument::AiComponent(_)));
+    }
+
+    #[test]
+    fn empty_and_unknown_documents_have_stable_diagnostics() {
+        let empty = parse_document(SourceFile::new(" // only a comment\n")).unwrap_err();
+        assert_eq!(empty.code(), "FSL-DIALECT-EMPTY");
+        assert!(empty.message.contains("spec, refinement, compose"));
+        let unknown = parse_document(SourceFile::new("mystery X {}")).unwrap_err();
+        assert_eq!(unknown.code(), "FSL-DIALECT-UNKNOWN");
+        assert_eq!(unknown.span.start.column, 1);
+        assert!(unknown.message.contains("spec, refinement, compose"));
+    }
+
+    #[test]
+    fn agent_frontend_rejects_extra_tokens() {
+        for source in ["agent A junk {}", "agent A {} spec B {}"] {
+            let error = parse_document(SourceFile::new(source)).unwrap_err();
+            assert_eq!(error.code(), "FSL-PARSE");
+        }
+    }
+}

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -454,11 +454,15 @@ impl DomainSaga {
 ///
 /// Returns [`ParseError`] when lexical, syntactic, or structural analysis fails.
 pub fn parse_domain(source: &str) -> Result<DomainSpec, ParseError> {
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
-    let mut parser = DomainParser { tokens, cursor: 0 };
+    let tokens = lex(source).map_err(ParseError::from)?;
+    parse_domain_tokens(tokens, 0)
+}
+
+pub(crate) fn parse_domain_tokens(
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<DomainSpec, ParseError> {
+    let mut parser = DomainParser { tokens, cursor };
     let domain = parser.domain()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after domain"));
@@ -1222,10 +1226,7 @@ impl DomainParser {
     fn time_value(&mut self) -> Result<String, ParseError> {
         let token = self.bump().clone();
         let TokenKind::Int(value) = token.kind else {
-            return Err(ParseError {
-                message: "expected time value".to_owned(),
-                span: token.span,
-            });
+            return Err(ParseError::new("expected time value", token.span));
         };
         let mut output = value.to_string();
         if let TokenKind::Ident(unit) = &self.peek().kind {
@@ -1256,10 +1257,10 @@ impl DomainParser {
         if is_dotted_reference(&expression) {
             Ok(expression)
         } else {
-            Err(ParseError {
-                message: "effect reference must be a dotted identifier path".to_owned(),
-                span: expression.span,
-            })
+            Err(ParseError::new(
+                "effect reference must be a dotted identifier path",
+                expression.span,
+            ))
         }
     }
 
@@ -1326,10 +1327,7 @@ impl DomainParser {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Ident(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected identifier", token.span)),
         }
     }
 
@@ -1340,10 +1338,7 @@ impl DomainParser {
                 text,
                 span: token.span,
             }),
-            _ => Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected identifier", token.span)),
         }
     }
 
@@ -1359,10 +1354,7 @@ impl DomainParser {
         let token = self.bump().clone();
         match token.kind {
             TokenKind::Int(value) => Ok(value),
-            _ => Err(ParseError {
-                message: "expected integer".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected integer", token.span)),
         }
     }
 
@@ -1375,10 +1367,7 @@ impl DomainParser {
     }
 
     fn error(&self, message: &str) -> ParseError {
-        ParseError {
-            message: message.to_owned(),
-            span: self.peek().span,
-        }
+        ParseError::new(message, self.peek().span)
     }
 }
 
@@ -1386,10 +1375,10 @@ fn expression_name(expression: SyntaxExpr) -> Result<SyntaxIdent, ParseError> {
     let span = expression.span;
     match expression.kind {
         SyntaxExprKind::Name(name) => Ok(name),
-        _ => Err(ParseError {
-            message: "domain enum members must be identifiers".to_owned(),
+        _ => Err(ParseError::new(
+            "domain enum members must be identifiers",
             span,
-        }),
+        )),
     }
 }
 

--- a/rust/fsl-syntax/src/lexer.rs
+++ b/rust/fsl-syntax/src/lexer.rs
@@ -48,6 +48,29 @@ pub fn lex(source: &str) -> Result<Vec<Token>, LexError> {
     Lexer::new(source).lex_all()
 }
 
+pub(crate) fn lex_declaration_prefix(source: &str) -> Result<Vec<Token>, LexError> {
+    let mut lexer = Lexer::new(source);
+    let mut tokens = Vec::new();
+    loop {
+        let token = lexer.next_token()?;
+        let annotation = matches!(&token.kind, TokenKind::Symbol(symbol) if symbol == "@");
+        let eof = matches!(token.kind, TokenKind::Eof);
+        tokens.push(token);
+        if eof || !annotation {
+            return Ok(tokens);
+        }
+        loop {
+            let token = lexer.next_token()?;
+            let annotation_end = matches!(&token.kind, TokenKind::Symbol(symbol) if symbol == ")");
+            let eof = matches!(token.kind, TokenKind::Eof);
+            tokens.push(token);
+            if annotation_end || eof {
+                break;
+            }
+        }
+    }
+}
+
 struct Lexer<'a> {
     source: &'a str,
     offset: usize,
@@ -68,36 +91,47 @@ impl<'a> Lexer<'a> {
     fn lex_all(mut self) -> Result<Vec<Token>, LexError> {
         let mut tokens = Vec::new();
         loop {
-            self.skip_trivia();
-            let start = self.pos();
-            let Some(ch) = self.peek() else {
-                tokens.push(Token {
-                    kind: TokenKind::Eof,
-                    span: Span { start, end: start },
-                });
+            let token = self.next_token()?;
+            let eof = matches!(token.kind, TokenKind::Eof);
+            tokens.push(token);
+            if eof {
                 return Ok(tokens);
-            };
-            let kind = if ch.is_ascii_alphabetic() || ch == '_' {
-                self.lex_ident()
-            } else if ch.is_ascii_digit() {
-                self.lex_int(start)?
-            } else if ch == '"' {
-                self.lex_string(start)?
-            } else {
-                self.lex_symbol(start)?
-            };
-            tokens.push(Token {
-                kind,
-                span: Span {
-                    start,
-                    end: self.pos(),
-                },
-            });
+            }
         }
+    }
+
+    fn next_token(&mut self) -> Result<Token, LexError> {
+        self.skip_trivia();
+        let start = self.pos();
+        let Some(ch) = self.peek() else {
+            return Ok(Token {
+                kind: TokenKind::Eof,
+                span: Span { start, end: start },
+            });
+        };
+        let kind = if ch.is_ascii_alphabetic() || ch == '_' {
+            self.lex_ident()
+        } else if ch.is_ascii_digit() {
+            self.lex_int(start)?
+        } else if ch == '"' {
+            self.lex_string(start)?
+        } else {
+            self.lex_symbol(start)?
+        };
+        Ok(Token {
+            kind,
+            span: Span {
+                start,
+                end: self.pos(),
+            },
+        })
     }
 
     fn skip_trivia(&mut self) {
         loop {
+            if self.offset == 0 && self.peek() == Some('\u{feff}') {
+                self.bump();
+            }
             while self.peek().is_some_and(char::is_whitespace) {
                 self.bump();
             }
@@ -173,7 +207,7 @@ impl<'a> Lexer<'a> {
             return Ok(TokenKind::Symbol((*symbol).to_owned()));
         }
         let ch = self.bump().expect("peeked character");
-        if "{}()[],:;.+-*/%<>=.|".contains(ch) {
+        if "{}()[],:;.+-*/%<>=.|@".contains(ch) {
             Ok(TokenKind::Symbol(ch.to_string()))
         } else {
             Err(LexError {
@@ -226,6 +260,13 @@ mod tests {
         assert_eq!(tokens[0].span.start.line, 2);
         assert_eq!(tokens[0].span.start.column, 1);
         assert_eq!(tokens[1].kind, TokenKind::Symbol("<=".to_owned()));
+    }
+
+    #[test]
+    fn leading_bom_is_trivia() {
+        let tokens = lex("\u{feff}  spec Example {}").unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Ident("spec".to_owned()));
+        assert_eq!(tokens[0].span.start.column, 4);
     }
 
     #[test]

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -12,6 +12,7 @@ mod ai;
 mod annotation;
 mod ast;
 mod db;
+mod dispatch;
 mod domain;
 mod lexer;
 mod parser;
@@ -30,6 +31,10 @@ pub use db::{
     DbArtifact, DbCheck, DbColumn, DbColumnRef, DbDatabase, DbEnvironment, DbEnvironmentArtifact,
     DbFlag, DbFlagCondition, DbMigration, DbMigrationOp, DbSystem, DbTable, parse_db_system,
 };
+pub use dispatch::{
+    DIALECT_KEYWORDS, ParsedDocument, SourceFile, declaration_keyword, dialect_keyword,
+    parse_document, validate_frontend_registry,
+};
 pub use domain::{
     DomainAggregate, DomainAssignment, DomainAwait, DomainCommand, DomainDecide, DomainEffect,
     DomainError, DomainEvent, DomainEvolve, DomainField, DomainInvariant, DomainLoc,
@@ -45,8 +50,9 @@ pub use surface::{
     PreservationItem, ProcessCover, ProcessField, ProcessFields, ProcessItem, ProcessTransition,
     RefinementItem, RefinementParam, RequirementAction, RequirementActionItem,
     RequirementBlockItem, RequirementBranch, RequirementsItem, SpecItem, StateField, Statement,
-    SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement,
-    SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr, VerifyItem,
+    SurfaceAgent, SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance,
+    SurfaceRefinement, SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr,
+    VerifyItem,
 };
 pub use syntax_expr::{
     SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxIdent, SyntaxLValue, SyntaxOperator,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -27,6 +27,34 @@ fn join_span(start: Span, end: Span) -> Span {
 pub struct ParseError {
     pub message: String,
     pub span: Span,
+    code: &'static str,
+}
+
+impl ParseError {
+    #[must_use]
+    pub fn new(message: impl Into<String>, span: Span) -> Self {
+        Self::coded("FSL-PARSE", message, span)
+    }
+
+    #[must_use]
+    pub fn coded(code: &'static str, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            message: message.into(),
+            span,
+            code,
+        }
+    }
+
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl From<crate::LexError> for ParseError {
+    fn from(error: crate::LexError) -> Self {
+        Self::new(error.message, error.span)
+    }
 }
 
 impl fmt::Display for ParseError {
@@ -48,10 +76,7 @@ impl std::error::Error for ParseError {}
 /// Returns [`ParseError`] when lexical analysis fails or the token sequence is
 /// not accepted by the FSL expression grammar.
 pub fn parse_expr(source: &str) -> Result<Expr, ParseError> {
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
+    let tokens = lex(source).map_err(ParseError::from)?;
     let mut parser = Parser { tokens, cursor: 0 };
     let expr = parser.expression(0)?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
@@ -67,10 +92,7 @@ pub fn parse_expr(source: &str) -> Result<Expr, ParseError> {
 /// Returns [`ParseError`] when the source is not a syntactically valid kernel
 /// spec. Other top-level dialects are rejected by this phase-0 entrypoint.
 pub fn parse_surface_spec(source: &str) -> Result<SurfaceSpec, ParseError> {
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
+    let tokens = lex(source).map_err(ParseError::from)?;
     let mut parser = Parser { tokens, cursor: 0 };
     let spec = parser.surface_spec()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
@@ -86,20 +108,14 @@ pub fn parse_surface_spec(source: &str) -> Result<SurfaceSpec, ParseError> {
 /// Returns [`ParseError`] for invalid syntax or a top-level dialect that has
 /// not yet reached the Phase-0 parser gate.
 pub fn parse_surface_document(source: &str) -> Result<SurfaceDocument, ParseError> {
-    if source.trim_start().starts_with("dbsystem") {
-        return crate::parse_db_system(source).map(SurfaceDocument::Db);
-    }
-    if source.trim_start().starts_with("domain ") {
-        return crate::parse_domain(source).map(SurfaceDocument::Domain);
-    }
-    if source.trim_start().starts_with("ai_component ") {
-        return crate::parse_ai_component(source).map(SurfaceDocument::AiComponent);
-    }
-    let tokens = lex(source).map_err(|error| ParseError {
-        message: error.message,
-        span: error.span,
-    })?;
-    let mut parser = Parser { tokens, cursor: 0 };
+    crate::parse_document(crate::SourceFile::new(source)).map(|parsed| parsed.surface)
+}
+
+pub(crate) fn parse_shared_tokens(
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceDocument, ParseError> {
+    let mut parser = Parser { tokens, cursor };
     let document = if parser.peek_ident("spec") {
         SurfaceDocument::Spec(parser.surface_spec()?)
     } else if parser.peek_ident("refinement") {
@@ -757,10 +773,10 @@ impl Parser {
             TokenKind::Ident(kind) if kind == "goal" => {
                 Ok(GovernanceArtifactRef::Goal(self.req_id()?, token.span))
             }
-            _ => Err(ParseError {
-                message: "expected policy or goal reference".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new(
+                "expected policy or goal reference",
+                token.span,
+            )),
         }
     }
 
@@ -939,10 +955,7 @@ impl Parser {
             let id = self.req_id()?;
             let token = self.bump().clone();
             let TokenKind::String(text) = token.kind else {
-                return Err(ParseError {
-                    message: "expected string literal".to_owned(),
-                    span: token.span,
-                });
+                return Err(ParseError::new("expected string literal", token.span));
             };
             Some(ProcessCover {
                 id,
@@ -1781,10 +1794,7 @@ impl Parser {
                     token.span,
                 ));
             } else {
-                return Err(ParseError {
-                    message: "expected instances or values".to_owned(),
-                    span: token.span,
-                });
+                return Err(ParseError::new("expected instances or values", token.span));
             }
             self.eat_symbol(";");
         }
@@ -2010,10 +2020,7 @@ impl Parser {
         if let TokenKind::Ident(value) = token.kind {
             Ok(value)
         } else {
-            Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            })
+            Err(ParseError::new("expected identifier", token.span))
         }
     }
 
@@ -2026,10 +2033,7 @@ impl Parser {
         if let TokenKind::String(value) = token.kind {
             Ok((value, token.span))
         } else {
-            Err(ParseError {
-                message: "expected string literal".to_owned(),
-                span: token.span,
-            })
+            Err(ParseError::new("expected string literal", token.span))
         }
     }
 
@@ -2039,10 +2043,10 @@ impl Parser {
             TokenKind::Ident(value) => value,
             TokenKind::Int(value) => value.to_string(),
             _ => {
-                return Err(ParseError {
-                    message: "expected requirement identifier".to_owned(),
-                    span: token.span,
-                });
+                return Err(ParseError::new(
+                    "expected requirement identifier",
+                    token.span,
+                ));
             }
         };
         while self.peek_symbol("-") {
@@ -2068,10 +2072,7 @@ impl Parser {
     }
 
     fn error(&self, message: &str) -> ParseError {
-        ParseError {
-            message: message.to_owned(),
-            span: self.peek().span,
-        }
+        ParseError::new(message, self.peek().span)
     }
 }
 

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -599,6 +599,12 @@ pub struct SurfaceCompose {
     pub items: Vec<ComposeItem>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SurfaceAgent {
+    pub name: String,
+    pub span: Span,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SurfaceDocument {
     Spec(SurfaceSpec),
@@ -610,6 +616,7 @@ pub enum SurfaceDocument {
     Db(DbSystem),
     Domain(DomainSpec),
     AiComponent(AiComponent),
+    Agent(SurfaceAgent),
 }
 
 impl MetaTag {
@@ -1709,6 +1716,9 @@ impl SurfaceDocument {
             Self::Db(system) => system.python_ast(),
             Self::Domain(domain) => domain.python_ast(),
             Self::AiComponent(component) => component.python_ast(),
+            Self::Agent(agent) => json!({
+                "$type": "Agent", "name": agent.name, "loc": agent.span.python_loc(),
+            }),
         }
     }
 }

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -390,11 +390,10 @@ impl SyntaxExpr {
                 right: Box::new(right.into_kernel()?),
             },
             SyntaxExprKind::Membership { .. } => {
-                return Err(ParseError {
-                    message: "finite membership is domain syntax and requires domain lowering"
-                        .to_owned(),
+                return Err(ParseError::new(
+                    "finite membership is domain syntax and requires domain lowering",
                     span,
-                });
+                ));
             }
             SyntaxExprKind::Neg(value) => Expr::Neg(Box::new(value.into_kernel()?)),
             SyntaxExprKind::Not(value) => Expr::Not(Box::new(value.into_kernel()?)),
@@ -894,10 +893,7 @@ impl SyntaxParser<'_> {
                     span: join(token.span, self.previous_span()),
                 })
             }
-            _ => Err(ParseError {
-                message: "expected expression".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected expression", token.span)),
         }
     }
 
@@ -1245,10 +1241,7 @@ impl SyntaxParser<'_> {
                 text,
                 span: token.span,
             }),
-            _ => Err(ParseError {
-                message: "expected identifier".to_owned(),
-                span: token.span,
-            }),
+            _ => Err(ParseError::new("expected identifier", token.span)),
         }
     }
 
@@ -1272,19 +1265,13 @@ impl SyntaxParser<'_> {
         if self.at_boundary() {
             self.boundary_error(message)
         } else {
-            ParseError {
-                message: message.to_owned(),
-                span: self.peek().span,
-            }
+            ParseError::new(message, self.peek().span)
         }
     }
 
     fn boundary_error(&self, message: &str) -> ParseError {
         let end = self.previous_span().end;
-        ParseError {
-            message: message.to_owned(),
-            span: Span { start: end, end },
-        }
+        ParseError::new(message, Span { start: end, end })
     }
 }
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3199,19 +3199,6 @@ fn format_fsl_value(model: &KernelModel, value: &FslValue, ty: &TypeRef) -> Stri
 
 fn run_check(path: &Path) -> (Value, i32) {
     if let Ok(source) = std::fs::read_to_string(path)
-        && source.trim_start().starts_with("agent ")
-    {
-        let name = declaration_name(source.trim_start(), "agent ").unwrap_or_default();
-        let mut output = envelope();
-        output.insert("result".to_owned(), json!("ok"));
-        output.insert("spec".to_owned(), json!(name));
-        output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
-        output.insert("warnings".to_owned(), json!([]));
-        output.insert("ai_analysis_result".to_owned(), json!("agent_analyzed"));
-        output.insert("agent_analysis_result".to_owned(), json!("agent_analyzed"));
-        return (Value::Object(output), 0);
-    }
-    if let Ok(source) = std::fs::read_to_string(path)
         && is_ai_project(&source)
     {
         let mut output = envelope();
@@ -3232,10 +3219,24 @@ fn run_check(path: &Path) -> (Value, i32) {
         );
         return (Value::Object(output), 0);
     }
-    if let Ok(source) = std::fs::read_to_string(path)
-        && let Err(error) = fsl_syntax::parse_surface_document(&source)
-    {
-        return (error_output("parse", &error.to_string()), 2);
+    if let Ok(source) = std::fs::read_to_string(path) {
+        match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
+            Ok(fsl_syntax::ParsedDocument {
+                surface: fsl_syntax::SurfaceDocument::Agent(agent),
+                ..
+            }) => {
+                let mut output = envelope();
+                output.insert("result".to_owned(), json!("ok"));
+                output.insert("spec".to_owned(), json!(agent.name));
+                output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
+                output.insert("warnings".to_owned(), json!([]));
+                output.insert("ai_analysis_result".to_owned(), json!("agent_analyzed"));
+                output.insert("agent_analysis_result".to_owned(), json!("agent_analyzed"));
+                return (Value::Object(output), 0);
+            }
+            Ok(_) => {}
+            Err(error) => return (surface_parse_error_output(&error), 2),
+        }
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -3369,21 +3370,13 @@ fn run_conformance(
 }
 
 fn source_dialect(source: &str) -> &str {
-    let first = source
-        .lines()
-        .map(str::trim_start)
-        .find(|line| !line.is_empty() && !line.starts_with("//"))
-        .and_then(|line| line.split_whitespace().next());
-    match first {
-        Some("spec") => "kernel",
-        Some("requirements") => "requirements",
-        Some("business") => "business",
-        Some("domain") => "domain",
-        Some("database" | "db") => "db",
-        Some("governance") => "governance",
-        Some("component") => "ai-component",
-        Some(other) => other,
-        None => "unknown",
+    match fsl_syntax::dialect_keyword(source) {
+        Ok("spec") => "kernel",
+        Ok("dbsystem") => "db",
+        Ok("ai_component") => "ai-component",
+        Ok("agent") => "ai-agent",
+        Ok(keyword) => keyword,
+        Err(_) => "unknown",
     }
 }
 
@@ -4131,11 +4124,26 @@ struct AiProjectSummary {
     raw_blocks: Vec<String>,
 }
 fn is_ai_project(source: &str) -> bool {
+    const PROJECT_BLOCKS: &[&str] = &[
+        "ai_action",
+        "ai_component",
+        "ai_contract",
+        "ai_migration",
+        "authority",
+        "dataset",
+        "evaluator",
+        "failure_mode",
+        "observed_property",
+        "retriever",
+        "statistical_property",
+        "trust_boundary",
+    ];
     source.lines().any(|line| {
         line.trim_start().starts_with("statistical_property ")
             || line.trim_start().starts_with("ai_migration ")
             || line.trim_start().starts_with("observed_property ")
-    })
+    }) && fsl_syntax::declaration_keyword(source)
+        .is_ok_and(|keyword| PROJECT_BLOCKS.contains(&keyword.as_str()))
 }
 fn declaration_name(line: &str, prefix: &str) -> Option<String> {
     line.trim()
@@ -7206,6 +7214,7 @@ fn surface_document_name(document: &fsl_syntax::SurfaceDocument) -> Option<&str>
         fsl_syntax::SurfaceDocument::Business(document) => Some(&document.name),
         fsl_syntax::SurfaceDocument::Requirements(document) => Some(&document.name),
         fsl_syntax::SurfaceDocument::Compose(document) => Some(&document.name),
+        fsl_syntax::SurfaceDocument::Agent(document) => Some(&document.name),
         _ => None,
     }
 }
@@ -12708,10 +12717,23 @@ fn run_verify(
     explicit_budget: usize,
     k_ind: usize,
 ) -> (Value, i32) {
-    if let Ok(source) = std::fs::read_to_string(path)
-        && let Err(error) = fsl_syntax::parse_surface_document(&source)
-    {
-        return (error_output("parse", &error.to_string()), 2);
+    if let Ok(source) = std::fs::read_to_string(path) {
+        match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
+            Err(error) => return (surface_parse_error_output(&error), 2),
+            Ok(fsl_syntax::ParsedDocument {
+                surface: fsl_syntax::SurfaceDocument::Agent(_),
+                ..
+            }) => {
+                return (
+                    error_output(
+                        "parse",
+                        "agent documents cannot be verified as Kernel specs",
+                    ),
+                    2,
+                );
+            }
+            Ok(_) => {}
+        }
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -13374,6 +13396,14 @@ fn error_output(kind: &str, message: &str) -> Value {
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message));
     Value::Object(output)
+}
+
+fn surface_parse_error_output(error: &fsl_syntax::ParseError) -> Value {
+    let mut output = error_output("parse", &error.to_string());
+    let object = output.as_object_mut().expect("error envelope");
+    object.insert("diagnostic_code".to_owned(), json!(error.code()));
+    object.insert("loc".to_owned(), error.span.python_loc());
+    output
 }
 
 fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -8090,7 +8090,12 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "parse",
-          "message": "unexpected character '&' at 6:47"
+          "message": "unexpected character '&' at 6:47",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 47
+          }
         }
       },
       "verify": {
@@ -8170,7 +8175,12 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "parse",
-          "message": "expected expression at 6:42"
+          "message": "expected expression at 6:42",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 42
+          }
         }
       },
       "verify": {
@@ -8190,7 +8200,12 @@
           "fsl": "1.0",
           "result": "error",
           "kind": "parse",
-          "message": "expected expression at 6:44"
+          "message": "expected expression at 6:44",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 44
+          }
         }
       },
       "verify": {

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -5,6 +5,23 @@ of rules as of v2.x.
 
 ## 1. Top-level structure
 
+The native parser selects every dialect from one shared lexer/registry. A leading
+UTF-8 BOM, whitespace, and `//` comments are trivia. Typed document annotations
+may precede the dialect keyword and attach to the document rather than affecting
+dispatch:
+
+```fsl
+@requirement("REQ-DOC", "document contract")
+@acme.review(owner.platform, 2, true)
+spec <Name> { ... }
+```
+
+Document annotations support `@requirement(id, text?)`, `@undecided(reason)`,
+`@kind(id, text?)`, and multi-segment custom namespaces. Annotation argument
+keywords are never dialect keywords. Annotation syntax on declarations inside a
+document remains outside this subset. Empty/unknown documents use the stable
+`FSL-DIALECT-EMPTY` / `FSL-DIALECT-UNKNOWN` diagnostics.
+
 ```fsl
 spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadata badge (explain/html); never verified
   const <NAME> = <const expr>             // integer constant (expressions allowed: CAP - 1, etc.)
@@ -1246,8 +1263,10 @@ annotation carrier. An outer requirement can therefore coexist with an inner
 `undecided` marker. Explicit `covers` and requirement-block annotations retain
 their own spans; `undecided` is reserved and cannot be an explicit requirement
 ID. Multiple-relation JSON outputs use `requirements` and preserve singular
-fields as lexical compatibility projections. `@...` parser syntax is still separate. See
-`docs/DESIGN-undecided.md` and `docs/DESIGN-annotations.md`. This syntax and its
+fields as lexical compatibility projections. Document-level `@...` syntax is
+available as described in §1; annotation placement on declarations inside the
+document remains separate. See `docs/DESIGN-undecided.md`,
+`docs/DESIGN-annotations.md`, and `docs/DESIGN-dialect-dispatch.md`. This syntax and its
 report surfaces are native Rust CLI features; the frozen Python reference is
 not extended.
 

--- a/src/fslc/ai_parser.py
+++ b/src/fslc/ai_parser.py
@@ -489,16 +489,18 @@ AI_PARSER = Lark(
 
 
 def is_ai_component_source(src):
-    return src.lstrip().startswith("ai_component")
+    from .dialect_registry import dialect_keyword
+    return dialect_keyword(src) == "ai_component"
 
 
 def is_ai_agent_source(src):
-    return src.lstrip().startswith("agent")
+    from .dialect_registry import dialect_keyword
+    return dialect_keyword(src) == "agent"
 
 
 def is_ai_source(src):
-    stripped = src.lstrip()
-    return stripped.startswith("ai_component") or stripped.startswith("agent")
+    from .dialect_registry import dialect_keyword
+    return dialect_keyword(src) in {"ai_component", "agent"}
 
 
 def parse_ai_component(src):

--- a/src/fslc/ai_project.py
+++ b/src/fslc/ai_project.py
@@ -188,13 +188,16 @@ class _Block:
 
 
 def is_ai_project_source(src: str) -> bool:
-    stripped = src.lstrip()
+    from .dialect_registry import inspect_source
+
+    parser_source = inspect_source(src).source
+    stripped = parser_source.lstrip()
     if not stripped:
         return False
     first = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\b", stripped)
     if not first or first.group(1) not in PROJECT_BLOCKS:
         return False
-    blocks = _top_blocks(src)
+    blocks = _top_blocks(parser_source)
     return len(blocks) != 1 or blocks[0].kind != "ai_component"
 
 

--- a/src/fslc/ai_stochastic.py
+++ b/src/fslc/ai_stochastic.py
@@ -187,7 +187,9 @@ def drift_ai_project(
 
 def ai_compat_profile_from_file(path, environment: Optional[str] = None) -> dict:
     src = Path(path).read_text(encoding="utf-8")
-    if not is_ai_project_source(src) and src.lstrip().startswith("ai_component"):
+    from .dialect_registry import dialect_keyword
+
+    if not is_ai_project_source(src) and dialect_keyword(src) == "ai_component":
         components = [parse_ai_component(src)]
     else:
         components = list(parse_ai_project(src, name=Path(path).stem).components)

--- a/src/fslc/db_parser.py
+++ b/src/fslc/db_parser.py
@@ -399,7 +399,8 @@ DB_PARSER = Lark(
 
 
 def is_dbsystem_source(src):
-    return src.lstrip().startswith("dbsystem")
+    from .dialect_registry import dialect_keyword
+    return dialect_keyword(src) == "dbsystem"
 
 
 def parse_dbsystem(src):

--- a/src/fslc/dialect_registry.py
+++ b/src/fslc/dialect_registry.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Token-aware dialect selection shared by the retained Python/LSP surfaces."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+DIALECT_KEYWORDS = (
+    "spec",
+    "refinement",
+    "compose",
+    "business",
+    "governance",
+    "requirements",
+    "domain",
+    "dbsystem",
+    "ai_component",
+    "agent",
+)
+
+if len(DIALECT_KEYWORDS) != len(set(DIALECT_KEYWORDS)):
+    raise RuntimeError("duplicate FSL dialect registry keyword")
+
+
+@dataclass(frozen=True)
+class DialectDispatch:
+    keyword: Optional[str]
+    source: str
+
+
+def inspect_source(source: str) -> DialectDispatch:
+    """Return the first declaration keyword and a position-preserving parser view.
+
+    The native Rust lexer is authoritative. This retained adapter mirrors its
+    BOM/comment/top-level-annotation significance rules so the Python LSP picks
+    the same frontend without copying raw ``lstrip().startswith`` branches.
+    """
+
+    chars = list(source)
+    cursor = 0
+    if chars[:1] == ["\ufeff"]:
+        chars[0] = " "
+        cursor = 1
+    cursor = _skip_trivia(source, cursor)
+    requirements: dict[str, Optional[str]] = {}
+    while cursor < len(source) and source[cursor] == "@":
+        scanned = _annotation(source, cursor)
+        if scanned is None:
+            return DialectDispatch(keyword=None, source="".join(chars))
+        end, path, arguments = scanned
+        if path == "requirement":
+            requirement_id = arguments[0][1]
+            text = arguments[1][1] if len(arguments) == 2 else None
+            if requirement_id.lower() == "undecided" or (
+                requirement_id in requirements and requirements[requirement_id] != text
+            ):
+                return DialectDispatch(keyword=None, source="".join(chars))
+            requirements[requirement_id] = text
+        for index in range(cursor, end):
+            if chars[index] not in "\r\n":
+                chars[index] = " "
+        cursor = _skip_trivia(source, end)
+    start = cursor
+    while cursor < len(source) and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor += 1
+    keyword = source[start:cursor] or None
+    if keyword not in DIALECT_KEYWORDS:
+        keyword = None
+    return DialectDispatch(keyword=keyword, source="".join(chars))
+
+
+def dialect_keyword(source: str) -> Optional[str]:
+    return inspect_source(source).keyword
+
+
+def _skip_trivia(source: str, cursor: int) -> int:
+    while True:
+        while cursor < len(source) and source[cursor].isspace():
+            cursor += 1
+        if source.startswith("//", cursor):
+            newline = source.find("\n", cursor + 2)
+            cursor = len(source) if newline < 0 else newline + 1
+            continue
+        return cursor
+
+
+def _ident_end(source: str, cursor: int) -> Optional[int]:
+    if cursor >= len(source) or not (
+        source[cursor].isascii()
+        and (source[cursor].isalpha() or source[cursor] == "_")
+    ):
+        return None
+    cursor += 1
+    while cursor < len(source) and source[cursor].isascii() and (
+        source[cursor].isalnum() or source[cursor] == "_"
+    ):
+        cursor += 1
+    return cursor
+
+
+def _symbol_path(source: str, cursor: int) -> Optional[tuple[int, str]]:
+    end = _ident_end(source, cursor)
+    if end is None:
+        return None
+    segments = [source[cursor:end]]
+    while True:
+        dot = _skip_trivia(source, end)
+        if dot >= len(source) or source[dot] != ".":
+            return end, ".".join(segments)
+        cursor = _skip_trivia(source, dot + 1)
+        end = _ident_end(source, cursor)
+        if end is None:
+            return None
+        segments.append(source[cursor:end])
+
+
+def _annotation_value(source: str, cursor: int) -> Optional[tuple[int, str, str]]:
+    if cursor >= len(source):
+        return None
+    if source[cursor] == '"':
+        end = source.find('"', cursor + 1)
+        if end < 0 or "\n" in source[cursor + 1 : end]:
+            return None
+        return end + 1, "string", source[cursor + 1 : end]
+    if source[cursor].isascii() and source[cursor].isdigit():
+        end = cursor + 1
+        while end < len(source) and source[end].isascii() and source[end].isdigit():
+            end += 1
+        text = source[cursor:end]
+        if int(text) > 9_223_372_036_854_775_807:
+            return None
+        return end, "integer", text
+    path = _symbol_path(source, cursor)
+    if path is None:
+        return None
+    end, text = path
+    if text.split(".", 1)[0] in ("true", "false"):
+        if "." in text:
+            return None
+        return end, "boolean", text
+    return end, "symbol", text
+
+
+def _annotation(
+    source: str, cursor: int
+) -> Optional[tuple[int, str, list[tuple[str, str]]]]:
+    cursor = _skip_trivia(source, cursor + 1)
+    parsed_path = _symbol_path(source, cursor)
+    if parsed_path is None:
+        return None
+    path_end, path = parsed_path
+    cursor = _skip_trivia(source, path_end)
+    if cursor >= len(source) or source[cursor] != "(":
+        return None
+    cursor = _skip_trivia(source, cursor + 1)
+    arguments: list[tuple[str, str]] = []
+    while cursor < len(source) and source[cursor] != ")":
+        value = _annotation_value(source, cursor)
+        if value is None:
+            return None
+        cursor, kind, text = value
+        arguments.append((kind, text))
+        cursor = _skip_trivia(source, cursor)
+        if cursor < len(source) and source[cursor] == ")":
+            break
+        if cursor >= len(source) or source[cursor] != ",":
+            return None
+        cursor = _skip_trivia(source, cursor + 1)
+        if cursor >= len(source) or source[cursor] == ")":
+            return None
+    if cursor >= len(source) or source[cursor] != ")":
+        return None
+    if path in ("requirement", "kind"):
+        if len(arguments) not in (1, 2) or any(kind != "string" for kind, _ in arguments):
+            return None
+    elif path == "undecided":
+        if len(arguments) != 1 or arguments[0][0] != "string":
+            return None
+    if path in ("requirement", "kind", "undecided") and not arguments[0][1].strip():
+        return None
+    return cursor + 1, path, arguments

--- a/src/fslc/domain_parser.py
+++ b/src/fslc/domain_parser.py
@@ -177,8 +177,8 @@ def _clean(text):
 
 
 def is_domain_source(src: str) -> bool:
-    stripped = src.lstrip()
-    return stripped.startswith("domain ")
+    from .dialect_registry import dialect_keyword
+    return dialect_keyword(src) == "domain"
 
 
 @v_args(inline=True, meta=True)

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -9,9 +9,8 @@ contextual, so declarations and references are classified by parse-tree
 position, not by spelling. The `ai_component`/`agent`/`dbsystem`/`domain`
 frontend dialects have their own Lark grammars (``fslc.ai_parser``/
 ``fslc.db_parser``/``fslc.domain_parser``) that never reach the kernel
-grammar at all -- ``build_index`` picks the matching raw parser via
-``is_ai_source``/``is_dbsystem_source``/``is_domain_source`` before falling
-back to the kernel ``PARSER``, so those files no longer fail to parse here
+grammar at all -- ``build_index`` picks the matching raw parser through the
+shared dialect registry before falling back to the kernel ``PARSER``, so those files no longer fail to parse here
 just because indexing hard-codes the kernel grammar. fsl-ai *project* files
 (``is_ai_project_source``) are a further special case: they are not
 Lark-parsed at all (``ai_project.py`` scans top-level blocks with regexes),
@@ -33,10 +32,11 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 from lark import Tree, Token
 
 from fslc.grammar import PARSER
-from fslc.ai_parser import AI_PARSER, is_ai_source
+from fslc.ai_parser import AI_PARSER
 from fslc.ai_project import _top_blocks, is_ai_project_source
-from fslc.db_parser import DB_PARSER, is_dbsystem_source
-from fslc.domain_parser import PARSER as DOMAIN_PARSER, is_domain_source
+from fslc.db_parser import DB_PARSER
+from fslc.domain_parser import PARSER as DOMAIN_PARSER
+from fslc.dialect_registry import inspect_source
 
 
 VALUE_ROLES = {
@@ -569,11 +569,12 @@ class DocumentIndex:
 
 
 def _parser_for_source(source: str):
-    if is_dbsystem_source(source):
+    keyword = inspect_source(source).keyword
+    if keyword == "dbsystem":
         return DB_PARSER
-    if is_domain_source(source):
+    if keyword == "domain":
         return DOMAIN_PARSER
-    if is_ai_source(source):
+    if keyword in {"ai_component", "agent"}:
         return AI_PARSER
     return PARSER
 
@@ -616,7 +617,8 @@ def build_index(source: str, path: Optional[str] = None) -> DocumentIndex:
 
     if is_ai_project_source(source):
         return _build_ai_project_index(source, path)
-    tree = _parser_for_source(source).parse(source)
+    dispatch = inspect_source(source)
+    tree = _parser_for_source(source).parse(dispatch.source)
     builder = _IndexBuilder(source, path)
     builder.visit(tree, None, None)
     return DocumentIndex(

--- a/src/fslc/parser.py
+++ b/src/fslc/parser.py
@@ -23,12 +23,13 @@ from .dialects import (
     expand_spec_domains,
 )
 from .db_expand import expand_dbsystem
-from .db_parser import is_dbsystem_source, parse_dbsystem
+from .db_parser import parse_dbsystem
 from .ai_expand import expand_ai_component
-from .ai_parser import is_ai_component_source, parse_ai_component
+from .ai_parser import parse_ai_component
 from .domain_expand import expand_domain
-from .domain_parser import is_domain_source, parse_domain
+from .domain_parser import parse_domain
 from .predicates import expand_named_predicates
+from .dialect_registry import inspect_source
 
 
 _EXPR_PARSER = None
@@ -60,11 +61,8 @@ def parse_surface_src(src):
     db/AI/domain grammars have their own typed surface IR and are intentionally
     rejected here; :func:`parse_src` remains the public all-frontend entrypoint.
     """
-    if (
-        is_dbsystem_source(src)
-        or is_ai_component_source(src)
-        or is_domain_source(src)
-    ):
+    dispatch = inspect_source(src)
+    if dispatch.keyword in {"dbsystem", "ai_component", "agent", "domain"}:
         from .model import FslError
 
         raise FslError(
@@ -72,7 +70,7 @@ def parse_surface_src(src):
             kind="semantics",
         )
     try:
-        tree = PARSER.parse(src)
+        tree = PARSER.parse(dispatch.source)
     except UnexpectedInput as exc:
         exc.source = src
         raise
@@ -86,7 +84,9 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
     comes from ``fslc verify --instances``/``--values`` and replaces the matching
     ``verify { ... }`` bounds before dialect desugaring runs.
     """
-    if is_dbsystem_source(src):
+    dispatch = inspect_source(src)
+    parser_source = dispatch.source
+    if dispatch.keyword == "dbsystem":
         has_bounds_overrides = bool(
             bounds_overrides
             and (bounds_overrides.get("instances") or bounds_overrides.get("values"))
@@ -97,11 +97,11 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
                 "--instances/--values do not apply to dbsystem; set finite schema windows in the dbsystem file",
                 kind="semantics",
             )
-        system = parse_dbsystem(src)
+        system = parse_dbsystem(parser_source)
         expanded = expand_dbsystem(system)
         return expanded.ast, expanded.display_names
 
-    if is_ai_component_source(src):
+    if dispatch.keyword == "ai_component":
         has_bounds_overrides = bool(
             bounds_overrides
             and (bounds_overrides.get("instances") or bounds_overrides.get("values"))
@@ -112,11 +112,11 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
                 "--instances/--values do not apply to ai_component; declare finite tool authority in the ai_component file",
                 kind="semantics",
             )
-        component = parse_ai_component(src)
+        component = parse_ai_component(parser_source)
         expanded = expand_ai_component(component)
         return expanded.ast, expanded.display_names
 
-    if is_domain_source(src):
+    if dispatch.keyword == "domain":
         has_bounds_overrides = bool(
             bounds_overrides
             and (bounds_overrides.get("instances") or bounds_overrides.get("values"))
@@ -127,11 +127,11 @@ def parse_src(src, base_dir=None, bounds_overrides=None):
                 "--instances/--values do not apply to domain; declare finite ID/value ranges in the domain file",
                 kind="semantics",
             )
-        domain = parse_domain(src)
+        domain = parse_domain(parser_source)
         expanded = expand_domain(domain)
         return expanded.ast, expanded.display_names
 
-    ast = parse_surface_src(src)
+    ast = parse_surface_src(parser_source)
     ast = expand_named_predicates(ast)
     if bounds_overrides:
         ast = apply_verify_bounds_overrides(ast, bounds_overrides)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,6 @@
+# Workflow lessons
+
+- When the user makes the native Rust implementation the completion authority,
+  do not block delivery on a stalled full Python suite. Stop that suite when
+  directed, retain only focused compatibility evidence, and finish the Rust
+  workspace gates.

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -30,15 +30,36 @@ from pathlib import Path
 from lark import Token, Tree
 
 from fslc.ai_parser import is_ai_agent_source, is_ai_source
-from fslc.ai_project import is_ai_project_source
+from fslc.ai_project import PROJECT_BLOCKS, is_ai_project_source
 from fslc.cli import _build_arg_parser
 from fslc.db_parser import is_dbsystem_source
+from fslc.dialect_registry import DIALECT_KEYWORDS
 from fslc.domain_parser import is_domain_source
 from fslc.grammar import GRAMMAR
 from fslc.lsp.index import DOMAIN_PARSER, _IndexBuilder, _parser_for_source, build_index
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
+
+
+def test_retained_python_dialect_registry_matches_native_authority():
+    source = (ROOT / "rust" / "fsl-syntax" / "src" / "dispatch.rs").read_text()
+    block = re.search(r"frontends!\s*\{(?P<body>.*?)\n\}", source, re.DOTALL)
+    assert block is not None
+    native = tuple(re.findall(r'"([a-z_]+)"\s*=>', block.group("body")))
+    assert native == DIALECT_KEYWORDS
+
+
+def test_native_ai_project_block_gate_matches_retained_parser():
+    source = (ROOT / "rust" / "fslc" / "src" / "main.rs").read_text()
+    block = re.search(
+        r"const PROJECT_BLOCKS: &\[&str\] = &\[(?P<body>.*?)\n\s*\];",
+        source,
+        re.DOTALL,
+    )
+    assert block is not None
+    native = set(re.findall(r'"([a-z_]+)"', block.group("body")))
+    assert native == PROJECT_BLOCKS
 
 # ---------------------------------------------------------------------------
 # 1. LSP index coverage

--- a/tests/test_dialect_conformance.py
+++ b/tests/test_dialect_conformance.py
@@ -18,7 +18,6 @@ No ``pytest.skip`` anywhere in this file: every non-conformance file is a
 """
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -28,6 +27,7 @@ import pytest
 from fslc.ai_parser import is_ai_agent_source, is_ai_component_source
 from fslc.ai_project import is_ai_project_source
 from fslc.cli import run_verify
+from fslc.dialect_registry import dialect_keyword
 from fslc.parser import parse_src
 from fslc.runtime import Monitor
 
@@ -44,7 +44,6 @@ INJECTED = "INJECTED"
 CONFORMANCE = "CONFORMANCE"
 UNKNOWN = "UNKNOWN"
 
-_CONSTRUCT_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\b")
 _KEYWORD_TO_DIALECT = {d.construct: key for key, d in DIALECTS.items()}
 
 
@@ -74,16 +73,6 @@ def _injected(front: list[str]) -> bool:
     return any(ln.startswith("// inject:") or ln.startswith("// expect-detector:") for ln in front)
 
 
-def _top_construct(src: str) -> Optional[str]:
-    for line in src.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("//"):
-            continue
-        m = _CONSTRUCT_RE.match(stripped)
-        return m.group(1) if m else None
-    return None
-
-
 def classify(path: Path) -> Classified:
     src = path.read_text(encoding="utf-8")
     rel = path.relative_to(ROOT).as_posix()
@@ -95,7 +84,7 @@ def classify(path: Path) -> Classified:
     if is_ai_agent_source(src):
         return Classified(path, EXCLUDED, reason="ai-agent")
 
-    construct = _top_construct(src)
+    construct = dialect_keyword(src)
     if construct == "refinement":
         return Classified(path, REFINEMENT)
 
@@ -107,9 +96,7 @@ def classify(path: Path) -> Classified:
         return Classified(path, INJECTED, dialect=dialect)
 
     dialect = _KEYWORD_TO_DIALECT.get(construct)
-    # is_ai_component_source uses a bare startswith("ai_component") check, which
-    # is exactly _KEYWORD_TO_DIALECT's "ai_component" -> "ai" lookup too, kept
-    # explicit here so a change to either check can't silently diverge.
+    # Keep the compatibility predicate coupled to the shared registry result.
     if construct == "ai_component":
         assert is_ai_component_source(src), path
     if dialect is None:

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -788,3 +788,41 @@ def test_build_index_handles_dbsystem_dialect_without_crashing():
     column_loc = index.definition_at(column_ref.range.start.line, column_ref.range.start.character)
     assert column_loc is not None
     assert column_loc.range == column_decl.selection_range
+
+
+def test_build_index_uses_registry_after_bom_comments_and_top_level_annotations():
+    domain_source = "\ufeff// leading comment\n@acme.route(spec, requirements)\ndomain Orders {}"
+    agent_source = "// leading comment\n@acme.owner(\"platform\")\nagent Parent {}"
+
+    domain = build_index(domain_source, "orders.fsl")
+    agent = build_index(agent_source, "parent.fsl")
+
+    assert _symbol(domain, "Orders", "domain").selection_range.start.line == 2
+    assert _symbol(agent, "Parent", "agent").selection_range.start.line == 2
+
+
+def test_registry_handles_annotation_trivia_and_rejects_invalid_shapes():
+    from fslc.dialect_registry import inspect_source
+
+    source = '@ // comment\n acme . owner (\"platform\", // argument\n team . ops)\nspec Routed {}'
+    index = build_index(source, "routed.fsl")
+    assert _symbol(index, "Routed", "spec").selection_range.start.line == 3
+
+    for invalid in (
+        "@acme.owner spec Routed {}",
+        "@é.owner() spec Routed {}",
+        "@requirement() spec Routed {}",
+        '@requirement("undecided") spec Routed {}',
+        '@requirement("REQ-1", "first")\n@requirement("REQ-1", "second")\nspec Routed {}',
+        "@acme.limit(9223372036854775808) spec Routed {}",
+        "@acme.owner(team,) spec Routed {}",
+        "@acme.owner(true.team) spec Routed {}",
+    ):
+        assert inspect_source(invalid).keyword is None
+
+    for valid in (
+        '@requirement("REQ-1", "") spec Routed {}',
+        '@kind("safety", "") spec Routed {}',
+        "@acme.limit(9223372036854775807) spec Routed {}",
+    ):
+        assert inspect_source(valid).keyword == "spec"

--- a/tests/test_rust_cli_semantics.py
+++ b/tests/test_rust_cli_semantics.py
@@ -516,6 +516,71 @@ def test_rust_generic_check_recognizes_ai_agent_and_project():
     )
 
 
+def test_rust_check_dispatches_after_trivia_and_reports_stable_dialect_errors(tmp_path):
+    agent_path = tmp_path / "agent.fsl"
+    agent_path.write_text(
+        "\ufeff// leading comment\n@acme.owner(\"platform\")\nagent Routed {}",
+        encoding="utf-8",
+    )
+    empty_path = tmp_path / "empty.fsl"
+    empty_path.write_text("// comment only\n", encoding="utf-8")
+    unknown_path = tmp_path / "unknown.fsl"
+    unknown_path.write_text("mystery Unknown {}", encoding="utf-8")
+    disguised_project_path = tmp_path / "disguised-project.fsl"
+    disguised_project_path.write_text(
+        "mystery Unknown {}\nstatistical_property Quality {}", encoding="utf-8"
+    )
+    invalid_agent_path = tmp_path / "invalid-agent.fsl"
+    invalid_agent_path.write_text("agent Routed {} spec Hidden {}", encoding="utf-8")
+    evidence_project_path = tmp_path / "evidence-project.fsl"
+    evidence_project_path.write_text(
+        'dataset Eval { source "eval.jsonl" }\nstatistical_property Quality {}',
+        encoding="utf-8",
+    )
+    opaque_project_path = tmp_path / "opaque-project.fsl"
+    opaque_project_path.write_text(
+        "ai_action Draft { arbitrary & opaque ? text }\nstatistical_property Quality {}",
+        encoding="utf-8",
+    )
+
+    agent_status, agent = _run_rust("check", str(agent_path))
+    empty_status, empty = _run_rust("check", str(empty_path))
+    unknown_status, unknown = _run_rust("check", str(unknown_path))
+    disguised_status, disguised = _run_rust("check", str(disguised_project_path))
+    invalid_agent_status, invalid_agent = _run_rust("check", str(invalid_agent_path))
+    evidence_status, evidence = _run_rust("check", str(evidence_project_path))
+    opaque_status, opaque = _run_rust("check", str(opaque_project_path))
+
+    assert (agent_status, agent["spec"], agent["dialect"]) == (
+        0,
+        "Routed",
+        "fsl-ai-agent.v0",
+    )
+    assert (empty_status, empty["diagnostic_code"], empty["loc"]) == (
+        2,
+        "FSL-DIALECT-EMPTY",
+        {"line": 2, "column": 1},
+    )
+    assert unknown_status == 2
+    assert unknown["diagnostic_code"] == "FSL-DIALECT-UNKNOWN"
+    assert unknown["loc"] == {"line": 1, "column": 1}
+    assert "spec, refinement, compose" in unknown["message"]
+    assert (disguised_status, disguised["diagnostic_code"]) == (
+        2,
+        "FSL-DIALECT-UNKNOWN",
+    )
+    assert invalid_agent_status == 2
+    assert invalid_agent["diagnostic_code"] == "FSL-PARSE"
+    assert (evidence_status, evidence["ai_analysis_result"]) == (
+        0,
+        "ai_project_analyzed",
+    )
+    assert (opaque_status, opaque["ai_analysis_result"]) == (
+        0,
+        "ai_project_analyzed",
+    )
+
+
 def test_rust_verify_preserves_parse_error_classification():
     for spec in (
         "examples/gallery/errors/parse_missing_expression.fsl",


### PR DESCRIPTION
## Summary

- add the canonical Rust `parse_document(SourceFile)` entrypoint with a single token-based frontend registry for all supported dialects
- preserve document annotations and span-carrying multi-segment `SymbolPath` values through kernel lowering, including scoped and compose-component paths
- replace raw-prefix CLI/LSP dispatch with stable empty/unknown diagnostics and coupled Rust/Python registry checks

## Contract changes

- empty, annotation-only, and unknown documents now return stable diagnostic codes and exact locations
- registered frontends consume the same token stream produced by the shared lexer
- generic `agent` checking validates its evidence envelope while leaving body analysis to the dedicated AI surface
- AI project evidence scanning is gated by the first significant known project block while preserving opaque evidence bodies

## Validation

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked --quiet`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `pytest tests/test_rust_cli_contract.py -q` (10 passed)
- focused LSP, dispatch parity, annotation propagation, and CLI diagnostic tests
- native `check`, BMC depth 8, and induction smoke tests on `specs/cart_v1.fsl`
- independent soundness, coupled-change, and final reviews: no findings

Closes #247
