### PR TITLE
refactor(refine): unify action correspondences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   #278).
 
 ### Changed
+- Standalone refinement files, requirements `implements` blocks, action-level
+  `maps` clauses, and synthesized auto/identity mappings now lower through one
+  typed `ActionCorrespondence` IR. Impl parameter annotations, target arity and
+  argument types, actor compatibility, duplicate origins/spans, progress lookup,
+  and concrete refinement execution share that validation path; requirements
+  auto-mapping no longer has a separate indexing path (issue #238).
 - Native/WASM parity now runs every Worker-supported surface document from the
   shared `specs/` and `examples/` corpus and structurally compares complete
   envelopes. Only schema-validated timing/backend identity and replay-validated

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -136,9 +136,14 @@ structural sources:
   properties, scenarios, KPI/control nodes.
 - `property_state_graph`: user properties connected to state variables they read.
 - `refinement_graph`: standalone refinement mappings with impl/abs spec names,
-  state maps, action maps, stutters, and preserve-progress declarations.
+  state maps, action maps, correspondence origins, stutters, and
+  preserve-progress declarations. This command has only the mapping file, so it
+  is an unresolved structural projection and does not claim typed validation or
+  synthesize `maps auto` actions.
 - `traceability_graph`: project-manifest graph over business/requirements/design
-  files and refinement mappings.
+  files and refinement mappings. The project supplies both endpoint models, so
+  action edges are built from the checked `ActionCorrespondence` IR, including
+  synthesized auto correspondences.
 
 Direct `.toml` inputs to `fslc analyze` are treated as project manifests; the
 default filename is `fsl-project.toml`, but review copies with other names are

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -152,7 +152,10 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
    separately). An empty body auto-generates identity maps when process/action/
    stage names match. `maps auto` is allowed for same-name kernel-wrapper
    state/actions, explicit maps override it, and auto-mapped process transitions
-   are statically actor-checked. The refine-violation JSON passes through the
+   are statically actor-checked. Explicit `implements` items, action/branch
+   `maps`, and implicit identity/stutter mappings all lower to the shared typed
+   action-correspondence IR; there is no dialect-specific action validator. The
+   refine-violation JSON passes through the
    `requirement` of the impl action involved (extension of §1.2).
 8. `acceptance <ID> "<text>" { <action call>...  expect <expr> }` and
    `expect <Entity> <id> in <Stage>` →

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -58,6 +58,14 @@ refinement CartImplRefinesCart {
   order). They may be written bare (`u`) or with a type annotation matching the
   impl action declaration (`u: UserId`). The abs-side arguments are expressions
   using them and the impl state.
+- Every surface route lowers to one typed `ActionCorrespondence`:
+  `impl_action: ActionRef`, resolved `impl_params: Vec<ParamDef>`, a typed
+  action/stutter target, `CorrespondenceOrigin`, and a source span. Standalone
+  files, inline `implements`, requirement-action `maps`, and auto synthesis use
+  the same resolver for impl/target existence, parameter annotations, arity,
+  argument expression types, actor compatibility, and duplicate detection.
+  Progress declarations and the concrete Monitor consume the same action
+  identity. Success JSON remains the existing name-to-target projection.
 - `preserve progress { respond <AbsLeadsTo> by <impl_action>, ... }` is an
   optional liveness-preserving refinement check. It does not change ordinary
   safety refinement. When present, fslc pulls the named abstract `leadsTo` P/Q
@@ -134,26 +142,17 @@ requirements Impl {
 }
 ```
 
-This is not a new mechanism: `refinement_action`'s transformer output
-(`("action_map", name, params, target, loc)`) is the same AST node the
-separate-file parser already produces, and the inline desugar
-(dialects.py `_expand_requirements_with_display`) already merges
-`implements["maps"]` (the block's items) into the same `mapping_items` list
-as the auto-derived action maps from requirement-action `maps` clauses and
-process transitions, before building the same `("refinement", ...)` AST that
-`refine.py.build_refinement` consumes for both the inline and separate-file
-paths. Adding the grammar alternative was the entire change; `dialects.py`
-and `refine.py` needed none.
+The Rust frontend preserves the route as `CorrespondenceOrigin`, then lowers
+the shared surface item into the typed IR described in §1. Requirement-action
+`maps` clauses and branch maps are adapted to the same item before validation;
+implicit identity/stutter correspondences call the same resolver directly.
 
 Two consequences fall out of reusing the same merge, not from new logic:
 
-- **Duplicate correspondence.** `build_refinement` already rejects a second
-  `action_map` entry for the same impl action name
-  (`kind: "type"`, `"duplicate action map for '<name>'"`). Since the inline
-  block's items are merged ahead of the auto-derived ones, an impl action that
-  has *both* a `maps` clause and a matching inline `action ...` item now hits
-  that same pre-existing check — mirroring what a separate-file mapping that
-  lists an action twice already does.
+- **Duplicate correspondence.** A second correspondence for the same impl
+  action is rejected before semantic resolution. The diagnostic reports both
+  origin kinds and both line/column sites, whether the conflict is within a
+  standalone file or between `implements` and an action-level `maps` clause.
 - **Branch-split action names.** `branches` splits an action into aliased
   kernel actions (`name__b1`, `name__b2`, ...; dialects.py
   `_split_branch_action`), so the impl spec `build_refinement` type-checks

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1126,6 +1126,13 @@ refinement CartImplRefinesCart {
   Formal params may be bare names or `name: Type` annotations matching the impl action declaration.
   `stutter` is an internal step in which the abstract state does not change.
 
+All four authoring routes—standalone `action`, inline `implements` action,
+requirement-action `maps`, and auto/identity synthesis—resolve to the same typed
+action-correspondence IR. The common validation checks impl identity and typed
+parameters, target identity/arity, argument expressions, and auto-mapped actor
+compatibility. A duplicate diagnostic names both origin kinds and source
+locations; explicit entries still take precedence over auto synthesis.
+
 Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including `if <condition> then <expr> else <expr>`.
 Both branches are name- and type-checked even when the condition is constant.
@@ -1559,8 +1566,9 @@ verify {
   `maps <abs_act>(...)` clause on the requirement-level action; `maps auto`
   covers same-name kernel-wrapper state/actions, and explicit maps override it.
   An impl action with both a `maps` clause and a matching inline `action ...`
-  item is a duplicate-correspondence, `kind: "type"` check-time error (same as
-  a mapping file that lists the same action twice). Auto-mapped process
+  item is a duplicate-correspondence, `kind: "type"` check-time error naming
+  both origins and locations (same as a mapping file that lists the same action
+  twice). Auto-mapped process
   transitions are actor-checked; a transition whose actor differs from the
   business action's actor is a check-time error.
 - `acceptance` is replay-verified at check time by the concrete Monitor (a
@@ -2176,8 +2184,10 @@ DESIGN-*.md).
   directories in batch mode;
   directories are expanded recursively for `*.fsl` and sorted deterministically.
   Standalone refinement mappings can be viewed with `--projection
-  refinement_graph`; project manifests can be viewed with `--projection
-  traceability_graph`. `--format dot` and `--format mermaid` export graph-shaped
+  refinement_graph`; this is an unresolved structural view because the command
+  has no impl/abs model paths. Project manifests can be viewed with `--projection
+  traceability_graph`; their action edges use the checked correspondence IR and
+  include synthesized auto mappings. `--format dot` and `--format mermaid` export graph-shaped
   projections for review diagrams while keeping JSON as the default. `--profile
   ai-review` emits review findings such as `disconnected_requirement`,
   `unanchored_property`, `progressless_cycle`, `unwritten_state`,

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1184,6 +1184,12 @@ not depart from the behavior of abs (see <code>DESIGN-refinement.md</code>).</p>
   Formal params may be bare names or <code>name: Type</code> annotations matching the impl action declaration.
   <code>stutter</code> is an internal step in which the abstract state does not change.</li>
 </ul>
+<p>All four authoring routes—standalone <code>action</code>, inline <code>implements</code> action,
+requirement-action <code>maps</code>, and auto/identity synthesis—resolve to the same typed
+action-correspondence IR. The common validation checks impl identity and typed
+parameters, target identity/arity, argument expressions, and auto-mapped actor
+compatibility. A duplicate diagnostic names both origin kinds and source
+locations; explicit entries still take precedence over auto synthesis.</p>
 <p>Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
 Both branches are name- and type-checked even when the condition is constant.</p>
