### PR TITLE
feat(parser): add token-based dialect registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Native document parsing now lexes once and dispatches all ten supported
+  top-level dialects through one token registry. BOM/comments/whitespace and
+  typed top-level annotations are handled before dispatch; keyword-like
+  annotation arguments cannot select a frontend. Duplicate keys fail closed,
+  empty/unknown documents expose stable codes, spans, and supported keys,
+  recursive agents and AI projects no longer use raw-prefix CLI exceptions,
+  and the retained Python LSP mirrors the significant-token contract with
+  offset-preserving parity tests. `SymbolPath` now retains multi-segment
+  identifiers and its full span (issue #247).
 - Native Rust now carries ordered, typed `Requirement`, `Undecided`, `Kind`,
   and namespaced `Custom` annotations through a common target-keyed IR. Legacy
   declaration strings, spec badges, requirement blocks, process `covers`, and

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -41,8 +41,10 @@ property and the `leadsTo` property.
 
 ## Adapters and compatibility
 
-The current source grammar still has a single optional legacy string slot; `@...`
-syntax is a separate issue. Native lowering adapts all existing sources into the
+Declarations retain their optional legacy string slot. Issue #247 additionally
+allows typed `@...` metadata immediately before a top-level document declaration;
+`DESIGN-token-registry.md` supersedes the earlier parser-syntax non-goal only for
+that document boundary. Native lowering adapts all existing sources into the
 typed carrier:
 
 - declaration `"REQ-3: text"` becomes `Requirement`;
@@ -99,7 +101,7 @@ suppression, and exact declaration matching—remain unchanged.
 
 ## Non-goals
 
-- `@requirement`, `@kind`, or arbitrary `@namespace` parser syntax;
+- declaration-local `@...` syntax below the document boundary;
 - formatter or source migrator behavior;
 - macro execution or verifier semantics selected by an annotation;
 - publishing annotations by mutating Public Kernel v1/v2.

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -89,6 +89,14 @@ Every AST node retains line and column information. `kind: "parse"` and `loc`
 must match the Python result for the corpus; detailed parser messages and expected
 token lists may differ only where the parity allowlist says so.
 
+Issue #247 makes the native `fsl-syntax::parse_document` token registry the
+authority for document dispatch. Native CLI/library/tool/Worker entrypoints use
+that API (or its compatibility adapter) and specialized frontends borrow its one
+token stream. The retained Python LSP cannot link the Rust crate, so its parser
+selection is explicitly a compatibility adapter with the same ordered keys and
+significant-token rules; parity tests, not independent language authority, keep
+it aligned. See `DESIGN-token-registry.md`.
+
 Phase 0 adds a temporary Python AST JSON exporter and compares the Rust AST with
 the tuple AST for every corpus file. Dialect expansion remains a pure AST-to-AST
 stage before `build_spec`, matching the current requirements, business,

--- a/docs/DESIGN-token-registry.md
+++ b/docs/DESIGN-token-registry.md
@@ -1,0 +1,87 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Token-based document frontend registry
+
+Status: accepted. Implemented by issue #247.
+
+## Decision
+
+Every native document entrypoint constructs one `SourceFile`, lexes it once,
+and selects a frontend from the first significant declaration token. The
+ordered registry keys are:
+
+```text
+spec refinement compose business governance requirements domain dbsystem ai_component agent
+```
+
+Whitespace, `//` comments, and a UTF-8 BOM are lexer trivia. Before the
+declaration, the dispatcher consumes zero or more document annotations; tokens
+inside annotation arguments never participate in dialect selection. An empty
+document reports `FSL-PARSE-EMPTY-DOCUMENT`. An unknown first identifier reports
+`FSL-PARSE-UNSUPPORTED-DIALECT`, its exact token span, and the ordered supported
+key list. Registry construction rejects duplicate keys with
+`FSL-PARSE-DUPLICATE-DIALECT-KEY`.
+
+The selected frontend receives the original `SourceFile` and a borrow of the
+same token slice. Public dialect-specific parsers remain compatibility adapters:
+they may lex a standalone source once and then call the token frontend, but a
+registry dispatch never re-lexes. `ai_component` owns both standalone hard
+contracts and project evidence files; the latter is a semantic variant selected
+only after the registry has chosen that frontend. Recursive `agent` documents
+likewise use the registry rather than a CLI prefix exception.
+
+## Document annotations and paths
+
+This design supersedes only the `DESIGN-annotations.md` non-goal that excluded
+`@...` parser syntax. A document annotation is metadata attached to the selected
+top-level declaration:
+
+```fsl
+@requirement("REQ-247", "dispatch contract")
+@acme.review.owner(team.platform)
+spec RegistryDemo {}
+```
+
+The grammar is `@` plus a dotted symbol path and an optional parenthesized,
+comma-separated argument list. Arguments are strings, integers, Booleans, or
+symbol paths. `requirement`, `kind`, and `undecided` map to the existing typed
+annotation variants; other paths are `Custom`. They do not execute macros or
+change verifier semantics.
+
+`SymbolPath` is the shared loss-aware path primitive. It stores multiple
+`SyntaxIdent` segments and the complete source span; parsing, equality, display,
+and diagnostics operate on that structure. Legacy one-namespace APIs may use an
+explicit adapter, but are not the authoritative path representation.
+
+## Entrypoints and preprocessing
+
+Native CLI, library, tools, and Worker paths call `parse_document` directly or
+through the compatibility `parse_surface_document` adapter. Any future literate
+or Markdown extraction occurs before `SourceFile` construction; the extracted
+source and its source map then enter this pipeline, and dialect frontends do not
+perform extraction.
+
+The retained Python implementation is frozen except for its LSP surface and
+cannot link the Rust crate. Its LSP frontend selection is therefore a
+compatibility adapter: it mirrors the ordered native keys and significant-token
+rules, masks BOM/annotation prefixes without changing offsets, and is locked by
+parity tests. It is not language authority; disagreement is a failing
+compatibility test and is resolved in favor of the native registry contract.
+
+## Compatibility and evidence
+
+- Existing unannotated AST projections, Kernel v1/v2 JSON, and CLI success
+  envelopes are unchanged.
+- Document annotations enter the existing target-keyed annotation registry at
+  target `spec`; specialized frontends retain them in `ParsedDocument`.
+- Corpus tests cover all registered dialects. Focused tests cover BOM/comments,
+  annotations, keyword-like arguments, duplicate keys, exact diagnostics,
+  agent/project dispatch, and LSP offset preservation.
+
+## Non-goals
+
+- one giant grammar for all dialects;
+- removal of dialect-specific declaration parsers;
+- macro execution or annotation-selected verifier behavior;
+- redesign of Markdown/literate extraction;
+- changes to Public Kernel v1/v2 schemas.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -20,6 +20,24 @@ the implementation design of each feature can be reached from
 
 ## 1. Structure of a specification
 
+Every document begins with one registered declaration keyword: `spec`,
+`refinement`, `compose`, `business`, `governance`, `requirements`, `domain`,
+`dbsystem`, `ai_component`, or `agent`. Leading whitespace, `//` comments, and a
+UTF-8 BOM do not affect dispatch. Typed document metadata may precede the
+declaration:
+
+```fsl
+@requirement("REQ-247", "shared dispatch")
+@acme.review.owner(team.platform, 2, true)
+spec Example {}
+```
+
+Annotation names and symbol arguments are multi-segment paths. Arguments may be
+strings, integers, Booleans, or symbol paths. `requirement`, `kind`, and
+`undecided` use the built-in typed annotation variants; other paths are inert
+custom metadata. Annotation argument keywords are never dialect selectors. See
+`DESIGN-token-registry.md`.
+
 ```fsl
 spec <Name> ["<kind>: <intent>"] {   // optional spec-level tag → metadata badge (explain/html); never verified
   const <NAME> = <constant expr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@
 | [`DESIGN-underspecification.md`](DESIGN-underspecification.md) | bounded `divergent_choice` / `unconstrained_effect` AI-review findings and question-form output |
 | [`DESIGN-undecided.md`](DESIGN-undecided.md) | reserved `undecided:` declaration metadata, affected-requirement projection, ledger/HTML display, and acknowledged underspecification findings |
 | [`DESIGN-annotations.md`](DESIGN-annotations.md) | shared typed requirement/undecided/kind/custom annotation IR, validation, adapters, ordering, and compatibility boundaries |
+| [`DESIGN-token-registry.md`](DESIGN-token-registry.md) | shared-lexer document dispatch, frontend registry, stable empty/unknown diagnostics, document annotations, `SymbolPath`, and LSP compatibility |
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
 | [`DESIGN-domain.md`](DESIGN-domain.md) | fsl-domain (`domain`) Functional DDD / async effect dialect: aggregate ownership, command/event decide/evolve lowering, saga/process-manager actions, effect lifecycle state, findings, multi-target scaffolds, and runtime replay |
 | [`DESIGN-effect.md`](DESIGN-effect.md) | fsl-effect lifecycle semantics used by fsl-domain: correlation, retry, timeout, idempotency, and guarantee boundary |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -71,7 +71,21 @@
 </tr>
 </tbody>
 </table></div></details>
-<details id="1-structure-of-a-specification"><summary>1. Structure of a specification<span class="tree-blurb"> — The declaration / state / init / action shape of a spec.</span></summary><div class="tree-body"><pre><code class="language-fsl">spec &lt;Name&gt; [&quot;&lt;kind&gt;: &lt;intent&gt;&quot;] {   // optional spec-level tag → metadata badge (explain/html); never verified
+<details id="1-structure-of-a-specification"><summary>1. Structure of a specification<span class="tree-blurb"> — The declaration / state / init / action shape of a spec.</span></summary><div class="tree-body"><p>Every document begins with one registered declaration keyword: <code>spec</code>,
+<code>refinement</code>, <code>compose</code>, <code>business</code>, <code>governance</code>, <code>requirements</code>, <code>domain</code>,
+<code>dbsystem</code>, <code>ai_component</code>, or <code>agent</code>. Leading whitespace, <code>//</code> comments, and a
+UTF-8 BOM do not affect dispatch. Typed document metadata may precede the
+declaration:</p>
+<pre><code class="language-fsl">@requirement(&quot;REQ-247&quot;, &quot;shared dispatch&quot;)
+@acme.review.owner(team.platform, 2, true)
+spec Example {}
+</code></pre>
+<p>Annotation names and symbol arguments are multi-segment paths. Arguments may be
+strings, integers, Booleans, or symbol paths. <code>requirement</code>, <code>kind</code>, and
+<code>undecided</code> use the built-in typed annotation variants; other paths are inert
+custom metadata. Annotation argument keywords are never dialect selectors. See
+<code>DESIGN-token-registry.md</code>.</p>
+<pre><code class="language-fsl">spec &lt;Name&gt; [&quot;&lt;kind&gt;: &lt;intent&gt;&quot;] {   // optional spec-level tag → metadata badge (explain/html); never verified
   const &lt;NAME&gt; = &lt;constant expr&gt;
   type  &lt;Name&gt; = &lt;lo&gt;..&lt;hi&gt;            // domain type (bounded integer)
   symmetric type &lt;Name&gt; = &lt;lo&gt;..&lt;hi&gt;   // domain whose values are interchangeable identities

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -71,7 +71,21 @@
 </tr>
 </tbody>
 </table></div></details>
-<details id="1-structure-of-a-specification"><summary>1. Structure of a specification<span class="tree-blurb"> — spec 宣言・状態・初期状態・アクションの基本構造。</span></summary><div class="tree-body"><pre><code class="language-fsl">spec &lt;Name&gt; [&quot;&lt;kind&gt;: &lt;intent&gt;&quot;] {   // optional spec-level tag → metadata badge (explain/html); never verified
+<details id="1-structure-of-a-specification"><summary>1. Structure of a specification<span class="tree-blurb"> — spec 宣言・状態・初期状態・アクションの基本構造。</span></summary><div class="tree-body"><p>Every document begins with one registered declaration keyword: <code>spec</code>,
+<code>refinement</code>, <code>compose</code>, <code>business</code>, <code>governance</code>, <code>requirements</code>, <code>domain</code>,
+<code>dbsystem</code>, <code>ai_component</code>, or <code>agent</code>. Leading whitespace, <code>//</code> comments, and a
+UTF-8 BOM do not affect dispatch. Typed document metadata may precede the
+declaration:</p>
+<pre><code class="language-fsl">@requirement(&quot;REQ-247&quot;, &quot;shared dispatch&quot;)
+@acme.review.owner(team.platform, 2, true)
+spec Example {}
+</code></pre>
+<p>Annotation names and symbol arguments are multi-segment paths. Arguments may be
+strings, integers, Booleans, or symbol paths. <code>requirement</code>, <code>kind</code>, and
+<code>undecided</code> use the built-in typed annotation variants; other paths are inert
+custom metadata. Annotation argument keywords are never dialect selectors. See
+<code>DESIGN-token-registry.md</code>.</p>
+<pre><code class="language-fsl">spec &lt;Name&gt; [&quot;&lt;kind&gt;: &lt;intent&gt;&quot;] {   // optional spec-level tag → metadata badge (explain/html); never verified
   const &lt;NAME&gt; = &lt;constant expr&gt;
   type  &lt;Name&gt; = &lt;lo&gt;..&lt;hi&gt;            // domain type (bounded integer)
   symmetric type &lt;Name&gt; = &lt;lo&gt;..&lt;hi&gt;   // domain whose values are interchangeable identities

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -5,8 +5,9 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use fsl_syntax::{
-    ActionItem, Binder, ComposeItem, Expr, LValue, Param, QualifiedName, SpecItem, Statement,
-    SurfaceCompose, SurfaceDocument, SurfaceSpec, SyncAction, TypeExpr, parse_surface_document,
+    ActionItem, Binder, ComposeItem, Expr, LValue, Param, QualifiedName, SourceFile, SpecItem,
+    Statement, SurfaceCompose, SurfaceDocument, SurfaceSpec, SyncAction, TypeExpr, parse_document,
+    parse_surface_document,
 };
 
 use crate::{CoreError, KernelSpec, PredicateExpander, expand_spec_domains, substitute};
@@ -53,7 +54,9 @@ pub fn parse_kernel_source(
     source: &str,
     resolver: &dyn FileResolver,
 ) -> Result<KernelSpec, CoreError> {
-    match parse_surface_document(source)? {
+    let parsed = parse_document(&SourceFile::anonymous(source))?;
+    let annotations = parsed.annotations;
+    let mut kernel = match parsed.surface {
         SurfaceDocument::Spec(spec) => crate::lower_direct_spec(spec),
         SurfaceDocument::Business(business) => crate::lower_business(business),
         SurfaceDocument::Requirements(requirements) => crate::lower_requirements(requirements),
@@ -61,14 +64,24 @@ pub fn parse_kernel_source(
         SurfaceDocument::Db(system) => crate::lower_db(&system),
         SurfaceDocument::Domain(domain) => crate::lower_domain(&domain),
         SurfaceDocument::AiComponent(component) => crate::lower_ai_component(component),
+        SurfaceDocument::AiProject(_) => Err(CoreError {
+            message: "AI project evidence documents do not lower to a kernel model".to_owned(),
+            line: 1,
+            column: 1,
+            origin: None,
+        }),
         SurfaceDocument::Compose(compose) => lower_compose(compose, resolver),
-        SurfaceDocument::Refinement(_) => Err(CoreError {
+        SurfaceDocument::Refinement(_) | SurfaceDocument::Agent(_) => Err(CoreError {
             message: "top-level document has not reached the kernel lowering gate".to_owned(),
             line: 1,
             column: 1,
             origin: None,
         }),
+    }?;
+    for annotation in annotations.source_order().iter().cloned() {
+        kernel.bind_annotation("spec", annotation);
     }
+    Ok(kernel)
 }
 
 /// Parse and lower source while attaching the caller-known root file identity

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -1242,20 +1242,18 @@ impl<'a> Resolver<'a> {
     }
 
     fn qualified_name(name: &SyntaxQualifiedName) -> QualifiedName {
-        QualifiedName {
-            namespace: name.namespace.as_ref().map(|value| value.text.clone()),
-            name: name.name.text.clone(),
-        }
+        let (namespace, name) = name.path.legacy_parts();
+        QualifiedName { namespace, name }
     }
 
     fn qualified_logical_type(&self, name: &SyntaxQualifiedName) -> Result<LogicalType, CoreError> {
-        if name.namespace.is_some() {
+        if name.has_namespace() {
             return Err(error_at(
                 "namespaced domain binder types are not supported",
-                name.span,
+                name.span(),
             ));
         }
-        Ok(match name.name.text.as_str() {
+        Ok(match name.name().text.as_str() {
             "Int" => LogicalType::Int,
             "Bool" => LogicalType::Bool,
             other if self.types.iter().any(|ty| ty.name == other) => {
@@ -1264,7 +1262,7 @@ impl<'a> Resolver<'a> {
             other => {
                 return Err(error_at(
                     format!("unknown domain type '{other}'"),
-                    name.span,
+                    name.span(),
                 ));
             }
         })

--- a/rust/fsl-core/tests/typed_annotations.rs
+++ b/rust/fsl-core/tests/typed_annotations.rs
@@ -38,6 +38,30 @@ spec TypedAnnotations "design: annotation carrier" {
 }
 
 #[test]
+fn top_level_annotations_are_passed_to_the_dispatched_declaration() {
+    let kernel = parse_kernel_source(
+        r#"@requirement("REQ-DOCUMENT", "document contract")
+@acme.review.owner(team.platform)
+spec AnnotatedDocument {}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse top-level annotations");
+    let annotations = kernel.annotations().annotations_for("spec");
+    assert_eq!(annotations.source_order().len(), 2);
+    assert!(matches!(
+        &annotations.source_order()[0],
+        Annotation::Requirement { id, text, .. }
+            if id == "REQ-DOCUMENT" && text.as_deref() == Some("document contract")
+    ));
+    assert!(matches!(
+        &annotations.source_order()[1],
+        Annotation::Custom { namespace, .. }
+            if namespace.to_string() == "acme.review.owner"
+    ));
+}
+
+#[test]
 fn keeps_multiple_typed_annotations_and_legacy_projection_on_one_declaration() {
     let mut kernel = direct_spec();
     let target = action_target("publish");

--- a/rust/fsl-syntax/src/ai.rs
+++ b/rust/fsl-syntax/src/ai.rs
@@ -132,25 +132,45 @@ pub fn parse_ai_component(source: &str) -> Result<AiComponent, ParseError> {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = AiParser {
-        source,
-        tokens,
-        cursor: 0,
-    };
-    let component = parser.component()?;
-    if !matches!(parser.peek().kind, TokenKind::Eof) {
-        return Err(parser.error("unexpected token after ai_component"));
+    parse_ai_component_tokens(source, &tokens, 0)
+}
+
+pub(crate) fn parse_ai_component_tokens(
+    source: &str,
+    tokens: &[Token],
+    cursor: usize,
+) -> Result<AiComponent, ParseError> {
+    let (component, cursor) = parse_ai_component_prefix(source, tokens, cursor)?;
+    if !matches!(tokens[cursor].kind, TokenKind::Eof) {
+        return Err(ParseError {
+            message: "unexpected token after ai_component".to_owned(),
+            span: tokens[cursor].span,
+        });
     }
     Ok(component)
 }
 
-struct AiParser<'a> {
-    source: &'a str,
-    tokens: Vec<Token>,
+pub(crate) fn parse_ai_component_prefix(
+    source: &str,
+    tokens: &[Token],
+    cursor: usize,
+) -> Result<(AiComponent, usize), ParseError> {
+    let mut parser = AiParser {
+        source,
+        tokens,
+        cursor,
+    };
+    let component = parser.component()?;
+    Ok((component, parser.cursor))
+}
+
+struct AiParser<'source, 'tokens> {
+    source: &'source str,
+    tokens: &'tokens [Token],
     cursor: usize,
 }
 
-impl AiParser<'_> {
+impl AiParser<'_, '_> {
     fn component(&mut self) -> Result<AiComponent, ParseError> {
         let loc = self.loc();
         self.expect_ident_value("ai_component")?;

--- a/rust/fsl-syntax/src/annotation.rs
+++ b/rust/fsl-syntax/src/annotation.rs
@@ -6,11 +6,14 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::Span;
+use crate::{Span, SyntaxIdent};
 
 /// A namespaced symbol such as `acme.review.owner`.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SymbolPath(Vec<String>);
+#[derive(Clone, Debug)]
+pub struct SymbolPath {
+    segments: Vec<SyntaxIdent>,
+    span: Span,
+}
 
 impl SymbolPath {
     /// Construct a validated symbol path.
@@ -22,25 +25,119 @@ impl SymbolPath {
         segments: impl IntoIterator<Item = String>,
         span: Span,
     ) -> Result<Self, AnnotationError> {
-        let segments = segments.into_iter().collect::<Vec<_>>();
-        if segments.is_empty() || segments.iter().any(|segment| segment.trim().is_empty()) {
+        let segments = segments
+            .into_iter()
+            .map(|text| SyntaxIdent { text, span })
+            .collect::<Vec<_>>();
+        Self::from_idents(segments, span)
+    }
+
+    /// Construct a symbol path while retaining every identifier span.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationError`] when the path is empty or contains an empty segment.
+    pub fn from_idents(segments: Vec<SyntaxIdent>, span: Span) -> Result<Self, AnnotationError> {
+        if segments.is_empty()
+            || segments
+                .iter()
+                .any(|segment| segment.text.trim().is_empty())
+        {
             return Err(AnnotationError::new(
                 "custom annotation namespace must contain non-empty segments",
                 span,
             ));
         }
-        Ok(Self(segments))
+        Ok(Self { segments, span })
     }
 
     #[must_use]
