### PR TITLE
feat(expr): support general conditional expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Conditional expressions (`if condition then a else b`) are now accepted in
+  every expression context. The shared parser replaces the refinement-only
+  path; concrete, explicit, symbolic, analysis, mutation, formatter, LSP, and
+  Public Kernel paths use one node, and partial operations are evaluated only
+  on the selected branch (issue #245).
 - `Option<T>` now supports structural `==` / `!=` between complete Option
   values, including `some(expr)`. Concrete and symbolic evaluation compare the
   presence tag first and ignore the payload when absent; `is some(binding)`

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -211,10 +211,10 @@ expression bug).
   range but with a different value is reported as before as an
   init-correspondence violation (`abs_state_mismatch`).
 
-## 2.5 Conditional Expressions in Mapping Expressions (v2.2 — Resolving DOGFOOD-3 F9)
+## 2.5 Shared Conditional Expressions (v2.7 — issue #245)
 
-**Only in the expressions of the mapping file** is a conditional expression
-allowed:
+Refinement mappings use the same conditional expression as every other FSL
+expression context:
 
 ```fsl
 refinement SeatImplRefinesBooking {
@@ -232,10 +232,9 @@ refinement SeatImplRefinesBooking {
 }
 ```
 
-- Syntax: `if <expr> then <expr> else <expr>` (else required; nesting allowed.
-  `then`/`else` are keywords only inside the mapping-expression grammar). It
-  **cannot be used in ordinary .fsl spec files** (grammatically, it appears only
-  in expressions inside refinement).
+- Syntax: `if <expr> then <expr> else <expr>` (else required; nesting is
+  right-associative). The shared parser accepts it in ordinary specs,
+  refinements, requirements, and lowered domain expressions.
 - Typing rule: both arms of then/else are the same logical type. Option vs
   Option (including none), enum vs enum, Int/domain vs Int/domain, Bool vs Bool,
   struct vs struct are allowed. A type mismatch is `kind: "type"` at check time.
@@ -244,13 +243,15 @@ refinement SeatImplRefinesBooking {
   per field (the same convention as the existing merge of an if statement). The
   value of a none arm is don't care (a free variable is fine — if present is
   false it is not read).
-- Allowed positions: the right-hand side of `map`, and the argument expressions
-  of `action ... -> b(<expr list>)`.
-- An AST node `("ite", c, a, b)` is added to eval_expr (a general-purpose
-  implementation), but it is not generated from the body-spec grammar. If in the
-  future this is opened to general expressions, additional design such as the
-  path condition of partial_op would be needed, so it is not opened in this
-  release (this limitation is also stated in LANGUAGE.md).
+- The surface and Kernel AST use one `Conditional` node. Refinement no longer
+  has a separate expression parser.
+- Concrete evaluation executes only the selected branch. Static name/type
+  checking visits both branches. Symbolic evaluation uses one typed `ite`.
+- A partial operation in a branch is guarded by that branch's path condition,
+  so an unselected division, remainder, or sequence operation cannot fail.
+- Public Kernel JSON continues to use the existing `kind: "ite"` node. Because
+  the node and its semantics already existed in both v1 and v2 schemas, this
+  change does not alter either schema version.
 
 ## 3. CLI / JSON
 

--- a/docs/DOGFOOD-3.md
+++ b/docs/DOGFOOD-3.md
@@ -42,11 +42,12 @@ file + path classification in Monitor.
   seat-reservation domain we initially considered needed something equivalent to
   `map seats[s] = (st == Sold ? some(holder) : none)`, and since FSL had no conditional expression, it could not be
   expressed as a mapping, so we changed the domain.
-  → Implemented as an **`if-then-else` expression restricted to mapping expressions** (DESIGN-refinement §2.5).
+  → Initially implemented as an **`if-then-else` expression restricted to mapping expressions** (DESIGN-refinement §2.5).
   The abandoned seat-reservation domain itself became a second concrete example, and we confirmed that
   `map seats[s] = if slots[s].st == Sold then slots[s].holder else none` passes refines in
   `specs/seat_booking{,_impl}.fsl` + `seat_refines.fsl` (the abstract side's count aggregation evaluates correctly
-  over the conditional mapping value). It is not opened up to the ordinary spec expression grammar.
+  over the conditional mapping value). Issue #245 later promoted the same node
+  to the shared expression grammar; this paragraph records the original v2.2 limitation.
 - **F10: the Adapter wiring convention is clear enough.** observe()'s projection (display-name keys, Seq as list,
   Option as None|value) follows the LANGUAGE.md convention with no hesitation. It is practically powerful that the
   random walk automatically reconciles settle's "nothing to settle" guard with the spec's `requires pending > 0`.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -439,10 +439,8 @@ exactly one `level[k]`, every enabled action strictly decreases the total, so
 induction returns `"proved"` with `"completeness": "unbounded"`. This idiom
 only covers designs where *every* enabled action decreases the total. For
 per-entity progress under interleaving, prefer the `helpful` form above.
-(Conditional expressions can't substitute for a per-branch measure either:
-`if/then/else` is legal only in
-refinement-mapping expressions (§10), not in the general expression grammar
-that `decreases` draws from.)
+(A conditional measure can select between integer expressions, but it does not
+by itself prove the per-entity decrease required by the `helpful` form.)
 
 ## 2. Types
 
@@ -515,6 +513,14 @@ variable capture instead of inventing internal binder names. See
   as `a / b` with whitespace)
 - Comparison: `== != < <= > >=`
 - Logical: `and or not =>`
+- Conditional: `if condition then when_true else when_false`. The condition is
+  `Bool`; both branches are checked and must have the same logical type. It is
+  available anywhere an expression is accepted, including guards, assignments,
+  properties, function arguments, ranking expressions, constants, and
+  refinement mappings. Conditional expressions associate to the right and each
+  branch extends to the enclosing delimiter; use parentheses when a following
+  operator should apply to the whole conditional. Concrete evaluation executes
+  only the selected branch, while name and type checking always visits both.
 - Quantification (bounded): `forall x: T { expr }` / `exists x: T { expr }` (can be filtered with `where expr`),
   the v0 form `forall i in lo..hi: expr` is also allowed. Expression quantifiers
   can also range over a Set or Seq value: `forall x in active { ... }` /
