### PR TITLE
feat: unify finite binder aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Finite quantifiers, `count`, `sum`, `unique`, and `exactlyOne` now share one
+  Binder/Aggregate IR across typed, range, Set, and Seq domains. Optional
+  filters use one scope/type-check path; empty aggregates are zero and Seq
+  duplicates preserve positional multiplicity. Legacy colon quantifiers remain
+  detectable as non-canonical input, business/requirements KPI declarations
+  survive as typed metadata projections, and collection aggregates normalize to
+  existing Public Kernel v1/v2 expression shapes (issues #242 and #217).
 - Requirements expressions now accept `stage(entity)` and qualified
   `<process-path>.stage(entity)` through the same structural node and resolver
   as business expressions. Entity-typed binders/parameters select the process;

--- a/docs/DESIGN-collection-aggregates.md
+++ b/docs/DESIGN-collection-aggregates.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Shared finite Binder and Aggregate IR
+
+## Decision
+
+Quantifiers and aggregate operators use one finite Binder representation:
+
+- `x: Type`
+- `x in lo..hi`
+- `x in collection`
+- an optional `where predicate` on every form
+
+`count`, `sum`, `unique`, and `exactlyOne` are represented by one
+`Aggregate { kind, binder, value }` node. Only `sum` carries `value`; the other
+kinds derive their result from the number of matching bindings. The former
+typed-only `Count`/`Sum` nodes and named-binder cardinality node are removed.
+This makes scope, type checking, traversal, substitution, mutation, analysis,
+concrete evaluation, and symbolic evaluation share the same Binder path.
+
+## Source forms
+
+The canonical quantifier spelling uses braces:
+
+```fsl
+forall x in queue where x > 0 { ready(x) }
+```
+
+The loss-aware syntax tree records both brace use and the legacy colon marker.
+The 2.x `forall x in queue: ready(x)` spelling is accepted as non-canonical
+input and canonical rendering uses braces.
+
+Aggregate forms are:
+
+```fsl
+count(x: Item where selected[x])
+count(x in queue where x > 0)
+sum(x in queue of x.amount where x.valid)
+unique(x in queue where x.id == wanted)
+exactlyOne(x in 0..CAP-1 where occupied[x])
+```
+
+Map, unbounded domains, and general folds are outside this design. `.size()`
+remains available and is not rewritten into an aggregate.
+
+## Finite semantics
+
+A typed Binder enumerates its finite declared domain. A range Binder enumerates
+both endpoints inclusively. A Set Binder enumerates distinct present members.
+A Seq Binder enumerates the live prefix by position; equal values in different
+positions are distinct bindings for cardinality and summation.
+
+The filter is evaluated after inserting the bound value. Empty matching sets
+produce `count = 0` and `sum = 0`; `unique` is true and `exactlyOne` is false.
+Concrete Monitor/BFS and symbolic verification call the same Binder-shaped
+enumeration/filter logic. Symbolic Seq candidates retain the per-slot
+`index < length` membership guard.
+
+## Public Kernel boundary
+
+Public Kernel v1/v2 keeps its existing typed `count` and `sum` JSON shapes.
+Collection and range aggregates are normalized at export:
+
+- Set candidates use the finite element domain plus `.contains(candidate)`.
+- Seq candidates expand to the fixed capacity with `index < .size()` and
+  `.at(index)` inside an `ite` branch.
+- Range candidates expand to their statically finite integer values.
+
+The result uses only already-published conditional, arithmetic, membership, and
+collection-method nodes. This preserves schema/version compatibility and keeps
+partial Seq access guarded. A future direct aggregate-binder JSON shape would
+require a Public Kernel major version.
+
+## KPI projections
+
+`kpi name = count Entity in Stage` in business and requirements documents is
+validated against the resolved process and stored as `ProjectionDef` metadata
+containing the same typed `Aggregate::Count` IR. It creates no state, action, or
+invariant. Native explain output reads the retained name/entity/stage metadata;
+unknown or ambiguous entities and unknown stages fail during lowering.
+
+## Required evidence
+
+Tests cover typed/range/Set/Seq filters, empty collections, duplicate Seq
+multiplicity, nested aggregate evaluation, non-Bool filter rejection,
+Monitor/symbolic/explicit agreement, canonical rendering, legacy source-form
+retention, KPI metadata without ghost invariants, and schema-compatible Public
+Kernel normalization.

--- a/docs/DESIGN-dialects.md
+++ b/docs/DESIGN-dialects.md
@@ -127,8 +127,10 @@ types/state/init, `requirement` blocks, `fair action`, `branches`, and explicit
    Bool, or enum type". Carried fields are never auto-mapped for refinement —
    only the stage map (`e_stage`) participates in `maps auto`.
 3. `kpi k = count E in S` → no kernel state/action/invariant. The declaration is
-   recorded as metadata for the projection
-   `count(c: E where e_stage[c] == S)`.
+   validated and retained as typed `ProjectionDef` metadata whose expression is
+   the shared `Aggregate::Count` plus a typed Binder for
+   `count(c: E where e_stage[c] == S)`. Native `explain` reads this projection;
+   no ghost counter or consistency invariant is generated.
 4. `requirement <ID> "<text>" { items }` → lift the contained action /
    invariant / reachable / leadsTo to top level and attach
    `meta = {id: ID, text}` to each element (the Stage 1 mechanism). The ID is
@@ -251,9 +253,10 @@ verify {
       requirement is also acceptable — for implementation simplicity it is fine
       to put "by Manager" into meta.text)
    - duplicate transition labels with the same name are a type error.
-3. `kpi k = count X in S` → no kernel state/action/invariant. The declaration is
-   recorded as metadata for the projection
-   `count(c: X where x_stage[c] == S)`.
+3. `kpi k = count X in S` follows the same typed `ProjectionDef`/
+   `Aggregate::Count` path as requirements KPI declarations. Unknown entities
+   and stages are rejected before model construction; native `explain` exposes
+   the retained metadata. No kernel state/action/invariant is generated.
 4. `control <ID> "<text>" [owner NAME] [severity NAME] [applies_to NAME]...`
    records business/governance metadata only. It does not generate kernel state
    or properties by itself. A control becomes checkable when a policy or goal

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -158,6 +158,17 @@ detects, for a fixed list of feature rows, whether each is:
 
 No row is ever hardcoded to a fixed level: every detector inspects the
 generated JSON (expression trees, `outcome.kind`, state snapshots) directly.
+
+Collection/range aggregates are source and private checked-IR features, not a
+new Public Kernel v1/v2 representation. Before export, finite `count`/`sum`
+over Set, Seq, or range binders is normalized to existing `ite`, arithmetic,
+membership, `.size()`, and `.at()` expression nodes. Seq expansion includes the
+structural `index < size` guard for every capacity slot, so inactive slots are
+not counted and partial-operation evidence remains guarded. Existing typed
+aggregate JSON keeps its exact `{binding, domain, condition}` shape (`sum`
+without a filter retains `condition: null`). Adding `{binder: ...}` to the
+published `count`/`sum` kinds would be a representation change and therefore
+requires a future Public Kernel major version.
 `coverage_matrix()` is itself the enforcement gate: if any feature row falls
 short of its required level, it returns `Err` naming every shortfall instead
 of producing a matrix that silently under-reports coverage. This is how

--- a/docs/DESIGN-layers.md
+++ b/docs/DESIGN-layers.md
@@ -106,8 +106,10 @@ verify {
 Expansion rules: `process` → enum + `Map<CaseId, Stage>` + an action per
 transition (`by <actor>` is action metadata; a transition whose actor has a
 parameter becomes a parameter of the actor type). `kpi name = count Entity in
-Stage` → declarative projection metadata only, not a ghost counter and not an
-automatic `_kpi_*` invariant. `control ID "text"` is governance metadata only;
+Stage` → a typed `ProjectionDef` containing the shared Aggregate/Binder IR,
+available to native explain but not a ghost counter or automatic `_kpi_*`
+invariant. Entity/stage resolution is checked during lowering. `control ID
+"text"` is governance metadata only;
 `policy/goal ... satisfies CTRL` attaches that control to the generated
 invariant/leadsTo/reachable so violations identify both the broken policy and the
 control it was meant to satisfy. Readable `every ... must eventually ...`
@@ -196,8 +198,9 @@ verify {
   to the stage enum, entity stage map, carried field maps, deterministic init,
   and fair transition actions. Transition `with`/`when`/`set`/`covers` lower to
   action params, requires, assignments, and metadata.
-- `kpi name = count E in S` records a declarative projection available to
-  explain/scenarios without adding a ghost counter.
+- `kpi name = count E in S` records the same typed Aggregate/Binder projection
+  as the business layer, available to explain/scenarios without adding a ghost
+  counter.
 - `requirement` block → **attach `req_id` / `req_text` metadata** to the
   contained kernel elements (action/invariant/leadsTo). All JSON output
   (violated / unknown_cti / coverage diagnostics / scenarios) carries

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -521,14 +521,20 @@ variable capture instead of inventing internal binder names. See
   branch extends to the enclosing delimiter; use parentheses when a following
   operator should apply to the whole conditional. Concrete evaluation executes
   only the selected branch, while name and type checking always visits both.
-- Quantification (bounded): `forall x: T { expr }` / `exists x: T { expr }` (can be filtered with `where expr`),
-  the v0 form `forall i in lo..hi: expr` is also allowed. Expression quantifiers
-  can also range over a Set or Seq value: `forall x in active { ... }` /
-  `exists x in queue { ... }`; for Seq this ranges over the live prefix values.
-- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
-- Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
-  `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
-  matching binding, while `exactlyOne` means exactly one.
+- Finite binders: `x: T`, `x in lo..hi`, or `x in set_or_seq`, each optionally
+  followed by `where predicate`. The predicate is `Bool` and is scoped after
+  `x` is bound. Maps and unbounded collections are not binder domains.
+- Quantification (bounded): the canonical forms are `forall binder { expr }`
+  and `exists binder { expr }`. The 2.x legacy colon/no-braces spelling such as
+  `forall i in lo..hi: expr` remains accepted but is non-canonical. A Seq binder
+  visits its live prefix in position order and preserves duplicate values.
+- Aggregation: `count(binder)` and `sum(binder of value)`. Examples include
+  `count(x: T where p)`, `count(x in queue where p)`,
+  `sum(x in queue of x.amount where p)`, and range equivalents. Empty domains
+  produce `0`; Seq duplicates contribute once per live position, while Set
+  membership contributes once per distinct member.
+- Cardinality predicates: `unique(binder)` / `exactlyOne(binder)`. `unique`
+  means at most one matching binding, while `exactlyOne` means exactly one.
 - Option: `x == none` / `x != none` / `x == some(e)` / `x != some(e)`.
   Equality is structural: `none` equals only `none`, while two `some` values are
   equal exactly when their payloads are equal. `x is some(v)` remains the form

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | [`DESIGN-layers.md`](DESIGN-layers.md) | **Shared kernel + three dialects** (consulting / requirements / design): overall concept and validation |
 | [`DESIGN-dialects.md`](DESIGN-dialects.md) | Implementation spec for the dialects (declaration tags, fsl-req, fsl-biz) |
 | [`DESIGN-requirements-stage.md`](DESIGN-requirements-stage.md) | Shared typed `stage()` resolution and lowering for business and requirements expressions |
+| [`DESIGN-collection-aggregates.md`](DESIGN-collection-aggregates.md) | Shared finite Binder/Aggregate IR, Set/Seq/range semantics, KPI metadata projections, and Public Kernel normalization |
 | [`DESIGN-dialect-dispatch.md`](DESIGN-dialect-dispatch.md) | Shared-lexer dialect registry, significant-token rules, document annotations, diagnostics, and frontend contract |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -582,14 +582,20 @@ variable capture instead of inventing internal binder names. See
   branch extends to the enclosing delimiter; use parentheses when a following
   operator should apply to the whole conditional. Concrete evaluation executes
   only the selected branch, while name and type checking always visits both.</li>
-<li>Quantification (bounded): <code>forall x: T { expr }</code> / <code>exists x: T { expr }</code> (can be filtered with <code>where expr</code>),
-  the v0 form <code>forall i in lo..hi: expr</code> is also allowed. Expression quantifiers
-  can also range over a Set or Seq value: <code>forall x in active { ... }</code> /
-  <code>exists x in queue { ... }</code>; for Seq this ranges over the live prefix values.</li>
-<li>Aggregation: <code>count(x: T where expr)</code>, <code>sum(x: T of expr [where expr])</code></li>
-<li>Cardinality predicates: <code>unique(x: T where expr)</code> / <code>exactlyOne(x: T where expr)</code>;
-  <code>x in set_or_seq [where expr]</code> is also allowed. <code>unique</code> means at most one
-  matching binding, while <code>exactlyOne</code> means exactly one.</li>
+<li>Finite binders: <code>x: T</code>, <code>x in lo..hi</code>, or <code>x in set_or_seq</code>, each optionally
+  followed by <code>where predicate</code>. The predicate is <code>Bool</code> and is scoped after
+  <code>x</code> is bound. Maps and unbounded collections are not binder domains.</li>
+<li>Quantification (bounded): the canonical forms are <code>forall binder { expr }</code>
+  and <code>exists binder { expr }</code>. The 2.x legacy colon/no-braces spelling such as
+  <code>forall i in lo..hi: expr</code> remains accepted but is non-canonical. A Seq binder
+  visits its live prefix in position order and preserves duplicate values.</li>
+<li>Aggregation: <code>count(binder)</code> and <code>sum(binder of value)</code>. Examples include
+  <code>count(x: T where p)</code>, <code>count(x in queue where p)</code>,
+  <code>sum(x in queue of x.amount where p)</code>, and range equivalents. Empty domains
+  produce <code>0</code>; Seq duplicates contribute once per live position, while Set
+  membership contributes once per distinct member.</li>
+<li>Cardinality predicates: <code>unique(binder)</code> / <code>exactlyOne(binder)</code>. <code>unique</code>
+  means at most one matching binding, while <code>exactlyOne</code> means exactly one.</li>
 <li>Option: <code>x == none</code> / <code>x != none</code> / <code>x == some(e)</code> / <code>x != some(e)</code>.
   Equality is structural: <code>none</code> equals only <code>none</code>, while two <code>some</code> values are
   equal exactly when their payloads are equal. <code>x is some(v)</code> remains the form

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -582,14 +582,20 @@ variable capture instead of inventing internal binder names. See
   branch extends to the enclosing delimiter; use parentheses when a following
   operator should apply to the whole conditional. Concrete evaluation executes
   only the selected branch, while name and type checking always visits both.</li>
-<li>Quantification (bounded): <code>forall x: T { expr }</code> / <code>exists x: T { expr }</code> (can be filtered with <code>where expr</code>),
-  the v0 form <code>forall i in lo..hi: expr</code> is also allowed. Expression quantifiers
-  can also range over a Set or Seq value: <code>forall x in active { ... }</code> /
-  <code>exists x in queue { ... }</code>; for Seq this ranges over the live prefix values.</li>
-<li>Aggregation: <code>count(x: T where expr)</code>, <code>sum(x: T of expr [where expr])</code></li>
-<li>Cardinality predicates: <code>unique(x: T where expr)</code> / <code>exactlyOne(x: T where expr)</code>;
-  <code>x in set_or_seq [where expr]</code> is also allowed. <code>unique</code> means at most one
-  matching binding, while <code>exactlyOne</code> means exactly one.</li>
+<li>Finite binders: <code>x: T</code>, <code>x in lo..hi</code>, or <code>x in set_or_seq</code>, each optionally
+  followed by <code>where predicate</code>. The predicate is <code>Bool</code> and is scoped after
+  <code>x</code> is bound. Maps and unbounded collections are not binder domains.</li>
+<li>Quantification (bounded): the canonical forms are <code>forall binder { expr }</code>
+  and <code>exists binder { expr }</code>. The 2.x legacy colon/no-braces spelling such as
+  <code>forall i in lo..hi: expr</code> remains accepted but is non-canonical. A Seq binder
+  visits its live prefix in position order and preserves duplicate values.</li>
+<li>Aggregation: <code>count(binder)</code> and <code>sum(binder of value)</code>. Examples include
+  <code>count(x: T where p)</code>, <code>count(x in queue where p)</code>,
+  <code>sum(x in queue of x.amount where p)</code>, and range equivalents. Empty domains
+  produce <code>0</code>; Seq duplicates contribute once per live position, while Set
+  membership contributes once per distinct member.</li>
+<li>Cardinality predicates: <code>unique(binder)</code> / <code>exactlyOne(binder)</code>. <code>unique</code>
+  means at most one matching binding, while <code>exactlyOne</code> means exactly one.</li>
 <li>Option: <code>x == none</code> / <code>x != none</code> / <code>x == some(e)</code> / <code>x != some(e)</code>.
   Equality is structural: <code>none</code> equals only <code>none</code>, while two <code>some</code> values are
   equal exactly when their payloads are equal. <code>x is some(v)</code> remains the form

--- a/examples/collection_aggregates.fsl
+++ b/examples/collection_aggregates.fsl
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec CollectionAggregates {
+  type Item = 0..2
+
+  state {
+    selected: Set<Item>,
+    queue: Seq<Item, 4>,
+    empty_queue: Seq<Item, 4>
+  }
+
+  init {
+    selected = Set { 0, 2 }
+    queue = Seq { 1, 1, 2 }
+    empty_queue = Seq {}
+  }
+
+  action keep() {
+    selected = selected
+  }
+
+  invariant CollectionValues {
+    unique(item in selected where item > 0)
+      and exactlyOne(item in queue where item == 2)
+      and not unique(item in queue where item == 1)
+      and unique(item in empty_queue)
+      and not exactlyOne(item in empty_queue)
+  }
+}

--- a/examples/e2e/1_business.fsl
+++ b/examples/e2e/1_business.fsl
@@ -48,9 +48,9 @@ business ExpenseToBe {
     transition pay          Approved  -> Paid      by Finance
   }
 
-  // Management metric: the number of completed payments. Because kpi
-  // auto-generates a same-named counter-consistency invariant, undercounting
-  // and double-counting of payments are also part of the verification target.
+  // Management metric: the number of completed payments. KPI declarations are
+  // typed projection metadata for explain/scenarios; they do not add ghost
+  // state or an automatic invariant.
   kpi paid_claims = count Claim in Paid
 
   // ── Control policies ─────────────────────────────────────────────

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -168,6 +168,7 @@ fn composed_kernel(name: String, items: Vec<SpecItem>, annotations: Annotations)
         },
         origins: crate::OriginRegistry::default(),
         annotations: fsl_syntax::AnnotationRegistry::default(),
+        projections: Vec::new(),
     };
     kernel.annotations.extend(crate::SPEC_TARGET, annotations);
     kernel
