### PR TITLE
fix(python): scope faithfulness to diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- Python compatibility envelopes now scope faithfulness routing to actual
+  diagnostics, so user state fields named `kind`, `classification`, or other
+  diagnostic discriminators neither crash nor receive routing metadata (issue
+  #278).
+
 ### Changed
 - Native/WASM parity now runs every Worker-supported surface document from the
   shared `specs/` and `examples/` corpus and structurally compares complete

--- a/docs/DESIGN-blame-assignment.md
+++ b/docs/DESIGN-blame-assignment.md
@@ -150,9 +150,9 @@ spec)` helper (display label + `__`→`.`). explain.py re-imports under the old 
 
 No existing field changes meaning or disappears; exit codes untouched. Display discipline: all
 names pass through `display_label`/`_public_model_bindings`/`render.public_var` (no `__`
-leakage). Nested blame entries avoid the reserved discriminators `result`/`violation_kind`/
-`covered` and use `kind` only in the already-established `blocking` entry sense, so
-`with_faithfulness`'s recursive walk stays inert on them.
+leakage). Faithfulness routing is provenance-scoped to the result root and its
+immediate `warnings`, `unreached`, and `action_coverage` diagnostic slots, so nested
+blame and user-authored state are copied without interpreting their keys as diagnostics.
 
 ## 7. Ripple / tests
 

--- a/docs/DESIGN-ui.md
+++ b/docs/DESIGN-ui.md
@@ -134,9 +134,9 @@ spec ReturnUI "ui: return-request screen flow (behavioral slice only)" { … }
 - **Files it moved**: `grammar.py` (optional `meta_tag?` on `spec_def`), `model.py`
   (`spec["kind"]`), `explain.py` (`skeleton.spec_kind` + readable line), `html_report.py`
   (title badge), `docs/LANGUAGE.md`, `skills/fsl/reference.md`, this note, and a
-  regression test. One pitfall absorbed: the enveloped result tree reserves the key
-  `kind` for the string diagnostic discriminator scanned by `with_faithfulness` /
-  `trace_type_for`, so the surfaced field is named `spec_kind`, not `kind`.
+  regression test. The surfaced field remains `spec_kind` to distinguish spec metadata
+  from the established diagnostic `kind`; faithfulness routing is provenance-scoped and
+  does not interpret arbitrary nested payload keys as diagnostics.
 
 ## Invariant principle
 

--- a/src/fslc/diagnostics.py
+++ b/src/fslc/diagnostics.py
@@ -21,6 +21,7 @@ def faithfulness_class_for(diagnostic):
     kind = diagnostic.get("kind")
     violation_kind = diagnostic.get("violation_kind")
     result = diagnostic.get("result")
+    classification = diagnostic.get("classification")
 
     if kind == "partial_op" or violation_kind == "partial_op":
         return "partial_op_unguarded"
@@ -30,12 +31,12 @@ def faithfulness_class_for(diagnostic):
             result == "reachable_failed"
             or kind == "reachable_failed"
             or diagnostic.get("covered") is False
-            or diagnostic.get("classification") in {
+            or (isinstance(classification, str) and classification in {
                 "insufficient_depth",
                 "over_constrained",
-            }):
+            })):
         return "intent_unexercised"
-    if kind in {
+    if isinstance(kind, str) and kind in {
             "leadsTo_refinement_failed",
             "leadsto_refinement_failed",
             "liveness_not_refined",
@@ -96,14 +97,30 @@ def trace_type_for(diagnostic):
     return None
 
 
+def _copy_payload(value):
+    if isinstance(value, list):
+        return [_copy_payload(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _copy_payload(item) for key, item in value.items()}
+    return value
+
+
 def with_faithfulness(value):
-    """Return value with additive faithfulness routing fields on diagnostics."""
+    """Add routing fields to a result and its immediate diagnostic slots."""
     if isinstance(value, list):
         return [with_faithfulness(v) for v in value]
     if not isinstance(value, dict):
         return value
 
-    out = {k: with_faithfulness(v) for k, v in value.items()}
+    out = {key: _copy_payload(item) for key, item in value.items()}
+    for key in ("warnings", "unreached"):
+        if isinstance(value.get(key), list):
+            out[key] = [with_faithfulness(item) for item in value[key]]
+    if isinstance(value.get("action_coverage"), dict):
+        out["action_coverage"] = {
+            name: with_faithfulness(item)
+            for name, item in value["action_coverage"].items()
+        }
     cls = faithfulness_class_for(out)
     if cls is not None:
         out.setdefault("faithfulness_class", cls)

--- a/src/fslc/explain.py
+++ b/src/fslc/explain.py
@@ -375,8 +375,7 @@ def _skeleton(spec, source_lines):
     properties.extend(_property_skeleton("reachable", reach, spec)
                       for reach in spec.get("reachables", []))
     return {
-        # `spec_kind`, not `kind`: the enveloped result tree reserves `kind` for the
-        # string diagnostic discriminator that with_faithfulness/trace_type_for scan.
+        # `spec_kind` distinguishes spec metadata from the diagnostic `kind` field.
         "spec_kind": spec.get("kind"),
         "state": {
             _public_name(name, spec): _public_type(ty)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from fslc.bmc import verify
+from fslc.diagnostics import faithfulness_class_for, with_faithfulness
+from fslc.model import build_spec
+from fslc.parser import parse
+
+
+def test_faithfulness_routing_ignores_user_state_payloads():
+    state = {
+        "kind": {"0": "U"},
+        "classification": ["insufficient_depth"],
+        "nested": {
+            "kind": "partial_op",
+            "violation_kind": "partial_op",
+            "result": "reachable_failed",
+            "covered": False,
+            "classification": "over_constrained",
+        },
+    }
+    output = with_faithfulness({
+        "result": "verified",
+        "trace": [{"step": 0, "state": state}],
+        "warnings": [{"kind": "tautology_over_frozen"}],
+        "unreached": [{"classification": "insufficient_depth"}],
+        "action_coverage": {"blocked": {"covered": False}},
+    })
+
+    assert output["trace"][0]["state"] == state
+    assert output["warnings"][0]["faithfulness_class"] == "frozen_only_invariant"
+    assert output["unreached"][0]["faithfulness_class"] == "intent_unexercised"
+    assert output["action_coverage"]["blocked"]["faithfulness_class"] == "intent_unexercised"
+    assert faithfulness_class_for({"kind": {"0": "U"}}) is None
+    assert faithfulness_class_for({"classification": ["over_constrained"]}) is None
+
+
+def test_verify_accepts_map_state_named_kind():
+    source = """
+spec KindCrash {
+  type I = 0..1
+  enum K { U, R }
+  state { kind: Map<I, K>, other: Map<I, K> }
+  init { forall i: I { kind[i] = U other[i] = U } }
+  action t(i: I) { requires kind[i] == U kind[i] = R }
+  invariant Inv { forall i: I { kind[i] == R => other[i] == U } }
+  reachable Done { exists i: I { kind[i] == R } }
+}
+"""
+
+    output = verify(build_spec(parse(source)), 4, deadlock_mode="ignore")
+
+    assert output["result"] == "verified"
+    assert output["reachables"]["Done"]["witness"]

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -30,8 +30,7 @@ def test_spec_level_kind_tag_surfaces_in_explain_and_readable():
         "id": "ui",
         "text": "return-request screen flow (behavioral slice only)",
     }
-    # The full CLI envelope path (with_faithfulness / trace_type_for) walks every
-    # nested dict; a `spec_kind` dict under a reserved key would crash it. Guard.
+    # The full CLI envelope preserves nested spec metadata without routing it as a diagnostic.
     enveloped = run_explain(str(ui), depth=3)
     assert enveloped["result"] == "explained"
     readable = explain_file(str(ui), depth=3, readable=True)["readable"]


### PR DESCRIPTION
## Summary

Fix the frozen Python compatibility surface so `with_faithfulness()` no longer interprets arbitrary trace/witness state dictionaries as diagnostics. A `Map` state named `kind` now verifies normally, and hashable state values resembling `partial_op`, `reachable_failed`, or coverage classifications no longer receive false routing metadata.

## Why

- Goal: close both the reported `unhashable type: dict` crash and the quieter metadata-corruption variant.
- Reason: type guards stop invalid set membership, while provenance-scoped traversal prevents user state from entering diagnostic classification at all.
- Rejected alternative: type guards alone still misclassify hashable user values; renaming/reserving FSL state fields would leak an output implementation detail into the language.

## Contract and blast radius

- Affected: `src/fslc/diagnostics.py` in the explicitly requested frozen Python compatibility surface.
- Routing remains additive on the result root and its immediate `warnings[]`, `unreached[]`, and `action_coverage.*` diagnostic slots.
- Trace, witness, bindings, params, nested structs, and other user-authored payloads are deep-copied without interpreting their keys.
- Native Rust behavior and the FSL language are unchanged.

## Invariants

- Existing root, warning, unreached, and action-coverage `faithfulness_class` / `recommended_action` fields remain present.
- User state names and values remain unrestricted by diagnostic discriminator names.
- The helper returns copied containers rather than mutating or aliasing its input.

## Evidence

- [x] Focused regression/positive contracts: 8 passed
- [x] Actual minimized `Map` state named `kind`: `result: verified` with reachable witness
- [x] Independent review: `merge_ready=true`, no findings; includes deep `warnings` collision and copy-isolation counterexamples
- [x] Compile check and `git diff --check`
- [x] Full Python suite: 1434 passed, 78 skipped; two failures reproduced unchanged on detached `origin/main` and tracked as a separate #273 follow-up (moved `PROJECT_BLOCKS` meta-test and stale generated language pages)

## Failure modes and detection

- Non-string discriminator crashes → direct dict/list guard tests.
- Hashable user state is silently annotated → nested collision matrix in `tests/test_diagnostics.py`.
- Real nested diagnostics lose routing → warning/unreached/action-coverage positive assertions plus existing integration tests.

## Rollout and rollback

- Rollout: normal package/CLI use after merge; no migration.
- Rollback: revert this PR, which would intentionally restore the reported crash and false routing behavior.

## Review focus

- `src/fslc/diagnostics.py`: root provenance boundary and copy behavior
- `tests/test_diagnostics.py`: crash, silent collision, and positive-slot coverage
- Design-note updates: removal of the obsolete arbitrary-recursive-scan assumption

Closes #278