### PR TITLE
feat(requirements): support stage access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Requirements expressions now accept `stage(entity)` and qualified
+  `<process-path>.stage(entity)` through the same structural node and resolver
+  as business expressions. Entity-typed binders/parameters select the process;
+  qualified process declarations disambiguate shared entity types; generated
+  stage maps remain Kernel detail while public origins, explain output, and
+  violations retain the source accessor (issue #243).
 - Conditional expressions (`if condition then a else b`) are now accepted in
   every expression context. The shared parser replaces the refinement-only
   path; concrete, explicit, symbolic, analysis, mutation, formatter, LSP, and

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -37,9 +37,9 @@ exhaustively; the registry says what may exist there.
   eval/regress/drift/compat`, `formal_result:"not_run"`) and `ai-agent`
   (`is_ai_agent_source`; structural analysis, `agent_analyzed`, not formal proof).
 - `MONITOR_EXCLUSIONS: dict[str, str]` — repo-relative path → reason, for
-  individual files the Monitor legitimately rejects. Today exactly one:
-  `examples/self/no_actions.fsl` (deliberate no-action edge fixture; BMC side
-  covered by `tests/test_self_examples.py`).
+  individual files the frozen Python Monitor legitimately rejects. Each entry
+  names its active native or BMC-side coverage, and a stale entry fails the
+  harness once the Monitor starts accepting it.
 
 ## Classification (automatic, in the harness)
 

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -169,13 +169,17 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
 9. The name of the expanded spec is the name of `requirements`. All other items
    (type/enum/struct/state/init/top-level actions, etc.) pass through unchanged.
 10. `terminal { <expr> }` is one of these pass-through items (added as a
-    `requirements_item` grammar alternative, #69) — it takes the generic
-    `_expand_item` fallback (`return [item], []`), so no dialects.py case was
-    added for it specifically. Only one `terminal` block is allowed per spec
-    (the kernel's own rule, unchanged). If the spec uses `process E { ... }`,
-    the predicate is written against the synthesized stage map
-    (`e_stage[c]`, rule 2 above) — the natural-language `stage(c)` form is
-    business-only (§3.2 rule 7).
+    `requirements_item` grammar alternative (#69). Only one `terminal` block
+    is allowed per spec (the kernel's own rule, unchanged). The shared stage
+    resolver accepts `stage(c)` in this and every other requirements expression
+    context, derives the process from `c`'s entity type, and rewrites it to
+    `e_stage[c]`. Requirements never derive terminal states from process sinks.
+11. A qualified process declaration (`process claims.Claim`) keeps its shared
+    `SymbolPath`. Several process paths may have the same final entity segment;
+    unqualified `stage(c)` then reports every candidate, while
+    `claims.Claim.stage(c)` selects the exact path. Business and requirements
+    use the same `Expr::Stage` node and resolver, and public Kernel provenance
+    records both the lowered state symbol and source accessor span.
 
 ### 2.3 Tests (tests/test_req_dialect.py)
 

--- a/docs/DESIGN-requirements-stage.md
+++ b/docs/DESIGN-requirements-stage.md
@@ -1,0 +1,38 @@
+# Requirements stage access
+
+Status: accepted
+
+## Contract
+
+Business and requirements expressions use one structural source node:
+`Expr::Stage { process: Option<SymbolPath>, entity, ... }`. The node must be
+eliminated before checked Kernel construction. Concrete evaluation, symbolic
+evaluation, and public Kernel export reject an unlowered node.
+
+The resolver tracks typed parameters and binders. `stage(c)` selects every
+process whose final entity type is `c`'s type. One candidate lowers to the
+generated process stage-map index. Zero candidates and non-entity/unbound
+arguments are type errors. Several candidates are ambiguous and list their
+paths. `<path>.stage(c)` filters by the exact structural `SymbolPath`.
+
+Process declarations accept the same path representation. An unqualified
+`process Claim` retains the existing generated names. Qualified declarations,
+such as `process claims.Claim`, share the entity type `Claim` while generating
+path-distinct enum and state symbols.
+
+The resolved map value supplies the expected stage enum, so ordinary Kernel
+type checking validates the compared member. Requirements `terminal` remains
+explicit; process sinks are not promoted to terminal states.
+
+## Origin and presentation
+
+Lowering binds the generated stage map to its process declaration and binds
+each source stage access to its containing Kernel target. Public Kernel v2
+therefore contains the lowered state symbol plus a `resolve_stage_access`
+origin step and source span. Explain and violation formatting structurally
+recognize generated stage-map origins and render `stage(c)` without changing
+the checked expression.
+
+Acceptance expressions use the same resolver before Monitor replay. No
+dialect-specific runtime implementation or generated-name source fallback is
+permitted.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -632,11 +632,11 @@ variable.
   states**, `terminal` lets you select **which stops are intentional**.
   Example: `terminal { status == Done or status == Failed }`.
   - **requirements**: `terminal { }` is a `requirements_item` and passes
-    through unchanged to the kernel spec (§13.2). Inside a spec that uses
-    `process E { ... }`, write the predicate against the synthesized stage
-    map — the lowercased process/entity name + `_stage` (e.g. `process Claim`
-    → `claim_stage`), so `terminal { forall c: Claim { claim_stage[c] ==
-    Approved or claim_stage[c] == Rejected } }`.
+    through to the kernel spec (§13.2). Inside a spec that uses `process E {
+    ... }`, use the source-level accessor, for example `terminal { forall c:
+    Claim { stage(c) == Approved or stage(c) == Rejected } }`. It resolves from
+    `c`'s entity type and lowers to the generated stage map; the generated
+    `claim_stage` name is not part of requirements source syntax.
   - **business**: no `terminal` syntax exists at all — it is derived
     automatically from each process's sink stages (stages with no outgoing
     `transition`); see §13.3.
@@ -1587,11 +1587,18 @@ verify {
   `submit[a <= AUTO_LIMIT]`), and the `maps` clause provides the action
   correspondence to the upper layer.
 - `terminal { <expr> }` is allowed at the top level of a `requirements` spec
-  and passes through to the kernel unchanged (§6) — there is exactly one
-  `terminal` block per spec, same as the kernel. If the spec uses
-  `process E { ... }`, the predicate must reference the synthesized stage map
-  (`<entity-lowercased>_stage`, e.g. `claim_stage` for `process Claim`), not
-  `stage(c)` (that natural-language form is business-only, §13.3).
+  and lowers to the kernel (§6) — there is exactly one `terminal` block per
+  spec, same as the kernel. `stage(c)` is available in all requirements
+  expression contexts when `c` is a typed entity parameter or binder. The
+  entity type selects its process and stage enum, and the checked expression
+  lowers to the generated stage-map index. No sink stage becomes terminal
+  automatically in requirements.
+- A process may use a qualified path when one entity participates in several
+  processes: `process claims.Claim { ... }`. Unqualified `stage(c)` is an error
+  when several processes correspond to `Claim`; use
+  `claims.Claim.stage(c)` (arbitrary-depth `SymbolPath`) to select one. A
+  missing process, non-entity argument, unknown stage member, or unresolved
+  qualifier is a source-located type error.
 
 ### 13.3 Consulting layer: `business` (the fsl-biz dialect)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 |---|---|
 | [`DESIGN-layers.md`](DESIGN-layers.md) | **Shared kernel + three dialects** (consulting / requirements / design): overall concept and validation |
 | [`DESIGN-dialects.md`](DESIGN-dialects.md) | Implementation spec for the dialects (declaration tags, fsl-req, fsl-biz) |
+| [`DESIGN-requirements-stage.md`](DESIGN-requirements-stage.md) | Shared typed `stage()` resolution and lowering for business and requirements expressions |
 | [`DESIGN-dialect-dispatch.md`](DESIGN-dialect-dispatch.md) | Shared-lexer dialect registry, significant-token rules, document annotations, diagnostics, and frontend contract |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -715,11 +715,11 @@ variable.</p></div></details>
   states</strong>, <code>terminal</code> lets you select <strong>which stops are intentional</strong>.
   Example: <code>terminal { status == Done or status == Failed }</code>.</li>
 <li><strong>requirements</strong>: <code>terminal { }</code> is a <code>requirements_item</code> and passes
-    through unchanged to the kernel spec (§13.2). Inside a spec that uses
-    <code>process E { ... }</code>, write the predicate against the synthesized stage
-    map — the lowercased process/entity name + <code>_stage</code> (e.g. <code>process Claim</code>
-    → <code>claim_stage</code>), so <code>terminal { forall c: Claim { claim_stage[c] ==
-    Approved or claim_stage[c] == Rejected } }</code>.</li>
+    through to the kernel spec (§13.2). Inside a spec that uses <code>process E {
+    ... }</code>, use the source-level accessor, for example <code>terminal { forall c:
+    Claim { stage(c) == Approved or stage(c) == Rejected } }</code>. It resolves from
+    <code>c</code>'s entity type and lowers to the generated stage map; the generated
+    <code>claim_stage</code> name is not part of requirements source syntax.</li>
 <li><strong>business</strong>: no <code>terminal</code> syntax exists at all — it is derived
     automatically from each process's sink stages (stages with no outgoing
     <code>transition</code>); see §13.3.</li>
@@ -1610,11 +1610,18 @@ verify {
   <code>submit[a &lt;= AUTO_LIMIT]</code>), and the <code>maps</code> clause provides the action
   correspondence to the upper layer.</li>
 <li><code>terminal { &lt;expr&gt; }</code> is allowed at the top level of a <code>requirements</code> spec
-  and passes through to the kernel unchanged (§6) — there is exactly one
-  <code>terminal</code> block per spec, same as the kernel. If the spec uses
-  <code>process E { ... }</code>, the predicate must reference the synthesized stage map
-  (<code>&lt;entity-lowercased&gt;_stage</code>, e.g. <code>claim_stage</code> for <code>process Claim</code>), not
-  <code>stage(c)</code> (that natural-language form is business-only, §13.3).</li>
+  and lowers to the kernel (§6) — there is exactly one <code>terminal</code> block per
+  spec, same as the kernel. <code>stage(c)</code> is available in all requirements
+  expression contexts when <code>c</code> is a typed entity parameter or binder. The
+  entity type selects its process and stage enum, and the checked expression
+  lowers to the generated stage-map index. No sink stage becomes terminal
+  automatically in requirements.</li>
+<li>A process may use a qualified path when one entity participates in several
+  processes: <code>process claims.Claim { ... }</code>. Unqualified <code>stage(c)</code> is an error
+  when several processes correspond to <code>Claim</code>; use
+  <code>claims.Claim.stage(c)</code> (arbitrary-depth <code>SymbolPath</code>) to select one. A
+  missing process, non-entity argument, unknown stage member, or unresolved
+  qualifier is a source-located type error.</li>
 </ul>
 <h3 id="133-consulting-layer-business-the-fsl-biz-dialect">13.3 Consulting layer: <code>business</code> (the fsl-biz dialect)</h3>
 <p>Write business processes, policies, and KPIs with zero implementation

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -715,11 +715,11 @@ variable.</p></div></details>
   states</strong>, <code>terminal</code> lets you select <strong>which stops are intentional</strong>.
   Example: <code>terminal { status == Done or status == Failed }</code>.</li>
 <li><strong>requirements</strong>: <code>terminal { }</code> is a <code>requirements_item</code> and passes
-    through unchanged to the kernel spec (§13.2). Inside a spec that uses
-    <code>process E { ... }</code>, write the predicate against the synthesized stage
-    map — the lowercased process/entity name + <code>_stage</code> (e.g. <code>process Claim</code>
-    → <code>claim_stage</code>), so <code>terminal { forall c: Claim { claim_stage[c] ==
-    Approved or claim_stage[c] == Rejected } }</code>.</li>
+    through to the kernel spec (§13.2). Inside a spec that uses <code>process E {
+    ... }</code>, use the source-level accessor, for example <code>terminal { forall c:
+    Claim { stage(c) == Approved or stage(c) == Rejected } }</code>. It resolves from
+    <code>c</code>'s entity type and lowers to the generated stage map; the generated
+    <code>claim_stage</code> name is not part of requirements source syntax.</li>
 <li><strong>business</strong>: no <code>terminal</code> syntax exists at all — it is derived
     automatically from each process's sink stages (stages with no outgoing
     <code>transition</code>); see §13.3.</li>
@@ -1610,11 +1610,18 @@ verify {
   <code>submit[a &lt;= AUTO_LIMIT]</code>), and the <code>maps</code> clause provides the action
   correspondence to the upper layer.</li>
 <li><code>terminal { &lt;expr&gt; }</code> is allowed at the top level of a <code>requirements</code> spec
-  and passes through to the kernel unchanged (§6) — there is exactly one
-  <code>terminal</code> block per spec, same as the kernel. If the spec uses
-  <code>process E { ... }</code>, the predicate must reference the synthesized stage map
-  (<code>&lt;entity-lowercased&gt;_stage</code>, e.g. <code>claim_stage</code> for <code>process Claim</code>), not
-  <code>stage(c)</code> (that natural-language form is business-only, §13.3).</li>
+  and lowers to the kernel (§6) — there is exactly one <code>terminal</code> block per
+  spec, same as the kernel. <code>stage(c)</code> is available in all requirements
+  expression contexts when <code>c</code> is a typed entity parameter or binder. The
+  entity type selects its process and stage enum, and the checked expression
+  lowers to the generated stage-map index. No sink stage becomes terminal
+  automatically in requirements.</li>
+<li>A process may use a qualified path when one entity participates in several
+  processes: <code>process claims.Claim { ... }</code>. Unqualified <code>stage(c)</code> is an error
+  when several processes correspond to <code>Claim</code>; use
+  <code>claims.Claim.stage(c)</code> (arbitrary-depth <code>SymbolPath</code>) to select one. A
+  missing process, non-entity argument, unknown stage member, or unresolved
+  qualifier is a source-located type error.</li>
 </ul>
 <h3 id="133-consulting-layer-business-the-fsl-biz-dialect">13.3 Consulting layer: <code>business</code> (the fsl-biz dialect)</h3>
 <p>Write business processes, policies, and KPIs with zero implementation

--- a/examples/requirements_stage.fsl
+++ b/examples/requirements_stage.fsl
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved, Rejected
+    initial Draft
+    transition approve Draft -> Approved by Manager
+    transition reject Draft -> Rejected by Manager
+  }
+
+  invariant KnownStage {
+    forall c: Claim {
+      stage(c) == Draft or stage(c) == Approved or stage(c) == Rejected
+    }
+  }
+
+  terminal {
+    forall c: Claim { stage(c) == Approved or stage(c) == Rejected }
+  }
+}
+
+verify { instances Claim = 2 }

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
 
 use fsl_syntax::{
     ActionItem, Annotation, Annotations, Binder, BusinessGoalBody, BusinessItem,
@@ -11,11 +13,17 @@ use fsl_syntax::{
     SurfaceGovernance, SurfaceRequirements, SurfaceSpec, TimeItem, TypeExpr, VerifyItem,
 };
 
-use crate::{CoreError, KernelSpec, lower_direct_spec, substitute_expr};
+use crate::{
+    CoreError, KernelSpec, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite,
+    TERMINAL_TARGET, action_target, lower_direct_spec, state_target, substitute_expr,
+};
 
 #[derive(Clone)]
 struct Process {
     name: String,
+    entity: String,
+    path: Vec<String>,
+    qualifier: Option<String>,
     stages: Vec<String>,
     initial: String,
     transitions: Vec<ProcessTransition>,
@@ -102,19 +110,634 @@ fn process_state(name: &str) -> String {
     format!("{}_stage", name.to_lowercase())
 }
 
+fn process_symbol(path: &fsl_syntax::SymbolPath) -> String {
+    if !path.has_namespace() {
+        return path.name().to_owned();
+    }
+    let source = path.segments().join(".");
+    let mut encoded = String::with_capacity(source.len() * 2);
+    for byte in source.as_bytes() {
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    format!("0q{encoded}")
+}
+
+fn process_path(document: &str, path: &fsl_syntax::SymbolPath) -> Vec<String> {
+    if path.has_namespace() {
+        path.segments().to_vec()
+    } else {
+        vec![document.to_owned(), path.name().to_owned()]
+    }
+}
+
 fn process_enum(name: &str) -> String {
     format!("{name}Stage")
+}
+
+fn stage_access(process: &Process, entity: Expr) -> Expr {
+    Expr::Index(
+        Box::new(Expr::Var(process_state(&process.name))),
+        Box::new(entity),
+    )
 }
 
 fn stage_is(process: &Process, binder: &str, stage: &str) -> Expr {
     Expr::Binary {
         op: "==".to_owned(),
-        left: Box::new(Expr::Index(
-            Box::new(Expr::Var(process_state(&process.name))),
-            Box::new(Expr::Var(binder.to_owned())),
-        )),
+        left: Box::new(stage_access(process, Expr::Var(binder.to_owned()))),
         right: Box::new(Expr::Var(stage.to_owned())),
     }
+}
+
+fn qualified_type_name(name: &QualifiedName) -> String {
+    name.namespace.as_ref().map_or_else(
+        || name.name.clone(),
+        |namespace| format!("{namespace}.{}", name.name),
+    )
+}
+
+struct StageResolver<'a> {
+    processes: &'a [Process],
+    occurrences: RefCell<Vec<StageOccurrence>>,
+}
+
+struct StageOccurrence {
+    span: fsl_syntax::Span,
+    source: String,
+    state: String,
+}
+
+impl StageResolver<'_> {
+    fn new(processes: &[Process]) -> StageResolver<'_> {
+        StageResolver {
+            processes,
+            occurrences: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn take_occurrences(&self) -> Vec<StageOccurrence> {
+        std::mem::take(&mut *self.occurrences.borrow_mut())
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn expression(
+        &self,
+        expression: Expr,
+        environment: &BTreeMap<String, String>,
+    ) -> Result<Expr, CoreError> {
+        Ok(match expression {
+            Expr::Stage {
+                process: qualifier,
+                entity,
+                entity_span,
+                span,
+            } => {
+                let Expr::Var(name) = entity.as_ref() else {
+                    return Err(core_error(
+                        "stage(...) expects a typed entity parameter or binder".to_owned(),
+                        entity_span,
+                    ));
+                };
+                let Some(entity_type) = environment.get(name) else {
+                    return Err(core_error(
+                        format!(
+                            "stage({name}) cannot be resolved; '{name}' is not a typed parameter or binder"
+                        ),
+                        entity_span,
+                    ));
+                };
+                let candidates = self
+                    .processes
+                    .iter()
+                    .filter(|candidate| candidate.entity == *entity_type)
+                    .collect::<Vec<_>>();
+                let candidates = if let Some(path) = &qualifier {
+                    let matching = candidates
+                        .iter()
+                        .copied()
+                        .filter(|candidate| {
+                            path.segments() == [candidate.entity.as_str()]
+                                || path.segments() == candidate.path
+                        })
+                        .collect::<Vec<_>>();
+                    if matching.is_empty() {
+                        return Err(core_error(
+                            format!(
+                                "process path '{path}' does not resolve for entity type '{entity_type}'"
+                            ),
+                            path.span(),
+                        ));
+                    }
+                    matching
+                } else {
+                    candidates
+                };
+                let [resolved] = candidates.as_slice() else {
+                    if candidates.is_empty() {
+                        return Err(core_error(
+                            format!(
+                                "stage({name}) refers to type '{entity_type}', which has no process"
+                            ),
+                            span,
+                        ));
+                    }
+                    let names = candidates
+                        .iter()
+                        .map(|candidate| candidate.path.join("."))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(core_error(
+                        format!(
+                            "stage({name}) is ambiguous for type '{entity_type}'; candidates: {names}; use <process>.stage({name})"
+                        ),
+                        span,
+                    ));
+                };
+                self.occurrences.borrow_mut().push(StageOccurrence {
+                    span,
+                    source: qualifier.as_ref().map_or_else(
+                        || format!("stage({name})"),
+                        |path| format!("{path}.stage({name})"),
+                    ),
+                    state: process_state(&resolved.name),
+                });
+                stage_access(resolved, *entity)
+            }
+            Expr::Some(value) => Expr::Some(Box::new(self.expression(*value, environment)?)),
+            Expr::Set(values) => Expr::Set(
+                values
+                    .into_iter()
+                    .map(|value| self.expression(value, environment))
+                    .collect::<Result<_, _>>()?,
+            ),
+            Expr::Seq(values) => Expr::Seq(
+                values
+                    .into_iter()
+                    .map(|value| self.expression(value, environment))
+                    .collect::<Result<_, _>>()?,
+            ),
+            Expr::Struct { name, fields } => Expr::Struct {
+                name,
+                fields: fields
+                    .into_iter()
+                    .map(|(name, value)| Ok((name, self.expression(value, environment)?)))
+                    .collect::<Result<_, CoreError>>()?,
+            },
+            Expr::Call { name, args, span } => Expr::Call {
+                name,
+                args: args
+                    .into_iter()
+                    .map(|argument| self.expression(argument, environment))
+                    .collect::<Result<_, _>>()?,
+                span,
+            },
+            Expr::Index(base, index) => Expr::Index(
+                Box::new(self.expression(*base, environment)?),
+                Box::new(self.expression(*index, environment)?),
+            ),
+            Expr::Field(base, name) => {
+                Expr::Field(Box::new(self.expression(*base, environment)?), name)
+            }
+            Expr::Method {
+                receiver,
+                name,
+                args,
+            } => Expr::Method {
+                receiver: Box::new(self.expression(*receiver, environment)?),
+                name,
+                args: args
+                    .into_iter()
+                    .map(|argument| self.expression(argument, environment))
+                    .collect::<Result<_, _>>()?,
+            },
+            Expr::Binary { op, left, right } => Expr::Binary {
+                op,
+                left: Box::new(self.expression(*left, environment)?),
+                right: Box::new(self.expression(*right, environment)?),
+            },
+            Expr::Neg(value) => Expr::Neg(Box::new(self.expression(*value, environment)?)),
+            Expr::Not(value) => Expr::Not(Box::new(self.expression(*value, environment)?)),
+            Expr::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+                spans,
+            } => Expr::Conditional {
+                condition: Box::new(self.expression(*condition, environment)?),
+                then_expr: Box::new(self.expression(*then_expr, environment)?),
+                else_expr: Box::new(self.expression(*else_expr, environment)?),
+                spans,
+            },
+            Expr::Is { expr, pattern } => Expr::Is {
+                expr: Box::new(self.expression(*expr, environment)?),
+                pattern,
+            },
+            Expr::Quantified {
+                quantifier,
+                binder,
+                body,
+            } => {
+                let (binder, nested) = self.binder(binder, environment)?;
+                Expr::Quantified {
+                    quantifier,
+                    binder,
+                    body: Box::new(self.expression(*body, &nested)?),
+                }
+            }
+            Expr::Count {
+                name,
+                type_name,
+                condition,
+            } => {
+                let mut nested = environment.clone();
+                nested.insert(name.clone(), qualified_type_name(&type_name));
+                Expr::Count {
+                    name,
+                    type_name,
+                    condition: Box::new(self.expression(*condition, &nested)?),
+                }
+            }
+            Expr::Sum {
+                name,
+                type_name,
+                body,
+                condition,
+            } => {
+                let mut nested = environment.clone();
+                nested.insert(name.clone(), qualified_type_name(&type_name));
+                Expr::Sum {
+                    name,
+                    type_name,
+                    body: Box::new(self.expression(*body, &nested)?),
+                    condition: condition
+                        .map(|value| self.expression(*value, &nested).map(Box::new))
+                        .transpose()?,
+                }
+            }
+            Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
+                name,
+                expr: Box::new(self.expression(*expr, environment)?),
+                span,
+            },
+            Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
+                name,
+                left: Box::new(self.expression(*left, environment)?),
+                right: Box::new(self.expression(*right, environment)?),
+            },
+            Expr::TernaryNamed {
+                name,
+                first,
+                second,
+                third,
+            } => Expr::TernaryNamed {
+                name,
+                first: Box::new(self.expression(*first, environment)?),
+                second: Box::new(self.expression(*second, environment)?),
+                third: Box::new(self.expression(*third, environment)?),
+            },
+            Expr::BinderNamed { name, binder } => {
+                let (binder, _) = self.binder(binder, environment)?;
+                Expr::BinderNamed { name, binder }
+            }
+            other => other,
+        })
+    }
+
+    fn binder(
+        &self,
+        binder: Binder,
+        environment: &BTreeMap<String, String>,
+    ) -> Result<(Binder, BTreeMap<String, String>), CoreError> {
+        let mut nested = environment.clone();
+        let binder = match binder {
+            Binder::Typed {
+                name,
+                type_name,
+                where_expr,
+            } => {
+                nested.insert(name.clone(), qualified_type_name(&type_name));
+                Binder::Typed {
+                    name,
+                    type_name,
+                    where_expr: where_expr
+                        .map(|value| self.expression(*value, &nested).map(Box::new))
+                        .transpose()?,
+                }
+            }
+            Binder::Range { name, lo, hi } => {
+                nested.insert(name.clone(), "Int".to_owned());
+                Binder::Range {
+                    name,
+                    lo: Box::new(self.expression(*lo, environment)?),
+                    hi: Box::new(self.expression(*hi, environment)?),
+                }
+            }
+            Binder::Collection {
+                name,
+                collection,
+                where_expr,
+            } => Binder::Collection {
+                name,
+                collection: Box::new(self.expression(*collection, environment)?),
+                where_expr: where_expr
+                    .map(|value| self.expression(*value, &nested).map(Box::new))
+                    .transpose()?,
+            },
+        };
+        Ok((binder, nested))
+    }
+}
+
+fn resolve_stage_expression(
+    resolver: &StageResolver<'_>,
+    expression: &mut Expr,
+    environment: &BTreeMap<String, String>,
+) -> Result<(), CoreError> {
+    *expression = resolver.expression(expression.clone(), environment)?;
+    Ok(())
+}
+
+fn resolve_stage_type(
+    resolver: &StageResolver<'_>,
+    ty: &mut TypeExpr,
+    environment: &BTreeMap<String, String>,
+) -> Result<(), CoreError> {
+    match ty {
+        TypeExpr::Range(lo, hi) => {
+            resolve_stage_expression(resolver, lo, environment)?;
+            resolve_stage_expression(resolver, hi, environment)
+        }
+        TypeExpr::Map(key, value) | TypeExpr::Relation(key, value) => {
+            resolve_stage_type(resolver, key, environment)?;
+            resolve_stage_type(resolver, value, environment)
+        }
+        TypeExpr::Set(item) | TypeExpr::Option(item) => {
+            resolve_stage_type(resolver, item, environment)
+        }
+        TypeExpr::Seq(item, size) => {
+            resolve_stage_type(resolver, item, environment)?;
+            resolve_stage_expression(resolver, size, environment)
+        }
+        TypeExpr::Int | TypeExpr::Bool | TypeExpr::Name(_) => Ok(()),
+    }
+}
+
+fn resolve_stage_parameters(
+    resolver: &StageResolver<'_>,
+    parameters: &mut [Param],
+) -> Result<BTreeMap<String, String>, CoreError> {
+    let mut environment = BTreeMap::new();
+    for parameter in parameters {
+        match parameter {
+            Param::Typed(name, ty) => {
+                environment.insert(name.clone(), qualified_type_name(ty));
+            }
+            Param::Range(name, lo, hi) => {
+                resolve_stage_expression(resolver, lo, &environment)?;
+                resolve_stage_expression(resolver, hi, &environment)?;
+                environment.insert(name.clone(), "Int".to_owned());
+            }
+        }
+    }
+    Ok(environment)
+}
+
+fn resolve_stage_lvalue(
+    resolver: &StageResolver<'_>,
+    target: &mut LValue,
+    environment: &BTreeMap<String, String>,
+) -> Result<(), CoreError> {
+    match target {
+        LValue::Index(_, index) => resolve_stage_expression(resolver, index, environment),
+        LValue::Field(base, _) => resolve_stage_lvalue(resolver, base, environment),
+        LValue::Var(_) => Ok(()),
+    }
+}
+
+fn resolve_stage_statements(
+    resolver: &StageResolver<'_>,
+    statements: &mut [Statement],
+    environment: &BTreeMap<String, String>,
+) -> Result<(), CoreError> {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, value, .. } => {
+                resolve_stage_lvalue(resolver, target, environment)?;
+                resolve_stage_expression(resolver, value, environment)?;
+            }
+            Statement::If {
+                condition,
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                resolve_stage_expression(resolver, condition, environment)?;
+                resolve_stage_statements(resolver, then_statements, environment)?;
+                resolve_stage_statements(resolver, else_statements, environment)?;
+            }
+            Statement::ForAll {
+                binder, statements, ..
+            } => {
+                let (rewritten_binder, nested) = resolver.binder(binder.clone(), environment)?;
+                *binder = rewritten_binder;
+                resolve_stage_statements(resolver, statements, &nested)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn resolve_stage_action_items(
+    resolver: &StageResolver<'_>,
+    items: &mut [ActionItem],
+    environment: &BTreeMap<String, String>,
+) -> Result<(), CoreError> {
+    for item in items {
+        match item {
+            ActionItem::Requires(expression, _)
+            | ActionItem::Ensures(expression, _)
+            | ActionItem::Let(_, expression, _) => {
+                resolve_stage_expression(resolver, expression, environment)?;
+            }
+            ActionItem::Statement(statement) => {
+                resolve_stage_statements(resolver, std::slice::from_mut(statement), environment)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn stage_origin_targets(item: &SpecItem) -> Vec<String> {
+    match item {
+        SpecItem::Action { name, .. } => vec![action_target(name)],
+        SpecItem::Terminal { .. } => vec![TERMINAL_TARGET.to_owned()],
+        _ => property_targets(item),
+    }
+}
+
+fn stage_origin(target: &str, occurrence: &StageOccurrence, dialect: &str) -> OriginChain {
+    OriginChain {
+        id: OriginId(format!(
+            "{dialect}:stage-access:{}:{}",
+            occurrence.span.start.offset, occurrence.span.end.offset
+        )),
+        dialect: dialect.to_owned(),
+        primary: Some(OriginSite {
+            source_file: None,
+            span: Some(occurrence.span),
+            dialect: dialect.to_owned(),
+            declaration_path: target.split(':').map(str::to_owned).collect(),
+        }),
+        secondary: Vec::new(),
+        lowering_steps: vec![LoweringStep {
+            kind: "resolve_stage_access".to_owned(),
+            detail: Some(format!(
+                "{} -> {}[entity]",
+                occurrence.source, occurrence.state
+            )),
+        }],
+        generated: false,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn resolve_stage_items(
+    items: &mut [SpecItem],
+    processes: &[Process],
+    dialect: &str,
+) -> Result<OriginRegistry, CoreError> {
+    let resolver = StageResolver::new(processes);
+    let mut origins = OriginRegistry::default();
+    for process in processes {
+        let target = state_target(&process_state(&process.name));
+        origins.bind(
+            target.clone(),
+            OriginChain {
+                id: OriginId(format!(
+                    "{dialect}:process-stage-map:{}:{}",
+                    process.span.start.offset, process.span.end.offset
+                )),
+                dialect: dialect.to_owned(),
+                primary: Some(OriginSite {
+                    source_file: None,
+                    span: Some(process.span),
+                    dialect: dialect.to_owned(),
+                    declaration_path: process.path.clone(),
+                }),
+                secondary: Vec::new(),
+                lowering_steps: std::iter::once(LoweringStep {
+                    kind: "synthesize_stage_map".to_owned(),
+                    detail: Some(process_state(&process.name)),
+                })
+                .chain(process.qualifier.as_ref().map(|qualifier| LoweringStep {
+                    kind: "qualified_process_path".to_owned(),
+                    detail: Some(qualifier.clone()),
+                }))
+                .collect(),
+                generated: true,
+            },
+        );
+    }
+    let empty = BTreeMap::new();
+    for item in items {
+        debug_assert!(resolver.take_occurrences().is_empty());
+        match item {
+            SpecItem::Const { value, .. } => {
+                resolve_stage_expression(&resolver, value, &empty)?;
+            }
+            SpecItem::Def { params, value, .. } => {
+                let environment = params
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), qualified_type_name(ty)))
+                    .collect();
+                resolve_stage_expression(&resolver, value, &environment)?;
+            }
+            SpecItem::Type { lo, hi, .. } => {
+                resolve_stage_expression(&resolver, lo, &empty)?;
+                resolve_stage_expression(&resolver, hi, &empty)?;
+            }
+            SpecItem::Struct { fields, .. } => {
+                for (_, ty) in fields {
+                    resolve_stage_type(&resolver, ty, &empty)?;
+                }
+            }
+            SpecItem::State(fields) => {
+                for field in fields {
+                    resolve_stage_type(&resolver, &mut field.ty, &empty)?;
+                    if let Some(initializer) = &mut field.initializer {
+                        resolve_stage_expression(&resolver, initializer, &empty)?;
+                    }
+                }
+            }
+            SpecItem::Init { statements, .. } => {
+                resolve_stage_statements(&resolver, statements, &empty)?;
+            }
+            SpecItem::Action {
+                params,
+                items: action_items,
+                ..
+            } => {
+                let environment = resolve_stage_parameters(&resolver, params)?;
+                resolve_stage_action_items(&resolver, action_items, &environment)?;
+            }
+            SpecItem::Invariant { expr, .. }
+            | SpecItem::Trans { expr, .. }
+            | SpecItem::Reachable { expr, .. }
+            | SpecItem::Terminal { expr, .. } => {
+                resolve_stage_expression(&resolver, expr, &empty)?;
+            }
+            SpecItem::Until { before, after, .. } | SpecItem::Unless { before, after, .. } => {
+                resolve_stage_expression(&resolver, before, &empty)?;
+                resolve_stage_expression(&resolver, after, &empty)?;
+            }
+            SpecItem::LeadsTo {
+                binders,
+                before,
+                after,
+                decreases,
+                within,
+                helpful,
+                ..
+            } => {
+                let mut environment = empty.clone();
+                for binder in binders {
+                    let (rewritten_binder, nested) =
+                        resolver.binder(binder.clone(), &environment)?;
+                    *binder = rewritten_binder;
+                    environment = nested;
+                }
+                resolve_stage_expression(&resolver, before, &environment)?;
+                resolve_stage_expression(&resolver, after, &environment)?;
+                if let Some(expression) = decreases {
+                    resolve_stage_expression(&resolver, expression, &environment)?;
+                }
+                if let Some(expression) = within {
+                    resolve_stage_expression(&resolver, expression, &environment)?;
+                }
+                for action in helpful {
+                    for argument in &mut action.args {
+                        resolve_stage_expression(&resolver, argument, &environment)?;
+                    }
+                }
+            }
+            SpecItem::VerifyBounds { items, .. } => {
+                for item in items {
+                    if let VerifyItem::Values(_, lo, hi, _) = item {
+                        resolve_stage_expression(&resolver, lo, &empty)?;
+                        resolve_stage_expression(&resolver, hi, &empty)?;
+                    }
+                }
+            }
+            SpecItem::Enum { .. } | SpecItem::Entity(..) | SpecItem::Number(..) => {}
+        }
+        let occurrences = resolver.take_occurrences();
+        for target in stage_origin_targets(item) {
+            for occurrence in &occurrences {
+                origins.bind(target.clone(), stage_origin(&target, occurrence, dialect));
+            }
+        }
+    }
+    Ok(origins)
 }
 
 fn or_all(mut expressions: Vec<Expr>) -> Expr {
@@ -224,7 +847,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
                 *span,
             )
         })?;
-        if !entities.iter().any(|(entity, _)| entity == name) {
+        if !entities.iter().any(|(entity, _)| entity == name.name()) {
             return Err(core_error(
                 format!("process '{name}' has no matching entity declaration"),
                 *span,
@@ -242,7 +865,10 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             }
         }
         processes.push(Process {
-            name: name.clone(),
+            name: process_symbol(name),
+            entity: name.name().to_owned(),
+            path: process_path(&business.name, name),
+            qualifier: name.has_namespace().then(|| name.to_string()),
             stages,
             initial,
             transitions,
@@ -287,7 +913,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
                     StateField::generated(
                         process_state(&process.name),
                         TypeExpr::Map(
-                            Box::new(TypeExpr::Name(process.name.clone())),
+                            Box::new(TypeExpr::Name(process.entity.clone())),
                             Box::new(TypeExpr::Name(process_enum(&process.name))),
                         ),
                         process.span,
@@ -299,7 +925,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             statements: processes
                 .iter()
                 .map(|process| Statement::ForAll {
-                    binder: typed_binder("c", &process.name),
+                    binder: typed_binder("c", &process.entity),
                     statements: vec![Statement::Assign {
                         target: LValue::Index(
                             process_state(&process.name),
@@ -337,7 +963,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             );
             items.push(SpecItem::Action {
                 name: transition.name.clone(),
-                params: vec![Param::Typed("c".to_owned(), qualified(&process.name))],
+                params: vec![Param::Typed("c".to_owned(), qualified(&process.entity))],
                 items: vec![
                     ActionItem::Requires(
                         stage_is(process, "c", &transition.source),
@@ -376,7 +1002,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
                 .collect::<Vec<_>>();
             Expr::Quantified {
                 quantifier: "forall".to_owned(),
-                binder: typed_binder("c", &process.name),
+                binder: typed_binder("c", &process.entity),
                 body: Box::new(or_all(sinks)),
             }
         })
@@ -389,7 +1015,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
     }
     let by_name = processes
         .iter()
-        .map(|process| (process.name.as_str(), process))
+        .map(|process| (process.entity.as_str(), process))
         .collect::<BTreeMap<_, _>>();
     for policy in policies {
         let BusinessItem::Policy {
@@ -505,11 +1131,15 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             annotations: goal_annotations.clone(),
         });
     }
-    let mut kernel = lower_direct_spec(SurfaceSpec {
-        name: business.name,
-        meta: None,
-        items,
-    })?;
+    let origins = resolve_stage_items(&mut items, &processes, "business")?;
+    let mut kernel = crate::lower_direct_spec_with_origins(
+        SurfaceSpec {
+            name: business.name,
+            meta: None,
+            items,
+        },
+        origins,
+    )?;
     for (target, annotation) in explicit_annotations {
         kernel.bind_annotation(target, annotation);
     }
@@ -529,6 +1159,67 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
 struct RequirementsProcess {
     process: Process,
     fields: Vec<ProcessField>,
+}
+
+fn requirements_processes(
+    requirements: &SurfaceRequirements,
+) -> Result<Vec<RequirementsProcess>, CoreError> {
+    requirements
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            RequirementsItem::Process(item) => Some(item),
+            _ => None,
+        })
+        .map(|item| {
+            let BusinessItem::Process {
+                name,
+                fields,
+                items,
+                span,
+            } = item
+            else {
+                return Err(core_error(
+                    "expected process declaration".to_owned(),
+                    zero_span(),
+                ));
+            };
+            let mut stages = None;
+            let mut initial = None;
+            let mut transitions = Vec::new();
+            for item in items {
+                match item {
+                    ProcessItem::Stages(values, _) => stages = Some(values.clone()),
+                    ProcessItem::Initial(value, _) => initial = Some(value.clone()),
+                    ProcessItem::Transition(transition) => {
+                        transitions.push(transition.as_ref().clone());
+                    }
+                }
+            }
+            Ok(RequirementsProcess {
+                process: Process {
+                    name: process_symbol(name),
+                    entity: name.name().to_owned(),
+                    path: process_path(&requirements.name, name),
+                    qualifier: name.has_namespace().then(|| name.to_string()),
+                    stages: stages.ok_or_else(|| {
+                        core_error(format!("process '{name}' must declare stages"), *span)
+                    })?,
+                    initial: initial.ok_or_else(|| {
+                        core_error(
+                            format!("process '{name}' must declare initial stage"),
+                            *span,
+                        )
+                    })?,
+                    transitions,
+                    span: *span,
+                },
+                fields: fields
+                    .as_ref()
+                    .map_or_else(Vec::new, |fields| fields.fields.clone()),
+            })
+        })
+        .collect()
 }
 
 fn process_field_state(process: &str, field: &str) -> String {
@@ -756,7 +1447,6 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
     let mut numbers = Vec::new();
     let mut instance_bounds = BTreeMap::new();
     let mut value_bounds = BTreeMap::new();
-    let mut process_items = Vec::new();
     let mut requirement_items = Vec::new();
     let mut standalone_actions = Vec::new();
     let mut time_items = None;
@@ -782,7 +1472,6 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
                 }
             }
             RequirementsItem::Common(item) => common.push(item.clone()),
-            RequirementsItem::Process(item) => process_items.push(item),
             RequirementsItem::Requirement { .. } => requirement_items.push(item),
             RequirementsItem::Action(action) => standalone_actions.push(action),
             RequirementsItem::Time { items, span } => {
@@ -799,9 +1488,11 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
     }
     for item in &requirements.items {
         if let RequirementsItem::Process(BusinessItem::Process { name, span, .. }) = item
-            && !entities.iter().any(|(candidate, _)| candidate == name)
+            && !entities
+                .iter()
+                .any(|(candidate, _)| candidate == name.name())
         {
-            entities.push((name.clone(), *span));
+            entities.push((name.name().to_owned(), *span));
         }
     }
     let mut items = Vec::new();
@@ -836,52 +1527,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
     }
     items.extend(common);
 
-    let mut processes = Vec::new();
-    for item in process_items {
-        let BusinessItem::Process {
-            name,
-            fields,
-            items,
-            span,
-        } = item
-        else {
-            return Err(core_error(
-                "expected process declaration".to_owned(),
-                zero_span(),
-            ));
-        };
-        let mut stages = None;
-        let mut initial = None;
-        let mut transitions = Vec::new();
-        for item in items {
-            match item {
-                ProcessItem::Stages(values, _) => stages = Some(values.clone()),
-                ProcessItem::Initial(value, _) => initial = Some(value.clone()),
-                ProcessItem::Transition(transition) => {
-                    transitions.push(transition.as_ref().clone());
-                }
-            }
-        }
-        processes.push(RequirementsProcess {
-            process: Process {
-                name: name.clone(),
-                stages: stages.ok_or_else(|| {
-                    core_error(format!("process '{name}' must declare stages"), *span)
-                })?,
-                initial: initial.ok_or_else(|| {
-                    core_error(
-                        format!("process '{name}' must declare initial stage"),
-                        *span,
-                    )
-                })?,
-                transitions,
-                span: *span,
-            },
-            fields: fields
-                .as_ref()
-                .map_or_else(Vec::new, |fields| fields.fields.clone()),
-        });
-    }
+    let processes = requirements_processes(&requirements)?;
     for process in &processes {
         items.push(SpecItem::Enum {
             name: process_enum(&process.process.name),
@@ -896,7 +1542,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
         state.push(StateField::generated(
             process_state(process_name),
             TypeExpr::Map(
-                Box::new(TypeExpr::Name(process_name.clone())),
+                Box::new(TypeExpr::Name(process.process.entity.clone())),
                 Box::new(TypeExpr::Name(process_enum(process_name))),
             ),
             process.process.span,
@@ -935,7 +1581,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
             });
         }
         init.push(Statement::ForAll {
-            binder: typed_binder("c", process_name),
+            binder: typed_binder("c", &process.process.entity),
             statements: init_body,
             span: process.process.span,
         });
@@ -1014,7 +1660,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
             );
             let mut params = vec![Param::Typed(
                 "c".to_owned(),
-                qualified(&process.process.name),
+                qualified(&process.process.entity),
             )];
             params.extend(transition.inputs.clone());
             items.push(SpecItem::Action {
@@ -1375,11 +2021,19 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
             });
         }
     }
-    let mut kernel = lower_direct_spec(SurfaceSpec {
-        name: requirements.name,
-        meta: None,
-        items,
-    })?;
+    let stage_processes = processes
+        .iter()
+        .map(|process| process.process.clone())
+        .collect::<Vec<_>>();
+    let origins = resolve_stage_items(&mut items, &stage_processes, "requirements")?;
+    let mut kernel = crate::lower_direct_spec_with_origins(
+        SurfaceSpec {
+            name: requirements.name,
+            meta: None,
+            items,
+        },
+        origins,
+    )?;
     for (target, annotation) in extra_annotations {
         kernel.bind_annotation(target, annotation);
     }
@@ -1580,6 +2234,11 @@ pub fn requirements_trace_contract(
     let SurfaceDocument::Requirements(requirements) = document else {
         return Ok(None);
     };
+    let stage_processes = requirements_processes(&requirements)?
+        .into_iter()
+        .map(|process| process.process)
+        .collect::<Vec<_>>();
+    let stage_resolver = StageResolver::new(&stage_processes);
     let mut acceptance = Vec::new();
     let mut forbidden = Vec::new();
     for item in requirements.items {
@@ -1605,7 +2264,8 @@ pub fn requirements_trace_contract(
             } => {
                 let annotations = trace_case_annotations(&id, &text, span, &surface_annotations)?;
                 let expectation = match expectation {
-                    fsl_syntax::AcceptanceExpectation::Expr(expr, _) => {
+                    fsl_syntax::AcceptanceExpectation::Expr(mut expr, _) => {
+                        resolve_stage_expression(&stage_resolver, &mut expr, &BTreeMap::new())?;
                         RequirementsTraceExpectation::Expr(expr)
                     }
                     fsl_syntax::AcceptanceExpectation::Stage {

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -3261,7 +3261,9 @@ fn bind_expression_tree(
             bind_expression_tree(registry, &child("then"), then_expr, origin);
             bind_expression_tree(registry, &child("else"), else_expr, origin);
         }
-        Expr::Is { expr, .. } | Expr::UnaryNamed { expr, .. } => {
+        Expr::Is { expr, .. }
+        | Expr::Stage { entity: expr, .. }
+        | Expr::UnaryNamed { expr, .. } => {
             bind_expression_tree(registry, &child("operand"), expr, origin);
         }
         Expr::Quantified { body, .. }

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -1137,7 +1137,7 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
     }
 }
 
-fn visit_expr_children(
+pub(crate) fn visit_expr_children(
     expr: &Expr,
     visitor: &mut impl FnMut(&Expr) -> Result<(), CoreError>,
 ) -> Result<(), CoreError> {
@@ -1145,6 +1145,7 @@ fn visit_expr_children(
         Expr::Some(expr)
         | Expr::Neg(expr)
         | Expr::Not(expr)
+        | Expr::Stage { entity: expr, .. }
         | Expr::UnaryNamed { expr, .. }
         | Expr::Is { expr, .. } => visitor(expr)?,
         Expr::Set(items) | Expr::Seq(items) => {

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -1334,6 +1334,7 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
         Expr::Some(expr)
         | Expr::Neg(expr)
         | Expr::Not(expr)
+        | Expr::Stage { entity: expr, .. }
         | Expr::UnaryNamed { expr, .. }
         | Expr::Is { expr, .. }
         | Expr::Field(expr, _) => vec![expr],

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -275,6 +275,7 @@ fn infer_type(
         Expr::Call { name, .. } => Err(error(format!(
             "unlowered predicate call '{name}' in public Kernel"
         ))),
+        Expr::Stage { .. } => Err(error("unlowered stage access in public Kernel")),
         Expr::Index(base, _) => match resolve(model, &infer_type(base, env, model, None)?)? {
             TypeRef::Map(_, value) | TypeRef::Relation(_, value) => Ok(*value),
             TypeRef::Seq(item, _) => Ok(*item),
@@ -599,6 +600,9 @@ fn expr_json(
             return Err(error(format!(
                 "unlowered predicate call '{name}' in public Kernel"
             )));
+        }
+        Expr::Stage { .. } => {
+            return Err(error("unlowered stage access in public Kernel"));
         }
         Expr::Index(collection, index) => {
             let collection_ty = resolve(model, &infer_type(collection, env, model, None)?)?;
@@ -1247,7 +1251,9 @@ fn walk_partial(
             children.push(left);
             children.push(right);
         }
-        Expr::Field(value, _) | Expr::UnaryNamed { expr: value, .. } => children.push(value),
+        Expr::Field(value, _)
+        | Expr::Stage { entity: value, .. }
+        | Expr::UnaryNamed { expr: value, .. } => children.push(value),
         Expr::Method { receiver, args, .. } => {
             children.push(receiver);
             children.extend(args);

--- a/rust/fsl-core/tests/requirements_stage.rs
+++ b/rust/fsl-core/tests/requirements_stage.rs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+#![allow(clippy::needless_raw_string_hashes)]
+
+use fsl_core::{
+    FsResolver, KernelExpr, PublicKernelVersion, RequirementsTraceExpectation, build_model,
+    parse_kernel_source, parse_kernel_source_with_file, public_kernel_contract_for_version,
+    requirements_trace_contract,
+};
+
+fn checked(source: &str) -> fsl_core::KernelModel {
+    build_model(
+        parse_kernel_source(source, &FsResolver::new(".")).expect("parse requirements source"),
+    )
+    .expect("build requirements model")
+}
+
+#[test]
+fn requirements_terminal_lowers_stage_access_to_the_generated_state_map() {
+    let model = checked(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  terminal { forall c: Claim { stage(c) == Approved } }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+
+    let KernelExpr::Quantified { body, .. } = model.terminal.expect("terminal expression") else {
+        panic!("expected quantified terminal")
+    };
+    let KernelExpr::Binary { left, .. } = *body else {
+        panic!("expected stage comparison")
+    };
+    assert_eq!(
+        *left,
+        KernelExpr::Index(
+            Box::new(KernelExpr::Var("claim_stage".to_owned())),
+            Box::new(KernelExpr::Var("c".to_owned())),
+        )
+    );
+}
+
+#[test]
+fn qualified_stage_access_uses_the_shared_symbol_path_parser() {
+    let model = checked(
+        r#"
+requirements claims {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant Qualified {
+    forall c: Claim { claims.Claim.stage(c) == Draft or Claim.stage(c) == Approved }
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+
+    assert_eq!(model.invariants.len(), 1);
+}
+
+const QUALIFIED_PROCESSES: &str = r#"
+requirements ClaimRequirements {
+  process claims.Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  process legacy.Claim {
+    stages Imported, Archived
+    initial Imported
+    transition archive Imported -> Archived by Manager
+  }
+  invariant Qualified {
+    forall c: Claim { claims.Claim.stage(c) == Draft and legacy.Claim.stage(c) == Imported }
+  }
+}
+verify { instances Claim = 1 }
+"#;
+
+#[test]
+fn qualified_process_path_disambiguates_multiple_processes_for_one_entity() {
+    let model = checked(QUALIFIED_PROCESSES);
+
+    let stage_maps = model
+        .state
+        .iter()
+        .filter(|(name, _)| name.starts_with("0q"))
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+    assert_eq!(stage_maps.len(), 2);
+    assert_ne!(stage_maps[0], stage_maps[1]);
+}
+
+#[test]
+fn qualified_process_symbols_are_injective_across_segment_boundaries() {
+    let source = QUALIFIED_PROCESSES
+        .replace("claims.Claim", "a.b.Claim")
+        .replace("legacy.Claim", "a_b.Claim");
+    let model = checked(&source);
+
+    assert_eq!(
+        model
+            .state
+            .iter()
+            .filter(|(name, _)| name.starts_with("0q"))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn unqualified_stage_reports_all_ambiguous_process_candidates() {
+    let source = r#"
+requirements ClaimRequirements {
+  process claims.Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  process legacy.Claim {
+    stages Imported, Archived
+    initial Imported
+    transition archive Imported -> Archived by Manager
+  }
+  invariant Ambiguous { forall c: Claim { stage(c) == Draft } }
+}
+verify { instances Claim = 1 }
+"#;
+    let error = parse_kernel_source(source, &FsResolver::new(".")).expect_err("stage must fail");
+
+    assert!(error.message.contains("ambiguous for type 'Claim'"));
+    assert!(error.message.contains("claims.Claim"));
+    assert!(error.message.contains("legacy.Claim"));
+}
+
+#[test]
+fn stage_rejects_an_untyped_argument_at_the_argument_span() {
+    let source = r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant Invalid { stage(missing) == Draft }
+}
+verify { instances Claim = 1 }
+"#;
+    let error = parse_kernel_source(source, &FsResolver::new(".")).expect_err("stage must fail");
+
+    assert!(
+        error
+            .message
+            .contains("'missing' is not a typed parameter or binder")
+    );
+    assert_eq!(error.line, 8);
+    assert_eq!(error.column, 29);
+}
+
+#[test]
+fn stage_rejects_a_typed_value_whose_type_has_no_process() {
+    let source = r#"
+requirements ClaimLifecycle {
+  type User = 0..1
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant Invalid { forall user: User { stage(user) == Draft } }
+}
+verify { instances Claim = 1 }
+"#;
+    let error = parse_kernel_source(source, &FsResolver::new(".")).expect_err("stage must fail");
+
+    assert!(error.message.contains("type 'User', which has no process"));
+}
+
+#[test]
+fn business_and_requirements_stage_access_lower_to_the_same_expression() {
+    let business = checked(
+        r#"
+business ClaimBusiness {
+  actor Manager
+  entity Claim
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  policy P-1 "valid stage" invariant {
+    forall c: Claim { stage(c) == Draft or stage(c) == Approved }
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+    let requirements = checked(
+        r#"
+requirements ClaimRequirements {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant P_1 {
+    forall c: Claim { stage(c) == Draft or stage(c) == Approved }
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+
+    assert_eq!(business.invariants[0].expr, requirements.invariants[0].expr);
+}
+
+#[test]
+fn acceptance_expectation_uses_the_same_stage_resolver() {
+    let contract = requirements_trace_contract(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  acceptance AC-1 "all claims start as draft" {
+    expect forall c: Claim { stage(c) == Draft }
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    )
+    .expect("trace contract")
+    .expect("requirements traces");
+
+    let Some(RequirementsTraceExpectation::Expr(KernelExpr::Quantified { body, .. })) =
+        &contract.acceptance[0].expectation
+    else {
+        panic!("expected quantified acceptance expression")
+    };
+    let KernelExpr::Binary { left, .. } = body.as_ref() else {
+        panic!("expected stage comparison")
+    };
+    assert!(matches!(
+        left.as_ref(),
+        KernelExpr::Index(collection, _)
+            if collection.as_ref() == &KernelExpr::Var("claim_stage".to_owned())
+    ));
+}
+
+#[test]
+fn public_kernel_keeps_the_lowered_symbol_and_surface_stage_origin() {
+    let source = r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant StageVisible { forall c: Claim { stage(c) == Draft } }
+}
+verify { instances Claim = 1 }
+"#;
+    let kernel = parse_kernel_source_with_file(
+        source,
+        &FsResolver::new("fixtures"),
+        "fixtures/claim_lifecycle.fsl",
+    )
+    .expect("lower requirements");
+    let model = build_model(kernel.clone()).expect("checked requirements model");
+    let contract = public_kernel_contract_for_version(
+        &kernel,
+        &model,
+        "fixtures/claim_lifecycle.fsl",
+        "requirements",
+        PublicKernelVersion::V2,
+    )
+    .expect("public Kernel v2");
+
+    assert!(
+        contract["properties"]["invariants"][0]["expression"]
+            .to_string()
+            .contains("claim_stage")
+    );
+    let stage_origin = contract["provenance"]["origins"]
+        .as_array()
+        .expect("origins")
+        .iter()
+        .find(|origin| {
+            origin["lowering_steps"].as_array().is_some_and(|steps| {
+                steps
+                    .iter()
+                    .any(|step| step["kind"] == "resolve_stage_access")
+            })
+        })
+        .expect("stage origin");
+    assert_eq!(stage_origin["primary"]["span"]["line"], 8);
+    assert_eq!(
+        stage_origin["lowering_steps"][0]["detail"],
+        "stage(c) -> claim_stage[entity]"
+    );
+}
+
+#[test]
+fn requirement_action_parameters_use_stage_in_general_expressions() {
+    let model = checked(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  requirement REQ-AUDIT "draft claims can be audited" {
+    action audit(c: Claim) { requires stage(c) == Draft }
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+
+    let audit = model
+        .actions
+        .iter()
+        .find(|action| action.name == "audit")
+        .expect("audit action");
+    assert!(matches!(
+        &audit.requires[0],
+        KernelExpr::Binary { left, .. }
+            if matches!(left.as_ref(), KernelExpr::Index(collection, _)
+                if collection.as_ref() == &KernelExpr::Var("claim_stage".to_owned()))
+    ));
+}
+
+#[test]
+fn requirements_process_sinks_do_not_create_an_implicit_terminal() {
+    let model = checked(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+}
+verify { instances Claim = 1 }
+"#,
+    );
+
+    assert!(model.terminal.is_none());
+}
+
+#[test]
+fn stage_member_is_checked_against_the_resolved_process_enum() {
+    let kernel = parse_kernel_source(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant Invalid { forall c: Claim { stage(c) == Missing } }
+}
+verify { instances Claim = 1 }
+"#,
+        &FsResolver::new("."),
+    )
+    .expect("stage access lowers before enum checking");
+    let error = build_model(kernel).expect_err("unknown stage member must fail");
+
+    assert!(error.message.contains("cannot type identifier 'Missing'"));
+}
+
+#[test]
+fn stage_arity_is_rejected_by_the_shared_expression_parser() {
+    let error = parse_kernel_source(
+        r#"
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant Invalid { stage() == Draft }
+}
+verify { instances Claim = 1 }
+"#,
+        &FsResolver::new("."),
+    )
+    .expect_err("invalid stage arity must fail");
+
+    assert_eq!(error.message, "stage expects exactly one argument");
+    assert_eq!(error.line, 8);
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -707,6 +707,7 @@ fn collect_state_references(
         | Expr::Neg(value)
         | Expr::Not(value)
         | Expr::Field(value, _)
+        | Expr::Stage { entity: value, .. }
         | Expr::UnaryNamed { expr: value, .. }
         | Expr::Is { expr: value, .. } => {
             collect_state_references(value, state_names, output);

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -104,6 +104,7 @@ pub fn eval(
         Expr::Call { name, .. } => {
             Err(runtime_error(format!("unexpanded predicate call '{name}'")))
         }
+        Expr::Stage { .. } => Err(runtime_error("unlowered stage access")),
         Expr::Index(base, index) => {
             let base = eval(base, state, bindings, model, old_state)?;
             let index = eval(index, state, bindings, model, old_state)?;

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
+use crate::SymbolPath;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -133,6 +134,12 @@ pub enum Expr {
         body: Box<Expr>,
         condition: Option<Box<Expr>>,
     },
+    Stage {
+        process: Option<Box<SymbolPath>>,
+        entity: Box<Expr>,
+        entity_span: Span,
+        span: Span,
+    },
     UnaryNamed {
         name: String,
         expr: Box<Expr>,
@@ -198,6 +205,7 @@ impl Binder {
 
 impl Expr {
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn python_ast(&self) -> Value {
         match self {
             Self::Num(value) => json!(["num", value]),
@@ -270,8 +278,27 @@ impl Expr {
                 body.python_ast(),
                 condition.as_deref().map(Expr::python_ast)
             ]),
-            Self::UnaryNamed { name, expr, span } => match name.as_str() {
-                "stage" => json!(["stage", expr.python_ast(), span.python_loc()]),
+            Self::Stage {
+                process,
+                entity,
+                span,
+                ..
+            } => process.as_ref().map_or_else(
+                || json!(["stage", entity.python_ast(), span.python_loc()]),
+                |process| {
+                    json!([
+                        "qualified_stage",
+                        process.to_string(),
+                        entity.python_ast(),
+                        span.python_loc()
+                    ])
+                },
+            ),
+            Self::UnaryNamed {
+                name,
+                expr,
+                span: _,
+            } => match name.as_str() {
                 "old" | "abs" => json!([name, expr.python_ast()]),
                 "rel_acyclic" | "rel_functional" | "rel_injective" | "rel_domain" | "rel_range" => {
                     json!([name, expr.python_ast()])

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -14,7 +14,8 @@ use crate::{
     RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
     RequirementBranch, RequirementsItem, Span, SpecItem, Statement, SurfaceBusiness,
     SurfaceCompose, SurfaceDocument, SurfaceGovernance, SurfaceRefinement, SurfaceRequirements,
-    SurfaceSpec, SyncAction, SyncRef, TimeItem, Token, TokenKind, TypeExpr, VerifyItem, lex,
+    SurfaceSpec, SymbolPath, SyncAction, SyncRef, SyntaxIdent, TimeItem, Token, TokenKind,
+    TypeExpr, VerifyItem, lex,
 };
 
 fn join_span(start: Span, end: Span) -> Span {
@@ -956,7 +957,23 @@ impl Parser {
 
     fn business_process(&mut self) -> Result<BusinessItem, ParseError> {
         let span = self.bump().span;
-        let name = self.expect_ident()?;
+        let mut segments = Vec::new();
+        loop {
+            let segment_span = self.peek().span;
+            segments.push(SyntaxIdent {
+                text: self.expect_ident()?,
+                span: segment_span,
+            });
+            if !self.eat_symbol(".") {
+                break;
+            }
+        }
+        let path_span = join_span(
+            segments.first().expect("process path is non-empty").span,
+            segments.last().expect("process path is non-empty").span,
+        );
+        let name = SymbolPath::from_idents(segments, path_span)
+            .map_err(|error| ParseError::new(error.message, error.span))?;
         let fields = if self.peek_ident("with") {
             let fields_span = self.bump().span;
             let mut fields = Vec::new();

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -3,7 +3,9 @@
 
 use serde_json::{Map, Value, json};
 
-use crate::{AiComponent, Annotations, Binder, DbSystem, DomainSpec, Expr, QualifiedName, Span};
+use crate::{
+    AiComponent, Annotations, Binder, DbSystem, DomainSpec, Expr, QualifiedName, Span, SymbolPath,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MetaTag {
@@ -364,7 +366,7 @@ pub enum BusinessItem {
     Actor(Vec<String>, Span),
     Entity(String, Span),
     Process {
-        name: String,
+        name: SymbolPath,
         fields: Option<ProcessFields>,
         items: Vec<ProcessItem>,
         span: Span,
@@ -1256,7 +1258,7 @@ impl BusinessItem {
                 span,
             } => json!([
                 "biz_process",
-                name,
+                name.to_string(),
                 fields.as_ref().map(ProcessFields::python_ast),
                 items
                     .iter()

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -334,9 +334,22 @@ impl SyntaxExpr {
             SyntaxExprKind::Call { callee, args } => {
                 let name = callee.text;
                 let call_span = callee.span;
+                let argument_span = args.first().map_or(call_span, |argument| argument.span);
+                if name == "stage" && args.len() != 1 {
+                    return Err(ParseError::new(
+                        "stage expects exactly one argument",
+                        call_span,
+                    ));
+                }
                 let args = convert_list(args)?;
                 match (name.as_str(), args.as_slice()) {
-                    ("stage" | "old" | "abs", [expr]) => Expr::UnaryNamed {
+                    ("stage", [entity]) => Expr::Stage {
+                        process: None,
+                        entity: Box::new(entity.clone()),
+                        entity_span: argument_span,
+                        span,
+                    },
+                    ("old" | "abs", [expr]) => Expr::UnaryNamed {
                         name,
                         expr: Box::new(expr.clone()),
                         span: call_span,
@@ -377,11 +390,33 @@ impl SyntaxExpr {
                 receiver,
                 method,
                 args,
-            } => Expr::Method {
-                receiver: Box::new(receiver.into_kernel()?),
-                name: method.text,
-                args: convert_list(args)?,
-            },
+            } => {
+                if method.text == "stage" {
+                    let process = expression_path(&receiver).ok_or_else(|| {
+                        ParseError::new("stage qualifier must be a symbol path", receiver.span)
+                    })?;
+                    let entity_span = args.first().map_or(method.span, |argument| argument.span);
+                    let mut args = convert_list(args)?;
+                    if args.len() != 1 {
+                        return Err(ParseError::new(
+                            "stage expects exactly one argument",
+                            method.span,
+                        ));
+                    }
+                    Expr::Stage {
+                        process: Some(Box::new(process)),
+                        entity: Box::new(args.remove(0)),
+                        entity_span,
+                        span,
+                    }
+                } else {
+                    Expr::Method {
+                        receiver: Box::new(receiver.into_kernel()?),
+                        name: method.text,
+                        args: convert_list(args)?,
+                    }
+                }
+            }
             SyntaxExprKind::Binary { op, left, right } => Expr::Binary {
                 op: op.canonical,
                 left: Box::new(left.into_kernel()?),
@@ -987,7 +1022,15 @@ impl SyntaxParser<'_> {
                 let args = self.expression_list(")")?;
                 if !matches!(
                     name.text.as_str(),
-                    "contains" | "add" | "remove" | "push" | "pop" | "head" | "at" | "size"
+                    "contains"
+                        | "add"
+                        | "remove"
+                        | "push"
+                        | "pop"
+                        | "head"
+                        | "at"
+                        | "size"
+                        | "stage"
                 ) {
                     return Err(self.error("unknown FSL collection method"));
                 }
@@ -1298,6 +1341,31 @@ impl SyntaxParser<'_> {
         let end = self.previous_span().end;
         ParseError::new(message, Span { start: end, end })
     }
+}
+
+fn expression_path(expression: &SyntaxExpr) -> Option<SymbolPath> {
+    fn segments(expression: &SyntaxExpr, output: &mut Vec<SyntaxIdent>) -> bool {
+        match &expression.kind {
+            SyntaxExprKind::Name(name) => {
+                output.push(name.clone());
+                true
+            }
+            SyntaxExprKind::Field { receiver, field } => {
+                if !segments(receiver, output) {
+                    return false;
+                }
+                output.push(field.clone());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    let mut path = Vec::new();
+    if !segments(expression, &mut path) {
+        return None;
+    }
+    SymbolPath::from_idents(path, expression.span).ok()
 }
 
 fn join(first: Span, last: Span) -> Span {

--- a/rust/fsl-tools/src/analysis.rs
+++ b/rust/fsl-tools/src/analysis.rs
@@ -134,6 +134,7 @@ fn binder_name(binder: &Binder) -> &str {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn expr_reads_bound(
     expr: &Expr,
     state: &BTreeSet<String>,
@@ -146,7 +147,11 @@ fn expr_reads_bound(
                 reads.insert(name.clone());
             }
         }
-        Expr::Some(value) | Expr::Neg(value) | Expr::Not(value) | Expr::Field(value, _) => {
+        Expr::Some(value)
+        | Expr::Neg(value)
+        | Expr::Not(value)
+        | Expr::Field(value, _)
+        | Expr::Stage { entity: value, .. } => {
             reads.extend(expr_reads_bound(value, state, bound));
         }
         Expr::Index(base, index)

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -464,6 +464,24 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                 });
             }
         }
+        Expr::Stage {
+            process,
+            entity,
+            entity_span,
+            span,
+        } => {
+            for mutation in expr_mutations(entity, enums) {
+                output.push(ExprMutation {
+                    expr: Expr::Stage {
+                        process: process.clone(),
+                        entity: Box::new(mutation.expr.clone()),
+                        entity_span: *entity_span,
+                        span: *span,
+                    },
+                    ..mutation
+                });
+            }
+        }
         Expr::BinaryNamed { name, left, right } => {
             for mutation in expr_mutations(left, enums) {
                 output.push(ExprMutation {

--- a/rust/fsl-tools/src/undecided.rs
+++ b/rust/fsl-tools/src/undecided.rs
@@ -10,6 +10,7 @@ use fsl_core::{
 };
 use serde_json::{Value, json};
 
+#[allow(clippy::too_many_lines)]
 fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> {
     fn collect(expr: &KernelExpr, roots: &mut BTreeSet<String>) {
         match expr {
@@ -20,6 +21,7 @@ fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> 
             | KernelExpr::Neg(value)
             | KernelExpr::Not(value)
             | KernelExpr::Field(value, _)
+            | KernelExpr::Stage { entity: value, .. }
             | KernelExpr::UnaryNamed { expr: value, .. } => collect(value, roots),
             KernelExpr::Index(left, right)
             | KernelExpr::Binary { left, right, .. }

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -66,6 +66,7 @@ pub(crate) fn eval<S: SmtSolver>(
         Expr::Call { name, .. } => Err(VerifyError::new(format!(
             "unexpanded predicate call '{name}'"
         ))),
+        Expr::Stage { .. } => Err(VerifyError::new("unlowered stage access")),
         Expr::Index(base, index) => {
             let base = eval(solver, model, base, state, bindings, old_state)?;
             let index = eval(solver, model, index, state, bindings, old_state)?;

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -307,6 +307,17 @@ fn map_key(value: &FslValue) -> String {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn expr_text(expr: &Expr) -> String {
+    expr_text_with_origins(None, expr)
+}
+
+/// Render an expression with source-level names recovered from lowering origins.
+#[must_use]
+pub fn source_expr_text(model: &KernelModel, expr: &Expr) -> String {
+    expr_text_with_origins(Some(model), expr)
+}
+
+#[allow(clippy::too_many_lines)]
+fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
     fn precedence(expr: &Expr) -> u8 {
         match expr {
             Expr::Conditional { .. } | Expr::Quantified { .. } => 0,
@@ -326,8 +337,8 @@ pub fn expr_text(expr: &Expr) -> String {
         }
     }
 
-    fn operand(expr: &Expr, minimum: u8) -> String {
-        let rendered = expr_text(expr);
+    fn operand(model: Option<&KernelModel>, expr: &Expr, minimum: u8) -> String {
+        let rendered = expr_text_with_origins(model, expr);
         if precedence(expr) < minimum {
             format!("({rendered})")
         } else {
@@ -335,7 +346,7 @@ pub fn expr_text(expr: &Expr) -> String {
         }
     }
 
-    fn binder_text(binder: &Binder) -> String {
+    fn binder_text(model: Option<&KernelModel>, binder: &Binder) -> String {
         match binder {
             Binder::Typed {
                 name,
@@ -344,21 +355,25 @@ pub fn expr_text(expr: &Expr) -> String {
             } => {
                 let mut text = format!("{name}: {}", display_name(&type_name.name));
                 if let Some(condition) = where_expr {
-                    let _ = write!(text, " where {}", expr_text(condition));
+                    let _ = write!(text, " where {}", expr_text_with_origins(model, condition));
                 }
                 text
             }
             Binder::Range { name, lo, hi } => {
-                format!("{name} in {}..{}", expr_text(lo), expr_text(hi))
+                format!(
+                    "{name} in {}..{}",
+                    expr_text_with_origins(model, lo),
+                    expr_text_with_origins(model, hi)
+                )
             }
             Binder::Collection {
                 name,
                 collection,
                 where_expr,
             } => {
-                let mut text = format!("{name} in {}", expr_text(collection));
+                let mut text = format!("{name} in {}", expr_text_with_origins(model, collection));
                 if let Some(condition) = where_expr {
-                    let _ = write!(text, " where {}", expr_text(condition));
+                    let _ = write!(text, " where {}", expr_text_with_origins(model, condition));
                 }
                 text
             }
@@ -369,14 +384,22 @@ pub fn expr_text(expr: &Expr) -> String {
         Expr::Num(value) => value.to_string(),
         Expr::Bool(value) => value.to_string(),
         Expr::None => "none".to_owned(),
-        Expr::Some(value) => format!("some({})", expr_text(value)),
+        Expr::Some(value) => format!("some({})", expr_text_with_origins(model, value)),
         Expr::Set(values) => format!(
             "Set {{{}}}",
-            values.iter().map(expr_text).collect::<Vec<_>>().join(", ")
+            values
+                .iter()
+                .map(|value| expr_text_with_origins(model, value))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Expr::Seq(values) => format!(
             "Seq {{{}}}",
-            values.iter().map(expr_text).collect::<Vec<_>>().join(", ")
+            values
+                .iter()
+                .map(|value| expr_text_with_origins(model, value))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Expr::Struct { name, fields } => format!(
             "{} {{ {} }}",
@@ -387,7 +410,7 @@ pub fn expr_text(expr: &Expr) -> String {
                 fields
             }
             .into_iter()
-            .map(|(name, value)| format!("{name}: {}", expr_text(value)))
+            .map(|(name, value)| { format!("{name}: {}", expr_text_with_origins(model, value)) })
             .collect::<Vec<_>>()
             .join(", ")
         ),
@@ -395,19 +418,56 @@ pub fn expr_text(expr: &Expr) -> String {
         Expr::Call { name, args, .. } => format!(
             "{}({})",
             display_name(name),
-            args.iter().map(expr_text).collect::<Vec<_>>().join(", ")
+            args.iter()
+                .map(|argument| expr_text_with_origins(model, argument))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
-        Expr::Index(base, index) => format!("{}[{}]", operand(base, 10), expr_text(index)),
-        Expr::Field(base, field) => format!("{}.{field}", operand(base, 10)),
+        Expr::Index(base, index) => {
+            let stage_qualifier = model.and_then(|model| {
+                let Expr::Var(name) = base.as_ref() else {
+                    return None;
+                };
+                let origin = model.state_origin(name)?;
+                origin
+                    .lowering_steps
+                    .iter()
+                    .any(|step| step.kind == "synthesize_stage_map")
+                    .then(|| {
+                        origin
+                            .lowering_steps
+                            .iter()
+                            .find(|step| step.kind == "qualified_process_path")
+                            .and_then(|step| step.detail.as_deref())
+                    })
+            });
+            if let Some(qualifier) = stage_qualifier {
+                format!(
+                    "{}stage({})",
+                    qualifier.map_or_else(String::new, |path| format!("{path}.")),
+                    expr_text_with_origins(model, index)
+                )
+            } else {
+                format!(
+                    "{}[{}]",
+                    operand(model, base, 10),
+                    expr_text_with_origins(model, index)
+                )
+            }
+        }
+        Expr::Field(base, field) => format!("{}.{field}", operand(model, base, 10)),
         Expr::Method {
             receiver,
             name,
             args,
         } => format!(
             "{}.{}({})",
-            operand(receiver, 10),
+            operand(model, receiver, 10),
             name,
-            args.iter().map(expr_text).collect::<Vec<_>>().join(", ")
+            args.iter()
+                .map(|argument| expr_text_with_origins(model, argument))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Expr::Binary { op, left, right } => {
             let (left_minimum, right_minimum) = match op.as_str() {
@@ -421,12 +481,12 @@ pub fn expr_text(expr: &Expr) -> String {
             };
             format!(
                 "{} {op} {}",
-                operand(left, left_minimum),
-                operand(right, right_minimum)
+                operand(model, left, left_minimum),
+                operand(model, right, right_minimum)
             )
         }
-        Expr::Neg(value) => format!("-{}", operand(value, 9)),
-        Expr::Not(value) => format!("not {}", operand(value, 4)),
+        Expr::Neg(value) => format!("-{}", operand(model, value, 9)),
+        Expr::Not(value) => format!("not {}", operand(model, value, 4)),
         Expr::Conditional {
             condition,
             then_expr,
@@ -434,19 +494,23 @@ pub fn expr_text(expr: &Expr) -> String {
             ..
         } => format!(
             "if {} then {} else {}",
-            expr_text(condition),
-            expr_text(then_expr),
-            expr_text(else_expr)
+            expr_text_with_origins(model, condition),
+            expr_text_with_origins(model, then_expr),
+            expr_text_with_origins(model, else_expr)
         ),
         Expr::Is { expr, pattern } => match pattern {
-            Pattern::None => format!("{} is none", operand(expr, 6)),
-            Pattern::Some(name) => format!("{} is some({name})", operand(expr, 6)),
+            Pattern::None => format!("{} is none", operand(model, expr, 6)),
+            Pattern::Some(name) => format!("{} is some({name})", operand(model, expr, 6)),
         },
         Expr::Quantified {
             quantifier,
             binder,
             body,
-        } => format!("{quantifier} {}: {}", binder_text(binder), expr_text(body)),
+        } => format!(
+            "{quantifier} {}: {}",
+            binder_text(model, binder),
+            expr_text_with_origins(model, body)
+        ),
         Expr::Count {
             name,
             type_name,
@@ -454,7 +518,7 @@ pub fn expr_text(expr: &Expr) -> String {
         } => format!(
             "count({name}: {} where {})",
             display_name(&type_name.name),
-            expr_text(condition)
+            expr_text_with_origins(model, condition)
         ),
         Expr::Sum {
             name,
@@ -464,10 +528,16 @@ pub fn expr_text(expr: &Expr) -> String {
         } => format!(
             "sum({name}: {} of {}{})",
             display_name(&type_name.name),
-            expr_text(body),
-            condition
-                .as_ref()
-                .map_or_else(String::new, |value| format!(" where {}", expr_text(value)))
+            expr_text_with_origins(model, body),
+            condition.as_ref().map_or_else(String::new, |value| {
+                format!(" where {}", expr_text_with_origins(model, value))
+            })
+        ),
+        Expr::Stage {
+            process, entity, ..
+        } => process.as_ref().map_or_else(
+            || format!("stage({})", expr_text_with_origins(model, entity)),
+            |process| format!("{process}.stage({})", expr_text_with_origins(model, entity)),
         ),
         Expr::UnaryNamed { name, expr, .. } => {
             let public = match name.as_str() {
@@ -478,10 +548,15 @@ pub fn expr_text(expr: &Expr) -> String {
                 "rel_range" => "range",
                 other => other,
             };
-            format!("{public}({})", expr_text(expr))
+            format!("{public}({})", expr_text_with_origins(model, expr))
         }
         Expr::BinaryNamed { name, left, right } => {
-            format!("{}({}, {})", name, expr_text(left), expr_text(right))
+            format!(
+                "{}({}, {})",
+                name,
+                expr_text_with_origins(model, left),
+                expr_text_with_origins(model, right)
+            )
         }
         Expr::TernaryNamed {
             name,
@@ -491,10 +566,12 @@ pub fn expr_text(expr: &Expr) -> String {
         } => format!(
             "{}({}, {}, {})",
             name,
-            expr_text(first),
-            expr_text(second),
-            expr_text(third)
+            expr_text_with_origins(model, first),
+            expr_text_with_origins(model, second),
+            expr_text_with_origins(model, third)
         ),
-        Expr::BinderNamed { name, binder } => format!("{name}({})", binder_text(binder)),
+        Expr::BinderNamed { name, binder } => {
+            format!("{name}({})", binder_text(model, binder))
+        }
     }
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -4748,8 +4748,8 @@ fn model_skeleton(model: &KernelModel) -> Value {
                     .and_then(|site| site.declaration_path.last())
                     .map_or_else(|| fslc_rust::display_name(&action.name), String::clone),
                 "params": action.params.iter().map(|param|param_skeleton(model,param)).collect::<Vec<_>>(),
-                "requires_text": action.requires.iter().map(|expr|format!("requires {}",fslc_rust::expr_text(expr))).collect::<Vec<_>>(),
-                "ensures_text": action.ensures.iter().map(|expr|format!("ensures {}",fslc_rust::expr_text(expr))).collect::<Vec<_>>(),
+                "requires_text": action.requires.iter().map(|expr|format!("requires {}",fslc_rust::source_expr_text(model,expr))).collect::<Vec<_>>(),
+                "ensures_text": action.ensures.iter().map(|expr|format!("ensures {}",fslc_rust::source_expr_text(model,expr))).collect::<Vec<_>>(),
                 "writes": statement_writes(&action.statements), "requirement": Value::Null,
             });
             if let Value::Object(value) = &mut value {
@@ -4789,7 +4789,7 @@ fn model_skeleton(model: &KernelModel) -> Value {
                     .and_then(|site| site.declaration_path.last())
                     .map_or_else(|| fslc_rust::display_name(&property.name), String::clone),
                 "kind":kind,
-                "body_text":fslc_rust::expr_text(&property.expr),
+                "body_text":fslc_rust::source_expr_text(model,&property.expr),
                 "requirement":Value::Null
             });
             if let Value::Object(value) = &mut value {
@@ -4808,7 +4808,7 @@ fn model_skeleton(model: &KernelModel) -> Value {
         }));
     }
     for property in &model.leadstos {
-        let mut value = json!({"name":fslc_rust::display_name(&property.name),"kind":"leadsTo","body_text":format!("{} ~> {}",fslc_rust::expr_text(&property.before),fslc_rust::expr_text(&property.after)),"requirement":Value::Null});
+        let mut value = json!({"name":fslc_rust::display_name(&property.name),"kind":"leadsTo","body_text":format!("{} ~> {}",fslc_rust::source_expr_text(model,&property.before),fslc_rust::source_expr_text(model,&property.after)),"requirement":Value::Null});
         if let Value::Object(value) = &mut value {
             insert_requirement_metadata(value, &property.annotations, property.meta.as_ref());
         }
@@ -5303,6 +5303,7 @@ fn expression_state_roots(
             | KernelExpr::Neg(value)
             | KernelExpr::Not(value)
             | KernelExpr::Field(value, _)
+            | KernelExpr::Stage { entity: value, .. }
             | KernelExpr::UnaryNamed { expr: value, .. } => collect(value, roots),
             KernelExpr::Index(base, index)
             | KernelExpr::BinaryNamed {
@@ -5681,6 +5682,7 @@ fn invariant_violation_explanation(
     explanation.insert(
         "blame".to_owned(),
         violation_blame_json(
+            model,
             violation.kind.as_str(),
             violation.name.as_str(),
             property.map(|property| &property.expr),
@@ -6021,6 +6023,7 @@ fn expression_mutant_count(
         | KernelExpr::Neg(value)
         | KernelExpr::Not(value)
         | KernelExpr::Field(value, _)
+        | KernelExpr::Stage { entity: value, .. }
         | KernelExpr::UnaryNamed { expr: value, .. } => {
             expression_mutant_count(value, enum_siblings)
         }
@@ -12301,6 +12304,7 @@ fn violation_bindings_json(
 }
 
 fn violation_blame_json(
+    model: &KernelModel,
     kind: &str,
     name: &str,
     expr: Option<&KernelExpr>,
@@ -12321,7 +12325,7 @@ fn violation_blame_json(
     };
     let mut conjunct = json!({
         "index": 0,
-        "text": fslc_rust::expr_text(expr),
+        "text": fslc_rust::source_expr_text(model, expr),
         "holds": false,
     });
     if !violating_bindings.is_null()

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -949,6 +949,7 @@ fn render_bmc_violation(
     output.insert(
         "blame".to_owned(),
         violation_blame_json(
+            model,
             violation.kind.as_str(),
             violation.name.as_str(),
             property.map(|property| &property.expr),

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -542,7 +542,7 @@ pub fn render_boundary_output(
     if violation.kind == "type_bound" {
         output.insert(
             "blame".to_owned(),
-            violation_blame_json(&violation.kind, &violation.name, None, violating),
+            violation_blame_json(model, &violation.kind, &violation.name, None, violating),
         );
     }
     output.insert(
@@ -692,6 +692,7 @@ fn render_violation(
     output.insert(
         "blame".to_owned(),
         violation_blame_json(
+            model,
             &violation.kind,
             &violation.name,
             property.map(|property| &property.expr),
@@ -1191,6 +1192,7 @@ fn violation_bindings_json(
 }
 
 fn violation_blame_json(
+    model: &KernelModel,
     kind: &str,
     name: &str,
     expr: Option<&KernelExpr>,
@@ -1211,7 +1213,7 @@ fn violation_blame_json(
     };
     let mut conjunct = json!({
         "index": 0,
-        "text": crate::expr_text(expr),
+        "text": crate::source_expr_text(model, expr),
         "holds": false,
     });
     if !violating_bindings.is_null()

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -209,6 +209,63 @@ fn formatter_parenthesizes_a_conditional_used_as_an_operator_operand() {
 }
 
 #[test]
+fn requirements_stage_is_readable_in_explain_and_violation_evidence() {
+    let fixture = "rust/fslc/tests/fixtures/requirements_stage.fsl";
+    let (explained, status) = run_cli(&["explain", fixture, "--depth", "1"]);
+
+    assert_eq!(status, 0, "{explained}");
+    assert_eq!(
+        explained["skeleton"]["properties"][0]["body_text"],
+        "forall c: Claim: stage(c) == Draft"
+    );
+    assert_eq!(
+        explained["skeleton"]["properties"][0]["origin"]["lowering_steps"][0]["detail"],
+        "stage(c) -> claim_stage[entity]"
+    );
+
+    let (violated, status) = run_cli(&[
+        "verify",
+        fixture,
+        "--depth",
+        "1",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{violated}");
+    assert_eq!(
+        violated["blame"]["conjuncts"][0]["text"],
+        "forall c: Claim: stage(c) == Draft"
+    );
+}
+
+#[test]
+fn qualified_requirements_stage_keeps_its_process_path_in_evidence() {
+    let fixture = "rust/fslc/tests/fixtures/requirements_stage_qualified.fsl";
+    let expected =
+        "forall c: Claim: claims.Claim.stage(c) == Draft and legacy.Claim.stage(c) == Imported";
+    let (explained, status) = run_cli(&["explain", fixture, "--depth", "1"]);
+
+    assert_eq!(status, 0, "{explained}");
+    assert_eq!(
+        explained["skeleton"]["properties"][0]["body_text"],
+        expected
+    );
+
+    let (violated, status) = run_cli(&[
+        "verify",
+        fixture,
+        "--depth",
+        "1",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{violated}");
+    assert_eq!(violated["blame"]["conjuncts"][0]["text"], expected);
+}
+
+#[test]
 fn typed_requirement_relations_reach_strict_tags_scenarios_and_diagnostics() {
     let spec = "rust/fslc/tests/fixtures/typed_annotation_outputs.fsl";
     let requirements = "rust/fslc/tests/fixtures/typed_annotation_requirements.txt";

--- a/rust/fslc/tests/fixtures/requirements_stage.fsl
+++ b/rust/fslc/tests/fixtures/requirements_stage.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements ClaimLifecycle {
+  process Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+  invariant StageVisible { forall c: Claim { stage(c) == Draft } }
+}
+verify { instances Claim = 1 }

--- a/rust/fslc/tests/fixtures/requirements_stage_qualified.fsl
+++ b/rust/fslc/tests/fixtures/requirements_stage_qualified.fsl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements QualifiedStageEvidence {
+  process claims.Claim {
+    stages Draft, Approved
+    initial Draft
+    transition approve Draft -> Approved by Manager
+  }
+
+  process legacy.Claim {
+    stages Imported, Archived
+    initial Imported
+    transition archive Imported -> Archived by Manager
+  }
+
+  invariant QualifiedStage {
+    forall c: Claim {
+      claims.Claim.stage(c) == Draft and legacy.Claim.stage(c) == Imported
+    }
+  }
+}
+
+verify { instances Claim = 1 }

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1506,10 +1506,14 @@ verify {
   and add `display_name`.
 - Elements inside a requirement automatically get {id, text} metadata.
 - `terminal { <expr> }` is allowed at the top level (pass-through to the
-  kernel, one block per spec, same as the kernel). In the process+data
-  profile, write the predicate against the synthesized stage map
-  (`<entity-lowercased>_stage`, e.g. `claim_stage` for `process Claim`) — not
-  `stage(c)`, which is business-only.
+  kernel, one block per spec, same as the kernel). In the process+data profile,
+  write `stage(c)` for a typed entity binder or parameter; it resolves to the
+  process stage enum and lowers to the synthesized stage map. Requirements do
+  not infer terminal states from sink stages.
+- If several qualified processes share an entity type, declare paths such as
+  `process claims.Claim` and use `claims.Claim.stage(c)` to disambiguate.
+  Arbitrary-depth paths use the shared `SymbolPath` parser; generated
+  `*_stage` names are not requirements source vocabulary.
 
 ### Drawing the layer boundary
 

--- a/tests/dialect_registry.py
+++ b/tests/dialect_registry.py
@@ -84,4 +84,10 @@ MONITOR_EXCLUSIONS: dict[str, str] = {
         "not parse @... before a nested declaration. Native coverage lives "
         "in rust/fsl-syntax tests"
     ),
+    "examples/requirements_stage.fsl": (
+        "native-only requirements stage() syntax (issue #243); the frozen "
+        "Python reference intentionally retains the pre-Rust compatibility "
+        "surface. Native Monitor, symbolic, CLI, origin, and parser coverage "
+        "lives in the Rust workspace tests"
+    ),
 }

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -1289,6 +1289,12 @@
       "warnings": []
     }
   },
+  "examples/requirements_stage.fsl": {
+    "check": {
+      "kind": "type",
+      "result": "error"
+    }
+  },
   "examples/self/fslc_monitor.fsl": {
     "check": {
       "result": "ok",


### PR DESCRIPTION
## Problem

Requirements expressions exposed synthesized `*_stage` map names, while business already offered `stage(entity)`. This leaked frontend implementation details and prevented typed, source-readable stage access in terminal/invariant/action/acceptance contexts.

## Contract change

- Add one structural `stage()` expression node shared by business and requirements.
- Resolve unqualified access from the typed entity and support arbitrary-depth qualified `SymbolPath` disambiguation.
- Lower every resolved access to the synthesized stage map before Kernel validation.
- Preserve lowered symbols plus source spans/origins in Public Kernel v2 and restore source-level accessors in explain/violation evidence.
- Keep requirements terminal semantics explicit; sink stages are not promoted automatically.
- Use injective internal symbols for qualified process paths.

## Evidence

- Rust focused stage/parser/core/CLI tests: passed
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`: passed
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`: passed
- Rust workspace test/build: passed (four local 1Password approval-signing tests excluded)
- Python compatibility: 1450 passed, 81 skipped, 3 local Git-signing tests deselected
- Corpus snapshot: 189 passed, 1 skipped
- Dialect conformance harness: 192 passed
- Independent review: no remaining findings

Closes #243