@@ -1120,12 +1126,9 @@ refinement CartImplRefinesCart {
   Formal params may be bare names or `name: Type` annotations matching the impl action declaration.
   `stutter` is an internal step in which the abstract state does not change.
 
-Only in the expressions of a refinement mapping file may you use
-`if <expr> then <expr> else <expr>`. This is valid only in the right-hand side
-of `map` and in the argument expressions of `action ... -> abs(<expr list>)`,
-and is not part of the expression grammar of an ordinary `.fsl` spec file. The
-two arms of then/else must have the same logical type
-(Bool, Int/domain/enum, Option, struct).
+Refinement maps and action arguments use the same expression grammar and type
+rules as ordinary specs, including `if <condition> then <expr> else <expr>`.
+Both branches are name- and type-checked even when the condition is constant.
 
 ```bash
 fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8

--- a/docs/intro/design-layer.en.html
+++ b/docs/intro/design-layer.en.html
@@ -164,7 +164,7 @@
     </div>
 
     <div class="callout reveal" style="margin-top:24px">
-      <p style="margin:0"><b>Two mapping mechanisms hide internal detail.</b> <code>action ... -&gt; stutter</code> hides an internal-only operation, and a <code>map</code> expression absorbs internal fields (for example <code>map stock[i] = impl_stock[i] - reserved[i]</code> hides a <code>reserved</code> field). <code>maps auto</code> synthesizes identity entries for same-named state and actions; explicit entries override it. <code>if … then … else …</code> is allowed <i>only</i> inside mapping expressions, never in an ordinary <code>spec</code>.</p>
+      <p style="margin:0"><b>Two mapping mechanisms hide internal detail.</b> <code>action ... -&gt; stutter</code> hides an internal-only operation, and a <code>map</code> expression absorbs internal fields (for example <code>map stock[i] = impl_stock[i] - reserved[i]</code> hides a <code>reserved</code> field). <code>maps auto</code> synthesizes identity entries for same-named state and actions; explicit entries override it. Mapping expressions use the same <code>if … then … else …</code> syntax and type rules as ordinary specs.</p>
     </div>
   </div>
 </section>

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -450,10 +450,8 @@ exactly one <code>level[k]</code>, every enabled action strictly decreases the t
 induction returns <code>"proved"</code> with <code>"completeness": "unbounded"</code>. This idiom
 only covers designs where <em>every</em> enabled action decreases the total. For
 per-entity progress under interleaving, prefer the <code>helpful</code> form above.
-(Conditional expressions can't substitute for a per-branch measure either:
-<code>if/then/else</code> is legal only in
-refinement-mapping expressions (§10), not in the general expression grammar
-that <code>decreases</code> draws from.)</p></div></details>
+(A conditional measure can select between integer expressions, but it does not
+by itself prove the per-entity decrease required by the <code>helpful</code> form.)</p></div></details>
 <details id="2-types"><summary>2. Types<span class="tree-blurb"> — Primitive types, enums, structs, Seq, Option.</span></summary><div class="tree-body"><table>
 <thead>
 <tr>
@@ -576,6 +574,14 @@ variable capture instead of inventing internal binder names. See
   as <code>a / b</code> with whitespace)</li>
 <li>Comparison: <code>== != &lt; &lt;= &gt; &gt;=</code></li>
 <li>Logical: <code>and or not =&gt;</code></li>
+<li>Conditional: <code>if condition then when_true else when_false</code>. The condition is
+  <code>Bool</code>; both branches are checked and must have the same logical type. It is
+  available anywhere an expression is accepted, including guards, assignments,
+  properties, function arguments, ranking expressions, constants, and
+  refinement mappings. Conditional expressions associate to the right and each
+  branch extends to the enclosing delimiter; use parentheses when a following
+  operator should apply to the whole conditional. Concrete evaluation executes
+  only the selected branch, while name and type checking always visits both.</li>
 <li>Quantification (bounded): <code>forall x: T { expr }</code> / <code>exists x: T { expr }</code> (can be filtered with <code>where expr</code>),
   the v0 form <code>forall i in lo..hi: expr</code> is also allowed. Expression quantifiers
   can also range over a Set or Seq value: <code>forall x in active { ... }</code> /
@@ -1178,12 +1184,9 @@ not depart from the behavior of abs (see <code>DESIGN-refinement.md</code>).</p>
   Formal params may be bare names or <code>name: Type</code> annotations matching the impl action declaration.
   <code>stutter</code> is an internal step in which the abstract state does not change.</li>
 </ul>
-<p>Only in the expressions of a refinement mapping file may you use
-<code>if &lt;expr&gt; then &lt;expr&gt; else &lt;expr&gt;</code>. This is valid only in the right-hand side
-of <code>map</code> and in the argument expressions of <code>action ... -&gt; abs(&lt;expr list&gt;)</code>,
-and is not part of the expression grammar of an ordinary <code>.fsl</code> spec file. The
-two arms of then/else must have the same logical type
-(Bool, Int/domain/enum, Option, struct).</p>
+<p>Refinement maps and action arguments use the same expression grammar and type
+rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
+Both branches are name- and type-checked even when the condition is constant.</p>
 <pre><code class="language-bash">fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 </code></pre>
 <p>Success: <code>result: "refines"</code> (exit 0). Violation: <code>refinement_failed</code> (exit 1)

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -450,10 +450,8 @@ exactly one <code>level[k]</code>, every enabled action strictly decreases the t
 induction returns <code>"proved"</code> with <code>"completeness": "unbounded"</code>. This idiom
 only covers designs where <em>every</em> enabled action decreases the total. For
 per-entity progress under interleaving, prefer the <code>helpful</code> form above.
-(Conditional expressions can't substitute for a per-branch measure either:
-<code>if/then/else</code> is legal only in
-refinement-mapping expressions (§10), not in the general expression grammar
-that <code>decreases</code> draws from.)</p></div></details>
+(A conditional measure can select between integer expressions, but it does not
+by itself prove the per-entity decrease required by the <code>helpful</code> form.)</p></div></details>
 <details id="2-types"><summary>2. Types<span class="tree-blurb"> — 基本型、列挙、構造体、Seq、Option などの型システム。</span></summary><div class="tree-body"><table>
 <thead>
 <tr>
@@ -576,6 +574,14 @@ variable capture instead of inventing internal binder names. See
   as <code>a / b</code> with whitespace)</li>
 <li>Comparison: <code>== != &lt; &lt;= &gt; &gt;=</code></li>
 <li>Logical: <code>and or not =&gt;</code></li>
+<li>Conditional: <code>if condition then when_true else when_false</code>. The condition is
+  <code>Bool</code>; both branches are checked and must have the same logical type. It is
+  available anywhere an expression is accepted, including guards, assignments,
+  properties, function arguments, ranking expressions, constants, and
+  refinement mappings. Conditional expressions associate to the right and each
+  branch extends to the enclosing delimiter; use parentheses when a following
+  operator should apply to the whole conditional. Concrete evaluation executes
+  only the selected branch, while name and type checking always visits both.</li>
 <li>Quantification (bounded): <code>forall x: T { expr }</code> / <code>exists x: T { expr }</code> (can be filtered with <code>where expr</code>),
   the v0 form <code>forall i in lo..hi: expr</code> is also allowed. Expression quantifiers
   can also range over a Set or Seq value: <code>forall x in active { ... }</code> /
@@ -1178,12 +1184,9 @@ not depart from the behavior of abs (see <code>DESIGN-refinement.md</code>).</p>
   Formal params may be bare names or <code>name: Type</code> annotations matching the impl action declaration.
   <code>stutter</code> is an internal step in which the abstract state does not change.</li>
 </ul>
-<p>Only in the expressions of a refinement mapping file may you use
-<code>if &lt;expr&gt; then &lt;expr&gt; else &lt;expr&gt;</code>. This is valid only in the right-hand side
-of <code>map</code> and in the argument expressions of <code>action ... -&gt; abs(&lt;expr list&gt;)</code>,
-and is not part of the expression grammar of an ordinary <code>.fsl</code> spec file. The
-two arms of then/else must have the same logical type
-(Bool, Int/domain/enum, Option, struct).</p>
+<p>Refinement maps and action arguments use the same expression grammar and type
+rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
+Both branches are name- and type-checked even when the condition is constant.</p>
 <pre><code class="language-bash">fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 </code></pre>
 <p>Success: <code>result: "refines"</code> (exit 0). Violation: <code>refinement_failed</code> (exit 1)

--- a/docs/intro/syntax.en.html
+++ b/docs/intro/syntax.en.html
@@ -311,10 +311,11 @@ requires stock[i] &gt; 0</code></pre>
         <p>Always guard <code>at(i)</code> with a range condition.</p>
       </div>
       <div class="syntax-card">
-        <h3>Mapping-only conditional</h3>
-        <pre><code>map holder[s: SeatId] =
-  if slots[s].st == Sold then slots[s].buyer else none</code></pre>
-        <p><code>if c then a else b</code> is allowed in refinement mapping expressions.</p>
+        <h3>Conditional expression</h3>
+        <pre><code>invariant EffectiveLimit {
+  limit == if premium then PREMIUM_LIMIT else STANDARD_LIMIT
+}</code></pre>
+        <p><code>if c then a else b</code> is allowed anywhere an expression is accepted. Both branches have one type; only the selected branch is evaluated.</p>
       </div>
     </div>
   </div>

--- a/docs/intro/syntax.ja.html
+++ b/docs/intro/syntax.ja.html
@@ -360,10 +360,11 @@ requires stock[i] &gt; 0
         <p>Option値全体の比較には <code>x == some(e)</code>、後続式で中身へ名前をつける場合は <code>x is some(v)</code> を使います。</p>
       </div>
       <div class="syntax-card">
-        <h3>詳細化の対応表だけで使える if式</h3>
-        <pre><code>map holder[s: SeatId] =
-  if slots[s].st == Sold then slots[s].buyer else none</code></pre>
-        <p><code>if c then a else b</code> は詳細化の <code>map</code> や <code>action</code> 引数の中だけで使えます。通常の <code>spec</code> の式では使いません。</p>
+        <h3>条件式</h3>
+        <pre><code>invariant EffectiveLimit {
+  limit == if premium then PREMIUM_LIMIT else STANDARD_LIMIT
+}</code></pre>
+        <p><code>if c then a else b</code> は式を書けるすべての場所で使えます。両 branch は同じ型を持ち、実行時には選択された branch だけを評価します。</p>
       </div>
     </div>
   </div>

--- a/examples/conditional_expressions.fsl
+++ b/examples/conditional_expressions.fsl
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ConditionalExpressions {
+  type Count = 0..2
+
+  state {
+    count: Count,
+    fast: Bool
+  }
+
+  init {
+    count = if true then 0 else 1 / 0
+    fast = false
+  }
+
+  action advance() {
+    requires if fast then count < 2 else count == 0
+    count = if fast then count + 1 else 2
+    fast = not fast
+  }
+
+  invariant InBounds {
+    (if fast then count else 2 - count) >= 0
+  }
+}

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -692,11 +692,13 @@ fn rewrite_expr(expr: Expr, component: &Component, bound: &HashSet<String>) -> E
         },
         Expr::Neg(expr) => Expr::Neg(Box::new(rewrite_expr(*expr, component, bound))),
         Expr::Not(expr) => Expr::Not(Box::new(rewrite_expr(*expr, component, bound))),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
-        } => Expr::IfThenElse {
+            spans,
+        } => Expr::Conditional {
+            spans,
             condition: Box::new(rewrite_expr(*condition, component, bound)),
             then_expr: Box::new(rewrite_expr(*then_expr, component, bound)),
             else_expr: Box::new(rewrite_expr(*else_expr, component, bound)),
@@ -1163,11 +1165,13 @@ fn resolve_alias_expr(
         },
         Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr(*expr, components)?)),
         Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr(*expr, components)?)),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
-        } => Expr::IfThenElse {
+            spans,
+        } => Expr::Conditional {
+            spans,
             condition: Box::new(resolve_alias_expr(*condition, components)?),
             then_expr: Box::new(resolve_alias_expr(*then_expr, components)?),
             else_expr: Box::new(resolve_alias_expr(*else_expr, components)?),

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -1051,11 +1051,13 @@ impl<'a> Resolver<'a> {
                     ty: result_type,
                 }
             }
-            SyntaxExprKind::IfThenElse {
+            SyntaxExprKind::Conditional {
                 condition,
                 then_expr,
                 else_expr,
             } => {
+                let (condition_span, then_span, else_span) =
+                    (condition.span, then_expr.span, else_expr.span);
                 let condition = self.resolve_expr(
                     condition,
                     Some(&LogicalType::Bool),
@@ -1073,7 +1075,12 @@ impl<'a> Resolver<'a> {
                     expanding_can,
                 )?;
                 ResolvedExpr {
-                    expr: Expr::IfThenElse {
+                    expr: Expr::Conditional {
+                        spans: Box::new(fsl_syntax::ConditionalSpans {
+                            condition: condition_span,
+                            then_expr: then_span,
+                            else_expr: else_span,
+                        }),
                         condition: Box::new(condition.expr),
                         then_expr: Box::new(then_expr.expr),
                         else_expr: Box::new(else_expr.expr),
@@ -2858,7 +2865,7 @@ fn expression_lowering_steps(expression: &SyntaxExpr) -> Vec<LoweringStep> {
                     visit(argument, output);
                 }
             }
-            SyntaxExprKind::IfThenElse {
+            SyntaxExprKind::Conditional {
                 condition,
                 then_expr,
                 else_expr,
@@ -3198,10 +3205,11 @@ fn bind_expression_tree(
             bind_expression_tree(registry, &child("left"), left, origin);
             bind_expression_tree(registry, &child("right"), right, origin);
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             bind_expression_tree(registry, &child("condition"), condition, origin);
             bind_expression_tree(registry, &child("then"), then_expr, origin);

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -1051,11 +1051,13 @@ impl PredicateExpander {
             },
             Expr::Neg(expr) => Expr::Neg(Box::new(self.expand_expr(*expr, stack)?)),
             Expr::Not(expr) => Expr::Not(Box::new(self.expand_expr(*expr, stack)?)),
-            Expr::IfThenElse {
+            Expr::Conditional {
                 condition,
                 then_expr,
                 else_expr,
-            } => Expr::IfThenElse {
+                spans,
+            } => Expr::Conditional {
+                spans,
                 condition: Box::new(self.expand_expr(*condition, stack)?),
                 then_expr: Box::new(self.expand_expr(*then_expr, stack)?),
                 else_expr: Box::new(self.expand_expr(*else_expr, stack)?),
@@ -1172,10 +1174,11 @@ fn visit_expr_children(
                 visitor(arg)?;
             }
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             visitor(condition)?;
             visitor(then_expr)?;
@@ -1361,11 +1364,13 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
         },
         Expr::Neg(expr) => Expr::Neg(Box::new(substitute(*expr, replacements))),
         Expr::Not(expr) => Expr::Not(Box::new(substitute(*expr, replacements))),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
-        } => Expr::IfThenElse {
+            spans,
+        } => Expr::Conditional {
+            spans,
             condition: Box::new(substitute(*condition, replacements)),
             then_expr: Box::new(substitute(*then_expr, replacements)),
             else_expr: Box::new(substitute(*else_expr, replacements)),

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -301,6 +301,13 @@ impl ModelError {
     }
 }
 
+fn with_type_diagnostic_origin(mut error: ModelError, span: Span) -> ModelError {
+    if error.origin.is_none() {
+        error.origin = Some(Box::new(type_diagnostic_origin(span)));
+    }
+    error
+}
+
 impl fmt::Display for ModelError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let location = self
@@ -707,19 +714,23 @@ impl ModelBuilder {
             .collect::<BTreeMap<_, _>>();
         for (index, statement) in model.init.iter().enumerate() {
             crate::public_kernel::validate_statement_types(statement, &model).map_err(|error| {
-                if let Some((name, span)) = inline_initializers.get(&index) {
+                let origin = error.span.map(type_diagnostic_origin);
+                if let Some((name, _)) = inline_initializers.get(&index) {
                     model_error(format!(
                         "invalid inline initializer for '{name}': {}",
                         error.message
                     ))
-                    .with_origin(Some(source_origin(name, *span, None)))
+                    .with_origin(origin)
                 } else {
                     model_error(format!("invalid init statement: {}", error.message))
+                        .with_origin(origin)
                 }
             })?;
         }
-        crate::public_kernel::validate_model_expression_types(&model)
-            .map_err(|error| model_error(format!("invalid model expression: {}", error.message)))?;
+        crate::public_kernel::validate_model_expression_types(&model).map_err(|error| {
+            let origin = error.span.map(type_diagnostic_origin);
+            model_error(format!("invalid model expression: {}", error.message)).with_origin(origin)
+        })?;
         Ok(model)
     }
 
@@ -1217,6 +1228,25 @@ fn source_origin(name: &str, primary: Span, secondary: Option<Span>) -> OriginCh
     }
 }
 
+fn type_diagnostic_origin(span: Span) -> OriginChain {
+    OriginChain {
+        id: OriginId(format!(
+            "kernel:type-diagnostic:{}:{}",
+            span.start.offset, span.end.offset
+        )),
+        dialect: "kernel".to_owned(),
+        primary: Some(OriginSite {
+            source_file: None,
+            span: Some(span),
+            dialect: "kernel".to_owned(),
+            declaration_path: Vec::new(),
+        }),
+        secondary: Vec::new(),
+        lowering_steps: Vec::new(),
+        generated: false,
+    }
+}
+
 fn lvalue_root(target: &LValue) -> &str {
     match target {
         LValue::Var(name) | LValue::Index(name, _) => name,
@@ -1298,10 +1328,11 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
         Expr::Method { receiver, args, .. } => std::iter::once(receiver.as_ref())
             .chain(args.iter())
             .collect(),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => vec![condition, then_expr, else_expr],
         Expr::Quantified { binder, body, .. } => binder_exprs(binder)
             .into_iter()
@@ -1375,36 +1406,175 @@ fn synthetic_span() -> fsl_syntax::Span {
 }
 
 fn eval_const(expr: &Expr, consts: &BTreeMap<String, Value>) -> Result<Value, ModelError> {
+    eval_const_typed(expr, consts, true)?
+        .value
+        .ok_or_else(|| model_error("constant expression produced no value"))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConstType {
+    Int,
+    Bool,
+}
+
+struct TypedConst {
+    ty: ConstType,
+    value: Option<Value>,
+}
+
+fn require_const_type(actual: ConstType, expected: ConstType) -> Result<(), ModelError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(model_error("constant expression type mismatch"))
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn eval_const_typed(
+    expr: &Expr,
+    consts: &BTreeMap<String, Value>,
+    evaluate: bool,
+) -> Result<TypedConst, ModelError> {
+    let typed = |ty, value| TypedConst {
+        ty,
+        value: evaluate.then_some(value),
+    };
     match expr {
-        Expr::Num(value) => Ok(Value::Int(*value)),
-        Expr::Bool(value) => Ok(Value::Bool(*value)),
-        Expr::Var(name) => consts
-            .get(name)
-            .cloned()
-            .ok_or_else(|| model_error(format!("unknown constant '{name}'"))),
-        Expr::Neg(expr) => Ok(Value::Int(checked_neg(as_int(&eval_const(
-            expr, consts,
-        )?)?)?)),
-        Expr::Not(expr) => Ok(Value::Bool(!as_bool(&eval_const(expr, consts)?)?)),
+        Expr::Num(value) => Ok(typed(ConstType::Int, Value::Int(*value))),
+        Expr::Bool(value) => Ok(typed(ConstType::Bool, Value::Bool(*value))),
+        Expr::Var(name) => match consts.get(name).cloned() {
+            Some(value @ Value::Int(_)) => Ok(typed(ConstType::Int, value)),
+            Some(value @ Value::Bool(_)) => Ok(typed(ConstType::Bool, value)),
+            Some(_) => Err(model_error("unsupported constant value type")),
+            None => Err(model_error(format!("unknown constant '{name}'"))),
+        },
+        Expr::Neg(value) => {
+            let value = eval_const_typed(value, consts, evaluate)?;
+            require_const_type(value.ty, ConstType::Int)?;
+            let value = value
+                .value
+                .map(|value| checked_neg(as_int(&value)?).map(Value::Int))
+                .transpose()?;
+            Ok(TypedConst {
+                ty: ConstType::Int,
+                value,
+            })
+        }
+        Expr::Not(value) => {
+            let value = eval_const_typed(value, consts, evaluate)?;
+            require_const_type(value.ty, ConstType::Bool)?;
+            let value = value
+                .value
+                .map(|value| as_bool(&value).map(|value| Value::Bool(!value)))
+                .transpose()?;
+            Ok(TypedConst {
+                ty: ConstType::Bool,
+                value,
+            })
+        }
         Expr::Binary { op, left, right } => {
-            let left = eval_const(left, consts)?;
-            let right = eval_const(right, consts)?;
-            eval_const_binary(op, &left, &right)
+            let left = eval_const_typed(left, consts, evaluate)?;
+            let right = eval_const_typed(right, consts, evaluate)?;
+            let result_type = match op.as_str() {
+                "+" | "-" | "*" | "/" | "%" => {
+                    require_const_type(left.ty, ConstType::Int)?;
+                    require_const_type(right.ty, ConstType::Int)?;
+                    ConstType::Int
+                }
+                "<" | "<=" | ">" | ">=" => {
+                    require_const_type(left.ty, ConstType::Int)?;
+                    require_const_type(right.ty, ConstType::Int)?;
+                    ConstType::Bool
+                }
+                "and" | "or" | "=>" => {
+                    require_const_type(left.ty, ConstType::Bool)?;
+                    require_const_type(right.ty, ConstType::Bool)?;
+                    ConstType::Bool
+                }
+                "==" | "!=" => {
+                    require_const_type(left.ty, right.ty)?;
+                    ConstType::Bool
+                }
+                _ => return Err(model_error(format!("unsupported constant operator '{op}'"))),
+            };
+            let value = left
+                .value
+                .zip(right.value)
+                .map(|(left, right)| eval_const_binary(op, &left, &right))
+                .transpose()?;
+            Ok(TypedConst {
+                ty: result_type,
+                value,
+            })
+        }
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            spans,
+        } => {
+            let condition = eval_const_typed(condition, consts, evaluate)
+                .map_err(|error| with_type_diagnostic_origin(error, spans.condition))?;
+            require_const_type(condition.ty, ConstType::Bool)
+                .map_err(|error| with_type_diagnostic_origin(error, spans.condition))?;
+            let selected = condition.value.as_ref().map(as_bool).transpose()?;
+            let then_expr = eval_const_typed(then_expr, consts, evaluate && selected == Some(true))
+                .map_err(|error| with_type_diagnostic_origin(error, spans.then_expr))?;
+            let else_expr =
+                eval_const_typed(else_expr, consts, evaluate && selected == Some(false))
+                    .map_err(|error| with_type_diagnostic_origin(error, spans.else_expr))?;
+            require_const_type(else_expr.ty, then_expr.ty)
+                .map_err(|error| with_type_diagnostic_origin(error, spans.else_expr))?;
+            Ok(TypedConst {
+                ty: then_expr.ty,
+                value: if selected == Some(true) {
+                    then_expr.value
+                } else {
+                    else_expr.value
+                },
+            })
         }
         Expr::BinaryNamed { name, left, right } if name == "min" || name == "max" => {
-            let left = as_int(&eval_const(left, consts)?)?;
-            let right = as_int(&eval_const(right, consts)?)?;
-            Ok(Value::Int(if name == "min" {
-                left.min(right)
-            } else {
-                left.max(right)
-            }))
+            let left = eval_const_typed(left, consts, evaluate)?;
+            let right = eval_const_typed(right, consts, evaluate)?;
+            require_const_type(left.ty, ConstType::Int)?;
+            require_const_type(right.ty, ConstType::Int)?;
+            let value = left
+                .value
+                .zip(right.value)
+                .map(|(left, right)| {
+                    let left = as_int(&left)?;
+                    let right = as_int(&right)?;
+                    Ok(Value::Int(if name == "min" {
+                        left.min(right)
+                    } else {
+                        left.max(right)
+                    }))
+                })
+                .transpose()?;
+            Ok(TypedConst {
+                ty: ConstType::Int,
+                value,
+            })
         }
-        Expr::UnaryNamed { name, expr, .. } if name == "abs" => Ok(Value::Int(
-            as_int(&eval_const(expr, consts)?)?
-                .checked_abs()
-                .ok_or_else(|| model_error("integer overflow in abs"))?,
-        )),
+        Expr::UnaryNamed { name, expr, .. } if name == "abs" => {
+            let value = eval_const_typed(expr, consts, evaluate)?;
+            require_const_type(value.ty, ConstType::Int)?;
+            let value = value
+                .value
+                .map(|value| {
+                    as_int(&value)?
+                        .checked_abs()
+                        .map(Value::Int)
+                        .ok_or_else(|| model_error("integer overflow in abs"))
+                })
+                .transpose()?;
+            Ok(TypedConst {
+                ty: ConstType::Int,
+                value,
+            })
+        }
         _ => Err(model_error("expression is not constant")),
     }
 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -56,6 +56,14 @@ impl PublicKernelVersion {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKernelError {
     pub message: String,
+    pub span: Option<Span>,
+}
+
+impl PublicKernelError {
+    fn with_span(mut self, span: Span) -> Self {
+        self.span.get_or_insert(span);
+        self
+    }
 }
 
 impl fmt::Display for PublicKernelError {
@@ -69,6 +77,7 @@ impl std::error::Error for PublicKernelError {}
 fn error(message: impl Into<String>) -> PublicKernelError {
     PublicKernelError {
         message: message.into(),
+        span: None,
     }
 }
 
@@ -80,6 +89,18 @@ fn span_json(path: &str, span: Span) -> Value {
         "end_line": span.end.line,
         "end_column": span.end.column,
     })
+}
+
+fn unknown_span() -> Span {
+    let position = SourcePos {
+        offset: 0,
+        line: 1,
+        column: 1,
+    };
+    Span {
+        start: position,
+        end: position,
+    }
 }
 
 fn statement_span(statement: &Statement) -> Span {
@@ -143,6 +164,24 @@ fn base_env(model: &KernelModel) -> TypeEnv {
     env
 }
 
+pub(crate) fn validate_expression_type(
+    expr: &Expr,
+    expected: &TypeRef,
+    bindings: &[(String, TypeRef)],
+    model: &KernelModel,
+) -> Result<(), PublicKernelError> {
+    let mut env = base_env(model);
+    env.extend(bindings.iter().cloned());
+    expr_json(expr, &env, model, "", unknown_span(), Some(expected)).map(|_| ())
+}
+
+pub(crate) fn expression_binder_type(
+    binder: &Binder,
+    model: &KernelModel,
+) -> Result<TypeRef, PublicKernelError> {
+    binder_type(binder, &base_env(model), model)
+}
+
 fn qualified_name(name: &fsl_syntax::QualifiedName) -> Result<String, PublicKernelError> {
     if name.namespace.is_some() {
         return Err(error(
@@ -160,8 +199,8 @@ fn binder_type(
     match binder {
         Binder::Typed { type_name, .. } => Ok(TypeRef::Named(qualified_name(type_name)?)),
         Binder::Range { lo, hi, .. } => {
-            ensure_assignable(lo, &TypeRef::Int, env, model)?;
-            ensure_assignable(hi, &TypeRef::Int, env, model)?;
+            ensure_assignable(lo, &TypeRef::Int, env, model, unknown_span())?;
+            ensure_assignable(hi, &TypeRef::Int, env, model, unknown_span())?;
             match (lo.as_ref(), hi.as_ref()) {
                 (Expr::Num(lo), Expr::Num(hi)) => Ok(TypeRef::Range(*lo, *hi)),
                 _ => Ok(TypeRef::Int),
@@ -283,7 +322,7 @@ fn infer_type(
         Expr::Not(_) | Expr::Is { .. } | Expr::Quantified { .. } | Expr::BinderNamed { .. } => {
             Ok(TypeRef::Bool)
         }
-        Expr::IfThenElse { then_expr, .. } => infer_type(then_expr, env, model, expected),
+        Expr::Conditional { then_expr, .. } => infer_type(then_expr, env, model, expected),
         Expr::UnaryNamed { name, expr, .. } => match name.as_str() {
             "old" => infer_type(expr, env, model, expected),
             "abs" => Ok(TypeRef::Int),
@@ -331,41 +370,45 @@ fn ensure_assignable(
     expected: &TypeRef,
     env: &TypeEnv,
     model: &KernelModel,
+    span: Span,
 ) -> Result<(), PublicKernelError> {
-    let resolved = resolve(model, expected)?;
+    let resolved = resolve(model, expected).map_err(|error| error.with_span(span))?;
     match (expr, &resolved) {
         (Expr::None, TypeRef::Option(_)) => return Ok(()),
         (Expr::Some(item), TypeRef::Option(expected_item)) => {
-            return ensure_assignable(item, expected_item, env, model);
+            return ensure_assignable(item, expected_item, env, model, span);
         }
         (Expr::Set(items), TypeRef::Set(expected_item))
         | (Expr::Seq(items), TypeRef::Seq(expected_item, _)) => {
             for item in items {
-                ensure_assignable(item, expected_item, env, model)?;
+                ensure_assignable(item, expected_item, env, model, span)?;
             }
             return Ok(());
         }
         (
-            Expr::IfThenElse {
+            Expr::Conditional {
+                condition,
                 then_expr,
                 else_expr,
-                ..
+                spans,
             },
             _,
         ) => {
-            ensure_assignable(then_expr, expected, env, model)?;
-            ensure_assignable(else_expr, expected, env, model)?;
+            ensure_assignable(condition, &TypeRef::Bool, env, model, spans.condition)?;
+            ensure_assignable(then_expr, expected, env, model, spans.then_expr)?;
+            ensure_assignable(else_expr, expected, env, model, spans.else_expr)?;
             return Ok(());
         }
         _ => {}
     }
-    let actual = infer_type(expr, env, model, None)?;
-    if types_compatible(&actual, expected, model)? {
+    let actual = infer_type(expr, env, model, None).map_err(|error| error.with_span(span))?;
+    if types_compatible(&actual, expected, model).map_err(|error| error.with_span(span))? {
         Ok(())
     } else {
         Err(error(format!(
             "expression of type {actual:?} is not assignable to {expected:?}"
-        )))
+        ))
+        .with_span(span))
     }
 }
 
@@ -467,13 +510,14 @@ fn expr_json(
     span: Span,
     expected: Option<&TypeRef>,
 ) -> Result<Value, PublicKernelError> {
-    let ty = infer_type(expr, env, model, expected)?;
+    let ty = infer_type(expr, env, model, expected).map_err(|error| error.with_span(span))?;
     if let Some(expected) = expected
-        && !types_compatible(&ty, expected, model)?
+        && !types_compatible(&ty, expected, model).map_err(|error| error.with_span(span))?
     {
         return Err(error(format!(
             "expression of type {ty:?} is not assignable to {expected:?}"
-        )));
+        ))
+        .with_span(span));
     }
     let mut output = Map::from_iter([
         ("kind".to_owned(), Value::String("unknown".to_owned())),
@@ -638,23 +682,31 @@ fn expr_json(
                 expr_json(operand, env, model, path, span, None)?,
             );
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            spans,
         } => {
             output.insert("kind".to_owned(), json!("ite"));
             output.insert(
                 "condition".to_owned(),
-                expr_json(condition, env, model, path, span, Some(&TypeRef::Bool))?,
+                expr_json(
+                    condition,
+                    env,
+                    model,
+                    path,
+                    spans.condition,
+                    Some(&TypeRef::Bool),
+                )?,
             );
             output.insert(
                 "then".to_owned(),
-                expr_json(then_expr, env, model, path, span, Some(&ty))?,
+                expr_json(then_expr, env, model, path, spans.then_expr, Some(&ty))?,
             );
             output.insert(
                 "else".to_owned(),
-                expr_json(else_expr, env, model, path, span, Some(&ty))?,
+                expr_json(else_expr, env, model, path, spans.else_expr, Some(&ty))?,
             );
         }
         Expr::Is { expr, pattern } => {
@@ -861,7 +913,7 @@ fn statement_json(
             span,
         } => {
             let ty = lvalue_type(target, env, model)?;
-            ensure_assignable(value, &ty, env, model)?;
+            ensure_assignable(value, &ty, env, model, *span)?;
             Ok(json!({
                 "kind":"assign","type":{"kind":"statement"},"span":span_json(path,*span),
                 "target":lvalue_json(target,env,model,path,*span)?,
@@ -1078,6 +1130,7 @@ fn walk_partial(
     model: &KernelModel,
     path: &str,
     span: Span,
+    path_condition: Option<&Expr>,
     output: &mut Vec<Value>,
 ) -> Result<(), PublicKernelError> {
     if let Expr::Method {
@@ -1113,6 +1166,7 @@ fn walk_partial(
                 right: Box::new(Expr::Num(0)),
             }
         };
+        let failure = guard_failure(failure, path_condition);
         output.push(json!({
             "operation":name,
             "failure_condition":expr_json(&failure,env,model,path,span,Some(&TypeRef::Bool))?,
@@ -1144,6 +1198,7 @@ fn walk_partial(
                 right: Box::new(size),
             }),
         };
+        let failure = guard_failure(failure, path_condition);
         output.push(json!({
             "operation":"index",
             "failure_condition":expr_json(&failure,env,model,path,span,Some(&TypeRef::Bool))?,
@@ -1159,12 +1214,27 @@ fn walk_partial(
             left: right.clone(),
             right: Box::new(Expr::Num(0)),
         };
+        let failure = guard_failure(failure, path_condition);
         output.push(json!({
             "operation":if op == "/" {"divide"} else {"remainder"},
             "failure_condition":expr_json(&failure,env,model,path,span,Some(&TypeRef::Bool))?,
             "state_effect_on_failure":"rollback",
             "span":span_json(path,span),
         }));
+    }
+    if let Expr::Conditional {
+        condition,
+        then_expr,
+        else_expr,
+        ..
+    } = expr
+    {
+        walk_partial(condition, env, model, path, span, path_condition, output)?;
+        let then_path = extend_path_condition(path_condition, condition.as_ref(), false);
+        walk_partial(then_expr, env, model, path, span, Some(&then_path), output)?;
+        let else_path = extend_path_condition(path_condition, condition.as_ref(), true);
+        walk_partial(else_expr, env, model, path, span, Some(&else_path), output)?;
+        return Ok(());
     }
     let mut children: Vec<&Expr> = Vec::new();
     match expr {
@@ -1182,11 +1252,7 @@ fn walk_partial(
             children.push(receiver);
             children.extend(args);
         }
-        Expr::IfThenElse {
-            condition,
-            then_expr,
-            else_expr,
-        } => children.extend([condition.as_ref(), then_expr.as_ref(), else_expr.as_ref()]),
+        Expr::Conditional { .. } => unreachable!("handled above"),
         Expr::Is { expr, .. } => children.push(expr),
         Expr::Quantified { body, .. } => children.push(body),
         Expr::Count { condition, .. } => children.push(condition),
@@ -1212,9 +1278,33 @@ fn walk_partial(
         | Expr::BinderNamed { .. } => {}
     }
     for child in children {
-        walk_partial(child, env, model, path, span, output)?;
+        walk_partial(child, env, model, path, span, path_condition, output)?;
     }
     Ok(())
+}
+
+fn guard_failure(failure: Expr, path_condition: Option<&Expr>) -> Expr {
+    match path_condition {
+        Some(condition) => Expr::Binary {
+            op: "and".to_owned(),
+            left: Box::new(condition.clone()),
+            right: Box::new(failure),
+        },
+        None => failure,
+    }
+}
+
+fn extend_path_condition(path: Option<&Expr>, condition: &Expr, negated: bool) -> Expr {
+    let condition = if negated {
+        Expr::Not(Box::new(condition.clone()))
+    } else {
+        condition.clone()
+    };
+    path.map_or(condition.clone(), |path| Expr::Binary {
+        op: "and".to_owned(),
+        left: Box::new(path.clone()),
+        right: Box::new(condition),
+    })
 }
 
 fn statement_partial(
@@ -1226,7 +1316,7 @@ fn statement_partial(
 ) -> Result<(), PublicKernelError> {
     match statement {
         Statement::Assign { value, span, .. } => {
-            walk_partial(value, env, model, path, *span, output)?;
+            walk_partial(value, env, model, path, *span, None, output)?;
         }
         Statement::If {
             condition,
@@ -1234,7 +1324,7 @@ fn statement_partial(
             else_statements,
             span,
         } => {
-            walk_partial(condition, env, model, path, *span, output)?;
+            walk_partial(condition, env, model, path, *span, None, output)?;
             for item in then_statements.iter().chain(else_statements) {
                 statement_partial(item, env, model, path, output)?;
             }
@@ -1680,6 +1770,7 @@ pub fn public_kernel_contract(
                             model,
                             source_path,
                             span,
+                            None,
                             &mut partial,
                         )?;
                         requires.push(value.clone());
@@ -1701,6 +1792,7 @@ pub fn public_kernel_contract(
                             model,
                             source_path,
                             action.span,
+                            None,
                             &mut partial,
                         )?;
                         let ty = infer_type(expression, &local, model, None)?;
@@ -1737,6 +1829,7 @@ pub fn public_kernel_contract(
                     model,
                     source_path,
                     action.span,
+                    None,
                     &mut partial,
                 )?;
             }
@@ -1920,5 +2013,27 @@ mod tests {
         let error = build_model(kernel).expect_err("mismatched Option payloads must fail check");
 
         assert!(error.message.contains("is not assignable"));
+    }
+
+    #[test]
+    fn conditional_partial_operation_is_guarded_by_its_branch() {
+        let source = "spec S { type N = 0..1 state { x: N, gate: Bool } init { x = 0 gate = true } action choose() { x = if gate then 1 else 1 / 0 } invariant I { true } }";
+        let kernel = parse_direct_kernel_spec(source).expect("parse");
+        let model = build_model(kernel.clone()).expect("model");
+        let contract =
+            public_kernel_contract(&kernel, &model, "s.fsl", "kernel").expect("contract");
+        let partial = &contract["actions"][0]["partial_operations"][0];
+        let value = &contract["actions"][0]["updates"][0]["value"];
+
+        assert_eq!(value["kind"], "ite");
+        assert_eq!(value["condition"]["name"], "gate");
+        assert_eq!(partial["operation"], "divide");
+        assert_eq!(partial["failure_condition"]["kind"], "binary");
+        assert_eq!(partial["failure_condition"]["operator"], "and");
+        assert_eq!(partial["failure_condition"]["left"]["kind"], "not");
+        assert_eq!(
+            partial["failure_condition"]["left"]["operand"]["name"],
+            "gate"
+        );
     }
 }

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -9,7 +9,7 @@ use fsl_syntax::{
     SurfaceRefinement,
 };
 
-use crate::{FileResolver, KernelModel, TypeRef, build_model, parse_kernel_source};
+use crate::{FileResolver, KernelModel, ParamDef, TypeRef, build_model, parse_kernel_source};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateMap {
@@ -256,6 +256,7 @@ fn build_refinement(
             &mut action_maps,
         )?;
     }
+    validate_refinement_expressions(implementation, abstraction, &state_maps, &action_maps)?;
     for (name, _) in &abstraction.state {
         if !state_maps.contains_key(name) {
             return Err(refinement_error(
@@ -307,6 +308,169 @@ fn build_refinement(
         action_maps,
         progress,
     })
+}
+
+fn validate_refinement_expressions(
+    implementation: &KernelModel,
+    abstraction: &KernelModel,
+    state_maps: &BTreeMap<String, StateMap>,
+    action_maps: &BTreeMap<String, ActionMap>,
+) -> Result<(), RefinementError> {
+    let context = refinement_type_context(implementation, abstraction);
+    for state_map in state_maps.values() {
+        validate_state_map(state_map, abstraction, &context)?;
+    }
+    for action_map in action_maps.values() {
+        validate_action_map(action_map, implementation, abstraction, &context)?;
+    }
+    Ok(())
+}
+
+fn refinement_type_context(implementation: &KernelModel, abstraction: &KernelModel) -> KernelModel {
+    let mut context = implementation.clone();
+    for (name, value) in &abstraction.consts {
+        context.consts.entry(name.clone()).or_insert(value.clone());
+    }
+    for (name, definition) in &abstraction.types {
+        context
+            .types
+            .entry(name.clone())
+            .or_insert(definition.clone());
+    }
+    for (name, value) in &abstraction.enum_members {
+        context
+            .enum_members
+            .entry(name.clone())
+            .or_insert(value.clone());
+    }
+    context
+}
+
+fn validate_state_map(
+    state_map: &StateMap,
+    abstraction: &KernelModel,
+    context: &KernelModel,
+) -> Result<(), RefinementError> {
+    let mut expected = abstraction
+        .state_type(&state_map.name)
+        .expect("state maps were checked against abstraction state")
+        .clone();
+    let mut bindings = Vec::new();
+    if let Some(binder) = &state_map.binder {
+        let binder_ty = crate::public_kernel::expression_binder_type(binder, context)
+            .map_err(|error| invalid_state_map_at_map(state_map, "binder", &error.message))?;
+        let TypeRef::Map(key, value) = expected else {
+            return Err(refinement_error(
+                format!(
+                    "map '{}' has a binder but its abstract state is not a Map",
+                    state_map.name
+                ),
+                state_map.span,
+            ));
+        };
+        let binder_name = match binder {
+            Binder::Typed { name, .. }
+            | Binder::Range { name, .. }
+            | Binder::Collection { name, .. } => name.clone(),
+        };
+        crate::public_kernel::validate_expression_type(
+            &Expr::Var(binder_name.clone()),
+            &key,
+            &[(binder_name.clone(), binder_ty.clone())],
+            context,
+        )
+        .map_err(|error| invalid_state_map_at_map(state_map, "binder", &error.message))?;
+        bindings.push((binder_name, binder_ty));
+        expected = *value;
+    }
+    crate::public_kernel::validate_expression_type(&state_map.expr, &expected, &bindings, context)
+        .map_err(|error| {
+            invalid_state_map(
+                state_map,
+                "expression",
+                &error.message,
+                error
+                    .span
+                    .expect("mapped expression type errors carry source spans"),
+            )
+        })
+}
+
+fn invalid_state_map_at_map(state_map: &StateMap, part: &str, message: &str) -> RefinementError {
+    refinement_error(
+        format!("invalid map {part} for '{}': {message}", state_map.name),
+        state_map.span,
+    )
+}
+
+fn invalid_state_map(
+    state_map: &StateMap,
+    part: &str,
+    message: &str,
+    span: Span,
+) -> RefinementError {
+    refinement_error(
+        format!("invalid map {part} for '{}': {message}", state_map.name),
+        Some(span),
+    )
+}
+
+fn validate_action_map(
+    action_map: &ActionMap,
+    implementation: &KernelModel,
+    abstraction: &KernelModel,
+    context: &KernelModel,
+) -> Result<(), RefinementError> {
+    let ActionMapTarget::Action { name, args } = &action_map.target else {
+        return Ok(());
+    };
+    let implementation_action = implementation
+        .actions
+        .iter()
+        .find(|action| action.name == action_map.name)
+        .expect("action maps were checked against implementation actions");
+    let abstraction_action = abstraction
+        .actions
+        .iter()
+        .find(|action| action.name == *name)
+        .expect("action maps were checked against abstraction actions");
+    let bindings = implementation_action
+        .params
+        .iter()
+        .map(|param| (param.name().to_owned(), parameter_type(param)))
+        .collect::<Vec<_>>();
+    for (index, (argument, parameter)) in args.iter().zip(&abstraction_action.params).enumerate() {
+        crate::public_kernel::validate_expression_type(
+            argument,
+            &parameter_type(parameter),
+            &bindings,
+            context,
+        )
+        .map_err(|error| {
+            refinement_error(
+                format!(
+                    "invalid argument {} for action '{}' -> '{}': {}",
+                    index + 1,
+                    action_map.name,
+                    name,
+                    error.message
+                ),
+                Some(
+                    error
+                        .span
+                        .expect("mapped argument type errors carry source spans"),
+                ),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn parameter_type(parameter: &ParamDef) -> TypeRef {
+    match parameter {
+        ParamDef::Typed { ty, .. } => ty.clone(),
+        ParamDef::Range { lo, hi, .. } => TypeRef::Range(*lo, *hi),
+    }
 }
 
 fn apply_auto_maps(

--- a/rust/fsl-core/tests/conditional_expressions.rs
+++ b/rust/fsl-core/tests/conditional_expressions.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source, parse_refinement};
+
+fn build(source: &str) -> Result<fsl_core::KernelModel, fsl_core::ModelError> {
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
+    build_model(kernel)
+}
+
+#[test]
+fn constant_conditionals_validate_both_branches_but_evaluate_only_the_selected_one() {
+    let model = build(
+        "spec S { const Limit = if true then 1 else 1 / 0 type N = 0..Limit state { x: N } init { x = 0 } action stay() { x = x } invariant I { true } }",
+    )
+    .expect("unselected partial operation must not run");
+    assert_eq!(model.consts["Limit"], fsl_core::FslValue::Int(1));
+
+    let unknown_source = "spec S {\n  const Limit = if true then 1 else Missing\n  type N = 0..Limit\n  state { x: N }\n  init { x = 0 }\n  action stay() { x = x }\n  invariant I { true }\n}";
+    let unknown = build(unknown_source).expect_err("both branches must be name checked");
+    assert!(unknown.message.contains("unknown constant 'Missing'"));
+    let unknown_span = unknown
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("constant branch diagnostic span");
+    assert_eq!(
+        &unknown_source[unknown_span.start.offset..unknown_span.end.offset],
+        "Missing"
+    );
+
+    let mismatch_source = "spec S {\n  const Limit = if true then 1 else false\n  type N = 0..Limit\n  state { x: N }\n  init { x = 0 }\n  action stay() { x = x }\n  invariant I { true }\n}";
+    let mismatch = build(mismatch_source).expect_err("both branches must have one type");
+    assert!(mismatch.message.contains("type mismatch"));
+    let mismatch_span = mismatch
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("constant mismatch diagnostic span");
+    assert_eq!(
+        &mismatch_source[mismatch_span.start.offset..mismatch_span.end.offset],
+        "false"
+    );
+
+    let bad_condition_source = "spec S {\n  const Limit = if 1 then 1 else 0\n  type N = 0..Limit\n  state { x: N }\n  init { x = 0 }\n  action stay() { x = x }\n  invariant I { true }\n}";
+    let bad_condition = build(bad_condition_source).expect_err("constant condition must be Bool");
+    let condition_span = bad_condition
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("constant condition diagnostic span");
+    assert_eq!(
+        &bad_condition_source[condition_span.start.offset..condition_span.end.offset],
+        "1"
+    );
+}
+
+#[test]
+fn conditional_type_rules_apply_in_general_expression_positions() {
+    build(
+        "spec Ranking { type N = 0..2 state { pending: Bool, age: N, remaining: N } init { pending = false age = 0 remaining = 0 } action stay() { pending = pending age = age remaining = remaining } leadsTo Progress { pending ~> not pending decreases if pending then age else remaining } }",
+    )
+    .expect("conditional ranking expression");
+
+    let bad_condition_source = "spec S {\n  state { x: Int }\n  init { x = 0 }\n  action stay() {\n    x = if 1 then 1 else 0\n  }\n  invariant I { true }\n}";
+    let bad_condition = build(bad_condition_source).expect_err("condition must be Bool");
+    assert!(bad_condition.message.contains("not assignable to Bool"));
+    let condition_span = bad_condition
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("condition diagnostic span");
+    assert_eq!(
+        &bad_condition_source[condition_span.start.offset..condition_span.end.offset],
+        "1"
+    );
+
+    let bad_branch_source = "spec S {\n  state { x: Int }\n  init { x = 0 }\n  action stay() {\n    x = if true then 1 else false\n  }\n  invariant I { true }\n}";
+    let bad_branch = build(bad_branch_source).expect_err("branches must match");
+    assert!(bad_branch.message.contains("not assignable to Int"));
+    let branch_span = bad_branch
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("branch diagnostic span");
+    assert_eq!(
+        &bad_branch_source[branch_span.start.offset..branch_span.end.offset],
+        "false"
+    );
+
+    let unknown_branch_source = "spec S {\n  state { x: Int }\n  init { x = 0 }\n  action stay() {\n    x = if true then 1 else Missing\n  }\n  invariant I { true }\n}";
+    let unknown_branch = build(unknown_branch_source).expect_err("both branches are name checked");
+    assert!(
+        unknown_branch
+            .message
+            .contains("cannot type identifier 'Missing'")
+    );
+    let unknown_span = unknown_branch
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("unknown branch diagnostic span");
+    assert_eq!(
+        &unknown_branch_source[unknown_span.start.offset..unknown_span.end.offset],
+        "Missing"
+    );
+
+    let inline_source = "spec S {\n  state { x: Int = if 1 then 0 else 1 }\n  action stay() { x = x }\n  invariant I { true }\n}";
+    let inline = build(inline_source).expect_err("inline condition must be Bool");
+    let inline_span = inline
+        .origin
+        .as_ref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("inline condition diagnostic span");
+    assert_eq!(
+        &inline_source[inline_span.start.offset..inline_span.end.offset],
+        "1"
+    );
+    assert!(!inline.to_string().contains("conflicting assignment"));
+}
+
+#[test]
+fn refinement_conditionals_use_the_shared_static_type_rules() {
+    let implementation = build(
+        "spec Impl { type N = 0..1 state { x: N, gate: Bool } init { x = 0 gate = true } action stay() { x = x gate = gate } invariant I { true } }",
+    )
+    .expect("implementation");
+    let abstraction = build(
+        "spec Abs { type N = 0..1 state { y: N } init { y = 0 } action stay() { y = y } invariant I { true } }",
+    )
+    .expect("abstraction");
+
+    parse_refinement(
+        "refinement R { impl Impl abs Abs map y = if gate then x else 0 action stay() -> stay() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("valid conditional mapping");
+
+    let unknown = parse_refinement(
+        "refinement R { impl Impl abs Abs map y = if true then x else Missing + 1 action stay() -> stay() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("unselected branch must be name checked");
+    assert!(unknown.message.contains("cannot type identifier 'Missing'"));
+
+    let bad_condition_source = "refinement R {\n  impl Impl\n  abs Abs\n  map y = if x then 1 else 0\n  action stay() -> stay()\n}";
+    let bad_condition = parse_refinement(bad_condition_source, &implementation, &abstraction)
+        .expect_err("mapping condition must be Bool");
+    assert!(bad_condition.message.contains("not assignable to Bool"));
+    let condition_span = bad_condition.span.expect("mapping condition span");
+    assert_eq!(
+        &bad_condition_source[condition_span.start.offset..condition_span.end.offset],
+        "x"
+    );
+
+    let mismatch_source = "refinement R {\n  impl Impl\n  abs Abs\n  map y = if true then 1 else false\n  action stay() -> stay()\n}";
+    let mismatch = parse_refinement(mismatch_source, &implementation, &abstraction)
+        .expect_err("mapping branches must match");
+    assert!(
+        mismatch.message.contains("not assignable"),
+        "{}",
+        mismatch.message
+    );
+    let branch_span = mismatch.span.expect("mapping branch span");
+    assert_eq!(
+        &mismatch_source[branch_span.start.offset..branch_span.end.offset],
+        "false"
+    );
+}
+
+#[test]
+fn requirements_and_domain_dialects_share_conditional_syntax() {
+    build(
+        "requirements R { type N = 0..1 state { x: N, gate: Bool } init { x = 0 gate = true } action choose() { x = if gate then 1 else 0 gate = gate } invariant Choice { if gate then x == 0 else x == 1 } }",
+    )
+    .expect("requirements conditional");
+
+    build(
+        "domain D { enum Status { A, B } aggregate Item { id ItemId state { status: Status = A; gate: Bool = true; } command Step {} event Stepped {} decide Step { requires if gate then status == A else status == B emits Stepped } evolve Stepped { status = if gate then B else A } invariant Choice { if gate then status == A else status == B } } }",
+    )
+    .expect("domain conditional");
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -746,10 +746,11 @@ fn collect_state_references(
                 collect_state_references(argument, state_names, output);
             }
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             collect_state_references(condition, state_names, output);
             collect_state_references(then_expr, state_names, output);

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -149,10 +149,11 @@ pub fn eval(
         Expr::Not(expr) => Ok(Value::Bool(!as_bool(eval(
             expr, state, bindings, model, old_state,
         )?)?)),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             if as_bool(eval(condition, state, bindings, model, old_state)?)? {
                 eval(then_expr, state, bindings, model, old_state)

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -39,6 +39,13 @@ pub struct QualifiedName {
     pub name: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConditionalSpans {
+    pub condition: Span,
+    pub then_expr: Span,
+    pub else_expr: Span,
+}
+
 impl QualifiedName {
     #[must_use]
     pub fn python_ast(&self) -> Value {
@@ -100,10 +107,11 @@ pub enum Expr {
     },
     Neg(Box<Expr>),
     Not(Box<Expr>),
-    IfThenElse {
+    Conditional {
         condition: Box<Expr>,
         then_expr: Box<Expr>,
         else_expr: Box<Expr>,
+        spans: Box<ConditionalSpans>,
     },
     Is {
         expr: Box<Expr>,
@@ -221,10 +229,11 @@ impl Expr {
             }
             Self::Neg(expr) => json!(["neg", expr.python_ast()]),
             Self::Not(expr) => json!(["not", expr.python_ast()]),
-            Self::IfThenElse {
+            Self::Conditional {
                 condition,
                 then_expr,
                 else_expr,
+                ..
             } => json!([
                 "ite",
                 condition.python_ast(),

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -27,7 +27,7 @@ pub use annotation::{
     Annotation, AnnotationError, AnnotationRegistry, AnnotationValue, Annotations, RequirementLink,
     SymbolPath,
 };
-pub use ast::{Binder, Expr, Pattern, QualifiedName, SourcePos, Span};
+pub use ast::{Binder, ConditionalSpans, Expr, Pattern, QualifiedName, SourcePos, Span};
 pub use db::{
     DbArtifact, DbCheck, DbColumn, DbColumnRef, DbDatabase, DbEnvironment, DbEnvironmentArtifact,
     DbFlag, DbFlagCondition, DbMigration, DbMigrationOp, DbSystem, DbTable, parse_db_system,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -610,7 +610,7 @@ impl Parser {
         } else {
             let name = self.expect_ident()?;
             self.expect_symbol("(")?;
-            ActionTarget::Action(name, self.ref_expr_list(")")?)
+            ActionTarget::Action(name, self.expression_list(")")?)
         };
         Ok(MapsClause { target, span })
     }
@@ -705,7 +705,7 @@ impl Parser {
         self.expect_symbol("(")?;
         Ok(AcceptanceStep {
             name,
-            args: self.ref_expr_list(")")?,
+            args: self.expression_list(")")?,
             span,
         })
     }
@@ -1258,7 +1258,7 @@ impl Parser {
             return Ok(RefinementItem::Map {
                 name,
                 binder,
-                expr: Box::new(self.ref_expr()?),
+                expr: Box::new(self.expression(0)?),
                 span,
             });
         }
@@ -1291,7 +1291,7 @@ impl Parser {
             } else {
                 let target_name = self.expect_ident()?;
                 self.expect_symbol("(")?;
-                ActionTarget::Action(target_name, self.ref_expr_list(")")?)
+                ActionTarget::Action(target_name, self.expression_list(")")?)
             };
             return Ok(RefinementItem::Action {
                 name,
@@ -1322,54 +1322,6 @@ impl Parser {
             return Ok(RefinementItem::PreserveProgress { responses, span });
         }
         Err(self.error("expected refinement item"))
-    }
-
-    fn ref_expr(&mut self) -> Result<Expr, ParseError> {
-        if self.eat_ident("if") {
-            let condition = self.expression(0)?;
-            self.expect_ident_value("then")?;
-            let then_expr = self.ref_expr()?;
-            self.expect_ident_value("else")?;
-            let else_expr = self.ref_expr()?;
-            return Ok(Expr::IfThenElse {
-                condition: Box::new(condition),
-                then_expr: Box::new(then_expr),
-                else_expr: Box::new(else_expr),
-            });
-        }
-        if matches!(&self.peek().kind, TokenKind::Ident(_)) && self.peek_n_is_symbol(1, "{") {
-            let name = self.expect_ident()?;
-            self.expect_symbol("{")?;
-            let mut fields = Vec::new();
-            loop {
-                let field = self.expect_ident()?;
-                self.expect_symbol(":")?;
-                fields.push((field, self.ref_expr()?));
-                if self.eat_symbol("}") {
-                    break;
-                }
-                self.expect_symbol(",")?;
-                if self.eat_symbol("}") {
-                    break;
-                }
-            }
-            return Ok(Expr::Struct { name, fields });
-        }
-        self.expression(0)
-    }
-
-    fn ref_expr_list(&mut self, close: &str) -> Result<Vec<Expr>, ParseError> {
-        let mut items = Vec::new();
-        if self.eat_symbol(close) {
-            return Ok(items);
-        }
-        loop {
-            items.push(self.ref_expr()?);
-            if self.eat_symbol(close) {
-                return Ok(items);
-            }
-            self.expect_symbol(",")?;
-        }
     }
 
     #[allow(clippy::too_many_lines)]
@@ -2096,10 +2048,6 @@ impl Parser {
         matches!(&self.peek().kind, TokenKind::Symbol(value) if value == expected)
     }
 
-    fn peek_n_is_symbol(&self, offset: usize, expected: &str) -> bool {
-        matches!(&self.peek_n(offset).kind, TokenKind::Symbol(value) if value == expected)
-    }
-
     fn bump(&mut self) -> &Token {
         let index = self.cursor;
         if !matches!(self.tokens[index].kind, TokenKind::Eof) {
@@ -2219,6 +2167,41 @@ mod tests {
                     ["num", 7]
                 ],
                 ["not", ["bool", false]]
+            ])
+        );
+    }
+
+    #[test]
+    fn conditional_is_available_at_every_expression_precedence() {
+        assert_eq!(
+            ast("1 + if true then 2 else 3 * 4"),
+            json!([
+                "bin",
+                "+",
+                ["num", 1],
+                [
+                    "ite",
+                    ["bool", true],
+                    ["num", 2],
+                    ["bin", "*", ["num", 3], ["num", 4]]
+                ]
+            ])
+        );
+        assert_eq!(
+            ast("if true then if false then 1 else 2 else 3"),
+            json!([
+                "ite",
+                ["bool", true],
+                ["ite", ["bool", false], ["num", 1], ["num", 2]],
+                ["num", 3]
+            ])
+        );
+        assert_eq!(
+            ast("max(if true then 1 else 2, 3)"),
+            json!([
+                "max",
+                ["ite", ["bool", true], ["num", 1], ["num", 2]],
+                ["num", 3]
             ])
         );
     }

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -149,7 +149,7 @@ pub enum SyntaxExprKind {
     Neg(Box<SyntaxExpr>),
     Not(Box<SyntaxExpr>),
     Group(Box<SyntaxExpr>),
-    IfThenElse {
+    Conditional {
         condition: Box<SyntaxExpr>,
         then_expr: Box<SyntaxExpr>,
         else_expr: Box<SyntaxExpr>,
@@ -254,7 +254,7 @@ impl SyntaxExpr {
             SyntaxExprKind::Neg(value) => format!("-{}", value.render_source()),
             SyntaxExprKind::Not(value) => format!("not {}", value.render_source()),
             SyntaxExprKind::Group(value) => format!("({})", value.render_source()),
-            SyntaxExprKind::IfThenElse {
+            SyntaxExprKind::Conditional {
                 condition,
                 then_expr,
                 else_expr,
@@ -396,11 +396,16 @@ impl SyntaxExpr {
             SyntaxExprKind::Neg(value) => Expr::Neg(Box::new(value.into_kernel()?)),
             SyntaxExprKind::Not(value) => Expr::Not(Box::new(value.into_kernel()?)),
             SyntaxExprKind::Group(value) => value.into_kernel()?,
-            SyntaxExprKind::IfThenElse {
+            SyntaxExprKind::Conditional {
                 condition,
                 then_expr,
                 else_expr,
-            } => Expr::IfThenElse {
+            } => Expr::Conditional {
+                spans: Box::new(crate::ConditionalSpans {
+                    condition: condition.span,
+                    then_expr: then_expr.span,
+                    else_expr: else_expr.span,
+                }),
                 condition: Box::new(condition.into_kernel()?),
                 then_expr: Box::new(then_expr.into_kernel()?),
                 else_expr: Box::new(else_expr.into_kernel()?),
@@ -785,6 +790,22 @@ impl SyntaxParser<'_> {
     }
 
     fn prefix(&mut self) -> Result<SyntaxExpr, ParseError> {
+        if self.eat_ident("if") {
+            let start = self.previous_span();
+            let condition = self.expression(0)?;
+            self.expect_ident_value("then")?;
+            let then_expr = self.expression(0)?;
+            self.expect_ident_value("else")?;
+            let else_expr = self.expression(0)?;
+            return Ok(SyntaxExpr {
+                span: join(start, else_expr.span),
+                kind: SyntaxExprKind::Conditional {
+                    condition: Box::new(condition),
+                    then_expr: Box::new(then_expr),
+                    else_expr: Box::new(else_expr),
+                },
+            });
+        }
         if self.peek_ident("forall") || self.peek_ident("exists") {
             let start = self.peek().span;
             let quantifier = self.expect_ident()?;

--- a/rust/fsl-syntax/tests/domain_typed_expressions.rs
+++ b/rust/fsl-syntax/tests/domain_typed_expressions.rs
@@ -108,6 +108,35 @@ fn domain_expressions_are_typed_spanned_and_preserve_legacy_operators() {
 }
 
 #[test]
+fn conditional_retains_its_own_and_each_child_span() {
+    let source = r"domain ConditionalSpans {
+  enum Status { Pending, Done }
+  aggregate Order {
+    state { status: Status = Pending; ready: Bool = false; }
+    invariant selected { if ready then status == Done else status == Pending }
+  }
+}";
+    let domain = parse_domain(source).expect("parse conditional");
+    let expression = &domain.aggregates[0].invariants[0].expr;
+    let SyntaxExprKind::Conditional {
+        condition,
+        then_expr,
+        else_expr,
+    } = &expression.kind
+    else {
+        panic!("expected conditional: {expression:?}");
+    };
+
+    assert_eq!(
+        text(source, expression),
+        "if ready then status == Done else status == Pending"
+    );
+    assert_eq!(text(source, condition), "ready");
+    assert_eq!(text(source, then_expr), "status == Done");
+    assert_eq!(text(source, else_expr), "status == Pending");
+}
+
+#[test]
 fn malformed_domain_expression_reports_the_original_source_span() {
     let source = r"domain Broken {
   aggregate Order {

--- a/rust/fsl-tools/src/analysis.rs
+++ b/rust/fsl-tools/src/analysis.rs
@@ -168,10 +168,11 @@ fn expr_reads_bound(
             reads.extend(expr_reads_bound(left, state, bound));
             reads.extend(expr_reads_bound(right, state, bound));
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             reads.extend(expr_reads_bound(condition, state, bound));
             reads.extend(expr_reads_bound(then_expr, state, bound));

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -321,14 +321,16 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                 });
             }
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            spans,
         } => {
             for mutation in expr_mutations(condition, enums) {
                 output.push(ExprMutation {
-                    expr: Expr::IfThenElse {
+                    expr: Expr::Conditional {
+                        spans: spans.clone(),
                         condition: Box::new(mutation.expr.clone()),
                         then_expr: then_expr.clone(),
                         else_expr: else_expr.clone(),
@@ -338,7 +340,8 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
             }
             for mutation in expr_mutations(then_expr, enums) {
                 output.push(ExprMutation {
-                    expr: Expr::IfThenElse {
+                    expr: Expr::Conditional {
+                        spans: spans.clone(),
                         condition: condition.clone(),
                         then_expr: Box::new(mutation.expr.clone()),
                         else_expr: else_expr.clone(),
@@ -348,7 +351,8 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
             }
             for mutation in expr_mutations(else_expr, enums) {
                 output.push(ExprMutation {
-                    expr: Expr::IfThenElse {
+                    expr: Expr::Conditional {
+                        spans: spans.clone(),
                         condition: condition.clone(),
                         then_expr: then_expr.clone(),
                         else_expr: Box::new(mutation.expr.clone()),

--- a/rust/fsl-tools/src/typestate.rs
+++ b/rust/fsl-tools/src/typestate.rs
@@ -284,9 +284,16 @@ fn parse_expr(value: &Value, context: &str) -> Result<Expr, String> {
             .collect::<Result<Vec<_>, String>>()?;
             Ok(Expr::Struct { fields })
         }
-        "ite" => Ok(Expr::Placeholder("if_expr".to_owned())),
+        "ite" => Err(format!(
+            "public Kernel {context} uses conditional expressions, which typestate does not support"
+        )),
         "forall" | "exists" => Ok(Expr::Placeholder("quant".to_owned())),
-        _ => Ok(Expr::Placeholder(kind.to_owned())),
+        "count" | "sum" | "old" | "abs" | "min" | "max" | "rel_acyclic" | "rel_functional"
+        | "rel_injective" | "rel_domain" | "rel_range" | "rel_reachable" | "unique"
+        | "exactly_one" => Ok(Expr::Placeholder(kind.to_owned())),
+        _ => Err(format!(
+            "public Kernel {context}.kind has unknown expression kind '{kind}'"
+        )),
     }
 }
 

--- a/rust/fsl-tools/src/undecided.rs
+++ b/rust/fsl-tools/src/undecided.rs
@@ -27,10 +27,11 @@ fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> 
                 collect(left, roots);
                 collect(right, roots);
             }
-            KernelExpr::IfThenElse {
+            KernelExpr::Conditional {
                 condition,
                 then_expr,
                 else_expr,
+                ..
             }
             | KernelExpr::TernaryNamed {
                 first: condition,

--- a/rust/fsl-tools/tests/conditional_analysis.rs
+++ b/rust/fsl-tools/tests/conditional_analysis.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+#[test]
+fn analysis_reads_condition_and_both_conditional_branches() {
+    let source = "spec S { state { gate: Bool, left: Bool, right: Bool } init { gate = true left = true right = false } action choose() { requires if gate then left else right gate = gate } invariant I { true } }";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let tsg = fsl_tools::build_tsg(&model);
+    let reads = tsg["edges"]
+        .as_array()
+        .expect("edges")
+        .iter()
+        .filter(|edge| edge["from"] == "action:choose" && edge["kind"] == "reads")
+        .filter_map(|edge| edge["to"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert!(reads.contains("state:gate"));
+    assert!(reads.contains("state:left"));
+    assert!(reads.contains("state:right"));
+}

--- a/rust/fsl-tools/tests/option_mutation.rs
+++ b/rust/fsl-tools/tests/option_mutation.rs
@@ -33,3 +33,35 @@ spec OptionMutation {
             .any(|mutant| mutant.op == "enum_constant_swap")
     );
 }
+
+#[test]
+fn mutates_expressions_inside_conditional_branches() {
+    let spec = parse_surface_spec(
+        r"
+spec ConditionalMutation {
+  enum Status { Pending, Done }
+  state { current: Status, gate: Bool }
+  init { current = Pending gate = true }
+  action stay() {
+    requires if gate then current == Pending else current == Done
+    current = current
+    gate = gate
+  }
+  invariant Expected { true }
+}
+",
+    )
+    .expect("parse conditional spec");
+
+    let mutants = enumerate_builtin_mutants(&spec);
+    assert!(
+        mutants
+            .iter()
+            .any(|mutant| mutant.op == "equality_operator_flip")
+    );
+    assert!(
+        mutants
+            .iter()
+            .any(|mutant| mutant.op == "enum_constant_swap")
+    );
+}

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -105,10 +105,11 @@ pub(crate) fn eval<S: SmtSolver>(
             let value = eval(solver, model, inner, state, bindings, old_state)?;
             Ok(bool_value(solver, solver.not(bool_term(&value)?)?))
         }
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             let condition = eval(solver, model, condition, state, bindings, old_state)?;
             let then_value = eval(solver, model, then_expr, state, bindings, old_state)?;

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -43,6 +43,8 @@ spec Agreement {
   action advance() { requires x < 2  x = x + 1  flag = not flag }
   invariant Arithmetic { (x / 2) * 2 + (x % 2) == x }
   invariant Mixed { (x < 0) or flag or not flag }
+  invariant Conditional { (if flag then x else -x) >= -2 }
+  invariant UnselectedPartialOperation { if true then x == x else x / 0 == 0 }
   invariant OptionTruthTable {
     empty == none and empty == also_empty and empty != first and first != none and
     first == same and first != different and first == some(-2)

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -309,7 +309,7 @@ fn map_key(value: &FslValue) -> String {
 pub fn expr_text(expr: &Expr) -> String {
     fn precedence(expr: &Expr) -> u8 {
         match expr {
-            Expr::Quantified { .. } => 0,
+            Expr::Conditional { .. } | Expr::Quantified { .. } => 0,
             Expr::Binary { op, .. } => match op.as_str() {
                 "=>" => 1,
                 "or" => 2,
@@ -427,10 +427,11 @@ pub fn expr_text(expr: &Expr) -> String {
         }
         Expr::Neg(value) => format!("-{}", operand(value, 9)),
         Expr::Not(value) => format!("not {}", operand(value, 4)),
-        Expr::IfThenElse {
+        Expr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => format!(
             "if {} then {} else {}",
             expr_text(condition),

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2391,10 +2391,11 @@ fn mapping_json_expr(
                 .as_i64()
                 .ok_or_else(|| "mapping negation requires integer".to_owned())?
         )),
-        KernelExpr::IfThenElse {
+        KernelExpr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => {
             if mapping_json_expr(condition, raw, bindings, model)?
                 .as_bool()
@@ -5317,10 +5318,11 @@ fn expression_state_roots(
                 collect(base, roots);
                 collect(index, roots);
             }
-            KernelExpr::IfThenElse {
+            KernelExpr::Conditional {
                 condition,
                 then_expr,
                 else_expr,
+                ..
             }
             | KernelExpr::TernaryNamed {
                 first: condition,
@@ -6051,10 +6053,11 @@ fn expression_mutant_count(
             .iter()
             .map(|(_, value)| expression_mutant_count(value, enum_siblings))
             .sum(),
-        KernelExpr::IfThenElse {
+        KernelExpr::Conditional {
             condition,
             then_expr,
             else_expr,
+            ..
         } => [condition.as_ref(), then_expr, else_expr]
             .into_iter()
             .map(|value| expression_mutant_count(value, enum_siblings))

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -100,6 +100,92 @@ fn native_cli_preserves_bmc_outcomes() {
 }
 
 #[test]
+fn general_conditionals_cross_cli_verification_and_replay_paths() {
+    let spec = "examples/conditional_expressions.fsl";
+    let (checked, status) = run_cli(&["check", spec]);
+    assert_eq!(status, 0);
+    assert_eq!(checked["result"], "ok");
+
+    let (conformance, status) = run_cli(&["conformance", spec, "--depth", "1"]);
+    assert_eq!(status, 0);
+    assert_eq!(conformance["schema_version"], "1.0.0");
+    assert_eq!(conformance["kernel_schema_version"], "1.0.0");
+    assert_eq!(conformance["vectors"][0]["outcome"]["state"]["count"], 2);
+
+    let (bounded, status) = run_cli(&[
+        "verify",
+        spec,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0);
+    assert_eq!(bounded["result"], "verified");
+
+    let (induction, status) = run_cli(&[
+        "verify",
+        spec,
+        "--engine",
+        "induction",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0);
+    assert_eq!(induction["result"], "proved");
+
+    let trace = std::env::temp_dir().join(format!(
+        "fsl-conditional-replay-{}.json",
+        std::process::id()
+    ));
+    std::fs::write(&trace, r#"[{"action":"advance","params":{}}]"#).expect("write replay trace");
+    let trace_path = trace.to_str().expect("UTF-8 trace path");
+    let (replayed, status) = run_cli(&["replay", spec, "--trace", trace_path]);
+    std::fs::remove_file(trace).expect("remove replay trace");
+    assert_eq!(status, 0);
+    assert_eq!(replayed["result"], "conformant");
+    assert_eq!(replayed["steps_checked"], 1);
+}
+
+#[test]
+fn conditional_type_diagnostics_point_to_the_invalid_child_expression() {
+    for (fixture, location) in [
+        (
+            "rust/fslc/tests/fixtures/conditional_type_error.fsl",
+            "at 7:29",
+        ),
+        (
+            "rust/fslc/tests/fixtures/conditional_const_type_error.fsl",
+            "at 4:37",
+        ),
+    ] {
+        let (value, status) = run_cli(&["check", fixture]);
+
+        assert_eq!(status, 2, "{fixture}");
+        assert_eq!(value["result"], "error", "{fixture}");
+        assert_eq!(value["kind"], "semantics", "{fixture}");
+        assert!(
+            value["message"]
+                .as_str()
+                .is_some_and(|message| message.ends_with(location)),
+            "{fixture}: {value}"
+        );
+    }
+}
+
+#[test]
+fn formatter_parenthesizes_a_conditional_used_as_an_operator_operand() {
+    let expression = fsl_syntax::parse_expr("(if c then a else b) + 1").expect("parse expression");
+
+    assert_eq!(
+        fslc_rust::expr_text(&expression),
+        "(if c then a else b) + 1"
+    );
+}
+
+#[test]
 fn typed_requirement_relations_reach_strict_tags_scenarios_and_diagnostics() {
     let spec = "rust/fslc/tests/fixtures/typed_annotation_outputs.fsl";
     let requirements = "rust/fslc/tests/fixtures/typed_annotation_requirements.txt";

--- a/rust/fslc/tests/fixtures/conditional_const_type_error.fsl
+++ b/rust/fslc/tests/fixtures/conditional_const_type_error.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ConditionalConstTypeError {
+  const Limit = if true then 1 else Missing
+  type N = 0..Limit
+  state { x: N }
+  init { x = 0 }
+  action stay() { x = x }
+  invariant Safe { true }
+}

--- a/rust/fslc/tests/fixtures/conditional_type_error.fsl
+++ b/rust/fslc/tests/fixtures/conditional_type_error.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ConditionalTypeError {
+  state { x: Int }
+  init { x = 0 }
+  action stay() {
+    x = if true then 1 else Missing
+  }
+  invariant Safe { true }
+}

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -120,6 +120,25 @@ fn typestate_consumes_the_versioned_public_kernel_contract() {
 }
 
 #[test]
+fn typestate_rejects_conditional_nodes_instead_of_omitting_them() {
+    let source = "spec S { type N = 0..1 state { x: N, gate: Bool } init { x = 0 gate = true } action choose() { x = if gate then 1 else 0 gate = gate } invariant I { true } }";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel.clone()).expect("build model");
+    let mut contract = fsl_core::public_kernel_contract(&kernel, &model, "s.fsl", "kernel")
+        .expect("export public Kernel");
+
+    let error = fsl_tools::analyze_typestate(&contract)
+        .expect_err("unsupported conditional must not be silently ignored");
+    assert!(error.contains("conditional expressions"));
+
+    contract["actions"][0]["updates"][0]["value"]["kind"] =
+        Value::String("unknown_node".to_owned());
+    let error = fsl_tools::analyze_typestate(&contract)
+        .expect_err("unknown public Kernel nodes must be rejected");
+    assert!(error.contains("unknown expression kind 'unknown_node'"));
+}
+
+#[test]
 fn typestate_rejects_an_incompatible_public_kernel_version() {
     let path = fixture("kernel_contract.fsl");
     let (kernel, model) = load(&path);
@@ -559,5 +578,6 @@ fn published_schema_ids_match_the_rust_api_constants() {
     let kinds = kernel["$defs"]["expression"]["properties"]["kind"]["enum"]
         .as_array()
         .expect("expression kind enum");
+    assert!(kinds.contains(&Value::String("ite".to_owned())));
     assert!(!kinds.contains(&Value::String("totally_unknown".to_owned())));
 }

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -566,7 +566,7 @@ refinement <Name> {
   maps auto                                      // optional identity defaults for same-named compatible state/actions
   map <abs_var> = <expr over impl state>          // scalar abstract variable
   map <abs_var>[<x>: <KeyType>] = <expr>          // per-element mapping of a Map
-  // conditional expressions allowed only inside mapping/argument expressions: if <c> then <a> else <b> (else required)
+  // map and action arguments use the same expressions as specs, including if <c> then <a> else <b>
   action <impl_act>(<formal params>...) -> <abs_act>(<expr>...) | stutter
   // formal params may be bare names or name: Type annotations matching the impl action
   // explicit map/action entries override maps auto; incompatible same-name candidates are type errors
@@ -647,10 +647,11 @@ cannot be assigned both inline and in `init`.
 - Relation: `.contains(a,b) .add(a,b) .remove(a,b)`,
   `reachable(r,a,b) acyclic(r) functional(r) injective(r) domain(r) range(r)`.
   `reachable`/`acyclic` require a self-relation (`relation T -> T`).
+- conditional expression: `if c then a else b` in any expression position;
+  `c` is Bool, both branches have one logical type and are checked statically,
+  while only the selected branch is evaluated
 - ensures/trans only: `old(expr)` / leadsTo only: `P ~> Q`,
-  `P ~> within K Q`, plus optional `decreases <int expr>` for induction ranking /
-  mapping-expression only:
-  `if c then a else b`
+  `P ~> within K Q`, plus optional `decreases <int expr>` for induction ranking
 
 ## 4. Statements (init / action body)
 

--- a/src/fslc/grammar.py
+++ b/src/fslc/grammar.py
@@ -38,12 +38,12 @@ refinement_def: "refinement" NAME "{" refinement_item* "}"
 refinement_impl: "impl" NAME
 refinement_abs: "abs" NAME
 maps_auto_def: "maps" "auto"
-map_def: "map" NAME ["[" binder "]"] "=" ref_expr
+map_def: "map" NAME ["[" binder "]"] "=" expr
 refinement_action: "action" NAME "(" [refinement_param ("," refinement_param)*] ")" "->" action_target
 refinement_param: NAME [":" type]
 action_target: stutter_target | mapped_action_target
 stutter_target: "stutter"
-mapped_action_target: NAME "(" [ref_expr ("," ref_expr)*] ")"
+mapped_action_target: NAME "(" [expr ("," expr)*] ")"
 preserve_progress_def: "preserve" "progress" "{" progress_item* "}"
 ?progress_item: progress_respond
 progress_respond: "respond" NAME "by" NAME ("," NAME)* ","?
@@ -155,6 +155,7 @@ postfix_suffix: "[" expr "]" -> idx_suffix
                | "." "size" "(" ")" -> method_size
                | "." NAME -> field_suffix
 ?atom: INT -> num
+     | _IF expr "then" expr _ELSE expr -> ite
      | "true" -> true_lit
      | "false" -> false_lit
      | "none" -> none_lit
@@ -183,11 +184,6 @@ postfix_suffix: "[" expr "]" -> idx_suffix
 struct_fields: "{" NAME ":" expr ("," NAME ":" expr)* ","? "}"
 expr_list: expr ("," expr)*
 
-?ref_expr: _IF ref_expr "then" ref_expr _ELSE ref_expr -> ite
-         | NAME ref_struct_fields -> struct_lit
-         | expr
-ref_struct_fields: "{" NAME ":" ref_expr ("," NAME ":" ref_expr)* ","? "}" -> struct_fields
-
 requirements_def: "requirements" NAME "{" requirements_item* "}"
 ?requirements_item: implements_def | requirement_def | acceptance_def | forbidden_def | kpi_def
                   | const_def | type_def | enum_def | struct_def | entity_def | number_def
@@ -205,10 +201,10 @@ branches_def: "branches" "{" branch_when+ "}"
 branch_when: "when" expr "{" stmt* "}" maps_clause
 maps_clause: "maps" req_action_target
 req_action_target: stutter_target | req_mapped_action_target
-req_mapped_action_target: NAME "(" [ref_expr ("," ref_expr)*] ")"
+req_mapped_action_target: NAME "(" [expr ("," expr)*] ")"
 acceptance_def: "acceptance" REQ_ID STRING "{" acceptance_step* acceptance_expect "}"
 acceptance_step: NAME "(" [acceptance_arg ("," acceptance_arg)*] ")"
-acceptance_arg: ref_expr
+acceptance_arg: expr
 acceptance_expect: "expect" expr -> acceptance_expect
                  | "expect" NAME INT "in" NAME -> acceptance_expect_stage
 forbidden_def: "forbidden" REQ_ID STRING "{" acceptance_step* "expect" "rejected" "}"

--- a/src/fslc/render.py
+++ b/src/fslc/render.py
@@ -111,7 +111,7 @@ def _expr_prec(expr):
         return _PREC_IS
     if tag == "neg":
         return _PREC_NEG
-    if tag in ("forall", "exists"):
+    if tag in ("ite", "forall", "exists"):
         return _PREC_QUANT
     return _PREC_ATOM
 

--- a/src/fslc/runtime.py
+++ b/src/fslc/runtime.py
@@ -677,6 +677,9 @@ def _eval_concrete_impl(e, state, binds, spec, old_state=None, in_ensures=False)
         _err(f"unknown operator '{op}'")
     if tag in ("forall", "exists"):
         return _eval_quant(e, state, binds, spec, old_state, in_ensures)
+    if tag == "ite":
+        branch = e[2] if eval_concrete(e[1], state, binds, spec, old_state, in_ensures) else e[3]
+        return eval_concrete(branch, state, binds, spec, old_state, in_ensures)
     if tag in ("unique", "exactly_one"):
         return _eval_one(e, state, binds, spec, old_state, in_ensures)
     if tag == "count":

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -125,6 +125,12 @@
       "result": "error"
     }
   },
+  "examples/conditional_expressions.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/consulting/asis_expense.fsl": {
     "check": {
       "result": "ok",

--- a/tests/test_acceptance_enum_args.py
+++ b/tests/test_acceptance_enum_args.py
@@ -1,5 +1,5 @@
 """Tests for enum member names (and const/bool literals) as acceptance/forbidden
-action arguments (#67). Grammar already parsed these as `ref_expr`; the only
+action arguments (#67). The expression grammar already parsed these; the only
 rejection point was `_literal_value` in `fslc.acceptance`, whose `var` branch
 only resolved `spec["consts"]`."""
 from fslc.acceptance import _literal_value, validate_acceptance, validate_forbidden

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -333,6 +333,8 @@ def test_expr_to_text_parenthesizes_where_semantics_require_it():
         _expr_to_text(_bin("-", _bin("-", _var("a"), _var("b")), _var("c")))
         == "a - b - c"
     )
+    conditional = ("ite", _var("c"), _var("a"), _var("b"))
+    assert _expr_to_text(_bin("+", conditional, ("num", 1))) == "(if c then a else b) + 1"
 
 
 def test_expr_to_text_omits_parens_not_required_by_precedence():

--- a/tests/test_lsp_index.py
+++ b/tests/test_lsp_index.py
@@ -141,6 +141,29 @@ def test_raw_tree_index_extracts_spec_definitions_references_and_ranges():
     assert init_i_loc.range == init_i.selection_range
 
 
+def test_raw_tree_index_visits_every_conditional_branch():
+    source = """spec ConditionalIndex {
+  state { condition: Bool, then_value: Bool, else_value: Bool }
+  init { condition = true then_value = true else_value = false }
+  action stay() {
+    condition = condition
+    then_value = then_value
+    else_value = else_value
+  }
+  invariant Choice { if condition then then_value else else_value }
+}
+"""
+    index = build_index(source, "conditional.fsl")
+
+    for name in ("condition", "then_value", "else_value"):
+        references = [
+            reference
+            for reference in index.references
+            if reference.name == name and reference.role == "value"
+        ]
+        assert len(references) >= 2, f"conditional reference not indexed: {name}"
+
+
 def test_domain_canonical_enum_is_indexed_with_members():
     source = """domain Orders {
   enum Status { Pending, Approved }

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -3,7 +3,6 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from lark.exceptions import UnexpectedInput
 
 from fslc import parse, build_spec, FslError
 from fslc.cli import run_refine, exit_code
@@ -255,15 +254,21 @@ def test_seat_conditional_map_type_mismatch_is_type_error(tmp_path):
     assert exit_code(r) == 2
 
 
-def test_ite_syntax_is_not_allowed_in_normal_specs():
+def test_ite_syntax_is_shared_with_normal_specs():
     src = """
-spec BadIte {
+spec GeneralIte {
   state { x: Int }
   init { x = if true then 1 else 0 }
+  action stay() { x = x }
 }
 """
-    with pytest.raises(UnexpectedInput):
-        parse(src)
+    spec = build_spec(parse(src))
+    assert spec["init"][0][2] == (
+        "ite",
+        ("bool", True),
+        ("num", 1),
+        ("num", 0),
+    )
 
 
 def test_stutter_violation_when_reserve_changes_abs_stock(tmp_path):


### PR DESCRIPTION
## Problem

Conditional expressions were limited to refinement mappings even though the Kernel, runtime, and symbolic semantics already had ITE support. This left ordinary specs, requirements, and domain expressions on separate parser paths and allowed refinement type gaps.

## Contract change

- Accept if CONDITION then THEN else ELSE in every expression position with shared precedence and parser handling.
- Preserve exact condition and branch spans through the Kernel AST and diagnostics.
- Type-check both branches and require one compatible result type while evaluating only the selected branch.
- Apply the shared rules to constants, refinement state/action maps, requirements, domain lowering, Public Kernel JSON, analysis, mutation, formatting, LSP indexing, concrete runtime, explicit BFS, and symbolic verification.
- Gate partial operations by the selected branch path condition.
- Remove the refinement-only expression grammar path.
- Keep Public Kernel schema versions unchanged because the existing v1/v2 contracts already publish the ite node.

## Verification

- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --workspace --locked
- cargo build --manifest-path rust/Cargo.toml --workspace --locked
- Python full suite: 1445 passed, 81 skipped
- Rust CLI compatibility: 12 passed
- Independent review: no blocker or major findings

Closes #245