### PR TITLE
feat(syntax): extend declaration-level @annotation to domain/dbsystem/ai_component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   to every action/property it contains. A malformed or stray annotation
   (nothing to attach to) reports a precise coded diagnostic
   (`FSL-ANNOTATION-TARGET`/`-ARGUMENTS`/`-PATH`/`-SYNTAX`). Public Kernel v1/v2
-  JSON and `python_ast` projections remain unchanged; `domain`/`dbsystem`/
-  `ai_component` nested declarations are not yet covered and are tracked by a
-  follow-up issue (issue #241; follow-up #281).
+  JSON and `python_ast` projections remain unchanged (issue #241).
+- Native Rust now also accepts the same declaration-level `@...` syntax on
+  `domain` (aggregate `command`/`decide`/`evolve`/`invariant`, `projection`,
+  `effect`, saga `step`), `ai_component` (`tool`, `authority` and its
+  individual rule lines, `fallback` and its `when` items, `check`), and
+  `dbsystem` (`migration`, `check compatibility` rule lines) nested
+  declarations. A `command`/`decide`/matching-`evolve` group unions onto the
+  one action they generate together; an `effect` or saga `step` broadcasts to
+  every action it generates. `AiAuthority`'s `may_suggest`/`may_execute`/
+  `requires_human_approval`/`forbidden` rule lists are now span/annotation-
+  carrying `AiAuthorityRule` nodes while `python_ast()` still projects the
+  original plain string-array JSON shape. A `dbsystem` migration or
+  compatibility-rule annotation reaches the checked model and TSG/ledger by
+  rendering back to `@...` source rather than through the lossy legacy
+  `quote_meta` string convention. Public Kernel v1/v2 JSON and `python_ast`
+  projections remain unchanged (issue #281).
 - Approval records can now opt into detached Ed25519 signatures with
   `approval create --signing-key`. The strict v2 schema binds the complete
   canonical record, while `approval check`, `approval diff`, and `ledger`

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -4,7 +4,8 @@
 
 Status: accepted. Typed IR implemented by issue #237; declaration-level
 `@...` syntax for the shared spec/business/requirements/compose frontend
-implemented by issue #241.
+implemented by issue #241; `domain`/`dbsystem`/`ai_component` nested
+declaration coverage implemented by issue #281.
 
 ## Decision
 
@@ -26,8 +27,10 @@ token-based dialect dispatch. `DESIGN-dialect-dispatch.md` is authoritative for
 annotations immediately before a top-level document. Issue #241 (see
 "Declaration-level syntax" below) added the same `@...` grammar immediately
 before a declaration nested inside a document, for the shared
-spec/business/requirements/compose frontend; `domain`/`dbsystem`/`ai_component`
-nested declarations are a tracked follow-up (#281), not yet supported.
+spec/business/requirements/compose frontend. Issue #281 (see "domain/db/ai
+nested declaration syntax" below) extended the same grammar to the three
+specialized frontends that do not share that parser: `domain`, `dbsystem`,
+and `ai_component`.
 
 ## Carrier and declaration coverage
 
@@ -134,14 +137,8 @@ silently mismatched.
 
 `domain`/`dbsystem`/`ai_component` nested declarations (aggregate
 command/decide/evolve/effect/saga steps, migration/compatibility rules, AI
-tool authority/approval rules) have no metadata channel — legacy or `@...` —
-today; only their one top-level document annotation works, via the same
-dispatch-level mechanism every dialect keyword gets. Extending `@...` there is
-a tracked follow-up (#281), not a gap in this issue's scope: those dialects need a
-first-ever nested annotation channel from scratch (and, for `ai_component`'s
-authority rules, restructuring a flat `Vec<String>` rule list into
-span-carrying nodes), which is independent design work with no legacy-compat
-constraint to preserve.
+tool authority/approval rules) gained the same `@...` grammar in issue #281;
+see "domain/db/ai nested declaration syntax" below.
 
 Within the shared frontend itself, `governance` and `refinement` declarations
 (`authority`, `control`, `delegates`, `preservation`, `impl`/`abs`/`map`/action
@@ -154,6 +151,129 @@ declaration" error, since those two dialects' item loops were not changed to
 hook the shared annotation-parsing mechanism), just not the more specific
 `FSL-ANNOTATION-TARGET` code the hooked dialects use for the same kind of
 mistake.
+
+## domain/db/ai nested declaration syntax (issue #281)
+
+`domain` (`rust/fsl-syntax/src/domain.rs`), `dbsystem`
+(`rust/fsl-syntax/src/db.rs`), and `ai_component` (`rust/fsl-syntax/src/ai.rs`)
+are specialized frontends with their own hand-rolled, token-cursor `*Parser`
+structs — none of them share `parser.rs`'s `Parser`. Each therefore carries
+its own `pending_annotations: Annotations` field and duplicates the same three
+helpers (`take_leading_annotations`/`take_annotations`/
+`expect_no_pending_annotations`) rather than reusing `parser.rs`'s `Parser`
+directly. All three still call the one shared `annotation_parse::annotation`
+free function (`pub(crate)`, same crate) to parse an individual `@name(...)`
+group, so there is still no per-dialect copy of the actual `@...` token
+grammar — only of the leading/pending-buffer bookkeeping around it.
+Unifying the four duplicated pending-annotation state machines behind one
+trait is deferred as acknowledged design debt; none of the four parser
+structs share a common base to hang it from without a larger refactor this
+issue did not need.
+
+Accepted declarations, one attachment point per dialect concept:
+
+| Dialect | Accepts `@...` on |
+| --- | --- |
+| `domain` | aggregate `command`, `decide`, `evolve`, `invariant`, `projection` (both aggregate-nested and top-level); `effect`; saga `step` |
+| `ai_component` | `tool` (including the `tools [a, b];` shorthand, broadcast per name); `authority` block and each of its `may_suggest`/`may_execute`/`requires_human_approval`/`forbidden` rule lines; `fallback` block and each `when` item; `check hard` block and each `rule` line |
+| `dbsystem` | `migration`; each `check compatibility { rule ...; }` line |
+
+`ai_component`'s `check hard { rule ...; }` and `dbsystem`'s `check compatibility { rule ...; }` are structurally the same "named-rule list inside a check block" shape and both accept an annotation on each individual `rule` line — matching `authority`'s per-rule-line granularity — but not symmetrically at the block level: `ai_component`'s `check hard { ... }` block itself also accepts a leading annotation (mirroring `authority`/`fallback`, which likewise accept one on their own block), while `dbsystem`'s `check compatibility { ... }` block itself does not (a leading annotation there still reports `FSL-ANNOTATION-TARGET`; only `migration` accepts one at the `dbsystem` top level). Per-rule annotations on either block do not currently reach any Kernel target through the rule name alone (`ai_component` has no real Kernel lowering at all; a `dbsystem` compatibility rule's annotations reach the checked model only when that rule is enabled and generates at least one invariant — see below), so the per-rule granularity here is primarily about API/traceability completeness (a user can name and independently track any individual rule the same way they can any individual tool or authority rule), not about an existing consumption path.
+
+Everywhere else in these three dialects a leading `@...` reports the coded
+`FSL-ANNOTATION-TARGET` diagnostic, the same as the shared frontend: a
+migration's individual `add`/`drop`/`rename`/... operation line, a `dbsystem`
+scalar declaration (`database`/`artifact`/`environment`), an `ai_component`
+scalar declaration (`model`/`prompt`/`retriever`/`temperature`/`input`/
+`output`), and a domain declaration outside the accepted list (`type`/`enum`/
+`value_object`/`state`/`event`/`error`/`on_stale`/`await`/saga
+`starts_on`/`compensation`/`outbox`/`inbox`) all reject a stray annotation at
+its own precise span rather than silently dropping it or falling through to a
+generic parse error.
+
+Union and broadcast follow the same "one generated Kernel target can be fed
+by more than one surface declaration" pattern issue #241 established for
+`until`'s dual bind:
+
+- A `command`/`decide` pair sharing one command name, plus every `evolve`
+  block matching an event that `decide` emits, union into the one synthesized
+  `{aggregate}_{command}` action (`domain_lowering.rs::lower_aggregate_actions`).
+- One `effect`'s annotations broadcast to every action it generates: each
+  `{effect}_complete_{event}` outcome action, the `{effect}_retry` action (if
+  `retry.max_attempts` is set), and the `{effect}_SuccessSticky` progress
+  property. An outcome-event `evolve` block's own annotations additionally
+  union into that event's `complete` action, and into a saga's
+  `saga_{saga}_observe_{event}` action when a saga step awaits the same
+  event — the same "the annotation follows whichever generated action
+  actually executes this declaration" rule the aggregate case uses.
+- One saga `step`'s annotations broadcast to both the `saga_{saga}_{step}`
+  action and its `_timeout` variant (if the step declares one).
+- An aggregate or saga `invariant`'s annotations flow to its one generated
+  `SpecItem::Invariant`. Domain-level `invariant` was not in issue #281's own
+  declaration list, but is the same kind of aggregate-direct declaration as
+  `command`/`decide`/`evolve`; leaving it out would reproduce the exact
+  policy/goal asymmetry issue #241's coupled-change review caught, so it was
+  included from the start here instead of as a follow-up gap.
+- `DomainProjection` and `ai_component`'s `tool`/`authority`/`fallback`/`check`
+  nodes are not lowered into any executable Kernel target at all (confirmed:
+  `lower_domain_surface` never reads `domain.projections`, and
+  `lower_ai_component` is a catalog-sentinel stub with no per-declaration
+  content). Their annotations are preserved on the frontend AST and reachable
+  through `python_ast()`/direct AST inspection, with no `AnnotationRegistry`
+  binding to reach — there is no Kernel target for one to attach to.
+
+`ai_component`'s `AiAuthority` restructuring: `may_suggest`/`may_execute`/
+`requires_human_approval`/`forbidden` change from `Vec<String>` to
+`Vec<AiAuthorityRule>`, where `AiAuthorityRule { name, annotations, loc }`.
+`AiAuthority::python_ast()` reconstructs the original plain `Vec<String>` JSON
+shape (`rule.name` only) so the public JSON projection is unchanged; the
+typed carrier is additive. Every Rust call site that used to compare a
+`&String` name directly (`rust/fslc/src/main.rs`'s specialized-document
+validation, `rust/fsl-tools/src/ai.rs`'s `check_ai`/`replay_ai`) was updated
+to compare `rule.name` instead.
+
+`dbsystem`'s existing `DbMigration`/`DbMigrationOp` already declare a field
+named `annotations: Vec<String>` — a pre-#281, unrelated legacy mechanism
+(the `destructive`/`irreversible`/`rollbackable`/`lossy`/`lossless` migration
+keyword flags, still projected into `python_ast()` under the same JSON key).
+The new typed carrier could not reuse that name, so `DbMigration` gained a
+second, distinctly named field: `decl_annotations: Annotations`. Compatibility
+rules changed shape instead of gaining a same-named field:
+`DbCheck.rules: Vec<String>` became `Vec<DbCheckRule>`, where
+`DbCheckRule { name, annotations, span }`; `DbCheck::python_ast()`
+reconstructs the original plain `Vec<String>` rule-name list.
+
+`db_kernel_source` (`rust/fsl-core/src/db.rs`) still synthesizes the
+dbsystem's executable kernel as FSL source text re-parsed through the shared
+spec grammar (`fsl_syntax::parse_surface_spec`) — issue #281 did not replace
+that architecture, which would have been a much larger change unrelated to
+annotations. What changed is *what floats through the text*: a migration's
+`decl_annotations` and a matching `DbCheckRule`'s `annotations` are rendered
+back to literal `@requirement(...)`/`@undecided(...)`/`@kind(...)`/custom
+`@ns.path(...)` source lines (`Annotation::render_source()`,
+`rust/fsl-syntax/src/annotation.rs`) immediately before the corresponding
+synthesized `action`/`invariant`, rather than being squeezed through the
+lossy `quote_meta("ID", "text")` single-`MetaTag` string convention the
+system-generated `DB-MIGRATION`/`DB-NOT-NULL`/`DB-COMPAT-READ`/
+`DB-COMPAT-WRITE` labels still use unchanged. Re-parsing then binds them as
+ordinary typed `Annotation`s through the exact same
+`collect_declaration_annotations` path every other dialect uses, so they
+reach `AnnotationRegistry`/`KernelModel`/TSG/the audit ledger with no new
+plumbing. Because the lexer has no string-escape syntax
+(`rust/fsl-syntax/src/lexer.rs::lex_string` stops at the first `"` or
+newline), `Annotation::render_source()` sanitizes backslash, `"`, and
+newline characters out of a `String` argument value before quoting it — the
+same character class `quote_meta` already sanitizes, extended to cover
+newlines too since this is a fresh code path rather than an existing one.
+This sanitization only affects a `String` value containing those characters;
+Integer, Boolean, and Symbol arguments round-trip exactly.
+
+`tools/check_rust_surface_parity.py`'s `SUPPORTED_SPECIALIZED_FRONTENDS`
+already includes `ai-component`/`db`/`domain`; since no new field was
+projected into any of these three dialects' `python_ast()`, corpus parity is
+unaffected by construction (the tool is not CI-wired — see the Python
+compatibility gate note in the repository's CLAUDE.md — but was still run
+manually against the corpus to confirm).
 
 ## Validation and semantic isolation
 
@@ -179,10 +299,17 @@ suppression, and exact declaration matching—remain unchanged.
 
 ## Non-goals
 
-- `@requirement`, `@undecided`, `@kind`, or arbitrary `@namespace` syntax on a
-  `domain`/`dbsystem`/`ai_component` nested declaration (tracked by follow-up
-  issue #281; their one top-level document annotation already works, same as
-  every other dialect keyword);
+- `@requirement`/`@undecided`/`@kind`/custom `@namespace` syntax on
+  `governance`/`refinement` declarations, or on a `domain`/`dbsystem`
+  declaration outside the accepted list above (`DomainType`/`DomainAward`/
+  `DomainAwait`/`DomainSagaCompensation`, a `DbMigrationOp`, dbsystem
+  `database`/`artifact`/`environment`) — these still report the coded
+  `FSL-ANNOTATION-TARGET` diagnostic rather than silently accepting or
+  dropping the annotation;
+- unifying the four duplicated `pending_annotations` parser state machines
+  (`parser.rs`, `domain.rs`, `ai.rs`, `db.rs`) behind one shared trait;
+- replacing `db_kernel_source`'s text-synthesis-and-reparse architecture with
+  direct `KernelSpec`/`SpecItem` construction;
 - formatter or source migrator behavior;
 - macro execution or verifier semantics selected by an annotation;
 - publishing annotations by mutating Public Kernel v1/v2.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1456,11 +1456,29 @@ arguments, namespaces, or syntax report `FSL-ANNOTATION-ARGUMENTS` /
 string/`covers` forms both desugar into the same typed relation and simply
 union when both are present on one declaration (identical `(id, text)` pairs
 deduplicate; conflicting text for one requirement ID is a checked-model error).
-Declaration-level annotations on `domain`/`dbsystem`/`ai_component` nested
-declarations (their top-level document annotation already works) are tracked
-by a follow-up issue (#281) and are not yet supported. `@...` on a nested declaration
-is a native-only surface addition — the frozen Python reference does not parse
-it, so specs that use it are outside the Python-parity corpus by construction.
+As of issue #281, the same `@...` grammar also attaches to nested
+declarations in the three specialized frontends that do not share this
+parser: `domain` (aggregate `command`, `decide`, `evolve`, `invariant`,
+`projection`, `effect`, saga `step`), `ai_component` (`tool`, the `tools
+[a, b];` shorthand, the `authority` block and each of its rule lines,
+`fallback` and each `when` item, `check`), and `dbsystem` (`migration`, and
+each `rule` line inside `check compatibility { ... }`). A `command`/`decide`
+pair (plus any `evolve` block the decide's emitted events reach) union onto
+the one action they together generate; an `effect`'s or saga `step`'s
+annotations broadcast to every action it generates (a step's own action and
+its `_timeout` variant; an effect's per-outcome `_complete_*` actions, its
+`_retry` action, and its success-sticky progress property). Everywhere else
+in these three dialects — a migration operation line, a `dbsystem`/
+`ai_component` scalar declaration, a domain declaration outside the accepted
+list — a stray annotation still reports the coded `FSL-ANNOTATION-TARGET`
+diagnostic. See `DESIGN-annotations.md`'s "domain/db/ai nested declaration
+syntax" section for the full attachment table, the `AiAuthority` rule
+restructuring, and how a `dbsystem` migration/compatibility-rule annotation
+reaches the checked model without going through the lossy legacy
+`quote_meta` string convention. `@...` on a nested declaration remains a
+native-only surface addition — the frozen Python reference does not parse
+it, so specs that use it are outside the Python-parity corpus by
+construction.
 
 ### 13.2 Requirements layer: `requirements` (the fsl-req dialect)
 

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1484,11 +1484,29 @@ arguments, namespaces, or syntax report <code>FSL-ANNOTATION-ARGUMENTS</code> /
 string/<code>covers</code> forms both desugar into the same typed relation and simply
 union when both are present on one declaration (identical <code>(id, text)</code> pairs
 deduplicate; conflicting text for one requirement ID is a checked-model error).
-Declaration-level annotations on <code>domain</code>/<code>dbsystem</code>/<code>ai_component</code> nested
-declarations (their top-level document annotation already works) are tracked
-by a follow-up issue (#281) and are not yet supported. <code>@...</code> on a nested declaration
-is a native-only surface addition — the frozen Python reference does not parse
-it, so specs that use it are outside the Python-parity corpus by construction.</p>
+As of issue #281, the same <code>@...</code> grammar also attaches to nested
+declarations in the three specialized frontends that do not share this
+parser: <code>domain</code> (aggregate <code>command</code>, <code>decide</code>, <code>evolve</code>, <code>invariant</code>,
+<code>projection</code>, <code>effect</code>, saga <code>step</code>), <code>ai_component</code> (<code>tool</code>, the <code>tools
+[a, b];</code> shorthand, the <code>authority</code> block and each of its rule lines,
+<code>fallback</code> and each <code>when</code> item, <code>check</code>), and <code>dbsystem</code> (<code>migration</code>, and
+each <code>rule</code> line inside <code>check compatibility { ... }</code>). A <code>command</code>/<code>decide</code>
+pair (plus any <code>evolve</code> block the decide's emitted events reach) union onto
+the one action they together generate; an <code>effect</code>'s or saga <code>step</code>'s
+annotations broadcast to every action it generates (a step's own action and
+its <code>_timeout</code> variant; an effect's per-outcome <code>_complete_*</code> actions, its
+<code>_retry</code> action, and its success-sticky progress property). Everywhere else
+in these three dialects — a migration operation line, a <code>dbsystem</code>/
+<code>ai_component</code> scalar declaration, a domain declaration outside the accepted
+list — a stray annotation still reports the coded <code>FSL-ANNOTATION-TARGET</code>
+diagnostic. See <code>DESIGN-annotations.md</code>'s "domain/db/ai nested declaration
+syntax" section for the full attachment table, the <code>AiAuthority</code> rule
+restructuring, and how a <code>dbsystem</code> migration/compatibility-rule annotation
+reaches the checked model without going through the lossy legacy
+<code>quote_meta</code> string convention. <code>@...</code> on a nested declaration remains a
+native-only surface addition — the frozen Python reference does not parse
+it, so specs that use it are outside the Python-parity corpus by
+construction.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1484,11 +1484,29 @@ arguments, namespaces, or syntax report <code>FSL-ANNOTATION-ARGUMENTS</code> /
 string/<code>covers</code> forms both desugar into the same typed relation and simply
 union when both are present on one declaration (identical <code>(id, text)</code> pairs
 deduplicate; conflicting text for one requirement ID is a checked-model error).
-Declaration-level annotations on <code>domain</code>/<code>dbsystem</code>/<code>ai_component</code> nested
-declarations (their top-level document annotation already works) are tracked
-by a follow-up issue (#281) and are not yet supported. <code>@...</code> on a nested declaration
-is a native-only surface addition — the frozen Python reference does not parse
-it, so specs that use it are outside the Python-parity corpus by construction.</p>
+As of issue #281, the same <code>@...</code> grammar also attaches to nested
+declarations in the three specialized frontends that do not share this
+parser: <code>domain</code> (aggregate <code>command</code>, <code>decide</code>, <code>evolve</code>, <code>invariant</code>,
+<code>projection</code>, <code>effect</code>, saga <code>step</code>), <code>ai_component</code> (<code>tool</code>, the <code>tools
+[a, b];</code> shorthand, the <code>authority</code> block and each of its rule lines,
+<code>fallback</code> and each <code>when</code> item, <code>check</code>), and <code>dbsystem</code> (<code>migration</code>, and
+each <code>rule</code> line inside <code>check compatibility { ... }</code>). A <code>command</code>/<code>decide</code>
+pair (plus any <code>evolve</code> block the decide's emitted events reach) union onto
+the one action they together generate; an <code>effect</code>'s or saga <code>step</code>'s
+annotations broadcast to every action it generates (a step's own action and
+its <code>_timeout</code> variant; an effect's per-outcome <code>_complete_*</code> actions, its
+<code>_retry</code> action, and its success-sticky progress property). Everywhere else
+in these three dialects — a migration operation line, a <code>dbsystem</code>/
+<code>ai_component</code> scalar declaration, a domain declaration outside the accepted
+list — a stray annotation still reports the coded <code>FSL-ANNOTATION-TARGET</code>
+diagnostic. See <code>DESIGN-annotations.md</code>'s "domain/db/ai nested declaration
+syntax" section for the full attachment table, the <code>AiAuthority</code> rule
+restructuring, and how a <code>dbsystem</code> migration/compatibility-rule annotation
+reaches the checked model without going through the lossy legacy
+<code>quote_meta</code> string convention. <code>@...</code> on a nested declaration remains a
+native-only surface addition — the frozen Python reference does not parse
+it, so specs that use it are outside the Python-parity corpus by
+construction.</p>
 <h3 id="132-requirements-layer-requirements-the-fsl-req-dialect">13.2 Requirements layer: <code>requirements</code> (the fsl-req dialect)</h3>
 <pre><code class="language-fsl">requirements ExpenseRequirements {
   implements ExpenseToBe from &quot;1_business.fsl&quot; { }

--- a/examples/annotations/annotated_ai_component.fsl
+++ b/examples/annotations/annotated_ai_component.fsl
@@ -1,0 +1,70 @@
+// ════════════════════════════════════════════════════════════════
+// Declaration-level @annotation syntax on ai_component nested
+// declarations (issue #281) — sample corpus
+//
+// Demonstrates `@requirement(id, text?)` attached directly to a tool,
+// an authority block and its individual rule lines, a fallback block
+// and one of its `when` items, and a hard check block and one of its
+// individual rule lines. See docs/DESIGN-annotations.md's "domain/db/ai
+// nested declaration syntax" section for the `AiAuthority`/`AiHardCheck`
+// restructuring into `AiAuthorityRule`/`AiCheckRule { name, annotations,
+// loc }` and the unchanged `python_ast()` JSON shape.
+//
+// Native-only: the frozen Python reference does not parse `@...`
+// before an ai_component nested declaration, so this file is excluded
+// from the Python Monitor conformance sweep (tests/dialect_registry.py
+// MONITOR_EXCLUSIONS); native coverage lives in rust/fsl-syntax tests.
+//
+//   fslc check examples/annotations/annotated_ai_component.fsl
+// ════════════════════════════════════════════════════════════════
+ai_component AnnotatedRefundAgent {
+  model refund_model_v1;
+  prompt refund_prompt_v1;
+  input RefundRequestV1;
+  output RefundDecisionV1;
+
+  tool SearchOrder {
+    schema SearchOrderV1;
+    precondition order_exists;
+    effect read_order;
+  }
+
+  @requirement("REQ-REFUND-TOOL", "refund execution is a declared, schema-checked tool")
+  tool RefundPayment irreversible {
+    schema RefundPaymentV1;
+    precondition order_paid;
+    precondition amount_refundable;
+    effect payment_refunded;
+  }
+
+  tool DeleteCustomerData irreversible {
+    schema DeleteCustomerDataV1;
+    effect customer_data_deleted;
+  }
+
+  @kind("safety", "authority boundary for this component")
+  authority {
+    may_suggest SearchOrder;
+    may_execute SearchOrder;
+    @requirement("REQ-APPROVAL", "refunds require a human in the loop")
+    requires_human_approval RefundPayment;
+    @requirement("REQ-FORBIDDEN", "customer data deletion is never agent-initiated")
+    forbidden DeleteCustomerData;
+  }
+
+  fallback {
+    @requirement("REQ-FALLBACK", "low-confidence decisions escalate to a human")
+    when low_confidence require human_review;
+    when missing_order_evidence require refuse_with_reason;
+  }
+
+  @requirement("REQ-HARD-CHECK", "the hard contract enforces schema and approval rules")
+  check hard {
+    rule tool_authority;
+    @requirement("REQ-APPROVAL-CHECK", "human approval is verified before execution")
+    rule human_approval_required;
+    rule forbidden_tool_blocked;
+    rule tool_schema_declared;
+    rule tool_precondition_declared;
+  }
+}

--- a/examples/annotations/annotated_dbsystem.fsl
+++ b/examples/annotations/annotated_dbsystem.fsl
@@ -1,0 +1,60 @@
+// ════════════════════════════════════════════════════════════════
+// Declaration-level @annotation syntax on dbsystem nested declarations
+// (issue #281) — sample corpus
+//
+// Demonstrates `@requirement(id, text?)` attached directly to a
+// `migration` and to a `rule` line inside `check compatibility { ... }`.
+// The typed annotation reaches the checked model through
+// `Annotation::render_source()` rather than the legacy `quote_meta`
+// string convention — see docs/DESIGN-annotations.md's "domain/db/ai
+// nested declaration syntax" section.
+//
+// Native-only: the frozen Python reference does not parse `@...` before
+// a dbsystem nested declaration, so this file is excluded from the
+// Python Monitor conformance sweep (tests/dialect_registry.py
+// MONITOR_EXCLUSIONS); native coverage lives in rust/fsl-syntax and
+// rust/fsl-core tests.
+//
+//   fslc check examples/annotations/annotated_dbsystem.fsl
+//   fslc verify examples/annotations/annotated_dbsystem.fsl --depth 6
+// ════════════════════════════════════════════════════════════════
+dbsystem AnnotatedCompat {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column nickname: Text absent;
+    }
+  }
+
+  @requirement("REQ-MIGRATION", "the nickname column rollout is traceable")
+  migration add_nickname from 0 to 1 {
+    add users.nickname nullable;
+  }
+
+  artifact server_v1 {
+    reads users.id;
+    writes users.id;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.nickname;
+    writes users.nickname;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v1 when schema 0..0;
+    supported server_v1 when schema 0..0;
+    active server_v2 when schema 1..1;
+    supported server_v2 when schema 1..1;
+  }
+
+  check compatibility {
+    rule all_active_reads_exist;
+    rule all_active_writes_exist;
+    rule removed_only_after_unused;
+    @requirement("REQ-NOT-NULL", "not_null columns must be backfilled first")
+    rule not_null_after_backfill;
+  }
+}

--- a/examples/annotations/annotated_domain.fsl
+++ b/examples/annotations/annotated_domain.fsl
@@ -1,0 +1,76 @@
+// ════════════════════════════════════════════════════════════════
+// Declaration-level @annotation syntax on domain nested declarations
+// (issue #281) — sample corpus
+//
+// Demonstrates `@requirement(id, text?)` attached directly to an
+// aggregate command/decide/evolve/invariant, a projection, and an
+// effect. Saga `step` attachment (also part of issue #281) is covered
+// by rust/fsl-syntax/tests/dialect_declaration_annotations.rs and
+// rust/fsl-core/tests/typed_annotations.rs instead of this file, to
+// keep this example's saga-free reachability easy to verify by
+// inspection. See docs/DESIGN-annotations.md's "domain/db/ai nested
+// declaration syntax" section and docs/LANGUAGE.md §13.1.
+//
+// Native-only: the frozen Python reference does not parse `@...` before
+// a domain nested declaration, so this file is excluded from the
+// Python Monitor conformance sweep (tests/dialect_registry.py
+// MONITOR_EXCLUSIONS); native coverage lives in rust/fsl-syntax and
+// rust/fsl-core tests.
+//
+//   fslc check examples/annotations/annotated_domain.fsl
+//   fslc verify examples/annotations/annotated_domain.fsl --depth 6
+// ════════════════════════════════════════════════════════════════
+domain AnnotatedOrders {
+  implementation_profile functional_ddd
+
+  aggregate Order {
+    id OrderId
+
+    state {
+      placed: Bool = false;
+      shipped: Bool = false;
+    }
+
+    @requirement("REQ-COMMAND", "placing an order is traceable")
+    command Place {
+      input order_id: OrderId
+    }
+
+    event Placed { order_id: OrderId }
+    event Shipped { order_id: OrderId }
+
+    @requirement("REQ-DECIDE", "an order can only be placed once")
+    decide Place {
+      requires not shipped
+      emits Placed
+    }
+
+    @requirement("REQ-EVOLVE", "placement and shipment update tracked state")
+    evolve Placed {
+      placed = true
+    }
+
+    evolve Shipped {
+      shipped = true
+    }
+
+    @requirement("REQ-INVARIANT", "an order is placed before it ships")
+    invariant NoShippingUnplaced {
+      shipped -> placed
+    }
+  }
+
+  @requirement("REQ-EFFECT", "shipment is an idempotent side effect of placement")
+  effect Ship {
+    idempotency_key Placed.order_id
+    correlation_id Placed.order_id
+    handles Placed
+    emits one_of [Shipped]
+  }
+
+  @requirement("REQ-PROJECTION", "external readers observe shipment status")
+  projection OrderObservedState {
+    from Order
+    fields [shipped]
+  }
+}

--- a/rust/fsl-core/src/db.rs
+++ b/rust/fsl-core/src/db.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use fsl_syntax::{DbColumnRef, DbEnvironmentArtifact, DbSystem};
+use fsl_syntax::{Annotations, DbColumnRef, DbEnvironmentArtifact, DbSystem};
 
 fn safe(name: &str) -> String {
     let mut output = name
@@ -77,6 +77,18 @@ fn quote_meta(id: &str, text: &str) -> String {
     )
 }
 
+/// Render a declaration's typed annotations back to `@name(args...)` source
+/// lines so the synthesized kernel source carries them through the shared
+/// grammar's own annotation parser, rather than through the lossy legacy
+/// `"ID: text"` meta-string convention.
+fn annotation_lines(annotations: &Annotations, indent: &str) -> Vec<String> {
+    annotations
+        .source_order()
+        .iter()
+        .map(|annotation| format!("{indent}{}", annotation.render_source()))
+        .collect()
+}
+
 /// Render the executable kernel used by generic check/verify for a dbsystem.
 #[must_use]
 #[allow(clippy::too_many_lines)]
@@ -117,8 +129,19 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
         .into_iter()
         .collect::<BTreeSet<_>>()
     } else {
-        system.check.rules.iter().map(String::as_str).collect()
+        system
+            .check
+            .rules
+            .iter()
+            .map(|rule| rule.name.as_str())
+            .collect()
     };
+    let rule_annotations = system
+        .check
+        .rules
+        .iter()
+        .map(|rule| (rule.name.as_str(), &rule.annotations))
+        .collect::<BTreeMap<_, _>>();
 
     let mut lines = vec![format!(
         "spec {} \"db: database multi-environment compatibility\" {{",
@@ -167,6 +190,7 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
                 migration.name, migration.from_schema, migration.to_schema
             ),
         );
+        lines.extend(annotation_lines(&migration.decl_annotations, "  "));
         lines.push(format!("  action {action}() {metadata} {{"));
         lines.push(format!(
             "    requires schema_version == {}",
@@ -258,9 +282,14 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
     }
 
     if rules.contains("not_null_after_backfill") {
+        let annotations = rule_annotations
+            .get("not_null_after_backfill")
+            .map(|value| (*value).clone())
+            .unwrap_or_default();
         for key in columns.keys() {
             let member = column_member(key);
             let name = invariant_name(&["db_not_null_after_backfill", &key.0, &key.1]);
+            lines.extend(annotation_lines(&annotations, "  "));
             lines.push(format!(
                 "  invariant {name} {} {{ not column_not_null[{member}] or (column_exists[{member}] and column_backfilled[{member}]) }}",
                 quote_meta(
@@ -299,6 +328,13 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
                 if !rules.contains(rule) && !rules.contains("removed_only_after_unused") {
                     continue;
                 }
+                let mut annotations = rule_annotations
+                    .get(rule)
+                    .map(|value| (*value).clone())
+                    .unwrap_or_default();
+                if let Some(extra) = rule_annotations.get("removed_only_after_unused") {
+                    annotations.extend(extra.source_order().iter().cloned());
+                }
                 for column in artifact.capabilities.get(capability).into_iter().flatten() {
                     let mut parts = vec![
                         prefix.to_owned(),
@@ -318,6 +354,7 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
                         verb,
                         column_label(column)
                     );
+                    lines.extend(annotation_lines(&annotations, "  "));
                     lines.push(format!(
                         "  invariant {name} {} {{ {} }}",
                         quote_meta(id, &text),

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -1997,7 +1997,13 @@ fn metadata(id: impl Into<String>, text: impl Into<String>) -> MetaTag {
     }
 }
 
-fn action(name: String, params: Vec<Param>, items: Vec<ActionItem>, span: Span) -> SpecItem {
+fn action(
+    name: String,
+    params: Vec<Param>,
+    items: Vec<ActionItem>,
+    span: Span,
+    annotations: Annotations,
+) -> SpecItem {
     SpecItem::Action {
         name,
         params,
@@ -2006,8 +2012,17 @@ fn action(name: String, params: Vec<Param>, items: Vec<ActionItem>, span: Span) 
         fair: false,
         meta: None,
         sync: false,
-        annotations: Annotations::default(),
+        annotations,
     }
+}
+
+fn evolve_annotations(aggregate: &DomainAggregate, event: &str) -> Annotations {
+    aggregate
+        .evolves
+        .iter()
+        .find(|evolve| evolve.event == event)
+        .map(|evolve| evolve.annotations.clone())
+        .unwrap_or_default()
 }
 
 fn field_params(resolver: &Resolver<'_>, fields: &[DomainField]) -> Result<Vec<Param>, CoreError> {
@@ -2392,6 +2407,16 @@ fn lower_aggregate_actions(
                     }));
                 }
             }
+            let mut annotations = command.annotations.clone();
+            annotations.extend(decide.annotations.source_order().iter().cloned());
+            for event in &decide.emits {
+                annotations.extend(
+                    evolve_annotations(aggregate, event)
+                        .source_order()
+                        .iter()
+                        .cloned(),
+                );
+            }
             items.push(action(
                 format!(
                     "{}_{}",
@@ -2401,6 +2426,7 @@ fn lower_aggregate_actions(
                 field_params(resolver, &command.inputs)?,
                 action_items,
                 span,
+                annotations,
             ));
         }
     }
@@ -2481,6 +2507,13 @@ fn lower_effect_actions(
                 span,
             }));
             action_items.extend(resolver.evolve_items(aggregate, event_name, &scope)?);
+            let mut annotations = effect.annotations.clone();
+            annotations.extend(
+                evolve_annotations(aggregate, event_name)
+                    .source_order()
+                    .iter()
+                    .cloned(),
+            );
             items.push(action(
                 format!(
                     "{}_complete_{}",
@@ -2490,6 +2523,7 @@ fn lower_effect_actions(
                 field_params(resolver, &params)?,
                 action_items,
                 span,
+                annotations,
             ));
         }
         if let Some(maximum) = effect.retry.max_attempts {
@@ -2551,6 +2585,7 @@ fn lower_effect_actions(
                 )],
                 action_items,
                 span,
+                effect.annotations.clone(),
             ));
         }
     }
@@ -2611,6 +2646,7 @@ fn saga_guards(
     Ok(guards)
 }
 
+#[allow(clippy::too_many_lines)]
 fn lower_saga_actions(
     resolver: &Resolver<'_>,
     domain: &DomainSpec,
@@ -2636,6 +2672,7 @@ fn lower_saga_actions(
                 .map(ActionItem::Statement)
                 .collect::<Vec<_>>();
             action_items.extend(resolver.evolve_items(aggregate, &event_name, &scope)?);
+            let annotations = evolve_annotations(aggregate, &event_name);
             items.push(action(
                 format!(
                     "saga_{}_observe_{}",
@@ -2645,6 +2682,7 @@ fn lower_saga_actions(
                 field_params(resolver, &event.fields)?,
                 action_items,
                 span,
+                annotations,
             ));
         }
         for (index, step) in saga.steps.iter().enumerate() {
@@ -2662,7 +2700,13 @@ fn lower_saga_actions(
                     .map(ActionItem::Statement),
             );
             let action_name = format!("saga_{}_{}", lower_name(&saga.name), lower_name(&step.name));
-            items.push(action(action_name.clone(), Vec::new(), action_items, span));
+            items.push(action(
+                action_name.clone(),
+                Vec::new(),
+                action_items,
+                span,
+                step.annotations.clone(),
+            ));
             if let Some(timeout) = &step.timeout_event {
                 let mut timeout_items = guards
                     .into_iter()
@@ -2679,6 +2723,7 @@ fn lower_saga_actions(
                     Vec::new(),
                     timeout_items,
                     span,
+                    step.annotations.clone(),
                 ));
             }
         }
@@ -2706,6 +2751,7 @@ fn lower_saga_actions(
                 Vec::new(),
                 action_items,
                 span,
+                Annotations::default(),
             ));
         }
     }
@@ -2728,7 +2774,7 @@ fn lower_properties(
                     "DOMAIN-INVARIANT",
                     format!("{}.{}", aggregate.name, invariant.name),
                 )),
-                annotations: Annotations::default(),
+                annotations: invariant.annotations.clone(),
             });
         }
     }
@@ -2743,7 +2789,7 @@ fn lower_properties(
                     "DOMAIN-SAGA",
                     format!("{}.{}", saga.name, invariant.name),
                 )),
-                annotations: Annotations::default(),
+                annotations: invariant.annotations.clone(),
             });
         }
     }
