### PR TITLE
feat(cli): identify verifier runtime versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Changed
+- Native CLI and browser Worker result envelopes now identify the verifier,
+  `fsl-core`, and loaded Z3 versions through one `versions` schema. Native
+  verdict-cache keys and entries use the linked Z3 runtime version instead of a
+  hard-coded release string (issue #268).
 - Domain finite variants now use canonical `enum Name { Member, ... }` syntax,
   while bounded numeric domains remain `type Name = lo..hi`. The 2.x legacy
   union spelling remains compatible with a stable

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -194,6 +194,14 @@ contract, including non-obvious details:
 
 - `"fsl":"1.0"` is first, JSON is indented by two spaces, and non-ASCII text is
   emitted without ASCII escaping;
+- `versions` identifies the verifier package, `fsl-core`, and the linked Z3
+  runtime using the version it reports; native and
+  Worker envelopes use the same component schema even though their verifier
+  and backend names differ. The check/verify envelope contract is published as
+  `schemas/fslc/envelope.v1.schema.json`;
+- a Worker failure before Z3 initialization is a transport-level
+  `transportError`, not a check/verify envelope, because no loaded solver
+  version exists to report;
 - `faithfulness` defaults are applied recursively to nested result dictionaries;
 - `trace_type` is a top-level trailing default;
 - exit codes 0/1/2/3 retain their current meaning;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2035,7 +2035,12 @@ result = prove(spec, k_ind=1, base_depth=8)   # k-induction
 ```
 
 Returns a dict with the same structure as the CLI (the CLI wraps it with a
-`"fsl": "1.0"` envelope).
+`"fsl": "1.0"` envelope). Native CLI and browser Worker `check`/`verify`
+envelopes also contain `versions.verifier`, `versions.core`, and
+`versions.solver` objects. Each object has `name` and `version`; the solver
+object additionally has `backend`. Solver versions come from the loaded native
+or browser Z3 runtime rather than a CLI constant. The machine-readable contract
+is `schemas/fslc/envelope.v1.schema.json`.
 
 ## 15. Validation suite (the spec ≠ intent gap)
 

--- a/rust/fsl-core/src/diagnostics.rs
+++ b/rust/fsl-core/src/diagnostics.rs
@@ -6,6 +6,25 @@ use serde_json::{Map, Value, json};
 
 use crate::{KernelModel, TypeRef, display_name};
 
+/// Return implementation versions for native and Worker check/verify envelopes.
+#[must_use]
+pub fn version_metadata(
+    verifier: &str,
+    verifier_version: &str,
+    solver_backend: &str,
+    solver_version: &str,
+) -> Value {
+    json!({
+        "verifier": {"name": verifier, "version": verifier_version},
+        "core": {"name": "fsl-core", "version": env!("CARGO_PKG_VERSION")},
+        "solver": {
+            "name": "z3",
+            "backend": solver_backend,
+            "version": solver_version,
+        },
+    })
+}
+
 #[must_use]
 pub fn model_warnings(model: &KernelModel) -> Vec<Value> {
     let mut warnings = model

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -36,7 +36,9 @@ pub use compose::{
     FileResolver, FsResolver, lower_compose, parse_kernel_source, parse_kernel_source_with_file,
 };
 pub use db::db_kernel_source;
-pub use diagnostics::{insert_requirement_metadata, model_warnings, requirement_metadata};
+pub use diagnostics::{
+    insert_requirement_metadata, model_warnings, requirement_metadata, version_metadata,
+};
 pub use dialect::{
     GovernanceContract, GovernanceDelegate, GovernancePreservation, RequirementsTraceCase,
     RequirementsTraceContract, RequirementsTraceExpectation, RequirementsTraceStep,

--- a/rust/fsl-solver-z3/src/lib.rs
+++ b/rust/fsl-solver-z3/src/lib.rs
@@ -8,6 +8,12 @@ use z3::{Model, Solver};
 
 const REQUIRED_Z3_VERSION: &str = "4.16.0";
 
+/// Return the version reported by the linked Z3 library.
+#[must_use]
+pub fn version() -> &'static str {
+    z3::full_version()
+}
+
 #[derive(Clone, Debug)]
 pub enum Z3Term {
     Bool(Bool),
@@ -48,7 +54,7 @@ impl Z3Solver {
     ///
     /// Returns an error when the loaded Z3 library is not version 4.16.0.
     pub fn new() -> SolverResult<Self> {
-        let version = z3::full_version().to_owned();
+        let version = version().to_owned();
         let required_prefix = format!("Z3 {REQUIRED_Z3_VERSION}.");
         if !version.starts_with(&required_prefix) {
             return Err(SolverError::new(format!(
@@ -435,6 +441,7 @@ mod tests {
                 .version()
                 .starts_with(&format!("Z3 {REQUIRED_Z3_VERSION}."))
         );
+        assert_eq!(solver.version(), version());
         let x = solver.constant("x", &Sort::Int)?;
         let four = solver.int_value(4);
         let seven = solver.int_value(7);

--- a/rust/fsl-solver-z3js/src/lib.rs
+++ b/rust/fsl-solver-z3js/src/lib.rs
@@ -51,6 +51,14 @@ extern "C" {
     fn js_unsat_core() -> Array;
     #[wasm_bindgen(js_namespace = globalThis, js_name = fslZ3ModelEval)]
     fn js_model_eval(term: u32, boolean: bool) -> JsValue;
+    #[wasm_bindgen(js_namespace = globalThis, js_name = fslZ3Version)]
+    fn js_version() -> String;
+}
+
+/// Return the version reported by the initialized browser Z3 runtime.
+#[must_use]
+pub fn version() -> String {
+    js_version()
 }
 
 #[derive(Clone, Debug)]
@@ -69,7 +77,7 @@ impl Z3JsSolver {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            version: "Z3 4.16.0 (z3-solver npm)".to_owned(),
+            version: version(),
             stack_depth: 0,
         }
     }

--- a/rust/fsl-wasm/build.mjs
+++ b/rust/fsl-wasm/build.mjs
@@ -42,3 +42,4 @@ await cp(resolve(pkg, "fsl_wasm_bg.wasm"), resolve(dist, "fsl_wasm_bg.wasm"));
 await cp(resolve(root, "web/index.html"), resolve(dist, "index.html"));
 await cp(resolve(root, "web/client.mjs"), resolve(dist, "client.mjs"));
 await cp(resolve(root, "web/cases.mjs"), resolve(dist, "cases.mjs"));
+await cp(resolve(root, "web/worker-protocol.mjs"), resolve(dist, "worker-protocol.mjs"));

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -62,27 +62,37 @@ impl FileResolver for MemoryResolver {
     }
 }
 
-fn envelope() -> Map<String, Value> {
+fn envelope(solver_version: &str) -> Map<String, Value> {
     let mut output = Map::new();
     output.insert("fsl".to_owned(), json!("1.0"));
+    output.insert(
+        "versions".to_owned(),
+        fsl_core::version_metadata(
+            "fsl-wasm",
+            env!("CARGO_PKG_VERSION"),
+            "z3-solver-wasm",
+            solver_version,
+        ),
+    );
     output
 }
 
-fn error(kind: &str, message: impl AsRef<str>) -> Value {
-    let mut output = envelope();
+fn error(solver_version: &str, kind: &str, message: impl AsRef<str>) -> Value {
+    let mut output = envelope(solver_version);
     output.insert("result".to_owned(), json!("error"));
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message.as_ref()));
     Value::Object(output)
 }
 
-fn build(request: &Request) -> Result<KernelModel, Value> {
+fn build(request: &Request, solver_version: &str) -> Result<KernelModel, Value> {
     let resolver = MemoryResolver {
         files: request.files.clone(),
     };
     let kernel = fsl_core::parse_kernel_source(&request.source, &resolver)
-        .map_err(|failure| error("parse", failure.to_string()))?;
-    fsl_core::build_model(kernel).map_err(|failure| error("semantics", failure.to_string()))
+        .map_err(|failure| error(solver_version, "parse", failure.to_string()))?;
+    fsl_core::build_model(kernel)
+        .map_err(|failure| error(solver_version, "semantics", failure.to_string()))
 }
 
 fn has_bounds(model: &KernelModel, ty: &TypeRef) -> bool {
@@ -115,20 +125,20 @@ fn invariant_names(model: &KernelModel) -> Vec<String> {
     names
 }
 
-fn check(request: &Request) -> Value {
-    let model = match build(request) {
+fn check(request: &Request, solver_version: &str) -> Value {
+    let model = match build(request, solver_version) {
         Ok(model) => model,
         Err(error) => return error,
     };
-    let mut output = envelope();
+    let mut output = envelope(solver_version);
     output.insert("result".to_owned(), json!("ok"));
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("warnings".to_owned(), Value::Array(model_warnings(&model)));
     Value::Object(output)
 }
 
-async fn verify(request: &Request) -> Value {
-    let model = match build(request) {
+async fn verify(request: &Request, solver_version: &str) -> Value {
+    let model = match build(request, solver_version) {
         Ok(model) => model,
         Err(error) => return error,
     };
@@ -136,14 +146,19 @@ async fn verify(request: &Request) -> Value {
     let result =
         match fsl_verifier::verify_bounded(&model, &mut solver, request.options.depth).await {
             Ok(result) => result,
-            Err(failure) => return error("semantics", failure.to_string()),
+            Err(failure) => return error(solver_version, "semantics", failure.to_string()),
         };
-    render_verify(&model, &request.options, result)
+    render_verify(&model, &request.options, result, solver_version)
 }
 
 #[allow(clippy::too_many_lines)]
-fn render_verify(model: &KernelModel, options: &Options, result: fsl_verifier::BmcResult) -> Value {
-    let mut output = envelope();
+fn render_verify(
+    model: &KernelModel,
+    options: &Options,
+    result: fsl_verifier::BmcResult,
+    solver_version: &str,
+) -> Value {
+    let mut output = envelope(solver_version);
     output.insert("spec".to_owned(), json!(model.name));
     if let Some(violation) = result.violation {
         output.insert("result".to_owned(), json!("violated"));
@@ -296,28 +311,46 @@ fn render_verify(model: &KernelModel, options: &Options, result: fsl_verifier::B
 }
 
 /// Execute one Worker request and return the stable JSON envelope as text.
+///
+/// # Panics
+///
+/// Panics only if an in-memory `serde_json::Value` cannot be serialized.
 #[wasm_bindgen]
 pub async fn run(request_json: String) -> String {
+    let solver_version = fsl_solver_z3js::version();
     let request = match serde_json::from_str::<Request>(&request_json) {
         Ok(request) => request,
         Err(failure) => {
-            return error("io", format!("invalid request JSON: {failure}")).to_string();
+            return error(
+                &solver_version,
+                "io",
+                format!("invalid request JSON: {failure}"),
+            )
+            .to_string();
         }
     };
     let output = match request.cmd.as_str() {
-        "check" => check(&request),
-        "verify" => verify(&request).await,
+        "check" => check(&request, &solver_version),
+        "verify" => verify(&request, &solver_version).await,
         command => error(
+            &solver_version,
             "usage",
             format!("command '{command}' is not available in the browser Worker"),
         ),
     };
-    serde_json::to_string_pretty(&output).unwrap_or_else(|failure| {
-        format!(
-            "{{\"fsl\":\"1.0\",\"result\":\"error\",\"kind\":\"internal\",\"message\":{}}}",
-            serde_json::to_string(&failure.to_string()).unwrap_or_else(|_| "null".to_owned())
-        )
-    })
+    serde_json::to_string_pretty(&output).expect("JSON values serialize")
+}
+
+/// Render an internal verifier error after the Worker solver runtime initialized.
+///
+/// # Panics
+///
+/// Panics only if an in-memory `serde_json::Value` cannot be serialized.
+#[wasm_bindgen]
+#[must_use]
+pub fn internal_error(message: String) -> String {
+    let output = error(&fsl_solver_z3js::version(), "internal", message);
+    serde_json::to_string_pretty(&output).expect("JSON values serialize")
 }
 
 #[cfg(test)]
@@ -325,6 +358,8 @@ mod tests {
     use super::*;
     use fsl_core::{FslValue, TraceAction, TraceStep};
     use fsl_verifier::{BmcResult, BmcViolation, LeadsToViolation};
+
+    const TEST_SOLVER_VERSION: &str = "Z3 4.16.0.0";
 
     fn model_from(source: &str) -> KernelModel {
         let resolver = MemoryResolver {
@@ -343,7 +378,8 @@ mod tests {
             options: Options::default(),
         };
 
-        let error = build(&request).expect_err("duplicate write must fail in Worker build");
+        let error = build(&request, TEST_SOLVER_VERSION)
+            .expect_err("duplicate write must fail in Worker build");
 
         assert_eq!(error["kind"], json!("semantics"));
         assert!(
@@ -378,9 +414,22 @@ mod tests {
             frontier_progress: false,
         };
 
-        let envelope = render_verify(&model, &Options::default(), result);
+        let envelope = render_verify(&model, &Options::default(), result, TEST_SOLVER_VERSION);
         let warnings = envelope["warnings"].as_array().expect("warnings array");
 
+        assert_eq!(envelope["versions"]["verifier"]["name"], "fsl-wasm");
+        assert_eq!(
+            envelope["versions"]["verifier"]["version"],
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(envelope["versions"]["core"]["name"], "fsl-core");
+        assert_eq!(envelope["versions"]["solver"]["name"], "z3");
+        assert_eq!(envelope["versions"]["solver"]["backend"], "z3-solver-wasm");
+        assert!(
+            envelope["versions"]["solver"]["version"]
+                .as_str()
+                .is_some_and(|version| version.starts_with("Z3 4.16.0"))
+        );
         assert_eq!(warnings.len(), 3);
         assert_eq!(warnings[0]["kind"], json!("vacuous_implication"));
         assert_eq!(
@@ -435,7 +484,7 @@ mod tests {
             deadlock: "error".to_owned(),
         };
 
-        let envelope = render_verify(&model, &options, result);
+        let envelope = render_verify(&model, &options, result, TEST_SOLVER_VERSION);
 
         assert_eq!(envelope["violation_kind"], json!("deadlock"));
     }

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -11,6 +11,14 @@ import { fileURLToPath } from "node:url";
 
 import "./build.mjs";
 import { cases } from "./web/cases.mjs";
+import { workerMessageError } from "./web/worker-protocol.mjs";
+
+const protocolError = workerMessageError({
+  transportError: { kind: "initialization", message: "probe" },
+});
+if (protocolError?.message !== "initialization: probe" || workerMessageError({ envelope: {} })) {
+  throw new Error("Worker transport-error protocol is not observable by the client");
+}
 
 const dist = fileURLToPath(new URL("./dist/", import.meta.url));
 const mime = {
@@ -141,7 +149,7 @@ async function nativeVerdict(testCase, index) {
     childProcess.on("close", () => {
       try {
         const envelope = JSON.parse(stdout);
-        resolve({ result: envelope.result, violation_kind: envelope.violation_kind ?? null });
+        resolve(envelope);
       } catch (error) { reject(new Error(`native CLI JSON failure: ${error}\n${stderr}`)); }
     });
   });
@@ -153,7 +161,44 @@ for (let index = 0; index < cases.length; index += 1) {
 const wasm = browser.envelopes.map((envelope) => (
   { result: envelope.result, violation_kind: envelope.violation_kind ?? null }
 ));
-if (JSON.stringify(native) !== JSON.stringify(wasm)) {
-  throw new Error(`native/WASM verdict mismatch: native=${JSON.stringify(native)} wasm=${JSON.stringify(wasm)}`);
+const versionKeys = ["core", "solver", "verifier"];
+const componentKeys = ["name", "version"];
+const solverKeys = ["backend", "name", "version"];
+function validateVersions(envelope, verifier, backend) {
+  if (JSON.stringify(Object.keys(envelope.versions ?? {}).sort()) !== JSON.stringify(versionKeys)) {
+    throw new Error(`invalid version envelope: ${JSON.stringify(envelope.versions)}`);
+  }
+  for (const component of ["core", "verifier"]) {
+    if (JSON.stringify(Object.keys(envelope.versions[component]).sort()) !== JSON.stringify(componentKeys)) {
+      throw new Error(`invalid ${component} version: ${JSON.stringify(envelope.versions[component])}`);
+    }
+  }
+  if (JSON.stringify(Object.keys(envelope.versions.solver).sort()) !== JSON.stringify(solverKeys)) {
+    throw new Error(`invalid solver version: ${JSON.stringify(envelope.versions.solver)}`);
+  }
+  if (envelope.versions.verifier.name !== verifier
+      || envelope.versions.core.name !== "fsl-core"
+      || envelope.versions.solver.name !== "z3"
+      || envelope.versions.solver.backend !== backend
+      || !envelope.versions.verifier.version
+      || !envelope.versions.core.version
+      || !envelope.versions.solver.version.startsWith("Z3 4.16.0")) {
+    throw new Error(`incorrect version identity: ${JSON.stringify(envelope.versions)}`);
+  }
+}
+for (let index = 0; index < native.length; index += 1) {
+  validateVersions(native[index], "fslc-rust", "native-z3");
+  validateVersions(browser.envelopes[index], "fsl-wasm", "z3-solver-wasm");
+  if (native[index].versions.verifier.version !== browser.envelopes[index].versions.verifier.version
+      || native[index].versions.core.version !== browser.envelopes[index].versions.core.version
+      || native[index].versions.solver.version !== browser.envelopes[index].versions.solver.version) {
+    throw new Error(`native/WASM version mismatch: native=${JSON.stringify(native[index].versions)} wasm=${JSON.stringify(browser.envelopes[index].versions)}`);
+  }
+}
+const nativeVerdicts = native.map((envelope) => (
+  { result: envelope.result, violation_kind: envelope.violation_kind ?? null }
+));
+if (JSON.stringify(nativeVerdicts) !== JSON.stringify(wasm)) {
+  throw new Error(`native/WASM verdict mismatch: native=${JSON.stringify(nativeVerdicts)} wasm=${JSON.stringify(wasm)}`);
 }
 console.log(JSON.stringify({ schema: "fsl-wasm-browser.v1", ok: true, cancelled: true, nativeParity: true }, null, 2));

--- a/rust/fsl-wasm/web/client.mjs
+++ b/rust/fsl-wasm/web/client.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cases } from "./cases.mjs";
+import { workerMessageError } from "./worker-protocol.mjs";
 
 const output = document.querySelector("#result");
 const heartbeat = setInterval(() => {
@@ -11,7 +12,14 @@ function runCase(testCase) {
   return new Promise((resolve, reject) => {
     const worker = new Worker("./worker.js");
     worker.addEventListener("message", ({ data }) => {
-      if (data.id !== testCase.id || !data.envelope) return;
+      if (data.id !== testCase.id) return;
+      const error = workerMessageError(data);
+      if (error) {
+        worker.terminate();
+        reject(error);
+        return;
+      }
+      if (!data.envelope) return;
       worker.terminate();
       resolve(data.envelope);
     });
@@ -36,7 +44,15 @@ function cancelAndRecover() {
       reject(new Error("cancel probe did not initialize"));
     }, 30_000);
     worker.addEventListener("message", ({ data }) => {
-      if (data.id !== "cancel-probe" || !data.progress) return;
+      if (data.id !== "cancel-probe") return;
+      const error = workerMessageError(data);
+      if (error) {
+        clearTimeout(timeout);
+        worker.terminate();
+        reject(error);
+        return;
+      }
+      if (!data.progress) return;
       clearTimeout(timeout);
       worker.terminate();
       resolve(true);

--- a/rust/fsl-wasm/web/worker-entry.mjs
+++ b/rust/fsl-wasm/web/worker-entry.mjs
@@ -11,7 +11,7 @@ globalThis.initZ3 = (options = {}) => rawInitZ3({
   locateFile: (path) => new URL(path, self.location.href).href,
 });
 
-import initWasm, { run } from "../pkg/fsl_wasm.js";
+import initWasm, { internal_error as internalError, run } from "../pkg/fsl_wasm.js";
 import { installZ3Bridge, terminateSolverThreads } from "./z3-bridge.mjs";
 
 let initialized;
@@ -30,24 +30,21 @@ async function initialize() {
 
 self.addEventListener("message", async ({ data }) => {
   const { id, cmd, source, files, options } = data ?? {};
+  let ready = false;
   try {
     self.postMessage({ id, progress: { phase: "initializing" } });
     await initialize();
+    ready = true;
     self.postMessage({ id, progress: { phase: "verifying", depth: options?.depth ?? 8 } });
     const envelope = JSON.parse(
       await run(JSON.stringify({ cmd, source, files, options })),
     );
     self.postMessage({ id, envelope });
   } catch (error) {
-    self.postMessage({
-      id,
-      envelope: {
-        fsl: "1.0",
-        result: "error",
-        kind: "internal",
-        message: error instanceof Error ? error.message : String(error),
-      },
-    });
+    const message = error instanceof Error ? error.message : String(error);
+    self.postMessage(ready
+      ? { id, envelope: JSON.parse(internalError(message)) }
+      : { id, transportError: { kind: "initialization", message } });
   } finally {
     await terminateSolverThreads();
   }

--- a/rust/fsl-wasm/web/worker-protocol.mjs
+++ b/rust/fsl-wasm/web/worker-protocol.mjs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export function workerMessageError(data) {
+  if (!data?.transportError) return null;
+  const { kind, message } = data.transportError;
+  return new Error(`${kind}: ${message}`);
+}

--- a/rust/fsl-wasm/web/z3-bridge.mjs
+++ b/rust/fsl-wasm/web/z3-bridge.mjs
@@ -11,6 +11,7 @@ export async function installZ3Bridge() {
   const { Array: Z3Array, Bool, If, Int, Solver } = ctx;
   const solver = new Solver();
   solver.set("unsat_core", true);
+  globalThis.fslZ3Version = () => initialized.getFullVersion();
   const terms = [null];
   const sorts = [null];
   const sortDescriptors = [null];

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -330,12 +330,12 @@ fn command() -> Result<(Value, i32), String> {
                     _ => return Err(format!("unknown check option '{option}'")),
                 }
             }
-            Ok(run_check_with_tags(
+            Ok(with_version_metadata(run_check_with_tags(
                 &path,
                 strict_tags,
                 requirements.as_deref(),
                 &edition,
-            ))
+            )))
         }
         "kernel" => {
             let mut path = None;
@@ -1434,7 +1434,7 @@ fn command() -> Result<(Value, i32), String> {
             let options = parse_verify_options(&mut args)?;
             Ok(if command == "verify" {
                 let result = run_verify_cli(&path, &options);
-                apply_domain_edition(result, &path, &options.edition)
+                with_version_metadata(apply_domain_edition(result, &path, &options.edition))
             } else {
                 if options.engine != "bmc"
                     || options.explicit_budget != DEFAULT_EXPLICIT_BUDGET
@@ -13188,6 +13188,22 @@ fn envelope() -> Map<String, Value> {
     let mut output = Map::new();
     output.insert("fsl".to_owned(), json!("1.0"));
     output
+}
+
+fn with_version_metadata((mut output, status): (Value, i32)) -> (Value, i32) {
+    output
+        .as_object_mut()
+        .expect("check/verify envelope")
+        .insert(
+            "versions".to_owned(),
+            fsl_core::version_metadata(
+                "fslc-rust",
+                env!("CARGO_PKG_VERSION"),
+                "native-z3",
+                fsl_solver_z3::version(),
+            ),
+        );
+    (output, status)
 }
 
 fn error_output(kind: &str, message: &str) -> Value {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1594,6 +1594,14 @@ fn collect_fsl_sources(path: &Path, output: &mut Vec<PathBuf>) -> std::io::Resul
 }
 
 fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String, String), String> {
+    verify_cache_keys_with_solver_version(path, options, fsl_solver_z3::version())
+}
+
+fn verify_cache_keys_with_solver_version(
+    path: &Path,
+    options: &CliVerifyOptions,
+    solver_version: &str,
+) -> Result<(String, String), String> {
     let canonical = path.canonicalize().map_err(|error| error.to_string())?;
     let base = canonical.parent().unwrap_or_else(|| Path::new("."));
     let mut sources = Vec::new();
@@ -1605,7 +1613,9 @@ fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String,
     if options.engine == "explicit" {
         digest.update(b"\0backend=native-explicit\0");
     } else {
-        digest.update(b"\0backend=native-z3\0solver=4.16.0\0");
+        digest.update(b"\0backend=native-z3\0solver=");
+        digest.update(solver_version.as_bytes());
+        digest.update(b"\0");
     }
     let executable = std::env::current_exe().map_err(|error| error.to_string())?;
     digest.update(b"executable\0");
@@ -1720,7 +1730,11 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value) {
         "schema": "fslc-rust-cache.v1",
         "key": key,
         "backend": if explicit { "native-explicit" } else { "native-z3" },
-        "solver_version": if explicit { Value::Null } else { json!("4.16.0") },
+        "solver_version": if explicit {
+            Value::Null
+        } else {
+            json!(fsl_solver_z3::version())
+        },
         "output": output,
     });
     if serde_json::to_vec(&entry)
@@ -2146,5 +2160,18 @@ mod tests {
 
         assert_ne!(bmc_keys, explicit_keys);
         assert_ne!(explicit_keys, smaller_keys);
+    }
+
+    #[test]
+    fn bmc_cache_keys_include_the_loaded_solver_version() {
+        let path = repository_path("examples/gallery/valid/tiny_turnstile.fsl");
+        let options = CliVerifyOptions::default();
+
+        let current = verify_cache_keys_with_solver_version(&path, &options, "Z3 4.16.0.0")
+            .expect("current solver cache keys");
+        let updated = verify_cache_keys_with_solver_version(&path, &options, "Z3 4.17.0.0")
+            .expect("updated solver cache keys");
+
+        assert_ne!(current, updated);
     }
 }

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -28,6 +28,23 @@ fn native_cli_checks_a_repository_spec_without_python() {
     assert_eq!(value["fsl"], "1.0");
     assert_eq!(value["result"], "ok");
     assert_eq!(value["spec"], "ShoppingCart");
+    assert_eq!(value["versions"]["verifier"]["name"], "fslc-rust");
+    assert_eq!(
+        value["versions"]["verifier"]["version"],
+        env!("CARGO_PKG_VERSION")
+    );
+    assert_eq!(value["versions"]["core"]["name"], "fsl-core");
+    assert_eq!(
+        value["versions"]["core"]["version"],
+        env!("CARGO_PKG_VERSION")
+    );
+    assert_eq!(value["versions"]["solver"]["name"], "z3");
+    assert_eq!(value["versions"]["solver"]["backend"], "native-z3");
+    assert!(
+        value["versions"]["solver"]["version"]
+            .as_str()
+            .is_some_and(|version| version.starts_with("Z3 4.16.0"))
+    );
 }
 
 #[test]

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7852,6 +7852,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "ok",
           "spec": "DomainExpressionCharacterization"
         }
@@ -7860,6 +7875,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "spec": "DomainExpressionCharacterization",
           "result": "verified",
           "depth": 2,
@@ -8003,6 +8033,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "ok",
           "spec": "DomainEffectSagaCharacterization"
         }
@@ -8011,6 +8056,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "spec": "DomainEffectSagaCharacterization",
           "result": "verified",
           "depth": 2,
@@ -8054,6 +8114,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "ok",
           "spec": "DomainLvalueCharacterization"
         }
@@ -8062,6 +8137,21 @@
         "exit": 0,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "spec": "DomainLvalueCharacterization",
           "result": "verified",
           "depth": 2,
@@ -8088,6 +8178,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "unexpected character '&' at 6:47",
@@ -8102,6 +8207,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "unexpected character '&' at 6:47"
@@ -8113,6 +8233,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29"
@@ -8122,6 +8257,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29"
@@ -8133,6 +8283,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41"
@@ -8142,6 +8307,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41"
@@ -8153,6 +8333,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37"
@@ -8162,6 +8357,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37"
@@ -8173,6 +8383,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:42",
@@ -8187,6 +8412,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:42"
@@ -8198,6 +8438,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:44",
@@ -8212,6 +8467,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:44"
@@ -8223,6 +8493,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41"
@@ -8232,6 +8517,21 @@
         "exit": 2,
         "output": {
           "fsl": "1.0",
+          "versions": {
+            "verifier": {
+              "name": "fslc-rust",
+              "version": "2.7.0"
+            },
+            "core": {
+              "name": "fsl-core",
+              "version": "2.7.0"
+            },
+            "solver": {
+              "name": "z3",
+              "backend": "native-z3",
+              "version": "Z3 4.16.0.0"
+            }
+          },
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41"

--- a/schemas/fslc/envelope.v1.schema.json
+++ b/schemas/fslc/envelope.v1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fsl.dev/schemas/fslc/envelope.v1.schema.json",
+  "title": "FSL native CLI and Worker check/verify envelope v1",
+  "type": "object",
+  "required": ["fsl", "versions", "result"],
+  "properties": {
+    "fsl": { "const": "1.0" },
+    "result": { "type": "string", "minLength": 1 },
+    "versions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verifier", "core", "solver"],
+      "properties": {
+        "verifier": { "$ref": "#/$defs/component" },
+        "core": { "$ref": "#/$defs/component" },
+        "solver": { "$ref": "#/$defs/solverComponent" }
+      }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "component": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "solverComponent": {
+      "type": "object",
+      "required": ["name", "version", "backend"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "backend": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/test_rust_cli_contract.py
+++ b/tests/test_rust_cli_contract.py
@@ -9,6 +9,7 @@ import copy
 import hashlib
 import json
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -276,3 +277,48 @@ def test_rust_help_matches_embedded_contract_at_every_command_path(rust_contract
         )
         assert proc.returncode == 0, (node["path"], proc.stdout, proc.stderr)
         assert proc.stdout == node["help"], node["path"]
+
+
+def test_native_check_and_verify_publish_versioned_envelopes(rust_contract):
+    del rust_contract
+    schema = json.loads(
+        (ROOT / "schemas/fslc/envelope.v1.schema.json").read_text(encoding="utf-8")
+    )
+    workspace = tomllib.loads((ROOT / "rust/Cargo.toml").read_text(encoding="utf-8"))
+    expected_version = workspace["workspace"]["package"]["version"]
+
+    for args in (
+        ["check", "specs/cart_v1.fsl"],
+        [
+            "verify",
+            "examples/gallery/valid/tiny_turnstile.fsl",
+            "--depth",
+            "2",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ],
+    ):
+        proc = subprocess.run(
+            [str(RUST), *args],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        envelope = json.loads(proc.stdout)
+        assert all(field in envelope for field in schema["required"])
+        versions_schema = schema["properties"]["versions"]
+        assert set(envelope["versions"]) == set(versions_schema["required"])
+        assert envelope["versions"]["verifier"] == {
+            "name": "fslc-rust",
+            "version": expected_version,
+        }
+        assert envelope["versions"]["core"] == {
+            "name": "fsl-core",
+            "version": expected_version,
+        }
+        assert envelope["versions"]["solver"]["name"] == "z3"
+        assert envelope["versions"]["solver"]["backend"] == "native-z3"
+        assert envelope["versions"]["solver"]["version"].startswith("Z3 4.16.0")


### PR DESCRIPTION
## Problem
`check`/`verify` JSON did not identify the verifier, core, or loaded solver that produced the evidence, and native cache keys hard-coded the Z3 release.

## Contract change
- publish one `versions.verifier/core/solver` schema for native and Worker check/verify envelopes
- query native and browser Z3 runtimes for their full version
- key and record native verdict caches with the loaded Z3 version
- separate pre-initialization Worker transport failures from versioned verifier envelopes
- publish `schemas/fslc/envelope.v1.schema.json` and update the language/design contracts

## Test evidence
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py -q` (11 passed)
- `npm --prefix rust/fsl-wasm run test:browser` (protocol, cancellation, native/WASM parity)
- independently reviewed: merge ready

Closes #268