@@ -721,38 +722,18 @@ fn rewrite_expr(expr: Expr, component: &Component, bound: &HashSet<String>) -> E
                 body: Box::new(rewrite_expr(*body, component, &nested)),
             }
         }
-        Expr::Count {
-            name,
-            mut type_name,
-            condition,
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
         } => {
-            if type_name.namespace.is_none() && component.names.types.contains(&type_name.name) {
-                type_name.name = prefix(&component.alias, &type_name.name);
-            }
+            let binder = rewrite_binder(binder, component, bound);
             let mut nested = bound.clone();
-            nested.insert(name.clone());
-            Expr::Count {
-                name,
-                type_name,
-                condition: Box::new(rewrite_expr(*condition, component, &nested)),
-            }
-        }
-        Expr::Sum {
-            name,
-            mut type_name,
-            body,
-            condition,
-        } => {
-            if type_name.namespace.is_none() && component.names.types.contains(&type_name.name) {
-                type_name.name = prefix(&component.alias, &type_name.name);
-            }
-            let mut nested = bound.clone();
-            nested.insert(name.clone());
-            Expr::Sum {
-                name,
-                type_name,
-                body: Box::new(rewrite_expr(*body, component, &nested)),
-                condition: condition.map(|expr| Box::new(rewrite_expr(*expr, component, &nested))),
+            nested.insert(binder_name(&binder).to_owned());
+            Expr::Aggregate {
+                kind,
+                binder,
+                value: value.map(|expr| Box::new(rewrite_expr(*expr, component, &nested))),
             }
         }
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
@@ -775,10 +756,6 @@ fn rewrite_expr(expr: Expr, component: &Component, bound: &HashSet<String>) -> E
             first: Box::new(rewrite_expr(*first, component, bound)),
             second: Box::new(rewrite_expr(*second, component, bound)),
             third: Box::new(rewrite_expr(*third, component, bound)),
-        },
-        Expr::BinderNamed { name, binder } => Expr::BinderNamed {
-            name,
-            binder: rewrite_binder(binder, component, bound),
         },
         other => other,
     }
@@ -803,11 +780,22 @@ fn rewrite_binder(binder: Binder, component: &Component, bound: &HashSet<String>
                     .map(|expr| Box::new(rewrite_expr(*expr, component, &nested))),
             }
         }
-        Binder::Range { name, lo, hi } => Binder::Range {
+        Binder::Range {
             name,
-            lo: Box::new(rewrite_expr(*lo, component, bound)),
-            hi: Box::new(rewrite_expr(*hi, component, bound)),
-        },
+            lo,
+            hi,
+            where_expr,
+        } => {
+            let mut nested = bound.clone();
+            nested.insert(name.clone());
+            Binder::Range {
+                name,
+                lo: Box::new(rewrite_expr(*lo, component, bound)),
+                hi: Box::new(rewrite_expr(*hi, component, bound)),
+                where_expr: where_expr
+                    .map(|expr| Box::new(rewrite_expr(*expr, component, &nested))),
+            }
+        }
         Binder::Collection {
             name,
             collection,
@@ -1078,10 +1066,18 @@ fn resolve_alias_binder(
                 .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
                 .transpose()?,
         },
-        Binder::Range { name, lo, hi } => Binder::Range {
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => Binder::Range {
             name,
             lo: Box::new(resolve_alias_expr(*lo, components)?),
             hi: Box::new(resolve_alias_expr(*hi, components)?),
+            where_expr: where_expr
+                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .transpose()?,
         },
         Binder::Collection {
             name,
@@ -1189,25 +1185,14 @@ fn resolve_alias_expr(
             binder: resolve_alias_binder(binder, components)?,
             body: Box::new(resolve_alias_expr(*body, components)?),
         },
-        Expr::Count {
-            name,
-            type_name,
-            condition,
-        } => Expr::Count {
-            name,
-            type_name: resolve_alias_qualified_name(type_name, components)?,
-            condition: Box::new(resolve_alias_expr(*condition, components)?),
-        },
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => Expr::Sum {
-            name,
-            type_name: resolve_alias_qualified_name(type_name, components)?,
-            body: Box::new(resolve_alias_expr(*body, components)?),
-            condition: condition
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => Expr::Aggregate {
+            kind,
+            binder: resolve_alias_binder(binder, components)?,
+            value: value
                 .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
                 .transpose()?,
         },
@@ -1231,10 +1216,6 @@ fn resolve_alias_expr(
             first: Box::new(resolve_alias_expr(*first, components)?),
             second: Box::new(resolve_alias_expr(*second, components)?),
             third: Box::new(resolve_alias_expr(*third, components)?),
-        },
-        Expr::BinderNamed { name, binder } => Expr::BinderNamed {
-            name,
-            binder: resolve_alias_binder(binder, components)?,
         },
         other => other,
     })

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
 use fsl_syntax::{
-    ActionItem, Annotation, Annotations, Binder, BusinessGoalBody, BusinessItem,
+    ActionItem, AggregateKind, Annotation, Annotations, Binder, BusinessGoalBody, BusinessItem,
     BusinessPolicyBody, Expr, GovernanceArtifactRef, GovernanceDelegateItem, GovernanceItem,
     LValue, MetaTag, Param, PreservationItem, ProcessField, ProcessItem, ProcessTransition,
     QualifiedName, RequirementAction, RequirementActionItem, RequirementBlockItem,
@@ -15,7 +15,8 @@ use fsl_syntax::{
 
 use crate::{
     CoreError, KernelSpec, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite,
-    TERMINAL_TARGET, action_target, lower_direct_spec, state_target, substitute_expr,
+    ProjectionDef, TERMINAL_TARGET, action_target, lower_direct_spec, state_target,
+    substitute_expr,
 };
 
 #[derive(Clone)]
@@ -28,6 +29,53 @@ struct Process {
     initial: String,
     transitions: Vec<ProcessTransition>,
     span: fsl_syntax::Span,
+}
+
+fn kpi_projection(item: &BusinessItem, processes: &[Process]) -> Result<ProjectionDef, CoreError> {
+    let BusinessItem::Kpi {
+        name,
+        case_name,
+        stage,
+        span,
+    } = item
+    else {
+        unreachable!("KPI projection requires a KPI item");
+    };
+    let candidates = processes
+        .iter()
+        .filter(|process| process.entity == *case_name)
+        .collect::<Vec<_>>();
+    let [process] = candidates.as_slice() else {
+        return Err(core_error(
+            if candidates.is_empty() {
+                format!("KPI '{name}' uses unknown entity '{case_name}'")
+            } else {
+                format!("KPI '{name}' has ambiguous process for entity '{case_name}'")
+            },
+            *span,
+        ));
+    };
+    if !process.stages.contains(stage) {
+        return Err(core_error(
+            format!("KPI '{name}' uses unknown stage '{stage}'"),
+            *span,
+        ));
+    }
+    Ok(ProjectionDef {
+        name: name.clone(),
+        entity: case_name.clone(),
+        stage: stage.clone(),
+        expr: Expr::Aggregate {
+            kind: AggregateKind::Count,
+            binder: Binder::Typed {
+                name: "c".to_owned(),
+                type_name: qualified(case_name),
+                where_expr: Some(Box::new(stage_is(process, "c", stage))),
+            },
+            value: None,
+        },
+        span: *span,
+    })
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -344,32 +392,16 @@ impl StageResolver<'_> {
                     body: Box::new(self.expression(*body, &nested)?),
                 }
             }
-            Expr::Count {
-                name,
-                type_name,
-                condition,
+            Expr::Aggregate {
+                kind,
+                binder,
+                value,
             } => {
-                let mut nested = environment.clone();
-                nested.insert(name.clone(), qualified_type_name(&type_name));
-                Expr::Count {
-                    name,
-                    type_name,
-                    condition: Box::new(self.expression(*condition, &nested)?),
-                }
-            }
-            Expr::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => {
-                let mut nested = environment.clone();
-                nested.insert(name.clone(), qualified_type_name(&type_name));
-                Expr::Sum {
-                    name,
-                    type_name,
-                    body: Box::new(self.expression(*body, &nested)?),
-                    condition: condition
+                let (binder, nested) = self.binder(binder, environment)?;
+                Expr::Aggregate {
+                    kind,
+                    binder,
+                    value: value
                         .map(|value| self.expression(*value, &nested).map(Box::new))
                         .transpose()?,
                 }
@@ -395,10 +427,6 @@ impl StageResolver<'_> {
                 second: Box::new(self.expression(*second, environment)?),
                 third: Box::new(self.expression(*third, environment)?),
             },
-            Expr::BinderNamed { name, binder } => {
-                let (binder, _) = self.binder(binder, environment)?;
-                Expr::BinderNamed { name, binder }
-            }
             other => other,
         })
     }
@@ -424,12 +452,20 @@ impl StageResolver<'_> {
                         .transpose()?,
                 }
             }
-            Binder::Range { name, lo, hi } => {
+            Binder::Range {
+                name,
+                lo,
+                hi,
+                where_expr,
+            } => {
                 nested.insert(name.clone(), "Int".to_owned());
                 Binder::Range {
                     name,
                     lo: Box::new(self.expression(*lo, environment)?),
                     hi: Box::new(self.expression(*hi, environment)?),
+                    where_expr: where_expr
+                        .map(|value| self.expression(*value, &nested).map(Box::new))
+                        .transpose()?,
                 }
             }
             Binder::Collection {
@@ -1131,6 +1167,12 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
             annotations: goal_annotations.clone(),
         });
     }
+    let projections = business
+        .items
+        .iter()
+        .filter(|item| matches!(item, BusinessItem::Kpi { .. }))
+        .map(|item| kpi_projection(item, &processes))
+        .collect::<Result<Vec<_>, _>>()?;
     let origins = resolve_stage_items(&mut items, &processes, "business")?;
     let mut kernel = crate::lower_direct_spec_with_origins(
         SurfaceSpec {
@@ -1140,6 +1182,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
         },
         origins,
     )?;
+    kernel.set_projections(projections);
     for (target, annotation) in explicit_annotations {
         kernel.bind_annotation(target, annotation);
     }
@@ -1397,6 +1440,7 @@ fn action_enabled_expression(action: &SpecItem) -> Option<Expr> {
                 name: name.clone(),
                 lo: Box::new(lo.clone()),
                 hi: Box::new(hi.clone()),
+                where_expr: None,
             },
         };
         expression = Expr::Quantified {
@@ -2025,6 +2069,15 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
         .iter()
         .map(|process| process.process.clone())
         .collect::<Vec<_>>();
+    let projections = requirements
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            RequirementsItem::Kpi(item) => Some(item),
+            _ => None,
+        })
+        .map(|item| kpi_projection(item, &stage_processes))
+        .collect::<Result<Vec<_>, _>>()?;
     let origins = resolve_stage_items(&mut items, &stage_processes, "requirements")?;
     let mut kernel = crate::lower_direct_spec_with_origins(
         SurfaceSpec {
@@ -2034,6 +2087,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
         },
         origins,
     )?;
+    kernel.set_projections(projections);
     for (target, annotation) in extra_annotations {
         kernel.bind_annotation(target, annotation);
     }

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -3,11 +3,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use fsl_syntax::{
-    ActionItem, Annotations, Binder, DomainAggregate, DomainDecide, DomainEffect, DomainField,
-    DomainLoc, DomainSaga, DomainSagaStep, DomainSpec, DomainType, DomainTypeSourceForm, Expr,
-    LValue, MetaTag, Param, Pattern, QualifiedName, Span, SpecItem, StateField, Statement,
-    SurfaceSpec, SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxLValue, SyntaxPattern,
-    SyntaxQualifiedName, SyntaxTypeExpr, SyntaxTypeExprKind, TypeExpr,
+    ActionItem, AggregateKind, Annotations, Binder, DomainAggregate, DomainDecide, DomainEffect,
+    DomainField, DomainLoc, DomainSaga, DomainSagaStep, DomainSpec, DomainType,
+    DomainTypeSourceForm, Expr, LValue, MetaTag, Param, Pattern, QualifiedName, Span, SpecItem,
+    StateField, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxLValue,
+    SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr, SyntaxTypeExprKind, TypeExpr,
 };
 
 use crate::CoreError;
@@ -1111,6 +1111,7 @@ impl<'a> Resolver<'a> {
                 quantifier,
                 binder,
                 body,
+                ..
             } => {
                 let (binder, nested) =
                     self.resolve_binder(binder, scope, aggregate, expanding_can)?;
@@ -1130,64 +1131,19 @@ impl<'a> Resolver<'a> {
                     ty: LogicalType::Bool,
                 }
             }