@@ -2787,7 +2833,7 @@ fn lower_properties(
                 "DOMAIN-EFFECT",
                 format!("{} success is sticky", effect.name),
             )),
-            annotations: Annotations::default(),
+            annotations: effect.annotations.clone(),
         });
     }
     Ok(())

--- a/rust/fsl-core/tests/typed_annotations.rs
+++ b/rust/fsl-core/tests/typed_annotations.rs
@@ -783,3 +783,213 @@ requirements ReservedTraceId {{
         assert_eq!(error.line, 6);
     }
 }
+
+#[test]
+fn domain_command_decide_and_evolve_annotations_union_into_one_action() {
+    let kernel = parse_kernel_source(
+        r#"
+domain Orders {
+  aggregate Order {
+    state { ready: Bool }
+    @requirement("REQ-COMMAND")
+    command Place {}
+    event Placed {}
+    @requirement("REQ-DECIDE")
+    decide Place { emits Placed }
+    @requirement("REQ-EVOLVE")
+    evolve Placed { ready = true }
+  }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated domain");
+    let model = build_model(kernel).expect("build checked model");
+    let action = model
+        .actions
+        .iter()
+        .find(|action| action.name == "order_place")
+        .expect("order_place action");
+    let mut ids = action
+        .annotations
+        .requirements()
+        .unwrap()
+        .into_iter()
+        .map(|link| link.id)
+        .collect::<Vec<_>>();
+    ids.sort();
+    assert_eq!(ids, ["REQ-COMMAND", "REQ-DECIDE", "REQ-EVOLVE"]);
+}
+
+#[test]
+fn domain_effect_annotations_broadcast_to_complete_and_retry_actions() {
+    let kernel = parse_kernel_source(
+        r#"
+domain Orders {
+  aggregate Order {
+    id OrderId
+    state { ready: Bool = false; }
+    command Place {
+      input order_id: OrderId
+    }
+    event Placed { order_id: OrderId }
+    event Shipped { order_id: OrderId }
+    decide Place { emits Placed }
+    evolve Placed { ready = true }
+    evolve Shipped { ready = true }
+  }
+  @requirement("REQ-EFFECT")
+  effect Ship {
+    correlation_id Placed.order_id
+    handles Placed
+    emits one_of [Shipped]
+    retry { max_attempts 3 }
+  }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated domain effect");
+    let model = build_model(kernel).expect("build checked model");
+    for name in ["ship_complete_shipped", "ship_retry"] {
+        let action = model
+            .actions
+            .iter()
+            .find(|action| action.name == name)
+            .unwrap_or_else(|| panic!("{name} action"));
+        assert_eq!(
+            action.annotations.requirements().unwrap()[0].id,
+            "REQ-EFFECT",
+            "action {name}"
+        );
+    }
+}
+
+#[test]
+fn domain_saga_step_annotations_broadcast_to_step_and_timeout_actions() {
+    let kernel = parse_kernel_source(
+        r#"
+domain Orders {
+  aggregate Order {
+    state { ready: Bool }
+    command Place {}
+    event Placed {}
+    event Shipped {}
+    decide Place { emits Placed }
+    evolve Placed { ready = true }
+    evolve Shipped { ready = true }
+  }
+  saga Fulfillment {
+    starts_on Placed
+    @requirement("REQ-STEP")
+    step Notify {
+      awaits one_of [Shipped]
+      timeout after 5m emits Shipped
+    }
+  }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated saga step");
+    let model = build_model(kernel).expect("build checked model");
+    for name in ["saga_fulfillment_notify", "saga_fulfillment_notify_timeout"] {
+        let action = model
+            .actions
+            .iter()
+            .find(|action| action.name == name)
+            .unwrap_or_else(|| panic!("{name} action"));
+        assert_eq!(
+            action.annotations.requirements().unwrap()[0].id,
+            "REQ-STEP",
+            "action {name}"
+        );
+    }
+}
+
+#[test]
+fn domain_invariant_annotations_reach_the_checked_property() {
+    let kernel = parse_kernel_source(
+        r#"
+domain Orders {
+  aggregate Order {
+    state { ready: Bool }
+    @requirement("REQ-INVARIANT")
+    invariant Stable { ready == ready }
+  }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated domain invariant");
+    let model = build_model(kernel).expect("build checked model");
+    let invariant = model
+        .invariants
+        .iter()
+        .find(|invariant| invariant.name == "Order_Stable")
+        .expect("Order_Stable invariant");
+    let mut ids = invariant
+        .annotations
+        .requirements()
+        .unwrap()
+        .into_iter()
+        .map(|link| link.id)
+        .collect::<Vec<_>>();
+    ids.sort();
+    assert_eq!(ids, ["DOMAIN-INVARIANT", "REQ-INVARIANT"]);
+}
+
+#[test]
+fn db_migration_and_check_rule_annotations_reach_the_checked_model() {
+    let kernel = parse_kernel_source(
+        r#"
+dbsystem Orders {
+  database Db {
+    schema 0
+    table orders {
+      column status: Value present backfilled not_null;
+    }
+  }
+  @requirement("REQ-MIGRATION")
+  migration AddStatus from 0 to 1 {
+    add orders.status not_null;
+  }
+  check compatibility {
+    @requirement("REQ-RULE")
+    rule not_null_after_backfill;
+  }
+}
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("parse annotated dbsystem");
+    let model = build_model(kernel).expect("build checked model");
+    let migrate = model
+        .actions
+        .iter()
+        .find(|action| action.name == "migrate_AddStatus")
+        .expect("migrate_AddStatus action");
+    let mut migrate_ids = migrate
+        .annotations
+        .requirements()
+        .unwrap()
+        .into_iter()
+        .map(|link| link.id)
+        .collect::<Vec<_>>();
+    migrate_ids.sort();
+    assert_eq!(migrate_ids, ["DB-MIGRATION", "REQ-MIGRATION"]);
+    let not_null_invariant = model
+        .invariants
+        .iter()
+        .find(|invariant| invariant.name.starts_with("db_not_null_after_backfill"))
+        .expect("not_null_after_backfill invariant");
+    let mut invariant_ids = not_null_invariant
+        .annotations
+        .requirements()
+        .unwrap()
+        .into_iter()
+        .map(|link| link.id)
+        .collect::<Vec<_>>();
+    invariant_ids.sort();
+    assert_eq!(invariant_ids, ["DB-NOT-NULL", "REQ-RULE"]);
+}

--- a/rust/fsl-syntax/src/ai.rs
+++ b/rust/fsl-syntax/src/ai.rs
@@ -3,7 +3,8 @@
 
 use serde_json::{Value, json};
 
-use crate::{ParseError, Span, Token, TokenKind, lex};
+use crate::annotation_parse;
+use crate::{Annotations, ParseError, Span, Token, TokenKind, lex};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AiLoc {
@@ -33,15 +34,24 @@ pub struct AiTool {
     pub irreversible: bool,
     pub preconditions: Vec<String>,
     pub effect: Option<String>,
+    pub annotations: Annotations,
+    pub loc: Option<AiLoc>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiAuthorityRule {
+    pub name: String,
+    pub annotations: Annotations,
     pub loc: Option<AiLoc>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AiAuthority {
-    pub may_suggest: Vec<String>,
-    pub may_execute: Vec<String>,
-    pub requires_human_approval: Vec<String>,
-    pub forbidden: Vec<String>,
+    pub may_suggest: Vec<AiAuthorityRule>,
+    pub may_execute: Vec<AiAuthorityRule>,
+    pub requires_human_approval: Vec<AiAuthorityRule>,
+    pub forbidden: Vec<AiAuthorityRule>,
+    pub annotations: Annotations,
     pub loc: Option<AiLoc>,
 }
 
@@ -49,12 +59,21 @@ pub struct AiAuthority {
 pub struct AiFallback {
     pub reason: String,
     pub target: String,
+    pub annotations: Annotations,
     pub loc: AiLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiCheckRule {
+    pub name: String,
+    pub annotations: Annotations,
+    pub loc: Option<AiLoc>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AiHardCheck {
-    pub rules: Vec<String>,
+    pub rules: Vec<AiCheckRule>,
+    pub annotations: Annotations,
     pub loc: Option<AiLoc>,
 }
 
@@ -99,13 +118,19 @@ impl AiTool {
     }
 }
 
+impl AiAuthorityRule {
+    fn names(rules: &[Self]) -> Vec<&str> {
+        rules.iter().map(|rule| rule.name.as_str()).collect()
+    }
+}
+
 impl AiAuthority {
     fn python_ast(&self) -> Value {
         json!({
-            "$type":"AiAuthority","may_suggest":self.may_suggest,
-            "may_execute":self.may_execute,
-            "requires_human_approval":self.requires_human_approval,
-            "forbidden":self.forbidden,"loc":self.loc.map(AiLoc::python_ast),
+            "$type":"AiAuthority","may_suggest":AiAuthorityRule::names(&self.may_suggest),
+            "may_execute":AiAuthorityRule::names(&self.may_execute),
+            "requires_human_approval":AiAuthorityRule::names(&self.requires_human_approval),
+            "forbidden":AiAuthorityRule::names(&self.forbidden),"loc":self.loc.map(AiLoc::python_ast),
         })
     }
 }
@@ -118,7 +143,11 @@ impl AiFallback {
 
 impl AiHardCheck {
     fn python_ast(&self) -> Value {
-        json!({"$type":"AiHardCheck","rules":self.rules,"loc":self.loc.map(AiLoc::python_ast)})
+        json!({
+            "$type":"AiHardCheck",
+            "rules":self.rules.iter().map(|rule| rule.name.as_str()).collect::<Vec<_>>(),
+            "loc":self.loc.map(AiLoc::python_ast),
+        })
     }
 }
 
@@ -141,6 +170,7 @@ pub(crate) fn parse_ai_component_tokens(
         source,
         tokens,
         cursor,
+        pending_annotations: Annotations::default(),
     };
     let component = parser.component()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
@@ -153,9 +183,72 @@ struct AiParser<'a> {
     source: &'a str,
     tokens: Vec<Token>,
     cursor: usize,
+    pending_annotations: Annotations,
 }
 
 impl AiParser<'_> {
+    /// Parse zero or more leading `@name(args...)` annotations into
+    /// `self.pending_annotations`, ready to be drained by whichever
+    /// declaration constructor runs next.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] for malformed annotation syntax, a failed
+    /// validation, or one or more annotations with no following declaration
+    /// in the same block.
+    fn take_leading_annotations(&mut self) -> Result<(), ParseError> {
+        while self.peek_symbol("@") {
+            let annotation = annotation_parse::annotation(&self.tokens, &mut self.cursor)?;
+            self.pending_annotations.push(annotation);
+        }
+        if let Some(first) = self.pending_annotations.source_order().first()
+            && (self.peek_symbol("}") || matches!(self.peek().kind, TokenKind::Eof))
+        {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation must be followed by a declaration in the same block",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Drain and validate the annotations collected for the declaration
+    /// currently under construction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] when the drained group fails validation.
+    fn take_annotations(&mut self) -> Result<Annotations, ParseError> {
+        let annotations = std::mem::take(&mut self.pending_annotations);
+        annotations.validate().map_err(|error| {
+            ParseError::coded("FSL-ANNOTATION-INVALID", error.message, error.span)
+        })?;
+        Ok(annotations)
+    }
+
+    /// Reject any annotation left over after parsing a declaration that does
+    /// not accept annotations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] coded `FSL-ANNOTATION-TARGET` when annotations
+    /// remain pending.
+    fn expect_no_pending_annotations(&mut self) -> Result<(), ParseError> {
+        if let Some(first) = self.pending_annotations.source_order().first() {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation cannot attach to this declaration",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     fn component(&mut self) -> Result<AiComponent, ParseError> {
         let loc = self.loc();
         self.expect_ident_value("ai_component")?;
@@ -176,25 +269,33 @@ impl AiParser<'_> {
             loc,
         };
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             if self.eat_ident("model") {
+                self.expect_no_pending_annotations()?;
                 component.model = Some(self.atom()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("prompt") {
+                self.expect_no_pending_annotations()?;
                 component.prompt = Some(self.atom()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("retriever") {
+                self.expect_no_pending_annotations()?;
                 component.retriever = Some(self.atom()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("temperature") {
+                self.expect_no_pending_annotations()?;
                 component.temperature = Some(self.number()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("input") {
+                self.expect_no_pending_annotations()?;
                 component.input_schema = Some(self.atom()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("output") {
+                self.expect_no_pending_annotations()?;
                 component.output_schema = Some(self.atom()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("tools") {
+                let annotations = self.take_annotations()?;
                 for name in self.names()? {
                     component.tools.push(AiTool {
                         name,
@@ -202,6 +303,7 @@ impl AiParser<'_> {
                         irreversible: false,
                         preconditions: Vec::new(),
                         effect: None,
+                        annotations: annotations.clone(),
                         loc: None,
                     });
                 }
@@ -222,6 +324,7 @@ impl AiParser<'_> {
     }
 
     fn tool(&mut self) -> Result<AiTool, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let name = self.expect_ident()?;
@@ -233,6 +336,7 @@ impl AiParser<'_> {
             irreversible,
             preconditions: Vec::new(),
             effect: None,
+            annotations,
             loc: Some(loc),
         };
         while !self.eat_symbol("}") {
@@ -251,6 +355,7 @@ impl AiParser<'_> {
     }
 
     fn authority(&mut self) -> Result<AiAuthority, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         if !self.peek_symbol("{") {
@@ -259,16 +364,28 @@ impl AiParser<'_> {
         self.expect_symbol("{")?;
         let mut authority = AiAuthority {
             loc: Some(loc),
+            annotations,
             ..AiAuthority::default()
         };
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
+            let rule_loc = self.loc();
             let kind = self.expect_ident()?;
+            let rule_annotations = self.take_annotations()?;
             let names = self.names()?;
+            let rules = names
+                .into_iter()
+                .map(|name| AiAuthorityRule {
+                    name,
+                    annotations: rule_annotations.clone(),
+                    loc: Some(rule_loc),
+                })
+                .collect::<Vec<_>>();
             match kind.as_str() {
-                "may_suggest" => authority.may_suggest.extend(names),
-                "may_execute" => authority.may_execute.extend(names),
-                "requires_human_approval" => authority.requires_human_approval.extend(names),
-                "forbidden" => authority.forbidden.extend(names),
+                "may_suggest" => authority.may_suggest.extend(rules),
+                "may_execute" => authority.may_execute.extend(rules),
+                "requires_human_approval" => authority.requires_human_approval.extend(rules),
+                "forbidden" => authority.forbidden.extend(rules),
                 _ => return Err(self.error("unknown authority declaration")),
             }
             self.eat_symbol(";");
@@ -277,17 +394,26 @@ impl AiParser<'_> {
     }
 
     fn fallback(&mut self) -> Result<Vec<AiFallback>, ParseError> {
+        let block_annotations = self.take_annotations()?;
         self.bump();
         self.expect_symbol("{")?;
         let mut items = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
+            let item_annotations = self.take_annotations()?;
             let loc = self.loc();
             self.expect_ident_value("when")?;
             let reason = self.expect_ident()?;
             self.expect_ident_value("require")?;
+            let mut annotations = block_annotations.clone();
+            annotations.extend(item_annotations.source_order().iter().cloned());
+            annotations.validate().map_err(|error| {
+                ParseError::coded("FSL-ANNOTATION-INVALID", error.message, error.span)
+            })?;
             items.push(AiFallback {
                 reason,
                 target: self.expect_ident()?,
+                annotations,
                 loc,
             });
             self.eat_symbol(";");
@@ -296,18 +422,27 @@ impl AiParser<'_> {
     }
 
     fn check(&mut self) -> Result<AiHardCheck, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         self.expect_ident_value("hard")?;
         self.expect_symbol("{")?;
         let mut rules = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
+            let rule_loc = self.loc();
+            let rule_annotations = self.take_annotations()?;
             self.expect_ident_value("rule")?;
-            rules.push(self.expect_ident()?);
+            rules.push(AiCheckRule {
+                name: self.expect_ident()?,
+                annotations: rule_annotations,
+                loc: Some(rule_loc),
+            });
             self.eat_symbol(";");
         }
         Ok(AiHardCheck {
             rules,
+            annotations,
             loc: Some(loc),
         })
     }

--- a/rust/fsl-syntax/src/annotation.rs
+++ b/rust/fsl-syntax/src/annotation.rs
@@ -138,6 +138,29 @@ pub enum AnnotationValue {
     Symbol(SymbolPath),
 }
 
+/// The lexer has no string escape syntax, so a rendered string literal
+/// replaces the characters that would otherwise break tokenization.
+fn sanitize_string_literal(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| match character {
+            '\\' | '"' | '\n' | '\r' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+impl AnnotationValue {
+    fn render_source(&self) -> String {
+        match self {
+            Self::String(value) => format!("\"{}\"", sanitize_string_literal(value)),
+            Self::Integer(value) => value.to_string(),
+            Self::Boolean(value) => value.to_string(),
+            Self::Symbol(path) => path.to_string(),
+        }
+    }
+}
+
 /// Typed metadata attached to a declaration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Annotation {
@@ -195,6 +218,52 @@ impl Annotation {
             span,
         }
     }
+
+    /// Render this annotation back to `@name(args...)` declaration syntax.
+    ///
+    /// String arguments are sanitized (backslash/quote/newline become `_`)
+    /// because the lexer has no string escape syntax; this is used to
+    /// re-embed typed annotations into synthesized FSL source (for example
+    /// the dbsystem kernel) without going through the lossy legacy
+    /// `"ID: text"` meta-string convention.
+    #[must_use]
+    pub fn render_source(&self) -> String {
+        match self {
+            Self::Requirement { id, text, .. } => render_call(
+                "requirement",
+                &std::iter::once(id.clone())
+                    .chain(text.clone())
+                    .map(AnnotationValue::String)
+                    .collect::<Vec<_>>(),
+            ),
+            Self::Undecided { reason, .. } => {
+                render_call("undecided", &[AnnotationValue::String(reason.clone())])
+            }
+            Self::Kind { id, text, .. } => render_call(
+                "kind",
+                &std::iter::once(id.clone())
+                    .chain(text.clone())
+                    .map(AnnotationValue::String)
+                    .collect::<Vec<_>>(),
+            ),
+            Self::Custom {
+                namespace,
+                arguments,
+                ..
+            } => render_call(&namespace.to_string(), arguments),
+        }
+    }
+}
+
+fn render_call(name: &str, arguments: &[AnnotationValue]) -> String {
+    format!(
+        "@{name}({})",
+        arguments
+            .iter()
+            .map(AnnotationValue::render_source)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// A normalized requirement relation derived from one or more annotations.

--- a/rust/fsl-syntax/src/db.rs
+++ b/rust/fsl-syntax/src/db.rs
@@ -5,7 +5,8 @@ use std::collections::BTreeMap;
 
 use serde_json::{Value, json};
 
-use crate::{ParseError, Span, Token, TokenKind, lex};
+use crate::annotation_parse;
+use crate::{Annotations, ParseError, Span, Token, TokenKind, lex};
 
 pub type DbColumnRef = (String, String);
 
@@ -52,6 +53,7 @@ pub struct DbMigration {
     pub to_schema: i64,
     pub ops: Vec<DbMigrationOp>,
     pub annotations: Vec<String>,
+    pub decl_annotations: Annotations,
     pub span: Span,
 }
 
@@ -97,8 +99,15 @@ pub struct DbEnvironment {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DbCheckRule {
+    pub name: String,
+    pub annotations: Annotations,
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DbCheck {
-    pub rules: Vec<String>,
+    pub rules: Vec<DbCheckRule>,
     pub span: Option<Span>,
 }
 
@@ -243,7 +252,8 @@ impl DbEnvironment {
 impl DbCheck {
     fn python_ast(&self) -> Value {
         json!({
-            "$type": "DbCheck", "rules": self.rules,
+            "$type": "DbCheck",
+            "rules": self.rules.iter().map(|rule| rule.name.as_str()).collect::<Vec<_>>(),
             "loc": self.span.map(Span::python_loc),
         })
     }
@@ -271,7 +281,11 @@ pub(crate) fn parse_db_system_tokens(
     tokens: Vec<Token>,
     cursor: usize,
 ) -> Result<DbSystem, ParseError> {
-    let mut parser = DbParser { tokens, cursor };
+    let mut parser = DbParser {
+        tokens,
+        cursor,
+        pending_annotations: Annotations::default(),
+    };
     let system = parser.system()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after dbsystem"));
@@ -282,9 +296,72 @@ pub(crate) fn parse_db_system_tokens(
 struct DbParser {
     tokens: Vec<Token>,
     cursor: usize,
+    pending_annotations: Annotations,
 }
 
 impl DbParser {
+    /// Parse zero or more leading `@name(args...)` annotations into
+    /// `self.pending_annotations`, ready to be drained by whichever
+    /// declaration constructor runs next.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] for malformed annotation syntax, a failed
+    /// validation, or one or more annotations with no following declaration
+    /// in the same block.
+    fn take_leading_annotations(&mut self) -> Result<(), ParseError> {
+        while self.peek_symbol("@") {
+            let annotation = annotation_parse::annotation(&self.tokens, &mut self.cursor)?;
+            self.pending_annotations.push(annotation);
+        }
+        if let Some(first) = self.pending_annotations.source_order().first()
+            && (self.peek_symbol("}") || matches!(self.peek().kind, TokenKind::Eof))
+        {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation must be followed by a declaration in the same block",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Drain and validate the annotations collected for the declaration
+    /// currently under construction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] when the drained group fails validation.
+    fn take_annotations(&mut self) -> Result<Annotations, ParseError> {
+        let annotations = std::mem::take(&mut self.pending_annotations);
+        annotations.validate().map_err(|error| {
+            ParseError::coded("FSL-ANNOTATION-INVALID", error.message, error.span)
+        })?;
+        Ok(annotations)
+    }
+
+    /// Reject any annotation left over after parsing a declaration that does
+    /// not accept annotations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] coded `FSL-ANNOTATION-TARGET` when annotations
+    /// remain pending.
+    fn expect_no_pending_annotations(&mut self) -> Result<(), ParseError> {
+        if let Some(first) = self.pending_annotations.source_order().first() {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation cannot attach to this declaration",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     fn system(&mut self) -> Result<DbSystem, ParseError> {
         let span = self.peek().span;
         self.expect_ident_value("dbsystem")?;
@@ -299,6 +376,7 @@ impl DbParser {
             span: None,
         };
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             match self.item()? {
                 DbItem::Database(value) => {
                     if database.replace(value).is_some() {
@@ -324,14 +402,18 @@ impl DbParser {
 
     fn item(&mut self) -> Result<DbItem, ParseError> {
         if self.peek_ident("database") {
+            self.expect_no_pending_annotations()?;
             Ok(DbItem::Database(self.database()?))
         } else if self.peek_ident("migration") {
             Ok(DbItem::Migration(self.migration()?))
         } else if self.peek_ident("artifact") {
+            self.expect_no_pending_annotations()?;
             Ok(DbItem::Artifact(self.artifact()?))
         } else if self.peek_ident("environment") {
+            self.expect_no_pending_annotations()?;
             Ok(DbItem::Environment(self.environment()?))
         } else if self.peek_ident("check") {
+            self.expect_no_pending_annotations()?;
             Ok(DbItem::Check(self.check()?))
         } else {
             Err(self.error("expected dbsystem declaration"))
@@ -419,6 +501,7 @@ impl DbParser {
     }
 
     fn migration(&mut self) -> Result<DbMigration, ParseError> {
+        let decl_annotations = self.take_annotations()?;
         let span = self.bump().span;
         let name = self.expect_ident()?;
         self.expect_ident_value("from")?;
@@ -429,6 +512,8 @@ impl DbParser {
         self.expect_symbol("{")?;
         let mut ops = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
+            self.expect_no_pending_annotations()?;
             ops.push(self.migration_op()?);
         }
         Ok(DbMigration {
@@ -437,6 +522,7 @@ impl DbParser {
             to_schema,
             ops,
             annotations,
+            decl_annotations,
             span,
         })
     }
@@ -618,8 +704,15 @@ impl DbParser {
         self.expect_symbol("{")?;
         let mut rules = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
+            let rule_span = self.peek().span;
+            let annotations = self.take_annotations()?;
             self.expect_ident_value("rule")?;
-            rules.push(self.expect_ident()?);
+            rules.push(DbCheckRule {
+                name: self.expect_ident()?,
+                annotations,
+                span: rule_span,
+            });
             self.eat_symbol(";");
         }
         Ok(DbCheck {

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -4,11 +4,12 @@
 use serde::Serialize;
 use serde_json::{Value, json};
 
+use crate::annotation_parse;
 use crate::syntax_expr::{
     ExpressionMode, SyntaxExpr, SyntaxExprKind, SyntaxIdent, SyntaxLValue, SyntaxTypeExpr,
     parse_tokens_expression, parse_tokens_lvalue,
 };
-use crate::{ParseError, Span, Token, TokenKind, lex};
+use crate::{Annotations, ParseError, Span, Token, TokenKind, lex};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct DomainLoc {
@@ -72,6 +73,7 @@ pub struct DomainType {
 pub struct DomainCommand {
     pub name: String,
     pub inputs: Vec<DomainField>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -101,6 +103,7 @@ pub struct DomainDecide {
     pub requires: Vec<SyntaxExpr>,
     pub rejects: Vec<DomainReject>,
     pub emits: Vec<String>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -117,6 +120,7 @@ pub struct DomainEvolve {
     pub event: String,
     pub requires: Vec<SyntaxExpr>,
     pub assignments: Vec<DomainAssignment>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -125,6 +129,7 @@ pub struct DomainInvariant {
     pub name: SyntaxIdent,
     pub expr: SyntaxExpr,
     pub span: Span,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -133,6 +138,7 @@ pub struct DomainProjection {
     pub name: String,
     pub source: String,
     pub fields: Vec<String>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -185,6 +191,7 @@ pub struct DomainEffect {
     pub compensation_events: Vec<String>,
     pub outbox: Option<String>,
     pub inbox: Option<String>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -207,6 +214,7 @@ pub struct DomainSagaStep {
     pub awaits: Vec<String>,
     pub timeout_after: Option<String>,
     pub timeout_event: Option<String>,
+    pub annotations: Annotations,
     pub loc: DomainLoc,
 }
 
@@ -389,6 +397,7 @@ impl DomainEffect {
             compensation_events: Vec::new(),
             outbox: None,
             inbox: None,
+            annotations: Annotations::default(),
             loc,
         }
     }
@@ -462,7 +471,11 @@ pub(crate) fn parse_domain_tokens(
     tokens: Vec<Token>,
     cursor: usize,
 ) -> Result<DomainSpec, ParseError> {
-    let mut parser = DomainParser { tokens, cursor };
+    let mut parser = DomainParser {
+        tokens,
+        cursor,
+        pending_annotations: Annotations::default(),
+    };
     let domain = parser.domain()?;
     if !matches!(parser.peek().kind, TokenKind::Eof) {
         return Err(parser.error("unexpected token after domain"));
@@ -473,9 +486,72 @@ pub(crate) fn parse_domain_tokens(
 struct DomainParser {
     tokens: Vec<Token>,
     cursor: usize,
+    pending_annotations: Annotations,
 }
 
 impl DomainParser {
+    /// Parse zero or more leading `@name(args...)` annotations into
+    /// `self.pending_annotations`, ready to be drained by whichever
+    /// declaration constructor runs next.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] for malformed annotation syntax, a failed
+    /// validation, or one or more annotations with no following declaration
+    /// in the same block.
+    fn take_leading_annotations(&mut self) -> Result<(), ParseError> {
+        while self.peek_symbol("@") {
+            let annotation = annotation_parse::annotation(&self.tokens, &mut self.cursor)?;
+            self.pending_annotations.push(annotation);
+        }
+        if let Some(first) = self.pending_annotations.source_order().first()
+            && (self.peek_symbol("}") || matches!(self.peek().kind, TokenKind::Eof))
+        {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation must be followed by a declaration in the same block",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Drain and validate the annotations collected for the declaration
+    /// currently under construction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] when the drained group fails validation.
+    fn take_annotations(&mut self) -> Result<Annotations, ParseError> {
+        let annotations = std::mem::take(&mut self.pending_annotations);
+        annotations.validate().map_err(|error| {
+            ParseError::coded("FSL-ANNOTATION-INVALID", error.message, error.span)
+        })?;
+        Ok(annotations)
+    }
+
+    /// Reject any annotation left over after parsing a declaration that does
+    /// not accept annotations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseError`] coded `FSL-ANNOTATION-TARGET` when annotations
+    /// remain pending.
+    fn expect_no_pending_annotations(&mut self) -> Result<(), ParseError> {
+        if let Some(first) = self.pending_annotations.source_order().first() {
+            let span = first.span();
+            self.pending_annotations = Annotations::default();
+            return Err(ParseError::coded(
+                "FSL-ANNOTATION-TARGET",
+                "annotation cannot attach to this declaration",
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     fn domain(&mut self) -> Result<DomainSpec, ParseError> {
         let loc = self.loc();
         self.expect_ident_value("domain")?;
@@ -489,7 +565,9 @@ impl DomainParser {
         let mut sagas = Vec::new();
         let mut projections = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             if self.eat_ident("implementation_profile") {
+                self.expect_no_pending_annotations()?;
                 implementation_profile = Some(self.expect_ident()?);
                 if self.eat_symbol("{") {
                     while !self.eat_symbol("}") {
@@ -500,20 +578,26 @@ impl DomainParser {
                 }
                 self.eat_symbol(";");
             } else if self.peek_ident("type") {
+                self.expect_no_pending_annotations()?;
                 types.push(self.domain_type()?);
             } else if self.peek_ident("enum") {
+                self.expect_no_pending_annotations()?;
                 types.push(self.domain_enum()?);
             } else if self.peek_ident("value_object") {
+                self.expect_no_pending_annotations()?;
                 types.push(self.value_object()?);
             } else if self.peek_ident("aggregate") {
+                self.expect_no_pending_annotations()?;
                 let (aggregate, nested_projections) = self.aggregate()?;
                 aggregates.push(aggregate);
                 projections.extend(nested_projections);
             } else if self.peek_ident("effect") {
                 effects.push(self.effect()?);
             } else if self.peek_ident("await") {
+                self.expect_no_pending_annotations()?;
                 awaits.push(self.await_block()?);
             } else if self.peek_ident("saga") {
+                self.expect_no_pending_annotations()?;
                 sagas.push(self.saga()?);
             } else if self.peek_ident("projection") {
                 projections.push(self.projection()?);
@@ -628,9 +712,11 @@ impl DomainParser {
         let mut fields = Vec::new();
         let mut invariants = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             if self.peek_ident("invariant") {
                 invariants.push(self.invariant()?);
             } else {
+                self.expect_no_pending_annotations()?;
                 fields.push(self.field(false, true)?);
             }
         }
@@ -666,10 +752,13 @@ impl DomainParser {
         let mut projections = Vec::new();
         let mut stale_policies = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             if self.eat_ident("id") {
+                self.expect_no_pending_annotations()?;
                 id_type = Some(self.expect_ident()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("state") {
+                self.expect_no_pending_annotations()?;
                 self.expect_symbol("{")?;
                 while !self.eat_symbol("}") {
                     state.push(self.field(false, true)?);
@@ -677,8 +766,10 @@ impl DomainParser {
             } else if self.peek_ident("command") {
                 commands.push(self.command()?);
             } else if self.peek_ident("event") {
+                self.expect_no_pending_annotations()?;
                 events.push(self.event()?);
             } else if self.peek_ident("error") {
+                self.expect_no_pending_annotations()?;
                 let error_loc = self.loc();
                 self.bump();
                 errors.push(DomainError {
@@ -695,6 +786,7 @@ impl DomainParser {
             } else if self.peek_ident("projection") {
                 projections.push(self.projection()?);
             } else if self.peek_ident("on_stale") {
+                self.expect_no_pending_annotations()?;
                 stale_policies.push(self.stale_policy()?);
             } else {
                 return Err(self.error("expected aggregate declaration"));
@@ -719,6 +811,7 @@ impl DomainParser {
     }
 
     fn command(&mut self) -> Result<DomainCommand, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let name = self.expect_ident()?;
@@ -727,7 +820,12 @@ impl DomainParser {
         while !self.eat_symbol("}") {
             inputs.push(self.field(true, false)?);
         }
-        Ok(DomainCommand { name, inputs, loc })
+        Ok(DomainCommand {
+            name,
+            inputs,
+            annotations,
+            loc,
+        })
     }
 
     fn event(&mut self) -> Result<DomainEvent, ParseError> {
@@ -786,6 +884,7 @@ impl DomainParser {
     }
 
     fn decide(&mut self) -> Result<DomainDecide, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let command = self.expect_ident()?;
@@ -818,11 +917,13 @@ impl DomainParser {
             requires,
             rejects,
             emits,
+            annotations,
             loc,
         })
     }
 
     fn evolve(&mut self) -> Result<DomainEvolve, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let event = self.expect_ident()?;
@@ -840,6 +941,7 @@ impl DomainParser {
             event,
             requires,
             assignments,
+            annotations,
             loc,
         })
     }
@@ -860,6 +962,7 @@ impl DomainParser {
     }
 
     fn invariant(&mut self) -> Result<DomainInvariant, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         let start = self.peek().span;
         self.bump();
@@ -871,11 +974,13 @@ impl DomainParser {
             name,
             expr,
             span: join(start, self.previous_span()),
+            annotations,
             loc,
         })
     }
 
     fn projection(&mut self) -> Result<DomainProjection, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let name = self.expect_ident()?;
@@ -897,6 +1002,7 @@ impl DomainParser {
             name,
             source,
             fields,
+            annotations,
             loc,
         })
     }
@@ -921,11 +1027,13 @@ impl DomainParser {
     }
 
     fn effect(&mut self) -> Result<DomainEffect, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let name = self.expect_ident()?;
         self.expect_symbol("{")?;
         let mut effect = DomainEffect::new(name, loc);
+        effect.annotations = annotations;
         while !self.eat_symbol("}") {
             if self.eat_ident("async") {
                 effect.async_effect = true;
@@ -1075,22 +1183,29 @@ impl DomainParser {
         let mut outboxes = Vec::new();
         let mut inboxes = Vec::new();
         while !self.eat_symbol("}") {
+            self.take_leading_annotations()?;
             if self.eat_ident("starts_on") {
+                self.expect_no_pending_annotations()?;
                 starts_on = Some(self.expect_ident()?);
                 self.eat_symbol(";");
             } else if self.peek_ident("step") {
                 steps.push(self.saga_step()?);
             } else if self.eat_ident("compensation") {
+                self.expect_no_pending_annotations()?;
                 self.expect_symbol("{")?;
                 while !self.eat_symbol("}") {
+                    self.take_leading_annotations()?;
+                    self.expect_no_pending_annotations()?;
                     compensations.push(self.saga_compensation()?);
                 }
             } else if self.peek_ident("invariant") {
                 invariants.push(self.invariant()?);
             } else if self.eat_ident("outbox") {
+                self.expect_no_pending_annotations()?;
                 outboxes.push(self.expect_ident()?);
                 self.eat_symbol(";");
             } else if self.eat_ident("inbox") {
+                self.expect_no_pending_annotations()?;
                 inboxes.push(self.expect_ident()?);
                 self.eat_symbol(";");
             } else {
@@ -1110,6 +1225,7 @@ impl DomainParser {
     }
 
     fn saga_step(&mut self) -> Result<DomainSagaStep, ParseError> {
+        let annotations = self.take_annotations()?;
         let loc = self.loc();
         self.bump();
         let name = self.expect_ident()?;
@@ -1123,6 +1239,7 @@ impl DomainParser {
             awaits: Vec::new(),
             timeout_after: None,
             timeout_event: None,
+            annotations,
             loc,
         };
         while !self.eat_symbol("}") {

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -21,7 +21,8 @@ mod surface;
 mod syntax_expr;
 
 pub use ai::{
-    AiAuthority, AiComponent, AiFallback, AiHardCheck, AiLoc, AiTool, parse_ai_component,
+    AiAuthority, AiAuthorityRule, AiCheckRule, AiComponent, AiFallback, AiHardCheck, AiLoc, AiTool,
+    parse_ai_component,
 };
 pub use annotation::{
     Annotation, AnnotationError, AnnotationRegistry, AnnotationValue, Annotations, RequirementLink,
@@ -29,8 +30,9 @@ pub use annotation::{
 };
 pub use ast::{Binder, Expr, Pattern, QualifiedName, SourcePos, Span};
 pub use db::{
-    DbArtifact, DbCheck, DbColumn, DbColumnRef, DbDatabase, DbEnvironment, DbEnvironmentArtifact,
-    DbFlag, DbFlagCondition, DbMigration, DbMigrationOp, DbSystem, DbTable, parse_db_system,
+    DbArtifact, DbCheck, DbCheckRule, DbColumn, DbColumnRef, DbDatabase, DbEnvironment,
+    DbEnvironmentArtifact, DbFlag, DbFlagCondition, DbMigration, DbMigrationOp, DbSystem, DbTable,
+    parse_db_system,
 };
 pub use dispatch::{
     DIALECT_KEYWORDS, ParsedDocument, SourceFile, declaration_keyword, dialect_keyword,

--- a/rust/fsl-syntax/tests/dialect_declaration_annotations.rs
+++ b/rust/fsl-syntax/tests/dialect_declaration_annotations.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_syntax::{Annotation, DomainSpec, parse_ai_component, parse_db_system, parse_domain};
+
+fn domain(source: &str) -> DomainSpec {
+    parse_domain(source).expect("parse domain")
+}
+
+#[test]
+fn aggregate_command_decide_evolve_and_projection_accept_leading_annotations() {
+    let spec = domain(
+        r#"
+domain Orders {
+  aggregate Order {
+    id OrderId
+    state { ready: Bool }
+    @requirement("REQ-CMD")
+    command Place { input qty: Int }
+    @requirement("REQ-DECIDE")
+    decide Place { emits Placed }
+    event Placed { qty: Int }
+    @requirement("REQ-EVOLVE")
+    evolve Placed { ready = true }
+    @requirement("REQ-INVARIANT")
+    invariant Ready { ready == ready }
+    @requirement("REQ-PROJECTION")
+    projection OrderView { from Order fields [ready] }
+  }
+}
+"#,
+    );
+    let aggregate = &spec.aggregates[0];
+    assert_eq!(aggregate.commands[0].annotations.source_order().len(), 1);
+    assert_eq!(aggregate.decides[0].annotations.source_order().len(), 1);
+    assert_eq!(aggregate.evolves[0].annotations.source_order().len(), 1);
+    assert_eq!(aggregate.invariants[0].annotations.source_order().len(), 1);
+    assert_eq!(spec.projections[0].annotations.source_order().len(), 1);
+}
+
+#[test]
+fn effect_and_saga_step_accept_leading_annotations() {
+    let spec = domain(
+        r#"
+domain Orders {
+  aggregate Order {
+    id OrderId
+    state { ready: Bool }
+    command Place { input qty: Int }
+    decide Place { emits Placed }
+    event Placed { qty: Int }
+    event Shipped { qty: Int }
+    evolve Placed { ready = true }
+  }
+  @requirement("REQ-EFFECT")
+  effect Ship {
+    handles Placed
+    success_event Shipped
+  }
+  saga Fulfillment {
+    starts_on Placed
+    @requirement("REQ-STEP")
+    step Notify {
+      awaits one_of [Shipped]
+    }
+  }
+}
+"#,
+    );
+    assert_eq!(spec.effects[0].annotations.source_order().len(), 1);
+    assert_eq!(spec.sagas[0].steps[0].annotations.source_order().len(), 1);
+}
+
+#[test]
+fn stray_annotation_before_unsupported_domain_declaration_is_a_target_error() {
+    let error =
+        parse_domain("domain Bad {\n  @requirement(\"REQ-1\")\n  type SchemaVersion = 0..1\n}\n")
+            .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn stray_annotation_before_closing_brace_in_aggregate_is_a_target_error() {
+    let error = parse_domain(
+        "domain Bad {\n  aggregate Order {\n    id OrderId\n    state { ready: Bool }\n    @requirement(\"REQ-1\")\n  }\n}\n",
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn ai_authority_rules_accept_annotations_and_expose_plain_name_python_ast() {
+    let component = parse_ai_component(
+        r#"
+ai_component Assistant {
+  tool Search { schema SearchV1; }
+  tool Execute { schema ExecuteV1; }
+  authority {
+    @requirement("REQ-SUGGEST")
+    may_suggest Search;
+    @requirement("REQ-EXECUTE")
+    may_execute Execute;
+  }
+}
+"#,
+    )
+    .expect("parse ai_component");
+    assert_eq!(component.authority.may_suggest[0].name, "Search");
+    assert_eq!(
+        component.authority.may_suggest[0]
+            .annotations
+            .source_order()
+            .len(),
+        1
+    );
+    assert_eq!(component.authority.may_execute[0].name, "Execute");
+    let ast = component.python_ast();
+    assert_eq!(
+        ast["authority"]["may_suggest"],
+        serde_json::json!(["Search"])
+    );
+    assert_eq!(
+        ast["authority"]["may_execute"],
+        serde_json::json!(["Execute"])
+    );
+}
+
+#[test]
+fn ai_scalar_declaration_before_annotation_is_a_target_error() {
+    let error =
+        parse_ai_component("ai_component Bad {\n  @requirement(\"REQ-1\")\n  model \"gpt\";\n}\n")
+            .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn db_migration_and_check_rule_accept_annotations() {
+    let system = parse_db_system(
+        r#"
+dbsystem Orders {
+  database Db {
+    schema 0
+    table orders {
+      column status: Value present backfilled not_null;
+    }
+  }
+  @requirement("REQ-MIGRATION")
+  migration AddStatus from 0 to 1 {
+    add orders.status not_null;
+  }
+  check compatibility {
+    @requirement("REQ-RULE")
+    rule not_null_after_backfill;
+  }
+}
+"#,
+    )
+    .expect("parse dbsystem");
+    assert_eq!(
+        system.migrations[0].decl_annotations.source_order().len(),
+        1
+    );
+    assert!(matches!(
+        &system.check.rules[0].annotations.source_order()[0],
+        Annotation::Requirement { id, .. } if id == "REQ-RULE"
+    ));
+}
+
+#[test]
+fn db_migration_op_before_annotation_is_a_target_error() {
+    let error = parse_db_system(
+        "dbsystem Bad {\n  database Db {\n    schema 0\n    table orders {\n      column status: Value present backfilled not_null;\n    }\n  }\n  migration AddStatus from 0 to 1 {\n    @requirement(\"REQ-1\")\n    add orders.status not_null;\n  }\n}\n",
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn stray_annotation_before_saga_does_not_leak_into_its_first_declaration() {
+    let error = parse_domain(
+        r#"
+domain Bad {
+  @undecided("whole saga design pending review")
+  saga Fulfillment {
+    invariant Stable { true }
+  }
+}
+"#,
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn stray_annotation_inside_saga_compensation_is_a_target_error() {
+    let error = parse_domain(
+        r#"
+domain Bad {
+  aggregate Order {
+    id OrderId
+    state { ready: Bool }
+    event A { }
+    event B { }
+  }
+  saga Fulfillment {
+    compensation {
+      @requirement("REQ-1")
+      when A after B {
+        emits A
+      }
+    }
+  }
+}
+"#,
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-TARGET");
+}
+
+#[test]
+fn ai_check_hard_rule_accepts_annotations() {
+    let component = parse_ai_component(
+        r#"
+ai_component Assistant {
+  tool Search { schema SearchV1; }
+  check hard {
+    @requirement("REQ-RULE")
+    rule tool_authority;
+    rule tool_schema_declared;
+  }
+}
+"#,
+    )
+    .expect("parse ai_component");
+    assert_eq!(component.check.rules[0].name, "tool_authority");
+    assert_eq!(component.check.rules[0].annotations.source_order().len(), 1);
+    assert!(
+        component.check.rules[1]
+            .annotations
+            .source_order()
+            .is_empty()
+    );
+    let ast = component.python_ast();
+    assert_eq!(
+        ast["check"]["rules"],
+        serde_json::json!(["tool_authority", "tool_schema_declared"])
+    );
+}
+
+#[test]
+fn ai_fallback_conflicting_block_and_item_requirement_text_is_a_checked_error() {
+    let error = parse_ai_component(
+        r#"
+ai_component Assistant {
+  tool Search { schema SearchV1; }
+  @requirement("REQ-X", "block text")
+  fallback {
+    @requirement("REQ-X", "item text")
+    when low_confidence require human_review;
+  }
+}
+"#,
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "FSL-ANNOTATION-INVALID");
+}

--- a/rust/fsl-tools/src/ai.rs
+++ b/rust/fsl-tools/src/ai.rs
@@ -47,11 +47,16 @@ pub fn check_ai(component: &AiComponent, kernel: Value) -> Value {
         .authority
         .requires_human_approval
         .iter()
+        .map(|rule| rule.name.as_str())
         .collect::<BTreeSet<_>>();
     for tool in &component.tools {
         if tool.irreversible
-            && component.authority.may_execute.contains(&tool.name)
-            && !approvals.contains(&tool.name)
+            && component
+                .authority
+                .may_execute
+                .iter()
+                .any(|rule| rule.name == tool.name)
+            && !approvals.contains(tool.name.as_str())
         {
             findings.push(finding(
                 component,
@@ -129,7 +134,7 @@ pub fn replay_ai(component: &AiComponent, events: &[Value]) -> Value {
                     .authority
                     .forbidden
                     .iter()
-                    .any(|item| item == tool_name)
+                    .any(|rule| rule.name == tool_name)
             {
                 findings.push(finding(component,Some(tool_name),"forbidden_tool_call","forbidden_tool_blocked","ai_hard_contract_violation","syntactic_hard",&json!({"event_index":index,"reason":"forbidden tool was observed in execute mode","event":"tool_call","component":component.name,"tool":tool_name,"mode":mode,"tool_schema":call.get("tool_schema"),"schema_valid":call.get("schema_valid"),"arg_keys":call.get("args").and_then(Value::as_object).map(|args|args.keys().cloned().collect::<Vec<_>>()).unwrap_or_default()}),&assumptions));
             }
@@ -138,7 +143,7 @@ pub fn replay_ai(component: &AiComponent, events: &[Value]) -> Value {
                     .authority
                     .requires_human_approval
                     .iter()
-                    .any(|item| item == tool_name)
+                    .any(|rule| rule.name == tool_name)
                 && !approvals.remove(tool_name)
             {
                 findings.push(finding(component,Some(tool_name),"human_approval_required_before_irreversible_tool","human_approval_required","ai_hard_contract_violation","syntactic_hard",&json!({"event_index":index,"reason":"tool execution was observed before human approval"}),&assumptions));

--- a/rust/fsl-tools/src/db.rs
+++ b/rust/fsl-tools/src/db.rs
@@ -234,7 +234,7 @@ fn artifact_by_name<'a>(system: &'a DbSystem, name: &str) -> Option<&'a DbArtifa
 }
 
 fn rule_enabled(system: &DbSystem, rule: &str) -> bool {
-    system.check.rules.is_empty() || system.check.rules.iter().any(|item| item == rule)
+    system.check.rules.is_empty() || system.check.rules.iter().any(|item| item.name == rule)
 }
 
 #[allow(clippy::too_many_lines)]

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3732,7 +3732,7 @@ fn validate_specialized_document(path: &Path) -> Result<(), String> {
                 .iter()
                 .map(|tool| tool.name.as_str())
                 .collect::<std::collections::BTreeSet<_>>();
-            for tool in component
+            for rule in component
                 .authority
                 .may_suggest
                 .iter()
@@ -3740,8 +3740,8 @@ fn validate_specialized_document(path: &Path) -> Result<(), String> {
                 .chain(&component.authority.requires_human_approval)
                 .chain(&component.authority.forbidden)
             {
-                if !tools.contains(tool.as_str()) {
-                    return Err(format!("unknown tool '{tool}' in authority block"));
+                if !tools.contains(rule.name.as_str()) {
+                    return Err(format!("unknown tool '{}' in authority block", rule.name));
                 }
             }
             Ok(())

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -38,9 +38,15 @@ attachment. They coexist with (and desugar to the same relation as) the legacy
 `"ID: text"` string slot and `covers`/`requirement` block relations — see §13.1.
 An annotation with nothing supported to attach to reports
 `FSL-ANNOTATION-TARGET`. `domain`/`dbsystem`/`ai_component` nested
-declarations don't yet accept `@...` (only their one top-level document
-annotation does; tracked by follow-up issue #281); this is native-only syntax
-the frozen Python reference does not parse.
+declarations also accept `@...` (issue #281): `domain` aggregate `command`,
+`decide`, `evolve`, `invariant`, `projection`, `effect`, and saga `step`;
+`ai_component` `tool`, the `tools [a, b];` shorthand, `authority` (and each
+rule line), `fallback` (and each `when` item), `check`; `dbsystem`
+`migration` and each `check compatibility { rule ...; }` line. A
+`command`/`decide` pair and any matching `evolve` union onto the one action
+they generate together; an `effect` or saga `step` broadcasts to every
+action it generates. This is native-only syntax the frozen Python reference
+does not parse.
 
 ```fsl
 spec <Name> ["<kind>: <intent>"] {        // optional spec-level tag → metadata badge (explain/html); never verified

--- a/tests/dialect_registry.py
+++ b/tests/dialect_registry.py
@@ -66,4 +66,22 @@ MONITOR_EXCLUSIONS: dict[str, str] = {
         "declaration. Native coverage lives in rust/fsl-syntax and "
         "rust/fsl-core tests"
     ),
+    "examples/annotations/annotated_domain.fsl": (
+        "native-only declaration-level @annotation syntax on domain nested "
+        "declarations (issue #281); the frozen Python reference does not "
+        "parse @... before a nested declaration. Native coverage lives in "
+        "rust/fsl-syntax and rust/fsl-core tests"
+    ),
+    "examples/annotations/annotated_dbsystem.fsl": (
+        "native-only declaration-level @annotation syntax on dbsystem nested "
+        "declarations (issue #281); the frozen Python reference does not "
+        "parse @... before a nested declaration. Native coverage lives in "
+        "rust/fsl-syntax and rust/fsl-core tests"
+    ),
+    "examples/annotations/annotated_ai_component.fsl": (
+        "native-only declaration-level @annotation syntax on ai_component "
+        "nested declarations (issue #281); the frozen Python reference does "
+        "not parse @... before a nested declaration. Native coverage lives "
+        "in rust/fsl-syntax tests"
+    ),
 }

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -119,7 +119,25 @@
       "warnings": []
     }
   },
+  "examples/annotations/annotated_ai_component.fsl": {
+    "check": {
+      "kind": "parse",
+      "result": "error"
+    }
+  },
   "examples/annotations/annotated_claims.fsl": {
+    "check": {
+      "kind": "parse",
+      "result": "error"
+    }
+  },
+  "examples/annotations/annotated_dbsystem.fsl": {
+    "check": {
+      "kind": "parse",
+      "result": "error"
+    }
+  },
+  "examples/annotations/annotated_domain.fsl": {
     "check": {
       "kind": "parse",
       "result": "error"

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -85,10 +85,11 @@ INTENTIONALLY_UNINDEXED = {
 _CORPUS_ROOTS = ("specs", "examples")
 _EXCLUDED_DIRS = (
     ROOT / "examples" / "gallery" / "errors",
-    # native-only declaration-level @annotation syntax (issue #241); the
-    # frozen LSP grammar (src/fslc/lsp/index.py) is not extended for it, same
-    # boundary as tests/dialect_registry.py's MONITOR_EXCLUSIONS entry for
-    # this file.
+    # native-only declaration-level @annotation syntax (issues #241 and
+    # #281, the latter extending it to domain/dbsystem/ai_component nested
+    # declarations); the frozen LSP grammar (src/fslc/lsp/index.py) is not
+    # extended for it, same boundary as tests/dialect_registry.py's
+    # MONITOR_EXCLUSIONS entries for these files.
     ROOT / "examples" / "annotations",
 )
 


### PR DESCRIPTION
## Summary
- Extends the declaration-level `@requirement(id, text?)` / `@undecided(reason)` / `@kind(id, text?)` / custom-namespace annotation syntax (issue #241) to the three specialized frontends that don't share `parser.rs`'s `Parser`: `domain` (aggregate `command`/`decide`/`evolve`/`invariant`, `projection`, `effect`, saga `step`), `ai_component` (`tool`, `authority` block and rule lines, `fallback` block and items, `check hard` block and rule lines), and `dbsystem` (`migration`, `check compatibility` rule lines).
- `AiAuthority`'s rule lists become `Vec<AiAuthorityRule>`; `AiHardCheck.rules`/`DbCheck.rules` become `Vec<AiCheckRule>`/`Vec<DbCheckRule>`. `python_ast()` reconstructs the original plain string-array JSON shape, so Public Kernel v1/v2 JSON and Python-parity surface AST are unchanged.
- `domain_lowering.rs` unions/broadcasts annotations onto every generated action/property a declaration feeds (aggregate `command`+`decide`+`evolve` union onto one action; effect complete/retry/SuccessSticky broadcast; saga step+timeout broadcast).
- `db_kernel_source` renders typed annotations back to `@...` source (new `Annotation::render_source()`) instead of the lossy legacy `quote_meta` string convention, so a migration/compatibility-rule annotation reaches `AnnotationRegistry`/TSG/the audit ledger.
- Fixes 4 defects found during independent soundness/coupled-change review (see Test plan).

## Test plan
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- [x] `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- [x] Full Python `pytest -q` (Python 3.13 venv, since the committed `.venv` is 3.9 and can't collect `tests/test_rust_cli_contract.py` due to an unrelated pre-existing `tomllib` gap from PR #282): 1429 passed, 79 skipped
- [x] `fslc check` / `verify --depth 6` / `analyze --projection requirement_property_graph` on all 3 new example files — union/broadcast confirmed end-to-end
- [x] Independent review via `fsl-soundness-reviewer` and `fsl-coupled-change-reviewer`, each run twice: initial pass found 4 real defects (all fixed with regression tests), second pass returned 問題なし on both
  - A stray annotation before a bare `saga { ... }` container silently leaked onto its first inner declaration instead of reporting `FSL-ANNOTATION-TARGET`
  - Same leak inside a saga `compensation { ... }` block
  - `ai_component`'s `check hard` block lacked `dbsystem`'s per-rule annotation granularity (added `AiCheckRule`)
  - `ai_component`'s `fallback()` merged block+item annotations without re-validating the merged group, silently accepting conflicting requirement text

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)