### PR TITLE
fix(syntax): complete dialect registry acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   for dialects; specialized frontends consume the original token stream. Add
   exact empty/unknown diagnostic codes, spans, and supported-keyword lists, an
   evidence-only `agent` surface, and span-retaining multi-segment `SymbolPath`
-  values (issue #247).
+  values. Qualified syntax shares the same arbitrary-depth path and per-segment
+  spans, dispatch errors expose machine-readable supported dialects, and LSP
+  diagnostics route annotated agent/AI-project sources consistently (issue #247).
 - Native Rust now carries ordered, typed `Requirement`, `Undecided`, `Kind`,
   and namespaced `Custom` annotations through a common target-keyed IR. Legacy
   declaration strings, spec badges, requirement blocks, process `covers`, and

--- a/docs/DESIGN-dialect-dispatch.md
+++ b/docs/DESIGN-dialect-dispatch.md
@@ -54,7 +54,8 @@ An empty/comment-only document returns `FSL-DIALECT-EMPTY` at EOF. An annotation
 without a target returns `FSL-DIALECT-ANNOTATION-TARGET`. An unknown first token
 returns `FSL-DIALECT-UNKNOWN` at that exact token and lists registry keywords in
 deterministic registration order. The CLI check/verify envelopes expose the code
-and `loc`; other syntax errors retain `FSL-PARSE` unless a narrower annotation
+and `loc`, plus a machine-readable `supported_dialects` list for these dispatch
+failures; other syntax errors retain `FSL-PARSE` unless a narrower annotation
 code applies.
 
 The BOM contributes its Unicode-scalar column and UTF-8 byte offset to following
@@ -72,8 +73,11 @@ spans. It is trivia only at byte offset zero.
   set, but those evidence blocks are not dialect registry entries.
 - Public Kernel v1/v2 JSON schemas do not gain annotation fields or a new dialect
   field. Existing normalized dialect strings are derived from the registry key.
-- `SymbolPath` stores its segments and complete span structurally. Display joins
-  segments only at the presentation boundary, and equality compares segments.
+- `SymbolPath` stores its segments, per-segment spans, and complete span
+  structurally. `SyntaxQualifiedName` uses the same arbitrary-depth path; its
+  frozen two-field Kernel projection is an explicit compatibility adapter.
+  Display joins segments only at the presentation boundary, and equality
+  compares segments.
 
 ## Verification obligations
 
@@ -82,5 +86,6 @@ spans. It is trivia only at byte offset zero.
 - duplicate keys fail registry validation;
 - annotation argument keywords never affect selection;
 - empty/unknown codes, spans, and supported-keyword order are stable;
-- CLI, library, Kernel lowering, LSP indexing, and the dialect corpus retain
-  their existing successful outcomes.
+- CLI, library, Kernel lowering, LSP indexing/diagnostics, and the dialect corpus
+  retain their existing successful outcomes, including agent and AI-project
+  editor diagnostics.

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1425,6 +1425,20 @@ explicit requirement ID. JSON consumers that expose multiple relations use a
 compatibility projection. See <code>DESIGN-undecided.md</code> and
 <code>DESIGN-annotations.md</code>. This is implemented by the authoritative native Rust
 CLI and is not backported to the frozen Python reference implementation.</p>
+<p>A document itself may now carry typed annotations before its dialect keyword:</p>
+<pre><code class="language-fsl">@requirement(&quot;REQ-DOC&quot;, &quot;this document owns the checkout contract&quot;)
+@acme.review(owner.platform, 2, true)
+spec Checkout { ... }
+</code></pre>
+<p>The shared lexer skips a leading BOM, whitespace, and <code>//</code> comments before
+these annotations, retains their order and spans, then selects the dialect from
+the following declaration keyword. Keywords inside annotation arguments do not
+participate in dispatch. This document-level subset supports <code>@requirement</code>,
+<code>@undecided</code>, <code>@kind</code>, and custom multi-segment namespaces; annotation placement
+on declarations inside the document remains tracked by issue #241. Empty and
+unknown documents report <code>FSL-DIALECT-EMPTY</code> / <code>FSL-DIALECT-UNKNOWN</code> with exact
+locations and the deterministic supported-keyword list. See
+<code>DESIGN-dialect-dispatch.md</code>.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1425,6 +1425,20 @@ explicit requirement ID. JSON consumers that expose multiple relations use a
 compatibility projection. See <code>DESIGN-undecided.md</code> and
 <code>DESIGN-annotations.md</code>. This is implemented by the authoritative native Rust
 CLI and is not backported to the frozen Python reference implementation.</p>
+<p>A document itself may now carry typed annotations before its dialect keyword:</p>
+<pre><code class="language-fsl">@requirement(&quot;REQ-DOC&quot;, &quot;this document owns the checkout contract&quot;)
+@acme.review(owner.platform, 2, true)
+spec Checkout { ... }
+</code></pre>
+<p>The shared lexer skips a leading BOM, whitespace, and <code>//</code> comments before
+these annotations, retains their order and spans, then selects the dialect from
+the following declaration keyword. Keywords inside annotation arguments do not
+participate in dispatch. This document-level subset supports <code>@requirement</code>,
+<code>@undecided</code>, <code>@kind</code>, and custom multi-segment namespaces; annotation placement
+on declarations inside the document remains tracked by issue #241. Empty and
+unknown documents report <code>FSL-DIALECT-EMPTY</code> / <code>FSL-DIALECT-UNKNOWN</code> with exact
+locations and the deterministic supported-keyword list. See
+<code>DESIGN-dialect-dispatch.md</code>.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -1242,20 +1242,18 @@ impl<'a> Resolver<'a> {
     }
 
     fn qualified_name(name: &SyntaxQualifiedName) -> QualifiedName {
-        QualifiedName {
-            namespace: name.namespace.as_ref().map(|value| value.text.clone()),
-            name: name.name.text.clone(),
-        }
+        let (namespace, name) = name.path.legacy_parts();
+        QualifiedName { namespace, name }
     }
 
     fn qualified_logical_type(&self, name: &SyntaxQualifiedName) -> Result<LogicalType, CoreError> {
-        if name.namespace.is_some() {
+        if name.has_namespace() {
             return Err(error_at(
                 "namespaced domain binder types are not supported",
-                name.span,
+                name.span(),
             ));
         }
-        Ok(match name.name.text.as_str() {
+        Ok(match name.name() {
             "Int" => LogicalType::Int,
             "Bool" => LogicalType::Bool,
             other if self.types.iter().any(|ty| ty.name == other) => {
@@ -1264,7 +1262,7 @@ impl<'a> Resolver<'a> {
             other => {
                 return Err(error_at(
                     format!("unknown domain type '{other}'"),
-                    name.span,
+                    name.span(),
                 ));
             }
         })

--- a/rust/fsl-syntax/src/annotation.rs
+++ b/rust/fsl-syntax/src/annotation.rs
@@ -6,12 +6,13 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::Span;
+use crate::{Span, SyntaxIdent};
 
 /// A namespaced symbol such as `acme.review.owner`.
 #[derive(Clone, Debug)]
 pub struct SymbolPath {
     segments: Vec<String>,
+    segment_spans: Vec<Span>,
     span: Span,
 }
 
@@ -32,7 +33,35 @@ impl SymbolPath {
                 span,
             ));
         }
-        Ok(Self { segments, span })
+        let segment_spans = vec![span; segments.len()];
+        Ok(Self {
+            segments,
+            segment_spans,
+            span,
+        })
+    }
+
+    /// Construct a path while retaining the exact span of every segment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationError`] when the path is empty or contains an empty segment.
+    pub fn from_idents(segments: Vec<SyntaxIdent>, span: Span) -> Result<Self, AnnotationError> {
+        if segments.is_empty()
+            || segments
+                .iter()
+                .any(|segment| segment.text.trim().is_empty())
+        {
+            return Err(AnnotationError::new(
+                "custom annotation namespace must contain non-empty segments",
+                span,
+            ));
+        }
+        Ok(Self {
+            segment_spans: segments.iter().map(|segment| segment.span).collect(),
+            segments: segments.into_iter().map(|segment| segment.text).collect(),
+            span,
+        })
     }
 
     #[must_use]
@@ -43,6 +72,34 @@ impl SymbolPath {
     #[must_use]
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    #[must_use]
+    pub fn segment_spans(&self) -> &[Span] {
+        &self.segment_spans
+    }
+
+    #[must_use]
+    pub fn has_namespace(&self) -> bool {
+        self.segments.len() > 1
+    }
+
+    /// Return the final path segment.
+    ///
+    /// # Panics
+    ///
+    /// This panics only if the private non-empty path invariant is violated.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.segments.last().expect("symbol paths are non-empty")
+    }
+
+    /// Adapt the loss-aware path to the frozen two-field Kernel name shape.
+    #[must_use]
+    pub fn legacy_parts(&self) -> (Option<String>, String) {
+        let namespace =
+            (self.segments.len() > 1).then(|| self.segments[..self.segments.len() - 1].join("."));
+        (namespace, self.name().to_owned())
     }
 }
 

--- a/rust/fsl-syntax/src/dispatch.rs
+++ b/rust/fsl-syntax/src/dispatch.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use crate::lexer::lex_declaration_prefix;
 use crate::{
     Annotation, AnnotationValue, Annotations, ParseError, Span, SurfaceAgent, SurfaceDocument,
-    SymbolPath, Token, TokenKind, lex,
+    SymbolPath, SyntaxIdent, Token, TokenKind, lex,
 };
 
 /// Original source passed beside the shared token stream to a dialect frontend.
@@ -410,7 +410,10 @@ fn symbol_path(tokens: &[Token], cursor: &mut usize) -> Result<(SymbolPath, Span
     loop {
         match &tokens[*cursor].kind {
             TokenKind::Ident(segment) => {
-                segments.push(segment.clone());
+                segments.push(SyntaxIdent {
+                    text: segment.clone(),
+                    span: tokens[*cursor].span,
+                });
                 *cursor += 1;
             }
             _ => {
@@ -431,7 +434,7 @@ fn symbol_path(tokens: &[Token], cursor: &mut usize) -> Result<(SymbolPath, Span
         start: start.start,
         end: end.end,
     };
-    SymbolPath::new(segments, span)
+    SymbolPath::from_idents(segments, span)
         .map(|path| (path, span))
         .map_err(|error| ParseError::coded("FSL-ANNOTATION-PATH", error.message, error.span))
 }

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -12,7 +12,7 @@
 use std::fmt;
 use std::ops::Deref;
 
-use crate::{Binder, Expr, ParseError, Pattern, QualifiedName, Span, Token, TokenKind};
+use crate::{Binder, Expr, ParseError, Pattern, QualifiedName, Span, SymbolPath, Token, TokenKind};
 
 /// An unresolved source identifier with its exact token span.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -52,9 +52,7 @@ pub struct SyntaxOperator {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SyntaxQualifiedName {
-    pub namespace: Option<SyntaxIdent>,
-    pub name: SyntaxIdent,
-    pub span: Span,
+    pub path: SymbolPath,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -493,18 +491,29 @@ impl fmt::Display for SyntaxLValue {
 }
 
 impl SyntaxQualifiedName {
-    fn render_source(&self) -> String {
-        self.namespace.as_ref().map_or_else(
-            || self.name.text.clone(),
-            |namespace| format!("{}.{}", namespace.text, self.name.text),
-        )
+    #[must_use]
+    pub fn render_source(&self) -> String {
+        self.path.to_string()
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        self.path.span()
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        self.path.name()
+    }
+
+    #[must_use]
+    pub fn has_namespace(&self) -> bool {
+        self.path.has_namespace()
     }
 
     fn into_kernel(self) -> QualifiedName {
-        QualifiedName {
-            namespace: self.namespace.map(|value| value.text),
-            name: self.name.text,
-        }
+        let (namespace, name) = self.path.legacy_parts();
+        QualifiedName { namespace, name }
     }
 }
 
@@ -1020,7 +1029,7 @@ impl SyntaxParser<'_> {
             };
             let end = where_expr
                 .as_deref()
-                .map_or(type_name.span, |expression| expression.span);
+                .map_or(type_name.span(), |expression| expression.span);
             return Ok(SyntaxBinder::Typed {
                 name,
                 type_name,
@@ -1101,22 +1110,17 @@ impl SyntaxParser<'_> {
     }
 
     fn qualified_name(&mut self) -> Result<SyntaxQualifiedName, ParseError> {
-        let first = self.expect_ident()?;
-        let start = first.span;
-        if self.eat_symbol(".") {
-            let name = self.expect_ident()?;
-            Ok(SyntaxQualifiedName {
-                namespace: Some(first),
-                span: join(start, name.span),
-                name,
-            })
-        } else {
-            Ok(SyntaxQualifiedName {
-                span: start,
-                namespace: None,
-                name: first,
-            })
+        let mut segments = vec![self.expect_ident()?];
+        while self.eat_symbol(".") {
+            segments.push(self.expect_ident()?);
         }
+        let span = join(
+            segments.first().expect("qualified path is non-empty").span,
+            segments.last().expect("qualified path is non-empty").span,
+        );
+        let path = SymbolPath::from_idents(segments, span)
+            .map_err(|error| ParseError::new(error.message, error.span))?;
+        Ok(SyntaxQualifiedName { path })
     }
 
     fn expression_list(&mut self, close: &str) -> Result<Vec<SyntaxExpr>, ParseError> {

--- a/rust/fsl-syntax/tests/domain_typed_expressions.rs
+++ b/rust/fsl-syntax/tests/domain_typed_expressions.rs
@@ -297,7 +297,7 @@ fn public_helper_nodes_retain_their_own_spans() {
     let source = r"domain SpannedHelpers {
   type Id = 0..1
   aggregate A {
-    invariant quantified { forall item: Id { item == 0 } }
+    invariant quantified { forall item: acme.types.Id { item == 0 } }
     invariant patterned { maybe is some(value) }
   }
 }";
@@ -307,7 +307,7 @@ fn public_helper_nodes_retain_their_own_spans() {
     assert_eq!(quantified.name.text, "quantified");
     assert_eq!(
         &source[quantified.span.start.offset..quantified.span.end.offset],
-        "invariant quantified { forall item: Id { item == 0 } }"
+        "invariant quantified { forall item: acme.types.Id { item == 0 } }"
     );
     let SyntaxExprKind::Quantified { binder, .. } = &quantified.expr.kind else {
         panic!("expected quantified expression");
@@ -318,10 +318,25 @@ fn public_helper_nodes_retain_their_own_spans() {
     else {
         panic!("expected typed binder");
     };
-    assert_eq!(&source[span.start.offset..span.end.offset], "item: Id");
     assert_eq!(
-        &source[type_name.span.start.offset..type_name.span.end.offset],
-        "Id"
+        &source[span.start.offset..span.end.offset],
+        "item: acme.types.Id"
+    );
+    let type_span = type_name.span();
+    assert_eq!(
+        &source[type_span.start.offset..type_span.end.offset],
+        "acme.types.Id"
+    );
+    assert_eq!(type_name.path.segments(), ["acme", "types", "Id"]);
+    assert_eq!(type_name.path.segment_spans().len(), 3);
+    assert_eq!(
+        type_name
+            .path
+            .segment_spans()
+            .iter()
+            .map(|span| &source[span.start.offset..span.end.offset])
+            .collect::<Vec<_>>(),
+        ["acme", "types", "Id"]
     );
 
     let patterned = &domain.aggregates[0].invariants[1].expr;

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -13403,6 +13403,15 @@ fn surface_parse_error_output(error: &fsl_syntax::ParseError) -> Value {
     let object = output.as_object_mut().expect("error envelope");
     object.insert("diagnostic_code".to_owned(), json!(error.code()));
     object.insert("loc".to_owned(), error.span.python_loc());
+    if matches!(
+        error.code(),
+        "FSL-DIALECT-EMPTY" | "FSL-DIALECT-ANNOTATION-TARGET" | "FSL-DIALECT-UNKNOWN"
+    ) {
+        object.insert(
+            "supported_dialects".to_owned(),
+            json!(fsl_syntax::DIALECT_KEYWORDS),
+        );
+    }
     output
 }
 

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -55,6 +55,9 @@ def check_source(
         _parse_error_result,
     )
     from fslc.analysis import analyze as analyze_structure
+    from fslc.ai_parser import parse_ai_source
+    from fslc.ai_project import is_ai_project_source, parse_ai_project
+    from fslc.dialect_registry import inspect_source
     from fslc.model import FslError, build_spec
     from fslc.parser import parse_src
     from fslc.refine import build_refinement
@@ -78,6 +81,24 @@ def check_source(
 
     try:
         base_dir = str(Path(path).parent) if path else "."
+        dispatch = inspect_source(source)
+        if dispatch.keyword == "agent":
+            agent = parse_ai_source(dispatch.source)
+            return _envelope({
+                "result": "ok",
+                "spec": agent.name,
+                "dialect": "fsl-ai-agent.v0",
+                "warnings": [],
+            })
+        if is_ai_project_source(source):
+            project_name = Path(path).stem if path else "AiProject"
+            parse_ai_project(dispatch.source, project_name)
+            return _envelope({
+                "result": "ok",
+                "spec": project_name,
+                "dialect": "fsl-ai-project.v0",
+                "warnings": [],
+            })
         domain_warnings = []
         if is_domain_source(source):
             domain = parse_domain(source)

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -826,3 +826,31 @@ def test_registry_handles_annotation_trivia_and_rejects_invalid_shapes():
         "@acme.limit(9223372036854775807) spec Routed {}",
     ):
         assert inspect_source(valid).keyword == "spec"
+
+
+def test_lsp_diagnostics_use_registry_for_annotations_agents_and_ai_projects():
+    annotated = check_source(
+        '@requirement("REQ-247")\nspec Routed { state { value: Int } }',
+        "routed.fsl",
+    )
+    agent = check_source(
+        '// leading\n@acme.owner("platform")\nagent Worker {}',
+        "worker.fsl",
+    )
+    project = check_source(
+        '@acme.owner("platform")\ndataset Eval { source "eval.jsonl" }\n'
+        "statistical_property Quality {}",
+        "quality.fsl",
+    )
+
+    assert (annotated["result"], annotated["spec"]) == ("ok", "Routed")
+    assert (agent["result"], agent["spec"], agent["dialect"]) == (
+        "ok",
+        "Worker",
+        "fsl-ai-agent.v0",
+    )
+    assert (project["result"], project["spec"], project["dialect"]) == (
+        "ok",
+        "quality",
+        "fsl-ai-project.v0",
+    )

--- a/tests/test_rust_cli_semantics.py
+++ b/tests/test_rust_cli_semantics.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from fslc.dialect_registry import DIALECT_KEYWORDS
+
 
 ROOT = Path(__file__).resolve().parents[1]
 RUST = ROOT / "rust" / "target" / "debug" / "fslc"
@@ -565,6 +567,8 @@ def test_rust_check_dispatches_after_trivia_and_reports_stable_dialect_errors(tm
     assert unknown["diagnostic_code"] == "FSL-DIALECT-UNKNOWN"
     assert unknown["loc"] == {"line": 1, "column": 1}
     assert "spec, refinement, compose" in unknown["message"]
+    assert empty["supported_dialects"] == list(DIALECT_KEYWORDS)
+    assert unknown["supported_dialects"] == list(DIALECT_KEYWORDS)
     assert (disguised_status, disguised["diagnostic_code"]) == (
         2,
         "FSL-DIALECT-UNKNOWN",


### PR DESCRIPTION
## Problem

PR #276 implemented Issue #247 and closed it, but three acceptance gaps remained: qualified syntax paths were limited to one namespace segment, dispatch errors lacked a machine-readable supported dialect list, and LSP diagnostics did not route annotated agent/AI-project documents consistently. The generated language reference was also stale after the merged documentation update.

## Contract changes

- Preserve arbitrary-depth qualified names and exact per-segment spans through SymbolPath, with an explicit legacy Kernel adapter.
- Add supported_dialects to empty/annotation-target/unknown native CLI dispatch error envelopes.
- Route annotated agent and AI-project sources through the shared registry in LSP diagnostics.
- Regenerate the English and Japanese language reference pages.
- Update the accepted dialect-dispatch design and changelog.

## Verification

- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --workspace --locked
- cargo build --manifest-path rust/Cargo.toml --workspace --locked
- python -m pytest -q: 1428 passed, 80 skipped
- Independent review: no blocking findings

Follow-up to #276. Refs #247.