### PR TITLE
feat(approval): add signed approval records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   unlisted choice drift and runtime probes for invalid choices and help paths.
 
 ### Added
+- Approval records can now opt into detached Ed25519 signatures with
+  `approval create --signing-key`. The strict v2 schema binds the complete
+  canonical record, while `approval check`, `approval diff`, and `ledger`
+  require explicit repeatable trust anchors and distinguish signed, unsigned,
+  and signature-invalid evidence. Unsigned v1 behavior is unchanged (issue
+  #269).
 - Native dialect selection now lexes each document once and dispatches through a
   duplicate-checked keyword registry shared by Kernel, CLI, WASM, and mirrored
   Python/LSP entrypoints. Leading BOM/comments/whitespace and typed top-level

--- a/docs/DESIGN-approval.md
+++ b/docs/DESIGN-approval.md
@@ -1,6 +1,6 @@
 # Digest-bound approval records
 
-Issue: #190
+Issues: #190, #269
 
 ## Goal
 
@@ -26,6 +26,7 @@ fslc approval create specs/order.fsl \
   --artifact order-ledger.md \
   --approver alice \
   --depth 8 \
+  --signing-key alice-private.pem \
   -o order.approval.json
 ```
 
@@ -43,11 +44,23 @@ fslc approval check specs/order.fsl --record order.approval.json
 fslc ledger specs/order.fsl --approval order.approval.json
 ```
 
+Signed v2 records require an explicit trust anchor on every consuming command:
+
+```bash
+fslc approval check specs/order.fsl --record order.approval.json \
+  --trust-key alice-public.pem
+fslc ledger specs/order.fsl --approval order.approval.json \
+  --trust-key alice-public.pem
+```
+
 The direct result is `approval_check` with `status:"approved"` or
-`status:"drifted"`. Drift remains an analysis result and exits 0. A malformed,
+`status:"drifted"`. A signed record can instead report
+`status:"signature-invalid"`, which exits 1 and never grants approval. Drift
+remains an analysis result and exits 0. A malformed,
 unsupported, wrong-spec, or locally unavailable Git-baseline record is an error
-and exits 2. Unknown sidecar fields are rejected so schema changes cannot be
-silently ignored.
+and exits 2. A signed record without its matching trust key is also a
+configuration error and exits 2. Unknown sidecar fields are rejected so schema
+changes cannot be silently ignored.
 
 When drift is reported, compare the approved commit to the current working tree
 (including uncommitted edits) without manually materializing the baseline:
@@ -55,6 +68,8 @@ When drift is reported, compare the approved commit to the current working tree
 ```bash
 fslc approval diff specs/order.fsl --record order.approval.json --depth 8
 ```
+
+Pass the same repeatable `--trust-key` option when diffing a signed record.
 
 The result is the ordinary bounded `semantic_diff` envelope plus `approval`
 baseline metadata. Before comparison, the materialized specification is hashed
@@ -91,7 +106,35 @@ The committed sidecar follows
 }
 ```
 
-Supported target kinds are `ledger`, `html`, and `scenarios`.
+Supported target kinds are `ledger`, `html`, and `scenarios`. Omitting
+`--signing-key` continues to produce this exact unsigned v1 contract.
+
+Signed records use
+[`schemas/fslc/approval/approval-record.v2.schema.json`](../schemas/fslc/approval/approval-record.v2.schema.json).
+They preserve the v1 `spec`, `target`, and `approval` objects and add:
+
+```json
+{
+  "schema": "fslc.approval.v2",
+  "signature": {
+    "algorithm": "ed25519",
+    "key_id": "sha256:<64 hex>",
+    "value": "<base64url without padding>"
+  }
+}
+```
+
+`--signing-key` accepts an unencrypted PKCS#8 PEM Ed25519 private key.
+`--trust-key` accepts an SPKI PEM Ed25519 public key and is repeatable. The key
+ID is SHA-256 over the raw 32-byte public key. No other key encodings or
+algorithms are accepted.
+
+The detached signature covers
+`b"fslc.approval.v2\0" || canonical_json(record_without_signature.value)`.
+Canonical JSON recursively sorts object keys and emits compact UTF-8 JSON while
+preserving array order. This binds the schema, signature algorithm and key ID,
+specification, target, and approval fields while remaining insensitive to JSON
+object order and whitespace.
 
 ## Digest contracts
 
@@ -141,11 +184,14 @@ order; a later record replaces an earlier decision for the same requirement ID.
 
 ## Trust boundary
 
-The `approver` string is attribution, not a cryptographic identity. Authenticity
-and authorization remain repository controls: signed commits where required,
-CODEOWNERS/review policy, branch protection, and audit-log retention. Editing the
-sidecar is equivalent to editing other governed repository evidence. A future
-schema version may add detached signatures without changing v1 verification.
+For unsigned v1, the `approver` string is attribution rather than a
+cryptographic identity. For signed v2, successful verification proves that the
+holder of the matching private key signed the complete record. Supplying a
+public key as a trust anchor does not by itself establish that the signer is
+authorized to approve a requirement. Authorization remains repository and
+organizational policy: controlled trust-key distribution, CODEOWNERS/review
+policy, branch protection, and audit-log retention. v1 parsing and verification
+remain unchanged and are never used as a fallback for a v2 record.
 
 ## Tests
 
@@ -158,3 +204,8 @@ Native integration coverage proves:
 - `approval diff` materializes the approved commit and reports semantic change;
 - ledger output matches the approval snapshot;
 - ledger, HTML, and scenarios are valid review targets.
+- v1 remains unsigned and byte-shape compatible;
+- v2 signing is stable across JSON object reordering;
+- missing or mismatched trust anchors fail closed;
+- tampering reports `signature-invalid` and never appears approved in a ledger;
+- signed checks, semantic diffs, and ledgers report the signature status.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -675,10 +675,10 @@ fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag review (§15)
 fslc html      <file.fsl> [--depth K] [-o report.html] # self-contained review report (§15)
-fslc ledger    <file.fsl> [--depth K] [--impl-log run.json] [--approval record.json] [-o ledger.md] # business audit ledger by requirement id (§15)
-fslc approval create <file.fsl> --kind ledger|html|scenarios --artifact <reviewed> --approver <name> [-o record.json]
-fslc approval check  <file.fsl> --record <record.json>       # approved | drifted
-fslc approval diff   <file.fsl> --record <record.json> [--depth K]
+fslc ledger    <file.fsl> [--depth K] [--impl-log run.json] [--approval record.json] [--trust-key public.pem] [-o ledger.md] # business audit ledger by requirement id (§15)
+fslc approval create <file.fsl> --kind ledger|html|scenarios --artifact <reviewed> --approver <name> [--signing-key private.pem] [-o record.json]
+fslc approval check  <file.fsl> --record <record.json> [--trust-key public.pem] # approved | drifted | signature-invalid
+fslc approval diff   <file.fsl> --record <record.json> [--depth K] [--trust-key public.pem]
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check <file.fsl> [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
 fslc domain analyze <file.fsl>                                  # aggregate/effect ownership summary
@@ -800,6 +800,15 @@ all match; otherwise it returns `drifted` with `spec_changed`,
 same status per requirement and includes the full baseline digest. `approval
 diff` materializes the approved commit and invokes the ordinary bounded semantic
 diff against the current working file. See `docs/DESIGN-approval.md`.
+
+Without `--signing-key`, `approval create` emits the unchanged unsigned
+`fslc.approval.v1` record. With an Ed25519 PKCS#8 PEM signing key it emits
+`fslc.approval.v2`; every check, diff, or ledger use of that record requires the
+matching SPKI PEM `--trust-key`. The v2 detached signature covers the full
+canonical record, and a cryptographic mismatch is `signature-invalid` rather
+than an approval. Trust-key possession authenticates a signer but authorization
+remains an organizational policy. The exact canonicalization and key formats
+are specified in `docs/DESIGN-approval.md`.
 
 Exit codes: `0` = verified / proved / scenarios/testgen generated / conformant / refines /
 mutated / explained / analyzed / semantic_diff (unless its explicit gate fails) /

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -32,6 +32,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,7 +115,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -127,6 +133,12 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -202,10 +214,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -230,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
@@ -248,10 +298,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -361,6 +441,8 @@ dependencies = [
 name = "fslc-rust"
 version = "2.7.0"
 dependencies = [
+ "base64",
+ "ed25519-dalek",
  "fsl-core",
  "fsl-runtime",
  "fsl-solver-z3",
@@ -454,7 +536,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -824,6 +906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +925,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -950,7 +1051,16 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -965,7 +1075,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1029,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1193,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1171,6 +1296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1330,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,8 @@ license = "Apache-2.0"
 rust-version = "1.85"
 
 [workspace.dependencies]
+base64 = "0.22"
+ed25519-dalek = { version = "=2.2.0", features = ["pkcs8", "pem"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sha2 = "0.10"

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -626,10 +626,17 @@ fn approval_cell(approvals: Option<&Value>, requirement_id: &str) -> String {
     let Some(entry) = approval_entry(approvals, requirement_id) else {
         return "— unapproved".to_owned();
     };
+    if entry.get("signature_status").and_then(Value::as_str) == Some("signature-invalid") {
+        return "❌ signature-invalid".to_owned();
+    }
+    let signature = match entry.get("signature_status").and_then(Value::as_str) {
+        Some("signed") => "signed",
+        _ => "unsigned",
+    };
     match entry.get("status").and_then(Value::as_str) {
-        Some("approved") => "✅ approved".to_owned(),
+        Some("approved") => format!("✅ approved ({signature})"),
         Some("drifted") => format!(
-            "⚠ drifted (since {})",
+            "⚠ drifted ({signature}; since {})",
             entry
                 .get("baseline_digest")
                 .and_then(Value::as_str)

--- a/rust/fslc/Cargo.toml
+++ b/rust/fslc/Cargo.toml
@@ -11,6 +11,8 @@ name = "fslc"
 path = "src/main.rs"
 
 [dependencies]
+base64.workspace = true
+ed25519-dalek.workspace = true
 fsl-core = { path = "../fsl-core" }
 fsl-runtime = { path = "../fsl-runtime" }
 fsl-solver-z3 = { path = "../fsl-solver-z3" }

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -1404,7 +1404,7 @@
           {
             "path": ["approval", "create"],
             "prog": "fslc approval create",
-            "help": "usage: fslc approval create [-h] --kind {ledger,html,scenarios} --artifact ARTIFACT --approver APPROVER [--requirement ID] [--depth DEPTH] [--deadlock {warn,error,ignore}] [--engine {bmc,induction}] [-o OUTPUT] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --kind {ledger,html,scenarios}\n  --artifact ARTIFACT   reviewed artifact generated with the recorded inputs\n  --approver APPROVER\n  --requirement ID      requirement ID to approve; repeatable, defaults to all\n  --depth DEPTH\n  --deadlock {warn,error,ignore}\n  --engine {bmc,induction}\n  -o, --output OUTPUT\n",
+            "help": "usage: fslc approval create [-h] --kind {ledger,html,scenarios} --artifact ARTIFACT --approver APPROVER [--requirement ID] [--signing-key PRIVATE_KEY] [--depth DEPTH] [--deadlock {warn,error,ignore}] [--engine {bmc,induction}] [-o OUTPUT] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --kind {ledger,html,scenarios}\n  --artifact ARTIFACT   reviewed artifact generated with the recorded inputs\n  --approver APPROVER\n  --requirement ID      requirement ID to approve; repeatable, defaults to all\n  --signing-key PRIVATE_KEY\n                        create a signed v2 record with a PKCS#8 Ed25519 key\n  --depth DEPTH\n  --deadlock {warn,error,ignore}\n  --engine {bmc,induction}\n  -o, --output OUTPUT\n",
             "actions": [
               {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
               {"dest":"file","required":true,"positional":true,"action":"store"},
@@ -1412,6 +1412,7 @@
               {"dest":"artifact","required":true,"flags":["--artifact"],"action":"store"},
               {"dest":"approver","required":true,"flags":["--approver"],"action":"store"},
               {"dest":"requirement","required":false,"flags":["--requirement"],"repeatable":true,"action":"store"},
+              {"dest":"signing_key","required":false,"flags":["--signing-key"],"action":"store"},
               {"dest":"depth","required":false,"flags":["--depth"],"default":8,"action":"store"},
               {"dest":"deadlock","required":false,"flags":["--deadlock"],"choices":["warn","error","ignore"],"default":"ignore","action":"store"},
               {"dest":"engine","required":false,"flags":["--engine"],"choices":["bmc","induction"],"default":"bmc","action":"store"},
@@ -1422,23 +1423,25 @@
           {
             "path": ["approval", "check"],
             "prog": "fslc approval check",
-            "help": "usage: fslc approval check [-h] --record RECORD file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help       show this help message and exit\n  --record RECORD\n",
+            "help": "usage: fslc approval check [-h] --record RECORD [--trust-key PUBLIC_KEY] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --record RECORD\n  --trust-key PUBLIC_KEY\n                        trusted SPKI Ed25519 public key; repeatable\n",
             "actions": [
               {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
               {"dest":"file","required":true,"positional":true,"action":"store"},
-              {"dest":"record","required":true,"flags":["--record"],"action":"store"}
+              {"dest":"record","required":true,"flags":["--record"],"action":"store"},
+              {"dest":"trust_key","required":false,"flags":["--trust-key"],"repeatable":true,"action":"store"}
             ],
             "commands": []
           },
           {
             "path": ["approval", "diff"],
             "prog": "fslc approval diff",
-            "help": "usage: fslc approval diff [-h] --record RECORD [--depth DEPTH] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help       show this help message and exit\n  --record RECORD\n  --depth DEPTH\n",
+            "help": "usage: fslc approval diff [-h] --record RECORD [--depth DEPTH] [--trust-key PUBLIC_KEY] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --record RECORD\n  --depth DEPTH\n  --trust-key PUBLIC_KEY\n                        trusted SPKI Ed25519 public key; repeatable\n",
             "actions": [
               {"dest":"help","required":false,"flags":["-h","--help"],"nargs":0,"action":"store"},
               {"dest":"file","required":true,"positional":true,"action":"store"},
               {"dest":"record","required":true,"flags":["--record"],"action":"store"},
-              {"dest":"depth","required":false,"flags":["--depth"],"default":8,"action":"store"}
+              {"dest":"depth","required":false,"flags":["--depth"],"default":8,"action":"store"},
+              {"dest":"trust_key","required":false,"flags":["--trust-key"],"repeatable":true,"action":"store"}
             ],
             "commands": []
           }
@@ -1449,7 +1452,7 @@
           "ledger"
         ],
         "prog": "fslc ledger",
-        "help": "usage: fslc ledger [-h] [--depth DEPTH] [-o OUTPUT] [--deadlock {warn,error,ignore}] [--impl-log IMPL_LOG] [--engine {bmc,induction}] [--evidence EVIDENCE] [--approval RECORD] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  -o, --output OUTPUT\n  --deadlock {warn,error,ignore}\n  --impl-log IMPL_LOG   optional implementation trace JSON to score conformance\n                        (fslc replay)\n  --engine {bmc,induction}\n                        use k-induction so a requirement's assurance class can\n                        reach 'proved' (#171)\n  --evidence EVIDENCE   path to a saved stdout envelope (JSON) from an external-\n                        evidence producer (fslc ai eval/replay/drift, fslc db\n                        observe, fslc domain replay, ...); repeatable\n  --approval RECORD     digest-bound approval record to check; repeatable\n",
+        "help": "usage: fslc ledger [-h] [--depth DEPTH] [-o OUTPUT] [--deadlock {warn,error,ignore}] [--impl-log IMPL_LOG] [--engine {bmc,induction}] [--evidence EVIDENCE] [--approval RECORD] [--trust-key PUBLIC_KEY] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  -o, --output OUTPUT\n  --deadlock {warn,error,ignore}\n  --impl-log IMPL_LOG   optional implementation trace JSON to score conformance\n                        (fslc replay)\n  --engine {bmc,induction}\n                        use k-induction so a requirement's assurance class can\n                        reach 'proved' (#171)\n  --evidence EVIDENCE   path to a saved stdout envelope (JSON) from an external-\n                        evidence producer (fslc ai eval/replay/drift, fslc db\n                        observe, fslc domain replay, ...); repeatable\n  --approval RECORD     digest-bound approval record to check; repeatable\n  --trust-key PUBLIC_KEY\n                        trusted SPKI Ed25519 public key; repeatable\n",
         "actions": [
           {
             "dest": "help",
@@ -1534,6 +1537,15 @@
             "required": false,
             "flags": [
               "--approval"
+            ],
+            "repeatable": true,
+            "action": "store"
+          },
+          {
+            "dest": "trust_key",
+            "required": false,
+            "flags": [
+              "--trust-key"
             ],
             "repeatable": true,
             "action": "store"

--- a/rust/fslc/src/approval.rs
+++ b/rust/fslc/src/approval.rs
@@ -3,17 +3,23 @@
 
 //! Versioned approval records that bind reviewed artifacts to normalized FSL.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use base64::Engine;
+use ed25519_dalek::pkcs8::{DecodePrivateKey, DecodePublicKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use fsl_core::KernelModel;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 pub const APPROVAL_SCHEMA: &str = "fslc.approval.v1";
+pub const APPROVAL_SCHEMA_V2: &str = "fslc.approval.v2";
+pub const SIGNATURE_ALGORITHM: &str = "ed25519";
 pub const SPEC_DIGEST_ALGORITHM: &str = "fsl-kernel-ast-v1+sha256";
 pub const ARTIFACT_DIGEST_ALGORITHM: &str = "fsl-rendered-artifact-v1+sha256";
 
@@ -61,6 +67,84 @@ pub struct ApprovalRecord {
     pub spec: SpecBinding,
     pub target: TargetBinding,
     pub approval: ApprovalMetadata,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetachedSignature {
+    pub algorithm: String,
+    pub key_id: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalRecordV2 {
+    pub schema: String,
+    pub spec: SpecBinding,
+    pub target: TargetBinding,
+    pub approval: ApprovalMetadata,
+    pub signature: DetachedSignature,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VersionedApprovalRecord {
+    V1(ApprovalRecord),
+    V2(ApprovalRecordV2),
+}
+
+impl VersionedApprovalRecord {
+    #[must_use]
+    pub fn binding(&self) -> ApprovalRecord {
+        match self {
+            Self::V1(record) => record.clone(),
+            Self::V2(record) => ApprovalRecord {
+                schema: APPROVAL_SCHEMA.to_owned(),
+                spec: record.spec.clone(),
+                target: record.target.clone(),
+                approval: record.approval.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct TrustStore {
+    keys: BTreeMap<String, VerifyingKey>,
+}
+
+impl TrustStore {
+    pub fn load(paths: &[PathBuf]) -> Result<Self, String> {
+        let mut keys = BTreeMap::new();
+        for path in paths {
+            let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+            let key = VerifyingKey::from_public_key_pem(&source).map_err(|error| {
+                format!("invalid Ed25519 public key '{}': {error}", path.display())
+            })?;
+            keys.insert(key_id(&key), key);
+        }
+        Ok(Self { keys })
+    }
+
+    pub fn verify(&self, record: &ApprovalRecordV2) -> Result<bool, String> {
+        let key = self.keys.get(&record.signature.key_id).ok_or_else(|| {
+            format!(
+                "no trusted Ed25519 public key matches '{}'",
+                record.signature.key_id
+            )
+        })?;
+        let raw = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&record.signature.value)
+            .map_err(|error| format!("invalid detached signature encoding: {error}"))?;
+        if base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&raw) != record.signature.value {
+            return Err("detached signature is not canonical base64url-no-pad".to_owned());
+        }
+        let signature = Signature::from_slice(&raw)
+            .map_err(|error| format!("invalid Ed25519 signature: {error}"))?;
+        Ok(key
+            .verify_strict(&signature_payload(record)?, &signature)
+            .is_ok())
+    }
 }
 
 fn is_location(value: &Map<String, Value>) -> bool {
@@ -118,6 +202,25 @@ fn stable_json(value: &Value, strip_execution_metadata: bool) -> Value {
         }
         _ => value.clone(),
     }
+}
+
+fn key_id(key: &VerifyingKey) -> String {
+    sha256_bytes(key.as_bytes())
+}
+
+fn signature_payload(record: &ApprovalRecordV2) -> Result<Vec<u8>, String> {
+    let mut value = serde_json::to_value(record).map_err(|error| error.to_string())?;
+    value
+        .get_mut("signature")
+        .and_then(Value::as_object_mut)
+        .expect("serialized v2 signature is an object")
+        .remove("value");
+    let mut payload = APPROVAL_SCHEMA_V2.as_bytes().to_vec();
+    payload.push(0);
+    payload.extend(
+        serde_json::to_vec(&stable_json(&value, false)).map_err(|error| error.to_string())?,
+    );
+    Ok(payload)
 }
 
 /// Remove execution-only noise before binding a human-facing artifact.
@@ -285,6 +388,27 @@ pub fn read_record(path: &Path) -> Result<ApprovalRecord, String> {
     Ok(record)
 }
 
+pub fn read_versioned_record(path: &Path) -> Result<VersionedApprovalRecord, String> {
+    #[derive(Deserialize)]
+    struct SchemaHeader {
+        schema: String,
+    }
+
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let header: SchemaHeader = serde_json::from_str(&source)
+        .map_err(|error| format!("invalid approval record: {error}"))?;
+    match header.schema.as_str() {
+        APPROVAL_SCHEMA => read_record(path).map(VersionedApprovalRecord::V1),
+        APPROVAL_SCHEMA_V2 => {
+            let record: ApprovalRecordV2 = serde_json::from_str(&source)
+                .map_err(|error| format!("invalid approval record: {error}"))?;
+            validate_record_v2(&record)?;
+            Ok(VersionedApprovalRecord::V2(record))
+        }
+        schema => Err(format!("unsupported approval schema '{schema}'")),
+    }
+}
+
 pub fn validate_record(record: &ApprovalRecord) -> Result<(), String> {
     if record.schema != APPROVAL_SCHEMA {
         return Err(format!("unsupported approval schema '{}'", record.schema));
@@ -353,6 +477,36 @@ pub fn validate_record(record: &ApprovalRecord) -> Result<(), String> {
     Ok(())
 }
 
+pub fn validate_record_v2(record: &ApprovalRecordV2) -> Result<(), String> {
+    if record.schema != APPROVAL_SCHEMA_V2 {
+        return Err(format!("unsupported approval schema '{}'", record.schema));
+    }
+    validate_record(&ApprovalRecord {
+        schema: APPROVAL_SCHEMA.to_owned(),
+        spec: record.spec.clone(),
+        target: record.target.clone(),
+        approval: record.approval.clone(),
+    })?;
+    if record.signature.algorithm != SIGNATURE_ALGORITHM {
+        return Err(format!(
+            "unsupported approval signature algorithm '{}'",
+            record.signature.algorithm
+        ));
+    }
+    if !is_sha256(&record.signature.key_id) {
+        return Err("approval record contains an invalid signature key ID".to_owned());
+    }
+    let raw = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&record.signature.value)
+        .map_err(|error| format!("invalid detached signature encoding: {error}"))?;
+    if raw.len() != Signature::BYTE_SIZE
+        || base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&raw) != record.signature.value
+    {
+        return Err("approval record contains an invalid detached signature".to_owned());
+    }
+    Ok(())
+}
+
 fn is_sha256(value: &str) -> bool {
     value.len() == 71
         && value.starts_with("sha256:")
@@ -401,6 +555,39 @@ fn is_canonical_utc_timestamp(value: &str) -> bool {
 }
 
 pub fn write_record(path: &Path, record: &ApprovalRecord) -> Result<(), String> {
+    let mut encoded = serde_json::to_string_pretty(record).map_err(|error| error.to_string())?;
+    encoded.push('\n');
+    std::fs::write(path, encoded).map_err(|error| error.to_string())
+}
+
+pub fn sign_record(record: ApprovalRecord, private_key: &Path) -> Result<ApprovalRecordV2, String> {
+    validate_record(&record)?;
+    let source = std::fs::read_to_string(private_key).map_err(|error| error.to_string())?;
+    let key = SigningKey::from_pkcs8_pem(&source).map_err(|error| {
+        format!(
+            "invalid Ed25519 private key '{}': {error}",
+            private_key.display()
+        )
+    })?;
+    let mut signed = ApprovalRecordV2 {
+        schema: APPROVAL_SCHEMA_V2.to_owned(),
+        spec: record.spec,
+        target: record.target,
+        approval: record.approval,
+        signature: DetachedSignature {
+            algorithm: SIGNATURE_ALGORITHM.to_owned(),
+            key_id: key_id(&key.verifying_key()),
+            value: String::new(),
+        },
+    };
+    let signature = key.sign(&signature_payload(&signed)?);
+    signed.signature.value =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
+    Ok(signed)
+}
+
+pub fn write_record_v2(path: &Path, record: &ApprovalRecordV2) -> Result<(), String> {
+    validate_record_v2(record)?;
     let mut encoded = serde_json::to_string_pretty(record).map_err(|error| error.to_string())?;
     encoded.push('\n');
     std::fs::write(path, encoded).map_err(|error| error.to_string())

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -412,6 +412,7 @@ fn command() -> Result<(Value, i32), String> {
                     let mut deadlock = "ignore".to_owned();
                     let mut engine = "bmc".to_owned();
                     let mut output = None;
+                    let mut signing_key = None;
                     while let Some(option) = args.next() {
                         match option.as_str() {
                             "--kind" => kind = Some(required_option_value(&mut args, "--kind")?),
@@ -426,6 +427,12 @@ fn command() -> Result<(Value, i32), String> {
                             }
                             "--requirement" => requirements
                                 .push(required_option_value(&mut args, "--requirement")?),
+                            "--signing-key" => {
+                                signing_key = Some(PathBuf::from(required_option_value(
+                                    &mut args,
+                                    "--signing-key",
+                                )?));
+                            }
                             "--depth" => {
                                 depth = required_option_value(&mut args, "--depth")?
                                     .parse()
@@ -469,24 +476,36 @@ fn command() -> Result<(Value, i32), String> {
                             engine,
                         },
                         output.as_deref(),
+                        signing_key.as_deref(),
                     ))
                 }
                 "check" => {
-                    if args.next().as_deref() != Some("--record") {
-                        return Err("approval check requires --record RECORD.json".to_owned());
+                    let mut record = None;
+                    let mut trust_keys = Vec::new();
+                    while let Some(option) = args.next() {
+                        match option.as_str() {
+                            "--record" => {
+                                record = Some(PathBuf::from(required_option_value(
+                                    &mut args, "--record",
+                                )?));
+                            }
+                            "--trust-key" => trust_keys.push(PathBuf::from(required_option_value(
+                                &mut args,
+                                "--trust-key",
+                            )?)),
+                            _ => return Err(format!("unknown approval check option '{option}'")),
+                        }
                     }
-                    let record = PathBuf::from(
-                        args.next()
-                            .ok_or_else(|| "--record requires a path".to_owned())?,
-                    );
-                    if args.next().is_some() {
-                        return Err("unexpected approval check argument".to_owned());
-                    }
-                    Ok(run_approval_check(&path, &record))
+                    Ok(run_approval_check(
+                        &path,
+                        &record.ok_or_else(|| "approval check requires --record".to_owned())?,
+                        &trust_keys,
+                    ))
                 }
                 "diff" => {
                     let mut record = None;
                     let mut depth = 8_usize;
+                    let mut trust_keys = Vec::new();
                     while let Some(option) = args.next() {
                         match option.as_str() {
                             "--record" => {
@@ -501,6 +520,10 @@ fn command() -> Result<(Value, i32), String> {
                                         "--depth must be a non-negative integer".to_owned()
                                     })?;
                             }
+                            "--trust-key" => trust_keys.push(PathBuf::from(required_option_value(
+                                &mut args,
+                                "--trust-key",
+                            )?)),
                             _ => return Err(format!("unknown approval diff option '{option}'")),
                         }
                     }
@@ -508,6 +531,7 @@ fn command() -> Result<(Value, i32), String> {
                         &path,
                         &record.ok_or_else(|| "approval diff requires --record".to_owned())?,
                         depth,
+                        &trust_keys,
                     ))
                 }
                 _ => Err(format!("unknown approval subcommand '{subcommand}'")),
@@ -1000,6 +1024,7 @@ fn command() -> Result<(Value, i32), String> {
             let mut impl_log = None;
             let mut evidence = Vec::new();
             let mut approval_records = Vec::new();
+            let mut trust_keys = Vec::new();
             let mut deadlock = if command == "ledger" {
                 "ignore".to_owned()
             } else {
@@ -1054,6 +1079,9 @@ fn command() -> Result<(Value, i32), String> {
                     "--approval" if command == "ledger" => approval_records.push(PathBuf::from(
                         required_option_value(&mut args, "--approval")?,
                     )),
+                    "--trust-key" if command == "ledger" => trust_keys.push(PathBuf::from(
+                        required_option_value(&mut args, "--trust-key")?,
+                    )),
                     "--strict" => strict = true,
                     _ => return Err(format!("unknown {command} option '{option}'")),
                 }
@@ -1071,6 +1099,7 @@ fn command() -> Result<(Value, i32), String> {
                     impl_log.as_deref(),
                     &evidence,
                     &approval_records,
+                    &trust_keys,
                     output.as_deref(),
                 ),
                 _ => unreachable!(),
@@ -8101,6 +8130,7 @@ fn approval_artifact(
             None,
             &[],
             &[],
+            &[],
             None,
         ),
         "html" => run_html_report(path, inputs.depth, &inputs.deadlock, &inputs.engine, None),
@@ -8138,6 +8168,7 @@ fn run_approval_create(
     selected_requirements: &[String],
     inputs: &approval::GenerationInputs,
     output_path: Option<&Path>,
+    signing_key: Option<&Path>,
 ) -> (Value, i32) {
     if !matches!(kind, "ledger" | "html" | "scenarios") {
         return (
@@ -8247,22 +8278,63 @@ fn run_approval_create(
         },
         Path::to_path_buf,
     );
-    if let Err(error) = approval::write_record(&destination, &record) {
-        return (error_output("io", &error), 2);
-    }
+    let record = if let Some(signing_key) = signing_key {
+        let record = match approval::sign_record(record, signing_key) {
+            Ok(record) => record,
+            Err(error) => return (error_output("io", &error), 2),
+        };
+        if let Err(error) = approval::write_record_v2(&destination, &record) {
+            return (error_output("io", &error), 2);
+        }
+        serde_json::to_value(record).expect("approval v2 serializes")
+    } else {
+        if let Err(error) = approval::write_record(&destination, &record) {
+            return (error_output("io", &error), 2);
+        }
+        serde_json::to_value(record).expect("approval v1 serializes")
+    };
     let mut output = envelope();
     output.insert("result".to_owned(), json!("created"));
     output.insert("kind".to_owned(), json!("approval_record"));
     output.insert("output".to_owned(), json!(destination));
-    output.insert(
-        "record".to_owned(),
-        serde_json::to_value(record).unwrap_or(Value::Null),
-    );
+    output.insert("record".to_owned(), record);
     (Value::Object(output), 0)
 }
 
-fn approval_evaluation(path: &Path, record_path: &Path) -> Result<Value, Value> {
-    let record = approval::read_record(record_path).map_err(|error| error_output("io", &error))?;
+fn approval_evaluation(
+    path: &Path,
+    record_path: &Path,
+    trust: &approval::TrustStore,
+) -> Result<Value, Value> {
+    let versioned =
+        approval::read_versioned_record(record_path).map_err(|error| error_output("io", &error))?;
+    let (record, signature_status, key_id) = match &versioned {
+        approval::VersionedApprovalRecord::V1(record) => (record.clone(), "unsigned", Value::Null),
+        approval::VersionedApprovalRecord::V2(record) => {
+            let verified = trust
+                .verify(record)
+                .map_err(|error| error_output("io", &error))?;
+            if !verified {
+                return Ok(json!({
+                    "status": "signature-invalid",
+                    "signature_status": "signature-invalid",
+                    "key_id": record.signature.key_id,
+                    "reasons": ["signature_invalid"],
+                    "record": record_path.display().to_string(),
+                    "target_kind": record.target.kind,
+                    "approver": record.approval.approver,
+                    "approved_at": record.approval.approved_at,
+                    "requirements": record.approval.requirements,
+                    "baseline_digest": record.spec.digest,
+                }));
+            }
+            (
+                versioned.binding(),
+                "signed",
+                json!(record.signature.key_id),
+            )
+        }
+    };
     let (repo, relative_path, _head) =
         approval::git_location(path).map_err(|error| error_output("io", &error))?;
     if record.spec.path != relative_path {
@@ -8282,17 +8354,27 @@ fn approval_evaluation(path: &Path, record_path: &Path) -> Result<Value, Value> 
     let normalized_artifact = approval::normalized_artifact(&record.target.kind, &artifact)
         .map_err(|error| error_output("internal", &error))?;
     let current_artifact_digest = approval::sha256_bytes(&normalized_artifact);
-    Ok(approval::evaluate(
+    let mut evaluation = approval::evaluate(
         &record,
         record_path,
         &current_spec_digest,
         &current_artifact_digest,
         env!("CARGO_PKG_VERSION"),
-    ))
+    );
+    let output = evaluation
+        .as_object_mut()
+        .expect("approval evaluation object");
+    output.insert("signature_status".to_owned(), json!(signature_status));
+    output.insert("key_id".to_owned(), key_id);
+    Ok(evaluation)
 }
 
-fn run_approval_check(path: &Path, record_path: &Path) -> (Value, i32) {
-    let evaluation = match approval_evaluation(path, record_path) {
+fn run_approval_check(path: &Path, record_path: &Path, trust_keys: &[PathBuf]) -> (Value, i32) {
+    let trust = match approval::TrustStore::load(trust_keys) {
+        Ok(trust) => trust,
+        Err(error) => return (error_output("io", &error), 2),
+    };
+    let evaluation = match approval_evaluation(path, record_path, &trust) {
         Ok(evaluation) => evaluation,
         Err(error) => return (error, 2),
     };
@@ -8301,14 +8383,22 @@ fn run_approval_check(path: &Path, record_path: &Path) -> (Value, i32) {
     if let Some(fields) = evaluation.as_object() {
         output.extend(fields.clone());
     }
-    (Value::Object(output), 0)
+    let status =
+        i32::from(evaluation.get("status").and_then(Value::as_str) == Some("signature-invalid"));
+    (Value::Object(output), status)
 }
 
-fn approval_overlay(path: &Path, record_paths: &[PathBuf]) -> Result<Value, Value> {
+fn approval_overlay(
+    path: &Path,
+    record_paths: &[PathBuf],
+    trust_keys: &[PathBuf],
+) -> Result<Value, Value> {
+    let trust =
+        approval::TrustStore::load(trust_keys).map_err(|error| error_output("io", &error))?;
     let mut requirements = Map::new();
     let mut records = Vec::new();
     for record_path in record_paths {
-        let evaluation = approval_evaluation(path, record_path)?;
+        let evaluation = approval_evaluation(path, record_path, &trust)?;
         for requirement in evaluation
             .get("requirements")
             .and_then(Value::as_array)
@@ -8332,6 +8422,7 @@ fn run_ledger_report(
     impl_log: Option<&Path>,
     evidence_paths: &[PathBuf],
     approval_paths: &[PathBuf],
+    trust_keys: &[PathBuf],
     output_path: Option<&Path>,
 ) -> (Value, i32) {
     let model = match load_model(path) {
@@ -8375,7 +8466,7 @@ fn run_ledger_report(
     let approvals = if approval_paths.is_empty() {
         None
     } else {
-        match approval_overlay(path, approval_paths) {
+        match approval_overlay(path, approval_paths, trust_keys) {
             Ok(approvals) => Some(approvals),
             Err(error) => return (error, 2),
         }
@@ -11319,10 +11410,39 @@ fn materialize_git_tree(repo: &Path, revision: &str, destination: &Path) -> Resu
     Ok(())
 }
 
-fn run_approval_diff(path: &Path, record_path: &Path, depth: usize) -> (Value, i32) {
-    let record = match approval::read_record(record_path) {
+#[allow(clippy::too_many_lines)]
+fn run_approval_diff(
+    path: &Path,
+    record_path: &Path,
+    depth: usize,
+    trust_keys: &[PathBuf],
+) -> (Value, i32) {
+    let versioned = match approval::read_versioned_record(record_path) {
         Ok(record) => record,
         Err(error) => return (error_output("io", &error), 2),
+    };
+    let trust = match approval::TrustStore::load(trust_keys) {
+        Ok(trust) => trust,
+        Err(error) => return (error_output("io", &error), 2),
+    };
+    let (record, signature_status, key_id) = match &versioned {
+        approval::VersionedApprovalRecord::V1(record) => (record.clone(), "unsigned", Value::Null),
+        approval::VersionedApprovalRecord::V2(record) => match trust.verify(record) {
+            Ok(true) => (
+                versioned.binding(),
+                "signed",
+                json!(record.signature.key_id),
+            ),
+            Ok(false) => {
+                let mut output = envelope();
+                output.insert("result".to_owned(), json!("approval_diff"));
+                output.insert("status".to_owned(), json!("signature-invalid"));
+                output.insert("signature_status".to_owned(), json!("signature-invalid"));
+                output.insert("key_id".to_owned(), json!(record.signature.key_id));
+                return (Value::Object(output), 1);
+            }
+            Err(error) => return (error_output("io", &error), 2),
+        },
     };
     let (repo, relative_path, _head) = match approval::git_location(path) {
         Ok(location) => location,
@@ -11395,6 +11515,8 @@ fn run_approval_diff(path: &Path, record_path: &Path, depth: usize) -> (Value, i
                 "record": record_path.display().to_string(),
                 "baseline_digest": record.spec.digest,
                 "baseline_commit": record.spec.git_commit,
+                "signature_status": signature_status,
+                "key_id": key_id,
             }),
         );
     }

--- a/rust/fslc/tests/issue_190_approval.rs
+++ b/rust/fslc/tests/issue_190_approval.rs
@@ -6,6 +6,8 @@ use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use ed25519_dalek::SigningKey;
+use ed25519_dalek::pkcs8::{EncodePrivateKey, EncodePublicKey};
 use serde_json::{Value, json};
 
 static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
@@ -125,6 +127,30 @@ fn normalize_digests(text: &str) -> String {
     String::from_utf8(output).expect("normalized ledger remains UTF-8")
 }
 
+#[allow(clippy::default_trait_access)]
+fn write_signing_keys(root: &Path, seed: u8, prefix: &str) -> (PathBuf, PathBuf) {
+    let signing = SigningKey::from_bytes(&[seed; 32]);
+    let private = root.join(format!("{prefix}-private.pem"));
+    let public = root.join(format!("{prefix}-public.pem"));
+    std::fs::write(
+        &private,
+        signing
+            .to_pkcs8_pem(Default::default())
+            .expect("encode private key")
+            .as_bytes(),
+    )
+    .expect("write private key");
+    std::fs::write(
+        &public,
+        signing
+            .verifying_key()
+            .to_public_key_pem(Default::default())
+            .expect("encode public key"),
+    )
+    .expect("write public key");
+    (private, public)
+}
+
 #[test]
 #[allow(clippy::too_many_lines)]
 fn approval_record_reports_approved_then_drifted_and_drives_semantic_diff() {
@@ -165,6 +191,7 @@ fn approval_record_reports_approved_then_drifted_and_drives_semantic_diff() {
         &["approval", "check", "spec.fsl", "--record", "approval.json"],
     ));
     assert_eq!(approved["status"], "approved");
+    assert_eq!(approved["signature_status"], "unsigned");
     assert_eq!(approved["reasons"], json!([]));
 
     let mut invalid_record: Value = serde_json::from_slice(
@@ -395,6 +422,203 @@ fn approval_record_reports_approved_then_drifted_and_drives_semantic_diff() {
     assert!(removed.contains("REQ-190"));
     assert!(removed.contains("現行仕様に要件IDなし"));
     assert!(removed.contains("drifted"));
+
+    std::fs::remove_dir_all(root).expect("remove temporary repository");
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn signed_v2_records_require_a_matching_trust_anchor_and_fail_closed() {
+    let root = approval_repo();
+    let (private, public) = write_signing_keys(&root, 7, "approval");
+    let (_, wrong_public) = write_signing_keys(&root, 9, "wrong");
+    successful(
+        &root,
+        &["ledger", "spec.fsl", "--depth", "2", "-o", "review.md"],
+    );
+    let created = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "create",
+            "spec.fsl",
+            "--kind",
+            "ledger",
+            "--artifact",
+            "review.md",
+            "--approver",
+            "alice",
+            "--depth",
+            "2",
+            "--signing-key",
+            private.to_str().expect("private path"),
+            "-o",
+            "signed.json",
+        ],
+    ));
+    assert_eq!(created["record"]["schema"], "fslc.approval.v2");
+    assert_eq!(created["record"]["signature"]["algorithm"], "ed25519");
+
+    let missing_trust = failed(
+        &root,
+        &["approval", "check", "spec.fsl", "--record", "signed.json"],
+    );
+    assert_eq!(missing_trust["kind"], "io");
+
+    let checked = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "signed.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+        ],
+    ));
+    assert_eq!(checked["status"], "approved");
+    assert_eq!(checked["signature_status"], "signed");
+
+    let wrong_trust = failed(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "signed.json",
+            "--trust-key",
+            wrong_public.to_str().expect("wrong public path"),
+        ],
+    );
+    assert_eq!(wrong_trust["kind"], "io");
+
+    let record = created["record"].clone();
+    let mut reordered = serde_json::Map::new();
+    for key in ["signature", "approval", "target", "spec", "schema"] {
+        reordered.insert(key.to_owned(), record[key].clone());
+    }
+    std::fs::write(
+        root.join("reordered.json"),
+        serde_json::to_vec_pretty(&Value::Object(reordered)).expect("serialize reordered record"),
+    )
+    .expect("write reordered record");
+    successful(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "reordered.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+        ],
+    );
+
+    let mut tampered = record;
+    tampered["approval"]["approver"] = json!("mallory");
+    std::fs::write(
+        root.join("tampered.json"),
+        serde_json::to_vec_pretty(&tampered).expect("serialize tampered record"),
+    )
+    .expect("write tampered record");
+    let invalid_output = run(
+        &root,
+        &[
+            "approval",
+            "check",
+            "spec.fsl",
+            "--record",
+            "tampered.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+        ],
+    );
+    assert_eq!(invalid_output.status.code(), Some(1));
+    let invalid = json_output(&invalid_output);
+    assert_eq!(invalid["status"], "signature-invalid");
+    assert_eq!(invalid["signature_status"], "signature-invalid");
+
+    successful(
+        &root,
+        &[
+            "ledger",
+            "spec.fsl",
+            "--depth",
+            "2",
+            "--approval",
+            "tampered.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+            "-o",
+            "invalid-ledger.md",
+        ],
+    );
+    let invalid_ledger =
+        std::fs::read_to_string(root.join("invalid-ledger.md")).expect("invalid ledger");
+    assert!(invalid_ledger.contains("❌ signature-invalid"));
+    assert!(!invalid_ledger.contains("✅ approved"));
+
+    successful(
+        &root,
+        &[
+            "ledger",
+            "spec.fsl",
+            "--depth",
+            "2",
+            "--approval",
+            "signed.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+            "-o",
+            "signed-ledger.md",
+        ],
+    );
+    let ledger = std::fs::read_to_string(root.join("signed-ledger.md")).expect("signed ledger");
+    assert!(ledger.contains("✅ approved (signed)"));
+
+    let diff = json_output(&successful(
+        &root,
+        &[
+            "approval",
+            "diff",
+            "spec.fsl",
+            "--record",
+            "signed.json",
+            "--depth",
+            "2",
+            "--trust-key",
+            public.to_str().expect("public path"),
+        ],
+    ));
+    assert_eq!(diff["approval"]["signature_status"], "signed");
+
+    let original = std::fs::read_to_string(root.join("spec.fsl")).expect("read fixture");
+    std::fs::write(
+        root.join("spec.fsl"),
+        original.replace("approved = true", "approved = false"),
+    )
+    .expect("write semantic change");
+    successful(
+        &root,
+        &[
+            "ledger",
+            "spec.fsl",
+            "--depth",
+            "2",
+            "--approval",
+            "signed.json",
+            "--trust-key",
+            public.to_str().expect("public path"),
+            "-o",
+            "signed-drift-ledger.md",
+        ],
+    );
+    let signed_drift =
+        std::fs::read_to_string(root.join("signed-drift-ledger.md")).expect("signed drift ledger");
+    assert!(signed_drift.contains("⚠ drifted (signed; since sha256:"));
 
     std::fs::remove_dir_all(root).expect("remove temporary repository");
 }

--- a/schemas/fslc/approval/approval-record.v2.schema.json
+++ b/schemas/fslc/approval/approval-record.v2.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fsl.dev/schemas/fslc/approval/approval-record.v2.schema.json",
+  "title": "FSL signed approval record v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "spec", "target", "approval", "signature"],
+  "properties": {
+    "schema": { "const": "fslc.approval.v2" },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "digest_algorithm", "digest", "git_commit"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "digest_algorithm": { "const": "fsl-kernel-ast-v1+sha256" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "git_commit": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "path", "digest_algorithm", "digest", "generator", "generator_version", "inputs"],
+      "properties": {
+        "kind": { "enum": ["ledger", "html", "scenarios"] },
+        "path": { "type": "string", "minLength": 1 },
+        "digest_algorithm": { "const": "fsl-rendered-artifact-v1+sha256" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "generator": { "const": "fslc" },
+        "generator_version": { "type": "string", "minLength": 1 },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["depth", "deadlock", "engine"],
+          "properties": {
+            "depth": { "type": "integer", "minimum": 0 },
+            "deadlock": { "enum": ["warn", "error", "ignore"] },
+            "engine": { "enum": ["bmc", "induction"] }
+          }
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approver", "approved_at", "requirements"],
+      "properties": {
+        "approver": { "type": "string", "minLength": 1 },
+        "approved_at": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        },
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "key_id", "value"],
+      "properties": {
+        "algorithm": { "const": "ed25519" },
+        "key_id": { "$ref": "#/$defs/sha256" },
+        "value": { "type": "string", "pattern": "^[A-Za-z0-9_-]{86}$" }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}

--- a/tests/rust_only_surface.json
+++ b/tests/rust_only_surface.json
@@ -32,7 +32,7 @@
       ],
       "parent_index": 1,
       "prog": "fslc approval check",
-      "help_sha256": "4d6712f7502b3fa1ed3961330d467dcc5a3d07a78d05c5a92f17b84650dc013e",
+      "help_sha256": "5983559d3cab53308a58da533ad4681455f4eb3af5cc04c3fda170bd6d9bad29",
       "actions": [
         {
           "dest": "help",
@@ -57,6 +57,15 @@
             "--record"
           ],
           "action": "store"
+        },
+        {
+          "dest": "trust_key",
+          "required": false,
+          "flags": [
+            "--trust-key"
+          ],
+          "repeatable": true,
+          "action": "store"
         }
       ],
       "commands": []
@@ -68,7 +77,7 @@
       ],
       "parent_index": 0,
       "prog": "fslc approval create",
-      "help_sha256": "581f1401ef342238de077018d64efe62b754b57de8719fdd0cb19abea181761e",
+      "help_sha256": "ecaf05b0288085634eb5c103373e80cb461d49d4b573249e3e2a435a520f6256",
       "actions": [
         {
           "dest": "help",
@@ -122,6 +131,14 @@
             "--requirement"
           ],
           "repeatable": true,
+          "action": "store"
+        },
+        {
+          "dest": "signing_key",
+          "required": false,
+          "flags": [
+            "--signing-key"
+          ],
           "action": "store"
         },
         {
@@ -179,7 +196,7 @@
       ],
       "parent_index": 2,
       "prog": "fslc approval diff",
-      "help_sha256": "4168a8172ca50a3c84ac5113a6c02944e2322169716cd8c72c0af7cf3efab9f0",
+      "help_sha256": "201998a1041e0189f38f96955da44165d153a4bce9cb472d2bb7f81b24b40912",
       "actions": [
         {
           "dest": "help",
@@ -212,6 +229,15 @@
             "--depth"
           ],
           "default": 8,
+          "action": "store"
+        },
+        {
+          "dest": "trust_key",
+          "required": false,
+          "flags": [
+            "--trust-key"
+          ],
+          "repeatable": true,
           "action": "store"
         }
       ],
@@ -325,6 +351,21 @@
     },
     {
       "path": [
+        "ledger"
+      ],
+      "index": 9,
+      "action": {
+        "dest": "trust_key",
+        "required": false,
+        "flags": [
+          "--trust-key"
+        ],
+        "repeatable": true,
+        "action": "store"
+      }
+    },
+    {
+      "path": [
         "verify"
       ],
       "index": 5,
@@ -385,7 +426,7 @@
         "ledger"
       ],
       "python_sha256": "9bc531a1d829f7e1da5b9deaba1e36c57005357cb54be9715f2f601582b6ed9e",
-      "rust_sha256": "ba5dc8215863e6b2c4f81ade041a09fd9413647746e67e5b6ab841d6b11b44b3"
+      "rust_sha256": "c58d89663831ed7fe21dc38c63b99dc76f5c2d3d05f5a23be579daf68121e4d0"
     },
     {
       "path": [

--- a/tests/snapshots/approval_ledger.md
+++ b/tests/snapshots/approval_ledger.md
@@ -2,10 +2,10 @@
 
 | 要件ID | 業務目的 | 状態 | 承認状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |
 |---|---|---|---|---|---|---|---|---|
-| REQ-190 | an approved review remains approved | 🟢 反例なし | ✅ approved | bounded(BMC depth 2) | — | — | — | — |
+| REQ-190 | an approved review remains approved | 🟢 反例なし | ✅ approved (unsigned) | bounded(BMC depth 2) | — | — | — | — |
 
 ## 承認照合
 
 | 要件ID | 承認状態 | 承認基準 digest | 承認対象 | drift理由 | semantic diff |
 |---|---|---|---|---|---|
-| REQ-190 | ✅ approved | `sha256:<digest>` | ledger | — | `—` |
+| REQ-190 | ✅ approved (unsigned) | `sha256:<digest>` | ledger | — | `—` |


### PR DESCRIPTION
## Problem

Approval v1 records only provide repository-governed attribution. Consumers cannot cryptographically authenticate that a record was produced by a trusted signing key.

## Contract change

- Add strict `fslc.approval.v2` records with detached Ed25519 signatures over domain-framed canonical JSON.
- Keep unsigned v1 creation, parsing, validation, and evaluation unchanged when `--signing-key` is omitted.
- Accept PKCS#8 PEM private keys for creation and explicit repeatable SPKI PEM trust anchors for check, diff, and ledger.
- Fail closed for missing/mismatched trust anchors and report cryptographic mismatch as `signature-invalid` with exit 1.
- Distinguish unsigned, signed, and signature-invalid records in direct results and ledger output, including drifted records.

## Evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py -q` (11 passed)
- Focused approval integration: 4 passed, including canonical reordering, missing/wrong trust anchors, tampering, signed/invalid/drifted ledger output, and signed semantic diff.
- Independent security review: merge ready, no remaining findings.

## Documentation

Updates `docs/DESIGN-approval.md`, `docs/LANGUAGE.md`, the v2 JSON schema, CLI contract allowlist, ledger snapshot, and `CHANGELOG.md`.

Closes #269