-            SyntaxExprKind::Count {
-                name,
-                type_name,
-                condition,
+            SyntaxExprKind::Aggregate {
+                kind,
+                binder,
+                value,
             } => {
-                let logical = self.qualified_logical_type(type_name)?;
-                let mut nested = scope.clone();
-                nested.insert(
-                    name.text.clone(),
-                    Symbol {
-                        kernel_name: name.text.clone(),
-                        ty: logical,
-                    },
-                );
-                let condition = self.resolve_expr(
-                    condition,
-                    Some(&LogicalType::Bool),
-                    &nested,
-                    aggregate,
-                    expanding_can,
-                )?;
-                ResolvedExpr {
-                    expr: Expr::Count {
-                        name: name.text.clone(),
-                        type_name: Self::qualified_name(type_name),
-                        condition: Box::new(condition.expr),
-                    },
-                    ty: LogicalType::Int,
-                }
-            }
-            SyntaxExprKind::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => {
-                let logical = self.qualified_logical_type(type_name)?;
-                let mut nested = scope.clone();
-                nested.insert(
-                    name.text.clone(),
-                    Symbol {
-                        kernel_name: name.text.clone(),
-                        ty: logical,
-                    },
-                );
-                let body = self.resolve_expr(
-                    body,
-                    Some(&LogicalType::Int),
-                    &nested,
-                    aggregate,
-                    expanding_can,
-                )?;
-                let condition = condition
+                let (binder, nested) =
+                    self.resolve_binder(binder, scope, aggregate, expanding_can)?;
+                let value = value
                     .as_deref()
-                    .map(|condition| {
+                    .map(|value| {
                         self.resolve_expr(
-                            condition,
-                            Some(&LogicalType::Bool),
+                            value,
+                            Some(&LogicalType::Int),
                             &nested,
                             aggregate,
                             expanding_can,
@@ -1196,27 +1152,16 @@ impl<'a> Resolver<'a> {
                     })
                     .transpose()?;
                 ResolvedExpr {
-                    expr: Expr::Sum {
-                        name: name.text.clone(),
-                        type_name: Self::qualified_name(type_name),
-                        body: Box::new(body.expr),
-                        condition,
-                    },
-                    ty: LogicalType::Int,
-                }
-            }
-            SyntaxExprKind::BinderNamed { name, binder } => {
-                let (binder, _) = self.resolve_binder(binder, scope, aggregate, expanding_can)?;
-                ResolvedExpr {
-                    expr: Expr::BinderNamed {
-                        name: if name.text == "exactlyOne" {
-                            "exactly_one".to_owned()
-                        } else {
-                            name.text.clone()
-                        },
+                    expr: Expr::Aggregate {
+                        kind: *kind,
                         binder,
+                        value,
                     },
-                    ty: LogicalType::Bool,
+                    ty: if matches!(kind, AggregateKind::Count | AggregateKind::Sum) {
+                        LogicalType::Int
+                    } else {
+                        LogicalType::Bool
+                    },
                 }
             }
             SyntaxExprKind::Num(_)
@@ -1310,7 +1255,13 @@ impl<'a> Resolver<'a> {
                     nested,
                 ))
             }
-            SyntaxBinder::Range { name, lo, hi, .. } => {
+            SyntaxBinder::Range {
+                name,
+                lo,
+                hi,
+                where_expr,
+                ..
+            } => {
                 let lo = self.resolve_expr(
                     lo,
                     Some(&LogicalType::Int),
@@ -1333,11 +1284,25 @@ impl<'a> Resolver<'a> {
                         ty: LogicalType::Int,
                     },
                 );
+                let where_expr = where_expr
+                    .as_deref()
+                    .map(|value| {
+                        self.resolve_expr(
+                            value,
+                            Some(&LogicalType::Bool),
+                            &nested,
+                            aggregate,
+                            expanding_can,
+                        )
+                        .map(|value| Box::new(value.expr))
+                    })
+                    .transpose()?;
                 Ok((
                     Binder::Range {
                         name: name.text.clone(),
                         lo: Box::new(lo.expr),
                         hi: Box::new(hi.expr),
+                        where_expr,
                     },
                     nested,
                 ))
@@ -2922,20 +2887,15 @@ fn expression_lowering_steps(expression: &SyntaxExpr) -> Vec<LoweringStep> {
             }
             SyntaxExprKind::Is { expr, .. } => visit(expr, output),
             SyntaxExprKind::Quantified { body, .. } => visit(body, output),
-            SyntaxExprKind::Count { condition, .. } => visit(condition, output),
-            SyntaxExprKind::Sum {
-                body, condition, ..
-            } => {
-                visit(body, output);
-                if let Some(condition) = condition {
-                    visit(condition, output);
+            SyntaxExprKind::Aggregate { value, .. } => {
+                if let Some(value) = value {
+                    visit(value, output);
                 }
             }
             SyntaxExprKind::Num(_)
             | SyntaxExprKind::Bool(_)
             | SyntaxExprKind::None
-            | SyntaxExprKind::Name(_)
-            | SyntaxExprKind::BinderNamed { .. } => {}
+            | SyntaxExprKind::Name(_) => {}
         }
     }
 
@@ -3266,18 +3226,12 @@ fn bind_expression_tree(
         | Expr::UnaryNamed { expr, .. } => {
             bind_expression_tree(registry, &child("operand"), expr, origin);
         }
-        Expr::Quantified { body, .. }
-        | Expr::Count {
-            condition: body, ..
-        } => {
+        Expr::Quantified { body, .. } => {
             bind_expression_tree(registry, &child("body"), body, origin);
         }
-        Expr::Sum {
-            body, condition, ..
-        } => {
-            bind_expression_tree(registry, &child("body"), body, origin);
-            if let Some(condition) = condition {
-                bind_expression_tree(registry, &child("condition"), condition, origin);
+        Expr::Aggregate { value, .. } => {
+            if let Some(value) = value {
+                bind_expression_tree(registry, &child("value"), value, origin);
             }
         }
         Expr::TernaryNamed {
@@ -3290,7 +3244,7 @@ fn bind_expression_tree(
             bind_expression_tree(registry, &child("second"), second, origin);
             bind_expression_tree(registry, &child("third"), third, origin);
         }
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::BinderNamed { .. } => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => {}
     }
 }
 

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -14,10 +14,10 @@ use fsl_syntax::{
 use serde_json::Value;
 
 pub use fsl_syntax::{
-    Annotation, AnnotationError, AnnotationRegistry as KernelAnnotationRegistry, AnnotationValue,
-    Annotations, Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr,
-    LValue as KernelLValue, Pattern, QualifiedName, RequirementLink, Statement as KernelStatement,
-    SymbolPath,
+    AggregateKind as KernelAggregateKind, Annotation, AnnotationError,
+    AnnotationRegistry as KernelAnnotationRegistry, AnnotationValue, Annotations,
+    Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr, LValue as KernelLValue,
+    Pattern, QualifiedName, RequirementLink, Statement as KernelStatement, SymbolPath,
 };
 
 mod compose;
@@ -146,6 +146,16 @@ pub struct KernelSpec {
     spec: SurfaceSpec,
     origins: OriginRegistry,
     annotations: AnnotationRegistry,
+    projections: Vec<ProjectionDef>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectionDef {
+    pub name: String,
+    pub entity: String,
+    pub stage: String,
+    pub expr: Expr,
+    pub span: fsl_syntax::Span,
 }
 
 /// Build a checked kernel model from an already parsed surface specification.
@@ -161,6 +171,7 @@ pub fn build_surface_model(spec: SurfaceSpec) -> Result<KernelModel, ModelError>
         spec,
         origins: OriginRegistry::default(),
         annotations: AnnotationRegistry::default(),
+        projections: Vec::new(),
     })
 }
 
@@ -193,6 +204,15 @@ impl KernelSpec {
     #[must_use]
     pub fn annotations(&self) -> &AnnotationRegistry {
         &self.annotations
+    }
+
+    #[must_use]
+    pub fn projections(&self) -> &[ProjectionDef] {
+        &self.projections
+    }
+
+    pub(crate) fn set_projections(&mut self, projections: Vec<ProjectionDef>) {
+        self.projections = projections;
     }
 
     #[must_use]
@@ -374,6 +394,7 @@ fn lower_direct_spec_with_origins(
         spec,
         origins,
         annotations: AnnotationRegistry::default(),
+        projections: Vec::new(),
     })
 }
 
@@ -937,10 +958,18 @@ impl PredicateExpander {
                     .map(|expr| self.expand_expr(*expr, stack).map(Box::new))
                     .transpose()?,
             },
-            Binder::Range { name, lo, hi } => Binder::Range {
+            Binder::Range {
+                name,
+                lo,
+                hi,
+                where_expr,
+            } => Binder::Range {
                 name,
                 lo: Box::new(self.expand_expr(*lo, stack)?),
                 hi: Box::new(self.expand_expr(*hi, stack)?),
+                where_expr: where_expr
+                    .map(|expr| self.expand_expr(*expr, stack).map(Box::new))
+                    .transpose()?,
             },
             Binder::Collection {
                 name,
@@ -1077,25 +1106,14 @@ impl PredicateExpander {
                 binder: self.expand_binder(binder, stack)?,
                 body: Box::new(self.expand_expr(*body, stack)?),
             },
-            Expr::Count {
-                name,
-                type_name,
-                condition,
-            } => Expr::Count {
-                name,
-                type_name,
-                condition: Box::new(self.expand_expr(*condition, stack)?),
-            },
-            Expr::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => Expr::Sum {
-                name,
-                type_name,
-                body: Box::new(self.expand_expr(*body, stack)?),
-                condition: condition
+            Expr::Aggregate {
+                kind,
+                binder,
+                value,
+            } => Expr::Aggregate {
+                kind,
+                binder: self.expand_binder(binder, stack)?,
+                value: value
                     .map(|expr| self.expand_expr(*expr, stack).map(Box::new))
                     .transpose()?,
             },
@@ -1119,10 +1137,6 @@ impl PredicateExpander {
                 first: Box::new(self.expand_expr(*first, stack)?),
                 second: Box::new(self.expand_expr(*second, stack)?),
                 third: Box::new(self.expand_expr(*third, stack)?),
-            },
-            Expr::BinderNamed { name, binder } => Expr::BinderNamed {
-                name,
-                binder: self.expand_binder(binder, stack)?,
             },
             other => other,
         })
@@ -1191,13 +1205,10 @@ pub(crate) fn visit_expr_children(
             visit_binder_exprs(binder, visitor)?;
             visitor(body)?;
         }
-        Expr::Count { condition, .. } => visitor(condition)?,
-        Expr::Sum {
-            body, condition, ..
-        } => {
-            visitor(body)?;
-            if let Some(condition) = condition {
-                visitor(condition)?;
+        Expr::Aggregate { binder, value, .. } => {
+            visit_binder_exprs(binder, visitor)?;
+            if let Some(value) = value {
+                visitor(value)?;
             }
         }
         Expr::TernaryNamed {
@@ -1210,7 +1221,6 @@ pub(crate) fn visit_expr_children(
             visitor(second)?;
             visitor(third)?;
         }
-        Expr::BinderNamed { binder, .. } => visit_binder_exprs(binder, visitor)?,
         Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => {}
     }
     Ok(())
@@ -1226,9 +1236,14 @@ fn visit_binder_exprs(
                 visitor(expr)?;
             }
         }
-        Binder::Range { lo, hi, .. } => {
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
             visitor(lo)?;
             visitor(hi)?;
+            if let Some(expr) = where_expr {
+                visitor(expr)?;
+            }
         }
         Binder::Collection {
             collection,
@@ -1252,11 +1267,8 @@ fn bound_vars(expr: &Expr) -> HashSet<String> {
 
 fn collect_bound_vars(expr: &Expr, out: &mut HashSet<String>) {
     match expr {
-        Expr::Quantified { binder, .. } | Expr::BinderNamed { binder, .. } => {
+        Expr::Quantified { binder, .. } | Expr::Aggregate { binder, .. } => {
             out.insert(binder_name(binder).to_owned());
-        }
-        Expr::Count { name, .. } | Expr::Sum { name, .. } => {
-            out.insert(name.clone());
         }
         _ => {}
     }
@@ -1278,22 +1290,60 @@ fn free_vars_bound(expr: &Expr, bound: &HashSet<String>) -> HashSet<String> {
             HashSet::from([name.clone()])
         };
     }
-    let mut child_bound = bound.clone();
-    match expr {
-        Expr::Quantified { binder, .. } | Expr::BinderNamed { binder, .. } => {
-            child_bound.insert(binder_name(binder).to_owned());
+    if let Expr::Quantified { binder, body, .. } = expr {
+        let (mut out, nested_bound) = free_vars_binder(binder, bound);
+        out.extend(free_vars_bound(body, &nested_bound));
+        return out;
+    }
+    if let Expr::Aggregate { binder, value, .. } = expr {
+        let (mut out, nested_bound) = free_vars_binder(binder, bound);
+        if let Some(value) = value {
+            out.extend(free_vars_bound(value, &nested_bound));
         }
-        Expr::Count { name, .. } | Expr::Sum { name, .. } => {
-            child_bound.insert(name.clone());
-        }
-        _ => {}
+        return out;
     }
     let mut out = HashSet::new();
     let _ = visit_expr_children(expr, &mut |child| {
-        out.extend(free_vars_bound(child, &child_bound));
+        out.extend(free_vars_bound(child, bound));
         Ok(())
     });
     out
+}
+
+fn free_vars_binder(
+    binder: &Binder,
+    bound: &HashSet<String>,
+) -> (HashSet<String>, HashSet<String>) {
+    let mut nested_bound = bound.clone();
+    nested_bound.insert(binder_name(binder).to_owned());
+    let mut out = HashSet::new();
+    match binder {
+        Binder::Typed { where_expr, .. } => {
+            if let Some(filter) = where_expr {
+                out.extend(free_vars_bound(filter, &nested_bound));
+            }
+        }
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
+            out.extend(free_vars_bound(lo, bound));
+            out.extend(free_vars_bound(hi, bound));
+            if let Some(filter) = where_expr {
+                out.extend(free_vars_bound(filter, &nested_bound));
+            }
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            out.extend(free_vars_bound(collection, bound));
+            if let Some(filter) = where_expr {
+                out.extend(free_vars_bound(filter, &nested_bound));
+            }
+        }
+    }
+    (out, nested_bound)
 }
 
 fn binder_name(binder: &Binder) -> &str {
@@ -1386,31 +1436,31 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             quantifier,
             binder,
             body,
-        } => Expr::Quantified {
-            quantifier,
-            binder: substitute_binder(binder, replacements),
-            body: Box::new(substitute(*body, replacements)),
-        },
-        Expr::Count {
-            name,
-            type_name,
-            condition,
-        } => Expr::Count {
-            name,
-            type_name,
-            condition: Box::new(substitute(*condition, replacements)),
-        },
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => Expr::Sum {
-            name,
-            type_name,
-            body: Box::new(substitute(*body, replacements)),
-            condition: condition.map(|expr| Box::new(substitute(*expr, replacements))),
-        },
+        } => {
+            let (binder, mut contents, scoped) =
+                capture_avoiding_binding(binder, vec![*body], replacements);
+            Expr::Quantified {
+                quantifier,
+                binder: substitute_binder(binder, replacements),
+                body: Box::new(substitute(contents.remove(0), &scoped)),
+            }
+        }
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => {
+            let contents = value.map_or_else(Vec::new, |expr| vec![*expr]);
+            let (binder, mut contents, scoped) =
+                capture_avoiding_binding(binder, contents, replacements);
+            Expr::Aggregate {
+                kind,
+                binder: substitute_binder(binder, replacements),
+                value: contents
+                    .pop()
+                    .map(|expr| Box::new(substitute(expr, &scoped))),
+            }
+        }
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
             name,
             expr: Box::new(substitute(*expr, replacements)),
@@ -1432,10 +1482,6 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             second: Box::new(substitute(*second, replacements)),
             third: Box::new(substitute(*third, replacements)),
         },
-        Expr::BinderNamed { name, binder } => Expr::BinderNamed {
-            name,
-            binder: substitute_binder(binder, replacements),
-        },
         other => other,
     }
 }
@@ -1452,10 +1498,138 @@ pub fn substitute_expr<S: std::hash::BuildHasher>(
     substitute(expr, replacements)
 }
 
+fn without_replacement<S: std::hash::BuildHasher>(
+    replacements: &HashMap<String, Expr, S>,
+    binding: &str,
+) -> HashMap<String, Expr> {
+    replacements
+        .iter()
+        .filter(|(name, _)| name.as_str() != binding)
+        .map(|(name, expr)| (name.clone(), expr.clone()))
+        .collect()
+}
+
+fn capture_avoiding_binding<S: std::hash::BuildHasher>(
+    binder: Binder,
+    contents: Vec<Expr>,
+    replacements: &HashMap<String, Expr, S>,
+) -> (Binder, Vec<Expr>, HashMap<String, Expr>) {
+    let binding = binder_name(&binder).to_owned();
+    let scoped = without_replacement(replacements, &binding);
+    if !scoped
+        .values()
+        .any(|replacement| free_vars(replacement).contains(&binding))
+    {
+        return (binder, contents, scoped);
+    }
+
+    let mut names = HashSet::from([binding.clone()]);
+    names.extend(scoped.keys().cloned());
+    for replacement in scoped.values() {
+        collect_names(replacement, &mut names);
+    }
+    collect_binder_names(&binder, &mut names);
+    for content in &contents {
+        collect_names(content, &mut names);
+    }
+    let mut index = 0_u64;
+    let fresh = loop {
+        let candidate = format!("__{binding}_substitution_{index}");
+        if !names.contains(&candidate) {
+            break candidate;
+        }
+        index = index
+            .checked_add(1)
+            .expect("the identifier space is unbounded");
+    };
+    let rename = HashMap::from([(binding, Expr::Var(fresh.clone()))]);
+    let binder = rename_binder_binding(binder, fresh, &rename);
+    let contents = contents
+        .into_iter()
+        .map(|content| substitute(content, &rename))
+        .collect();
+    (binder, contents, scoped)
+}
+
+fn rename_binder_binding(binder: Binder, fresh: String, rename: &HashMap<String, Expr>) -> Binder {
+    match binder {
+        Binder::Typed {
+            type_name,
+            where_expr,
+            ..
+        } => Binder::Typed {
+            name: fresh,
+            type_name,
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+        },
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => Binder::Range {
+            name: fresh,
+            lo,
+            hi,
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+        },
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => Binder::Collection {
+            name: fresh,
+            collection,
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+        },
+    }
+}
+
+fn collect_binder_names(binder: &Binder, names: &mut HashSet<String>) {
+    names.insert(binder_name(binder).to_owned());
+    match binder {
+        Binder::Typed { where_expr, .. } => {
+            if let Some(filter) = where_expr {
+                collect_names(filter, names);
+            }
+        }
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
+            collect_names(lo, names);
+            collect_names(hi, names);
+            if let Some(filter) = where_expr {
+                collect_names(filter, names);
+            }
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            collect_names(collection, names);
+            if let Some(filter) = where_expr {
+                collect_names(filter, names);
+            }
+        }
+    }
+}
+
+fn collect_names(expr: &Expr, names: &mut HashSet<String>) {
+    if let Expr::Var(name) = expr {
+        names.insert(name.clone());
+    }
+    if let Expr::Quantified { binder, .. } | Expr::Aggregate { binder, .. } = expr {
+        collect_binder_names(binder, names);
+    }
+    let _ = visit_expr_children(expr, &mut |child| {
+        collect_names(child, names);
+        Ok(())
+    });
+}
+
 fn substitute_binder<S: std::hash::BuildHasher>(
     binder: Binder,
     replacements: &HashMap<String, Expr, S>,
 ) -> Binder {
+    let scoped = without_replacement(replacements, binder_name(&binder));
     match binder {
         Binder::Typed {
             name,
@@ -1464,12 +1638,18 @@ fn substitute_binder<S: std::hash::BuildHasher>(
         } => Binder::Typed {
             name,
             type_name,
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, replacements))),
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
         },
-        Binder::Range { name, lo, hi } => Binder::Range {
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => Binder::Range {
             name,
             lo: Box::new(substitute(*lo, replacements)),
             hi: Box::new(substitute(*hi, replacements)),
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
         },
         Binder::Collection {
             name,
@@ -1478,7 +1658,7 @@ fn substitute_binder<S: std::hash::BuildHasher>(
         } => Binder::Collection {
             name,
             collection: Box::new(substitute(*collection, replacements)),
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, replacements))),
+            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
         },
     }
 }

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -11,7 +11,8 @@ use fsl_syntax::{
 
 use crate::{
     INIT_TARGET, KernelSpec, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite,
-    SPEC_TARGET, TraceabilityRegistry, action_target, property_target, state_target, type_target,
+    ProjectionDef, SPEC_TARGET, TraceabilityRegistry, action_target, property_target, state_target,
+    type_target,
 };
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -139,6 +140,7 @@ pub struct KernelModel {
     pub reachables: Vec<PropertyDef>,
     pub leadstos: Vec<LeadsToDef>,
     pub terminal: Option<Expr>,
+    pub projections: Vec<ProjectionDef>,
     origins: OriginRegistry,
     annotations: AnnotationRegistry,
     traceability: TraceabilityRegistry,
@@ -371,6 +373,7 @@ struct ModelBuilder {
     spec: SurfaceSpec,
     origins: OriginRegistry,
     annotations: AnnotationRegistry,
+    projections: Vec<ProjectionDef>,
     consts: BTreeMap<String, Value>,
     types: BTreeMap<String, TypeDef>,
     enum_members: BTreeMap<String, Value>,
@@ -382,11 +385,13 @@ impl ModelBuilder {
             spec,
             origins,
             annotations,
+            projections,
         } = kernel;
         Self {
             spec,
             origins,
             annotations,
+            projections,
             consts: BTreeMap::new(),
             types: BTreeMap::new(),
             enum_members: BTreeMap::new(),
@@ -708,6 +713,7 @@ impl ModelBuilder {
             reachables,
             leadstos,
             terminal,
+            projections: self.projections,
             origins: self.origins,
             annotations: self.annotations,
             traceability,
@@ -735,6 +741,21 @@ impl ModelBuilder {
             let origin = error.span.map(type_diagnostic_origin);
             model_error(format!("invalid model expression: {}", error.message)).with_origin(origin)
         })?;
+        for projection in &model.projections {
+            crate::public_kernel::validate_expression_type(
+                &projection.expr,
+                &TypeRef::Int,
+                &[],
+                &model,
+            )
+            .map_err(|error| {
+                model_error(format!(
+                    "invalid KPI projection '{}': {}",
+                    projection.name, error.message
+                ))
+                .with_origin(Some(type_diagnostic_origin(projection.span)))
+            })?;
+        }
         Ok(model)
     }
 
@@ -1309,9 +1330,7 @@ fn first_state_reference(expr: &Expr, state_names: &BTreeSet<String>) -> Option<
 fn unsupported_inline_form(expr: &Expr) -> Option<&'static str> {
     let unsupported = match expr {
         Expr::Quantified { .. } => Some("a quantified expression"),
-        Expr::Count { .. } | Expr::Sum { .. } | Expr::BinderNamed { .. } => {
-            Some("a binder or aggregate expression")
-        }
+        Expr::Aggregate { .. } => Some("a binder or aggregate expression"),
         Expr::UnaryNamed { name, .. }
             if name == "old" || name == "stage" || name.starts_with("rel_") =>
         {
@@ -1357,11 +1376,9 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
             .into_iter()
             .chain(std::iter::once(body.as_ref()))
             .collect(),
-        Expr::Count { condition, .. } => vec![condition],
-        Expr::Sum {
-            body, condition, ..
-        } => std::iter::once(body.as_ref())
-            .chain(condition.as_deref())
+        Expr::Aggregate { binder, value, .. } => binder_exprs(binder)
+            .into_iter()
+            .chain(value.as_deref())
             .collect(),
         Expr::TernaryNamed {
             first,
@@ -1369,7 +1386,6 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
             third,
             ..
         } => vec![first, second, third],
-        Expr::BinderNamed { binder, .. } => binder_exprs(binder),
         Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => Vec::new(),
     }
 }
@@ -1377,7 +1393,12 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
 fn binder_exprs(binder: &Binder) -> Vec<&Expr> {
     match binder {
         Binder::Typed { where_expr, .. } => where_expr.iter().map(AsRef::as_ref).collect(),
-        Binder::Range { lo, hi, .. } => vec![lo, hi],
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => std::iter::once(lo.as_ref())
+            .chain(std::iter::once(hi.as_ref()))
+            .chain(where_expr.as_deref())
+            .collect(),
         Binder::Collection {
             collection,
             where_expr,

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -2,10 +2,13 @@
 
 //! Versioned normalized Kernel JSON for external compilers.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
-use fsl_syntax::{Binder, Expr, LValue, MetaTag, Pattern, SourcePos, Span, SpecItem, Statement};
+use fsl_syntax::{
+    AggregateKind, Binder, ConditionalSpans, Expr, LValue, MetaTag, Pattern, SourcePos, Span,
+    SpecItem, Statement,
+};
 use serde_json::{Map, Value, json};
 
 use crate::{
@@ -146,6 +149,7 @@ fn resolve<'a>(model: &'a KernelModel, ty: &'a TypeRef) -> Result<TypeRef, Publi
 }
 
 type TypeEnv = BTreeMap<String, TypeRef>;
+type FiniteBinderCandidates = (String, Vec<(Expr, Expr)>, Option<Expr>);
 
 fn base_env(model: &KernelModel) -> TypeEnv {
     let mut env = model.state.iter().cloned().collect::<TypeEnv>();
@@ -230,7 +234,9 @@ fn infer_type(
             Some(ty @ (TypeRef::Int | TypeRef::Range(_, _))) => Ok(ty),
             _ => Ok(TypeRef::Int),
         },
-        Expr::Bool(_) => Ok(TypeRef::Bool),
+        Expr::Bool(_) | Expr::Not(_) | Expr::Is { .. } | Expr::Quantified { .. } => {
+            Ok(TypeRef::Bool)
+        }
         Expr::None => match expected.map(|ty| resolve(model, ty)).transpose()? {
             Some(ty @ TypeRef::Option(_)) => Ok(ty),
             _ => Err(error("public Kernel cannot infer uncontextualized none")),
@@ -320,12 +326,14 @@ fn infer_type(
                 Ok(TypeRef::Int)
             }
         }
-        Expr::Neg(_) | Expr::Count { .. } | Expr::Sum { .. } | Expr::BinaryNamed { .. } => {
-            Ok(TypeRef::Int)
-        }
-        Expr::Not(_) | Expr::Is { .. } | Expr::Quantified { .. } | Expr::BinderNamed { .. } => {
-            Ok(TypeRef::Bool)
-        }
+        Expr::Neg(_) | Expr::BinaryNamed { .. } => Ok(TypeRef::Int),
+        Expr::Aggregate { kind, .. } => Ok(
+            if matches!(kind, AggregateKind::Count | AggregateKind::Sum) {
+                TypeRef::Int
+            } else {
+                TypeRef::Bool
+            },
+        ),
         Expr::Conditional { then_expr, .. } => infer_type(then_expr, env, model, expected),
         Expr::UnaryNamed { name, expr, .. } => match name.as_str() {
             "old" => infer_type(expr, env, model, expected),
@@ -453,13 +461,18 @@ fn binder_json(
         Binder::Typed {
             name, where_expr, ..
         } => ("typed", name, None, None, None, where_expr.as_deref()),
-        Binder::Range { name, lo, hi } => (
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => (
             "range",
             name,
             Some(lo.as_ref()),
             Some(hi.as_ref()),
             None,
-            None,
+            where_expr.as_deref(),
         ),
         Binder::Collection {
             name,
@@ -503,6 +516,217 @@ fn binder_json(
         );
     }
     Ok(output)
+}
+
+fn normalize_aggregate(
+    kind: AggregateKind,
+    binder: &Binder,
+    value: Option<&Expr>,
+    env: &TypeEnv,
+    model: &KernelModel,
+) -> Result<Expr, PublicKernelError> {
+    let (name, candidates, filter) = finite_binder_candidates(binder, env, model)?;
+    let mut terms = Vec::new();
+    for (candidate, membership) in candidates {
+        let replacements = HashMap::from([(name.clone(), candidate)]);
+        let condition = aggregate_condition(membership, filter.as_ref(), &replacements);
+        let selected = match kind {
+            AggregateKind::Count | AggregateKind::Unique | AggregateKind::ExactlyOne => {
+                Expr::Num(1)
+            }
+            AggregateKind::Sum => crate::substitute_expr(
+                value
+                    .ok_or_else(|| error("sum aggregate requires a value"))?
+                    .clone(),
+                &replacements,
+            ),
+        };
+        let span = unknown_span();
+        terms.push(Expr::Conditional {
+            condition: Box::new(condition),
+            then_expr: Box::new(selected),
+            else_expr: Box::new(Expr::Num(0)),
+            spans: Box::new(ConditionalSpans {
+                condition: span,
+                then_expr: span,
+                else_expr: span,
+            }),
+        });
+    }
+    Ok(aggregate_result(kind, terms))
+}
+
+fn finite_binder_candidates(
+    binder: &Binder,
+    env: &TypeEnv,
+    model: &KernelModel,
+) -> Result<FiniteBinderCandidates, PublicKernelError> {
+    let (name, candidates, filter) = match binder {
+        Binder::Typed {
+            name, where_expr, ..
+        } => {
+            let candidates = model
+                .domain_values(&binder_type(binder, env, model)?)
+                .map_err(|model_error| error(model_error.to_string()))?
+                .into_iter()
+                .map(|candidate| Ok((value_expression(candidate)?, Expr::Bool(true))))
+                .collect::<Result<Vec<_>, PublicKernelError>>()?;
+            (name, candidates, where_expr.as_deref())
+        }
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => {
+            let lo = static_public_int(lo, model)?;
+            let hi = static_public_int(hi, model)?;
+            let candidates = (lo..=hi)
+                .map(|candidate| (Expr::Num(candidate), Expr::Bool(true)))
+                .collect();
+            (name, candidates, where_expr.as_deref())
+        }
+        Binder::Collection {
+            name,
+            collection,
+            where_expr,
+        } => {
+            let collection_ty = resolve(model, &infer_type(collection, env, model, None)?)?;
+            let candidates = match collection_ty {
+                TypeRef::Set(element_ty) => model
+                    .domain_values(&element_ty)
+                    .map_err(|model_error| error(model_error.to_string()))?
+                    .into_iter()
+                    .map(|candidate| {
+                        let candidate = value_expression(candidate)?;
+                        let present = Expr::Method {
+                            receiver: collection.clone(),
+                            name: "contains".to_owned(),
+                            args: vec![candidate.clone()],
+                        };
+                        Ok((candidate, present))
+                    })
+                    .collect::<Result<Vec<_>, PublicKernelError>>()?,
+                TypeRef::Seq(_, capacity) => (0..capacity)
+                    .map(|index| {
+                        let index = i64::try_from(index)
+                            .map_err(|_| error("Seq capacity exceeds public integer range"))?;
+                        let candidate = Expr::Method {
+                            receiver: collection.clone(),
+                            name: "at".to_owned(),
+                            args: vec![Expr::Num(index)],
+                        };
+                        let present = Expr::Binary {
+                            op: "<".to_owned(),
+                            left: Box::new(Expr::Num(index)),
+                            right: Box::new(Expr::Method {
+                                receiver: collection.clone(),
+                                name: "size".to_owned(),
+                                args: Vec::new(),
+                            }),
+                        };
+                        Ok((candidate, present))
+                    })
+                    .collect::<Result<Vec<_>, PublicKernelError>>()?,
+                _ => return Err(error("collection binder requires Set or Seq")),
+            };
+            (name, candidates, where_expr.as_deref())
+        }
+    };
+    Ok((name.clone(), candidates, filter.cloned()))
+}
+
+fn aggregate_condition(
+    membership: Expr,
+    filter: Option<&Expr>,
+    replacements: &HashMap<String, Expr>,
+) -> Expr {
+    filter.map_or(membership.clone(), |filter| {
+        let span = unknown_span();
+        Expr::Conditional {
+            condition: Box::new(membership),
+            then_expr: Box::new(crate::substitute_expr(filter.clone(), replacements)),
+            else_expr: Box::new(Expr::Bool(false)),
+            spans: Box::new(ConditionalSpans {
+                condition: span,
+                then_expr: span,
+                else_expr: span,
+            }),
+        }
+    })
+}
+
+fn aggregate_result(kind: AggregateKind, terms: Vec<Expr>) -> Expr {
+    let total = terms
+        .into_iter()
+        .fold(Expr::Num(0), |left, right| Expr::Binary {
+            op: "+".to_owned(),
+            left: Box::new(left),
+            right: Box::new(right),
+        });
+    match kind {
+        AggregateKind::Count | AggregateKind::Sum => total,
+        AggregateKind::Unique => Expr::Binary {
+            op: "<=".to_owned(),
+            left: Box::new(total),
+            right: Box::new(Expr::Num(1)),
+        },
+        AggregateKind::ExactlyOne => Expr::Binary {
+            op: "==".to_owned(),
+            left: Box::new(total),
+            right: Box::new(Expr::Num(1)),
+        },
+    }
+}
+
+fn static_public_int(expr: &Expr, model: &KernelModel) -> Result<i64, PublicKernelError> {
+    match expr {
+        Expr::Num(value) => Ok(*value),
+        Expr::Var(name) => match model.consts.get(name) {
+            Some(crate::FslValue::Int(value)) => Ok(*value),
+            _ => Err(error(format!("'{name}' is not an integer const"))),
+        },
+        Expr::Neg(value) => static_public_int(value, model)?
+            .checked_neg()
+            .ok_or_else(|| error("integer overflow in range bound")),
+        _ => Err(error(
+            "public Kernel requires static aggregate range bounds",
+        )),
+    }
+}
+
+fn value_expression(value: crate::FslValue) -> Result<Expr, PublicKernelError> {
+    Ok(match value {
+        crate::FslValue::Int(value) => Expr::Num(value),
+        crate::FslValue::Bool(value) => Expr::Bool(value),
+        crate::FslValue::Enum { member, .. } => Expr::Var(member),
+        crate::FslValue::None => Expr::None,
+        crate::FslValue::Some(value) => Expr::Some(Box::new(value_expression(*value)?)),
+        crate::FslValue::Struct { type_name, fields } => Expr::Struct {
+            name: type_name,
+            fields: fields
+                .into_iter()
+                .map(|(name, value)| Ok((name, value_expression(value)?)))
+                .collect::<Result<Vec<_>, PublicKernelError>>()?,
+        },
+        crate::FslValue::Set(values) => Expr::Set(
+            values
+                .into_iter()
+                .map(value_expression)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        crate::FslValue::Seq(values) => Expr::Seq(
+            values
+                .into_iter()
+                .map(value_expression)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        crate::FslValue::Map(_) | crate::FslValue::Relation(_) => {
+            return Err(error(
+                "aggregate element has no public literal representation",
+            ));
+        }
+    })
 }
 
 #[allow(clippy::too_many_lines)]
@@ -637,6 +861,13 @@ fn expr_json(
             name,
             args,
         } => {
+            let receiver_ty = resolve(model, &infer_type(receiver, env, model, None)?)?;
+            let argument_type = match (name.as_str(), &receiver_ty) {
+                ("contains" | "add" | "remove", TypeRef::Set(item))
+                | ("contains" | "push", TypeRef::Seq(item, _)) => Some(item.as_ref()),
+                ("at", TypeRef::Seq(_, _)) => Some(&TypeRef::Int),
+                _ => None,
+            };
             output.insert("kind".to_owned(), json!("method"));
             output.insert(
                 "receiver".to_owned(),
@@ -647,7 +878,7 @@ fn expr_json(
                 "arguments".to_owned(),
                 Value::Array(
                     args.iter()
-                        .map(|arg| expr_json(arg, env, model, path, span, None))
+                        .map(|arg| expr_json(arg, env, model, path, span, argument_type))
                         .collect::<Result<_, _>>()?,
                 ),
             );
@@ -754,44 +985,72 @@ fn expr_json(
                 expr_json(body, &local, model, path, span, Some(&TypeRef::Bool))?,
             );
         }
-        Expr::Count {
-            name,
-            type_name,
-            condition,
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
         } => {
-            let domain = qualified_name(type_name)?;
+            if matches!(kind, AggregateKind::Count | AggregateKind::Sum)
+                && !matches!(binder, Binder::Typed { .. })
+            {
+                let normalized = normalize_aggregate(*kind, binder, value.as_deref(), env, model)?;
+                return expr_json(&normalized, env, model, path, span, expected);
+            }
+            let name = match binder {
+                Binder::Typed { name, .. }
+                | Binder::Range { name, .. }
+                | Binder::Collection { name, .. } => name,
+            };
+            let binder_ty = binder_type(binder, env, model)?;
             let mut local = env.clone();
-            local.insert(name.clone(), TypeRef::Named(domain.clone()));
-            output.insert("kind".to_owned(), json!("count"));
-            output.insert("binding".to_owned(), json!(name));
-            output.insert("domain".to_owned(), json!(domain));
+            local.insert(name.clone(), binder_ty);
             output.insert(
-                "condition".to_owned(),
-                expr_json(condition, &local, model, path, span, Some(&TypeRef::Bool))?,
+                "kind".to_owned(),
+                json!(match kind {
+                    AggregateKind::Count => "count",
+                    AggregateKind::Sum => "sum",
+                    AggregateKind::Unique => "unique",
+                    AggregateKind::ExactlyOne => "exactly_one",
+                }),
             );
-        }
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => {
-            let domain = qualified_name(type_name)?;
-            let mut local = env.clone();
-            local.insert(name.clone(), TypeRef::Named(domain.clone()));
-            output.insert("kind".to_owned(), json!("sum"));
-            output.insert("binding".to_owned(), json!(name));
-            output.insert("domain".to_owned(), json!(domain));
-            output.insert(
-                "value".to_owned(),
-                expr_json(body, &local, model, path, span, Some(&TypeRef::Int))?,
-            );
-            output.insert(
-                "condition".to_owned(),
-                condition.as_deref().map_or(Ok(Value::Null), |condition| {
-                    expr_json(condition, &local, model, path, span, Some(&TypeRef::Bool))
-                })?,
-            );
+            if let Binder::Typed {
+                type_name,
+                where_expr,
+                ..
+            } = binder
+                && matches!(kind, AggregateKind::Count | AggregateKind::Sum)
+            {
+                output.insert("binding".to_owned(), json!(name));
+                output.insert("domain".to_owned(), json!(qualified_name(type_name)?));
+                output.insert(
+                    "condition".to_owned(),
+                    match where_expr.as_deref() {
+                        Some(condition) => {
+                            expr_json(condition, &local, model, path, span, Some(&TypeRef::Bool))?
+                        }
+                        None if *kind == AggregateKind::Sum => Value::Null,
+                        None => expr_json(
+                            &Expr::Bool(true),
+                            &local,
+                            model,
+                            path,
+                            span,
+                            Some(&TypeRef::Bool),
+                        )?,
+                    },
+                );
+            } else {
+                output.insert(
+                    "binder".to_owned(),
+                    binder_json(binder, env, model, path, span)?,
+                );
+            }
+            if let Some(value) = value {
+                output.insert(
+                    "value".to_owned(),
+                    expr_json(value, &local, model, path, span, Some(&TypeRef::Int))?,
+                );
+            }
         }
         Expr::UnaryNamed { name, expr, .. } => {
             output.insert("kind".to_owned(), json!(name));
@@ -828,13 +1087,6 @@ fn expr_json(
             output.insert(
                 "target".to_owned(),
                 expr_json(third, env, model, path, span, None)?,
-            );
-        }
-        Expr::BinderNamed { name, binder } => {
-            output.insert("kind".to_owned(), json!(name));
-            output.insert(
-                "binder".to_owned(),
-                binder_json(binder, env, model, path, span)?,
             );
         }
     }
@@ -1243,6 +1495,35 @@ fn walk_partial(
         walk_partial(else_expr, env, model, path, span, Some(&else_path), output)?;
         return Ok(());
     }
+    if let Expr::Quantified {
+        quantifier,
+        binder,
+        body,
+    } = expr
+    {
+        walk_quantified_partial(
+            quantifier,
+            binder,
+            body,
+            env,
+            model,
+            path,
+            span,
+            path_condition,
+            output,
+        )?;
+        return Ok(());
+    }
+    if let Expr::Aggregate {
+        kind,
+        binder,
+        value,
+    } = expr
+    {
+        let normalized = normalize_aggregate(*kind, binder, value.as_deref(), env, model)?;
+        walk_partial(&normalized, env, model, path, span, path_condition, output)?;
+        return Ok(());
+    }
     let mut children: Vec<&Expr> = Vec::new();
     match expr {
         Expr::Some(item) | Expr::Neg(item) | Expr::Not(item) => children.push(item),
@@ -1261,33 +1542,84 @@ fn walk_partial(
             children.push(receiver);
             children.extend(args);
         }
-        Expr::Conditional { .. } => unreachable!("handled above"),
-        Expr::Is { expr, .. } => children.push(expr),
-        Expr::Quantified { body, .. } => children.push(body),
-        Expr::Count { condition, .. } => children.push(condition),
-        Expr::Sum {
-            body, condition, ..
-        } => {
-            children.push(body);
-            if let Some(condition) = condition {
-                children.push(condition);
-            }
+        Expr::Conditional { .. } | Expr::Quantified { .. } | Expr::Aggregate { .. } => {
+            unreachable!("handled above")
         }
+        Expr::Is { expr, .. } => children.push(expr),
         Expr::TernaryNamed {
             first,
             second,
             third,
             ..
         } => children.extend([first.as_ref(), second.as_ref(), third.as_ref()]),
-        Expr::Num(_)
-        | Expr::Bool(_)
-        | Expr::None
-        | Expr::Var(_)
-        | Expr::Call { .. }
-        | Expr::BinderNamed { .. } => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::Call { .. } => {}
     }
     for child in children {
         walk_partial(child, env, model, path, span, path_condition, output)?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_quantified_partial(
+    quantifier: &str,
+    binder: &Binder,
+    body: &Expr,
+    env: &TypeEnv,
+    model: &KernelModel,
+    path: &str,
+    span: Span,
+    path_condition: Option<&Expr>,
+    output: &mut Vec<Value>,
+) -> Result<(), PublicKernelError> {
+    let (name, candidates, filter) = finite_binder_candidates(binder, env, model)?;
+    let mut continuation = path_condition.cloned();
+    for (candidate, membership) in candidates {
+        let replacements = HashMap::from([(name.clone(), candidate)]);
+        let effective = aggregate_condition(membership, filter.as_ref(), &replacements);
+        let selected = crate::substitute_expr(body.clone(), &replacements);
+        let candidate_result = Expr::Conditional {
+            condition: Box::new(effective.clone()),
+            then_expr: Box::new(selected.clone()),
+            else_expr: Box::new(Expr::Bool(quantifier == "forall")),
+            spans: Box::new(ConditionalSpans {
+                condition: unknown_span(),
+                then_expr: unknown_span(),
+                else_expr: unknown_span(),
+            }),
+        };
+        walk_partial(
+            &candidate_result,
+            env,
+            model,
+            path,
+            span,
+            continuation.as_ref(),
+            output,
+        )?;
+        let selected_continues = if quantifier == "forall" {
+            selected
+        } else {
+            Expr::Not(Box::new(selected))
+        };
+        let candidate_continues = Expr::Conditional {
+            condition: Box::new(effective),
+            then_expr: Box::new(selected_continues),
+            else_expr: Box::new(Expr::Bool(true)),
+            spans: Box::new(ConditionalSpans {
+                condition: unknown_span(),
+                then_expr: unknown_span(),
+                else_expr: unknown_span(),
+            }),
+        };
+        continuation = Some(match continuation {
+            Some(previous) => Expr::Binary {
+                op: "and".to_owned(),
+                left: Box::new(previous),
+                right: Box::new(candidate_continues),
+            },
+            None => candidate_continues,
+        });
     }
     Ok(())
 }

--- a/rust/fsl-core/tests/binder_aggregates.rs
+++ b/rust/fsl-core/tests/binder_aggregates.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    FsResolver, KernelAggregateKind, KernelBinder, KernelExpr, build_model, parse_kernel_source,
+    public_kernel_contract, substitute_expr,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+
+fn contains_kind(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(|value| contains_kind(value, expected)),
+        Value::Object(values) => {
+            values.get("kind").and_then(Value::as_str) == Some(expected)
+                || values.values().any(|value| contains_kind(value, expected))
+        }
+        _ => false,
+    }
+}
+
+fn collect_aggregates<'a>(expr: &'a KernelExpr, output: &mut Vec<&'a KernelExpr>) {
+    match expr {
+        KernelExpr::Binary { left, right, .. } => {
+            collect_aggregates(left, output);
+            collect_aggregates(right, output);
+        }
+        KernelExpr::Aggregate { value, .. } => {
+            output.push(expr);
+            if let Some(value) = value {
+                collect_aggregates(value, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn aggregate_ir_uses_one_binder_shape_and_public_kernel_keeps_v1_expression_kinds() {
+    let source = r"
+spec AggregateIr {
+  type Item = 0..2
+  state { queue: Seq<Item, 3> }
+  init { queue = Seq { 1, 1 } }
+  action stay() { queue = queue }
+  invariant Values {
+    count(item in queue where item == 1) == 2 and
+    sum(item in queue of item where item > 0) == 2 and
+    unique(item in queue where item == 2)
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower source");
+    let model = build_model(kernel.clone()).expect("build model");
+    let property = &model.invariants[0].expr;
+    let mut aggregates = Vec::new();
+    collect_aggregates(property, &mut aggregates);
+    assert_eq!(aggregates.len(), 3);
+    assert!(aggregates.iter().all(|aggregate| matches!(
+        aggregate,
+        KernelExpr::Aggregate {
+            binder: KernelBinder::Collection { .. },
+            ..
+        }
+    )));
+
+    let public = public_kernel_contract(&kernel, &model, "aggregate.fsl", "spec")
+        .expect("export public Kernel");
+    assert!(!contains_kind(&public, "count"));
+    assert!(!contains_kind(&public, "sum"));
+    assert!(contains_kind(&public, "ite"));
+}
+
+#[test]
+fn aggregate_filters_are_checked_for_every_binder_kind() {
+    for expression in [
+        "count(item: Item where 1)",
+        "count(item in 0..2 where 1)",
+        "count(item in queue where 1)",
+    ] {
+        let source = format!(
+            "spec Invalid {{ type Item = 0..2 state {{ queue: Seq<Item, 2> }} init {{ queue = Seq {{}} }} action stay() {{ queue = queue }} invariant Bad {{ {expression} == 0 }} }}"
+        );
+        let kernel = parse_kernel_source(&source, &FsResolver::new(".")).expect("parse source");
+        let error = build_model(kernel).expect_err("non-Bool filter must fail");
+        assert!(error.message.contains("Bool"), "{}", error.message);
+    }
+}
+
+#[test]
+fn aggregate_rejects_map_binders() {
+    let source = r"
+spec InvalidMapAggregate {
+  type Item = 0..1
+  state { values: Map<Item, Item> }
+  init { forall item: Item { values[item] = 0 } }
+  action stay() { values[0] = values[0] }
+  invariant Bad { count(item in values) == 0 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
+    let error = build_model(kernel).expect_err("Map binder must fail");
+    assert!(
+        error
+            .message
+            .contains("collection binder requires Set or Seq")
+    );
+}
+
+#[test]
+fn business_and_requirements_kpis_are_typed_metadata_projections() {
+    for source in [
+        r"
+business KpiProjection {
+  actor User
+  entity Claim
+  process Claim {
+    stages Draft, Paid
+    initial Draft
+    transition Pay Draft -> Paid by User
+  }
+  kpi paid = count Claim in Paid
+}
+verify { instances Claim = 2 }
+",
+        r"
+requirements KpiProjection {
+  process Claim {
+    stages Draft, Paid
+    initial Draft
+    transition Pay Draft -> Paid by User
+  }
+  kpi paid = count Claim in Paid
+}
+verify { instances Claim = 2 }
+",
+    ] {
+        let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower KPI");
+        assert_eq!(kernel.projections().len(), 1);
+        assert!(matches!(
+            kernel.projections()[0].expr,
+            KernelExpr::Aggregate {
+                kind: KernelAggregateKind::Count,
+                binder: KernelBinder::Typed { .. },
+                value: None,
+            }
+        ));
+        let model = build_model(kernel).expect("validate KPI projection");
+        assert_eq!(model.projections[0].name, "paid");
+        assert!(
+            !model
+                .invariants
+                .iter()
+                .any(|property| property.name.starts_with("_kpi"))
+        );
+    }
+}
+
+#[test]
+fn kpi_rejects_unknown_stages_during_lowering() {
+    let source = r"
+business InvalidKpi {
+  actor User
+  entity Claim
+  process Claim {
+    stages Draft, Paid
+    initial Draft
+    transition Pay Draft -> Paid by User
+  }
+  kpi missing = count Claim in Missing
+}
+verify { instances Claim = 1 }
+";
+    let error = parse_kernel_source(source, &FsResolver::new(".")).expect_err("unknown stage");
+    assert!(error.message.contains("unknown stage 'Missing'"));
+}
+
+#[test]
+fn substitution_respects_nested_binder_shadowing() {
+    let expr = KernelExpr::Aggregate {
+        kind: KernelAggregateKind::Sum,
+        binder: KernelBinder::Range {
+            name: "item".to_owned(),
+            lo: Box::new(KernelExpr::Var("item".to_owned())),
+            hi: Box::new(KernelExpr::Num(2)),
+            where_expr: Some(Box::new(KernelExpr::Var("item".to_owned()))),
+        },
+        value: Some(Box::new(KernelExpr::Var("item".to_owned()))),
+    };
+    let substituted = substitute_expr(
+        expr,
+        &HashMap::from([("item".to_owned(), KernelExpr::Num(7))]),
+    );
+    let KernelExpr::Aggregate { binder, value, .. } = substituted else {
+        panic!("expected aggregate");
+    };
+    let KernelBinder::Range { lo, where_expr, .. } = binder else {
+        panic!("expected range binder");
+    };
+    assert_eq!(*lo, KernelExpr::Num(7));
+    assert_eq!(
+        *where_expr.expect("filter"),
+        KernelExpr::Var("item".to_owned())
+    );
+    assert_eq!(
+        *value.expect("sum value"),
+        KernelExpr::Var("item".to_owned())
+    );
+
+    let candidate = KernelExpr::Method {
+        receiver: Box::new(KernelExpr::Var("queue".to_owned())),
+        name: "at".to_owned(),
+        args: vec![KernelExpr::Num(0)],
+    };
+    let nested = KernelExpr::Aggregate {
+        kind: KernelAggregateKind::Count,
+        binder: KernelBinder::Collection {
+            name: "queue".to_owned(),
+            collection: Box::new(KernelExpr::Var("selected".to_owned())),
+            where_expr: Some(Box::new(KernelExpr::Binary {
+                op: "==".to_owned(),
+                left: Box::new(KernelExpr::Var("queue".to_owned())),
+                right: Box::new(KernelExpr::Var("item".to_owned())),
+            })),
+        },
+        value: None,
+    };
+    let substituted = substitute_expr(
+        nested,
+        &HashMap::from([("item".to_owned(), candidate.clone())]),
+    );
+    let KernelExpr::Aggregate { binder, .. } = substituted else {
+        panic!("expected nested aggregate");
+    };
+    let KernelBinder::Collection {
+        name, where_expr, ..
+    } = binder
+    else {
+        panic!("expected collection binder");
+    };
+    assert_ne!(name, "queue");
+    let KernelExpr::Binary { left, right, .. } = *where_expr.expect("filter") else {
+        panic!("expected equality filter");
+    };
+    assert_eq!(*left, KernelExpr::Var(name));
+    assert_eq!(*right, candidate);
+
+    let source_scoped_free_variable = KernelExpr::Aggregate {
+        kind: KernelAggregateKind::Count,
+        binder: KernelBinder::Collection {
+            name: "queue".to_owned(),
+            collection: Box::new(KernelExpr::Var("queue".to_owned())),
+            where_expr: None,
+        },
+        value: None,
+    };
+    let target = KernelExpr::Aggregate {
+        kind: KernelAggregateKind::Count,
+        binder: KernelBinder::Collection {
+            name: "queue".to_owned(),
+            collection: Box::new(KernelExpr::Var("selected".to_owned())),
+            where_expr: Some(Box::new(KernelExpr::Var("item".to_owned()))),
+        },
+        value: None,
+    };
+    let substituted = substitute_expr(
+        target,
+        &HashMap::from([("item".to_owned(), source_scoped_free_variable)]),
+    );
+    let KernelExpr::Aggregate {
+        binder: KernelBinder::Collection { name, .. },
+        ..
+    } = substituted
+    else {
+        panic!("expected collection aggregate");
+    };
+    assert_ne!(name, "queue");
+}
+
+#[test]
+fn public_partial_operations_expand_aggregate_binders_without_free_variables() {
+    let source = r"
+spec AggregatePartialOperations {
+  type Item = 0..1
+  state { queue: Seq<Item, 2>, total: Int }
+  init { queue = Seq {} total = 0 }
+  action collection() { total = sum(item in queue of 1 / item where 1 / item > 0) }
+  action typed() { total = sum(item: Item of 1 / item) }
+  action distinct() { requires unique(item: Item where 1 / item > 0) total = total }
+  action quantified() { requires forall item: Item { 1 / item > 0 } total = total }
+  action existential() { requires exists item: Item { item == 0 or 1 / (item - 1) > 0 } total = total }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower source");
+    let model = build_model(kernel.clone()).expect("build model");
+    let public = public_kernel_contract(&kernel, &model, "aggregate.fsl", "spec")
+        .expect("export public Kernel");
+    let actions = public["actions"].as_array().expect("actions");
+    let mut saw_existential = false;
+    for action in actions {
+        let operations = action["partial_operations"]
+            .as_array()
+            .expect("partial operations");
+        assert!(!operations.is_empty());
+        assert!(operations.iter().all(|operation| {
+            !operation["failure_condition"]
+                .to_string()
+                .contains("\"name\":\"item\"")
+        }));
+        assert!(operations.iter().all(|operation| {
+            operation["operation"] != "at"
+                || operation["failure_condition"]
+                    .to_string()
+                    .contains("\"operator\":\"and\"")
+        }));
+        if action["name"] == "existential" {
+            saw_existential = true;
+            let divisions = operations
+                .iter()
+                .filter(|operation| operation["operation"] == "divide")
+                .collect::<Vec<_>>();
+            assert_eq!(divisions.len(), 2);
+            assert!(
+                divisions[1]["failure_condition"]
+                    .to_string()
+                    .contains("\"kind\":\"not\"")
+            );
+        }
+    }
+    assert!(saw_existential);
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -490,13 +490,16 @@ fn compute_binder_values(
             let ty = TypeRef::Named(super::qualified_type(type_name)?);
             Ok(Some(model.domain_values(&ty)?))
         }
-        Binder::Range { lo, hi, .. } => {
-            match (const_int_bound(lo, model), const_int_bound(hi, model)) {
-                (Some(lo), Some(hi)) => Ok(Some((lo..=hi).map(Value::Int).collect())),
-                _ => Ok(None),
-            }
-        }
-        Binder::Typed { .. } | Binder::Collection { .. } => Ok(None),
+        Binder::Range {
+            lo,
+            hi,
+            where_expr: None,
+            ..
+        } => match (const_int_bound(lo, model), const_int_bound(hi, model)) {
+            (Some(lo), Some(hi)) => Ok(Some((lo..=hi).map(Value::Int).collect())),
+            _ => Ok(None),
+        },
+        Binder::Typed { .. } | Binder::Range { .. } | Binder::Collection { .. } => Ok(None),
     }
 }
 
@@ -614,10 +617,12 @@ fn walk_init(
                     }
                     Binder::Typed { .. } => {}
                 }
-                if let Binder::Typed { where_expr, .. } | Binder::Collection { where_expr, .. } =
-                    binder
-                    && let Some(where_expr) = where_expr
-                {
+                let where_expr = match binder {
+                    Binder::Typed { where_expr, .. }
+                    | Binder::Range { where_expr, .. }
+                    | Binder::Collection { where_expr, .. } => where_expr,
+                };
+                if let Some(where_expr) = where_expr {
                     check_init_expr(where_expr, &definitely_assigned, model)?;
                 }
                 let binder_values = compute_binder_values(binder, model)?;
@@ -761,15 +766,10 @@ fn collect_state_references(
             collect_binder_references(binder, state_names, output);
             collect_state_references(body, state_names, output);
         }
-        Expr::Count { condition, .. } => {
-            collect_state_references(condition, state_names, output);
-        }
-        Expr::Sum {
-            body, condition, ..
-        } => {
-            collect_state_references(body, state_names, output);
-            if let Some(condition) = condition {
-                collect_state_references(condition, state_names, output);
+        Expr::Aggregate { binder, value, .. } => {
+            collect_binder_references(binder, state_names, output);
+            if let Some(value) = value {
+                collect_state_references(value, state_names, output);
             }
         }
         Expr::TernaryNamed {
@@ -781,9 +781,6 @@ fn collect_state_references(
             collect_state_references(first, state_names, output);
             collect_state_references(second, state_names, output);
             collect_state_references(third, state_names, output);
-        }
-        Expr::BinderNamed { binder, .. } => {
-            collect_binder_references(binder, state_names, output);
         }
     }
 }
@@ -799,9 +796,14 @@ fn collect_binder_references(
                 collect_state_references(where_expr, state_names, output);
             }
         }
-        Binder::Range { lo, hi, .. } => {
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
             collect_state_references(lo, state_names, output);
             collect_state_references(hi, state_names, output);
+            if let Some(where_expr) = where_expr {
+                collect_state_references(where_expr, state_names, output);
+            }
         }
         Binder::Collection {
             collection,

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -7,10 +7,11 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
 use fsl_core::{
-    ActionCorrespondenceTarget, ActionDef, ActionGuard, FslValue as Value, KernelBinder as Binder,
-    KernelExpr as Expr, KernelLValue as LValue, KernelModel, KernelStatement as Statement,
-    ModelError, ParamDef, Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef,
-    display_name, insert_requirement_metadata, model_warnings, state_summary,
+    ActionCorrespondenceTarget, ActionDef, ActionGuard, FslValue as Value,
+    KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
+    KernelLValue as LValue, KernelModel, KernelStatement as Statement, ModelError, ParamDef,
+    Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
+    insert_requirement_metadata, model_warnings, state_summary,
 };
 use serde_json::{Value as JsonValue, json};
 
@@ -206,43 +207,32 @@ pub fn eval(
                 Ok(Value::Bool(false))
             }
         }
-        Expr::Count {
-            name,
-            type_name,
-            condition,
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
         } => {
-            let ty = qualified_type(type_name)?;
-            let mut count = 0_i64;
-            for value in model.domain_values(&TypeRef::Named(ty))? {
-                let mut local = bindings.clone();
-                local.insert(name.clone(), value);
-                if as_bool(eval(condition, state, &mut local, model, old_state)?)? {
-                    count += 1;
-                }
-            }
-            Ok(Value::Int(count))
-        }
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => {
-            let ty = qualified_type(type_name)?;
+            let mut matches = 0_i64;
             let mut sum = 0_i64;
-            for value in model.domain_values(&TypeRef::Named(ty))? {
-                let mut local = bindings.clone();
-                local.insert(name.clone(), value);
-                if let Some(condition) = condition {
-                    if !as_bool(eval(condition, state, &mut local, model, old_state)?)? {
-                        continue;
-                    }
+            for (candidate, mut local) in binder_values(binder, state, bindings, model, old_state)?
+            {
+                local.insert(binder_name(binder).to_owned(), candidate);
+                if !binder_where_holds(binder, state, &mut local, model, old_state)? {
+                    continue;
                 }
-                sum = sum
-                    .checked_add(as_int(eval(body, state, &mut local, model, old_state)?)?)
-                    .ok_or_else(|| runtime_error("integer overflow in sum"))?;
+                matches += 1;
+                if let Some(value) = value {
+                    sum = sum
+                        .checked_add(as_int(eval(value, state, &mut local, model, old_state)?)?)
+                        .ok_or_else(|| runtime_error("integer overflow in sum"))?;
+                }
             }
-            Ok(Value::Int(sum))
+            Ok(match kind {
+                AggregateKind::Count => Value::Int(matches),
+                AggregateKind::Sum => Value::Int(sum),
+                AggregateKind::Unique => Value::Bool(matches <= 1),
+                AggregateKind::ExactlyOne => Value::Bool(matches == 1),
+            })
         }
         Expr::UnaryNamed { name, expr, .. } => match name.as_str() {
             "old" => eval(
@@ -293,24 +283,6 @@ pub fn eval(
         Expr::TernaryNamed { name, .. } => Err(runtime_error(format!(
             "unsupported ternary function '{name}'"
         ))),
-        Expr::BinderNamed { name, binder } => {
-            let mut matches = 0_u32;
-            for (value, mut local) in binder_values(binder, state, bindings, model, old_state)? {
-                local.insert(binder_name(binder).to_owned(), value);
-                if binder_where_holds(binder, state, &mut local, model, old_state)? {
-                    matches += 1;
-                }
-            }
-            if name == "unique" {
-                Ok(Value::Bool(matches <= 1))
-            } else if name == "exactly_one" {
-                Ok(Value::Bool(matches == 1))
-            } else {
-                Err(runtime_error(format!(
-                    "unsupported binder function '{name}'"
-                )))
-            }
-        }
     }
 }
 
@@ -551,10 +523,9 @@ fn binder_where_holds(
     old_state: Option<&State>,
 ) -> Result<bool, RuntimeError> {
     let condition = match binder {
-        Binder::Typed { where_expr, .. } | Binder::Collection { where_expr, .. } => {
-            where_expr.as_deref()
-        }
-        Binder::Range { .. } => None,
+        Binder::Typed { where_expr, .. }
+        | Binder::Range { where_expr, .. }
+        | Binder::Collection { where_expr, .. } => where_expr.as_deref(),
     };
     condition.map_or(Ok(true), |condition| {
         as_bool(eval(condition, state, bindings, model, old_state)?)

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -98,6 +98,18 @@ fn deterministic_init_rejects_state_dependent_forall_domains() {
         "init forall over a state collection is not supported; state variable 's' is not allowed"
     );
 
+    let state_range_filter = model(
+        "spec StateRangeFilter { type Slot = 0..2 state { n: Slot, m: Map<Slot, Bool> } \
+         init { forall i in 0..2 where n == 0 { m[i] = true } n = 0 } \
+         action stay() { n = n } }",
+    );
+    let error = fsl_runtime::verify_explicit(state_range_filter, 2, 100)
+        .expect_err("state-dependent init range filter rejected");
+    assert_eq!(
+        error.message,
+        "init references state variable 'n' before it is assigned"
+    );
+
     let const_range = model(
         "spec ConstRange { const CAP = 2 type Slot = 0..2 \
          state { m: Map<Slot, Bool> } \

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -68,12 +68,21 @@ pub enum Binder {
         name: String,
         lo: Box<Expr>,
         hi: Box<Expr>,
+        where_expr: Option<Box<Expr>>,
     },
     Collection {
         name: String,
         collection: Box<Expr>,
         where_expr: Option<Box<Expr>>,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AggregateKind {
+    Count,
+    Sum,
+    Unique,
+    ExactlyOne,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -123,16 +132,10 @@ pub enum Expr {
         binder: Binder,
         body: Box<Expr>,
     },
-    Count {
-        name: String,
-        type_name: QualifiedName,
-        condition: Box<Expr>,
-    },
-    Sum {
-        name: String,
-        type_name: QualifiedName,
-        body: Box<Expr>,
-        condition: Option<Box<Expr>>,
+    Aggregate {
+        kind: AggregateKind,
+        binder: Binder,
+        value: Option<Box<Expr>>,
     },
     Stage {
         process: Option<Box<SymbolPath>>,
@@ -155,10 +158,6 @@ pub enum Expr {
         first: Box<Expr>,
         second: Box<Expr>,
         third: Box<Expr>,
-    },
-    BinderNamed {
-        name: String,
-        binder: Binder,
     },
 }
 
@@ -186,9 +185,23 @@ impl Binder {
                 type_name.python_ast(),
                 where_expr.as_deref().map(Expr::python_ast)
             ]),
-            Self::Range { name, lo, hi } => {
-                json!(["binder_range", name, lo.python_ast(), hi.python_ast()])
-            }
+            Self::Range {
+                name,
+                lo,
+                hi,
+                where_expr,
+            } => where_expr.as_deref().map_or_else(
+                || json!(["binder_range", name, lo.python_ast(), hi.python_ast()]),
+                |where_expr| {
+                    json!([
+                        "binder_range",
+                        name,
+                        lo.python_ast(),
+                        hi.python_ast(),
+                        where_expr.python_ast()
+                    ])
+                },
+            ),
             Self::Collection {
                 name,
                 collection,
@@ -256,28 +269,56 @@ impl Expr {
                 binder,
                 body,
             } => json!([quantifier, binder.python_ast(), body.python_ast()]),
-            Self::Count {
-                name,
-                type_name,
-                condition,
-            } => json!([
-                "count",
-                name,
-                type_name.python_ast(),
-                condition.python_ast()
-            ]),
-            Self::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => json!([
-                "sum",
-                name,
-                type_name.python_ast(),
-                body.python_ast(),
-                condition.as_deref().map(Expr::python_ast)
-            ]),
+            Self::Aggregate {
+                kind,
+                binder,
+                value,
+            } => match (kind, binder, value.as_deref()) {
+                (
+                    AggregateKind::Count,
+                    Binder::Typed {
+                        name,
+                        type_name,
+                        where_expr: Some(condition),
+                    },
+                    None,
+                ) => json!([
+                    "count",
+                    name,
+                    type_name.python_ast(),
+                    condition.python_ast()
+                ]),
+                (
+                    AggregateKind::Sum,
+                    Binder::Typed {
+                        name,
+                        type_name,
+                        where_expr,
+                    },
+                    Some(body),
+                ) => json!([
+                    "sum",
+                    name,
+                    type_name.python_ast(),
+                    body.python_ast(),
+                    where_expr.as_deref().map(Expr::python_ast)
+                ]),
+                (AggregateKind::Unique, binder, None) => json!(["unique", binder.python_ast()]),
+                (AggregateKind::ExactlyOne, binder, None) => {
+                    json!(["exactly_one", binder.python_ast()])
+                }
+                _ => json!([
+                    "aggregate",
+                    match kind {
+                        AggregateKind::Count => "count",
+                        AggregateKind::Sum => "sum",
+                        AggregateKind::Unique => "unique",
+                        AggregateKind::ExactlyOne => "exactly_one",
+                    },
+                    binder.python_ast(),
+                    value.as_deref().map(Expr::python_ast)
+                ]),
+            },
             Self::Stage {
                 process,
                 entity,
@@ -319,7 +360,6 @@ impl Expr {
                 second.python_ast(),
                 third.python_ast()
             ]),
-            Self::BinderNamed { name, binder } => json!([name, binder.python_ast()]),
         }
     }
 }

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -28,7 +28,9 @@ pub use annotation::{
     Annotation, AnnotationError, AnnotationRegistry, AnnotationValue, Annotations, RequirementLink,
     SymbolPath,
 };
-pub use ast::{Binder, ConditionalSpans, Expr, Pattern, QualifiedName, SourcePos, Span};
+pub use ast::{
+    AggregateKind, Binder, ConditionalSpans, Expr, Pattern, QualifiedName, SourcePos, Span,
+};
 pub use db::{
     DbArtifact, DbCheck, DbCheckRule, DbColumn, DbColumnRef, DbDatabase, DbEnvironment,
     DbEnvironmentArtifact, DbFlag, DbFlagCondition, DbMigration, DbMigrationOp, DbSystem, DbTable,

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1997,10 +1997,16 @@ impl Parser {
         let first = self.expression(0)?;
         if self.eat_symbol("..") {
             let hi = self.expression(0)?;
+            let where_expr = if self.eat_ident("where") {
+                Some(Box::new(self.expression(0)?))
+            } else {
+                None
+            };
             return Ok(Binder::Range {
                 name,
                 lo: Box::new(first),
                 hi: Box::new(hi),
+                where_expr,
             });
         }
         let where_expr = if self.eat_ident("where") {

--- a/rust/fsl-syntax/src/syntax_expr.rs
+++ b/rust/fsl-syntax/src/syntax_expr.rs
@@ -12,7 +12,10 @@
 use std::fmt;
 use std::ops::Deref;
 
-use crate::{Binder, Expr, ParseError, Pattern, QualifiedName, Span, SymbolPath, Token, TokenKind};
+use crate::{
+    AggregateKind, Binder, Expr, ParseError, Pattern, QualifiedName, Span, SymbolPath, Token,
+    TokenKind,
+};
 
 /// An unresolved source identifier with its exact token span.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -73,6 +76,7 @@ pub enum SyntaxBinder {
         name: SyntaxIdent,
         lo: Box<SyntaxExpr>,
         hi: Box<SyntaxExpr>,
+        where_expr: Option<Box<SyntaxExpr>>,
         span: Span,
     },
     Collection {
@@ -162,21 +166,13 @@ pub enum SyntaxExprKind {
         quantifier: SyntaxIdent,
         binder: SyntaxBinder,
         body: Box<SyntaxExpr>,
+        braced: bool,
+        legacy_colon: bool,
     },
-    Count {
-        name: SyntaxIdent,
-        type_name: SyntaxQualifiedName,
-        condition: Box<SyntaxExpr>,
-    },
-    Sum {
-        name: SyntaxIdent,
-        type_name: SyntaxQualifiedName,
-        body: Box<SyntaxExpr>,
-        condition: Option<Box<SyntaxExpr>>,
-    },
-    BinderNamed {
-        name: SyntaxIdent,
+    Aggregate {
+        kind: AggregateKind,
         binder: SyntaxBinder,
+        value: Option<Box<SyntaxExpr>>,
     },
 }
 
@@ -203,6 +199,11 @@ pub(crate) enum ExpressionMode {
 }
 
 impl SyntaxExpr {
+    /// Render this parsed expression using canonical source spelling.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a manually constructed `sum` aggregate omits its required value.
     #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn render_source(&self) -> String {
@@ -274,42 +275,30 @@ impl SyntaxExpr {
                 quantifier,
                 binder,
                 body,
+                ..
             } => format!(
                 "{} {} {{ {} }}",
                 quantifier.text,
                 binder.render_source(),
                 body.render_source()
             ),
-            SyntaxExprKind::Count {
-                name,
-                type_name,
-                condition,
-            } => format!(
-                "count({}: {} where {})",
-                name.text,
-                type_name.render_source(),
-                condition.render_source()
-            ),
-            SyntaxExprKind::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => {
-                let suffix = condition.as_deref().map_or_else(String::new, |condition| {
-                    format!(" where {}", condition.render_source())
-                });
-                format!(
-                    "sum({}: {} of {}{})",
-                    name.text,
-                    type_name.render_source(),
-                    body.render_source(),
-                    suffix
-                )
-            }
-            SyntaxExprKind::BinderNamed { name, binder } => {
-                format!("{}({})", name.text, binder.render_source())
-            }
+            SyntaxExprKind::Aggregate {
+                kind,
+                binder,
+                value,
+            } => match kind {
+                AggregateKind::Count => format!("count({})", binder.render_source()),
+                AggregateKind::Sum => format!(
+                    "sum({} of {}{})",
+                    binder.render_source_base(),
+                    value.as_deref().expect("sum has a value").render_source(),
+                    binder.where_expr().map_or_else(String::new, |filter| {
+                        format!(" where {}", filter.render_source())
+                    })
+                ),
+                AggregateKind::Unique => format!("unique({})", binder.render_source()),
+                AggregateKind::ExactlyOne => format!("exactlyOne({})", binder.render_source()),
+            },
         }
     }
 
@@ -456,40 +445,22 @@ impl SyntaxExpr {
                 quantifier,
                 binder,
                 body,
+                ..
             } => Expr::Quantified {
                 quantifier: quantifier.text,
                 binder: binder.into_kernel()?,
                 body: Box::new(body.into_kernel()?),
             },
-            SyntaxExprKind::Count {
-                name,
-                type_name,
-                condition,
-            } => Expr::Count {
-                name: name.text,
-                type_name: type_name.into_kernel(),
-                condition: Box::new(condition.into_kernel()?),
-            },
-            SyntaxExprKind::Sum {
-                name,
-                type_name,
-                body,
-                condition,
-            } => Expr::Sum {
-                name: name.text,
-                type_name: type_name.into_kernel(),
-                body: Box::new(body.into_kernel()?),
-                condition: condition
+            SyntaxExprKind::Aggregate {
+                kind,
+                binder,
+                value,
+            } => Expr::Aggregate {
+                kind,
+                binder: binder.into_kernel()?,
+                value: value
                     .map(|value| value.into_kernel().map(Box::new))
                     .transpose()?,
-            },
-            SyntaxExprKind::BinderNamed { name, binder } => Expr::BinderNamed {
-                name: if name.text == "exactlyOne" {
-                    "exactly_one".to_owned()
-                } else {
-                    name.text
-                },
-                binder: binder.into_kernel()?,
             },
         })
     }
@@ -617,20 +588,19 @@ impl fmt::Display for SyntaxTypeExpr {
 
 impl SyntaxBinder {
     fn render_source(&self) -> String {
+        let mut output = self.render_source_base();
+        if let Some(filter) = self.where_expr() {
+            output.push_str(" where ");
+            output.push_str(&filter.render_source());
+        }
+        output
+    }
+
+    fn render_source_base(&self) -> String {
         match self {
             Self::Typed {
-                name,
-                type_name,
-                where_expr,
-                ..
-            } => format!(
-                "{}: {}{}",
-                name.text,
-                type_name.render_source(),
-                where_expr.as_deref().map_or_else(String::new, |value| {
-                    format!(" where {}", value.render_source())
-                })
-            ),
+                name, type_name, ..
+            } => format!("{}: {}", name.text, type_name.render_source()),
             Self::Range { name, lo, hi, .. } => format!(
                 "{} in {}..{}",
                 name.text,
@@ -638,18 +608,16 @@ impl SyntaxBinder {
                 hi.render_source()
             ),
             Self::Collection {
-                name,
-                collection,
-                where_expr,
-                ..
-            } => format!(
-                "{} in {}{}",
-                name.text,
-                collection.render_source(),
-                where_expr.as_deref().map_or_else(String::new, |value| {
-                    format!(" where {}", value.render_source())
-                })
-            ),
+                name, collection, ..
+            } => format!("{} in {}", name.text, collection.render_source()),
+        }
+    }
+
+    fn where_expr(&self) -> Option<&SyntaxExpr> {
+        match self {
+            Self::Typed { where_expr, .. }
+            | Self::Range { where_expr, .. }
+            | Self::Collection { where_expr, .. } => where_expr.as_deref(),
         }
     }
 
@@ -667,10 +635,19 @@ impl SyntaxBinder {
                     .map(|value| value.into_kernel().map(Box::new))
                     .transpose()?,
             },
-            Self::Range { name, lo, hi, .. } => Binder::Range {
+            Self::Range {
+                name,
+                lo,
+                hi,
+                where_expr,
+                ..
+            } => Binder::Range {
                 name: name.text,
                 lo: Box::new(lo.into_kernel()?),
                 hi: Box::new(hi.into_kernel()?),
+                where_expr: where_expr
+                    .map(|value| value.into_kernel().map(Box::new))
+                    .transpose()?,
             },
             Self::Collection {
                 name,
@@ -845,8 +822,9 @@ impl SyntaxParser<'_> {
             let start = self.peek().span;
             let quantifier = self.expect_ident()?;
             let binder = self.binder()?;
-            self.eat_symbol(":");
-            let body = if self.eat_symbol("{") {
+            let legacy_colon = self.eat_symbol(":");
+            let braced = self.eat_symbol("{");
+            let body = if braced {
                 let body = self.expression(0)?;
                 self.expect_symbol("}")?;
                 body
@@ -859,6 +837,8 @@ impl SyntaxParser<'_> {
                     quantifier,
                     binder,
                     body: Box::new(body),
+                    braced,
+                    legacy_colon,
                 },
                 span,
             });
@@ -928,17 +908,18 @@ impl SyntaxParser<'_> {
                 self.sum(token.span)
             }
             TokenKind::Ident(name) if name == "unique" || name == "exactlyOne" => {
-                let ident = SyntaxIdent {
-                    text: name,
-                    span: token.span,
-                };
                 self.expect_symbol("(")?;
                 let binder = self.binder()?;
                 self.expect_symbol(")")?;
                 Ok(SyntaxExpr {
-                    kind: SyntaxExprKind::BinderNamed {
-                        name: ident,
+                    kind: SyntaxExprKind::Aggregate {
+                        kind: if name == "unique" {
+                            AggregateKind::Unique
+                        } else {
+                            AggregateKind::ExactlyOne
+                        },
                         binder,
+                        value: None,
                     },
                     span: join(token.span, self.previous_span()),
                 })
@@ -1107,12 +1088,20 @@ impl SyntaxParser<'_> {
         let first = self.expression(0)?;
         if self.eat_symbol("..") {
             let hi = Box::new(self.expression(0)?);
-            let span = join(start, hi.span);
+            let where_expr = if self.eat_ident("where") {
+                Some(Box::new(self.expression(0)?))
+            } else {
+                None
+            };
+            let end = where_expr
+                .as_deref()
+                .map_or(hi.span, |expression| expression.span);
             return Ok(SyntaxBinder::Range {
                 name,
                 lo: Box::new(first),
                 hi,
-                span,
+                where_expr,
+                span: join(start, end),
             });
         }
         let where_expr = if self.eat_ident("where") {
@@ -1133,17 +1122,13 @@ impl SyntaxParser<'_> {
 
     fn count(&mut self, start: Span) -> Result<SyntaxExpr, ParseError> {
         self.expect_symbol("(")?;
-        let name = self.expect_ident()?;
-        self.expect_symbol(":")?;
-        let type_name = self.qualified_name()?;
-        self.expect_ident_value("where")?;
-        let condition = self.expression(0)?;
+        let binder = self.binder()?;
         self.expect_symbol(")")?;
         Ok(SyntaxExpr {
-            kind: SyntaxExprKind::Count {
-                name,
-                type_name,
-                condition: Box::new(condition),
+            kind: SyntaxExprKind::Aggregate {
+                kind: AggregateKind::Count,
+                binder,
+                value: None,
             },
             span: join(start, self.previous_span()),
         })
@@ -1151,23 +1136,45 @@ impl SyntaxParser<'_> {
 
     fn sum(&mut self, start: Span) -> Result<SyntaxExpr, ParseError> {
         self.expect_symbol("(")?;
-        let name = self.expect_ident()?;
-        self.expect_symbol(":")?;
-        let type_name = self.qualified_name()?;
+        let mut binder = self.binder()?;
         self.expect_ident_value("of")?;
         let body = self.expression(0)?;
-        let condition = if self.eat_ident("where") {
+        let where_expr = if self.eat_ident("where") {
+            let where_span = self.previous_span();
+            let already_filtered = match &binder {
+                SyntaxBinder::Typed { where_expr, .. }
+                | SyntaxBinder::Range { where_expr, .. }
+                | SyntaxBinder::Collection { where_expr, .. } => where_expr.is_some(),
+            };
+            if already_filtered {
+                return Err(ParseError::new(
+                    "sum binder cannot contain two 'where' filters",
+                    where_span,
+                ));
+            }
             Some(Box::new(self.expression(0)?))
         } else {
             None
         };
+        if where_expr.is_some() {
+            match &mut binder {
+                SyntaxBinder::Typed {
+                    where_expr: filter, ..
+                }
+                | SyntaxBinder::Range {
+                    where_expr: filter, ..
+                }
+                | SyntaxBinder::Collection {
+                    where_expr: filter, ..
+                } => *filter = where_expr,
+            }
+        }
         self.expect_symbol(")")?;
         Ok(SyntaxExpr {
-            kind: SyntaxExprKind::Sum {
-                name,
-                type_name,
-                body: Box::new(body),
-                condition,
+            kind: SyntaxExprKind::Aggregate {
+                kind: AggregateKind::Sum,
+                binder,
+                value: Some(Box::new(body)),
             },
             span: join(start, self.previous_span()),
         })

--- a/rust/fsl-syntax/tests/domain_typed_expressions.rs
+++ b/rust/fsl-syntax/tests/domain_typed_expressions.rs
@@ -380,6 +380,64 @@ fn public_helper_nodes_retain_their_own_spans() {
 }
 
 #[test]
+fn binder_source_forms_retain_legacy_colons_and_render_canonical_aggregates() {
+    let source = r"domain BinderForms {
+  type Id = 0..2
+  aggregate A {
+    state { values: Set<Id> }
+    invariant canonical { forall item: Id { item >= 0 } }
+    invariant legacy { forall item: Id: item >= 0 }
+    invariant aggregates { count(item in values where item > 0) >= 0 and sum(item in values of item where item > 0) >= 0 }
+  }
+}";
+    let domain = parse_domain(source).expect("parse binder forms");
+    let SyntaxExprKind::Quantified {
+        braced,
+        legacy_colon,
+        ..
+    } = &domain.aggregates[0].invariants[0].expr.kind
+    else {
+        panic!("expected canonical quantifier");
+    };
+    assert!(*braced);
+    assert!(!*legacy_colon);
+
+    let legacy = &domain.aggregates[0].invariants[1].expr;
+    let SyntaxExprKind::Quantified {
+        braced,
+        legacy_colon,
+        ..
+    } = &legacy.kind
+    else {
+        panic!("expected legacy quantifier");
+    };
+    assert!(!*braced);
+    assert!(*legacy_colon);
+    assert_eq!(legacy.render_source(), "forall item: Id { item >= 0 }");
+    let reparsed = parse_domain(&format!(
+        "domain RoundTrip {{ type Id = 0..2 aggregate A {{ invariant I {{ {} }} }} }}",
+        legacy.render_source()
+    ))
+    .expect("parse canonical rendering");
+    assert_eq!(
+        reparsed.aggregates[0].invariants[0].expr.render_source(),
+        legacy.render_source()
+    );
+
+    assert_eq!(
+        domain.aggregates[0].invariants[2].expr.render_source(),
+        "count(item in values where item > 0) >= 0 and sum(item in values of item where item > 0) >= 0"
+    );
+}
+
+#[test]
+fn sum_rejects_two_where_filters_instead_of_overwriting_one() {
+    let error = parse_expr("sum(item in values where item > 0 of item where item < 2)")
+        .expect_err("duplicate sum filters must fail");
+    assert!(error.message.contains("two 'where' filters"));
+}
+
+#[test]
 fn canonical_enum_and_legacy_union_retain_source_form_spans_and_comments() {
     let source = r"domain Types {
   enum Status {

--- a/rust/fsl-tools/src/analysis.rs
+++ b/rust/fsl-tools/src/analysis.rs
@@ -107,9 +107,14 @@ fn binder_reads(
         Binder::Typed { where_expr, .. } => where_expr
             .as_deref()
             .map_or_else(BTreeSet::new, |expr| expr_reads_bound(expr, state, bound)),
-        Binder::Range { lo, hi, .. } => {
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
             let mut reads = expr_reads_bound(lo, state, bound);
             reads.extend(expr_reads_bound(hi, state, bound));
+            if let Some(expr) = where_expr {
+                reads.extend(expr_reads_bound(expr, state, bound));
+            }
             reads
         }
         Binder::Collection {
@@ -207,24 +212,12 @@ fn expr_reads_bound(
             reads.extend(binder_reads(binder, state, &next));
             reads.extend(expr_reads_bound(body, state, &next));
         }
-        Expr::Count {
-            name, condition, ..
-        } => {
+        Expr::Aggregate { binder, value, .. } => {
             let mut next = bound.clone();
-            next.insert(name.clone());
-            reads.extend(expr_reads_bound(condition, state, &next));
-        }
-        Expr::Sum {
-            name,
-            body,
-            condition,
-            ..
-        } => {
-            let mut next = bound.clone();
-            next.insert(name.clone());
-            reads.extend(expr_reads_bound(body, state, &next));
-            if let Some(condition) = condition {
-                reads.extend(expr_reads_bound(condition, state, &next));
+            next.insert(binder_name(binder).to_owned());
+            reads.extend(binder_reads(binder, state, &next));
+            if let Some(value) = value {
+                reads.extend(expr_reads_bound(value, state, &next));
             }
         }
         Expr::TernaryNamed {
@@ -237,7 +230,6 @@ fn expr_reads_bound(
             reads.extend(expr_reads_bound(second, state, bound));
             reads.extend(expr_reads_bound(third, state, bound));
         }
-        Expr::BinderNamed { binder, .. } => reads.extend(binder_reads(binder, state, bound)),
         Expr::Num(_) | Expr::Bool(_) | Expr::None => {}
     }
     reads

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -83,13 +83,19 @@ fn mutate_binder(
                 }
             }
         }
-        Binder::Range { name, lo, hi } => {
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => {
             for mutation in expr_mutations(lo, enums) {
                 output.push((
                     Binder::Range {
                         name: name.clone(),
                         lo: Box::new(mutation.expr.clone()),
                         hi: hi.clone(),
+                        where_expr: where_expr.clone(),
                     },
                     mutation,
                 ));
@@ -100,9 +106,23 @@ fn mutate_binder(
                         name: name.clone(),
                         lo: lo.clone(),
                         hi: Box::new(mutation.expr.clone()),
+                        where_expr: where_expr.clone(),
                     },
                     mutation,
                 ));
+            }
+            if let Some(condition) = where_expr {
+                for mutation in expr_mutations(condition, enums) {
+                    output.push((
+                        Binder::Range {
+                            name: name.clone(),
+                            lo: lo.clone(),
+                            hi: hi.clone(),
+                            where_expr: Some(Box::new(mutation.expr.clone())),
+                        },
+                        mutation,
+                    ));
+                }
             }
         }
         Binder::Collection {
@@ -401,47 +421,28 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                 });
             }
         }
-        Expr::Count {
-            name,
-            type_name,
-            condition,
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
         } => {
-            for mutation in expr_mutations(condition, enums) {
+            for (replacement, mutation) in mutate_binder(binder, enums) {
                 output.push(ExprMutation {
-                    expr: Expr::Count {
-                        name: name.clone(),
-                        type_name: type_name.clone(),
-                        condition: Box::new(mutation.expr.clone()),
+                    expr: Expr::Aggregate {
+                        kind: *kind,
+                        binder: replacement,
+                        value: value.clone(),
                     },
                     ..mutation
                 });
             }
-        }
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => {
-            for mutation in expr_mutations(body, enums) {
-                output.push(ExprMutation {
-                    expr: Expr::Sum {
-                        name: name.clone(),
-                        type_name: type_name.clone(),
-                        body: Box::new(mutation.expr.clone()),
-                        condition: condition.clone(),
-                    },
-                    ..mutation
-                });
-            }
-            if let Some(condition) = condition {
-                for mutation in expr_mutations(condition, enums) {
+            if let Some(value) = value {
+                for mutation in expr_mutations(value, enums) {
                     output.push(ExprMutation {
-                        expr: Expr::Sum {
-                            name: name.clone(),
-                            type_name: type_name.clone(),
-                            body: body.clone(),
-                            condition: Some(Box::new(mutation.expr.clone())),
+                        expr: Expr::Aggregate {
+                            kind: *kind,
+                            binder: binder.clone(),
+                            value: Some(Box::new(mutation.expr.clone())),
                         },
                         ..mutation
                     });
@@ -539,17 +540,6 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                         first: first.clone(),
                         second: second.clone(),
                         third: Box::new(mutation.expr.clone()),
-                    },
-                    ..mutation
-                });
-            }
-        }
-        Expr::BinderNamed { name, binder } => {
-            for (replacement, mutation) in mutate_binder(binder, enums) {
-                output.push(ExprMutation {
-                    expr: Expr::BinderNamed {
-                        name: name.clone(),
-                        binder: replacement,
                     },
                     ..mutation
                 });

--- a/rust/fsl-tools/src/undecided.rs
+++ b/rust/fsl-tools/src/undecided.rs
@@ -68,16 +68,12 @@ fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> 
                 collect_binder(binder, roots);
                 collect(body, roots);
             }
-            KernelExpr::Count { condition, .. } => collect(condition, roots),
-            KernelExpr::Sum {
-                body, condition, ..
-            } => {
-                collect(body, roots);
-                if let Some(condition) = condition {
-                    collect(condition, roots);
+            KernelExpr::Aggregate { binder, value, .. } => {
+                collect_binder(binder, roots);
+                if let Some(value) = value {
+                    collect(value, roots);
                 }
             }
-            KernelExpr::BinderNamed { binder, .. } => collect_binder(binder, roots),
             KernelExpr::Num(_) | KernelExpr::Bool(_) | KernelExpr::None => {}
         }
     }
@@ -89,9 +85,14 @@ fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> 
                     collect(expr, roots);
                 }
             }
-            KernelBinder::Range { lo, hi, .. } => {
+            KernelBinder::Range {
+                lo, hi, where_expr, ..
+            } => {
                 collect(lo, roots);
                 collect(hi, roots);
+                if let Some(expr) = where_expr {
+                    collect(expr, roots);
+                }
             }
             KernelBinder::Collection {
                 collection,
@@ -150,9 +151,10 @@ fn statement_roots(model: &KernelModel, statements: &[KernelStatement]) -> BTree
             KernelStatement::ForAll {
                 binder, statements, ..
             } => {
-                let binder_expr = KernelExpr::BinderNamed {
-                    name: "forall".to_owned(),
+                let binder_expr = KernelExpr::Quantified {
+                    quantifier: "forall".to_owned(),
                     binder: binder.clone(),
+                    body: Box::new(KernelExpr::Bool(true)),
                 };
                 roots.extend(expression_roots(model, &binder_expr));
                 roots.extend(statement_roots(model, statements));

--- a/rust/fsl-tools/tests/binder_aggregates.rs
+++ b/rust/fsl-tools/tests/binder_aggregates.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{FsResolver, parse_kernel_source};
+use fsl_tools::enumerate_builtin_mutants;
+
+#[test]
+fn mutation_visits_shared_binder_filters_and_sum_values() {
+    let source = r"
+spec AggregateMutation {
+  type Item = 0..2
+  state { queue: Seq<Item, 3> }
+  init { queue = Seq { 1 } }
+  action stay() {
+    requires sum(item in queue of item + 1 where item > 0) >= 0
+    queue = queue
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower source");
+    let mutants = enumerate_builtin_mutants(kernel.syntax());
+    assert!(
+        mutants
+            .iter()
+            .filter(|mutant| mutant.target.contains("stay requires"))
+            .filter(|mutant| mutant.op.starts_with("integer_literal_"))
+            .count()
+            >= 6
+    );
+}

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -3,7 +3,8 @@
 use std::collections::BTreeMap;
 
 use fsl_core::{
-    FslValue, KernelBinder as Binder, KernelExpr as Expr, KernelModel, Pattern, TypeDef, TypeRef,
+    FslValue, KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
+    KernelModel, Pattern, TypeDef, TypeRef,
 };
 use fsl_solver::SmtSolver;
 
@@ -134,57 +135,20 @@ pub(crate) fn eval<S: SmtSolver>(
         } => eval_quantified(
             solver, model, quantifier, binder, body, state, bindings, old_state,
         ),
-        Expr::Count {
-            name,
-            type_name,
-            condition,
-        } => {
-            let ty = qualified_type(type_name.namespace.as_deref(), &type_name.name)?;
-            let mut terms = Vec::new();
-            for value in model.domain_values(&TypeRef::Named(ty.clone()))? {
-                let mut local = bindings.clone();
-                local.insert(
-                    name.clone(),
-                    concrete_value(solver, model, &TypeRef::Named(ty.clone()), &value)?,
-                );
-                let condition = eval(solver, model, condition, state, &mut local, old_state)?;
-                terms.push(solver.ite(
-                    bool_term(&condition)?,
-                    &solver.int_value(1),
-                    &solver.int_value(0),
-                )?);
-            }
-            Ok(int_value(solver, sum_terms(solver, &terms)?))
-        }
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => {
-            let ty = qualified_type(type_name.namespace.as_deref(), &type_name.name)?;
-            let mut terms = Vec::new();
-            for value in model.domain_values(&TypeRef::Named(ty.clone()))? {
-                let mut local = bindings.clone();
-                local.insert(
-                    name.clone(),
-                    concrete_value(solver, model, &TypeRef::Named(ty.clone()), &value)?,
-                );
-                let body = eval(solver, model, body, state, &mut local, old_state)?;
-                let term = if let Some(condition) = condition {
-                    let condition = eval(solver, model, condition, state, &mut local, old_state)?;
-                    solver.ite(
-                        bool_term(&condition)?,
-                        int_term(&body)?,
-                        &solver.int_value(0),
-                    )?
-                } else {
-                    int_term(&body)?.clone()
-                };
-                terms.push(term);
-            }
-            Ok(int_value(solver, sum_terms(solver, &terms)?))
-        }
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => eval_aggregate(
+            solver,
+            model,
+            *kind,
+            binder,
+            value.as_deref(),
+            state,
+            bindings,
+            old_state,
+        ),
         Expr::UnaryNamed { name, expr, .. } => match name.as_str() {
             "old" => eval(
                 solver,
@@ -227,29 +191,6 @@ pub(crate) fn eval<S: SmtSolver>(
         Expr::TernaryNamed { name, .. } => Err(VerifyError::new(format!(
             "unsupported ternary expression '{name}'"
         ))),
-        Expr::BinderNamed { name, binder } => {
-            if name != "unique" && name != "exactly_one" {
-                return Err(VerifyError::new(format!(
-                    "unsupported binder expression '{name}'"
-                )));
-            }
-            let terms = binder_conditions(solver, model, binder, state, bindings, old_state)?;
-            let counts = terms
-                .iter()
-                .map(|term| {
-                    solver
-                        .ite(term, &solver.int_value(1), &solver.int_value(0))
-                        .map_err(VerifyError::from)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let count = sum_terms(solver, &counts)?;
-            let condition = if name == "unique" {
-                solver.le(&count, &solver.int_value(1))?
-            } else {
-                solver.equal(&count, &solver.int_value(1))?
-            };
-            Ok(bool_value(solver, condition))
-        }
     }
 }
 
@@ -684,6 +625,61 @@ fn binder_conditions<S: SmtSolver>(
     Ok(terms)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn eval_aggregate<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    kind: AggregateKind,
+    binder: &Binder,
+    value: Option<&Expr>,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<SymbolicValue<S::Term>, VerifyError> {
+    if kind != AggregateKind::Sum {
+        let conditions = binder_conditions(solver, model, binder, state, bindings, old_state)?;
+        let counts = conditions
+            .iter()
+            .map(|condition| {
+                solver
+                    .ite(condition, &solver.int_value(1), &solver.int_value(0))
+                    .map_err(VerifyError::from)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let count = sum_terms(solver, &counts)?;
+        return Ok(match kind {
+            AggregateKind::Count => int_value(solver, count),
+            AggregateKind::Unique => bool_value(solver, solver.le(&count, &solver.int_value(1))?),
+            AggregateKind::ExactlyOne => {
+                bool_value(solver, solver.equal(&count, &solver.int_value(1))?)
+            }
+            AggregateKind::Sum => unreachable!(),
+        });
+    }
+
+    let value = value.ok_or_else(|| VerifyError::new("sum aggregate requires a value"))?;
+    let mut terms = Vec::new();
+    for (name, candidate, membership) in
+        binder_candidates(solver, model, binder, state, bindings, old_state)?
+    {
+        let mut local = bindings.clone();
+        local.insert(name, candidate);
+        let value = eval(solver, model, value, state, &mut local, old_state)?;
+        let where_term = binder_where(solver, model, binder, state, &mut local, old_state)?;
+        let condition = match (membership, where_term) {
+            (Some(membership), Some(where_term)) => Some(solver.and(&[membership, where_term])?),
+            (Some(condition), None) | (None, Some(condition)) => Some(condition),
+            (None, None) => None,
+        };
+        terms.push(if let Some(condition) = condition {
+            solver.ite(&condition, int_term(&value)?, &solver.int_value(0))?
+        } else {
+            int_term(&value)?.clone()
+        });
+    }
+    Ok(int_value(solver, sum_terms(solver, &terms)?))
+}
+
 type ConditionalBinderCandidates<T> = Vec<(String, SymbolicValue<T>, Option<T>)>;
 
 fn binder_candidates<S: SmtSolver>(
@@ -757,7 +753,7 @@ pub(crate) fn binder_values<S: SmtSolver>(
                 .map(|value| Ok((name.clone(), concrete_value(solver, model, &ty, &value)?)))
                 .collect()
         }
-        Binder::Range { name, lo, hi } => {
+        Binder::Range { name, lo, hi, .. } => {
             let lo = static_int(lo, model)?;
             let hi = static_int(hi, model)?;
             (lo..=hi)
@@ -787,10 +783,9 @@ pub(crate) fn binder_where<S: SmtSolver>(
     old_state: Option<&SymbolicState<S::Term>>,
 ) -> Result<Option<S::Term>, VerifyError> {
     let where_expr = match binder {
-        Binder::Typed { where_expr, .. } | Binder::Collection { where_expr, .. } => {
-            where_expr.as_deref()
-        }
-        Binder::Range { .. } => None,
+        Binder::Typed { where_expr, .. }
+        | Binder::Range { where_expr, .. }
+        | Binder::Collection { where_expr, .. } => where_expr.as_deref(),
     };
     where_expr
         .map(|expr| {

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -116,3 +116,66 @@ spec NestedOptionEquality {
     assert!(explicit.violation.is_none(), "{explicit:?}");
     assert!(explicit.closure, "{explicit:?}");
 }
+
+#[test]
+fn binder_aggregates_agree_for_ranges_sets_and_duplicate_sequences() {
+    let source = r"
+spec BinderAggregateAgreement {
+  type Item = 0..2
+  state {
+    selected: Set<Item>,
+    queue: Seq<Item, 4>,
+    empty: Seq<Item, 4>
+  }
+  init {
+    selected = Set { 0, 2 }
+    queue = Seq { 1, 1, 2 }
+    empty = Seq {}
+  }
+  action stay() { selected = selected }
+  invariant AggregateValues {
+    count(item in selected) == 2 and
+    count(item in selected where item > 0) == 1 and
+    sum(item in selected of item) == 2 and
+    count(item in queue) == 3 and
+    count(item in queue where item == 1) == 2 and
+    sum(item in queue of item) == 4 and
+    sum(item in queue of item where item > 1) == 2 and
+    count(item in empty) == 0 and
+    sum(item in empty of item) == 0 and
+    count(item in 0..2 where item > 0) == 2 and
+    sum(item in 0..2 of item where item > 0) == 3 and
+    count(item in queue where count(other in queue where other == item) >= 1) == 3 and
+    count(item in queue where count(item in selected where item == 0) == 1) == 3 and
+    unique(item in queue where item == 2) and
+    exactlyOne(item in selected where item == 0)
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let property = model
+        .invariants
+        .iter()
+        .find(|property| property.name == "AggregateValues")
+        .expect("aggregate invariant");
+    let concrete = fsl_runtime::eval(
+        &property.expr,
+        &fsl_runtime::Monitor::new(model.clone())
+            .expect("create monitor")
+            .state,
+        &mut BTreeMap::new(),
+        &model,
+        None,
+    )
+    .expect("evaluate aggregate invariant");
+    assert_eq!(concrete, fsl_core::FslValue::Bool(true));
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let symbolic = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect("verify symbolically");
+    assert!(symbolic.violation.is_none(), "{symbolic:?}");
+    let explicit = fsl_runtime::verify_explicit(model, 2, 10).expect("verify explicitly");
+    assert!(explicit.violation.is_none(), "{explicit:?}");
+    assert!(explicit.closure, "{explicit:?}");
+}

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -4,7 +4,8 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Write;
 
 use fsl_core::{
-    FslValue, KernelBinder as Binder, KernelExpr as Expr, KernelModel, ParamDef, Pattern,
+    FslValue, KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
+    KernelModel, ParamDef, Pattern,
 };
 use serde_json::{Value, json};
 
@@ -512,19 +513,19 @@ fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
     }
 
     fn binder_text(model: Option<&KernelModel>, binder: &Binder) -> String {
+        let mut text = binder_base_text(model, binder);
+        if let Some(condition) = binder_filter(binder) {
+            let _ = write!(text, " where {}", expr_text_with_origins(model, condition));
+        }
+        text
+    }
+
+    fn binder_base_text(model: Option<&KernelModel>, binder: &Binder) -> String {
         match binder {
             Binder::Typed {
-                name,
-                type_name,
-                where_expr,
-            } => {
-                let mut text = format!("{name}: {}", display_name(&type_name.name));
-                if let Some(condition) = where_expr {
-                    let _ = write!(text, " where {}", expr_text_with_origins(model, condition));
-                }
-                text
-            }
-            Binder::Range { name, lo, hi } => {
+                name, type_name, ..
+            } => format!("{name}: {}", display_name(&type_name.name)),
+            Binder::Range { name, lo, hi, .. } => {
                 format!(
                     "{name} in {}..{}",
                     expr_text_with_origins(model, lo),
@@ -532,16 +533,16 @@ fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
                 )
             }
             Binder::Collection {
-                name,
-                collection,
-                where_expr,
-            } => {
-                let mut text = format!("{name} in {}", expr_text_with_origins(model, collection));
-                if let Some(condition) = where_expr {
-                    let _ = write!(text, " where {}", expr_text_with_origins(model, condition));
-                }
-                text
-            }
+                name, collection, ..
+            } => format!("{name} in {}", expr_text_with_origins(model, collection)),
+        }
+    }
+
+    fn binder_filter(binder: &Binder) -> Option<&Expr> {
+        match binder {
+            Binder::Typed { where_expr, .. }
+            | Binder::Range { where_expr, .. }
+            | Binder::Collection { where_expr, .. } => where_expr.as_deref(),
         }
     }
 
@@ -672,32 +673,27 @@ fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
             binder,
             body,
         } => format!(
-            "{quantifier} {}: {}",
+            "{quantifier} {} {{ {} }}",
             binder_text(model, binder),
             expr_text_with_origins(model, body)
         ),
-        Expr::Count {
-            name,
-            type_name,
-            condition,
-        } => format!(
-            "count({name}: {} where {})",
-            display_name(&type_name.name),
-            expr_text_with_origins(model, condition)
-        ),
-        Expr::Sum {
-            name,
-            type_name,
-            body,
-            condition,
-        } => format!(
-            "sum({name}: {} of {}{})",
-            display_name(&type_name.name),
-            expr_text_with_origins(model, body),
-            condition.as_ref().map_or_else(String::new, |value| {
-                format!(" where {}", expr_text_with_origins(model, value))
-            })
-        ),
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => match kind {
+            AggregateKind::Count => format!("count({})", binder_text(model, binder)),
+            AggregateKind::Sum => format!(
+                "sum({} of {}{})",
+                binder_base_text(model, binder),
+                expr_text_with_origins(model, value.as_deref().expect("sum has a value")),
+                binder_filter(binder).map_or_else(String::new, |filter| {
+                    format!(" where {}", expr_text_with_origins(model, filter))
+                })
+            ),
+            AggregateKind::Unique => format!("unique({})", binder_text(model, binder)),
+            AggregateKind::ExactlyOne => format!("exactlyOne({})", binder_text(model, binder)),
+        },
         Expr::Stage {
             process, entity, ..
         } => process.as_ref().map_or_else(
@@ -735,8 +731,5 @@ fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
             expr_text_with_origins(model, second),
             expr_text_with_origins(model, third)
         ),
-        Expr::BinderNamed { name, binder } => {
-            format!("{name}({})", binder_text(model, binder))
-        }
     }
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -4863,7 +4863,12 @@ fn model_skeleton(model: &KernelModel) -> Value {
                 None
             }
         }).collect::<Map<_,_>>(),
-        "stage_flows":model_stage_flows(model),"kpis":[]
+        "stage_flows":model_stage_flows(model),
+        "kpis":model.projections.iter().map(|projection| json!({
+            "name":projection.name,
+            "entity":projection.entity,
+            "stage":projection.stage,
+        })).collect::<Vec<_>>()
     })
 }
 
@@ -5358,16 +5363,12 @@ fn expression_state_roots(
                 collect_binder(binder, roots);
                 collect(body, roots);
             }
-            KernelExpr::Count { condition, .. } => collect(condition, roots),
-            KernelExpr::Sum {
-                body, condition, ..
-            } => {
-                collect(body, roots);
-                if let Some(condition) = condition {
-                    collect(condition, roots);
+            KernelExpr::Aggregate { binder, value, .. } => {
+                collect_binder(binder, roots);
+                if let Some(value) = value {
+                    collect(value, roots);
                 }
             }
-            KernelExpr::BinderNamed { binder, .. } => collect_binder(binder, roots),
             KernelExpr::Num(_) | KernelExpr::Bool(_) | KernelExpr::None => {}
         }
     }
@@ -5381,9 +5382,14 @@ fn expression_state_roots(
                     collect(expr, roots);
                 }
             }
-            fsl_core::KernelBinder::Range { lo, hi, .. } => {
+            fsl_core::KernelBinder::Range {
+                lo, hi, where_expr, ..
+            } => {
                 collect(lo, roots);
                 collect(hi, roots);
+                if let Some(expr) = where_expr {
+                    collect(expr, roots);
+                }
             }
             fsl_core::KernelBinder::Collection {
                 collection,
@@ -6081,9 +6087,7 @@ fn expression_mutant_count(
         KernelExpr::Bool(_)
         | KernelExpr::None
         | KernelExpr::Quantified { .. }
-        | KernelExpr::Count { .. }
-        | KernelExpr::Sum { .. }
-        | KernelExpr::BinderNamed { .. } => 0,
+        | KernelExpr::Aggregate { .. } => 0,
     }
 }
 

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -216,7 +216,7 @@ fn requirements_stage_is_readable_in_explain_and_violation_evidence() {
     assert_eq!(status, 0, "{explained}");
     assert_eq!(
         explained["skeleton"]["properties"][0]["body_text"],
-        "forall c: Claim: stage(c) == Draft"
+        "forall c: Claim { stage(c) == Draft }"
     );
     assert_eq!(
         explained["skeleton"]["properties"][0]["origin"]["lowering_steps"][0]["detail"],
@@ -235,7 +235,7 @@ fn requirements_stage_is_readable_in_explain_and_violation_evidence() {
     assert_eq!(status, 1, "{violated}");
     assert_eq!(
         violated["blame"]["conjuncts"][0]["text"],
-        "forall c: Claim: stage(c) == Draft"
+        "forall c: Claim { stage(c) == Draft }"
     );
 }
 
@@ -243,7 +243,7 @@ fn requirements_stage_is_readable_in_explain_and_violation_evidence() {
 fn qualified_requirements_stage_keeps_its_process_path_in_evidence() {
     let fixture = "rust/fslc/tests/fixtures/requirements_stage_qualified.fsl";
     let expected =
-        "forall c: Claim: claims.Claim.stage(c) == Draft and legacy.Claim.stage(c) == Imported";
+        "forall c: Claim { claims.Claim.stage(c) == Draft and legacy.Claim.stage(c) == Imported }";
     let (explained, status) = run_cli(&["explain", fixture, "--depth", "1"]);
 
     assert_eq!(status, 0, "{explained}");

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -640,14 +640,15 @@ cannot be assigned both inline and in `init`.
   (in `a//b` everything after `//` becomes a comment, so write division with a
   space: `a / b`)
 - Comparison: `== != < <= > >=` / logic: `and or not =>`
-- Quantification: `forall x: T { expr }`, `exists x: T { expr }` (`where expr`
-  allowed), `forall x in set_or_seq { expr }` / `exists x in set_or_seq { expr }`
-  for expression-only Set/Seq iteration, and the v0 form
-  `forall i in lo..hi: expr` (range is a constant expression: `0..CAP-1` recommended)
-- Aggregation: `count(x: T where expr)`, `sum(x: T of expr [where expr])`
-- Cardinality predicates: `unique(x: T where expr)` / `exactlyOne(x: T where expr)`;
-  `x in set_or_seq [where expr]` is also allowed. `unique` means at most one
-  matching binding; `exactlyOne` means exactly one.
+- Finite binders: `x: T`, `x in lo..hi`, or `x in set_or_seq`, each with an
+  optional `where BoolExpr`. Maps and unbounded domains are rejected.
+- Quantification: canonical `forall binder { expr }` / `exists binder { expr }`.
+  The 2.x colon/no-braces spelling remains accepted as non-canonical input.
+- Aggregation: `count(binder)` and `sum(binder of value)`, including collection
+  and range binders. Empty domains yield `0`; Seq duplicates count once per live
+  slot and Set members once per distinct value.
+- Cardinality predicates: `unique(binder)` / `exactlyOne(binder)`. `unique`
+  means at most one match; `exactlyOne` means exactly one.
 - Option: `x == none` `x != none` `x == some(e)` `x != some(e)` use structural
   equality (presence first, then payload when present). `x is some(v)` is still
   required when `v` must be bound for the rest of the formula; equality creates

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -143,6 +143,12 @@
       "result": "error"
     }
   },
+  "examples/collection_aggregates.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/conditional_expressions.fsl": {
     "check": {
       "result": "ok",


### PR DESCRIPTION
## Problem
Count, Sum, Unique, ExactlyOne, quantifiers, and KPI projections used overlapping binder representations and traversal logic. This blocked formatter work and left collection/range filters inconsistent across concrete, explicit, symbolic, analysis, and Public Kernel paths.

## Contract change
- Replace the separate aggregate variants with one AggregateKind plus shared Binder IR.
- Support typed, range, Set, and Seq binders with optional filters across all finite aggregates.
- Preserve Public Kernel v1/v2 expression schemas by normalizing collection/range aggregates to existing nodes with capture-avoiding substitution and scoped partial-operation guards.
- Keep KPI declarations as typed projection metadata instead of generated ghost state.
- Canonicalize quantifier rendering and reject duplicate sum filters.

## Evidence
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo build --workspace --locked
- cargo test --workspace --locked
- Python compatibility: 1455 passed, 81 skipped
- WASM browser/native parity: 324 cases
- Independent review: no unresolved findings

## Documentation
Updates LANGUAGE, design notes, skill reference, generated site reference, example corpus, snapshot, and CHANGELOG.

Closes #242
Closes #217