@@ -1583,8 +1589,9 @@ verify {
   <code>maps &lt;abs_act&gt;(...)</code> clause on the requirement-level action; <code>maps auto</code>
   covers same-name kernel-wrapper state/actions, and explicit maps override it.
   An impl action with both a <code>maps</code> clause and a matching inline <code>action ...</code>
-  item is a duplicate-correspondence, <code>kind: "type"</code> check-time error (same as
-  a mapping file that lists the same action twice). Auto-mapped process
+  item is a duplicate-correspondence, <code>kind: "type"</code> check-time error naming
+  both origins and locations (same as a mapping file that lists the same action
+  twice). Auto-mapped process
   transitions are actor-checked; a transition whose actor differs from the
   business action's actor is a check-time error.</li>
 <li><code>acceptance</code> is replay-verified at check time by the concrete Monitor (a
@@ -2159,8 +2166,10 @@ DESIGN-*.md).</p>
   directories in batch mode;
   directories are expanded recursively for <code>*.fsl</code> and sorted deterministically.
   Standalone refinement mappings can be viewed with <code>--projection
-  refinement_graph</code>; project manifests can be viewed with <code>--projection
-  traceability_graph</code>. <code>--format dot</code> and <code>--format mermaid</code> export graph-shaped
+  refinement_graph</code>; this is an unresolved structural view because the command
+  has no impl/abs model paths. Project manifests can be viewed with <code>--projection
+  traceability_graph</code>; their action edges use the checked correspondence IR and
+  include synthesized auto mappings. <code>--format dot</code> and <code>--format mermaid</code> export graph-shaped
   projections for review diagrams while keeping JSON as the default. <code>--profile
   ai-review</code> emits review findings such as <code>disconnected_requirement</code>,
   <code>unanchored_property</code>, <code>progressless_cycle</code>, <code>unwritten_state</code>,

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1184,6 +1184,12 @@ not depart from the behavior of abs (see <code>DESIGN-refinement.md</code>).</p>
   Formal params may be bare names or <code>name: Type</code> annotations matching the impl action declaration.
   <code>stutter</code> is an internal step in which the abstract state does not change.</li>
 </ul>
+<p>All four authoring routes—standalone <code>action</code>, inline <code>implements</code> action,
+requirement-action <code>maps</code>, and auto/identity synthesis—resolve to the same typed
+action-correspondence IR. The common validation checks impl identity and typed
+parameters, target identity/arity, argument expressions, and auto-mapped actor
+compatibility. A duplicate diagnostic names both origin kinds and source
+locations; explicit entries still take precedence over auto synthesis.</p>
 <p>Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
 Both branches are name- and type-checked even when the condition is constant.</p>
@@ -1583,8 +1589,9 @@ verify {
   <code>maps &lt;abs_act&gt;(...)</code> clause on the requirement-level action; <code>maps auto</code>
   covers same-name kernel-wrapper state/actions, and explicit maps override it.
   An impl action with both a <code>maps</code> clause and a matching inline <code>action ...</code>
-  item is a duplicate-correspondence, <code>kind: "type"</code> check-time error (same as
-  a mapping file that lists the same action twice). Auto-mapped process
+  item is a duplicate-correspondence, <code>kind: "type"</code> check-time error naming
+  both origins and locations (same as a mapping file that lists the same action
+  twice). Auto-mapped process
   transitions are actor-checked; a transition whose actor differs from the
   business action's actor is a check-time error.</li>
 <li><code>acceptance</code> is replay-verified at check time by the concrete Monitor (a
@@ -2159,8 +2166,10 @@ DESIGN-*.md).</p>
   directories in batch mode;
   directories are expanded recursively for <code>*.fsl</code> and sorted deterministically.
   Standalone refinement mappings can be viewed with <code>--projection
-  refinement_graph</code>; project manifests can be viewed with <code>--projection
-  traceability_graph</code>. <code>--format dot</code> and <code>--format mermaid</code> export graph-shaped
+  refinement_graph</code>; this is an unresolved structural view because the command
+  has no impl/abs model paths. Project manifests can be viewed with <code>--projection
+  traceability_graph</code>; their action edges use the checked correspondence IR and
+  include synthesized auto mappings. <code>--format dot</code> and <code>--format mermaid</code> export graph-shaped
   projections for review diagrams while keeping JSON as the default. <code>--profile
   ai-review</code> emits review findings such as <code>disconnected_requirement</code>,
   <code>unanchored_property</code>, <code>progressless_cycle</code>, <code>unwritten_state</code>,

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -15,8 +15,9 @@ use serde_json::Value;
 
 pub use fsl_syntax::{
     Annotation, AnnotationError, AnnotationRegistry as KernelAnnotationRegistry, AnnotationValue,
-    Annotations, Binder as KernelBinder, Expr as KernelExpr, LValue as KernelLValue, Pattern,
-    QualifiedName, RequirementLink, Statement as KernelStatement, SymbolPath,
+    Annotations, Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr,
+    LValue as KernelLValue, Pattern, QualifiedName, RequirementLink, Statement as KernelStatement,
+    SymbolPath,
 };
 
 mod compose;
@@ -61,8 +62,8 @@ pub use public_kernel::{
     public_kernel_contract, public_kernel_contract_for_version,
 };
 pub use refinement::{
-    ActionMap, ActionMapTarget, ImplementsContract, ProgressMap, Refinement, RefinementError,
-    StateMap, parse_refinement, requirements_implements,
+    ActionCorrespondence, ActionCorrespondenceTarget, ActionRef, ImplementsContract, ProgressMap,
+    Refinement, RefinementError, StateMap, parse_refinement, requirements_implements,
 };
 pub use trace::{TraceAction, TraceChange, TraceStep};
 pub use trace_json::{

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -145,6 +145,10 @@ pub struct KernelModel {
 }
 
 impl KernelModel {
+    pub(crate) fn resolve_surface_type(&self, ty: &TypeExpr) -> Result<TypeRef, ModelError> {
+        resolve_type(ty, &self.types, &self.consts)
+    }
+
     /// Enumerate a finite scalar domain.
     ///
     /// # Errors
@@ -849,33 +853,7 @@ impl ModelBuilder {
     }
 
     fn resolve_type(&self, ty: &TypeExpr) -> Result<TypeRef, ModelError> {
-        Ok(match ty {
-            TypeExpr::Int => TypeRef::Int,
-            TypeExpr::Bool => TypeRef::Bool,
-            TypeExpr::Name(name) => {
-                if !self.types.contains_key(name) {
-                    return Err(model_error(format!("unknown type '{name}'")));
-                }
-                TypeRef::Named(name.clone())
-            }
-            TypeExpr::Range(lo, hi) => TypeRef::Range(self.const_int(lo)?, self.const_int(hi)?),
-            TypeExpr::Map(key, value) => TypeRef::Map(
-                Box::new(self.resolve_type(key)?),
-                Box::new(self.resolve_type(value)?),
-            ),
-            TypeExpr::Relation(source, target) => TypeRef::Relation(
-                Box::new(self.resolve_type(source)?),
-                Box::new(self.resolve_type(target)?),
-            ),
-            TypeExpr::Set(inner) => TypeRef::Set(Box::new(self.resolve_type(inner)?)),
-            TypeExpr::Seq(inner, cap) => {
-                let cap = self.const_int(cap)?;
-                let cap = usize::try_from(cap)
-                    .map_err(|_| model_error("sequence capacity must be non-negative"))?;
-                TypeRef::Seq(Box::new(self.resolve_type(inner)?), cap)
-            }
-            TypeExpr::Option(inner) => TypeRef::Option(Box::new(self.resolve_type(inner)?)),
-        })
+        resolve_type(ty, &self.types, &self.consts)
     }
 
     fn action(
@@ -1097,6 +1075,46 @@ impl ModelBuilder {
             Value::Int(value) => Ok(value),
             _ => Err(model_error("constant expression must be an integer")),
         }
+    }
+}
+
+fn resolve_type(
+    ty: &TypeExpr,
+    types: &BTreeMap<String, TypeDef>,
+    consts: &BTreeMap<String, Value>,
+) -> Result<TypeRef, ModelError> {
+    Ok(match ty {
+        TypeExpr::Int => TypeRef::Int,
+        TypeExpr::Bool => TypeRef::Bool,
+        TypeExpr::Name(name) => {
+            if !types.contains_key(name) {
+                return Err(model_error(format!("unknown type '{name}'")));
+            }
+            TypeRef::Named(name.clone())
+        }
+        TypeExpr::Range(lo, hi) => TypeRef::Range(const_int(lo, consts)?, const_int(hi, consts)?),
+        TypeExpr::Map(key, value) => TypeRef::Map(
+            Box::new(resolve_type(key, types, consts)?),
+            Box::new(resolve_type(value, types, consts)?),
+        ),
+        TypeExpr::Relation(source, target) => TypeRef::Relation(
+            Box::new(resolve_type(source, types, consts)?),
+            Box::new(resolve_type(target, types, consts)?),
+        ),
+        TypeExpr::Set(inner) => TypeRef::Set(Box::new(resolve_type(inner, types, consts)?)),
+        TypeExpr::Seq(inner, cap) => {
+            let cap = usize::try_from(const_int(cap, consts)?)
+                .map_err(|_| model_error("sequence capacity must be non-negative"))?;
+            TypeRef::Seq(Box::new(resolve_type(inner, types, consts)?), cap)
+        }
+        TypeExpr::Option(inner) => TypeRef::Option(Box::new(resolve_type(inner, types, consts)?)),
+    })
+}
+
+fn const_int(expr: &Expr, consts: &BTreeMap<String, Value>) -> Result<i64, ModelError> {
+    match eval_const(expr, consts)? {
+        Value::Int(value) => Ok(value),
+        _ => Err(model_error("constant expression must be an integer")),
     }
 }
 

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -4,12 +4,14 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use fsl_syntax::{
-    ActionTarget, Binder, Expr, QualifiedName, RefinementItem, RefinementParam, RequirementAction,
-    RequirementActionItem, RequirementBlockItem, RequirementsItem, Span, SurfaceDocument,
-    SurfaceRefinement,
+    ActionTarget, Binder, CorrespondenceOrigin, Expr, MetaTag, QualifiedName, RefinementItem,
+    RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
+    RequirementsItem, Span, SurfaceDocument, SurfaceRefinement,
 };
 
-use crate::{FileResolver, KernelModel, ParamDef, TypeRef, build_model, parse_kernel_source};
+use crate::{
+    ActionDef, FileResolver, KernelModel, ParamDef, TypeRef, build_model, parse_kernel_source,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateMap {
@@ -20,23 +22,27 @@ pub struct StateMap {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ActionMapTarget {
+pub struct ActionRef(pub String);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActionCorrespondenceTarget {
     Stutter,
-    Action { name: String, args: Vec<Expr> },
+    Action { action: ActionRef, args: Vec<Expr> },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ActionMap {
-    pub name: String,
-    pub params: Vec<String>,
-    pub target: ActionMapTarget,
-    pub span: Option<Span>,
+pub struct ActionCorrespondence {
+    pub impl_action: ActionRef,
+    pub impl_params: Vec<ParamDef>,
+    pub target: ActionCorrespondenceTarget,
+    pub origin: CorrespondenceOrigin,
+    pub span: Span,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgressMap {
     pub leads_to: String,
-    pub actions: Vec<String>,
+    pub actions: Vec<ActionRef>,
     pub span: Span,
 }
 
@@ -46,7 +52,7 @@ pub struct Refinement {
     pub impl_name: String,
     pub abs_name: String,
     pub state_maps: BTreeMap<String, StateMap>,
-    pub action_maps: BTreeMap<String, ActionMap>,
+    pub action_correspondences: BTreeMap<String, ActionCorrespondence>,
     pub progress: Vec<ProgressMap>,
 }
 
@@ -89,7 +95,7 @@ pub fn parse_refinement(
     let SurfaceDocument::Refinement(surface) = document else {
         return Err(refinement_error("expected refinement document", None));
     };
-    build_refinement(surface, implementation, abstraction)
+    build_refinement(surface, implementation, abstraction, None)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -97,18 +103,21 @@ fn build_refinement(
     surface: SurfaceRefinement,
     implementation: &KernelModel,
     abstraction: &KernelModel,
+    implicit_actions: Option<Span>,
 ) -> Result<Refinement, RefinementError> {
     let mut impl_name = None;
     let mut abs_name = None;
-    let mut maps_auto = false;
+    let mut maps_auto = None;
     let mut state_maps = BTreeMap::new();
-    let mut action_maps = BTreeMap::new();
+    let mut action_correspondences = BTreeMap::new();
+    let mut action_sources = Vec::new();
     let mut progress = Vec::new();
+    let type_context = refinement_type_context(implementation, abstraction);
     for item in surface.items {
         match item {
             RefinementItem::Impl(name) => impl_name = Some(name),
             RefinementItem::Abs(name) => abs_name = Some(name),
-            RefinementItem::MapsAuto(_) => maps_auto = true,
+            RefinementItem::MapsAuto(span) => maps_auto = Some(span),
             RefinementItem::Map {
                 name,
                 binder,
@@ -143,83 +152,20 @@ fn build_refinement(
                 name,
                 params,
                 target,
+                origin,
                 span,
-            } => {
-                let Some(action) = implementation
-                    .actions
-                    .iter()
-                    .find(|action| action.name == name)
-                else {
-                    return Err(refinement_error(
-                        format!("unknown impl action '{name}'"),
-                        Some(span),
-                    ));
-                };
-                let param_names = params
-                    .iter()
-                    .map(|param| param.name.clone())
-                    .collect::<Vec<_>>();
-                let expected = action
-                    .params
-                    .iter()
-                    .map(|param| param.name().to_owned())
-                    .collect::<Vec<_>>();
-                if param_names != expected {
-                    return Err(refinement_error(
-                        format!(
-                            "action '{name}' parameter names/order must match impl ({expected:?})"
-                        ),
-                        Some(span),
-                    ));
-                }
-                let target = match target {
-                    ActionTarget::Stutter => ActionMapTarget::Stutter,
-                    ActionTarget::Action(target, args) => {
-                        let Some(abs_action) = abstraction
-                            .actions
-                            .iter()
-                            .find(|action| action.name == target)
-                        else {
-                            return Err(refinement_error(
-                                format!("unknown abstract action '{target}'"),
-                                Some(span),
-                            ));
-                        };
-                        if args.len() != abs_action.params.len() {
-                            return Err(refinement_error(
-                                format!(
-                                    "action '{name}' -> '{target}' expects {} arguments",
-                                    abs_action.params.len()
-                                ),
-                                Some(span),
-                            ));
-                        }
-                        ActionMapTarget::Action { name: target, args }
-                    }
-                };
-                if action_maps
-                    .insert(
-                        name.clone(),
-                        ActionMap {
-                            name: name.clone(),
-                            params: param_names,
-                            target,
-                            span: Some(span),
-                        },
-                    )
-                    .is_some()
-                {
-                    return Err(refinement_error(
-                        format!("duplicate action map for '{name}'"),
-                        Some(span),
-                    ));
-                }
-            }
+            } => action_sources.push(ActionCorrespondenceSource {
+                impl_action: name,
+                impl_params: params,
+                target,
+                origin,
+                span,
+            }),
             RefinementItem::PreserveProgress { responses, .. } => {
                 progress.extend(responses.into_iter().map(|(leads_to, actions, span)| {
                     ProgressMap {
                         leads_to,
-                        actions,
+                        actions: actions.into_iter().map(ActionRef).collect(),
                         span,
                     }
                 }));
@@ -248,15 +194,38 @@ fn build_refinement(
             None,
         ));
     }
-    if maps_auto {
-        apply_auto_maps(
+    validate_correspondence_duplicates(&action_sources)?;
+    for source in action_sources {
+        insert_action_correspondence(
+            &mut action_correspondences,
+            source,
             implementation,
             abstraction,
-            &mut state_maps,
-            &mut action_maps,
+            &type_context,
         )?;
     }
-    validate_refinement_expressions(implementation, abstraction, &state_maps, &action_maps)?;
+    if let Some(auto_span) = maps_auto {
+        apply_auto_state_maps(implementation, abstraction, &mut state_maps)?;
+        apply_auto_action_correspondences(
+            implementation,
+            abstraction,
+            &mut action_correspondences,
+            &type_context,
+            auto_span,
+            false,
+        )?;
+    }
+    if let Some(span) = implicit_actions {
+        apply_auto_action_correspondences(
+            implementation,
+            abstraction,
+            &mut action_correspondences,
+            &type_context,
+            span,
+            true,
+        )?;
+    }
+    validate_refinement_expressions(abstraction, &state_maps, &type_context)?;
     for (name, _) in &abstraction.state {
         if !state_maps.contains_key(name) {
             return Err(refinement_error(
@@ -266,7 +235,7 @@ fn build_refinement(
         }
     }
     for action in &implementation.actions {
-        if !action_maps.contains_key(&action.name) {
+        if !action_correspondences.contains_key(&action.name) {
             return Err(refinement_error(
                 format!(
                     "missing action correspondence for impl action '{}'",
@@ -288,13 +257,9 @@ fn build_refinement(
             ));
         }
         for action in &declaration.actions {
-            if !implementation
-                .actions
-                .iter()
-                .any(|candidate| candidate.name == *action)
-            {
+            if !action_correspondences.contains_key(&action.0) {
                 return Err(refinement_error(
-                    format!("unknown impl progress action '{action}'"),
+                    format!("unknown impl progress action '{}'", action.0),
                     Some(declaration.span),
                 ));
             }
@@ -305,23 +270,18 @@ fn build_refinement(
         impl_name,
         abs_name,
         state_maps,
-        action_maps,
+        action_correspondences,
         progress,
     })
 }
 
 fn validate_refinement_expressions(
-    implementation: &KernelModel,
     abstraction: &KernelModel,
     state_maps: &BTreeMap<String, StateMap>,
-    action_maps: &BTreeMap<String, ActionMap>,
+    context: &KernelModel,
 ) -> Result<(), RefinementError> {
-    let context = refinement_type_context(implementation, abstraction);
     for state_map in state_maps.values() {
-        validate_state_map(state_map, abstraction, &context)?;
-    }
-    for action_map in action_maps.values() {
-        validate_action_map(action_map, implementation, abstraction, &context)?;
+        validate_state_map(state_map, abstraction, context)?;
     }
     Ok(())
 }
@@ -415,57 +375,6 @@ fn invalid_state_map(
     )
 }
 
-fn validate_action_map(
-    action_map: &ActionMap,
-    implementation: &KernelModel,
-    abstraction: &KernelModel,
-    context: &KernelModel,
-) -> Result<(), RefinementError> {
-    let ActionMapTarget::Action { name, args } = &action_map.target else {
-        return Ok(());
-    };
-    let implementation_action = implementation
-        .actions
-        .iter()
-        .find(|action| action.name == action_map.name)
-        .expect("action maps were checked against implementation actions");
-    let abstraction_action = abstraction
-        .actions
-        .iter()
-        .find(|action| action.name == *name)
-        .expect("action maps were checked against abstraction actions");
-    let bindings = implementation_action
-        .params
-        .iter()
-        .map(|param| (param.name().to_owned(), parameter_type(param)))
-        .collect::<Vec<_>>();
-    for (index, (argument, parameter)) in args.iter().zip(&abstraction_action.params).enumerate() {
-        crate::public_kernel::validate_expression_type(
-            argument,
-            &parameter_type(parameter),
-            &bindings,
-            context,
-        )
-        .map_err(|error| {
-            refinement_error(
-                format!(
-                    "invalid argument {} for action '{}' -> '{}': {}",
-                    index + 1,
-                    action_map.name,
-                    name,
-                    error.message
-                ),
-                Some(
-                    error
-                        .span
-                        .expect("mapped argument type errors carry source spans"),
-                ),
-            )
-        })?;
-    }
-    Ok(())
-}
-
 fn parameter_type(parameter: &ParamDef) -> TypeRef {
     match parameter {
         ParamDef::Typed { ty, .. } => ty.clone(),
@@ -473,11 +382,10 @@ fn parameter_type(parameter: &ParamDef) -> TypeRef {
     }
 }
 
-fn apply_auto_maps(
+fn apply_auto_state_maps(
     implementation: &KernelModel,
     abstraction: &KernelModel,
     state_maps: &mut BTreeMap<String, StateMap>,
-    action_maps: &mut BTreeMap<String, ActionMap>,
 ) -> Result<(), RefinementError> {
     for (name, abs_ty) in &abstraction.state {
         if state_maps.contains_key(name) || implementation.state_type(name).is_none() {
@@ -519,39 +427,261 @@ fn apply_auto_maps(
             },
         );
     }
+    Ok(())
+}
+
+fn apply_auto_action_correspondences(
+    implementation: &KernelModel,
+    abstraction: &KernelModel,
+    action_correspondences: &mut BTreeMap<String, ActionCorrespondence>,
+    context: &KernelModel,
+    span: Span,
+    stutter_unmatched: bool,
+) -> Result<(), RefinementError> {
     for impl_action in &implementation.actions {
-        if action_maps.contains_key(&impl_action.name) {
+        if action_correspondences.contains_key(&impl_action.name) {
             continue;
         }
-        let Some(abs_action) = abstraction
+        let abs_action = abstraction
             .actions
             .iter()
-            .find(|action| action.name == impl_action.name)
-        else {
-            continue;
-        };
-        if impl_action.params.len() != abs_action.params.len() {
+            .find(|action| action.name == impl_action.name);
+        if abs_action.is_none() && !stutter_unmatched {
             continue;
         }
         let params = impl_action
             .params
             .iter()
-            .map(|param| param.name().to_owned())
+            .map(|param| RefinementParam {
+                name: param.name().to_owned(),
+                ty: None,
+            })
             .collect::<Vec<_>>();
-        action_maps.insert(
-            impl_action.name.clone(),
-            ActionMap {
-                name: impl_action.name.clone(),
-                params: params.clone(),
-                target: ActionMapTarget::Action {
-                    name: impl_action.name.clone(),
-                    args: params.into_iter().map(Expr::Var).collect(),
-                },
-                span: None,
+        insert_action_correspondence(
+            action_correspondences,
+            ActionCorrespondenceSource {
+                impl_action: impl_action.name.clone(),
+                impl_params: params,
+                target: abs_action.map_or(ActionTarget::Stutter, |abs_action| {
+                    ActionTarget::Action(
+                        abs_action.name.clone(),
+                        abs_action
+                            .params
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(index, parameter)| {
+                                impl_action
+                                    .params
+                                    .iter()
+                                    .find(|candidate| candidate.name() == parameter.name())
+                                    .or_else(|| impl_action.params.get(index))
+                                    .map(|candidate| Expr::Var(candidate.name().to_owned()))
+                            })
+                            .collect(),
+                    )
+                }),
+                origin: CorrespondenceOrigin::Auto,
+                span,
             },
-        );
+            implementation,
+            abstraction,
+            context,
+        )?;
     }
     Ok(())
+}
+
+struct ActionCorrespondenceSource {
+    impl_action: String,
+    impl_params: Vec<RefinementParam>,
+    target: ActionTarget,
+    origin: CorrespondenceOrigin,
+    span: Span,
+}
+
+fn validate_correspondence_duplicates(
+    sources: &[ActionCorrespondenceSource],
+) -> Result<(), RefinementError> {
+    let mut first_by_action = BTreeMap::new();
+    for source in sources {
+        if let Some(previous) = first_by_action.insert(source.impl_action.as_str(), source) {
+            return Err(refinement_error(
+                format!(
+                    "duplicate action correspondence for '{}': {} at {}:{} conflicts with {} at {}:{}",
+                    source.impl_action,
+                    previous.origin.as_str(),
+                    previous.span.start.line,
+                    previous.span.start.column,
+                    source.origin.as_str(),
+                    source.span.start.line,
+                    source.span.start.column,
+                ),
+                Some(source.span),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn insert_action_correspondence(
+    correspondences: &mut BTreeMap<String, ActionCorrespondence>,
+    source: ActionCorrespondenceSource,
+    implementation: &KernelModel,
+    abstraction: &KernelModel,
+    context: &KernelModel,
+) -> Result<(), RefinementError> {
+    let implementation_action = implementation
+        .actions
+        .iter()
+        .find(|action| action.name == source.impl_action)
+        .ok_or_else(|| {
+            refinement_error(
+                format!("unknown impl action '{}'", source.impl_action),
+                Some(source.span),
+            )
+        })?;
+    validate_impl_params(&source, implementation_action, context)?;
+    let target = lower_action_target(&source, implementation_action, abstraction, context)?;
+    correspondences.insert(
+        source.impl_action.clone(),
+        ActionCorrespondence {
+            impl_action: ActionRef(source.impl_action),
+            impl_params: implementation_action.params.clone(),
+            target,
+            origin: source.origin,
+            span: source.span,
+        },
+    );
+    Ok(())
+}
+
+fn validate_impl_params(
+    source: &ActionCorrespondenceSource,
+    action: &ActionDef,
+    context: &KernelModel,
+) -> Result<(), RefinementError> {
+    if action.params.len() != source.impl_params.len()
+        || action
+            .params
+            .iter()
+            .zip(&source.impl_params)
+            .any(|(actual, declared)| actual.name() != declared.name)
+    {
+        return Err(refinement_error(
+            format!(
+                "action map parameters for '{}' must match the impl action parameter names and order",
+                source.impl_action
+            ),
+            Some(source.span),
+        ));
+    }
+    for (actual, declared) in action.params.iter().zip(&source.impl_params) {
+        let Some(annotation) = &declared.ty else {
+            continue;
+        };
+        let resolved = context
+            .resolve_surface_type(annotation)
+            .map_err(|error| refinement_error(error.message, Some(source.span)))?;
+        if resolved != parameter_type(actual) {
+            return Err(refinement_error(
+                format!(
+                    "action map parameter '{}.{}' type does not match the impl action",
+                    source.impl_action, declared.name
+                ),
+                Some(source.span),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn lower_action_target(
+    source: &ActionCorrespondenceSource,
+    implementation_action: &ActionDef,
+    abstraction: &KernelModel,
+    context: &KernelModel,
+) -> Result<ActionCorrespondenceTarget, RefinementError> {
+    let target = match &source.target {
+        ActionTarget::Stutter => ActionCorrespondenceTarget::Stutter,
+        ActionTarget::Action(name, args) => {
+            let abstraction_action = abstraction
+                .actions
+                .iter()
+                .find(|action| action.name == *name)
+                .ok_or_else(|| {
+                    refinement_error(
+                        format!("unknown abstract action '{name}'"),
+                        Some(source.span),
+                    )
+                })?;
+            if abstraction_action.params.len() != args.len() {
+                return Err(refinement_error(
+                    format!(
+                        "action map '{}' -> '{}' has {} arguments, expected {}",
+                        source.impl_action,
+                        name,
+                        args.len(),
+                        abstraction_action.params.len()
+                    ),
+                    Some(source.span),
+                ));
+            }
+            let bindings = implementation_action
+                .params
+                .iter()
+                .map(|param| (param.name().to_owned(), parameter_type(param)))
+                .collect::<Vec<_>>();
+            for (index, (argument, parameter)) in
+                args.iter().zip(&abstraction_action.params).enumerate()
+            {
+                crate::public_kernel::validate_expression_type(
+                    argument,
+                    &parameter_type(parameter),
+                    &bindings,
+                    context,
+                )
+                .map_err(|error| {
+                    refinement_error(
+                        format!(
+                            "invalid argument {} for action '{}' -> '{}': {}",
+                            index + 1,
+                            source.impl_action,
+                            name,
+                            error.message
+                        ),
+                        error.span.or(Some(source.span)),
+                    )
+                })?;
+            }
+            if source.origin == CorrespondenceOrigin::Auto
+                && let (Some(impl_actor), Some(abs_actor)) = (
+                    action_actor(implementation_action.meta.as_ref()),
+                    action_actor(abstraction_action.meta.as_ref()),
+                )
+                && impl_actor != abs_actor
+            {
+                return Err(refinement_error(
+                    format!(
+                        "maps auto actor mismatch for action '{}': impl actor '{}' != abstract actor '{}'",
+                        source.impl_action, impl_actor, abs_actor
+                    ),
+                    Some(source.span),
+                ));
+            }
+            ActionCorrespondenceTarget::Action {
+                action: ActionRef(name.clone()),
+                args: args.clone(),
+            }
+        }
+    };
+    Ok(target)
+}
+
+fn action_actor(meta: Option<&MetaTag>) -> Option<&str> {
+    meta.and_then(|tag| tag.text.as_deref())
+        .and_then(|text| text.strip_prefix("by "))
+        .map(str::trim)
+        .filter(|actor| !actor.is_empty())
 }
 
 fn refinement_error(message: impl Into<String>, span: Option<Span>) -> RefinementError {
@@ -583,6 +713,7 @@ fn append_requirement_action_maps(action: &RequirementAction, items: &mut Vec<Re
                 name: format!("{}__b{}", action.name, index + 1),
                 params: params.clone(),
                 target: branch.maps.target.clone(),
+                origin: CorrespondenceOrigin::InlineMapsClause,
                 span: branch.maps.span,
             });
         }
@@ -591,6 +722,7 @@ fn append_requirement_action_maps(action: &RequirementAction, items: &mut Vec<Re
             name: action.name.clone(),
             params,
             target: mapping.target.clone(),
+            origin: CorrespondenceOrigin::InlineMapsClause,
             span: mapping.span,
         });
     }
@@ -714,55 +846,6 @@ pub fn requirements_implements(
             span,
         });
     }
-    let explicit_actions = items
-        .iter()
-        .filter_map(|item| match item {
-            RefinementItem::Action { name, .. } => Some(name.clone()),
-            _ => None,
-        })
-        .collect::<std::collections::BTreeSet<_>>();
-    for action in &implementation.actions {
-        if explicit_actions.contains(&action.name) {
-            continue;
-        }
-        let params = action
-            .params
-            .iter()
-            .map(|param| RefinementParam {
-                name: param.name().to_owned(),
-                ty: None,
-            })
-            .collect::<Vec<_>>();
-        let target = abstraction
-            .actions
-            .iter()
-            .find(|candidate| candidate.name == action.name)
-            .map_or(ActionTarget::Stutter, |abstract_action| {
-                let args = abstract_action
-                    .params
-                    .iter()
-                    .enumerate()
-                    .map(|(index, param)| {
-                        let name = action
-                            .params
-                            .iter()
-                            .find(|candidate| candidate.name() == param.name())
-                            .map_or_else(
-                                || action.params[index].name().to_owned(),
-                                |candidate| candidate.name().to_owned(),
-                            );
-                        Expr::Var(name)
-                    })
-                    .collect();
-                ActionTarget::Action(abstract_action.name.clone(), args)
-            });
-        items.push(RefinementItem::Action {
-            name: action.name.clone(),
-            params,
-            target,
-            span: action.span,
-        });
-    }
     let refinement = build_refinement(
         SurfaceRefinement {
             name: format!("{}Implements{}", implementation.name, abstraction.name),
@@ -770,6 +853,7 @@ pub fn requirements_implements(
         },
         implementation,
         &abstraction,
+        Some(span),
     )?;
     Ok(Some(ImplementsContract {
         abstraction,

--- a/rust/fsl-core/tests/action_correspondence.rs
+++ b/rust/fsl-core/tests/action_correspondence.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    ActionCorrespondenceTarget, CoreError, CorrespondenceOrigin, FileResolver, FsResolver,
+    build_model, parse_kernel_source, parse_refinement, requirements_implements,
+};
+
+fn build(source: &str) -> fsl_core::KernelModel {
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
+    build_model(kernel).expect("build model")
+}
+
+struct Resolver(&'static str);
+
+impl FileResolver for Resolver {
+    fn read(&self, _: &str) -> Result<String, CoreError> {
+        Ok(self.0.to_owned())
+    }
+}
+
+const ABS: &str = "spec Abs { type N = 0..1 state { done: Bool } init { done = false } action settle(x: N) { done = true } }";
+const IMPL: &str = "spec Impl { type N = 0..1 state { paid: Bool } init { paid = false } action pay(x: N, retry: N) { paid = true } }";
+
+#[test]
+fn standalone_correspondence_resolves_typed_params_once() {
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs map done = paid action pay(x: N, retry: N) -> settle(x) }",
+        &build(IMPL),
+        &build(ABS),
+    )
+    .expect("typed correspondence");
+    let correspondence = &mapping.action_correspondences["pay"];
+    assert_eq!(correspondence.origin, CorrespondenceOrigin::RefinementFile);
+    assert_eq!(correspondence.impl_params.len(), 2);
+    assert!(matches!(
+        &correspondence.target,
+        ActionCorrespondenceTarget::Action { action, args }
+            if action.0 == "settle" && args.len() == 1
+    ));
+
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs map done = paid action pay(x: Bool, retry: N) -> settle(x) }",
+        &build(IMPL),
+        &build(ABS),
+    )
+    .expect_err("typed params must match the implementation");
+    assert!(error.message.contains("pay.x' type does not match"));
+
+    let stutter = parse_refinement(
+        "refinement R { impl Impl abs Abs map done = paid action pay(x: N, retry: N) -> stutter }",
+        &build(IMPL),
+        &build(ABS),
+    )
+    .expect("stutter correspondence");
+    assert!(matches!(
+        stutter.action_correspondences["pay"].target,
+        ActionCorrespondenceTarget::Stutter
+    ));
+}
+
+#[test]
+fn maps_auto_uses_the_common_arity_and_type_checks() {
+    let implementation = build(
+        "spec Impl { type N = 0..1 state { flag: Bool } init { flag = false } action go(x: N) { flag = true } }",
+    );
+    let abstraction = build(
+        "spec Abs { type N = 0..1 state { flag: Bool } init { flag = false } action go(x: N, y: N) { flag = true } }",
+    );
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("incompatible same-name actions must fail during auto lowering");
+    assert!(error.message.contains("has 1 arguments, expected 2"));
+}
+
+#[test]
+fn requirements_routes_report_both_duplicate_origins() {
+    let source = r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    map done = paid
+    action pay(x: N, retry: N) -> settle(x)
+  }
+  type N = 0..1
+  state { paid: Bool }
+  init { paid = false }
+  action pay(x: N, retry: N) maps settle(x) { paid = true }
+}"#;
+    let implementation = build(source);
+    let error = requirements_implements(source, &Resolver(ABS), &implementation)
+        .expect_err("the implementation block and maps clause conflict");
+    assert!(error.message.contains("implements_block"));
+    assert!(error.message.contains("inline_maps_clause"));
+    assert!(error.message.contains("conflicts with"));
+
+    let standalone = parse_refinement(
+        "refinement R { impl Impl abs Abs map done = paid action pay(wrong: Bool, retry: N) -> settle(wrong) action pay(x: N, retry: N) -> stutter }",
+        &build(IMPL),
+        &build(ABS),
+    )
+    .expect_err("duplicates are diagnosed before either entry is resolved");
+    assert!(
+        standalone
+            .message
+            .contains("duplicate action correspondence")
+    );
+    assert!(standalone.message.contains("refinement_file"));
+}
+
+#[test]
+fn requirements_routes_lower_to_the_same_typed_target() {
+    let explicit = r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    map done = paid
+    action pay(x: N, retry: N) -> settle(x)
+  }
+  type N = 0..1
+  state { paid: Bool }
+  init { paid = false }
+  action pay(x: N, retry: N) { paid = true }
+}"#;
+    let inline = r#"requirements Impl {
+  implements Abs from "abs.fsl" { map done = paid }
+  type N = 0..1
+  state { paid: Bool }
+  init { paid = false }
+  action pay(x: N, retry: N) maps settle(x) { paid = true }
+}"#;
+    let explicit_contract = requirements_implements(explicit, &Resolver(ABS), &build(explicit))
+        .expect("explicit implements route")
+        .expect("implements contract");
+    let inline_contract = requirements_implements(inline, &Resolver(ABS), &build(inline))
+        .expect("inline maps route")
+        .expect("implements contract");
+    let explicit_mapping = &explicit_contract.refinement.action_correspondences["pay"];
+    let inline_mapping = &inline_contract.refinement.action_correspondences["pay"];
+    assert_eq!(explicit_mapping.target, inline_mapping.target);
+    assert_eq!(
+        explicit_mapping.origin,
+        CorrespondenceOrigin::ImplementsBlock
+    );
+    assert_eq!(
+        inline_mapping.origin,
+        CorrespondenceOrigin::InlineMapsClause
+    );
+}
+
+#[test]
+fn requirements_implicit_auto_returns_an_error_instead_of_indexing_past_params() {
+    let abstraction = "spec Abs { type N = 0..1 state { done: Bool } init { done = false } action pay(x: N, y: N) { done = true } }";
+    let source = r#"requirements Impl {
+  implements Abs from "abs.fsl" { map done = paid }
+  type N = 0..1
+  state { paid: Bool }
+  init { paid = false }
+  action pay(x: N) { paid = true }
+}"#;
+    let implementation = build(source);
+    let error = requirements_implements(source, &Resolver(abstraction), &implementation)
+        .expect_err("arity mismatch must be diagnosed");
+    assert!(error.message.contains("has 1 arguments, expected 2"));
+}
+
+#[test]
+fn auto_correspondence_checks_process_actor_compatibility() {
+    let abstraction = r"business Abs {
+  actor Manager
+  entity Case
+  process Case {
+    stages Open, Done
+    initial Open
+    transition approve Open -> Done by Manager
+  }
+}
+verify { instances Case = 2 }
+";
+    let source = r#"requirements Impl {
+  implements Abs from "abs.fsl" { }
+  process Case {
+    stages Open, Done
+    initial Open
+    transition approve Open -> Done by System
+  }
+}
+verify { instances Case = 2 }
+"#;
+    let implementation = build(source);
+    let error = requirements_implements(source, &Resolver(abstraction), &implementation)
+        .expect_err("auto-mapped actors must match");
+    assert!(error.message.contains("actor mismatch"));
+    assert!(error.message.contains("System"));
+    assert!(error.message.contains("Manager"));
+}

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
 use fsl_core::{
-    ActionDef, ActionGuard, ActionMapTarget, FslValue as Value, KernelBinder as Binder,
+    ActionCorrespondenceTarget, ActionDef, ActionGuard, FslValue as Value, KernelBinder as Binder,
     KernelExpr as Expr, KernelLValue as LValue, KernelModel, KernelStatement as Statement,
     ModelError, ParamDef, Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef,
     display_name, insert_requirement_metadata, model_warnings, state_summary,
@@ -1295,12 +1295,12 @@ pub fn check_refinement(
         &eval_model,
     )?;
     let action_map = mapping
-        .action_maps
+        .action_correspondences
         .iter()
         .map(|(name, mapping)| {
             let target = match &mapping.target {
-                ActionMapTarget::Stutter => "stutter".to_owned(),
-                ActionMapTarget::Action { name, .. } => name.clone(),
+                ActionCorrespondenceTarget::Stutter => "stutter".to_owned(),
+                ActionCorrespondenceTarget::Action { action, .. } => action.0.clone(),
             };
             (name.clone(), target)
         })
@@ -1419,9 +1419,9 @@ pub fn check_refinement(
                 mapping,
                 &eval_model,
             )?;
-            let action_map = &mapping.action_maps[&enabled.action];
+            let action_map = &mapping.action_correspondences[&enabled.action];
             match &action_map.target {
-                ActionMapTarget::Stutter => {
+                ActionCorrespondenceTarget::Stutter => {
                     if alpha_before != alpha_after {
                         check.failure = Some(refinement_failure(
                             "stutter_changed_abs",
@@ -1435,7 +1435,8 @@ pub fn check_refinement(
                         return Ok(check);
                     }
                 }
-                ActionMapTarget::Action { name, args } => {
+                ActionCorrespondenceTarget::Action { action, args } => {
+                    let name = &action.0;
                     let abs_action = abstraction
                         .actions
                         .iter()

--- a/rust/fsl-runtime/tests/action_correspondence.rs
+++ b/rust/fsl-runtime/tests/action_correspondence.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    CoreError, FileResolver, FsResolver, build_model, parse_kernel_source, parse_refinement,
+    requirements_implements,
+};
+use fsl_runtime::check_refinement;
+
+fn build(source: &str) -> fsl_core::KernelModel {
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
+    build_model(kernel).expect("build model")
+}
+
+struct Resolver(&'static str);
+
+impl FileResolver for Resolver {
+    fn read(&self, _: &str) -> Result<String, CoreError> {
+        Ok(self.0.to_owned())
+    }
+}
+
+#[test]
+fn explicit_and_auto_correspondences_have_the_same_concrete_verdict() {
+    const ABS: &str =
+        "spec Abs { type N = 0..1 state { x: N } init { x = 0 } action step(v: N) { x = v } }";
+    let implementation = build(
+        "spec Impl { type N = 0..1 state { x: N } init { x = 0 } action step(v: N) { x = v } }",
+    );
+    let abstraction = build(ABS);
+    let explicit = parse_refinement(
+        "refinement R { impl Impl abs Abs map x = x action step(v: N) -> step(v) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("explicit correspondence");
+    let automatic = parse_refinement(
+        "refinement R { impl Impl abs Abs maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("automatic correspondence");
+
+    let explicit_result = check_refinement(&implementation, &abstraction, &explicit, 2)
+        .expect("explicit refinement check");
+    let automatic_result = check_refinement(&implementation, &abstraction, &automatic, 2)
+        .expect("automatic refinement check");
+    assert_eq!(explicit_result, automatic_result);
+
+    for source in [
+        r#"requirements Impl {
+  implements Abs from "abs.fsl" { map x = x action step(v: N) -> step(v) }
+  type N = 0..1 state { x: N } init { x = 0 }
+  action step(v: N) { x = v }
+}"#,
+        r#"requirements Impl {
+  implements Abs from "abs.fsl" { map x = x }
+  type N = 0..1 state { x: N } init { x = 0 }
+  action step(v: N) maps step(v) { x = v }
+}"#,
+    ] {
+        let routed_implementation = build(source);
+        let contract = requirements_implements(source, &Resolver(ABS), &routed_implementation)
+            .expect("requirements correspondence route")
+            .expect("implements contract");
+        let routed_result = check_refinement(
+            &routed_implementation,
+            &contract.abstraction,
+            &contract.refinement,
+            2,
+        )
+        .expect("routed refinement check");
+        assert_eq!(explicit_result, routed_result);
+    }
+}

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -48,14 +48,14 @@ pub use lexer::{LexError, Token, TokenKind, lex};
 pub use parser::{ParseError, parse_expr, parse_surface_document, parse_surface_spec};
 pub use surface::{
     AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, BusinessGoalBody,
-    BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute, GovernanceArtifactRef,
-    GovernanceDelegateItem, GovernanceItem, HelpfulAction, LValue, MapsClause, MetaTag, Param,
-    PreservationItem, ProcessCover, ProcessField, ProcessFields, ProcessItem, ProcessTransition,
-    RefinementItem, RefinementParam, RequirementAction, RequirementActionItem,
-    RequirementBlockItem, RequirementBranch, RequirementsItem, SpecItem, StateField, Statement,
-    SurfaceAgent, SurfaceBusiness, SurfaceCompose, SurfaceDocument, SurfaceGovernance,
-    SurfaceRefinement, SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef, TimeItem, TypeExpr,
-    VerifyItem,
+    BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute, CorrespondenceOrigin,
+    GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem, HelpfulAction, LValue,
+    MapsClause, MetaTag, Param, PreservationItem, ProcessCover, ProcessField, ProcessFields,
+    ProcessItem, ProcessTransition, RefinementItem, RefinementParam, RequirementAction,
+    RequirementActionItem, RequirementBlockItem, RequirementBranch, RequirementsItem, SpecItem,
+    StateField, Statement, SurfaceAgent, SurfaceBusiness, SurfaceCompose, SurfaceDocument,
+    SurfaceGovernance, SurfaceRefinement, SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef,
+    TimeItem, TypeExpr, VerifyItem,
 };
 pub use syntax_expr::{
     SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxIdent, SyntaxLValue, SyntaxOperator,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -7,14 +7,14 @@ use crate::annotation_parse;
 use crate::syntax_expr::{ExpressionMode, parse_tokens_expression};
 use crate::{
     AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, Annotations, Binder,
-    BusinessGoalBody, BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute, Expr,
-    GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem, HelpfulAction, LValue,
-    MapsClause, MetaTag, Param, PreservationItem, ProcessCover, ProcessField, ProcessFields,
-    ProcessItem, ProcessTransition, QualifiedName, RefinementItem, RefinementParam,
-    RequirementAction, RequirementActionItem, RequirementBlockItem, RequirementBranch,
-    RequirementsItem, Span, SpecItem, Statement, SurfaceBusiness, SurfaceCompose, SurfaceDocument,
-    SurfaceGovernance, SurfaceRefinement, SurfaceRequirements, SurfaceSpec, SyncAction, SyncRef,
-    TimeItem, Token, TokenKind, TypeExpr, VerifyItem, lex,
+    BusinessGoalBody, BusinessItem, BusinessPolicyBody, ComposeItem, ControlAttribute,
+    CorrespondenceOrigin, Expr, GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem,
+    HelpfulAction, LValue, MapsClause, MetaTag, Param, PreservationItem, ProcessCover,
+    ProcessField, ProcessFields, ProcessItem, ProcessTransition, QualifiedName, RefinementItem,
+    RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
+    RequirementBranch, RequirementsItem, Span, SpecItem, Statement, SurfaceBusiness,
+    SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement, SurfaceRequirements,
+    SurfaceSpec, SyncAction, SyncRef, TimeItem, Token, TokenKind, TypeExpr, VerifyItem, lex,
 };
 
 fn join_span(start: Span, end: Span) -> Span {
@@ -241,7 +241,7 @@ impl Parser {
         self.expect_symbol("{")?;
         let mut items = Vec::new();
         while !self.eat_symbol("}") {
-            items.push(self.refinement_item()?);
+            items.push(self.refinement_item(CorrespondenceOrigin::RefinementFile)?);
         }
         Ok(SurfaceRefinement { name, items })
     }
@@ -500,7 +500,7 @@ impl Parser {
             if self.peek_ident("impl") || self.peek_ident("abs") {
                 return Err(self.error("impl and abs are not valid inside implements"));
             }
-            items.push(self.refinement_item()?);
+            items.push(self.refinement_item(CorrespondenceOrigin::ImplementsBlock)?);
         }
         Ok(RequirementsItem::Implements {
             name,
@@ -1232,7 +1232,10 @@ impl Parser {
             || self.peek_symbol("{")
     }
 
-    fn refinement_item(&mut self) -> Result<RefinementItem, ParseError> {
+    fn refinement_item(
+        &mut self,
+        origin: CorrespondenceOrigin,
+    ) -> Result<RefinementItem, ParseError> {
         if self.eat_ident("impl") {
             return Ok(RefinementItem::Impl(self.expect_ident()?));
         }
@@ -1297,6 +1300,7 @@ impl Parser {
                 name,
                 params,
                 target,
+                origin,
                 span,
             });
         }
@@ -1577,7 +1581,7 @@ impl Parser {
     fn next_is_type_delimiter(&self) -> bool {
         matches!(
             &self.peek_n(1).kind,
-            TokenKind::Symbol(symbol) if matches!(symbol.as_str(), "," | ">" | "}" | "->" | "=")
+            TokenKind::Symbol(symbol) if matches!(symbol.as_str(), "," | ")" | ">" | "}" | "->" | "=")
         )
     }
 

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -225,6 +225,26 @@ pub enum ActionTarget {
     Action(String, Vec<Expr>),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CorrespondenceOrigin {
+    InlineMapsClause,
+    ImplementsBlock,
+    RefinementFile,
+    Auto,
+}
+
+impl CorrespondenceOrigin {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InlineMapsClause => "inline_maps_clause",
+            Self::ImplementsBlock => "implements_block",
+            Self::RefinementFile => "refinement_file",
+            Self::Auto => "auto",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RefinementItem {
     Impl(String),
@@ -240,6 +260,7 @@ pub enum RefinementItem {
         name: String,
         params: Vec<RefinementParam>,
         target: ActionTarget,
+        origin: CorrespondenceOrigin,
         span: Span,
     },
     PreserveProgress {
@@ -1038,6 +1059,7 @@ impl RefinementItem {
                 name,
                 params,
                 target,
+                origin: _,
                 span,
             } => json!([
                 "action_map",

--- a/rust/fsl-tools/src/refinement_analysis.rs
+++ b/rust/fsl-tools/src/refinement_analysis.rs
@@ -135,6 +135,7 @@ pub fn analyze_refinement(refinement: &SurfaceRefinement) -> Value {
                 name,
                 params,
                 target,
+                origin,
                 span,
             } => {
                 let id = format!("action_map:{name}");
@@ -144,6 +145,7 @@ pub fn analyze_refinement(refinement: &SurfaceRefinement) -> Value {
                         "params".to_owned(),
                         json!(params.iter().map(|param| &param.name).collect::<Vec<_>>()),
                     );
+                    object.insert("origin".to_owned(), json!(origin.as_str()));
                 }
                 insert_node(&mut nodes, value);
                 insert_edge(&mut edges, edge(&ref_id, "declares", &id));

--- a/rust/fsl-tools/tests/refinement_correspondence.rs
+++ b/rust/fsl-tools/tests/refinement_correspondence.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_syntax::{SurfaceDocument, parse_surface_document};
+use fsl_tools::analyze_refinement;
+
+#[test]
+fn refinement_graph_exposes_correspondence_origin_and_shared_progress_identity() {
+    let document = parse_surface_document(
+        "refinement R { impl Impl abs Abs action step(v: N) -> run(v) preserve progress { respond Eventually by step } }",
+    )
+    .expect("parse refinement");
+    let SurfaceDocument::Refinement(refinement) = document else {
+        panic!("expected refinement document");
+    };
+    let graph = analyze_refinement(&refinement);
+    let action = graph["nodes"]
+        .as_array()
+        .expect("nodes")
+        .iter()
+        .find(|node| node["id"] == "action_map:step")
+        .expect("action node");
+    assert_eq!(action["origin"], "refinement_file");
+    assert!(
+        graph["edges"]
+            .as_array()
+            .expect("edges")
+            .iter()
+            .any(|edge| {
+                edge["from"] == "progress_response:Eventually" && edge["to"] == "impl_action:step"
+            })
+    );
+}

--- a/rust/fsl-verifier/src/refinement.rs
+++ b/rust/fsl-verifier/src/refinement.rs
@@ -87,7 +87,16 @@ pub async fn check_refinement_progress<S: SmtSolver>(
     let checked = mapping
         .progress
         .iter()
-        .map(|declaration| (declaration.leads_to.clone(), declaration.actions.clone()))
+        .map(|declaration| {
+            (
+                declaration.leads_to.clone(),
+                declaration
+                    .actions
+                    .iter()
+                    .map(|action| action.0.clone())
+                    .collect(),
+            )
+        })
         .collect();
     Ok(ProgressCheck {
         violation: result.leadsto_violation,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -10006,6 +10006,11 @@ fn project_traceability_output(path: &Path) -> Result<Value, String> {
         let fsl_syntax::SurfaceDocument::Refinement(refinement) = document else {
             return Err("expected refinement mapping".to_owned());
         };
+        let mapping_source = std::fs::read_to_string(&mapping_path)
+            .map_err(|error| format!("failed to read {}: {error}", mapping_path.display()))?;
+        let checked_refinement =
+            fsl_core::parse_refinement(&mapping_source, &implementation.model, &abstraction.model)
+                .map_err(|error| error.message)?;
         let display = analysis_display_path(&mapping_path);
         let refinement_id = format!("refinement:{layer}->{target}:{}", refinement.name);
         let file_id = format!("file:{layer}->{target}:{display}");
@@ -10096,76 +10101,6 @@ fn project_traceability_output(path: &Path) -> Result<Value, String> {
                         );
                     }
                 }
-                fsl_syntax::RefinementItem::Action {
-                    name,
-                    target: action_target,
-                    span,
-                    ..
-                } => {
-                    let map_id = format!("action_map:{layer}->{target}:{name}");
-                    let mut map_node = project_analysis_node(&map_id, "action_map", name);
-                    if let Value::Object(object) = &mut map_node {
-                        object.insert("loc".to_owned(), span.python_loc());
-                        object.insert("layer".to_owned(), json!(layer));
-                        object.insert("target_layer".to_owned(), json!(target));
-                    }
-                    insert_analysis_item(&mut nodes, map_node);
-                    insert_analysis_item(
-                        &mut edges,
-                        project_analysis_edge(&refinement_id, "declares", &map_id),
-                    );
-                    let impl_id = format!("{layer}:action:{name}");
-                    insert_analysis_item(
-                        &mut edges,
-                        project_analysis_edge(&map_id, "maps_action", &impl_id),
-                    );
-                    match action_target {
-                        fsl_syntax::ActionTarget::Stutter => {
-                            let stutter_id = format!("stutter_map:{layer}->{target}:{name}");
-                            let mut stutter =
-                                project_analysis_node(&stutter_id, "stutter_map", name);
-                            stutter
-                                .as_object_mut()
-                                .expect("node object")
-                                .insert("loc".to_owned(), span.python_loc());
-                            insert_analysis_item(&mut nodes, stutter);
-                            insert_analysis_item(
-                                &mut edges,
-                                project_analysis_edge(&map_id, "stutters", &stutter_id),
-                            );
-                        }
-                        fsl_syntax::ActionTarget::Action(abs_action, _) => {
-                            let abs_id = format!("{target}:action:{abs_action}");
-                            insert_analysis_item(
-                                &mut edges,
-                                project_analysis_edge(&impl_id, "maps_action", &abs_id),
-                            );
-                            if let Some(requirements) =
-                                abstraction.covers.get(&format!("action:{abs_action}"))
-                            {
-                                for requirement in requirements {
-                                    let mut anchor = project_analysis_edge(
-                                        &format!("{target}:{requirement}"),
-                                        "lower_anchor",
-                                        &impl_id,
-                                    );
-                                    if let Value::Object(object) = &mut anchor {
-                                        object.insert(
-                                            "formal_status".to_owned(),
-                                            json!("not_a_violation"),
-                                        );
-                                        object.insert(
-                                            "via".to_owned(),
-                                            json!("refinement_action_map"),
-                                        );
-                                        object.insert("layer".to_owned(), json!(layer));
-                                    }
-                                    insert_analysis_item(&mut edges, anchor);
-                                }
-                            }
-                        }
-                    }
-                }
                 fsl_syntax::RefinementItem::PreserveProgress { span, .. } => {
                     let id = format!("preserve_progress:{layer}->{target}:{}", refinement.name);
                     let mut node =
@@ -10180,6 +10115,66 @@ fn project_traceability_output(path: &Path) -> Result<Value, String> {
                     );
                 }
                 _ => {}
+            }
+        }
+        for correspondence in checked_refinement.action_correspondences.values() {
+            let name = &correspondence.impl_action.0;
+            let map_id = format!("action_map:{layer}->{target}:{name}");
+            let mut map_node = project_analysis_node(&map_id, "action_map", name);
+            if let Value::Object(object) = &mut map_node {
+                object.insert("loc".to_owned(), correspondence.span.python_loc());
+                object.insert("layer".to_owned(), json!(layer));
+                object.insert("target_layer".to_owned(), json!(target));
+                object.insert("origin".to_owned(), json!(correspondence.origin.as_str()));
+            }
+            insert_analysis_item(&mut nodes, map_node);
+            insert_analysis_item(
+                &mut edges,
+                project_analysis_edge(&refinement_id, "declares", &map_id),
+            );
+            let impl_id = format!("{layer}:action:{name}");
+            insert_analysis_item(
+                &mut edges,
+                project_analysis_edge(&map_id, "maps_action", &impl_id),
+            );
+            match &correspondence.target {
+                fsl_core::ActionCorrespondenceTarget::Stutter => {
+                    let stutter_id = format!("stutter_map:{layer}->{target}:{name}");
+                    let mut stutter = project_analysis_node(&stutter_id, "stutter_map", name);
+                    stutter
+                        .as_object_mut()
+                        .expect("node object")
+                        .insert("loc".to_owned(), correspondence.span.python_loc());
+                    insert_analysis_item(&mut nodes, stutter);
+                    insert_analysis_item(
+                        &mut edges,
+                        project_analysis_edge(&map_id, "stutters", &stutter_id),
+                    );
+                }
+                fsl_core::ActionCorrespondenceTarget::Action { action, .. } => {
+                    let abs_id = format!("{target}:action:{}", action.0);
+                    insert_analysis_item(
+                        &mut edges,
+                        project_analysis_edge(&impl_id, "maps_action", &abs_id),
+                    );
+                    if let Some(requirements) =
+                        abstraction.covers.get(&format!("action:{}", action.0))
+                    {
+                        for requirement in requirements {
+                            let mut anchor = project_analysis_edge(
+                                &format!("{target}:{requirement}"),
+                                "lower_anchor",
+                                &impl_id,
+                            );
+                            if let Value::Object(object) = &mut anchor {
+                                object.insert("formal_status".to_owned(), json!("not_a_violation"));
+                                object.insert("via".to_owned(), json!("refinement_action_map"));
+                                object.insert("layer".to_owned(), json!(layer));
+                            }
+                            insert_analysis_item(&mut edges, anchor);
+                        }
+                    }
+                }
             }
         }
     }
@@ -11786,7 +11781,9 @@ fn run_refine(
             "progress".to_owned(),
             json!({
                 "leadsTo": display(&violation.name),
-                "actions": declaration.map(|item| item.actions.clone()).unwrap_or_default(),
+                "actions": declaration
+                    .map(|item| item.actions.iter().map(|action| action.0.clone()).collect::<Vec<_>>())
+                    .unwrap_or_default(),
             }),
         );
         output.insert(
@@ -12083,12 +12080,17 @@ fn run_verify(
         return (semantic_error_output(&error), 2);
     }
     let mut has_trace_contract = false;
+    let mut implements = None;
     if let Ok(model) = load_model(path) {
         match validate_requirement_traces(path, &model) {
             Ok((Some(failure), _)) => return (failure, 2),
             Ok((None, has_contract)) => has_trace_contract = has_contract,
             Err(error) => return (semantic_error_output(&error), 2),
         }
+        implements = match implements_result(path, &model, depth) {
+            Ok(implements) => implements,
+            Err(error) => return (error_output("type", &error), 2),
+        };
     }
     let deadlock = match DeadlockMode::parse(deadlock_mode) {
         Ok(mode) => mode,
@@ -12124,8 +12126,7 @@ fn run_verify(
     };
     if let Value::Object(envelope) = &mut output
         && envelope.get("result").and_then(Value::as_str) != Some("error")
-        && let Ok(model) = load_model(path)
-        && let Ok(Some(implements)) = implements_result(path, &model, depth)
+        && let Some(implements) = implements
     {
         envelope.insert("implements".to_owned(), implements);
         if let Some(Value::Array(warnings)) = envelope.get_mut("warnings") {

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -70,6 +70,29 @@ fn native_check_and_verify_share_the_core_duplicate_write_gate() {
 }
 
 #[test]
+fn native_check_and_verify_reject_duplicate_correspondence_origins() {
+    let fixture = "rust/fslc/tests/fixtures/action_correspondence_duplicate.fsl";
+
+    for args in [
+        vec!["check", fixture],
+        vec!["verify", fixture, "--no-cache"],
+    ] {
+        let command = args[0];
+        let (value, status) = run_cli(&args);
+        assert_eq!(status, 2, "{command}: {value}");
+        assert_eq!(value["result"], "error", "{command}");
+        assert_eq!(value["kind"], "type", "{command}");
+        let message = value["message"].as_str().expect("diagnostic message");
+        assert!(message.contains("implements_block"), "{command}: {message}");
+        assert!(
+            message.contains("inline_maps_clause"),
+            "{command}: {message}"
+        );
+        assert_eq!(message.matches(" at ").count(), 2, "{command}: {message}");
+    }
+}
+
+#[test]
 fn native_cli_preserves_bmc_outcomes() {
     let (verified, status) = run_cli(&[
         "verify",

--- a/rust/fslc/tests/fixtures/action_correspondence_abs.fsl
+++ b/rust/fslc/tests/fixtures/action_correspondence_abs.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec CorrespondenceAbs {
+  type N = 0..1
+  state { done: Bool }
+  init { done = false }
+  action settle(x: N) { done = true }
+}

--- a/rust/fslc/tests/fixtures/action_correspondence_duplicate.fsl
+++ b/rust/fslc/tests/fixtures/action_correspondence_duplicate.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements CorrespondenceImpl {
+  implements CorrespondenceAbs from "action_correspondence_abs.fsl" {
+    map done = paid
+    action pay(x: N) -> settle(x)
+  }
+  type N = 0..1
+  state { paid: Bool }
+  init { paid = false }
+  action pay(x: N) maps settle(x) { paid = true }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -582,6 +582,13 @@ refinement <Name> {
 }
 ```
 
+Standalone action items, inline `implements` items, requirement-action `maps`,
+and auto/identity synthesis share one typed action-correspondence validator.
+Typed impl parameters, target arity/argument expressions, and auto actor
+compatibility are checked identically. Duplicate diagnostics identify both
+origin kinds and line/column sites; auto synthesis never replaces an explicit
+entry.
+
 Give impl and abs distinct enum/struct type names. Refinement merges type
 metadata by name; a same-named enum/struct with a different member list/field
 set on each side is rejected as `kind: "type"` (exit 2) rather than silently
@@ -1471,7 +1478,7 @@ verify {
   `maps auto` covers same-name kernel-wrapper actions). Writing both a `maps`
   clause on an action and a matching inline `action ...` item for the same impl
   action name is a duplicate-correspondence error (`kind: "type"`,
-  "duplicate action map for '<name>'"). An inline `action` item cannot target
+  with both origin kinds and locations). An inline `action` item cannot target
   a `branches`-split action by its pre-split name — reference the generated
   `name__b<N>` alias. Auto-mapped process transitions are statically
   actor-checked; an actor mismatch is a check-time type error.


### PR DESCRIPTION
## Problem
Action correspondences entered through standalone refinement files, requirements implements blocks, action-level maps, and auto synthesis, but their validation and consumers were split.

## Contract change
- Lower every route to one typed ActionCorrespondence with origin and span.
- Centralize duplicate, parameter/type, target/arity, argument, and auto-actor checks.
- Use ActionRef for runtime/progress and checked correspondences for model-aware project traceability.
- Report both origin kinds and locations for duplicates.
- Make verify fail closed on invalid implements correspondences, matching check.
- Preserve public refinement success JSON; analysis origin is additive.

## Evidence
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked (all implementation tests passed; four issue_190 approval tests cannot create signed temporary commits because the local 1Password signing socket is unavailable)
- cargo test --workspace --locked with those four environment-only tests skipped
- cargo build --workspace --locked
- focused core/runtime/tools/CLI correspondence regressions
- Python full suite: 1447 passed, 81 skipped; three temporary-Git tests hit the same signing-socket environment failure and the generated language snapshot was then regenerated and rechecked
- focused Python/reference suite: 60 passed
- independent review: green

Closes #238