### PR TITLE
test: repair full Python gate after parity consolidation

### DIFF
--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -973,6 +973,11 @@ explicitly bounded; when the final
 depth first witnesses a reachable/vacuity/coverage fact during normal
 exploration, <code>verified</code> also includes a <code>hint</code> that the state space is not
 obviously saturated at that depth and suggests a larger <code>--depth</code> or induction.</p>
+<p>Native and browser BMC set Z3 <code>random_seed</code> and <code>smt.random_seed</code> to <code>0</code>.
+This makes each backend deterministic under a fixed Z3 build, but concrete
+counterexamples and reachable/deadlock witnesses remain non-unique across
+native and WebAssembly builds. Consumers must use the verdict and replayable
+witness contract, not a particular satisfying assignment.</p>
 <p>When a leadsTo is declared and the result is <code>verified</code> / <code>proved</code>,
 <code>leads_to: { "&lt;Name&gt;": { "checked_to_depth": K } }</code> is attached
 (no counterexample is a bounded guarantee up to depth K, the same standing as a

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -973,6 +973,11 @@ explicitly bounded; when the final
 depth first witnesses a reachable/vacuity/coverage fact during normal
 exploration, <code>verified</code> also includes a <code>hint</code> that the state space is not
 obviously saturated at that depth and suggests a larger <code>--depth</code> or induction.</p>
+<p>Native and browser BMC set Z3 <code>random_seed</code> and <code>smt.random_seed</code> to <code>0</code>.
+This makes each backend deterministic under a fixed Z3 build, but concrete
+counterexamples and reachable/deadlock witnesses remain non-unique across
+native and WebAssembly builds. Consumers must use the verdict and replayable
+witness contract, not a particular satisfying assignment.</p>
 <p>When a leadsTo is declared and the result is <code>verified</code> / <code>proved</code>,
 <code>leads_to: { "&lt;Name&gt;": { "checked_to_depth": K } }</code> is attached
 (no counterexample is a bounded guarantee up to depth K, the same standing as a

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -51,7 +51,7 @@ def test_retained_python_dialect_registry_matches_native_authority():
 
 
 def test_native_ai_project_block_gate_matches_retained_parser():
-    source = (ROOT / "rust" / "fslc" / "src" / "main.rs").read_text()
+    source = (ROOT / "rust" / "fslc" / "src" / "frontend_output.rs").read_text()
     block = re.search(
         r"const PROJECT_BLOCKS: &\[&str\] = &\[(?P<body>.*?)\n\s*\];",
         source,


### PR DESCRIPTION
## Summary

Repair the two full-Python-suite follow-ups missed when #287 consolidated native/WASM parity code:

- point the native AI-project metatest at the new authoritative `frontend_output.rs` location;
- regenerate the English/Japanese language reference pages from the updated canonical `docs/LANGUAGE.md`.

## Why and scope

The #278 full-suite audit exposed these failures unchanged on detached `origin/main`. Neither is a runtime behavior change: one is a moved-source test reference, and the other is generated documentation freshness.

The smaller alternative—ignoring the full-suite failures because current PR CI runs only the frozen Rust contract subset—was rejected because it leaves the retained compatibility suite red.

## Invariants

- `PROJECT_BLOCKS` remains compared against the frozen Python parser from its single native authoritative definition.
- Generated pages remain byte-for-byte reproducible via `tools/build_site_reference.py`.
- No verifier, parser, Worker, or CLI behavior changes.

## Evidence

- [x] Previously failing focused cases: 3 passed
- [x] Full Python suite: 1436 passed, 78 skipped
- [x] Independent review: `MERGE_READY=true`, no findings
- [x] `git diff --check`
- [x] Base proof: the same two failures reproduced on detached `origin/main` at `d30f456`

## Rollout and rollback

- Rollout: merge only; generated static pages and tests update together.
- Rollback: revert this PR, which would restore the two full-suite failures.

## Review focus

- `tests/test_coupled_change_meta.py`: authoritative moved definition
- `docs/intro/language.{ja,en}.html`: generator-only canonical paragraph

Follow-up to #273 and #287.