### PR TITLE
feat(fmt): add lossless canonical formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc fmt` now formats one registered FSL document or stdin to canonical
+  stdout without mutating it; `--check` accepts multiple paths and reports a
+  machine-readable 0/1/2 result. A lossless token/trivia tree preserves line
+  comments, blank lines, raw spelling, spans, and annotation attachment while
+  domain enum/logical and quantifier legacy forms normalize to accepted
+  equivalents. Corpus-wide idempotence and location-free semantic round trips
+  cover every registered dialect; opaque agent bodies and ambiguous
+  comment-bearing structural rewrites fail at exact spans (issue #248).
 - `fslc verify --engine auto` composes the explicit-state and BMC engines:
   explicit runs first (faster, and can prove `closure: true`) and falls back
   transparently to BMC exactly when explicit cannot decide the spec on its

--- a/docs/DESIGN-dialect-dispatch.md
+++ b/docs/DESIGN-dialect-dispatch.md
@@ -67,7 +67,9 @@ spans. It is trivia only at byte offset zero.
   dispatch frontend validates the declaration header, balanced outer envelope,
   and trailing EOF, but deliberately leaves the body opaque. Structural agent
   grammar/graph analysis remains the `fslc ai check` surface. Kernel
-  verification rejects the evidence-only document, as before.
+  verification rejects the evidence-only document, as before. The canonical
+  formatter accepts an empty envelope and refuses a nonempty opaque body rather
+  than guessing its internal structure.
 - AI project/statistical block detection remains an AI-frontend feature scan;
   its first significant identifier must belong to the known AI project block
   set, but those evidence blocks are not dialect registry entries.

--- a/docs/DESIGN-formatter.md
+++ b/docs/DESIGN-formatter.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Lossless syntax and canonical formatter
+
+## Contract
+
+`fslc fmt FILE [--edition current|next]` formats one registered FSL document to
+stdout. It never changes the input file. `FILE` may be `-` for stdin.
+`fslc fmt PATH... --check` accepts one or more paths, emits a JSON
+`format_check` envelope, and exits 0 when every path is canonical, 1 when any
+path would change, and 2 for I/O, syntax, type, or unsafe-format errors. Stdin
+cannot be repeated or mixed with paths. There is deliberately no in-place
+option; mutation and multi-file migration belong to the edition migrator.
+
+Both formatting editions select an accepted, meaning-equivalent canonical
+surface. `next` does not authorize migrations, implicit defaults, declaration
+movement, or other changes that require judgment. In particular, `&&` remains
+invalid FSL; accepting or migrating it requires a separate language decision.
+
+## Lossless boundary
+
+The ordinary lexer remains the sole token authority. `lossless_document`
+combines its significant token spans with the untouched source slices between
+them:
+
+```text
+source bytes
+  |-- shared lexer --> token kind + span --> semantic parser / lowering
+  `-- span gaps ----> whitespace / line-comment nodes --> formatter
+```
+
+Concatenating every lossless node is byte-identical to the input. Raw token
+text therefore retains legacy spelling and delimiters while trivia retains
+line comments, blank lines, BOM/whitespace, UTF-8 bytes, and annotation
+attachment. A lexical failure produces an error node and keeps the complete
+source; formatting refuses it at the original span. The current language has
+`//` comments only, so this contract does not invent block comments.
+
+The semantic AST is not used as a pretty-print tree. Doing so would lose
+comments and source spelling. Formatting first parses through the shared
+dialect registry, applies only accepted equivalent source edits, formats token
+layout, and parses the result again. For file paths, the CLI additionally
+type-checks both the original and result when the dialect has a Kernel lowering
+gate. Stdin has no resolver base, so it receives the same syntax and
+safe-rewrite checks but not resolver-backed type checking.
+
+## Canonical and preserved forms
+
+The token layout fixes two-space indentation, brace line breaks, comma and
+colon spacing, optional semicolon line breaks, at most one preserved blank
+line, and no spaces around member/range paths. Stacked typed annotations and
+comments retain source order and attachment. Qualified `SymbolPath` segments
+remain adjacent.
+
+Accepted legacy domain enum unions become `enum Name { ... }`; legacy domain
+logical `||` and implication `->` become `or` and `=>` only in domain
+expression context. Domain `await ... on Event -> Event` routing keeps its
+arrow. Legacy quantifier separator colons become the common brace form. These
+edits do not rewrite abstractions such as `.size()` into `count`.
+
+## Refusal boundary
+
+The formatter returns `FSL-FMT-UNSAFE` without changing source when it cannot
+prove comment attachment or semantic ownership. The public refusal range is:
+
+- a nonempty opaque `agent` body, because the registry intentionally has no
+  native grammar for that body;
+- registry-external multi-declaration AI project files;
+- a legacy domain enum with an interior comment;
+- an unbraced quantifier whose body boundary cannot be identified from the
+  accepted separator form;
+- any lexical, parse, or checked-model error.
+
+The corpus gate covers every registered dialect. For the supported range it
+checks comment sequence preservation, byte-idempotence, and a location-free
+Public Kernel comparison; compose/refinement use exact token-kind comparison
+where a truthful Public Kernel export is unavailable. Declared malformed
+fixtures and the refusal range must leave their original bytes untouched.
+
+## Formatter and migrator ownership
+
+The formatter owns whitespace and already-accepted equivalent spellings. The
+edition migrator owns diagnostics, dry-run/write workflows, implicit-default
+insertion, inline-mapping movement, and any conversion that is not already an
+accepted semantic equivalence. This keeps one source-edit engine without
+turning formatting into an unsafe migration command.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -663,6 +663,8 @@ variable.
 
 ```
 fslc check     <file.fsl>                        # syntax / names / types only (fast)
+fslc fmt       <file.fsl|-> [--edition current|next] # canonical FSL to stdout; never mutates input
+fslc fmt       <path>... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    <file.fsl> [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance <file.fsl> [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
 fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexample is shortest)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 | [`DESIGN-requirements-stage.md`](DESIGN-requirements-stage.md) | Shared typed `stage()` resolution and lowering for business and requirements expressions |
 | [`DESIGN-collection-aggregates.md`](DESIGN-collection-aggregates.md) | Shared finite Binder/Aggregate IR, Set/Seq/range semantics, KPI metadata projections, and Public Kernel normalization |
 | [`DESIGN-dialect-dispatch.md`](DESIGN-dialect-dispatch.md) | Shared-lexer dialect registry, significant-token rules, document annotations, diagnostics, and frontend contract |
+| [`DESIGN-formatter.md`](DESIGN-formatter.md) | Lossless token/trivia boundary, canonical formatting policy, non-mutating CLI contract, and safe refusal range |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -314,6 +314,14 @@ scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime c
 event / effect evidence. The v0 implementation proves the finite modeled
 lifecycle; replay is observation evidence and saga history adds
 <code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code>.
+The native scaffold emitters consume checked Public Kernel v1 JSON plus the
+versioned <code>domain-scaffold-metadata.v1</code> compatibility bridge; they do not
+receive the private domain AST or reparse source expressions. Kernel/metadata
+version and dialect mismatches, duplicate Kernel members, and missing lowered
+type/state/action counterparts fail closed. Source expressions and effect/saga
+topology remain authoritative in the companion because Public Kernel v1 does
+not encode them. All five target outputs are locked to pre-migration goldens,
+and the valid domain corpus is generated for every target.
 It does not prove real gateway behavior, wall-clock timeouts, queue delivery, or
 production exactly-once semantics. See <code>docs/DESIGN-domain.md</code> and
 <code>docs/DESIGN-effect.md</code>.</p>
@@ -735,6 +743,8 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
+fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance &lt;file.fsl&gt; [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -314,6 +314,14 @@ scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime c
 event / effect evidence. The v0 implementation proves the finite modeled
 lifecycle; replay is observation evidence and saga history adds
 <code>DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY</code>.
+The native scaffold emitters consume checked Public Kernel v1 JSON plus the
+versioned <code>domain-scaffold-metadata.v1</code> compatibility bridge; they do not
+receive the private domain AST or reparse source expressions. Kernel/metadata
+version and dialect mismatches, duplicate Kernel members, and missing lowered
+type/state/action counterparts fail closed. Source expressions and effect/saga
+topology remain authoritative in the companion because Public Kernel v1 does
+not encode them. All five target outputs are locked to pre-migration goldens,
+and the valid domain corpus is generated for every target.
 It does not prove real gateway behavior, wall-clock timeouts, queue delivery, or
 production exactly-once semantics. See <code>docs/DESIGN-domain.md</code> and
 <code>docs/DESIGN-effect.md</code>.</p>
@@ -735,6 +743,8 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
+fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance &lt;file.fsl&gt; [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
 fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -16,6 +16,7 @@ mod db;
 mod dispatch;
 mod domain;
 mod lexer;
+mod lossless;
 mod parser;
 mod surface;
 mod syntax_expr;
@@ -47,6 +48,10 @@ pub use domain::{
     DomainSagaStep, DomainSpec, DomainStalePolicy, DomainType, DomainTypeSourceForm, parse_domain,
 };
 pub use lexer::{LexError, Token, TokenKind, lex};
+pub use lossless::{
+    FormatEdition, FormatError, LosslessDocument, LosslessKind, LosslessNode, format_source,
+    lossless_document,
+};
 pub use parser::{ParseError, parse_expr, parse_surface_document, parse_surface_spec};
 pub use surface::{
     AcceptanceExpectation, AcceptanceStep, ActionItem, ActionTarget, BusinessGoalBody,

--- a/rust/fsl-syntax/src/lossless.rs
+++ b/rust/fsl-syntax/src/lossless.rs
@@ -1,0 +1,848 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Lossless source nodes and the shared, trivia-preserving formatter.
+
+use std::fmt;
+
+use crate::{LexError, ParseError, SourceFile, Span, TokenKind, lex, parse_document};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LosslessKind {
+    Token(TokenKind),
+    Whitespace,
+    LineComment,
+    Error,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LosslessNode {
+    pub kind: LosslessKind,
+    pub text: String,
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LosslessDocument {
+    source: String,
+    nodes: Vec<LosslessNode>,
+    error: Option<LexError>,
+}
+
+impl LosslessDocument {
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    #[must_use]
+    pub fn nodes(&self) -> &[LosslessNode] {
+        &self.nodes
+    }
+
+    #[must_use]
+    pub const fn error(&self) -> Option<&LexError> {
+        self.error.as_ref()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FormatEdition {
+    Current,
+    Next,
+}
+
+impl FormatEdition {
+    /// Parse the public CLI spelling.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for editions that have no formatting policy.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "current" => Ok(Self::Current),
+            "next" => Ok(Self::Next),
+            _ => Err("--edition must be current or next".to_owned()),
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Next => "next",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FormatError {
+    Lex(LexError),
+    Parse(ParseError),
+    Unsafe { message: String, span: Span },
+}
+
+impl FormatError {
+    #[must_use]
+    pub const fn span(&self) -> Span {
+        match self {
+            Self::Lex(error) => error.span,
+            Self::Parse(error) => error.span,
+            Self::Unsafe { span, .. } => *span,
+        }
+    }
+}
+
+impl fmt::Display for FormatError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lex(error) => error.fmt(formatter),
+            Self::Parse(error) => error.fmt(formatter),
+            Self::Unsafe { message, span } => write!(
+                formatter,
+                "{message} at {}:{}",
+                span.start.line, span.start.column
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+/// Build a lossless tree from the shared token stream and its source gaps.
+/// Lexical failures are retained as error nodes so callers can refuse rewrites
+/// without losing the original bytes.
+#[must_use]
+pub fn lossless_document(source: &str) -> LosslessDocument {
+    let tokens = match lex(source) {
+        Ok(tokens) => tokens,
+        Err(error) => {
+            return LosslessDocument {
+                source: source.to_owned(),
+                nodes: vec![LosslessNode {
+                    kind: LosslessKind::Error,
+                    text: source.to_owned(),
+                    span: Span {
+                        start: position(source, 0),
+                        end: position(source, source.len()),
+                    },
+                }],
+                error: Some(error),
+            };
+        }
+    };
+    let mut nodes = Vec::new();
+    let mut offset = 0;
+    for token in tokens {
+        push_trivia(source, offset, token.span.start.offset, &mut nodes);
+        if matches!(token.kind, TokenKind::Eof) {
+            offset = token.span.end.offset;
+            continue;
+        }
+        nodes.push(LosslessNode {
+            kind: LosslessKind::Token(token.kind),
+            text: source[token.span.start.offset..token.span.end.offset].to_owned(),
+            span: token.span,
+        });
+        offset = token.span.end.offset;
+    }
+    push_trivia(source, offset, source.len(), &mut nodes);
+    LosslessDocument {
+        source: source.to_owned(),
+        nodes,
+        error: None,
+    }
+}
+
+fn push_trivia(source: &str, start: usize, end: usize, nodes: &mut Vec<LosslessNode>) {
+    let mut offset = start;
+    while offset < end {
+        let comment = source[offset..end].starts_with("//");
+        let node_start = offset;
+        if comment {
+            while offset < end && !source[offset..end].starts_with('\n') {
+                offset += source[offset..]
+                    .chars()
+                    .next()
+                    .expect("in bounds")
+                    .len_utf8();
+            }
+        } else {
+            while offset < end && !source[offset..end].starts_with("//") {
+                offset += source[offset..]
+                    .chars()
+                    .next()
+                    .expect("in bounds")
+                    .len_utf8();
+            }
+        }
+        let start_pos = position(source, node_start);
+        let end_pos = position(source, offset);
+        nodes.push(LosslessNode {
+            kind: if comment {
+                LosslessKind::LineComment
+            } else {
+                LosslessKind::Whitespace
+            },
+            text: source[node_start..offset].to_owned(),
+            span: Span {
+                start: start_pos,
+                end: end_pos,
+            },
+        });
+    }
+}
+
+fn position(source: &str, offset: usize) -> crate::SourcePos {
+    let prefix = &source[..offset];
+    let line = u32::try_from(prefix.bytes().filter(|byte| *byte == b'\n').count())
+        .expect("FSL source line count exceeds u32")
+        + 1;
+    let column = u32::try_from(
+        prefix
+            .rsplit_once('\n')
+            .map_or(prefix, |(_, tail)| tail)
+            .chars()
+            .count(),
+    )
+    .expect("FSL source column exceeds u32")
+        + 1;
+    crate::SourcePos {
+        offset,
+        line,
+        column,
+    }
+}
+
+/// Format one complete registered FSL document without mutating the source.
+///
+/// # Errors
+///
+/// Returns the original lexical or parse error. Sources containing a legacy
+/// domain enum with an interior comment are refused until that structural
+/// rewrite can preserve the comment attachment unambiguously.
+pub fn format_source(source: &str, _edition: FormatEdition) -> Result<String, FormatError> {
+    let tree = lossless_document(source);
+    if let Some(error) = tree.error() {
+        return Err(FormatError::Lex(error.clone()));
+    }
+    let parsed = parse_document(SourceFile::new(source)).map_err(FormatError::Parse)?;
+    refuse_opaque_agent(&tree, parsed.keyword)?;
+    let rewritten = rewrite_domain_enum(&tree, parsed.keyword)?;
+    let rewritten = rewrite_domain_logical(&lossless_document(&rewritten), parsed.keyword)?;
+    let rewritten = rewrite_quantifiers(&lossless_document(&rewritten))?;
+    let tree = lossless_document(&rewritten);
+    let mut formatter = Formatter::new();
+    formatter.write(tree.nodes());
+    let output = formatter.finish();
+    parse_document(SourceFile::new(&output)).map_err(FormatError::Parse)?;
+    Ok(output)
+}
+
+fn rewrite_domain_logical(tree: &LosslessDocument, dialect: &str) -> Result<String, FormatError> {
+    if dialect != "domain" {
+        return Ok(tree.source().to_owned());
+    }
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let mut edits = Vec::new();
+    for (index, node) in tokens.iter().enumerate() {
+        let Some(symbol) = token_symbol(node) else {
+            continue;
+        };
+        if symbol == "||" {
+            edits.push((
+                node.span.start.offset,
+                node.span.end.offset,
+                "or".to_owned(),
+            ));
+        } else if symbol == "->" {
+            let await_branch = index >= 2
+                && token_ident(tokens[index - 2]) == Some("on")
+                && token_ident(tokens[index - 1]).is_some()
+                && tokens
+                    .get(index + 1)
+                    .and_then(|node| token_ident(node))
+                    .is_some();
+            if !await_branch {
+                edits.push((
+                    node.span.start.offset,
+                    node.span.end.offset,
+                    "=>".to_owned(),
+                ));
+            }
+        }
+    }
+    apply_edits(tree.source(), edits)
+}
+
+fn refuse_opaque_agent(tree: &LosslessDocument, dialect: &str) -> Result<(), FormatError> {
+    if dialect != "agent" {
+        return Ok(());
+    }
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let open = tokens
+        .iter()
+        .position(|node| token_symbol(node) == Some("{"));
+    let close = tokens
+        .iter()
+        .rposition(|node| token_symbol(node) == Some("}"));
+    if let (Some(open), Some(close)) = (open, close)
+        && close > open + 1
+    {
+        return Err(FormatError::Unsafe {
+            message: "cannot format an opaque agent body without a native semantic grammar"
+                .to_owned(),
+            span: Span {
+                start: tokens[open + 1].span.start,
+                end: tokens[close - 1].span.end,
+            },
+        });
+    }
+    Ok(())
+}
+
+fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let mut edits = Vec::new();
+    for (start, token) in tokens.iter().enumerate() {
+        if !matches!(token_ident(token), Some("forall" | "exists")) {
+            continue;
+        }
+        let typed = tokens.get(start + 2).and_then(|node| token_symbol(node)) == Some(":");
+        let mut colons = Vec::new();
+        let mut brace = None;
+        let mut index = start + 1;
+        while let Some(node) = tokens.get(index) {
+            if node.span.start.line > token.span.start.line {
+                break;
+            }
+            match token_symbol(node) {
+                Some(":") => colons.push(index),
+                Some("{") => {
+                    brace = Some(index);
+                    break;
+                }
+                Some(";" | "}") => break,
+                _ => {}
+            }
+            index += 1;
+        }
+        let separator = colons.get(usize::from(typed)).copied();
+        if let Some(separator) = separator {
+            if brace == Some(separator + 1) {
+                edits.push((
+                    tokens[separator].span.start.offset,
+                    tokens[separator].span.end.offset,
+                    String::new(),
+                ));
+                continue;
+            }
+            let body_start = separator + 1;
+            let Some(body_end) = quantifier_body_end(&tokens, body_start) else {
+                return Err(FormatError::Unsafe {
+                    message: "cannot determine the end of an unbraced quantifier".to_owned(),
+                    span: token.span,
+                });
+            };
+            edits.push((
+                tokens[separator].span.start.offset,
+                tokens[separator].span.end.offset,
+                " {".to_owned(),
+            ));
+            edits.push((
+                tokens[body_end].span.end.offset,
+                tokens[body_end].span.end.offset,
+                " }".to_owned(),
+            ));
+        } else if brace.is_none() {
+            return Err(FormatError::Unsafe {
+                message: "cannot canonicalize a quantifier without braces or a separator colon"
+                    .to_owned(),
+                span: token.span,
+            });
+        }
+    }
+    apply_edits(tree.source(), edits)
+}
+
+fn quantifier_body_end(tokens: &[&LosslessNode], start: usize) -> Option<usize> {
+    let first = tokens.get(start)?;
+    let line = first.span.start.line;
+    let mut depth = 0_i32;
+    let mut end = None;
+    for (index, node) in tokens.iter().enumerate().skip(start) {
+        if node.span.start.line > line && depth == 0 {
+            break;
+        }
+        match token_symbol(node) {
+            Some("(" | "[" | "{") => depth += 1,
+            Some("}" | ";") if depth == 0 => break,
+            Some(")" | "]" | "}") => depth -= 1,
+            _ => {}
+        }
+        end = Some(index);
+    }
+    end
+}
+
+fn apply_edits(
+    source: &str,
+    mut edits: Vec<(usize, usize, String)>,
+) -> Result<String, FormatError> {
+    edits.sort_by_key(|(start, end, _)| (*start, *end));
+    if edits
+        .windows(2)
+        .any(|pair| pair[0].1 > pair[1].0 && pair[0].0 != pair[0].1)
+    {
+        return Err(FormatError::Unsafe {
+            message: "overlapping formatter edits are not safe".to_owned(),
+            span: Span {
+                start: position(source, edits[0].0),
+                end: position(source, edits[1].1),
+            },
+        });
+    }
+    let mut output = source.to_owned();
+    for (start, end, replacement) in edits.into_iter().rev() {
+        output.replace_range(start..end, &replacement);
+    }
+    Ok(output)
+}
+
+fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String, FormatError> {
+    if dialect != "domain" {
+        return Ok(tree.source().to_owned());
+    }
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let mut replacements = Vec::new();
+    let mut cursor = 0;
+    while cursor + 4 < tokens.len() {
+        if token_ident(tokens[cursor]) != Some("type")
+            || token_ident(tokens[cursor + 1]).is_none()
+            || token_symbol(tokens[cursor + 2]) != Some("=")
+        {
+            cursor += 1;
+            continue;
+        }
+        let start = cursor;
+        let mut index = cursor + 3;
+        let mut members = Vec::new();
+        while let Some(member) = tokens.get(index).and_then(|node| token_ident(node)) {
+            members.push(member);
+            index += 1;
+            if tokens.get(index).and_then(|node| token_symbol(node)) == Some("|") {
+                index += 1;
+                continue;
+            }
+            break;
+        }
+        if members.len() < 2 {
+            cursor += 1;
+            continue;
+        }
+        let semicolon = tokens.get(index).and_then(|node| token_symbol(node)) == Some(";");
+        let end = if semicolon { index } else { index - 1 };
+        let span = Span {
+            start: tokens[start].span.start,
+            end: tokens[end].span.end,
+        };
+        let original = &tree.source()[span.start.offset..span.end.offset];
+        if original.contains("//") {
+            return Err(FormatError::Unsafe {
+                message: "cannot canonicalize a legacy domain enum with interior comments"
+                    .to_owned(),
+                span,
+            });
+        }
+        replacements.push((
+            span,
+            format!(
+                "enum {} {{ {} }}",
+                token_ident(tokens[start + 1]).expect("checked name"),
+                members.join(", ")
+            ),
+        ));
+        cursor = index + usize::from(semicolon);
+    }
+    let mut output = tree.source().to_owned();
+    for (span, replacement) in replacements.into_iter().rev() {
+        output.replace_range(span.start.offset..span.end.offset, &replacement);
+    }
+    Ok(output)
+}
+
+fn token_ident(node: &LosslessNode) -> Option<&str> {
+    match &node.kind {
+        LosslessKind::Token(TokenKind::Ident(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn token_symbol(node: &LosslessNode) -> Option<&str> {
+    match &node.kind {
+        LosslessKind::Token(TokenKind::Symbol(value)) => Some(value),
+        _ => None,
+    }
+}
+
+struct Formatter {
+    output: String,
+    indent: usize,
+    line_start: bool,
+    pending_lines: usize,
+    pending_space: bool,
+    previous: Option<TokenKind>,
+    type_argument_depth: usize,
+    source_line_break: bool,
+}
+
+impl Formatter {
+    fn new() -> Self {
+        Self {
+            output: String::new(),
+            indent: 0,
+            line_start: true,
+            pending_lines: 0,
+            pending_space: false,
+            previous: None,
+            type_argument_depth: 0,
+            source_line_break: false,
+        }
+    }
+
+    fn write(&mut self, nodes: &[LosslessNode]) {
+        for node in nodes {
+            match &node.kind {
+                LosslessKind::Whitespace => self.whitespace(&node.text),
+                LosslessKind::LineComment => self.comment(&node.text),
+                LosslessKind::Token(kind) => self.token(kind, &node.text),
+                LosslessKind::Error => unreachable!("lexical errors are refused"),
+            }
+        }
+    }
+
+    fn whitespace(&mut self, value: &str) {
+        let lines = value.bytes().filter(|byte| *byte == b'\n').count();
+        if lines > 0 {
+            self.pending_lines = self.pending_lines.max(lines.min(2));
+            self.pending_space = false;
+            self.source_line_break = true;
+        } else if !value.is_empty() {
+            self.pending_space = true;
+        }
+    }
+
+    fn comment(&mut self, value: &str) {
+        let inline = !self.source_line_break && !self.line_start;
+        let lines_after_attachment = if inline { self.pending_lines } else { 0 };
+        if inline {
+            self.pending_lines = 0;
+            self.pending_space = true;
+        } else {
+            self.flush_pending();
+        }
+        if !self.line_start && !self.output.ends_with(' ') {
+            self.output.push(' ');
+        }
+        self.write_indent();
+        self.output.push_str(value.trim_end());
+        self.newline();
+        self.pending_lines = lines_after_attachment;
+        self.source_line_break = true;
+    }
+
+    fn token(&mut self, kind: &TokenKind, original: &str) {
+        let closes = matches!(kind, TokenKind::Symbol(symbol) if symbol == "}");
+        if closes {
+            self.indent = self.indent.saturating_sub(1);
+            if !self.line_start {
+                self.pending_lines = 1;
+            }
+        }
+        self.flush_pending();
+        let at_line_start = self.line_start;
+        self.write_indent();
+        if !at_line_start
+            && needs_space(
+                self.previous.as_ref(),
+                kind,
+                self.pending_space,
+                self.type_argument_depth,
+            )
+        {
+            self.output.push(' ');
+        }
+        self.output.push_str(original);
+        self.line_start = false;
+        self.pending_space = false;
+        match kind {
+            TokenKind::Symbol(symbol) if symbol == "{" => {
+                self.indent += 1;
+                self.pending_lines = 1;
+            }
+            TokenKind::Symbol(symbol) if symbol == "}" => self.pending_lines = 2,
+            TokenKind::Symbol(symbol) if symbol == ";" => self.pending_lines = 1,
+            _ => {}
+        }
+        if is_type_argument_open(self.previous.as_ref(), kind) {
+            self.type_argument_depth += 1;
+        } else if matches!(kind, TokenKind::Symbol(symbol) if symbol == ">")
+            && self.type_argument_depth > 0
+        {
+            self.type_argument_depth -= 1;
+        }
+        self.previous = Some(kind.clone());
+        self.source_line_break = false;
+    }
+
+    fn flush_pending(&mut self) {
+        if self.pending_lines > 0 {
+            if !self.line_start {
+                self.newline();
+            }
+            if self.pending_lines > 1 && !self.output.ends_with("\n\n") {
+                self.output.push('\n');
+            }
+            self.pending_lines = 0;
+        }
+    }
+
+    fn write_indent(&mut self) {
+        if self.line_start {
+            self.output.push_str(&"  ".repeat(self.indent));
+            self.line_start = false;
+        }
+    }
+
+    fn newline(&mut self) {
+        while self.output.ends_with(' ') {
+            self.output.pop();
+        }
+        if !self.output.ends_with('\n') {
+            self.output.push('\n');
+        }
+        self.line_start = true;
+    }
+
+    fn finish(mut self) -> String {
+        while self
+            .output
+            .ends_with(|character: char| character.is_whitespace())
+        {
+            self.output.pop();
+        }
+        self.output.push('\n');
+        self.output
+    }
+}
+
+fn needs_space(
+    previous: Option<&TokenKind>,
+    current: &TokenKind,
+    had_space: bool,
+    type_argument_depth: usize,
+) -> bool {
+    let Some(previous) = previous else {
+        return false;
+    };
+    let previous_symbol = match previous {
+        TokenKind::Symbol(value) => Some(value.as_str()),
+        _ => None,
+    };
+    let current_symbol = match current {
+        TokenKind::Symbol(value) => Some(value.as_str()),
+        _ => None,
+    };
+    if is_type_argument_open(Some(previous), current)
+        || type_argument_depth > 0 && current_symbol == Some(">")
+        || type_argument_depth > 0 && previous_symbol == Some("<")
+    {
+        return false;
+    }
+    if !had_space
+        && matches!(
+            (previous, current),
+            (TokenKind::Int(_), TokenKind::Ident(_))
+        )
+    {
+        return false;
+    }
+    if matches!(current_symbol, Some("," | ";" | ")" | "]" | "." | ".."))
+        || matches!(previous_symbol, Some("(" | "[" | "." | ".." | "@"))
+    {
+        return false;
+    }
+    if current_symbol == Some("[")
+        && matches!(previous, TokenKind::Ident(value) if !list_prefix(value))
+    {
+        return false;
+    }
+    if current_symbol == Some("(") {
+        return matches!(previous, TokenKind::Ident(value) if matches!(value.as_str(), "if" | "while"));
+    }
+    if matches!(current_symbol, Some(":")) {
+        return false;
+    }
+    if matches!(previous_symbol, Some("," | ":")) {
+        return true;
+    }
+    if current_symbol == Some("{") || previous_symbol == Some("}") {
+        return true;
+    }
+    had_space
+        || !matches!(previous_symbol, Some("(" | "[")) && !matches!(current_symbol, Some(")" | "]"))
+}
+
+fn is_type_argument_open(previous: Option<&TokenKind>, current: &TokenKind) -> bool {
+    matches!(
+        (previous, current),
+        (
+            Some(TokenKind::Ident(name)),
+            TokenKind::Symbol(symbol)
+        ) if symbol == "<" && matches!(name.as_str(), "Map" | "Set" | "Seq" | "Option")
+    )
+}
+
+fn list_prefix(value: &str) -> bool {
+    matches!(
+        value,
+        "authority"
+            | "context"
+            | "fields"
+            | "forbidden"
+            | "in"
+            | "may_execute"
+            | "may_suggest"
+            | "one_of"
+            | "requires_human_approval"
+            | "tools"
+            | "trusted"
+            | "untrusted"
+            | "visibility"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lossless_nodes_reconstruct_comments_blank_lines_and_token_spelling() {
+        let source = "// lead\n\ndomain D { invariant P { a || b -> not c } }\n";
+        let tree = lossless_document(source);
+        assert!(tree.error().is_none());
+        assert_eq!(
+            tree.nodes()
+                .iter()
+                .map(|node| node.text.as_str())
+                .collect::<String>(),
+            source
+        );
+        assert!(
+            tree.nodes()
+                .iter()
+                .any(|node| matches!(node.kind, LosslessKind::LineComment))
+        );
+    }
+
+    #[test]
+    fn malformed_source_is_retained_and_formatting_refuses_it() {
+        let source = "spec Broken { invariant P { x ` y } }";
+        let tree = lossless_document(source);
+        assert_eq!(tree.source(), source);
+        assert!(matches!(tree.nodes()[0].kind, LosslessKind::Error));
+        assert_eq!(tree.nodes()[0].text, source);
+        assert!(matches!(
+            format_source(source, FormatEdition::Current),
+            Err(FormatError::Lex(_))
+        ));
+    }
+
+    #[test]
+    fn formatter_is_idempotent_and_preserves_comments() {
+        let source =
+            include_str!("../../fslc/tests/fixtures/domain_characterization/expressions_valid.fsl");
+        let once = format_source(source, FormatEdition::Next).expect("format");
+        let twice = format_source(&once, FormatEdition::Next).expect("format twice");
+        assert_eq!(once, twice);
+        assert!(once.contains("// SPDX-License-Identifier: Apache-2.0"));
+        assert!(once.contains("enum OrderStatus"));
+        assert!(once.contains(" or "));
+        assert!(once.contains(" => "));
+    }
+
+    #[test]
+    fn commented_legacy_enum_is_refused_without_losing_source() {
+        let source = "domain D { type Status = Draft // keep\n | Done; }";
+        let error = format_source(source, FormatEdition::Next).expect_err("unsafe rewrite");
+        assert!(matches!(error, FormatError::Unsafe { .. }));
+        assert_eq!(lossless_document(source).source(), source);
+    }
+
+    #[test]
+    fn legacy_quantifier_colons_become_idempotent_braces() {
+        let source = include_str!("../../../specs/cart_buggy.fsl");
+        let once = format_source(source, FormatEdition::Next).expect("format quantifiers");
+        let twice = format_source(&once, FormatEdition::Next).expect("format twice");
+        assert_eq!(once, twice);
+        assert!(!once.contains("MAXI:"));
+        assert!(!once.contains("MAXU:"));
+        assert!(once.contains("forall i in 0..MAXI {"));
+    }
+
+    #[test]
+    fn nonempty_opaque_agent_body_is_refused() {
+        let source = "agent Planner { opaque_call() }";
+        let error = format_source(source, FormatEdition::Current).expect_err("opaque body");
+        assert!(matches!(error, FormatError::Unsafe { .. }));
+    }
+
+    #[test]
+    fn equivalent_layouts_converge_to_one_canonical_form() {
+        let compact = "spec S { state { stock: Map<Int, Bool> } init { stock[0] = false } invariant P { stock[0] == false } }";
+        let spaced = "spec S {\n  state { stock: Map < Int, Bool > }\n\n  init { stock [0] = false } invariant P { stock [0] == false }\n}\n";
+        let compact = format_source(compact, FormatEdition::Current).expect("compact format");
+        let spaced = format_source(spaced, FormatEdition::Current).expect("spaced format");
+        assert_eq!(compact, spaced);
+        assert!(compact.contains("\n  state {"));
+        assert!(compact.contains("Map<Int, Bool>"));
+        assert!(compact.contains("stock[0]"));
+    }
+
+    #[test]
+    fn detached_comment_blank_line_is_preserved() {
+        let source = "spec S {\n\n  // detached\n  state { x: Bool }\n  init { x = false }\n  invariant P { x == false }\n}\n";
+        let formatted = format_source(source, FormatEdition::Current).expect("format");
+        assert!(formatted.contains("spec S {\n\n  // detached\n"));
+    }
+
+    #[test]
+    fn trailing_comment_stays_attached_to_its_closing_brace() {
+        let source = "spec S { struct Pair { left: Bool, right: Bool } // attached\n state { x: Bool } init { x = false } invariant P { x == false } }";
+        let formatted = format_source(source, FormatEdition::Current).expect("format");
+        assert!(formatted.contains("} // attached\n\n  state"));
+    }
+
+    #[test]
+    fn domain_identifier_named_on_does_not_hide_legacy_implication() {
+        let source = "domain D { implementation_profile functional_ddd type Id = 0..1 aggregate A { id Id state { on: Bool = false; } invariant P { on -> not on } } }";
+        let formatted = format_source(source, FormatEdition::Next).expect("format");
+        assert!(formatted.contains("on => not on"));
+    }
+}

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -3,7 +3,7 @@
   "root": {
     "path": [],
     "prog": "fslc",
-    "help": "usage: fslc [-h] [-V] {version,check,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
+    "help": "usage: fslc [-h] [-V] {version,check,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    fmt                 format one FSL source or check multiple paths\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
     "actions": [
       {
         "dest": "help",
@@ -2267,6 +2267,43 @@
             "flags": ["--kernel-version"],
             "choices": ["1", "2"],
             "default": "1",
+            "action": "store"
+          }
+        ],
+        "commands": []
+      },
+      {
+        "path": ["fmt"],
+        "prog": "fslc fmt",
+        "help": "usage: fslc fmt [-h] [--check] [--edition {current,next}] path [path ...]\n\nFormat one registered FSL document to stdout without mutating it. Multiple paths are accepted only with --check. Use '-' for stdin.\n\npositional arguments:\n  path\n\noptions:\n  -h, --help            show this help message and exit\n  --check               report whether formatting is required (exit 0 clean, 1 changed)\n  --edition {current,next}\n                        formatting policy (default: current)\n",
+        "actions": [
+          {
+            "dest": "help",
+            "required": false,
+            "flags": ["-h", "--help"],
+            "nargs": 0,
+            "action": "store"
+          },
+          {
+            "dest": "path",
+            "required": true,
+            "positional": true,
+            "nargs": "+",
+            "action": "store"
+          },
+          {
+            "dest": "check",
+            "required": false,
+            "flags": ["--check"],
+            "nargs": 0,
+            "action": "store_true"
+          },
+          {
+            "dest": "edition",
+            "required": false,
+            "flags": ["--edition"],
+            "choices": ["current", "next"],
+            "default": "current",
             "action": "store"
           }
         ],

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Write as _;
 use std::future::Future;
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
@@ -246,6 +247,19 @@ fn main() {
     if print_cli_metadata() {
         return;
     }
+    if let Some((output, status)) = fmt_command() {
+        match output {
+            FmtCliOutput::Source(source) => print!("{source}"),
+            FmtCliOutput::Json(value) => println!(
+                "{}",
+                serde_json::to_string_pretty(&value).expect("serialize fmt output")
+            ),
+        }
+        if status != 0 {
+            std::process::exit(status);
+        }
+        return;
+    }
     let (output, reported_status) = match command() {
         Ok(result) => result,
         Err(error) => (error_output("usage", &error), 2),
@@ -258,6 +272,134 @@ fn main() {
     if status != 0 {
         std::process::exit(status);
     }
+}
+
+enum FmtCliOutput {
+    Source(String),
+    Json(Value),
+}
+
+fn fmt_command() -> Option<(FmtCliOutput, i32)> {
+    let mut args = std::env::args().skip(1);
+    if args.next().as_deref() != Some("fmt") {
+        return None;
+    }
+    Some(match parse_fmt_options(args) {
+        Ok(options) => run_fmt(&options),
+        Err(error) => (FmtCliOutput::Json(error_output("usage", &error)), 2),
+    })
+}
+
+struct FmtOptions {
+    paths: Vec<PathBuf>,
+    check: bool,
+    edition: fsl_syntax::FormatEdition,
+}
+
+fn parse_fmt_options(args: impl Iterator<Item = String>) -> Result<FmtOptions, String> {
+    let mut args = args.peekable();
+    let mut paths = Vec::new();
+    let mut check = false;
+    let mut edition = fsl_syntax::FormatEdition::Current;
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--check" => check = true,
+            "--edition" => {
+                edition = fsl_syntax::FormatEdition::parse(&required_option_value(
+                    &mut args,
+                    "--edition",
+                )?)?;
+            }
+            option if option.starts_with('-') && option != "-" => {
+                return Err(format!("unknown fmt option '{option}'"));
+            }
+            path => paths.push(PathBuf::from(path)),
+        }
+    }
+    if paths.is_empty() {
+        return Err("usage: fslc fmt FILE [--check] [--edition current|next]".to_owned());
+    }
+    if !check && paths.len() != 1 {
+        return Err("fmt accepts multiple paths only with --check".to_owned());
+    }
+    if paths.iter().filter(|path| path.as_os_str() == "-").count() > 1
+        || paths.len() > 1 && paths.iter().any(|path| path.as_os_str() == "-")
+    {
+        return Err("stdin '-' cannot be repeated or mixed with file paths".to_owned());
+    }
+    Ok(FmtOptions {
+        paths,
+        check,
+        edition,
+    })
+}
+
+fn run_fmt(options: &FmtOptions) -> (FmtCliOutput, i32) {
+    let mut files = Vec::new();
+    let mut any_changed = false;
+    for path in &options.paths {
+        let source = match read_fmt_source(path) {
+            Ok(source) => source,
+            Err(error) => return (FmtCliOutput::Json(error_output("io", &error)), 2),
+        };
+        let formatted = match fsl_syntax::format_source(&source, options.edition) {
+            Ok(formatted) => formatted,
+            Err(fsl_syntax::FormatError::Parse(error)) => {
+                return (FmtCliOutput::Json(surface_parse_error_output(&error)), 2);
+            }
+            Err(error) => return (FmtCliOutput::Json(format_error_output(&error)), 2),
+        };
+        if let Err(error) = validate_fmt_semantics(&source, path) {
+            return (FmtCliOutput::Json(semantic_error_output(&error)), 2);
+        }
+        if let Err(error) = validate_fmt_semantics(&formatted, path) {
+            return (FmtCliOutput::Json(semantic_error_output(&error)), 2);
+        }
+        let changed = source != formatted;
+        any_changed |= changed;
+        if options.check {
+            files.push(json!({"path":path.to_string_lossy(),"changed":changed}));
+        } else {
+            return (FmtCliOutput::Source(formatted), 0);
+        }
+    }
+    (
+        FmtCliOutput::Json(json!({
+            "fsl":"1.0",
+            "result":"format_check",
+            "edition":options.edition.as_str(),
+            "changed":any_changed,
+            "files":files
+        })),
+        i32::from(any_changed),
+    )
+}
+
+fn read_fmt_source(path: &Path) -> Result<String, String> {
+    if path.as_os_str() == "-" {
+        let mut source = String::new();
+        std::io::stdin()
+            .read_to_string(&mut source)
+            .map_err(|error| error.to_string())?;
+        Ok(source)
+    } else {
+        std::fs::read_to_string(path).map_err(|error| error.to_string())
+    }
+}
+
+fn validate_fmt_semantics(source: &str, path: &Path) -> Result<(), String> {
+    let dialect = fsl_syntax::dialect_keyword(source).map_err(|error| error.to_string())?;
+    if path.as_os_str() == "-" || matches!(dialect, "refinement" | "agent") {
+        return Ok(());
+    }
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let resolver = fsl_core::FsResolver::new(base);
+    let source_file = path.to_string_lossy();
+    let kernel = fsl_core::parse_kernel_source_with_file(source, &resolver, source_file)
+        .map_err(|error| error.to_string())?;
+    fsl_core::build_model(kernel)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 fn print_cli_metadata() -> bool {
@@ -12310,6 +12452,20 @@ fn error_output(kind: &str, message: &str) -> Value {
 
 fn surface_parse_error_output(error: &fsl_syntax::ParseError) -> Value {
     fslc_rust::frontend_output::render_surface_parse_error(envelope(), error)
+}
+
+fn format_error_output(error: &fsl_syntax::FormatError) -> Value {
+    let span = error.span();
+    let mut output = error_output("format", &error.to_string());
+    output
+        .as_object_mut()
+        .expect("format error envelope")
+        .extend([
+            ("code".to_owned(), json!("FSL-FMT-UNSAFE")),
+            ("loc".to_owned(), span.python_loc()),
+            ("span".to_owned(), json!(span)),
+        ]);
+    output
 }
 
 fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {

--- a/rust/fslc/tests/formatter_cli.rs
+++ b/rust/fslc/tests/formatter_cli.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::{collections::BTreeMap, ffi::OsStr};
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run fslc")
+}
+
+fn run_stdin(args: &[&str], source: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("run fslc");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(source.as_bytes())
+        .expect("write source");
+    child.wait_with_output().expect("wait for fslc")
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("JSON stdout")
+}
+
+#[test]
+fn fmt_stdout_stdin_check_and_error_contracts_are_non_destructive() {
+    let root = root();
+    let fixture =
+        root.join("rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl");
+    let original = fs::read_to_string(&fixture).expect("fixture");
+
+    let formatted = run(&["fmt", fixture.to_str().expect("path"), "--edition", "next"]);
+    assert!(formatted.status.success());
+    let formatted_source = String::from_utf8(formatted.stdout).expect("formatted UTF-8");
+    assert!(formatted_source.starts_with("domain DomainExpressionCharacterization"));
+    assert!(formatted_source.contains("enum OrderStatus"));
+    assert_eq!(fs::read_to_string(&fixture).expect("unchanged"), original);
+
+    let stdin = run_stdin(&["fmt", "-", "--edition", "next"], &original);
+    assert!(stdin.status.success());
+    assert_eq!(stdin.stdout, formatted_source.as_bytes());
+
+    let directory = root.join(format!("rust/target/formatter-cli-{}", std::process::id()));
+    fs::create_dir_all(&directory).expect("temp directory");
+    let dirty = directory.join("dirty.fsl");
+    fs::write(
+        &dirty,
+        "spec Tiny{state{x:Bool}init{x=false}invariant P{x==false}}",
+    )
+    .expect("dirty fixture");
+    let check = run(&["fmt", dirty.to_str().expect("path"), "--check"]);
+    assert_eq!(check.status.code(), Some(1));
+    assert_eq!(json(&check)["result"], "format_check");
+    assert_eq!(json(&check)["changed"], true);
+    assert_eq!(
+        fs::read_to_string(&dirty).expect("check is non-mutating"),
+        "spec Tiny{state{x:Bool}init{x=false}invariant P{x==false}}"
+    );
+
+    let malformed = directory.join("malformed.fsl");
+    fs::write(&malformed, "spec Broken { invariant P { x ` y } }").expect("malformed");
+    let error = run(&["fmt", malformed.to_str().expect("path"), "--check"]);
+    assert_eq!(error.status.code(), Some(2));
+    assert_eq!(json(&error)["result"], "error");
+    assert!(json(&error)["loc"]["line"].as_u64().is_some());
+    assert_eq!(
+        fs::read_to_string(&malformed).expect("error is non-mutating"),
+        "spec Broken { invariant P { x ` y } }"
+    );
+}
+
+#[test]
+fn registry_dialects_format_idempotently_or_refuse_the_opaque_agent_boundary() {
+    for path in [
+        "specs/cart_v1.fsl",
+        "specs/seat_refines.fsl",
+        "specs/bank_system.fsl",
+        "examples/e2e/1_business.fsl",
+        "examples/consulting/governance_controls.fsl",
+        "examples/e2e/2_requirements.fsl",
+        "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
+        "examples/db/safe_add_nullable_column.fsl",
+        "examples/ai/refund_agent_tool_safety.fsl",
+    ] {
+        let first = run(&["fmt", path]);
+        assert!(
+            first.status.success(),
+            "{path}: {}",
+            String::from_utf8_lossy(&first.stdout)
+        );
+        let source = String::from_utf8(first.stdout).expect("formatted UTF-8");
+        let second = run_stdin(&["fmt", "-"], &source);
+        assert!(second.status.success(), "{path} second format");
+        assert_eq!(second.stdout, source.as_bytes(), "{path} is not idempotent");
+    }
+
+    let agent = run(&["fmt", "examples/ai/recursive_support_agent.fsl"]);
+    assert_eq!(agent.status.code(), Some(2));
+    assert_eq!(json(&agent)["code"], "FSL-FMT-UNSAFE");
+}
+
+#[test]
+fn fmt_help_and_multiple_path_contract_are_fixed() {
+    let help = run(&["fmt", "--help"]);
+    assert!(help.status.success());
+    let help = String::from_utf8(help.stdout).expect("help UTF-8");
+    assert!(help.contains("--check"));
+    assert!(help.contains("--edition {current,next}"));
+
+    let multiple = run(&["fmt", "specs/cart_v1.fsl", "specs/payment.fsl"]);
+    assert_eq!(multiple.status.code(), Some(2));
+    assert_eq!(json(&multiple)["kind"], "usage");
+
+    let check = run(&["fmt", "specs/cart_v1.fsl", "specs/payment.fsl", "--check"]);
+    assert!(matches!(check.status.code(), Some(0 | 1)));
+    assert_eq!(json(&check)["files"].as_array().map(Vec::len), Some(2));
+}
+
+fn fsl_files(directory: &Path, output: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("scan corpus") {
+        let path = entry.expect("corpus entry").path();
+        if path.is_dir() {
+            fsl_files(&path, output);
+        } else if path.extension() == Some(OsStr::new("fsl")) {
+            output.push(path);
+        }
+    }
+}
+
+fn comments(source: &str) -> Vec<(String, bool)> {
+    let document = fsl_syntax::lossless_document(source);
+    let mut token_end_line = None;
+    let mut result = Vec::new();
+    for node in document.nodes() {
+        match node.kind {
+            fsl_syntax::LosslessKind::Token(_) => token_end_line = Some(node.span.end.line),
+            fsl_syntax::LosslessKind::LineComment => result.push((
+                node.text.clone(),
+                token_end_line == Some(node.span.start.line),
+            )),
+            fsl_syntax::LosslessKind::Whitespace | fsl_syntax::LosslessKind::Error => {}
+        }
+    }
+    result
+}
+
+fn without_spans(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.remove("span");
+            for value in object.values_mut() {
+                without_spans(value);
+            }
+        }
+        Value::Array(values) => values.iter_mut().for_each(without_spans),
+        _ => {}
+    }
+}
+
+fn checked_source(
+    source: &str,
+    resolver: &fsl_core::FsResolver,
+    path: &Path,
+) -> Result<(fsl_core::KernelSpec, fsl_core::KernelModel), String> {
+    fsl_core::parse_kernel_source_with_file(source, resolver, path.to_string_lossy())
+        .map_err(|error| error.to_string())
+        .and_then(|kernel| {
+            fsl_core::build_model(kernel.clone())
+                .map(|model| (kernel, model))
+                .map_err(|error| error.to_string())
+        })
+}
+
+fn assert_checked_round_trip(path: &Path, dialect: &str, source: &str, formatted: &str) -> bool {
+    let resolver = fsl_core::FsResolver::new(path.parent().expect("corpus parent"));
+    let (before, after) = match (
+        checked_source(source, &resolver, path),
+        checked_source(formatted, &resolver, path),
+    ) {
+        (Ok(before), Ok(after)) => (before, after),
+        (Err(_), Err(_)) => return false,
+        (before, after) => panic!(
+            "{} changed check outcome: before={before:?}, after={after:?}",
+            path.display()
+        ),
+    };
+    let ((before_kernel, before_model), (after_kernel, after_model)) = (before, after);
+    let mut before = fsl_core::public_kernel_contract(
+        &before_kernel,
+        &before_model,
+        &path.to_string_lossy(),
+        dialect,
+    )
+    .expect("original public Kernel");
+    let mut after = fsl_core::public_kernel_contract(
+        &after_kernel,
+        &after_model,
+        &path.to_string_lossy(),
+        dialect,
+    )
+    .expect("formatted public Kernel");
+    without_spans(&mut before);
+    without_spans(&mut after);
+    assert_eq!(before, after, "{}", path.display());
+
+    let before_verdict =
+        fsl_runtime::verify_explicit(before_model, 2, 10_000).map_err(|error| error.to_string());
+    let after_verdict =
+        fsl_runtime::verify_explicit(after_model, 2, 10_000).map_err(|error| error.to_string());
+    assert_eq!(before_verdict, after_verdict, "{}", path.display());
+    true
+}
+
+#[test]
+fn registered_corpus_is_idempotent_comment_lossless_and_semantically_stable() {
+    let root = root();
+    let mut files = Vec::new();
+    fsl_files(&root.join("specs"), &mut files);
+    fsl_files(&root.join("examples"), &mut files);
+    files.sort();
+    let mut dialects = BTreeMap::<&str, usize>::new();
+    let mut compared_models = 0;
+    let mut compared_verdicts = 0;
+    let mut stable_check_errors = 0;
+
+    for path in files {
+        let source = fs::read_to_string(&path).expect("read corpus source");
+        let Ok(dialect) = fsl_syntax::dialect_keyword(&source) else {
+            continue;
+        };
+        *dialects.entry(dialect).or_default() += 1;
+        let formatted = match fsl_syntax::format_source(&source, fsl_syntax::FormatEdition::Current)
+        {
+            Ok(formatted) => formatted,
+            Err(fsl_syntax::FormatError::Unsafe { .. }) if dialect == "agent" => continue,
+            Err(fsl_syntax::FormatError::Unsafe { message, .. })
+                if message.contains("legacy domain enum") =>
+            {
+                continue;
+            }
+            Err(fsl_syntax::FormatError::Parse(_))
+                if dialect == "ai_component" && source.contains("\nai_action ") =>
+            {
+                continue;
+            }
+            Err(fsl_syntax::FormatError::Parse(_))
+                if fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)).is_err() =>
+            {
+                continue;
+            }
+            Err(fsl_syntax::FormatError::Lex(_)) if fsl_syntax::lex(&source).is_err() => continue,
+            Err(error) => panic!("{}: {error}", path.display()),
+        };
+        let next = fsl_syntax::format_source(&source, fsl_syntax::FormatEdition::Next)
+            .unwrap_or_else(|error| panic!("{} next: {error}", path.display()));
+        assert_eq!(
+            formatted,
+            next,
+            "{} edition policies diverged",
+            path.display()
+        );
+        assert_eq!(
+            comments(&source),
+            comments(&formatted),
+            "{}",
+            path.display()
+        );
+        assert_eq!(
+            fsl_syntax::format_source(&formatted, fsl_syntax::FormatEdition::Current)
+                .expect("second format"),
+            formatted,
+            "{}",
+            path.display()
+        );
+
+        if matches!(dialect, "refinement" | "compose" | "agent") {
+            let before = fsl_syntax::lex(&source)
+                .expect("original tokens")
+                .into_iter()
+                .map(|token| token.kind)
+                .collect::<Vec<_>>();
+            let after = fsl_syntax::lex(&formatted)
+                .expect("formatted tokens")
+                .into_iter()
+                .map(|token| token.kind)
+                .collect::<Vec<_>>();
+            assert_eq!(before, after, "{}", path.display());
+            continue;
+        }
+
+        if assert_checked_round_trip(&path, dialect, &source, &formatted) {
+            compared_models += 1;
+            compared_verdicts += 1;
+        } else {
+            stable_check_errors += 1;
+        }
+    }
+
+    for dialect in fsl_syntax::DIALECT_KEYWORDS {
+        assert!(dialects.contains_key(dialect), "missing {dialect} corpus");
+    }
+    assert!(compared_models >= 100, "too few checked corpus models");
+    assert_eq!(compared_verdicts, compared_models);
+    assert!(
+        stable_check_errors > 0,
+        "corpus must exercise check refusal"
+    );
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -781,6 +781,8 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 
 ```
 fslc check <f>                                  # syntax / names / types only
+fslc fmt <f|-> [--edition current|next]         # canonical source on stdout; input is never mutated
+fslc fmt <path>... --check                      # JSON; exit 0 clean, 1 changed, 2 error
 fslc kernel <f> [--kernel-version 1|2]          # normalized typed Kernel JSON (default v1)
 fslc conformance <f> [--depth K=4] [--kernel-version 1|2] # matching vectors (default v1)
 fslc verify <f> [--depth K=8] [--engine bmc|induction|explicit|auto] [--k N=1]

--- a/tests/rust_only_surface.json
+++ b/tests/rust_only_surface.json
@@ -294,6 +294,56 @@
     },
     {
       "path": [
+        "fmt"
+      ],
+      "parent_index": 22,
+      "prog": "fslc fmt",
+      "help_sha256": "c654a55723b639a9249c635de5185066a1f1efd9804884de095a96eeefa22b0b",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "path",
+          "required": true,
+          "positional": true,
+          "nargs": "+",
+          "action": "store"
+        },
+        {
+          "dest": "check",
+          "required": false,
+          "flags": [
+            "--check"
+          ],
+          "nargs": 0,
+          "action": "store_true"
+        },
+        {
+          "dest": "edition",
+          "required": false,
+          "flags": [
+            "--edition"
+          ],
+          "choices": [
+            "current",
+            "next"
+          ],
+          "default": "current",
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
         "kernel"
       ],
       "parent_index": 21,
@@ -420,7 +470,7 @@
     {
       "path": [],
       "python_sha256": "731a3fd77cc65de2bd63dbf5fe84d72edd9361089f618aa0998fd294bd6f4392",
-      "rust_sha256": "cc7761e0e5839fa09423b77dba131e92100dfdca3b04c9e1c1316aff5b469949"
+      "rust_sha256": "0f31a4e2140917ea26fbc2505158bb2bffdcb48b3d52935b0ef87c1d6a88d899"
     },
     {
       "path": [


### PR DESCRIPTION
## Problem

FSL accepted legacy/current/next surface forms but had no comment-preserving canonical formatter. Reprinting from the semantic AST would lose trivia, raw spelling, spans, and declaration attachment.

## Contract change

- add a lexer-backed lossless token/trivia document separated from the semantic AST
- add non-mutating `fslc fmt FILE|-` output and multi-path `--check` JSON/0-1-2 exit contract
- support `--edition current|next` without authorizing semantic migration or in-place writes
- canonicalize indentation, braces, declaration spacing, type arguments, indexes, quantifier braces, domain enums, and accepted logical spellings
- preserve comment sequence/inline attachment, blank lines, typed annotations, and qualified paths
- refuse malformed, opaque, or comment-ambiguous rewrites at exact spans

## Evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `.venv/bin/python -m pytest -q` — 1455 passed, 81 skipped
- all registered dialects covered by corpus idempotence, comment attachment, Public Kernel, check outcome, current/next, and bounded explicit-verdict round trips
- independent review: no blockers

## Documentation

Updates the accepted formatter design, language/skill references, CLI contract/help, generated site reference, dialect boundary, and changelog.

Closes #248