-    pub fn segments(&self) -> &[String] {
-        &self.0
+    pub fn segments(&self) -> &[SyntaxIdent] {
+        &self.segments
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    #[must_use]
+    pub fn matches(&self, segments: &[&str]) -> bool {
+        self.segments.len() == segments.len()
+            && self
+                .segments
+                .iter()
+                .zip(segments)
+                .all(|(actual, expected)| actual.as_str() == *expected)
+    }
+
+    /// Return the final identifier segment.
+    ///
+    /// # Panics
+    ///
+    /// This panics only if the private non-empty path invariant is violated.
+    #[must_use]
+    pub fn name(&self) -> &SyntaxIdent {
+        self.segments.last().expect("symbol paths are non-empty")
+    }
+
+    #[must_use]
+    pub fn has_namespace(&self) -> bool {
+        self.segments.len() > 1
+    }
+
+    /// Adapt the loss-aware path to the frozen two-field kernel name shape.
+    #[must_use]
+    pub fn legacy_parts(&self) -> (Option<String>, String) {
+        let name = self.name().text.clone();
+        let namespace = (self.segments.len() > 1).then(|| {
+            self.segments[..self.segments.len() - 1]
+                .iter()
+                .map(SyntaxIdent::as_str)
+                .collect::<Vec<_>>()
+                .join(".")
+        });
+        (namespace, name)
+    }
+}
+
+impl PartialEq for SymbolPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.segments
+            .iter()
+            .map(SyntaxIdent::as_str)
+            .eq(other.segments.iter().map(SyntaxIdent::as_str))
+    }
+}
+
+impl Eq for SymbolPath {}
+
+impl PartialOrd for SymbolPath {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SymbolPath {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.segments
+            .iter()
+            .map(SyntaxIdent::as_str)
+            .cmp(other.segments.iter().map(SyntaxIdent::as_str))
     }
 }
 
 impl fmt::Display for SymbolPath {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0.join("."))
+        let mut segments = self.segments.iter();
+        if let Some(first) = segments.next() {
+            formatter.write_str(first.as_str())?;
+        }
+        for segment in segments {
+            formatter.write_str(".")?;
+            formatter.write_str(segment.as_str())?;
+        }
+        Ok(())
     }
 }
 
@@ -227,7 +324,7 @@ impl Annotations {
                     if namespace
                         .segments()
                         .iter()
-                        .any(|segment| segment.trim().is_empty())
+                        .any(|segment| segment.text.trim().is_empty())
                     {
                         return Err(AnnotationError::new(
                             "custom annotation namespace must contain non-empty segments",

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -4,14 +4,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct SourcePos {
     pub offset: usize,
     pub line: u32,
     pub column: u32,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Span {
     pub start: SourcePos,
     pub end: SourcePos,

--- a/rust/fsl-syntax/src/db.rs
+++ b/rust/fsl-syntax/src/db.rs
@@ -267,7 +267,14 @@ pub fn parse_db_system(source: &str) -> Result<DbSystem, ParseError> {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = DbParser { tokens, cursor: 0 };
+    parse_db_system_tokens(&tokens, 0)
+}
+
+pub(crate) fn parse_db_system_tokens(
+    tokens: &[Token],
+    cursor: usize,
+) -> Result<DbSystem, ParseError> {
+    let mut parser = DbParser { tokens, cursor };
     let system = parser.system()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after dbsystem"));
@@ -275,12 +282,12 @@ pub fn parse_db_system(source: &str) -> Result<DbSystem, ParseError> {
     Ok(system)
 }
 
-struct DbParser {
-    tokens: Vec<Token>,
+struct DbParser<'a> {
+    tokens: &'a [Token],
     cursor: usize,
 }
 
-impl DbParser {
+impl DbParser<'_> {
     fn system(&mut self) -> Result<DbSystem, ParseError> {
         let span = self.peek().span;
         self.expect_ident_value("dbsystem")?;

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -458,7 +458,14 @@ pub fn parse_domain(source: &str) -> Result<DomainSpec, ParseError> {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = DomainParser { tokens, cursor: 0 };
+    parse_domain_tokens(&tokens, 0)
+}
+
+pub(crate) fn parse_domain_tokens(
+    tokens: &[Token],
+    cursor: usize,
+) -> Result<DomainSpec, ParseError> {
+    let mut parser = DomainParser { tokens, cursor };
     let domain = parser.domain()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after domain"));
@@ -466,12 +473,12 @@ pub fn parse_domain(source: &str) -> Result<DomainSpec, ParseError> {
     Ok(domain)
 }
 
-struct DomainParser {
-    tokens: Vec<Token>,
+struct DomainParser<'a> {
+    tokens: &'a [Token],
     cursor: usize,
 }
 
-impl DomainParser {
+impl DomainParser<'_> {
     fn domain(&mut self) -> Result<DomainSpec, ParseError> {
         let loc = self.loc();
         self.expect_ident_value("domain")?;
@@ -1244,7 +1251,7 @@ impl DomainParser {
 
     fn expression(&mut self, line_terminated: bool) -> Result<SyntaxExpr, ParseError> {
         parse_tokens_expression(
-            &self.tokens,
+            self.tokens,
             &mut self.cursor,
             ExpressionMode::Domain,
             line_terminated,
@@ -1264,7 +1271,7 @@ impl DomainParser {
     }
 
     fn lvalue(&mut self) -> Result<SyntaxLValue, ParseError> {
-        parse_tokens_lvalue(&self.tokens, &mut self.cursor, ExpressionMode::Domain)
+        parse_tokens_lvalue(self.tokens, &mut self.cursor, ExpressionMode::Domain)
     }
 
     fn loc(&self) -> DomainLoc {

--- a/rust/fsl-syntax/src/lexer.rs
+++ b/rust/fsl-syntax/src/lexer.rs
@@ -98,7 +98,10 @@ impl<'a> Lexer<'a> {
 
     fn skip_trivia(&mut self) {
         loop {
-            while self.peek().is_some_and(char::is_whitespace) {
+            while self
+                .peek()
+                .is_some_and(|ch| ch.is_whitespace() || ch == '\u{feff}')
+            {
                 self.bump();
             }
             if self.remaining().starts_with("//") {
@@ -173,7 +176,7 @@ impl<'a> Lexer<'a> {
             return Ok(TokenKind::Symbol((*symbol).to_owned()));
         }
         let ch = self.bump().expect("peeked character");
-        if "{}()[],:;.+-*/%<>=.|".contains(ch) {
+        if "{}()[],:;.+-*/%<>=.|@".contains(ch) {
             Ok(TokenKind::Symbol(ch.to_string()))
         } else {
             Err(LexError {

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -37,7 +37,12 @@ pub use domain::{
     DomainSagaStep, DomainSpec, DomainStalePolicy, DomainType, DomainTypeSourceForm, parse_domain,
 };
 pub use lexer::{LexError, Token, TokenKind, lex};
-pub use parser::{ParseError, parse_expr, parse_surface_document, parse_surface_spec};
+pub use parser::{
+    DiagnosticCode, Dialect, DocumentHeader, FrontendRegistration, ParseError, ParsedDocument,
+    RegistryError, SourceFile, classify_document, parse_document, parse_expr,
+    parse_surface_document, parse_surface_spec, supported_dialect_keywords,
+    validate_frontend_registry,
+};
 pub use surface::{
     AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, BusinessGoalBody,
     BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute, GovernanceArtifactRef,
@@ -45,8 +50,9 @@ pub use surface::{
     PreservationItem, ProcessCover, ProcessField, ProcessFields, ProcessItem, ProcessTransition,
     RefinementItem, RefinementParam, RequirementAction, RequirementActionItem,
     RequirementBlockItem, RequirementBranch, RequirementsItem, SpecItem, StateField, Statement,
-    SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement,
-    SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr, VerifyItem,
+    SurfaceAgent, SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance,
+    SurfaceRefinement, SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr,
+    VerifyItem,
 };
 pub use syntax_expr::{
     SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxIdent, SyntaxLValue, SyntaxOperator,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1,20 +1,167 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
+use std::collections::BTreeSet;
 use std::fmt;
+use std::sync::OnceLock;
 
 use crate::syntax_expr::{ExpressionMode, parse_tokens_expression};
 use crate::{
-    AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, Binder, BusinessGoalBody,
-    BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute, Expr, GovernanceArtifactRef,
-    GovernanceDelegateItem, GovernanceItem, HelpfulAction, LValue, MapsClause, MetaTag, Param,
-    PreservationItem, ProcessCover, ProcessField, ProcessFields, ProcessItem, ProcessTransition,
-    QualifiedName, RefinementItem, RefinementParam, RequirementAction, RequirementActionItem,
-    RequirementBlockItem, RequirementBranch, RequirementsItem, Span, SpecItem, Statement,
-    SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement,
-    SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, Token, TokenKind, TypeExpr,
-    VerifyItem, lex,
+    AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, Annotation, AnnotationValue,
+    Annotations, Binder, BusinessGoalBody, BusinessItem, BusinessPolicyBody, ComposeItem,
+    ControlAttribute, Expr, GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem,
+    HelpfulAction, LValue, MapsClause, MetaTag, Param, PreservationItem, ProcessCover,
+    ProcessField, ProcessFields, ProcessItem, ProcessTransition, QualifiedName, RefinementItem,
+    RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
+    RequirementBranch, RequirementsItem, Span, SpecItem, Statement, SurfaceAgent, SurfaceBusiness,
+    SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement, SurfaceRequirements,
+    SurfaceSpec, SymbolPath, SyncAction, SyncRef, SyntaxIdent, TimeItem, Token, TokenKind,
+    TypeExpr, VerifyItem, lex,
 };
+
+const SUPPORTED_DIALECTS: [FrontendRegistration; 10] = [
+    FrontendRegistration::registered("spec", Dialect::Spec, parse_shared_frontend),
+    FrontendRegistration::registered("refinement", Dialect::Refinement, parse_shared_frontend),
+    FrontendRegistration::registered("compose", Dialect::Compose, parse_shared_frontend),
+    FrontendRegistration::registered("business", Dialect::Business, parse_shared_frontend),
+    FrontendRegistration::registered("governance", Dialect::Governance, parse_shared_frontend),
+    FrontendRegistration::registered("requirements", Dialect::Requirements, parse_shared_frontend),
+    FrontendRegistration::registered("domain", Dialect::Domain, parse_domain_frontend),
+    FrontendRegistration::registered("dbsystem", Dialect::DbSystem, parse_db_frontend),
+    FrontendRegistration::registered("ai_component", Dialect::AiComponent, parse_ai_frontend),
+    FrontendRegistration::registered("agent", Dialect::Agent, parse_agent_frontend),
+];
+
+static SUPPORTED_KEYWORDS: OnceLock<Vec<&'static str>> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DiagnosticCode {
+    Syntax,
+    EmptyDocument,
+    UnsupportedDialect,
+    DuplicateDialectKey,
+}
+
+impl DiagnosticCode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Syntax => "FSL-PARSE-SYNTAX",
+            Self::EmptyDocument => "FSL-PARSE-EMPTY-DOCUMENT",
+            Self::UnsupportedDialect => "FSL-PARSE-UNSUPPORTED-DIALECT",
+            Self::DuplicateDialectKey => "FSL-PARSE-DUPLICATE-DIALECT-KEY",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Dialect {
+    Spec,
+    Refinement,
+    Compose,
+    Business,
+    Governance,
+    Requirements,
+    Domain,
+    DbSystem,
+    AiComponent,
+    Agent,
+}
+
+type FrontendParser = fn(&str, &[Token], &DocumentHeader) -> Result<SurfaceDocument, ParseError>;
+
+#[derive(Clone, Copy, Debug)]
+pub struct FrontendRegistration {
+    pub keyword: &'static str,
+    pub dialect: Dialect,
+    frontend: Option<FrontendParser>,
+}
+
+impl FrontendRegistration {
+    #[must_use]
+    pub const fn new(keyword: &'static str, dialect: Dialect) -> Self {
+        Self {
+            keyword,
+            dialect,
+            frontend: None,
+        }
+    }
+
+    const fn registered(keyword: &'static str, dialect: Dialect, frontend: FrontendParser) -> Self {
+        Self {
+            keyword,
+            dialect,
+            frontend: Some(frontend),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RegistryError {
+    message: String,
+}
+
+impl RegistryError {
+    #[must_use]
+    pub const fn code(&self) -> DiagnosticCode {
+        DiagnosticCode::DuplicateDialectKey
+    }
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SourceFile<'a> {
+    name: Option<&'a str>,
+    text: &'a str,
+}
+
+impl<'a> SourceFile<'a> {
+    #[must_use]
+    pub const fn anonymous(text: &'a str) -> Self {
+        Self { name: None, text }
+    }
+
+    #[must_use]
+    pub const fn named(name: &'a str, text: &'a str) -> Self {
+        Self {
+            name: Some(name),
+            text,
+        }
+    }
+
+    #[must_use]
+    pub const fn text(self) -> &'a str {
+        self.text
+    }
+
+    #[must_use]
+    pub const fn name(self) -> Option<&'a str> {
+        self.name
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DocumentHeader {
+    pub dialect: Dialect,
+    pub annotations: Annotations,
+    pub declaration_span: Span,
+    declaration_index: usize,
+    registration_index: usize,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParsedDocument {
+    pub dialect: Dialect,
+    pub annotations: Annotations,
+    pub surface: SurfaceDocument,
+}
 
 fn join_span(start: Span, end: Span) -> Span {
     Span {
@@ -27,6 +174,31 @@ fn join_span(start: Span, end: Span) -> Span {
 pub struct ParseError {
     pub message: String,
     pub span: Span,
+}
+
+impl ParseError {
+    #[must_use]
+    pub fn code(&self) -> DiagnosticCode {
+        match self.message.as_str() {
+            "empty document" => DiagnosticCode::EmptyDocument,
+            message if message.starts_with("unsupported dialect '") => {
+                DiagnosticCode::UnsupportedDialect
+            }
+            message if message.starts_with("duplicate dialect registry key '") => {
+                DiagnosticCode::DuplicateDialectKey
+            }
+            _ => DiagnosticCode::Syntax,
+        }
+    }
+
+    #[must_use]
+    pub fn supported_keywords(&self) -> &'static [&'static str] {
+        if self.code() == DiagnosticCode::UnsupportedDialect {
+            supported_dialect_keywords()
+        } else {
+            &[]
+        }
+    }
 }
 
 impl fmt::Display for ParseError {
@@ -52,7 +224,10 @@ pub fn parse_expr(source: &str) -> Result<Expr, ParseError> {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = Parser { tokens, cursor: 0 };
+    let mut parser = Parser {
+        tokens: &tokens,
+        cursor: 0,
+    };
     let expr = parser.expression(0)?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after expression"));
@@ -71,12 +246,91 @@ pub fn parse_surface_spec(source: &str) -> Result<SurfaceSpec, ParseError> {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = Parser { tokens, cursor: 0 };
+    let mut parser = Parser {
+        tokens: &tokens,
+        cursor: 0,
+    };
     let spec = parser.surface_spec()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after spec"));
     }
     Ok(spec)
+}
+
+#[must_use]
+pub fn supported_dialect_keywords() -> &'static [&'static str] {
+    SUPPORTED_KEYWORDS
+        .get_or_init(|| {
+            SUPPORTED_DIALECTS
+                .iter()
+                .map(|registration| registration.keyword)
+                .collect()
+        })
+        .as_slice()
+}
+
+/// Validate that a frontend registry has one owner for every keyword.
+///
+/// # Errors
+///
+/// Returns [`RegistryError`] when a keyword occurs more than once.
+pub fn validate_frontend_registry(
+    registrations: &[FrontendRegistration],
+) -> Result<(), RegistryError> {
+    let mut keys = BTreeSet::new();
+    for registration in registrations {
+        if !keys.insert(registration.keyword) {
+            return Err(RegistryError {
+                message: format!("duplicate dialect registry key '{}'", registration.keyword),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Classify a source document from its first significant declaration token.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] for lexical errors, malformed annotations, empty
+/// documents, or unsupported top-level keywords.
+pub fn classify_document(source: &SourceFile<'_>) -> Result<DocumentHeader, ParseError> {
+    let tokens = lex(source.text()).map_err(|error| ParseError {
+        message: error.message,
+        span: error.span,
+    })?;
+    classify_tokens(&tokens)
+}
+
+/// Parse a document through the shared lexer and dialect registry.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when lexing, annotation parsing, dispatch, or the
+/// selected dialect frontend fails.
+pub fn parse_document(source: &SourceFile<'_>) -> Result<ParsedDocument, ParseError> {
+    validate_frontend_registry(&SUPPORTED_DIALECTS).map_err(|error| ParseError {
+        message: error.to_string(),
+        span: zero_span(),
+    })?;
+    let tokens = lex(source.text()).map_err(|error| ParseError {
+        message: error.message,
+        span: error.span,
+    })?;
+    let header = classify_tokens(&tokens)?;
+    let frontend = SUPPORTED_DIALECTS
+        .get(header.registration_index)
+        .and_then(|registration| registration.frontend)
+        .ok_or_else(|| ParseError {
+            message: "dialect registry entry has no frontend".to_owned(),
+            span: header.declaration_span,
+        })?;
+    let surface = frontend(source.text(), &tokens, &header)?;
+    Ok(ParsedDocument {
+        dialect: header.dialect,
+        annotations: header.annotations,
+        surface,
+    })
 }
 
 /// Parse a supported shared-grammar surface document.
@@ -86,34 +340,332 @@ pub fn parse_surface_spec(source: &str) -> Result<SurfaceSpec, ParseError> {
 /// Returns [`ParseError`] for invalid syntax or a top-level dialect that has
 /// not yet reached the Phase-0 parser gate.
 pub fn parse_surface_document(source: &str) -> Result<SurfaceDocument, ParseError> {
-    if source.trim_start().starts_with("dbsystem") {
-        return crate::parse_db_system(source).map(SurfaceDocument::Db);
+    parse_document(&SourceFile::anonymous(source)).map(|parsed| parsed.surface)
+}
+
+fn zero_span() -> Span {
+    let position = crate::SourcePos {
+        offset: 0,
+        line: 1,
+        column: 1,
+    };
+    Span {
+        start: position,
+        end: position,
     }
-    if source.trim_start().starts_with("domain ") {
-        return crate::parse_domain(source).map(SurfaceDocument::Domain);
-    }
-    if source.trim_start().starts_with("ai_component ") {
-        return crate::parse_ai_component(source).map(SurfaceDocument::AiComponent);
-    }
-    let tokens = lex(source).map_err(|error| ParseError {
+}
+
+fn classify_tokens(tokens: &[Token]) -> Result<DocumentHeader, ParseError> {
+    let mut cursor = 0;
+    let annotations = parse_document_annotations(tokens, &mut cursor)?;
+    annotations.validate().map_err(|error| ParseError {
         message: error.message,
         span: error.span,
     })?;
-    let mut parser = Parser { tokens, cursor: 0 };
-    let document = if parser.peek_ident("spec") {
-        SurfaceDocument::Spec(parser.surface_spec()?)
-    } else if parser.peek_ident("refinement") {
-        SurfaceDocument::Refinement(parser.surface_refinement()?)
-    } else if parser.peek_ident("business") {
-        SurfaceDocument::Business(parser.surface_business()?)
-    } else if parser.peek_ident("governance") {
-        SurfaceDocument::Governance(parser.surface_governance()?)
-    } else if parser.peek_ident("requirements") {
-        SurfaceDocument::Requirements(parser.surface_requirements()?)
-    } else if parser.peek_ident("compose") {
-        SurfaceDocument::Compose(parser.surface_compose()?)
+    let token = tokens
+        .get(cursor)
+        .unwrap_or_else(|| tokens.last().expect("lexer emits EOF"));
+    let TokenKind::Ident(keyword) = &token.kind else {
+        if matches!(token.kind, TokenKind::Eof) {
+            return Err(ParseError {
+                message: "empty document".to_owned(),
+                span: token.span,
+            });
+        }
+        return Err(ParseError {
+            message: "expected top-level declaration keyword".to_owned(),
+            span: token.span,
+        });
+    };
+    let (registration_index, registration) = SUPPORTED_DIALECTS
+        .iter()
+        .enumerate()
+        .find(|(_, registration)| registration.keyword == keyword)
+        .ok_or_else(|| ParseError {
+            message: format!("unsupported dialect '{keyword}'"),
+            span: token.span,
+        })?;
+    Ok(DocumentHeader {
+        dialect: registration.dialect,
+        annotations,
+        declaration_span: token.span,
+        declaration_index: cursor,
+        registration_index,
+    })
+}
+
+fn parse_document_annotations(
+    tokens: &[Token],
+    cursor: &mut usize,
+) -> Result<Annotations, ParseError> {
+    let mut annotations = Vec::new();
+    while token_is_symbol(tokens, *cursor, "@") {
+        annotations.push(parse_document_annotation(tokens, cursor)?);
+    }
+    Ok(Annotations::new(annotations))
+}
+
+fn parse_document_annotation(
+    tokens: &[Token],
+    cursor: &mut usize,
+) -> Result<Annotation, ParseError> {
+    let start = tokens[*cursor].span;
+    *cursor += 1;
+    let namespace = parse_symbol_path(tokens, cursor)?;
+    let mut arguments = Vec::new();
+    let mut end = namespace.span();
+    if token_is_symbol(tokens, *cursor, "(") {
+        *cursor += 1;
+        if !token_is_symbol(tokens, *cursor, ")") {
+            loop {
+                arguments.push(parse_annotation_value(tokens, cursor)?);
+                if token_is_symbol(tokens, *cursor, ")") {
+                    break;
+                }
+                expect_token_symbol(tokens, cursor, ",")?;
+            }
+        }
+        end = tokens[*cursor].span;
+        *cursor += 1;
+    }
+    let span = join_span(start, end);
+    annotation_from_parts(namespace, arguments, span)
+}
+
+fn annotation_from_parts(
+    namespace: SymbolPath,
+    arguments: Vec<AnnotationValue>,
+    span: Span,
+) -> Result<Annotation, ParseError> {
+    if namespace.matches(&["requirement"]) {
+        let (id, text) = annotation_id_and_text(&arguments, span)?;
+        return Ok(Annotation::Requirement { id, text, span });
+    }
+    if namespace.matches(&["kind"]) {
+        let (id, text) = annotation_id_and_text(&arguments, span)?;
+        return Ok(Annotation::Kind { id, text, span });
+    }
+    if namespace.matches(&["undecided"]) {
+        return match arguments.as_slice() {
+            [AnnotationValue::String(reason)] => Ok(Annotation::Undecided {
+                reason: reason.clone(),
+                span,
+            }),
+            _ => Err(ParseError {
+                message: "@undecided expects one string argument".to_owned(),
+                span,
+            }),
+        };
+    }
+    Ok(Annotation::Custom {
+        namespace,
+        arguments,
+        span,
+    })
+}
+
+fn annotation_id_and_text(
+    arguments: &[AnnotationValue],
+    span: Span,
+) -> Result<(String, Option<String>), ParseError> {
+    let id = match arguments.first() {
+        Some(AnnotationValue::String(value)) => value.clone(),
+        Some(AnnotationValue::Symbol(value)) => value.to_string(),
+        _ => {
+            return Err(ParseError {
+                message: "annotation expects a string or symbol ID".to_owned(),
+                span,
+            });
+        }
+    };
+    let text = match arguments.get(1) {
+        None => None,
+        Some(AnnotationValue::String(value)) => Some(value.clone()),
+        _ => {
+            return Err(ParseError {
+                message: "annotation text must be a string".to_owned(),
+                span,
+            });
+        }
+    };
+    if arguments.len() > 2 {
+        return Err(ParseError {
+            message: "annotation accepts at most two arguments".to_owned(),
+            span,
+        });
+    }
+    Ok((id, text))
+}
+
+fn parse_annotation_value(
+    tokens: &[Token],
+    cursor: &mut usize,
+) -> Result<AnnotationValue, ParseError> {
+    let token = tokens
+        .get(*cursor)
+        .unwrap_or_else(|| tokens.last().expect("lexer emits EOF"));
+    match &token.kind {
+        TokenKind::String(value) => {
+            *cursor += 1;
+            Ok(AnnotationValue::String(value.clone()))
+        }
+        TokenKind::Int(value) => {
+            *cursor += 1;
+            Ok(AnnotationValue::Integer(*value))
+        }
+        TokenKind::Ident(value) if value == "true" || value == "false" => {
+            *cursor += 1;
+            Ok(AnnotationValue::Boolean(value == "true"))
+        }
+        TokenKind::Ident(_) => parse_symbol_path(tokens, cursor).map(AnnotationValue::Symbol),
+        _ => Err(ParseError {
+            message: "expected annotation argument".to_owned(),
+            span: token.span,
+        }),
+    }
+}
+
+fn parse_symbol_path(tokens: &[Token], cursor: &mut usize) -> Result<SymbolPath, ParseError> {
+    let mut segments = vec![expect_token_ident(tokens, cursor)?];
+    while token_is_symbol(tokens, *cursor, ".") {
+        *cursor += 1;
+        segments.push(expect_token_ident(tokens, cursor)?);
+    }
+    let span = join_span(
+        segments.first().expect("path has one segment").span,
+        segments.last().expect("path has one segment").span,
+    );
+    SymbolPath::from_idents(segments, span).map_err(|error| ParseError {
+        message: error.message,
+        span: error.span,
+    })
+}
+
+fn expect_token_ident(tokens: &[Token], cursor: &mut usize) -> Result<SyntaxIdent, ParseError> {
+    let token = tokens
+        .get(*cursor)
+        .unwrap_or_else(|| tokens.last().expect("lexer emits EOF"));
+    if let TokenKind::Ident(text) = &token.kind {
+        *cursor += 1;
+        Ok(SyntaxIdent {
+            text: text.clone(),
+            span: token.span,
+        })
     } else {
-        return Err(parser.error("unsupported shared-grammar top-level declaration"));
+        Err(ParseError {
+            message: "expected identifier".to_owned(),
+            span: token.span,
+        })
+    }
+}
+
+fn expect_token_symbol(
+    tokens: &[Token],
+    cursor: &mut usize,
+    symbol: &str,
+) -> Result<(), ParseError> {
+    let token = tokens
+        .get(*cursor)
+        .unwrap_or_else(|| tokens.last().expect("lexer emits EOF"));
+    if matches!(&token.kind, TokenKind::Symbol(value) if value == symbol) {
+        *cursor += 1;
+        Ok(())
+    } else {
+        Err(ParseError {
+            message: format!("expected '{symbol}'"),
+            span: token.span,
+        })
+    }
+}
+
+fn token_is_symbol(tokens: &[Token], cursor: usize, symbol: &str) -> bool {
+    matches!(
+        tokens.get(cursor).map(|token| &token.kind),
+        Some(TokenKind::Symbol(value)) if value == symbol
+    )
+}
+
+fn parse_db_frontend(
+    source: &str,
+    tokens: &[Token],
+    header: &DocumentHeader,
+) -> Result<SurfaceDocument, ParseError> {
+    let _ = source;
+    crate::db::parse_db_system_tokens(tokens, header.declaration_index).map(SurfaceDocument::Db)
+}
+
+fn parse_domain_frontend(
+    source: &str,
+    tokens: &[Token],
+    header: &DocumentHeader,
+) -> Result<SurfaceDocument, ParseError> {
+    let _ = source;
+    crate::domain::parse_domain_tokens(tokens, header.declaration_index)
+        .map(SurfaceDocument::Domain)
+}
+
+fn parse_ai_frontend(
+    source: &str,
+    tokens: &[Token],
+    header: &DocumentHeader,
+) -> Result<SurfaceDocument, ParseError> {
+    let (component, cursor) =
+        crate::ai::parse_ai_component_prefix(source, tokens, header.declaration_index)?;
+    if matches!(tokens[cursor].kind, TokenKind::Eof) {
+        Ok(SurfaceDocument::AiComponent(component))
+    } else if tokens[cursor..].iter().any(|token| {
+        matches!(
+            &token.kind,
+            TokenKind::Ident(value)
+                if matches!(
+                    value.as_str(),
+                    "statistical_property" | "ai_migration" | "observed_property"
+                )
+        )
+    }) {
+        Ok(SurfaceDocument::AiProject(component))
+    } else {
+        Err(ParseError {
+            message: "unexpected token after ai_component".to_owned(),
+            span: tokens[cursor].span,
+        })
+    }
+}
+
+fn parse_agent_frontend(
+    source: &str,
+    tokens: &[Token],
+    header: &DocumentHeader,
+) -> Result<SurfaceDocument, ParseError> {
+    let _ = source;
+    parse_agent(tokens, header.declaration_index).map(SurfaceDocument::Agent)
+}
+
+fn parse_shared_frontend(
+    source: &str,
+    tokens: &[Token],
+    header: &DocumentHeader,
+) -> Result<SurfaceDocument, ParseError> {
+    let _ = source;
+    parse_shared_document(tokens, header.declaration_index, header.dialect)
+}
+
+fn parse_shared_document(
+    tokens: &[Token],
+    cursor: usize,
+    dialect: Dialect,
+) -> Result<SurfaceDocument, ParseError> {
+    let mut parser = Parser { tokens, cursor };
+    let document = match dialect {
+        Dialect::Spec => SurfaceDocument::Spec(parser.surface_spec()?),
+        Dialect::Refinement => SurfaceDocument::Refinement(parser.surface_refinement()?),
+        Dialect::Compose => SurfaceDocument::Compose(parser.surface_compose()?),
+        Dialect::Business => SurfaceDocument::Business(parser.surface_business()?),
+        Dialect::Governance => SurfaceDocument::Governance(parser.surface_governance()?),
+        Dialect::Requirements => SurfaceDocument::Requirements(parser.surface_requirements()?),
+        Dialect::Domain | Dialect::DbSystem | Dialect::AiComponent | Dialect::Agent => {
+            unreachable!("specialized frontend")
+        }
     };
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after surface document"));
@@ -121,12 +673,52 @@ pub fn parse_surface_document(source: &str) -> Result<SurfaceDocument, ParseErro
     Ok(document)
 }
 
-struct Parser {
-    tokens: Vec<Token>,
+fn parse_agent(tokens: &[Token], cursor: usize) -> Result<SurfaceAgent, ParseError> {
+    let mut cursor = cursor;
+    let start = tokens[cursor].span;
+    cursor += 1;
+    let name = expect_token_ident(tokens, &mut cursor)?.text;
+    expect_token_symbol(tokens, &mut cursor, "{")?;
+    let mut depth = 1_u32;
+    let mut end = start;
+    while depth > 0 {
+        let token = tokens
+            .get(cursor)
+            .unwrap_or_else(|| tokens.last().expect("lexer emits EOF"));
+        match &token.kind {
+            TokenKind::Symbol(symbol) if symbol == "{" => depth += 1,
+            TokenKind::Symbol(symbol) if symbol == "}" => {
+                depth -= 1;
+                end = token.span;
+            }
+            TokenKind::Eof => {
+                return Err(ParseError {
+                    message: "unterminated agent declaration".to_owned(),
+                    span: token.span,
+                });
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    if !matches!(tokens[cursor].kind, TokenKind::Eof) {
+        return Err(ParseError {
+            message: "unexpected token after agent declaration".to_owned(),
+            span: tokens[cursor].span,
+        });
+    }
+    Ok(SurfaceAgent {
+        name,
+        span: join_span(start, end),
+    })
+}
+
+struct Parser<'a> {
+    tokens: &'a [Token],
     cursor: usize,
 }
 
-impl Parser {
+impl Parser<'_> {
     fn surface_spec(&mut self) -> Result<SurfaceSpec, ParseError> {
         self.expect_ident_value("spec")?;
         let name = self.expect_ident()?;
@@ -1488,12 +2080,13 @@ impl Parser {
                 return Ok(result);
             }
         }
-        if let TokenKind::Ident(name) = &self.peek().kind {
-            if self.next_is_type_delimiter() {
-                let name = name.clone();
-                self.bump();
-                return Ok(TypeExpr::Name(name));
+        if matches!(self.peek().kind, TokenKind::Ident(_)) {
+            let checkpoint = self.cursor;
+            let path = self.symbol_path()?;
+            if self.current_is_type_delimiter() {
+                return Ok(TypeExpr::Name(path.to_string()));
             }
+            self.cursor = checkpoint;
         }
         let lo = self.expression(0)?;
         self.expect_symbol("..")?;
@@ -1501,9 +2094,9 @@ impl Parser {
         Ok(TypeExpr::Range(lo, hi))
     }
 
-    fn next_is_type_delimiter(&self) -> bool {
+    fn current_is_type_delimiter(&self) -> bool {
         matches!(
-            &self.peek_n(1).kind,
+            &self.peek().kind,
             TokenKind::Symbol(symbol) if matches!(symbol.as_str(), "," | ">" | "}" | "->" | "=")
         )
     }
@@ -1869,7 +2462,7 @@ impl Parser {
         );
         let mut cursor = self.cursor;
         let expression =
-            parse_tokens_expression(&self.tokens, &mut cursor, ExpressionMode::Kernel, false)?;
+            parse_tokens_expression(self.tokens, &mut cursor, ExpressionMode::Kernel, false)?;
         self.cursor = cursor;
         expression.into_kernel()
     }
@@ -1914,18 +2507,25 @@ impl Parser {
     }
 
     fn qualified_name(&mut self) -> Result<QualifiedName, ParseError> {
-        let first = self.expect_ident()?;
-        if self.eat_symbol(".") {
-            Ok(QualifiedName {
-                namespace: Some(first),
-                name: self.expect_ident()?,
-            })
-        } else {
-            Ok(QualifiedName {
-                namespace: None,
-                name: first,
-            })
+        let path = self.symbol_path()?;
+        let (namespace, name) = path.legacy_parts();
+        Ok(QualifiedName { namespace, name })
+    }
+
+    fn symbol_path(&mut self) -> Result<SymbolPath, ParseError> {
+        let mut segments = vec![self.expect_syntax_ident()?];
+        while self.eat_symbol(".") {
+            segments.push(self.expect_syntax_ident()?);
         }
+        let span = join_span(
+            segments.first().expect("qualified path is non-empty").span,
+            segments.last().expect("qualified path is non-empty").span,
+        );
+        let path = SymbolPath::from_idents(segments, span).map_err(|error| ParseError {
+            message: error.message,
+            span: error.span,
+        })?;
+        Ok(path)
     }
 
     fn expression_list(&mut self, close: &str) -> Result<Vec<Expr>, ParseError> {
@@ -2009,6 +2609,21 @@ impl Parser {
         let token = self.bump().clone();
         if let TokenKind::Ident(value) = token.kind {
             Ok(value)
+        } else {
+            Err(ParseError {
+                message: "expected identifier".to_owned(),
+                span: token.span,
+            })
+        }
+    }
+
+    fn expect_syntax_ident(&mut self) -> Result<SyntaxIdent, ParseError> {
+        let token = self.bump().clone();
+        if let TokenKind::Ident(text) = token.kind {
+            Ok(SyntaxIdent {
+                text,
+                span: token.span,
+            })
         } else {
             Err(ParseError {
                 message: "expected identifier".to_owned(),

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -599,6 +599,17 @@ pub struct SurfaceCompose {
     pub items: Vec<ComposeItem>,
 }
 
+/// Minimal syntax boundary for the recursive `agent` evidence dialect.
+///
+/// Structural agent semantics remain owned by the AI analysis frontend. The
+/// shared document parser retains the declaration identity and source extent so
+/// generic entrypoints no longer need raw prefix inspection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SurfaceAgent {
+    pub name: String,
+    pub span: Span,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SurfaceDocument {
     Spec(SurfaceSpec),
@@ -610,6 +621,8 @@ pub enum SurfaceDocument {
     Db(DbSystem),
     Domain(DomainSpec),
     AiComponent(AiComponent),
+    AiProject(AiComponent),
+    Agent(SurfaceAgent),
 }
 
 impl MetaTag {
@@ -1708,7 +1721,12 @@ impl SurfaceDocument {
             Self::Compose(compose) => compose.python_ast(),
             Self::Db(system) => system.python_ast(),
             Self::Domain(domain) => domain.python_ast(),
-            Self::AiComponent(component) => component.python_ast(),
+            Self::AiComponent(component) | Self::AiProject(component) => component.python_ast(),
+            Self::Agent(agent) => json!({
+                "$type": "AgentDocument",
+                "name": agent.name,
+                "loc": agent.span.python_loc(),
+            }),
         }
     }
 }

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -12,10 +12,10 @@
 use std::fmt;
 use std::ops::Deref;
 
-use crate::{Binder, Expr, ParseError, Pattern, QualifiedName, Span, Token, TokenKind};
+use crate::{Binder, Expr, ParseError, Pattern, QualifiedName, Span, SymbolPath, Token, TokenKind};
 
 /// An unresolved source identifier with its exact token span.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct SyntaxIdent {
     pub text: String,
     pub span: Span,
@@ -52,9 +52,7 @@ pub struct SyntaxOperator {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SyntaxQualifiedName {
-    pub namespace: Option<SyntaxIdent>,
-    pub name: SyntaxIdent,
-    pub span: Span,
+    pub path: SymbolPath,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -494,18 +492,29 @@ impl fmt::Display for SyntaxLValue {
 }
 
 impl SyntaxQualifiedName {
-    fn render_source(&self) -> String {
-        self.namespace.as_ref().map_or_else(
-            || self.name.text.clone(),
-            |namespace| format!("{}.{}", namespace.text, self.name.text),
-        )
+    #[must_use]
+    pub fn render_source(&self) -> String {
+        self.path.to_string()
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        self.path.span()
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &SyntaxIdent {
+        self.path.name()
+    }
+
+    #[must_use]
+    pub fn has_namespace(&self) -> bool {
+        self.path.has_namespace()
     }
 
     fn into_kernel(self) -> QualifiedName {
-        QualifiedName {
-            namespace: self.namespace.map(|value| value.text),
-            name: self.name.text,
-        }
+        let (namespace, name) = self.path.legacy_parts();
+        QualifiedName { namespace, name }
     }
 }
 
@@ -1024,7 +1033,7 @@ impl SyntaxParser<'_> {
             };
             let end = where_expr
                 .as_deref()
-                .map_or(type_name.span, |expression| expression.span);
+                .map_or(type_name.span(), |expression| expression.span);
             return Ok(SyntaxBinder::Typed {
                 name,
                 type_name,
@@ -1105,22 +1114,19 @@ impl SyntaxParser<'_> {
     }
 
     fn qualified_name(&mut self) -> Result<SyntaxQualifiedName, ParseError> {
-        let first = self.expect_ident()?;
-        let start = first.span;
-        if self.eat_symbol(".") {
-            let name = self.expect_ident()?;
-            Ok(SyntaxQualifiedName {
-                namespace: Some(first),
-                span: join(start, name.span),
-                name,
-            })
-        } else {
-            Ok(SyntaxQualifiedName {
-                span: start,
-                namespace: None,
-                name: first,
-            })
+        let mut segments = vec![self.expect_ident()?];
+        while self.eat_symbol(".") {
+            segments.push(self.expect_ident()?);
         }
+        let span = join(
+            segments.first().expect("qualified path is non-empty").span,
+            segments.last().expect("qualified path is non-empty").span,
+        );
+        let path = SymbolPath::from_idents(segments, span).map_err(|error| ParseError {
+            message: error.message,
+            span: error.span,
+        })?;
+        Ok(SyntaxQualifiedName { path })
     }
 
     fn expression_list(&mut self, close: &str) -> Result<Vec<SyntaxExpr>, ParseError> {

--- a/rust/fsl-syntax/tests/document_registry.rs
+++ b/rust/fsl-syntax/tests/document_registry.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_syntax::{
+    Annotation, AnnotationValue, DiagnosticCode, Dialect, FrontendRegistration, SourceFile,
+    SurfaceDocument, parse_document, supported_dialect_keywords, validate_frontend_registry,
+};
+
+fn span_at(offset: usize) -> fsl_syntax::Span {
+    let position = fsl_syntax::SourcePos {
+        offset,
+        line: 1,
+        column: u32::try_from(offset + 1).unwrap(),
+    };
+    fsl_syntax::Span {
+        start: position,
+        end: position,
+    }
+}
+
+const DIALECTS: [(&str, Dialect); 10] = [
+    ("spec", Dialect::Spec),
+    ("refinement", Dialect::Refinement),
+    ("compose", Dialect::Compose),
+    ("business", Dialect::Business),
+    ("governance", Dialect::Governance),
+    ("requirements", Dialect::Requirements),
+    ("domain", Dialect::Domain),
+    ("dbsystem", Dialect::DbSystem),
+    ("ai_component", Dialect::AiComponent),
+    ("agent", Dialect::Agent),
+];
+
+#[test]
+fn registry_classifies_every_supported_top_level_keyword() {
+    for (keyword, dialect) in DIALECTS {
+        let source = format!("{keyword} Demo {{}}");
+        let header = fsl_syntax::classify_document(&SourceFile::anonymous(&source))
+            .unwrap_or_else(|error| panic!("classify {keyword}: {error}"));
+        assert_eq!(header.dialect, dialect, "{keyword}");
+    }
+    assert_eq!(
+        supported_dialect_keywords(),
+        DIALECTS.map(|(keyword, _)| keyword).as_slice()
+    );
+}
+
+#[test]
+fn every_registered_frontend_parses_from_the_shared_document_entrypoint() {
+    let sources = [
+        "spec Demo {}",
+        "refinement Demo {}",
+        "compose Demo {}",
+        "business Demo {}",
+        "governance Demo {}",
+        "requirements Demo {}",
+        "domain Demo {}",
+        "dbsystem Demo { database app { schema 0 } }",
+        "ai_component Demo {}",
+        "agent Demo {}",
+    ];
+    for (source, (keyword, dialect)) in sources.into_iter().zip(DIALECTS) {
+        let parsed = parse_document(&SourceFile::anonymous(source))
+            .unwrap_or_else(|error| panic!("parse {keyword}: {error}"));
+        assert_eq!(parsed.dialect, dialect, "{keyword}");
+    }
+}
+
+#[test]
+fn dispatch_skips_bom_comments_whitespace_and_top_level_annotations() {
+    let source = "\u{feff} // leading\n\n@acme.review.owner(\"language\", 247, true, policy.strict)\n spec Demo {}";
+    let parsed = parse_document(&SourceFile::anonymous(source)).expect("parse annotated spec");
+
+    assert_eq!(parsed.dialect, Dialect::Spec);
+    assert!(matches!(parsed.surface, SurfaceDocument::Spec(_)));
+    let [
+        Annotation::Custom {
+            namespace,
+            arguments,
+            span,
+        },
+    ] = parsed.annotations.source_order()
+    else {
+        panic!("expected one custom document annotation")
+    };
+    assert_eq!(
+        namespace
+            .segments()
+            .iter()
+            .map(fsl_syntax::SyntaxIdent::as_str)
+            .collect::<Vec<_>>(),
+        ["acme", "review", "owner"]
+    );
+    assert_eq!(namespace.span().start.line, 3);
+    assert_eq!(namespace.span().end.column, 19);
+    assert_eq!(span.start.line, 3);
+    assert_eq!(arguments.len(), 4);
+    assert!(matches!(arguments[0], AnnotationValue::String(ref value) if value == "language"));
+    assert!(matches!(arguments[1], AnnotationValue::Integer(247)));
+    assert!(matches!(arguments[2], AnnotationValue::Boolean(true)));
+    assert!(
+        matches!(arguments[3], AnnotationValue::Symbol(ref value) if value.to_string() == "policy.strict")
+    );
+}
+
+#[test]
+fn annotation_argument_keywords_do_not_select_the_frontend() {
+    let source = "@routing(spec, domain, ai_component) business Demo {}";
+    let header = fsl_syntax::classify_document(&SourceFile::anonymous(source)).unwrap();
+    assert_eq!(header.dialect, Dialect::Business);
+    assert_eq!(header.declaration_span.start.column, 38);
+}
+
+#[test]
+fn qualified_syntax_uses_multi_segment_symbol_paths_and_structural_equality() {
+    let source = "spec Multi { state { value: acme.types.Status } }";
+    let parsed = parse_document(&SourceFile::anonymous(source)).expect("parse qualified type");
+    let SurfaceDocument::Spec(spec) = parsed.surface else {
+        panic!("expected spec")
+    };
+    let fsl_syntax::SpecItem::State(fields) = &spec.items[0] else {
+        panic!("expected state")
+    };
+    assert_eq!(
+        fields[0].ty,
+        fsl_syntax::TypeExpr::Name("acme.types.Status".to_owned())
+    );
+
+    let first = fsl_syntax::SymbolPath::new(
+        ["acme".to_owned(), "types".to_owned(), "Status".to_owned()],
+        span_at(1),
+    )
+    .unwrap();
+    let second = fsl_syntax::SymbolPath::new(
+        ["acme".to_owned(), "types".to_owned(), "Status".to_owned()],
+        span_at(99),
+    )
+    .unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.to_string(), "acme.types.Status");
+}
+
+#[test]
+fn duplicate_registry_keys_are_rejected() {
+    let duplicate = [
+        FrontendRegistration::new("spec", Dialect::Spec),
+        FrontendRegistration::new("spec", Dialect::Business),
+    ];
+    let error = validate_frontend_registry(&duplicate).expect_err("duplicate key");
+    assert_eq!(error.code(), DiagnosticCode::DuplicateDialectKey);
+    assert!(error.to_string().contains("spec"));
+}
+
+#[test]
+fn empty_and_unknown_documents_have_stable_structured_diagnostics() {
+    let empty_source = SourceFile::anonymous("\u{feff}// nothing here\n  ");
+    let empty = parse_document(&empty_source).expect_err("empty document");
+    assert_eq!(empty.code(), DiagnosticCode::EmptyDocument);
+    assert_eq!(empty.span.start.offset, empty_source.text().len());
+    assert!(empty.supported_keywords().is_empty());
+
+    let unknown =
+        parse_document(&SourceFile::anonymous("\n mystery Demo {}")).expect_err("unknown dialect");
+    assert_eq!(unknown.code(), DiagnosticCode::UnsupportedDialect);
+    assert_eq!((unknown.span.start.line, unknown.span.start.column), (2, 2));
+    assert_eq!(unknown.supported_keywords(), supported_dialect_keywords());
+}
+
+#[test]
+fn agent_is_dispatched_through_the_shared_document_api() {
+    let parsed = parse_document(&SourceFile::anonymous(
+        "// agent fixture\nagent Parent { agent Child {} }",
+    ))
+    .expect("parse agent document");
+    let SurfaceDocument::Agent(agent) = parsed.surface else {
+        panic!("expected agent surface")
+    };
+    assert_eq!(parsed.dialect, Dialect::Agent);
+    assert_eq!(agent.name, "Parent");
+    assert_eq!(agent.span.start.line, 2);
+}
+
+#[test]
+fn ai_project_is_a_semantic_variant_of_the_ai_component_registry_frontend() {
+    let source = r"ai_component Demo {}
+statistical_property Quality { target Demo }
+";
+    let parsed = parse_document(&SourceFile::anonymous(source)).expect("parse AI project");
+    assert_eq!(parsed.dialect, Dialect::AiComponent);
+    assert!(matches!(parsed.surface, SurfaceDocument::AiProject(_)));
+}

--- a/rust/fsl-syntax/tests/domain_typed_expressions.rs
+++ b/rust/fsl-syntax/tests/domain_typed_expressions.rs
@@ -297,7 +297,7 @@ fn public_helper_nodes_retain_their_own_spans() {
     let source = r"domain SpannedHelpers {
   type Id = 0..1
   aggregate A {
-    invariant quantified { forall item: Id { item == 0 } }
+    invariant quantified { forall item: acme.types.Id { item == 0 } }
     invariant patterned { maybe is some(value) }
   }
 }";
@@ -307,7 +307,7 @@ fn public_helper_nodes_retain_their_own_spans() {
     assert_eq!(quantified.name.text, "quantified");
     assert_eq!(
         &source[quantified.span.start.offset..quantified.span.end.offset],
-        "invariant quantified { forall item: Id { item == 0 } }"
+        "invariant quantified { forall item: acme.types.Id { item == 0 } }"
     );
     let SyntaxExprKind::Quantified { binder, .. } = &quantified.expr.kind else {
         panic!("expected quantified expression");
@@ -318,11 +318,16 @@ fn public_helper_nodes_retain_their_own_spans() {
     else {
         panic!("expected typed binder");
     };
-    assert_eq!(&source[span.start.offset..span.end.offset], "item: Id");
     assert_eq!(
-        &source[type_name.span.start.offset..type_name.span.end.offset],
-        "Id"
+        &source[span.start.offset..span.end.offset],
+        "item: acme.types.Id"
     );
+    let type_span = type_name.span();
+    assert_eq!(
+        &source[type_span.start.offset..type_span.end.offset],
+        "acme.types.Id"
+    );
+    assert!(type_name.path.matches(&["acme", "types", "Id"]));
 
     let patterned = &domain.aggregates[0].invariants[1].expr;
     let SyntaxExprKind::Is { pattern, .. } = &patterned.kind else {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3198,44 +3198,43 @@ fn format_fsl_value(model: &KernelModel, value: &FslValue, ty: &TypeRef) -> Stri
 }
 
 fn run_check(path: &Path) -> (Value, i32) {
-    if let Ok(source) = std::fs::read_to_string(path)
-        && source.trim_start().starts_with("agent ")
-    {
-        let name = declaration_name(source.trim_start(), "agent ").unwrap_or_default();
-        let mut output = envelope();
-        output.insert("result".to_owned(), json!("ok"));
-        output.insert("spec".to_owned(), json!(name));
-        output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
-        output.insert("warnings".to_owned(), json!([]));
-        output.insert("ai_analysis_result".to_owned(), json!("agent_analyzed"));
-        output.insert("agent_analysis_result".to_owned(), json!("agent_analyzed"));
-        return (Value::Object(output), 0);
-    }
-    if let Ok(source) = std::fs::read_to_string(path)
-        && is_ai_project(&source)
-    {
-        let mut output = envelope();
-        output.insert("result".to_owned(), json!("ok"));
-        output.insert(
-            "spec".to_owned(),
-            json!(
-                path.file_stem()
-                    .and_then(std::ffi::OsStr::to_str)
-                    .unwrap_or("AiProject")
-            ),
-        );
-        output.insert("dialect".to_owned(), json!("fsl-ai-project.v0"));
-        output.insert("warnings".to_owned(), json!([]));
-        output.insert(
-            "ai_analysis_result".to_owned(),
-            json!("ai_project_analyzed"),
-        );
-        return (Value::Object(output), 0);
-    }
-    if let Ok(source) = std::fs::read_to_string(path)
-        && let Err(error) = fsl_syntax::parse_surface_document(&source)
-    {
-        return (error_output("parse", &error.to_string()), 2);
+    if let Ok(source) = std::fs::read_to_string(path) {
+        let parsed = match fsl_syntax::parse_document(&fsl_syntax::SourceFile::anonymous(&source)) {
+            Ok(parsed) => parsed,
+            Err(error) => return (syntax_error_output(&error), 2),
+        };
+        match parsed.surface {
+            fsl_syntax::SurfaceDocument::Agent(agent) => {
+                let mut output = envelope();
+                output.insert("result".to_owned(), json!("ok"));
+                output.insert("spec".to_owned(), json!(agent.name));
+                output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
+                output.insert("warnings".to_owned(), json!([]));
+                output.insert("ai_analysis_result".to_owned(), json!("agent_analyzed"));
+                output.insert("agent_analysis_result".to_owned(), json!("agent_analyzed"));
+                return (Value::Object(output), 0);
+            }
+            fsl_syntax::SurfaceDocument::AiProject(_) => {
+                let mut output = envelope();
+                output.insert("result".to_owned(), json!("ok"));
+                output.insert(
+                    "spec".to_owned(),
+                    json!(
+                        path.file_stem()
+                            .and_then(std::ffi::OsStr::to_str)
+                            .unwrap_or("AiProject")
+                    ),
+                );
+                output.insert("dialect".to_owned(), json!("fsl-ai-project.v0"));
+                output.insert("warnings".to_owned(), json!([]));
+                output.insert(
+                    "ai_analysis_result".to_owned(),
+                    json!("ai_project_analyzed"),
+                );
+                return (Value::Object(output), 0);
+            }
+            _ => {}
+        }
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -3369,21 +3368,21 @@ fn run_conformance(
 }
 
 fn source_dialect(source: &str) -> &str {
-    let first = source
-        .lines()
-        .map(str::trim_start)
-        .find(|line| !line.is_empty() && !line.starts_with("//"))
-        .and_then(|line| line.split_whitespace().next());
-    match first {
-        Some("spec") => "kernel",
-        Some("requirements") => "requirements",
-        Some("business") => "business",
-        Some("domain") => "domain",
-        Some("database" | "db") => "db",
-        Some("governance") => "governance",
-        Some("component") => "ai-component",
-        Some(other) => other,
-        None => "unknown",
+    let Ok(header) = fsl_syntax::classify_document(&fsl_syntax::SourceFile::anonymous(source))
+    else {
+        return "unknown";
+    };
+    match header.dialect {
+        fsl_syntax::Dialect::Spec => "kernel",
+        fsl_syntax::Dialect::Refinement => "refinement",
+        fsl_syntax::Dialect::Compose => "compose",
+        fsl_syntax::Dialect::Business => "business",
+        fsl_syntax::Dialect::Governance => "governance",
+        fsl_syntax::Dialect::Requirements => "requirements",
+        fsl_syntax::Dialect::Domain => "domain",
+        fsl_syntax::Dialect::DbSystem => "db",
+        fsl_syntax::Dialect::AiComponent => "ai-component",
+        fsl_syntax::Dialect::Agent => "ai-agent",
     }
 }
 
@@ -4011,18 +4010,19 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
         Ok(source) => source,
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
-    if is_ai_project(&source) {
-        return run_ai_project_check(&source);
-    }
-    let component = match parse_surface_document(path) {
-        Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => component,
-        Ok(_) => {
+    let parsed = match fsl_syntax::parse_document(&fsl_syntax::SourceFile::anonymous(&source)) {
+        Ok(parsed) => parsed,
+        Err(error) => return (syntax_error_output(&error), 2),
+    };
+    let component = match parsed.surface {
+        fsl_syntax::SurfaceDocument::AiProject(_) => return run_ai_project_check(&source),
+        fsl_syntax::SurfaceDocument::AiComponent(component) => component,
+        _ => {
             return (
                 semantic_error_output("expected an ai_component document"),
                 2,
             );
         }
-        Err(error) => return (semantic_error_output(&error), 2),
     };
     let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
     if status == 2 {
@@ -4056,7 +4056,11 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
         Ok(source) => source,
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
-    if is_ai_project(&source) {
+    let parsed = match fsl_syntax::parse_document(&fsl_syntax::SourceFile::anonymous(&source)) {
+        Ok(parsed) => parsed,
+        Err(error) => return (syntax_error_output(&error), 2),
+    };
+    if matches!(&parsed.surface, fsl_syntax::SurfaceDocument::AiProject(_)) {
         let summary = ai_project_summary(&source);
         if selected_component.is_some_and(|selected| selected != summary.component) {
             return (
@@ -4091,15 +4095,11 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
             json!({"result":if findings.is_empty(){"replay_conformant"}else{"replay_nonconformant"},"dialect":"fsl-ai-hard.v0","finding_schema_version":"fsl-ai-finding.v0","event_schema_version":"fsl-ai-event.v0","ai_component":summary.component,"events_checked":events.len(),"formal_result":"not_run","evidence":{"kind":"runtime_replay","formal_proof":false},"assumptions":[],"findings":findings}),
         );
     }
-    let component = match parse_surface_document(path) {
-        Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => component,
-        Ok(_) => {
-            return (
-                semantic_error_output("expected an ai_component document"),
-                2,
-            );
-        }
-        Err(error) => return (semantic_error_output(&error), 2),
+    let fsl_syntax::SurfaceDocument::AiComponent(component) = parsed.surface else {
+        return (
+            semantic_error_output("expected an ai_component document"),
+            2,
+        );
     };
     if selected_component.is_some_and(|selected| selected != component.name) {
         return (
@@ -4129,13 +4129,6 @@ struct AiProjectSummary {
     observed: Vec<String>,
     migrations: Vec<String>,
     raw_blocks: Vec<String>,
-}
-fn is_ai_project(source: &str) -> bool {
-    source.lines().any(|line| {
-        line.trim_start().starts_with("statistical_property ")
-            || line.trim_start().starts_with("ai_migration ")
-            || line.trim_start().starts_with("observed_property ")
-    })
 }
 fn declaration_name(line: &str, prefix: &str) -> Option<String> {
     line.trim()
@@ -12708,10 +12701,23 @@ fn run_verify(
     explicit_budget: usize,
     k_ind: usize,
 ) -> (Value, i32) {
-    if let Ok(source) = std::fs::read_to_string(path)
-        && let Err(error) = fsl_syntax::parse_surface_document(&source)
-    {
-        return (error_output("parse", &error.to_string()), 2);
+    if let Ok(source) = std::fs::read_to_string(path) {
+        match fsl_syntax::parse_document(&fsl_syntax::SourceFile::anonymous(&source)) {
+            Err(error) => return (syntax_error_output(&error), 2),
+            Ok(parsed)
+                if matches!(
+                    parsed.surface,
+                    fsl_syntax::SurfaceDocument::Agent(_)
+                        | fsl_syntax::SurfaceDocument::AiProject(_)
+                ) =>
+            {
+                return (
+                    error_output("parse", "document dialect is not verifiable"),
+                    2,
+                );
+            }
+            Ok(_) => {}
+        }
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -13374,6 +13380,32 @@ fn error_output(kind: &str, message: &str) -> Value {
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message));
     Value::Object(output)
+}
+
+fn syntax_error_output(error: &fsl_syntax::ParseError) -> Value {
+    let mut output = error_output("parse", &error.to_string());
+    if error.code() == fsl_syntax::DiagnosticCode::Syntax {
+        return output;
+    }
+    if let Value::Object(output) = &mut output {
+        output.insert("code".to_owned(), json!(error.code().as_str()));
+        output.insert(
+            "loc".to_owned(),
+            json!({
+                "line": error.span.start.line,
+                "column": error.span.start.column,
+                "offset": error.span.start.offset,
+                "end_offset": error.span.end.offset,
+            }),
+        );
+        if !error.supported_keywords().is_empty() {
+            output.insert(
+                "supported_dialects".to_owned(),
+                json!(error.supported_keywords()),
+            );
+        }
+    }
+    output
 }
 
 fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -31,6 +31,50 @@ fn native_cli_checks_a_repository_spec_without_python() {
 }
 
 #[test]
+fn native_cli_exposes_registry_diagnostics_and_comment_safe_agent_dispatch() {
+    let directory = std::env::temp_dir().join(format!("fslc-registry-{}", std::process::id()));
+    std::fs::create_dir_all(&directory).expect("create registry fixture directory");
+    let empty = directory.join("empty.fsl");
+    let unknown = directory.join("unknown.fsl");
+    let agent = directory.join("agent.fsl");
+    std::fs::write(&empty, "\u{feff}// only trivia\n").expect("write empty fixture");
+    std::fs::write(&unknown, "mystery Demo {}\n").expect("write unknown fixture");
+    std::fs::write(&agent, "// leading\nagent Parent {}\n").expect("write agent fixture");
+
+    let (empty_output, empty_status) = run_cli(&["check", empty.to_str().expect("UTF-8 path")]);
+    assert_eq!(empty_status, 2);
+    assert_eq!(empty_output["code"], "FSL-PARSE-EMPTY-DOCUMENT");
+    assert_eq!(empty_output["loc"]["line"], 2);
+
+    let (unknown_output, unknown_status) =
+        run_cli(&["check", unknown.to_str().expect("UTF-8 path")]);
+    assert_eq!(unknown_status, 2);
+    assert_eq!(unknown_output["code"], "FSL-PARSE-UNSUPPORTED-DIALECT");
+    assert_eq!(
+        unknown_output["supported_dialects"],
+        serde_json::json!([
+            "spec",
+            "refinement",
+            "compose",
+            "business",
+            "governance",
+            "requirements",
+            "domain",
+            "dbsystem",
+            "ai_component",
+            "agent"
+        ])
+    );
+
+    let (agent_output, agent_status) = run_cli(&["check", agent.to_str().expect("UTF-8 path")]);
+    assert_eq!(agent_status, 0);
+    assert_eq!(agent_output["spec"], "Parent");
+    assert_eq!(agent_output["dialect"], "fsl-ai-agent.v0");
+
+    std::fs::remove_dir_all(directory).expect("remove registry fixture directory");
+}
+
+#[test]
 fn native_cli_preserves_bmc_outcomes() {
     let (verified, status) = run_cli(&[
         "verify",

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -5,6 +5,14 @@ of rules as of v2.x.
 
 ## 1. Top-level structure
 
+The native document registry recognizes `spec`, `refinement`, `compose`,
+`business`, `governance`, `requirements`, `domain`, `dbsystem`, `ai_component`,
+and `agent` after BOM/whitespace/`//` trivia. Optional document annotations use
+`@path.to.name(<string|integer|boolean|symbol-path>, ...)` immediately before the
+declaration. Keywords inside annotation arguments do not select a dialect.
+Unknown/empty documents fail with stable structured diagnostics; see
+`docs/DESIGN-token-registry.md`.
+
 ```fsl
 spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadata badge (explain/html); never verified
   const <NAME> = <const expr>             // integer constant (expressions allowed: CAP - 1, etc.)

--- a/src/fslc/lsp/dialect_dispatch.py
+++ b/src/fslc/lsp/dialect_dispatch.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Compatibility adapter for the native token-based dialect registry.
+
+The Rust ``fsl-syntax`` registry is authoritative.  The retained Python LSP
+uses this small scanner only to select its frozen Lark frontend; parity tests
+lock the ordered keys and significant-token rules to the native contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+SUPPORTED_DIALECT_KEYWORDS = (
+    "spec",
+    "refinement",
+    "compose",
+    "business",
+    "governance",
+    "requirements",
+    "domain",
+    "dbsystem",
+    "ai_component",
+    "agent",
+)
+
+
+@dataclass(frozen=True)
+class DialectDispatch:
+    keyword: str
+    declaration_offset: int
+
+
+def classify_lsp_dialect(source: str) -> DialectDispatch | None:
+    """Return the first significant declaration without inspecting raw lines."""
+    cursor = _skip_trivia(source, 0)
+    while cursor < len(source) and source[cursor] == "@":
+        cursor = _skip_annotation(source, cursor)
+        if cursor is None:
+            return None
+        cursor = _skip_trivia(source, cursor)
+    start = cursor
+    cursor = _skip_ident(source, cursor)
+    if cursor == start:
+        return None
+    keyword = source[start:cursor]
+    if keyword not in SUPPORTED_DIALECT_KEYWORDS:
+        return None
+    return DialectDispatch(keyword=keyword, declaration_offset=start)
+
+
+def mask_dispatch_prefix(source: str, declaration_offset: int) -> str:
+    """Hide BOM/annotations from frozen grammars while preserving locations."""
+    prefix = "".join("\n" if char == "\n" else " " for char in source[:declaration_offset])
+    return prefix + source[declaration_offset:]
+
+
+def _skip_trivia(source: str, cursor: int) -> int:
+    while True:
+        while cursor < len(source) and (source[cursor].isspace() or source[cursor] == "\ufeff"):
+            cursor += 1
+        if source.startswith("//", cursor):
+            newline = source.find("\n", cursor + 2)
+            cursor = len(source) if newline < 0 else newline + 1
+            continue
+        return cursor
+
+
+def _skip_annotation(source: str, cursor: int) -> int | None:
+    cursor += 1
+    cursor = _skip_trivia(source, cursor)
+    cursor = _skip_symbol_path(source, cursor)
+    if cursor is None:
+        return None
+    cursor = _skip_trivia(source, cursor)
+    if cursor >= len(source) or source[cursor] != "(":
+        return cursor
+    cursor = _skip_trivia(source, cursor + 1)
+    if cursor < len(source) and source[cursor] == ")":
+        return cursor + 1
+    while cursor < len(source):
+        cursor = _skip_annotation_value(source, cursor)
+        if cursor is None:
+            return None
+        cursor = _skip_trivia(source, cursor)
+        if cursor < len(source) and source[cursor] == ")":
+            return cursor + 1
+        if cursor >= len(source) or source[cursor] != ",":
+            return None
+        cursor = _skip_trivia(source, cursor + 1)
+    return None
+
+
+def _skip_annotation_value(source: str, cursor: int) -> int | None:
+    if cursor >= len(source):
+        return None
+    if source[cursor] == '"':
+        end = source.find('"', cursor + 1)
+        if end < 0 or "\n" in source[cursor + 1:end]:
+            return None
+        return end + 1
+    if source[cursor].isdigit() and source[cursor].isascii():
+        start = cursor
+        while (
+            cursor < len(source)
+            and source[cursor].isdigit()
+            and source[cursor].isascii()
+        ):
+            cursor += 1
+        if int(source[start:cursor]) > 2**63 - 1:
+            return None
+        return cursor
+    return _skip_symbol_path(source, cursor)
+
+
+def _skip_symbol_path(source: str, cursor: int) -> int | None:
+    end = _skip_ident(source, cursor)
+    if end == cursor:
+        return None
+    cursor = end
+    while True:
+        after_segment = _skip_trivia(source, cursor)
+        if after_segment >= len(source) or source[after_segment] != ".":
+            return cursor
+        next_start = _skip_trivia(source, after_segment + 1)
+        next_end = _skip_ident(source, next_start)
+        if next_end == next_start:
+            return None
+        cursor = next_end
+
+
+def _skip_ident(source: str, cursor: int) -> int:
+    if cursor >= len(source) or not (
+        source[cursor].isascii()
+        and (source[cursor].isalpha() or source[cursor] == "_")
+    ):
+        return cursor
+    cursor += 1
+    while cursor < len(source) and source[cursor].isascii() and (
+        source[cursor].isalnum() or source[cursor] == "_"
+    ):
+        cursor += 1
+    return cursor

--- a/src/fslc/lsp/index.py
+++ b/src/fslc/lsp/index.py
@@ -9,9 +9,8 @@ contextual, so declarations and references are classified by parse-tree
 position, not by spelling. The `ai_component`/`agent`/`dbsystem`/`domain`
 frontend dialects have their own Lark grammars (``fslc.ai_parser``/
 ``fslc.db_parser``/``fslc.domain_parser``) that never reach the kernel
-grammar at all -- ``build_index`` picks the matching raw parser via
-``is_ai_source``/``is_dbsystem_source``/``is_domain_source`` before falling
-back to the kernel ``PARSER``, so those files no longer fail to parse here
+grammar at all -- ``build_index`` uses the token-registry compatibility adapter
+before falling back to the kernel ``PARSER``, so those files no longer fail to parse here
 just because indexing hard-codes the kernel grammar. fsl-ai *project* files
 (``is_ai_project_source``) are a further special case: they are not
 Lark-parsed at all (``ai_project.py`` scans top-level blocks with regexes),
@@ -33,10 +32,11 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 from lark import Tree, Token
 
 from fslc.grammar import PARSER
-from fslc.ai_parser import AI_PARSER, is_ai_source
+from fslc.ai_parser import AI_PARSER
 from fslc.ai_project import _top_blocks, is_ai_project_source
-from fslc.db_parser import DB_PARSER, is_dbsystem_source
-from fslc.domain_parser import PARSER as DOMAIN_PARSER, is_domain_source
+from fslc.db_parser import DB_PARSER
+from fslc.domain_parser import PARSER as DOMAIN_PARSER
+from fslc.lsp.dialect_dispatch import classify_lsp_dialect, mask_dispatch_prefix
 
 
 VALUE_ROLES = {
@@ -569,11 +569,12 @@ class DocumentIndex:
 
 
 def _parser_for_source(source: str):
-    if is_dbsystem_source(source):
+    dispatch = classify_lsp_dialect(source)
+    if dispatch is not None and dispatch.keyword == "dbsystem":
         return DB_PARSER
-    if is_domain_source(source):
+    if dispatch is not None and dispatch.keyword == "domain":
         return DOMAIN_PARSER
-    if is_ai_source(source):
+    if dispatch is not None and dispatch.keyword in {"ai_component", "agent"}:
         return AI_PARSER
     return PARSER
 
@@ -614,9 +615,19 @@ def _build_ai_project_index(source: str, path: Optional[str]) -> "DocumentIndex"
 def build_index(source: str, path: Optional[str] = None) -> DocumentIndex:
     """Parse ``source`` and return a raw-tree symbol/reference index."""
 
-    if is_ai_project_source(source):
+    dispatch = classify_lsp_dialect(source)
+    if (
+        dispatch is not None
+        and dispatch.keyword == "ai_component"
+        and is_ai_project_source(source)
+    ):
         return _build_ai_project_index(source, path)
-    tree = _parser_for_source(source).parse(source)
+    parser_source = (
+        mask_dispatch_prefix(source, dispatch.declaration_offset)
+        if dispatch is not None
+        else source
+    )
+    tree = _parser_for_source(source).parse(parser_source)
     builder = _IndexBuilder(source, path)
     builder.visit(tree, None, None)
     return DocumentIndex(

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -24,6 +24,7 @@ from fslc.lsp.index import (
     build_index,
     encode_semantic_tokens,
 )
+from fslc.lsp.dialect_dispatch import classify_lsp_dialect, mask_dispatch_prefix
 
 
 SERVER_NAME = "fslc-lsp"
@@ -58,7 +59,9 @@ def check_source(
     from fslc.model import FslError, build_spec
     from fslc.parser import parse_src
     from fslc.refine import build_refinement
-    from fslc.domain_parser import is_domain_source, parse_domain
+    from fslc.ai_parser import parse_ai_source
+    from fslc.ai_project import is_ai_project_source, parse_ai_project
+    from fslc.domain_parser import parse_domain
 
     def acceptance_error(spec):
         checked = validate_acceptance(spec)
@@ -78,9 +81,36 @@ def check_source(
 
     try:
         base_dir = str(Path(path).parent) if path else "."
+        dispatch = classify_lsp_dialect(source)
+        parser_source = (
+            mask_dispatch_prefix(source, dispatch.declaration_offset)
+            if dispatch is not None
+            else source
+        )
+        if dispatch is not None and dispatch.keyword == "agent":
+            agent = parse_ai_source(parser_source)
+            return _envelope({
+                "result": "ok",
+                "spec": agent.name,
+                "dialect": "fsl-ai-agent.v0",
+                "warnings": [],
+            })
+        if (
+            dispatch is not None
+            and dispatch.keyword == "ai_component"
+            and is_ai_project_source(parser_source)
+        ):
+            project_name = Path(path).stem if path else "AiProject"
+            parse_ai_project(parser_source, project_name)
+            return _envelope({
+                "result": "ok",
+                "spec": project_name,
+                "dialect": "fsl-ai-project.v0",
+                "warnings": [],
+            })
         domain_warnings = []
-        if is_domain_source(source):
-            domain = parse_domain(source)
+        if dispatch is not None and dispatch.keyword == "domain":
+            domain = parse_domain(parser_source)
             for type_def in domain.types:
                 if type_def.source_form != "legacy_enum_union":
                     continue
@@ -97,7 +127,7 @@ def check_source(
                     "canonical_replacement": replacement,
                     "hint": f"replace the declaration with `{replacement}`",
                 })
-        ast, display_names = parse_src(source, base_dir)
+        ast, display_names = parse_src(parser_source, base_dir)
         if ast[0] == "refinement":
             impl_name, abs_name = _refinement_ast_names(ast)
             impl_spec = _build_resolved_spec(impl_name, name_resolver, parse_src, build_spec)
@@ -182,7 +212,13 @@ def _build_resolved_spec(name, name_resolver, parse_src, build_spec):
         target_source = target.read_text(encoding="utf-8")
     except OSError:
         return None
-    ast, display_names = parse_src(target_source, str(target.parent))
+    dispatch = classify_lsp_dialect(target_source)
+    parser_source = (
+        mask_dispatch_prefix(target_source, dispatch.declaration_offset)
+        if dispatch is not None
+        else target_source
+    )
+    ast, display_names = parse_src(parser_source, str(target.parent))
     return build_spec(ast, display_names)
 
 

--- a/tests/test_lsp_dialect_dispatch.py
+++ b/tests/test_lsp_dialect_dispatch.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+from fslc.lsp.dialect_dispatch import (
+    SUPPORTED_DIALECT_KEYWORDS,
+    classify_lsp_dialect,
+)
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from lark.exceptions import UnexpectedInput
+
+from fslc.lsp.index import build_index
+from fslc.lsp.server import check_source
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUST_FSLC = ROOT / "rust" / "target" / "debug" / "fslc"
+
+
+def test_lsp_registry_adapter_has_native_key_order_and_significant_token_rules():
+    assert SUPPORTED_DIALECT_KEYWORDS == (
+        "spec",
+        "refinement",
+        "compose",
+        "business",
+        "governance",
+        "requirements",
+        "domain",
+        "dbsystem",
+        "ai_component",
+        "agent",
+    )
+    source = '\ufeff// leading\n@routing(spec, domain, "ai_component") business Demo {}'
+    dispatch = classify_lsp_dialect(source)
+    assert dispatch is not None
+    assert dispatch.keyword == "business"
+    assert source[dispatch.declaration_offset:].startswith("business")
+
+
+def test_lsp_indexes_an_annotated_document_at_original_locations():
+    source = '\ufeff// leading\n@owner(team.platform)\nspec Demo {}'
+    index = build_index(source, "annotated.fsl")
+    demo = next(symbol for symbol in index.symbols if symbol.name == "Demo")
+    assert demo.selection_range.start.line == 2
+    assert demo.selection_range.start.character == 5
+
+
+def test_lsp_diagnostics_use_dispatch_for_annotations_comments_and_agents():
+    annotated = check_source(
+        '@requirement("REQ")\nspec Demo { state { value: Int } }', None
+    )
+    assert annotated["result"] == "ok"
+    assert annotated["spec"] == "Demo"
+
+    domain = check_source(
+        "// lead\ndomain Demo { enum Status { Ready } "
+        "aggregate Item { id ItemId state { status: Status = Ready; } } }",
+        None,
+    )
+    assert domain["result"] == "ok"
+    assert domain["spec"] == "Demo"
+
+    agent = check_source('// lead\nagent Worker {}', None)
+    assert agent["result"] == "ok"
+    assert agent["spec"] == "Worker"
+    assert agent["dialect"] == "fsl-ai-agent.v0"
+
+
+@pytest.mark.parametrize("source", ["@foo. spec Demo {}", "@foo..bar() spec Demo {}"])
+def test_lsp_rejects_malformed_annotation_paths(source):
+    assert classify_lsp_dialect(source) is None
+    with pytest.raises(UnexpectedInput):
+        build_index(source)
+
+
+def test_lsp_registry_keys_match_the_native_diagnostic_contract(tmp_path):
+    if not RUST_FSLC.exists():
+        subprocess.run(
+            ["cargo", "build", "--quiet", "--locked", "-p", "fslc-rust"],
+            cwd=ROOT / "rust",
+            check=True,
+        )
+    source = tmp_path / "unknown.fsl"
+    source.write_text("unknown Demo {}", encoding="utf-8")
+    completed = subprocess.run(
+        [str(RUST_FSLC), "check", str(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 2
+    output = json.loads(completed.stdout)
+    assert tuple(output["supported_dialects"]) == SUPPORTED_DIALECT_KEYWORDS


### PR DESCRIPTION
## Problem
Dialect selection was split across raw source prefix and first-line checks, making leading comments, BOMs, document annotations, and future attributes unreliable.

## Contract change
- lex each native document once and dispatch all ten supported dialects through one keyword-to-frontend registry
- preserve top-level typed annotations and reject duplicate registry keys
- add stable empty/unknown document codes, spans, and supported keyword evidence
- use multi-segment, spanned SymbolPath for annotation and qualified syntax, with an explicit frozen Kernel adapter
- route native CLI/library/specialized frontends and retained LSP indexing/diagnostics through the shared dispatch contract
- preserve existing CLI/JSON/corpus behavior and add direct native/LSP registry parity coverage

## Evidence
- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --workspace --locked
- cargo build --manifest-path rust/Cargo.toml --workspace --locked
- .venv/bin/python -m pytest -q: 1430 passed, 78 skipped
- independent review completed; two initial blocking findings were fixed and re-review found no blockers

## Documentation
Updated LANGUAGE, accepted token-registry design, annotation/Rust-port decisions, docs map, generated language references, agent reference, and changelog.

Closes #247