### PR TITLE
feat(migrate): add edition-aware migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `fslc lint` now reports edition-aware diagnostics with stable taxonomy,
+  severity, spans, canonical replacements, and machine applicability. `fslc
+  migrate` is dry-run by default and `--write` atomically applies only a fully
+  parsed, checked, location-free Public-Kernel-equivalent file set. Shared
+  formatter edits cover legacy enums/operators and quantifiers; typed metadata,
+  unambiguous local action correspondences, and implicit defaults use semantic
+  planners. Unsafe comment movement, branch/duplicate mappings, and invalid
+  `&&` are explicit refusals. The retained LSP exposes applicable diagnostics
+  as quick-fix Code Actions (issue #249).
 - `fslc fmt` now formats one registered FSL document or stdin to canonical
   stdout without mutating it; `--check` accepts multiple paths and reports a
   machine-readable 0/1/2 result. A lossless token/trivia tree preserves line

--- a/docs/DESIGN-formatter.md
+++ b/docs/DESIGN-formatter.md
@@ -15,7 +15,8 @@ option; mutation and multi-file migration belong to the edition migrator.
 Both formatting editions select an accepted, meaning-equivalent canonical
 surface. `next` does not authorize migrations, implicit defaults, declaration
 movement, or other changes that require judgment. In particular, `&&` remains
-invalid FSL; accepting or migrating it requires a separate language decision.
+invalid FSL; the migrator can identify it and suggest `and`, but cannot prove a
+pre-migration model and therefore refuses automatic application.
 
 ## Lossless boundary
 
@@ -84,3 +85,6 @@ edition migrator owns diagnostics, dry-run/write workflows, implicit-default
 insertion, inline-mapping movement, and any conversion that is not already an
 accepted semantic equivalence. This keeps one source-edit engine without
 turning formatting into an unsafe migration command.
+
+See [DESIGN-migration.md](DESIGN-migration.md) for the edition, refusal,
+transaction, and idempotence contracts.

--- a/docs/DESIGN-initialization.md
+++ b/docs/DESIGN-initialization.md
@@ -63,10 +63,11 @@ inventing a new implicit value.
 
 The edit inserts ` = <selected value>` immediately after the field type. Applying
 it preserves surrounding comments/trivia and yields the value already selected by
-the current semantics. The lossless formatter (#248) and edition migrator (#249)
-own whole-source rewriting and consume this diagnostic contract; this feature does
-not introduce an incomplete formatter or migrator command.
+the current semantics. The lossless formatter and edition migrator consume this
+diagnostic contract. `fslc migrate --edition next` inserts the selected value
+only after comparing the checked before/after Public Kernel; `--write` applies
+it with the other validated file edits.
 
-The next edition severity is reported as `error` for migration planning, but this
-design does not remove implicit-default parsing. Breaking removal remains gated by
-the edition migration policy.
+The next edition severity is `error`; `check --edition next` requires the
+initializer to be explicit. The current edition continues to parse the omitted
+form and report its warning.

--- a/docs/DESIGN-migration.md
+++ b/docs/DESIGN-migration.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Edition-aware lint and migration
+
+Status: accepted
+
+## Contract
+
+`fslc lint PATH... --edition current|next` reports stable diagnostics and never
+changes source. Exit 0 means no findings, 1 means findings exist, and 2 means an
+I/O or parse/check failure. Every finding includes its code, one of the stable
+taxonomies `deprecated`, `non_canonical`, `ambiguous_intent`, or
+`unsupported_in_edition`, severity, exact span, edition, canonical replacement,
+and whether its edits are machine-applicable.
+
+`fslc migrate PATH... --edition next` is a dry run. It emits the same findings
+plus a complete replacement edit for each changed file. `--write` is the only
+mutating mode. The command plans every input in memory, parses and checks the
+before/after sources, compares location-free Public Kernel JSON, prepares and
+syncs sibling temporary files, then replaces the validated set. An I/O failure
+during commit restores already-replaced files from same-directory hard-link
+backups. A process or filesystem crash cannot be made transactionally atomic
+across unrelated files by a portable CLI; recoverable `.bak` files are retained
+if the process is interrupted before cleanup.
+
+## Rewrite table
+
+| Legacy form | Canonical form | Automatic boundary |
+|---|---|---|
+| domain `type E = A \| B` | `enum E { A, B }` | refused when an interior comment has ambiguous attachment |
+| domain `\|\|` / expression `->` | `or` / `=>` | domain expressions only; `await ... on E -> E` routing is unchanged |
+| declaration string metadata | `@requirement`, `@undecided`, or root `@kind` | refused when moving the suffix would cross an attached comment |
+| colon quantifier | brace quantifier | refused when the body boundary is not structurally known |
+| requirement action `maps` | action correspondence in the single local `implements` block | refused for branches, duplicates, no block, or multiple blocks |
+| implicit field value | explicit initializer selected by current semantics | uses the existing `implicit_initial_value` insertion contract |
+
+`&&` is deliberately not an automatic rewrite. It is a lexical error in the
+accepted language, so no pre-migration checked model exists to compare. Lint and
+migrate return `unsupported_in_edition`, the exact span, and an `and` suggestion
+with `machine_applicable: false`.
+
+## Safety and idempotence
+
+The formatter and migrator share one byte-edit overlap/boundary validator and
+one planner for enum, logical-operator, and quantifier canonicalization. The
+migrator adds only semantic edits for metadata, mappings, and defaults. A safe
+result must parse and check before and after, retain the location-free Public
+Kernel, format idempotently, and produce no edits on a repeated migration.
+Migration equivalence compares the typed annotation carrier while ignoring the
+Public Kernel's closed singular compatibility projection, so replacing a legacy
+string spelling does not change the public contract; multiple distinct relations
+remain in the typed annotation registry and are not collapsed into that field.
+Refused findings prevent every write in the invocation; safe edits are still
+returned for review but are not partially applied.
+
+The retained Python implementation is not a second migrator. Its LSP adapter
+preserves migration data on diagnostics and exposes machine-applicable edits as
+quick-fix Code Actions; the authoritative planner remains native Rust.
+
+## Bulk update procedure
+
+1. Run `fslc lint PATH... --edition next` and resolve every refusal.
+2. Review `fslc migrate PATH... --edition next` machine edits.
+3. Run the same command with `--write`.
+4. Require `fslc migrate PATH... --edition next` to report zero changes,
+   `fslc fmt PATH... --check --edition next` to exit 0, and the project check /
+   verification gates to retain their verdicts.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -251,8 +251,10 @@ Domain declarations use `enum Name { Member, ... }` for finite variants and
 stable `deprecated_domain_enum_union` warning over the complete declaration,
 including a canonical replacement. `fslc check`, `fslc verify`, and
 `fslc domain check` accept `--edition current|next`; `next` rejects the legacy
-union spelling. Empty enums and duplicate members are errors, reported at the
-declaration and duplicate member respectively.
+union spelling. `fslc lint` reports the edition finding without mutation, and
+`fslc migrate --edition next` supplies the checked canonical edit. Empty enums
+and duplicate members are errors, reported at the declaration and duplicate
+member respectively.
 
 The native Rust frontend also retains a private origin chain for domain state,
 actions, guards, statements, and properties. Verification, counterexample, and
@@ -269,7 +271,8 @@ When a domain aggregate state field omits its initializer, the current edition
 preserves the established Bool `false`, enum first-member, range lower-bound, or
 external-placeholder `0` choice and emits `implicit_initial_value`. The warning
 contains the selected value, reason, current/next severity, field span, and a
-machine-applicable explicit-initializer insertion.
+machine-applicable explicit-initializer insertion. The next edition requires the
+initializer to be explicit.
 
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
@@ -663,6 +666,8 @@ variable.
 
 ```
 fslc check     <file.fsl>                        # syntax / names / types only (fast)
+fslc lint      <path>... [--edition current|next] # stable edition diagnostics; never mutates
+fslc migrate   <path>... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       <file.fsl|-> [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       <path>... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    <file.fsl> [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
@@ -719,6 +724,15 @@ fslc db import <file.sql> [--name Name] [-o out.fsl]            # minimal SQL DD
 fslc ai check <file.fsl> [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay <file.fsl> --logs events.jsonl                   # AI runtime event replay evidence
 ```
+
+Edition lint findings use the stable taxonomies `deprecated`,
+`non_canonical`, `ambiguous_intent`, and `unsupported_in_edition`. Migration
+handles legacy domain enums/operators, declaration string metadata, colon
+quantifiers, unambiguous local inline action mappings, and implicit defaults.
+It refuses source/comment movement that cannot be proven safe. `&&` remains an
+invalid token and is therefore reported with an `and` suggestion but is never
+machine-applied. See `docs/DESIGN-migration.md` for atomicity and bulk-update
+steps.
 
 The native Rust-only `kernel` command runs after dialect lowering and semantic
 checking. Its versioned JSON contains structural types for every expression,

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 | [`DESIGN-collection-aggregates.md`](DESIGN-collection-aggregates.md) | Shared finite Binder/Aggregate IR, Set/Seq/range semantics, KPI metadata projections, and Public Kernel normalization |
 | [`DESIGN-dialect-dispatch.md`](DESIGN-dialect-dispatch.md) | Shared-lexer dialect registry, significant-token rules, document annotations, diagnostics, and frontend contract |
 | [`DESIGN-formatter.md`](DESIGN-formatter.md) | Lossless token/trivia boundary, canonical formatting policy, non-mutating CLI contract, and safe refusal range |
+| [`DESIGN-migration.md`](DESIGN-migration.md) | Edition lint taxonomy, checked rewrite rules, explicit refusal boundaries, atomic write contract, and bulk-update procedure |
 | [`DESIGN-nfr.md`](DESIGN-nfr.md) | Non-functional requirements (mapping table, discrete-time SLA: time/urgent/age/deadline) |
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -287,8 +287,10 @@ domain expression.</p>
 stable <code>deprecated_domain_enum_union</code> warning over the complete declaration,
 including a canonical replacement. <code>fslc check</code>, <code>fslc verify</code>, and
 <code>fslc domain check</code> accept <code>--edition current|next</code>; <code>next</code> rejects the legacy
-union spelling. Empty enums and duplicate members are errors, reported at the
-declaration and duplicate member respectively.</p>
+union spelling. <code>fslc lint</code> reports the edition finding without mutation, and
+<code>fslc migrate --edition next</code> supplies the checked canonical edit. Empty enums
+and duplicate members are errors, reported at the declaration and duplicate
+member respectively.</p>
 <p>The native Rust frontend also retains a private origin chain for domain state,
 actions, guards, statements, and properties. Verification, counterexample, and
 <code>explain</code> diagnostics use the original domain declaration as their primary
@@ -303,7 +305,8 @@ target bindings, source-node reverse lookup, and explicit assurance/completeness
 preserves the established Bool <code>false</code>, enum first-member, range lower-bound, or
 external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
 contains the selected value, reason, current/next severity, field span, and a
-machine-applicable explicit-initializer insertion.</p>
+machine-applicable explicit-initializer insertion. The next edition requires the
+initializer to be explicit.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
@@ -743,6 +746,8 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc lint      &lt;path&gt;... [--edition current|next] # stable edition diagnostics; never mutates
+fslc migrate   &lt;path&gt;... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
@@ -799,6 +804,14 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p>Edition lint findings use the stable taxonomies <code>deprecated</code>,
+<code>non_canonical</code>, <code>ambiguous_intent</code>, and <code>unsupported_in_edition</code>. Migration
+handles legacy domain enums/operators, declaration string metadata, colon
+quantifiers, unambiguous local inline action mappings, and implicit defaults.
+It refuses source/comment movement that cannot be proven safe. <code>&amp;&amp;</code> remains an
+invalid token and is therefore reported with an <code>and</code> suggestion but is never
+machine-applied. See <code>docs/DESIGN-migration.md</code> for atomicity and bulk-update
+steps.</p>
 <p>The native Rust-only <code>kernel</code> command runs after dialect lowering and semantic
 checking. Its versioned JSON contains structural types for every expression,
 source spans, requirement/lowering origin, simultaneous-update semantics, and

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -287,8 +287,10 @@ domain expression.</p>
 stable <code>deprecated_domain_enum_union</code> warning over the complete declaration,
 including a canonical replacement. <code>fslc check</code>, <code>fslc verify</code>, and
 <code>fslc domain check</code> accept <code>--edition current|next</code>; <code>next</code> rejects the legacy
-union spelling. Empty enums and duplicate members are errors, reported at the
-declaration and duplicate member respectively.</p>
+union spelling. <code>fslc lint</code> reports the edition finding without mutation, and
+<code>fslc migrate --edition next</code> supplies the checked canonical edit. Empty enums
+and duplicate members are errors, reported at the declaration and duplicate
+member respectively.</p>
 <p>The native Rust frontend also retains a private origin chain for domain state,
 actions, guards, statements, and properties. Verification, counterexample, and
 <code>explain</code> diagnostics use the original domain declaration as their primary
@@ -303,7 +305,8 @@ target bindings, source-node reverse lookup, and explicit assurance/completeness
 preserves the established Bool <code>false</code>, enum first-member, range lower-bound, or
 external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
 contains the selected value, reason, current/next severity, field span, and a
-machine-applicable explicit-initializer insertion.</p>
+machine-applicable explicit-initializer insertion. The next edition requires the
+initializer to be explicit.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
@@ -743,6 +746,8 @@ variable.</p></div></details>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
 <details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+fslc lint      &lt;path&gt;... [--edition current|next] # stable edition diagnostics; never mutates
+fslc migrate   &lt;path&gt;... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
@@ -799,6 +804,14 @@ fslc db import &lt;file.sql&gt; [--name Name] [-o out.fsl]            # minimal 
 fslc ai check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction]   # ai_component hard-contract findings (§13.6)
 fslc ai replay &lt;file.fsl&gt; --logs events.jsonl                   # AI runtime event replay evidence
 </code></pre>
+<p>Edition lint findings use the stable taxonomies <code>deprecated</code>,
+<code>non_canonical</code>, <code>ambiguous_intent</code>, and <code>unsupported_in_edition</code>. Migration
+handles legacy domain enums/operators, declaration string metadata, colon
+quantifiers, unambiguous local inline action mappings, and implicit defaults.
+It refuses source/comment movement that cannot be proven safe. <code>&amp;&amp;</code> remains an
+invalid token and is therefore reported with an <code>and</code> suggestion but is never
+machine-applied. See <code>docs/DESIGN-migration.md</code> for atomicity and bulk-update
+steps.</p>
 <p>The native Rust-only <code>kernel</code> command runs after dialect lowering and semantic
 checking. Its versioned JSON contains structural types for every expression,
 source spans, requirement/lowering origin, simultaneous-update semantics, and

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -49,8 +49,9 @@ pub use domain::{
 };
 pub use lexer::{LexError, Token, TokenKind, lex};
 pub use lossless::{
-    FormatEdition, FormatError, LosslessDocument, LosslessKind, LosslessNode, format_source,
-    lossless_document,
+    CanonicalRewrite, CanonicalRewriteKind, FormatEdition, FormatError, LosslessDocument,
+    LosslessKind, LosslessNode, SourceEdit, apply_source_edits, canonical_rewrites, format_source,
+    lossless_document, source_position, source_span,
 };
 pub use parser::{ParseError, parse_expr, parse_surface_document, parse_surface_spec};
 pub use surface::{

--- a/rust/fsl-syntax/src/lossless.rs
+++ b/rust/fsl-syntax/src/lossless.rs
@@ -22,11 +22,50 @@ pub struct LosslessNode {
     pub span: Span,
 }
 
+impl LosslessNode {
+    #[must_use]
+    pub fn ident(&self) -> Option<&str> {
+        match &self.kind {
+            LosslessKind::Token(TokenKind::Ident(value)) => Some(value),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn symbol(&self) -> Option<&str> {
+        match &self.kind {
+            LosslessKind::Token(TokenKind::Symbol(value)) => Some(value),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LosslessDocument {
     source: String,
     nodes: Vec<LosslessNode>,
     error: Option<LexError>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceEdit {
+    pub span: Span,
+    pub replacement: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CanonicalRewriteKind {
+    DomainEnum,
+    LogicalOperator,
+    Quantifier,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CanonicalRewrite {
+    pub kind: CanonicalRewriteKind,
+    pub span: Span,
+    pub canonical_replacement: String,
+    pub edits: Vec<SourceEdit>,
 }
 
 impl LosslessDocument {
@@ -123,8 +162,8 @@ pub fn lossless_document(source: &str) -> LosslessDocument {
                     kind: LosslessKind::Error,
                     text: source.to_owned(),
                     span: Span {
-                        start: position(source, 0),
-                        end: position(source, source.len()),
+                        start: source_position(source, 0),
+                        end: source_position(source, source.len()),
                     },
                 }],
                 error: Some(error),
@@ -176,8 +215,8 @@ fn push_trivia(source: &str, start: usize, end: usize, nodes: &mut Vec<LosslessN
                     .len_utf8();
             }
         }
-        let start_pos = position(source, node_start);
-        let end_pos = position(source, offset);
+        let start_pos = source_position(source, node_start);
+        let end_pos = source_position(source, offset);
         nodes.push(LosslessNode {
             kind: if comment {
                 LosslessKind::LineComment
@@ -193,7 +232,14 @@ fn push_trivia(source: &str, start: usize, end: usize, nodes: &mut Vec<LosslessN
     }
 }
 
-fn position(source: &str, offset: usize) -> crate::SourcePos {
+#[must_use]
+/// Convert a valid UTF-8 byte boundary into a one-based source position.
+///
+/// # Panics
+///
+/// Panics when `offset` is not a source boundary or the line/column count
+/// exceeds `u32`.
+pub fn source_position(source: &str, offset: usize) -> crate::SourcePos {
     let prefix = &source[..offset];
     let line = u32::try_from(prefix.bytes().filter(|byte| *byte == b'\n').count())
         .expect("FSL source line count exceeds u32")
@@ -214,6 +260,20 @@ fn position(source: &str, offset: usize) -> crate::SourcePos {
     }
 }
 
+#[must_use]
+/// Build a source span from two valid UTF-8 byte boundaries.
+///
+/// # Panics
+///
+/// Panics under the same invalid-boundary or oversized-source conditions as
+/// [`source_position`].
+pub fn source_span(source: &str, start: usize, end: usize) -> Span {
+    Span {
+        start: source_position(source, start),
+        end: source_position(source, end),
+    }
+}
+
 /// Format one complete registered FSL document without mutating the source.
 ///
 /// # Errors
@@ -222,15 +282,14 @@ fn position(source: &str, offset: usize) -> crate::SourcePos {
 /// domain enum with an interior comment are refused until that structural
 /// rewrite can preserve the comment attachment unambiguously.
 pub fn format_source(source: &str, _edition: FormatEdition) -> Result<String, FormatError> {
-    let tree = lossless_document(source);
-    if let Some(error) = tree.error() {
-        return Err(FormatError::Lex(error.clone()));
-    }
-    let parsed = parse_document(SourceFile::new(source)).map_err(FormatError::Parse)?;
-    refuse_opaque_agent(&tree, parsed.keyword)?;
-    let rewritten = rewrite_domain_enum(&tree, parsed.keyword)?;
-    let rewritten = rewrite_domain_logical(&lossless_document(&rewritten), parsed.keyword)?;
-    let rewritten = rewrite_quantifiers(&lossless_document(&rewritten))?;
+    let rewrites = canonical_rewrites(source)?;
+    let rewritten = apply_source_edits(
+        source,
+        rewrites
+            .into_iter()
+            .flat_map(|rewrite| rewrite.edits)
+            .collect(),
+    )?;
     let tree = lossless_document(&rewritten);
     let mut formatter = Formatter::new();
     formatter.write(tree.nodes());
@@ -239,9 +298,28 @@ pub fn format_source(source: &str, _edition: FormatEdition) -> Result<String, Fo
     Ok(output)
 }
 
-fn rewrite_domain_logical(tree: &LosslessDocument, dialect: &str) -> Result<String, FormatError> {
+/// Plan the syntax-only canonical rewrites shared by formatting and migration.
+///
+/// # Errors
+///
+/// Returns the original parse failure or an unsafe-rewrite error when source
+/// trivia cannot be attached unambiguously.
+pub fn canonical_rewrites(source: &str) -> Result<Vec<CanonicalRewrite>, FormatError> {
+    let tree = lossless_document(source);
+    if let Some(error) = tree.error() {
+        return Err(FormatError::Lex(error.clone()));
+    }
+    let parsed = parse_document(SourceFile::new(source)).map_err(FormatError::Parse)?;
+    refuse_opaque_agent(&tree, parsed.keyword)?;
+    let mut rewrites = plan_domain_enum(&tree, parsed.keyword)?;
+    rewrites.extend(plan_domain_logical(&tree, parsed.keyword));
+    rewrites.extend(plan_quantifiers(&tree)?);
+    Ok(rewrites)
+}
+
+fn plan_domain_logical(tree: &LosslessDocument, dialect: &str) -> Vec<CanonicalRewrite> {
     if dialect != "domain" {
-        return Ok(tree.source().to_owned());
+        return Vec::new();
     }
     let tokens = tree
         .nodes()
@@ -250,33 +328,41 @@ fn rewrite_domain_logical(tree: &LosslessDocument, dialect: &str) -> Result<Stri
         .collect::<Vec<_>>();
     let mut edits = Vec::new();
     for (index, node) in tokens.iter().enumerate() {
-        let Some(symbol) = token_symbol(node) else {
+        let Some(symbol) = node.symbol() else {
             continue;
         };
         if symbol == "||" {
-            edits.push((
-                node.span.start.offset,
-                node.span.end.offset,
-                "or".to_owned(),
-            ));
+            edits.push(CanonicalRewrite {
+                kind: CanonicalRewriteKind::LogicalOperator,
+                span: node.span,
+                canonical_replacement: "or".to_owned(),
+                edits: vec![SourceEdit {
+                    span: node.span,
+                    replacement: "or".to_owned(),
+                }],
+            });
         } else if symbol == "->" {
             let await_branch = index >= 2
-                && token_ident(tokens[index - 2]) == Some("on")
-                && token_ident(tokens[index - 1]).is_some()
+                && tokens[index - 2].ident() == Some("on")
+                && tokens[index - 1].ident().is_some()
                 && tokens
                     .get(index + 1)
-                    .and_then(|node| token_ident(node))
+                    .and_then(|node| node.ident())
                     .is_some();
             if !await_branch {
-                edits.push((
-                    node.span.start.offset,
-                    node.span.end.offset,
-                    "=>".to_owned(),
-                ));
+                edits.push(CanonicalRewrite {
+                    kind: CanonicalRewriteKind::LogicalOperator,
+                    span: node.span,
+                    canonical_replacement: "=>".to_owned(),
+                    edits: vec![SourceEdit {
+                        span: node.span,
+                        replacement: "=>".to_owned(),
+                    }],
+                });
             }
         }
     }
-    apply_edits(tree.source(), edits)
+    edits
 }
 
 fn refuse_opaque_agent(tree: &LosslessDocument, dialect: &str) -> Result<(), FormatError> {
@@ -288,12 +374,8 @@ fn refuse_opaque_agent(tree: &LosslessDocument, dialect: &str) -> Result<(), For
         .iter()
         .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
         .collect::<Vec<_>>();
-    let open = tokens
-        .iter()
-        .position(|node| token_symbol(node) == Some("{"));
-    let close = tokens
-        .iter()
-        .rposition(|node| token_symbol(node) == Some("}"));
+    let open = tokens.iter().position(|node| node.symbol() == Some("{"));
+    let close = tokens.iter().rposition(|node| node.symbol() == Some("}"));
     if let (Some(open), Some(close)) = (open, close)
         && close > open + 1
     {
@@ -309,7 +391,7 @@ fn refuse_opaque_agent(tree: &LosslessDocument, dialect: &str) -> Result<(), For
     Ok(())
 }
 
-fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
+fn plan_quantifiers(tree: &LosslessDocument) -> Result<Vec<CanonicalRewrite>, FormatError> {
     let tokens = tree
         .nodes()
         .iter()
@@ -317,10 +399,10 @@ fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
         .collect::<Vec<_>>();
     let mut edits = Vec::new();
     for (start, token) in tokens.iter().enumerate() {
-        if !matches!(token_ident(token), Some("forall" | "exists")) {
+        if !matches!(token.ident(), Some("forall" | "exists")) {
             continue;
         }
-        let typed = tokens.get(start + 2).and_then(|node| token_symbol(node)) == Some(":");
+        let typed = tokens.get(start + 2).and_then(|node| node.symbol()) == Some(":");
         let mut colons = Vec::new();
         let mut brace = None;
         let mut index = start + 1;
@@ -328,7 +410,7 @@ fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
             if node.span.start.line > token.span.start.line {
                 break;
             }
-            match token_symbol(node) {
+            match node.symbol() {
                 Some(":") => colons.push(index),
                 Some("{") => {
                     brace = Some(index);
@@ -342,11 +424,15 @@ fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
         let separator = colons.get(usize::from(typed)).copied();
         if let Some(separator) = separator {
             if brace == Some(separator + 1) {
-                edits.push((
-                    tokens[separator].span.start.offset,
-                    tokens[separator].span.end.offset,
-                    String::new(),
-                ));
+                edits.push(CanonicalRewrite {
+                    kind: CanonicalRewriteKind::Quantifier,
+                    span: token.span,
+                    canonical_replacement: "braced quantifier".to_owned(),
+                    edits: vec![SourceEdit {
+                        span: tokens[separator].span,
+                        replacement: String::new(),
+                    }],
+                });
                 continue;
             }
             let body_start = separator + 1;
@@ -356,16 +442,24 @@ fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
                     span: token.span,
                 });
             };
-            edits.push((
-                tokens[separator].span.start.offset,
-                tokens[separator].span.end.offset,
-                " {".to_owned(),
-            ));
-            edits.push((
-                tokens[body_end].span.end.offset,
-                tokens[body_end].span.end.offset,
-                " }".to_owned(),
-            ));
+            edits.push(CanonicalRewrite {
+                kind: CanonicalRewriteKind::Quantifier,
+                span: token.span,
+                canonical_replacement: "braced quantifier".to_owned(),
+                edits: vec![
+                    SourceEdit {
+                        span: tokens[separator].span,
+                        replacement: " {".to_owned(),
+                    },
+                    SourceEdit {
+                        span: Span {
+                            start: tokens[body_end].span.end,
+                            end: tokens[body_end].span.end,
+                        },
+                        replacement: " }".to_owned(),
+                    },
+                ],
+            });
         } else if brace.is_none() {
             return Err(FormatError::Unsafe {
                 message: "cannot canonicalize a quantifier without braces or a separator colon"
@@ -374,7 +468,7 @@ fn rewrite_quantifiers(tree: &LosslessDocument) -> Result<String, FormatError> {
             });
         }
     }
-    apply_edits(tree.source(), edits)
+    Ok(edits)
 }
 
 fn quantifier_body_end(tokens: &[&LosslessNode], start: usize) -> Option<usize> {
@@ -386,7 +480,7 @@ fn quantifier_body_end(tokens: &[&LosslessNode], start: usize) -> Option<usize> 
         if node.span.start.line > line && depth == 0 {
             break;
         }
-        match token_symbol(node) {
+        match node.symbol() {
             Some("(" | "[" | "{") => depth += 1,
             Some("}" | ";") if depth == 0 => break,
             Some(")" | "]" | "}") => depth -= 1,
@@ -397,33 +491,53 @@ fn quantifier_body_end(tokens: &[&LosslessNode], start: usize) -> Option<usize> 
     end
 }
 
-fn apply_edits(
-    source: &str,
-    mut edits: Vec<(usize, usize, String)>,
-) -> Result<String, FormatError> {
-    edits.sort_by_key(|(start, end, _)| (*start, *end));
-    if edits
-        .windows(2)
-        .any(|pair| pair[0].1 > pair[1].0 && pair[0].0 != pair[0].1)
-    {
+/// Apply non-overlapping byte edits against one source snapshot.
+///
+/// # Errors
+///
+/// Returns an unsafe-format error when edits overlap or address invalid byte
+/// boundaries.
+pub fn apply_source_edits(source: &str, mut edits: Vec<SourceEdit>) -> Result<String, FormatError> {
+    if let Some(edit) = edits.iter().find(|edit| {
+        edit.span.start.offset > edit.span.end.offset
+            || edit.span.end.offset > source.len()
+            || !source.is_char_boundary(edit.span.start.offset)
+            || !source.is_char_boundary(edit.span.end.offset)
+    }) {
+        return Err(FormatError::Unsafe {
+            message: "formatter edit is outside a UTF-8 source boundary".to_owned(),
+            span: edit.span,
+        });
+    }
+    edits.sort_by_key(|edit| (edit.span.start.offset, edit.span.end.offset));
+    if edits.windows(2).any(|pair| {
+        pair[0].span.end.offset > pair[1].span.start.offset
+            && pair[0].span.start.offset != pair[0].span.end.offset
+    }) {
         return Err(FormatError::Unsafe {
             message: "overlapping formatter edits are not safe".to_owned(),
             span: Span {
-                start: position(source, edits[0].0),
-                end: position(source, edits[1].1),
+                start: edits[0].span.start,
+                end: edits[1].span.end,
             },
         });
     }
     let mut output = source.to_owned();
-    for (start, end, replacement) in edits.into_iter().rev() {
-        output.replace_range(start..end, &replacement);
+    for edit in edits.into_iter().rev() {
+        output.replace_range(
+            edit.span.start.offset..edit.span.end.offset,
+            &edit.replacement,
+        );
     }
     Ok(output)
 }
 
-fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String, FormatError> {
+fn plan_domain_enum(
+    tree: &LosslessDocument,
+    dialect: &str,
+) -> Result<Vec<CanonicalRewrite>, FormatError> {
     if dialect != "domain" {
-        return Ok(tree.source().to_owned());
+        return Ok(Vec::new());
     }
     let tokens = tree
         .nodes()
@@ -433,9 +547,9 @@ fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String,
     let mut replacements = Vec::new();
     let mut cursor = 0;
     while cursor + 4 < tokens.len() {
-        if token_ident(tokens[cursor]) != Some("type")
-            || token_ident(tokens[cursor + 1]).is_none()
-            || token_symbol(tokens[cursor + 2]) != Some("=")
+        if tokens[cursor].ident() != Some("type")
+            || tokens[cursor + 1].ident().is_none()
+            || tokens[cursor + 2].symbol() != Some("=")
         {
             cursor += 1;
             continue;
@@ -443,10 +557,10 @@ fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String,
         let start = cursor;
         let mut index = cursor + 3;
         let mut members = Vec::new();
-        while let Some(member) = tokens.get(index).and_then(|node| token_ident(node)) {
+        while let Some(member) = tokens.get(index).and_then(|node| node.ident()) {
             members.push(member);
             index += 1;
-            if tokens.get(index).and_then(|node| token_symbol(node)) == Some("|") {
+            if tokens.get(index).and_then(|node| node.symbol()) == Some("|") {
                 index += 1;
                 continue;
             }
@@ -456,7 +570,7 @@ fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String,
             cursor += 1;
             continue;
         }
-        let semicolon = tokens.get(index).and_then(|node| token_symbol(node)) == Some(";");
+        let semicolon = tokens.get(index).and_then(|node| node.symbol()) == Some(";");
         let end = if semicolon { index } else { index - 1 };
         let span = Span {
             start: tokens[start].span.start,
@@ -470,35 +584,20 @@ fn rewrite_domain_enum(tree: &LosslessDocument, dialect: &str) -> Result<String,
                 span,
             });
         }
-        replacements.push((
+        let replacement = format!(
+            "enum {} {{ {} }}",
+            tokens[start + 1].ident().expect("checked name"),
+            members.join(", ")
+        );
+        replacements.push(CanonicalRewrite {
+            kind: CanonicalRewriteKind::DomainEnum,
             span,
-            format!(
-                "enum {} {{ {} }}",
-                token_ident(tokens[start + 1]).expect("checked name"),
-                members.join(", ")
-            ),
-        ));
+            canonical_replacement: replacement.clone(),
+            edits: vec![SourceEdit { span, replacement }],
+        });
         cursor = index + usize::from(semicolon);
     }
-    let mut output = tree.source().to_owned();
-    for (span, replacement) in replacements.into_iter().rev() {
-        output.replace_range(span.start.offset..span.end.offset, &replacement);
-    }
-    Ok(output)
-}
-
-fn token_ident(node: &LosslessNode) -> Option<&str> {
-    match &node.kind {
-        LosslessKind::Token(TokenKind::Ident(value)) => Some(value),
-        _ => None,
-    }
-}
-
-fn token_symbol(node: &LosslessNode) -> Option<&str> {
-    match &node.kind {
-        LosslessKind::Token(TokenKind::Symbol(value)) => Some(value),
-        _ => None,
-    }
+    Ok(replacements)
 }
 
 struct Formatter {

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -3,7 +3,7 @@
   "root": {
     "path": [],
     "prog": "fslc",
-    "help": "usage: fslc [-h] [-V] {version,check,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    fmt                 format one FSL source or check multiple paths\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
+    "help": "usage: fslc [-h] [-V] {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    lint                report edition migration diagnostics\n    migrate             plan or atomically apply edition migrations\n    fmt                 format one FSL source or check multiple paths\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
     "actions": [
       {
         "dest": "help",
@@ -2305,6 +2305,74 @@
             "choices": ["current", "next"],
             "default": "current",
             "action": "store"
+          }
+        ],
+        "commands": []
+      },
+      {
+        "path": ["lint"],
+        "prog": "fslc lint",
+        "help": "usage: fslc lint [-h] [--edition {current,next}] path [path ...]\n\nReport stable edition diagnostics without mutating source files.\n\npositional arguments:\n  path\n\noptions:\n  -h, --help            show this help message and exit\n  --edition {current,next}\n                        lint policy (default: current)\n",
+        "actions": [
+          {
+            "dest": "help",
+            "required": false,
+            "flags": ["-h", "--help"],
+            "nargs": 0,
+            "action": "store"
+          },
+          {
+            "dest": "path",
+            "required": true,
+            "positional": true,
+            "nargs": "+",
+            "action": "store"
+          },
+          {
+            "dest": "edition",
+            "required": false,
+            "flags": ["--edition"],
+            "choices": ["current", "next"],
+            "default": "current",
+            "action": "store"
+          }
+        ],
+        "commands": []
+      },
+      {
+        "path": ["migrate"],
+        "prog": "fslc migrate",
+        "help": "usage: fslc migrate [-h] [--edition {current,next}] [--write] path [path ...]\n\nPlan machine-applicable edition edits without mutation. --write applies the validated file set atomically.\n\npositional arguments:\n  path\n\noptions:\n  -h, --help            show this help message and exit\n  --edition {current,next}\n                        target edition (default: next)\n  --write               atomically replace every validated input file\n",
+        "actions": [
+          {
+            "dest": "help",
+            "required": false,
+            "flags": ["-h", "--help"],
+            "nargs": 0,
+            "action": "store"
+          },
+          {
+            "dest": "path",
+            "required": true,
+            "positional": true,
+            "nargs": "+",
+            "action": "store"
+          },
+          {
+            "dest": "edition",
+            "required": false,
+            "flags": ["--edition"],
+            "choices": ["current", "next"],
+            "default": "next",
+            "action": "store"
+          },
+          {
+            "dest": "write",
+            "required": false,
+            "flags": ["--write"],
+            "nargs": 0,
+            "default": false,
+            "action": "store_true"
           }
         ],
         "commands": []

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 
 pub mod coverage;
 pub mod frontend_output;
+pub mod migration;
 pub mod origin_coverage;
 pub mod verification_output;
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write as _;
 use std::future::Future;
-use std::io::Read as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
@@ -387,6 +387,354 @@ fn read_fmt_source(path: &Path) -> Result<String, String> {
     }
 }
 
+struct MigrationOptions {
+    paths: Vec<PathBuf>,
+    edition: fslc_rust::migration::Edition,
+    write: bool,
+}
+
+fn parse_migration_options(
+    args: impl Iterator<Item = String>,
+    migrate: bool,
+) -> Result<MigrationOptions, String> {
+    let mut args = args.peekable();
+    let mut paths = Vec::new();
+    let mut edition = if migrate {
+        fslc_rust::migration::Edition::Next
+    } else {
+        fslc_rust::migration::Edition::Current
+    };
+    let mut write = false;
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--edition" => {
+                edition = fslc_rust::migration::Edition::parse(&required_option_value(
+                    &mut args,
+                    "--edition",
+                )?)?;
+            }
+            "--write" if migrate => write = true,
+            option if option.starts_with('-') => {
+                return Err(format!(
+                    "unknown {} option '{option}'",
+                    if migrate { "migrate" } else { "lint" }
+                ));
+            }
+            path => paths.push(PathBuf::from(path)),
+        }
+    }
+    if paths.is_empty() {
+        return Err(if migrate {
+            "usage: fslc migrate FILE... [--edition current|next] [--write]".to_owned()
+        } else {
+            "usage: fslc lint FILE... [--edition current|next]".to_owned()
+        });
+    }
+    let mut unique = std::collections::BTreeSet::new();
+    if paths.iter().any(|path| !unique.insert(path.clone())) {
+        return Err("the same migration path cannot be supplied twice".to_owned());
+    }
+    Ok(MigrationOptions {
+        paths,
+        edition,
+        write,
+    })
+}
+
+fn run_lint(options: &MigrationOptions) -> (Value, i32) {
+    let mut files = Vec::new();
+    let mut finding_count = 0_usize;
+    for path in &options.paths {
+        let (_, plan) = match load_migration_plan(path, options.edition) {
+            Ok(loaded) => loaded,
+            Err(error) => return (error, 2),
+        };
+        finding_count += plan.diagnostics.len();
+        files.push(json!({
+            "path": path,
+            "findings": plan.diagnostics.iter().map(|finding| finding.json(&path.to_string_lossy(), options.edition)).collect::<Vec<_>>(),
+        }));
+    }
+    (
+        json!({
+            "fsl":"1.0",
+            "result":"lint",
+            "edition":options.edition.as_str(),
+            "finding_count":finding_count,
+            "files":files,
+        }),
+        i32::from(finding_count > 0),
+    )
+}
+
+fn run_migrate(options: &MigrationOptions) -> (Value, i32) {
+    let mut planned = Vec::new();
+    let mut files = Vec::new();
+    let mut refused = false;
+    for path in &options.paths {
+        let (source, plan) = match load_migration_plan(path, options.edition) {
+            Ok(loaded) => loaded,
+            Err(error) => return (error, 2),
+        };
+        refused |= plan.refused();
+        let migrated = plan.migrated_source.as_ref();
+        if let Some(migrated) = migrated
+            && let Err(error) = validate_migration_semantics(&source, migrated, path)
+        {
+            return (semantic_error_output(&error), 2);
+        }
+        files.push(json!({
+            "path":path,
+            "changed":migrated.is_some(),
+            "findings":plan.diagnostics.iter().map(|finding| finding.json(&path.to_string_lossy(), options.edition)).collect::<Vec<_>>(),
+            "edits":migrated.map(|replacement| vec![json!({"start":0,"end":source.len(),"replacement":replacement})]).unwrap_or_default(),
+        }));
+        planned.push((path.clone(), migrated.cloned()));
+    }
+    if refused {
+        return (
+            json!({
+                "fsl":"1.0",
+                "result":"migration_refused",
+                "edition":options.edition.as_str(),
+                "written":false,
+                "files":files,
+            }),
+            2,
+        );
+    }
+    if options.write {
+        let writes = planned
+            .iter()
+            .filter_map(|(path, source)| {
+                source
+                    .as_ref()
+                    .map(|source| (path.as_path(), source.as_str()))
+            })
+            .collect::<Vec<_>>();
+        if let Err(error) = atomic_write_migrations(&writes) {
+            return (error_output("io", &error), 2);
+        }
+    }
+    let changed = planned
+        .iter()
+        .filter(|(_, source)| source.is_some())
+        .count();
+    (
+        json!({
+            "fsl":"1.0",
+            "result":"migrated",
+            "edition":options.edition.as_str(),
+            "changed":changed,
+            "written":options.write,
+            "files":files,
+        }),
+        0,
+    )
+}
+
+fn load_migration_plan(
+    path: &Path,
+    edition: fslc_rust::migration::Edition,
+) -> Result<(String, fslc_rust::migration::MigrationPlan), Value> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| error_output("io", &format!("{}: {error}", path.display())))?;
+    let plan = fslc_rust::migration::plan_migration(&source, &path.to_string_lossy(), edition)
+        .map_err(|error| migration_plan_error_output(&source, path, &error))?;
+    Ok((source, plan))
+}
+
+fn validate_migration_semantics(before: &str, after: &str, path: &Path) -> Result<(), String> {
+    let before = migration_kernel_contract(before, path)?;
+    let after = migration_kernel_contract(after, path)?;
+    if before == after {
+        Ok(())
+    } else {
+        Err(format!(
+            "migration changed the checked Public Kernel for '{}'",
+            path.display()
+        ))
+    }
+}
+
+fn migration_kernel_contract(source: &str, path: &Path) -> Result<Value, String> {
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let resolver = fsl_core::FsResolver::new(base);
+    let kernel = fsl_core::parse_kernel_source_with_file(source, &resolver, path.to_string_lossy())
+        .map_err(|error| error.to_string())?;
+    let model = fsl_core::build_model(kernel.clone()).map_err(|error| error.to_string())?;
+    if matches!(
+        fsl_syntax::parse_surface_document(source),
+        Ok(fsl_syntax::SurfaceDocument::Requirements(_))
+    ) {
+        fsl_core::requirements_implements(source, &resolver, &model)
+            .map_err(|error| error.to_string())?;
+    }
+    let mut contract = fsl_core::public_kernel_contract(
+        &kernel,
+        &model,
+        &path.to_string_lossy(),
+        source_dialect(source),
+    )
+    .map_err(|error| error.to_string())?;
+    remove_migration_locations(&mut contract);
+    remove_legacy_metadata_projection(&mut contract);
+    Ok(json!({
+        "kernel": contract,
+        "annotations": migration_annotation_contract(&model),
+    }))
+}
+
+fn remove_migration_locations(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            for key in ["span", "source_node_id", "source_node_ids", "reverse_index"] {
+                object.remove(key);
+            }
+            object.values_mut().for_each(remove_migration_locations);
+        }
+        Value::Array(values) => values.iter_mut().for_each(remove_migration_locations),
+        _ => {}
+    }
+}
+
+fn remove_legacy_metadata_projection(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.remove("requirement");
+            if let Some(Value::Object(origin)) = object.get_mut("origin") {
+                origin.remove("declaration");
+            }
+            object
+                .values_mut()
+                .for_each(remove_legacy_metadata_projection);
+        }
+        Value::Array(values) => values
+            .iter_mut()
+            .for_each(remove_legacy_metadata_projection),
+        _ => {}
+    }
+}
+
+fn migration_annotation_contract(model: &fsl_core::KernelModel) -> Value {
+    let mut targets = vec!["spec".to_owned(), "init".to_owned()];
+    targets.extend(
+        model
+            .actions
+            .iter()
+            .map(|action| fsl_core::action_target(&action.name)),
+    );
+    for (kind, properties) in [
+        ("invariant", &model.invariants),
+        ("trans", &model.transitions),
+        ("reachable", &model.reachables),
+    ] {
+        targets.extend(
+            properties
+                .iter()
+                .map(|property| fsl_core::property_target(kind, &property.name)),
+        );
+    }
+    targets.extend(
+        model
+            .leadstos
+            .iter()
+            .map(|property| fsl_core::property_target("leadsTo", &property.name)),
+    );
+    targets.sort();
+    targets.dedup();
+    Value::Object(
+        targets
+            .into_iter()
+            .filter_map(|target| {
+                let mut annotations = model
+                    .annotations_for(&target)
+                    .source_order()
+                    .iter()
+                    .map(fsl_syntax::Annotation::render_source)
+                    .collect::<Vec<_>>();
+                annotations.sort();
+                (!annotations.is_empty()).then(|| (target, json!(annotations)))
+            })
+            .collect(),
+    )
+}
+
+fn migration_plan_error_output(source: &str, path: &Path, message: &str) -> Value {
+    let mut output = match fsl_syntax::parse_surface_document(source) {
+        Err(error) => surface_parse_error_output(&error),
+        Ok(_) => semantic_error_output(message),
+    };
+    let object = output.as_object_mut().expect("error envelope");
+    object.insert("file".to_owned(), json!(path));
+    if let Some(Value::Object(location)) = object.get_mut("loc") {
+        location.insert("file".to_owned(), json!(path));
+    }
+    output
+}
+
+fn atomic_write_migrations(writes: &[(&Path, &str)]) -> Result<(), String> {
+    if writes.is_empty() {
+        return Ok(());
+    }
+    let nonce = format!("{}", std::process::id());
+    let mut prepared = Vec::new();
+    for (index, (path, source)) in writes.iter().enumerate() {
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+        if !metadata.file_type().is_file() {
+            return Err(format!(
+                "migration write target '{}' is not a regular file",
+                path.display()
+            ));
+        }
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let temp = parent.join(format!(".fslc-migrate-{nonce}-{index}.tmp"));
+        let backup = parent.join(format!(".fslc-migrate-{nonce}-{index}.bak"));
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .map_err(|error| error.to_string())?;
+        if let Err(error) = file
+            .write_all(source.as_bytes())
+            .and_then(|()| file.sync_all())
+            .and_then(|()| std::fs::set_permissions(&temp, metadata.permissions()))
+        {
+            let _ = std::fs::remove_file(&temp);
+            for (_, temp, _) in &prepared {
+                let _ = std::fs::remove_file(temp);
+            }
+            return Err(error.to_string());
+        }
+        prepared.push((path.to_path_buf(), temp, backup));
+    }
+    for (path, _, backup) in &prepared {
+        if let Err(error) = std::fs::hard_link(path, backup) {
+            for (_, temp, backup) in &prepared {
+                let _ = std::fs::remove_file(temp);
+                let _ = std::fs::remove_file(backup);
+            }
+            return Err(error.to_string());
+        }
+    }
+    for (committed, (path, temp, _)) in prepared.iter().enumerate() {
+        if let Err(error) = std::fs::rename(temp, path) {
+            for (path, _, backup) in prepared.iter().take(committed) {
+                let _ = std::fs::rename(backup, path);
+            }
+            for (_, temp, backup) in &prepared {
+                let _ = std::fs::remove_file(temp);
+                let _ = std::fs::remove_file(backup);
+            }
+            return Err(error.to_string());
+        }
+    }
+    for (_, _, backup) in &prepared {
+        let _ = std::fs::remove_file(backup);
+    }
+    Ok(())
+}
+
 fn validate_fmt_semantics(source: &str, path: &Path) -> Result<(), String> {
     let dialect = fsl_syntax::dialect_keyword(source).map_err(|error| error.to_string())?;
     if path.as_os_str() == "-" || matches!(dialect, "refinement" | "agent") {
@@ -481,6 +829,14 @@ fn command() -> Result<(Value, i32), String> {
                 requirements.as_deref(),
                 &edition,
             )))
+        }
+        "lint" => {
+            let options = parse_migration_options(args, false)?;
+            Ok(run_lint(&options))
+        }
+        "migrate" => {
+            let options = parse_migration_options(args, true)?;
+            Ok(run_migrate(&options))
         }
         "kernel" => {
             let mut path = None;
@@ -3590,74 +3946,51 @@ fn run_check_with_tags(
     apply_domain_edition((output, status), path, edition)
 }
 
-fn domain_enum_union_warnings(path: &Path) -> Vec<Value> {
-    let Ok(fsl_syntax::SurfaceDocument::Domain(domain)) = parse_surface_document(path) else {
-        return Vec::new();
-    };
-    domain
-        .types
-        .iter()
-        .filter(|ty| ty.source_form == fsl_syntax::DomainTypeSourceForm::LegacyEnumUnion)
-        .map(|ty| {
-            let replacement = format!("enum {} {{ {} }}", ty.name, ty.members.join(", "));
-            json!({
-                "kind": "deprecated_domain_enum_union",
-                "code": "deprecated_domain_enum_union",
-                "severity": "warning",
-                "message": format!("domain enum union syntax for '{}' is deprecated; use `{replacement}`", ty.name),
-                "loc": {
-                    "file": path,
-                    "line": ty.span.start.line,
-                    "column": ty.span.start.column,
-                    "end_line": ty.span.end.line,
-                    "end_column": ty.span.end.column,
-                },
-                "canonical_replacement": replacement,
-                "suggestion": {
-                    "kind": "replace",
-                    "replacement": replacement,
-                    "span": {
-                        "start": ty.span.start.offset,
-                        "end": ty.span.end.offset,
-                    },
-                },
-            })
-        })
-        .collect()
-}
-
-fn implicit_initial_value_warnings(path: &Path) -> Vec<Value> {
-    let Ok(source) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    fslc_rust::frontend_output::implicit_initial_value_warnings(&source, &path.to_string_lossy())
-}
-
 fn apply_domain_edition(
     (mut output, status): (Value, i32),
     path: &Path,
     edition: &str,
 ) -> (Value, i32) {
-    let mut legacy_additions = domain_enum_union_warnings(path);
-    if edition == "next" && !legacy_additions.is_empty() {
-        for finding in &mut legacy_additions {
-            finding["severity"] = json!("error");
-            finding["message"] = json!(format!(
-                "{}; legacy domain enum unions are not accepted in the next edition",
-                finding["message"]
-                    .as_str()
-                    .unwrap_or("deprecated domain enum union")
-            ));
-        }
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return (output, status);
+    };
+    let migration_edition = if edition == "next" {
+        fslc_rust::migration::Edition::Next
+    } else {
+        fslc_rust::migration::Edition::Current
+    };
+    let Ok(plan) =
+        fslc_rust::migration::plan_migration(&source, &path.to_string_lossy(), migration_edition)
+    else {
+        return (output, status);
+    };
+    let mut additions = plan
+        .diagnostics
+        .iter()
+        .filter(|finding| edition == "next" || finding.code == "deprecated_domain_enum_union")
+        .map(|finding| finding.json(&path.to_string_lossy(), migration_edition))
+        .collect::<Vec<_>>();
+    if edition != "next" {
+        additions.extend(fslc_rust::frontend_output::implicit_initial_value_warnings(
+            &source,
+            &path.to_string_lossy(),
+        ));
+    }
+    if edition == "next" && !additions.is_empty() {
+        let kind = if additions.iter().all(|finding| {
+            finding.get("code").and_then(Value::as_str) == Some("deprecated_domain_enum_union")
+        }) {
+            "deprecated_domain_enum_union"
+        } else {
+            "unsupported_in_edition"
+        };
         let mut error = envelope();
         error.insert("result".to_owned(), json!("error"));
-        error.insert("kind".to_owned(), json!("deprecated_domain_enum_union"));
+        error.insert("kind".to_owned(), json!(kind));
         error.insert("edition".to_owned(), json!(edition));
-        error.insert("findings".to_owned(), Value::Array(legacy_additions));
+        error.insert("findings".to_owned(), Value::Array(additions));
         return (Value::Object(error), 2);
     }
-    let mut additions = legacy_additions;
-    additions.extend(implicit_initial_value_warnings(path));
     if !additions.is_empty()
         && let Value::Object(envelope) = &mut output
     {

--- a/rust/fslc/src/migration.rs
+++ b/rust/fslc/src/migration.rs
@@ -1,0 +1,743 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_syntax::{
+    Annotation, CanonicalRewriteKind, CorrespondenceOrigin, LosslessKind, RequirementActionItem,
+    RequirementsItem, SourceEdit, Span, SurfaceDocument, TokenKind, canonical_rewrites,
+    lossless_document, source_position, source_span,
+};
+use serde_json::{Value, json};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Edition {
+    Current,
+    Next,
+}
+
+impl Edition {
+    /// Parse the public edition spelling.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an edition without a migration policy.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "current" => Ok(Self::Current),
+            "next" => Ok(Self::Next),
+            _ => Err("--edition must be current or next".to_owned()),
+        }
+    }
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Next => "next",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Taxonomy {
+    Deprecated,
+    NonCanonical,
+    AmbiguousIntent,
+    UnsupportedInEdition,
+}
+
+impl Taxonomy {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Deprecated => "deprecated",
+            Self::NonCanonical => "non_canonical",
+            Self::AmbiguousIntent => "ambiguous_intent",
+            Self::UnsupportedInEdition => "unsupported_in_edition",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MigrationDiagnostic {
+    pub code: &'static str,
+    pub taxonomy: Taxonomy,
+    pub message: String,
+    pub span: Span,
+    pub canonical_replacement: String,
+    pub machine_applicable: bool,
+    pub edits: Vec<SourceEdit>,
+}
+
+impl MigrationDiagnostic {
+    #[must_use]
+    pub fn json(&self, path: &str, edition: Edition) -> Value {
+        let mut value = json!({
+            "code": self.code,
+            "kind": self.code,
+            "taxonomy": self.taxonomy.as_str(),
+            "severity": if edition == Edition::Next { "error" } else { "warning" },
+            "edition": edition.as_str(),
+            "message": self.message,
+            "loc": {
+                "file": path,
+                "line": self.span.start.line,
+                "column": self.span.start.column,
+                "end_line": self.span.end.line,
+                "end_column": self.span.end.column,
+            },
+            "canonical_replacement": self.canonical_replacement,
+            "machine_applicable": self.machine_applicable,
+            "edits": self.edits.iter().map(|edit| json!({
+                "start": edit.span.start.offset,
+                "end": edit.span.end.offset,
+                "replacement": edit.replacement,
+            })).collect::<Vec<_>>(),
+        });
+        if self.edits.len() == 1 {
+            value["suggestion"] = json!({
+                "kind":"replace",
+                "replacement":self.edits[0].replacement,
+                "span":{
+                    "start":self.edits[0].span.start.offset,
+                    "end":self.edits[0].span.end.offset,
+                },
+                "machine_applicable":self.machine_applicable,
+            });
+        }
+        value
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MigrationPlan {
+    pub diagnostics: Vec<MigrationDiagnostic>,
+    pub migrated_source: Option<String>,
+}
+
+impl MigrationPlan {
+    #[must_use]
+    pub fn refused(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| !diagnostic.machine_applicable)
+    }
+}
+
+/// Plan all edition migrations against one immutable source snapshot.
+///
+/// # Errors
+///
+/// Returns a parse or edit error. Unsupported-but-recognizable legacy syntax
+/// is represented as a non-machine-applicable diagnostic instead.
+#[allow(clippy::too_many_lines)]
+pub fn plan_migration(source: &str, path: &str, edition: Edition) -> Result<MigrationPlan, String> {
+    let unsupported = unsupported_double_ampersands(source);
+    if !unsupported.is_empty() {
+        return Ok(MigrationPlan {
+            diagnostics: unsupported,
+            migrated_source: None,
+        });
+    }
+
+    let document = fsl_syntax::parse_surface_document(source).map_err(|error| error.to_string())?;
+    if matches!(document, SurfaceDocument::Agent(_)) {
+        return Ok(MigrationPlan {
+            diagnostics: Vec::new(),
+            migrated_source: None,
+        });
+    }
+    let mut diagnostics = Vec::new();
+    match canonical_rewrites(source) {
+        Ok(rewrites) => diagnostics.extend(rewrites.into_iter().map(|rewrite| {
+            let (code, taxonomy, message) = match rewrite.kind {
+                CanonicalRewriteKind::DomainEnum => (
+                    "deprecated_domain_enum_union",
+                    Taxonomy::Deprecated,
+                    "legacy domain enum union syntax is deprecated".to_owned(),
+                ),
+                CanonicalRewriteKind::LogicalOperator => (
+                    "legacy_logical_operator",
+                    Taxonomy::NonCanonical,
+                    "legacy logical operator spelling is non-canonical".to_owned(),
+                ),
+                CanonicalRewriteKind::Quantifier => (
+                    "legacy_quantifier_colon",
+                    Taxonomy::Deprecated,
+                    "legacy colon quantifier syntax is deprecated".to_owned(),
+                ),
+            };
+            MigrationDiagnostic {
+                code,
+                taxonomy,
+                message,
+                span: rewrite.span,
+                canonical_replacement: rewrite.canonical_replacement,
+                machine_applicable: true,
+                edits: rewrite.edits,
+            }
+        })),
+        Err(fsl_syntax::FormatError::Unsafe { message, span }) => {
+            let (code, canonical_replacement) = if message.contains("domain enum") {
+                (
+                    "deprecated_domain_enum_union",
+                    "move the interior comment, then use `enum Name { ... }`".to_owned(),
+                )
+            } else if message.contains("quantifier") {
+                (
+                    "legacy_quantifier_colon",
+                    "add an explicit brace-delimited quantifier body".to_owned(),
+                )
+            } else {
+                (
+                    "unsafe_source_attachment",
+                    "move the comment, then rerun migrate".to_owned(),
+                )
+            };
+            diagnostics.push(MigrationDiagnostic {
+                code,
+                taxonomy: Taxonomy::AmbiguousIntent,
+                message,
+                span,
+                canonical_replacement,
+                machine_applicable: false,
+                edits: Vec::new(),
+            });
+        }
+        Err(error) => return Err(error.to_string()),
+    }
+    diagnostics.extend(metadata_diagnostics(source));
+    diagnostics.extend(default_diagnostics(source, path));
+    diagnostics.extend(action_map_diagnostics(source, &document));
+
+    if diagnostics
+        .iter()
+        .any(|diagnostic| !diagnostic.machine_applicable)
+    {
+        return Ok(MigrationPlan {
+            diagnostics,
+            migrated_source: None,
+        });
+    }
+    if diagnostics.is_empty() {
+        return Ok(MigrationPlan {
+            diagnostics,
+            migrated_source: None,
+        });
+    }
+    let edits = diagnostics
+        .iter()
+        .flat_map(|diagnostic| diagnostic.edits.clone())
+        .collect::<Vec<_>>();
+    let rewritten =
+        fsl_syntax::apply_source_edits(source, edits).map_err(|error| error.to_string())?;
+    let formatted = fsl_syntax::format_source(
+        &rewritten,
+        match edition {
+            Edition::Current => fsl_syntax::FormatEdition::Current,
+            Edition::Next => fsl_syntax::FormatEdition::Next,
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    Ok(MigrationPlan {
+        migrated_source: (formatted != source).then_some(formatted),
+        diagnostics,
+    })
+}
+
+fn unsupported_double_ampersands(source: &str) -> Vec<MigrationDiagnostic> {
+    let mut diagnostics = raw_operator_offsets(source, "&&")
+        .into_iter()
+        .map(|offset| {
+            let span = source_span(source, offset, offset + 2);
+            MigrationDiagnostic {
+                code: "unsupported_double_ampersand",
+                taxonomy: Taxonomy::UnsupportedInEdition,
+                message:
+                    "`&&` is not valid FSL, so pre-migration semantic equivalence cannot be proven"
+                        .to_owned(),
+                span,
+                canonical_replacement: "and".to_owned(),
+                machine_applicable: false,
+                edits: vec![SourceEdit {
+                    span,
+                    replacement: "and".to_owned(),
+                }],
+            }
+        })
+        .collect::<Vec<_>>();
+    if !diagnostics.is_empty() {
+        diagnostics.extend(raw_operator_offsets(source, "||").into_iter().map(|offset| {
+            let span = source_span(source, offset, offset + 2);
+            MigrationDiagnostic {
+                code: "legacy_logical_operator",
+                taxonomy: Taxonomy::NonCanonical,
+                message: "`||` is non-canonical, but no edit is applied while the source also contains invalid `&&`"
+                    .to_owned(),
+                span,
+                canonical_replacement: "or".to_owned(),
+                machine_applicable: false,
+                edits: vec![SourceEdit {
+                    span,
+                    replacement: "or".to_owned(),
+                }],
+            }
+        }));
+        diagnostics.sort_by_key(|diagnostic| diagnostic.span.start.offset);
+    }
+    diagnostics
+}
+
+fn raw_operator_offsets(source: &str, operator: &str) -> Vec<usize> {
+    let bytes = source.as_bytes();
+    let needle = operator.as_bytes();
+    let mut offsets = Vec::new();
+    let mut index = 0;
+    let mut in_string = false;
+    let mut in_comment = false;
+    while index < bytes.len() {
+        if in_comment {
+            if bytes[index] == b'\n' {
+                in_comment = false;
+            }
+            index += 1;
+            continue;
+        }
+        if in_string {
+            if bytes[index] == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if bytes[index] == b'"' {
+            in_string = true;
+            index += 1;
+            continue;
+        }
+        if bytes[index..].starts_with(b"//") {
+            in_comment = true;
+            index += 2;
+            continue;
+        }
+        if bytes[index..].starts_with(needle) {
+            offsets.push(index);
+            index += needle.len();
+        } else {
+            index += 1;
+        }
+    }
+    offsets
+}
+
+fn metadata_diagnostics(source: &str) -> Vec<MigrationDiagnostic> {
+    let tree = lossless_document(source);
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let declaration_keywords = [
+        "spec",
+        "init",
+        "action",
+        "invariant",
+        "trans",
+        "reachable",
+        "until",
+        "unless",
+        "leadsTo",
+    ];
+    let mut diagnostics = Vec::new();
+    for (index, node) in tokens.iter().enumerate() {
+        let LosslessKind::Token(TokenKind::String(value)) = &node.kind else {
+            continue;
+        };
+        if tokens.get(index + 1).and_then(|node| node.symbol()) != Some("{") {
+            continue;
+        }
+        let boundary = (0..index)
+            .rev()
+            .find(|position| matches!(tokens[*position].symbol(), Some("{" | "}" | ";")));
+        let range_start = boundary.map_or(0, |position| position + 1);
+        let Some(keyword_index) = (range_start..index).find(|position| {
+            tokens[*position]
+                .ident()
+                .is_some_and(|keyword| declaration_keywords.contains(&keyword))
+        }) else {
+            continue;
+        };
+        let keyword = tokens[keyword_index].ident().expect("matched keyword");
+        let start_index = if keyword == "action"
+            && keyword_index > range_start
+            && tokens[keyword_index - 1].ident() == Some("fair")
+        {
+            keyword_index - 1
+        } else {
+            keyword_index
+        };
+        let declaration_start = tokens[start_index].span.start.offset;
+        let attachment_start = boundary.map_or(0, |position| tokens[position].span.end.offset);
+        let attachment = &source[attachment_start..node.span.start.offset];
+        if attachment.contains("//") || source[attachment_start..declaration_start].contains('@') {
+            diagnostics.push(MigrationDiagnostic {
+                code: "legacy_string_metadata",
+                taxonomy: Taxonomy::AmbiguousIntent,
+                message: "cannot move string metadata across an attached comment or annotation"
+                    .to_owned(),
+                span: node.span,
+                canonical_replacement: "move the comment, then use a typed annotation".to_owned(),
+                machine_applicable: false,
+                edits: Vec::new(),
+            });
+            continue;
+        }
+        let meta = fsl_syntax::MetaTag::parse(value, node.span);
+        let annotation = if keyword == "spec" {
+            Annotation::from_legacy_kind(meta.id, meta.text, node.span)
+        } else {
+            Annotation::from_legacy(meta.id, meta.text, node.span)
+        };
+        let replacement = annotation.render_source();
+        let indent = " ".repeat(tokens[start_index].span.start.column.saturating_sub(1) as usize);
+        let insertion = format!("{replacement}\n{indent}");
+        diagnostics.push(MigrationDiagnostic {
+            code: "legacy_string_metadata",
+            taxonomy: Taxonomy::Deprecated,
+            message: "legacy string metadata is deprecated; use a typed annotation".to_owned(),
+            span: node.span,
+            canonical_replacement: replacement,
+            machine_applicable: true,
+            edits: vec![
+                SourceEdit {
+                    span: Span {
+                        start: tokens[start_index].span.start,
+                        end: tokens[start_index].span.start,
+                    },
+                    replacement: insertion,
+                },
+                SourceEdit {
+                    span: node.span,
+                    replacement: String::new(),
+                },
+            ],
+        });
+    }
+    diagnostics
+}
+
+fn default_diagnostics(source: &str, path: &str) -> Vec<MigrationDiagnostic> {
+    crate::frontend_output::implicit_initial_value_warnings(source, path)
+        .into_iter()
+        .filter_map(|warning| {
+            let suggestion = warning.get("suggestion")?;
+            let edit_span = suggestion.get("span")?;
+            let start = usize::try_from(edit_span.get("start")?.as_u64()?).ok()?;
+            let end = usize::try_from(edit_span.get("end")?.as_u64()?).ok()?;
+            let replacement = suggestion.get("replacement")?.as_str()?.to_owned();
+            let location = warning.get("loc")?;
+            let line = u32::try_from(location.get("line")?.as_u64()?).ok()?;
+            let column = u32::try_from(location.get("column")?.as_u64()?).ok()?;
+            let end_line = u32::try_from(location.get("end_line")?.as_u64()?).ok()?;
+            let end_column = u32::try_from(location.get("end_column")?.as_u64()?).ok()?;
+            let diagnostic_span = source_span(
+                source,
+                source_offset(source, line, column)?,
+                source_offset(source, end_line, end_column)?,
+            );
+            Some(MigrationDiagnostic {
+                code: "implicit_initial_value",
+                taxonomy: Taxonomy::NonCanonical,
+                message: warning.get("message")?.as_str()?.to_owned(),
+                span: diagnostic_span,
+                canonical_replacement: warning.get("canonical_replacement")?.as_str()?.to_owned(),
+                machine_applicable: true,
+                edits: vec![SourceEdit {
+                    span: source_span(source, start, end),
+                    replacement,
+                }],
+            })
+        })
+        .collect()
+}
+
+fn source_offset(source: &str, line: u32, column: u32) -> Option<usize> {
+    if line == 0 || column == 0 {
+        return None;
+    }
+    let line_start = if line == 1 {
+        0
+    } else {
+        source
+            .match_indices('\n')
+            .nth(usize::try_from(line - 2).ok()?)?
+            .0
+            + 1
+    };
+    let tail = &source[line_start..];
+    let line_text = tail.split_once('\n').map_or(tail, |(head, _)| head);
+    let column_bytes = line_text
+        .chars()
+        .take(usize::try_from(column - 1).ok()?)
+        .map(char::len_utf8)
+        .sum::<usize>();
+    (column_bytes <= line_text.len()).then_some(line_start + column_bytes)
+}
+
+fn action_map_diagnostics(source: &str, document: &SurfaceDocument) -> Vec<MigrationDiagnostic> {
+    let SurfaceDocument::Requirements(requirements) = document else {
+        return Vec::new();
+    };
+    let implements = requirements
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            RequirementsItem::Implements { items, span, .. } => Some((items, *span)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut diagnostics = Vec::new();
+    for item in &requirements.items {
+        let action = match item {
+            RequirementsItem::Action(action) => action,
+            RequirementsItem::Requirement { items, .. } => {
+                for nested in items {
+                    if let fsl_syntax::RequirementBlockItem::Action(action) = nested {
+                        diagnostics.extend(action_map_diagnostic(source, action, &implements));
+                    }
+                }
+                continue;
+            }
+            _ => continue,
+        };
+        diagnostics.extend(action_map_diagnostic(source, action, &implements));
+    }
+    diagnostics
+}
+
+#[allow(clippy::too_many_lines)]
+fn action_map_diagnostic(
+    source: &str,
+    action: &fsl_syntax::RequirementAction,
+    implements: &[(&Vec<fsl_syntax::RefinementItem>, Span)],
+) -> Vec<MigrationDiagnostic> {
+    let mut diagnostics = Vec::new();
+    for item in &action.items {
+        if let RequirementActionItem::Branches { branches, .. } = item {
+            for branch in branches {
+                diagnostics.push(MigrationDiagnostic {
+                    code: "inline_action_maps",
+                    taxonomy: Taxonomy::AmbiguousIntent,
+                    message:
+                        "branch-specific maps cannot be moved to one unconditional correspondence"
+                            .to_owned(),
+                    span: branch.maps.span,
+                    canonical_replacement: "write an explicit refinement correspondence".to_owned(),
+                    machine_applicable: false,
+                    edits: Vec::new(),
+                });
+            }
+        }
+    }
+    let Some(maps) = &action.maps else {
+        return diagnostics;
+    };
+    if implements.len() != 1 {
+        diagnostics.push(MigrationDiagnostic {
+            code: "inline_action_maps",
+            taxonomy: Taxonomy::AmbiguousIntent,
+            message: "inline maps require exactly one local implements block for a safe move"
+                .to_owned(),
+            span: maps.span,
+            canonical_replacement: "move the mapping to an explicit implements or refinement block"
+                .to_owned(),
+            machine_applicable: false,
+            edits: Vec::new(),
+        });
+        return diagnostics;
+    }
+    let (items, implements_span) = implements[0];
+    if items.iter().any(|item| {
+        matches!(item, fsl_syntax::RefinementItem::Action { name, origin: CorrespondenceOrigin::ImplementsBlock, .. } if name == &action.name)
+    }) {
+        diagnostics.push(MigrationDiagnostic {
+            code: "inline_action_maps",
+            taxonomy: Taxonomy::AmbiguousIntent,
+            message: "an explicit correspondence already exists for this action".to_owned(),
+            span: maps.span,
+            canonical_replacement: "remove the duplicate after choosing one correspondence".to_owned(),
+            machine_applicable: false,
+            edits: Vec::new(),
+        });
+        return diagnostics;
+    }
+    let Some((maps_end, maps_text)) = maps_clause_text(source, maps.span.start.offset) else {
+        diagnostics.push(MigrationDiagnostic {
+            code: "inline_action_maps",
+            taxonomy: Taxonomy::AmbiguousIntent,
+            message: "cannot determine the complete inline maps clause".to_owned(),
+            span: maps.span,
+            canonical_replacement: "write an explicit correspondence".to_owned(),
+            machine_applicable: false,
+            edits: Vec::new(),
+        });
+        return diagnostics;
+    };
+    let Some(close) = block_close_offset(source, implements_span.start.offset) else {
+        return diagnostics;
+    };
+    if comment_immediately_before(source, close) {
+        diagnostics.push(MigrationDiagnostic {
+            code: "inline_action_maps",
+            taxonomy: Taxonomy::AmbiguousIntent,
+            message: "cannot insert a correspondence after a comment attached to the implements block closing brace"
+                .to_owned(),
+            span: maps.span,
+            canonical_replacement: "move the comment, then rerun migrate".to_owned(),
+            machine_applicable: false,
+            edits: Vec::new(),
+        });
+        return diagnostics;
+    }
+    let Some(params) = action_params_text(source, action.span.start.offset) else {
+        diagnostics.push(MigrationDiagnostic {
+            code: "inline_action_maps",
+            taxonomy: Taxonomy::AmbiguousIntent,
+            message: "cannot determine the action parameter list without losing source trivia"
+                .to_owned(),
+            span: maps.span,
+            canonical_replacement: "write an explicit correspondence".to_owned(),
+            machine_applicable: false,
+            edits: Vec::new(),
+        });
+        return diagnostics;
+    };
+    let target = maps_text.strip_prefix("maps ").unwrap_or(&maps_text);
+    let replacement = format!("action {}({params}) -> {target}", action.name);
+    let indent = " ".repeat(source_position(source, close).column.saturating_sub(1) as usize + 2);
+    diagnostics.push(MigrationDiagnostic {
+        code: "inline_action_maps",
+        taxonomy: Taxonomy::Deprecated,
+        message: "inline maps are deprecated; use an explicit action correspondence".to_owned(),
+        span: source_span(source, maps.span.start.offset, maps_end),
+        canonical_replacement: replacement.clone(),
+        machine_applicable: true,
+        edits: vec![
+            SourceEdit {
+                span: source_span(source, maps.span.start.offset, maps_end),
+                replacement: String::new(),
+            },
+            SourceEdit {
+                span: source_span(source, close, close),
+                replacement: format!("{indent}{replacement}\n"),
+            },
+        ],
+    });
+    diagnostics
+}
+
+fn maps_clause_text(source: &str, start: usize) -> Option<(usize, String)> {
+    let tree = lossless_document(source);
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let index = tokens
+        .iter()
+        .position(|node| node.span.start.offset == start)?;
+    if tokens[index].ident() != Some("maps") {
+        return None;
+    }
+    let end = if tokens.get(index + 1)?.ident() == Some("stutter") {
+        tokens[index + 1].span.end.offset
+    } else {
+        let open =
+            (index + 1..tokens.len()).find(|position| tokens[*position].symbol() == Some("("))?;
+        matching_symbol(&tokens, open, "(", ")")?
+    };
+    Some((end, source[start..end].to_owned()))
+}
+
+fn action_params_text(source: &str, start: usize) -> Option<String> {
+    let tree = lossless_document(source);
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let action = tokens
+        .iter()
+        .position(|node| node.span.start.offset == start)?;
+    let open = (action..tokens.len()).find(|position| tokens[*position].symbol() == Some("("))?;
+    let close = matching_symbol_index(&tokens, open, "(", ")")?;
+    let params_start = tokens[open].span.end.offset;
+    let params_end = tokens[close].span.start.offset;
+    if tree.nodes().iter().any(|node| {
+        matches!(node.kind, LosslessKind::LineComment)
+            && node.span.start.offset >= params_start
+            && node.span.end.offset <= params_end
+    }) {
+        return None;
+    }
+    Some(source[params_start..params_end].to_owned())
+}
+
+fn block_close_offset(source: &str, start: usize) -> Option<usize> {
+    let tree = lossless_document(source);
+    let tokens = tree
+        .nodes()
+        .iter()
+        .filter(|node| matches!(node.kind, LosslessKind::Token(_)))
+        .collect::<Vec<_>>();
+    let item = tokens
+        .iter()
+        .position(|node| node.span.start.offset == start)?;
+    let open = (item..tokens.len()).find(|position| tokens[*position].symbol() == Some("{"))?;
+    let close = matching_symbol_index(&tokens, open, "{", "}")?;
+    Some(tokens[close].span.start.offset)
+}
+
+fn comment_immediately_before(source: &str, offset: usize) -> bool {
+    let tree = lossless_document(source);
+    let Some(close) = tree
+        .nodes()
+        .iter()
+        .position(|node| node.span.start.offset == offset && node.symbol() == Some("}"))
+    else {
+        return false;
+    };
+    tree.nodes()[..close]
+        .iter()
+        .rev()
+        .find(|node| !matches!(node.kind, LosslessKind::Whitespace))
+        .is_some_and(|node| matches!(node.kind, LosslessKind::LineComment))
+}
+
+fn matching_symbol(
+    tokens: &[&fsl_syntax::LosslessNode],
+    open: usize,
+    left: &str,
+    right: &str,
+) -> Option<usize> {
+    let close = matching_symbol_index(tokens, open, left, right)?;
+    Some(tokens[close].span.end.offset)
+}
+
+fn matching_symbol_index(
+    tokens: &[&fsl_syntax::LosslessNode],
+    open: usize,
+    left: &str,
+    right: &str,
+) -> Option<usize> {
+    let mut depth = 0_u32;
+    for (index, token) in tokens.iter().enumerate().skip(open) {
+        if token.symbol() == Some(left) {
+            depth += 1;
+        } else if token.symbol() == Some(right) {
+            depth -= 1;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
+}

--- a/rust/fslc/tests/edition_migrator.rs
+++ b/rust/fslc/tests/edition_migrator.rs
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+
+use serde_json::Value;
+
+struct FixtureDir(PathBuf);
+
+static FIXTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+impl FixtureDir {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-edition-migrator-{}-{nonce}-{}",
+            std::process::id(),
+            FIXTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        ));
+        std::fs::create_dir(&path).expect("create fixture directory");
+        Self(path)
+    }
+
+    fn write(&self, name: &str, source: &str) -> PathBuf {
+        let path = self.0.join(name);
+        std::fs::write(&path, source).expect("write fixture");
+        path
+    }
+}
+
+impl Drop for FixtureDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run fslc")
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn text(path: &Path) -> String {
+    std::fs::read_to_string(path).expect("read fixture")
+}
+
+#[test]
+fn dry_run_write_repeat_and_formatter_contracts_are_consistent() {
+    let directory = FixtureDir::new();
+    let original = r"domain Legacy {
+  type Status = Pending | Done
+  aggregate Job {
+    state { status: Status }
+    command Finish {}
+    event Finished {}
+    decide Finish {
+      requires status == Pending || status == Done
+      emits Finished
+    }
+    evolve Finished { status = Done }
+    invariant valid { status == Pending -> status == Pending }
+  }
+}
+";
+    let path = directory.write("legacy.fsl", original);
+    let path_text = path.to_str().expect("UTF-8 path");
+
+    let dry = run(&["migrate", path_text, "--edition", "next"]);
+    assert!(
+        dry.status.success(),
+        "{}",
+        String::from_utf8_lossy(&dry.stdout)
+    );
+    let dry_json = json(&dry);
+    assert_eq!(dry_json["result"], "migrated");
+    assert_eq!(dry_json["written"], false);
+    assert_eq!(text(&path), original);
+    let codes = dry_json["files"][0]["findings"]
+        .as_array()
+        .expect("findings")
+        .iter()
+        .filter_map(|finding| finding["code"].as_str())
+        .collect::<Vec<_>>();
+    assert!(codes.contains(&"deprecated_domain_enum_union"));
+    assert!(codes.contains(&"legacy_logical_operator"));
+    assert!(codes.contains(&"implicit_initial_value"));
+
+    let write = run(&["migrate", path_text, "--edition", "next", "--write"]);
+    assert!(
+        write.status.success(),
+        "{}",
+        String::from_utf8_lossy(&write.stdout)
+    );
+    assert_eq!(json(&write)["written"], true);
+    let migrated = text(&path);
+    assert!(migrated.contains("enum Status"));
+    assert!(migrated.contains("status: Status = Pending"));
+    assert!(migrated.contains(" or "));
+    assert!(migrated.contains(" => "));
+
+    let repeated = run(&["migrate", path_text, "--edition", "next"]);
+    assert!(repeated.status.success());
+    assert_eq!(json(&repeated)["changed"], 0);
+    assert_eq!(text(&path), migrated);
+
+    let formatted = run(&["fmt", path_text, "--check", "--edition", "next"]);
+    assert!(
+        formatted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&formatted.stdout)
+    );
+    let checked = run(&["check", path_text, "--edition", "next"]);
+    assert!(
+        checked.status.success(),
+        "{}",
+        String::from_utf8_lossy(&checked.stdout)
+    );
+}
+
+#[test]
+fn legacy_quantifier_colon_migrates_to_braces() {
+    let directory = FixtureDir::new();
+    let path = directory.write(
+        "quantifier.fsl",
+        r"spec Quantifier {
+  const MAX = 1
+  type Id = 0..1
+  state { ready: Map<Id, Bool> }
+  init { forall i in 0..MAX: { ready[i] = false } }
+  invariant Typed { forall i in 0..MAX: ready[i] == true or ready[i] == false }
+}
+",
+    );
+    let path_text = path.to_str().expect("UTF-8 path");
+    let output = run(&["migrate", path_text, "--edition", "next", "--write"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        json(&output)["files"][0]["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .any(|finding| finding["code"] == "legacy_quantifier_colon")
+    );
+    let source = text(&path);
+    assert!(!source.contains("MAX:"));
+    assert!(source.contains("forall i in 0..MAX {"));
+}
+
+#[test]
+fn string_metadata_uses_typed_annotations_without_changing_public_kernel() {
+    let directory = FixtureDir::new();
+    let path = directory.write(
+        "metadata.fsl",
+        r#"spec Tagged "safety: sample" {
+  state { ready: Bool }
+  init "undecided: initial policy" { ready = false }
+  action publish() "REQ-PUBLISH: publishing is traceable" { ready = true }
+  invariant Ready "REQ-READY: ready remains Boolean" { ready == true or ready == false }
+}
+"#,
+    );
+    let path_text = path.to_str().expect("UTF-8 path");
+    let migrated = run(&["migrate", path_text, "--edition", "next", "--write"]);
+    assert!(
+        migrated.status.success(),
+        "{}",
+        String::from_utf8_lossy(&migrated.stdout)
+    );
+    let source = text(&path);
+    assert!(source.contains("@kind(\"safety\", \"sample\")\nspec Tagged"));
+    assert!(source.contains("@undecided(\"initial policy\")"));
+    assert!(source.contains("@requirement(\"REQ-PUBLISH\", \"publishing is traceable\")"));
+    assert!(!source.contains("\"REQ-READY:"));
+}
+
+#[test]
+fn invalid_double_ampersand_and_ambiguous_maps_are_explicit_refusals() {
+    let directory = FixtureDir::new();
+    let invalid = directory.write(
+        "invalid.fsl",
+        "domain Bad { aggregate A { invariant bad { true && false } } }\n",
+    );
+    let invalid_text = invalid.to_str().expect("UTF-8 path");
+    let lint = run(&["lint", invalid_text, "--edition", "next"]);
+    assert_eq!(lint.status.code(), Some(1));
+    let finding = &json(&lint)["files"][0]["findings"][0];
+    assert_eq!(finding["taxonomy"], "unsupported_in_edition");
+    assert_eq!(finding["canonical_replacement"], "and");
+    assert_eq!(finding["machine_applicable"], false);
+    let migrate = run(&["migrate", invalid_text, "--edition", "next", "--write"]);
+    assert_eq!(migrate.status.code(), Some(2));
+    assert_eq!(json(&migrate)["result"], "migration_refused");
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let duplicate = root.join("tests/fixtures/action_correspondence_duplicate.fsl");
+    let duplicate_output = run(&[
+        "migrate",
+        duplicate.to_str().expect("UTF-8 path"),
+        "--edition",
+        "next",
+    ]);
+    assert_eq!(duplicate_output.status.code(), Some(2));
+    assert_eq!(
+        json(&duplicate_output)["files"][0]["findings"][0]["taxonomy"],
+        "ambiguous_intent"
+    );
+}
+
+#[test]
+fn ai_native_legacy_operator_attempt_reports_each_unsupported_token() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/domain_characterization/legacy_logical_parse_error.fsl");
+    let output = run(&[
+        "lint",
+        root.to_str().expect("UTF-8 path"),
+        "--edition",
+        "next",
+    ]);
+    assert_eq!(output.status.code(), Some(1));
+    let findings = json(&output)["files"][0]["findings"]
+        .as_array()
+        .expect("findings")
+        .clone();
+    assert_eq!(findings.len(), 2);
+    assert_eq!(
+        findings
+            .iter()
+            .map(|finding| finding["code"].as_str().expect("code"))
+            .collect::<Vec<_>>(),
+        ["unsupported_double_ampersand", "legacy_logical_operator"]
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["machine_applicable"] == false)
+    );
+}
+
+#[test]
+fn malformed_input_reports_the_file_and_parse_location() {
+    let directory = FixtureDir::new();
+    let malformed = directory.write(
+        "malformed.fsl",
+        "spec Broken { state { ready: Bool } invariant Missing { ready == } }\n",
+    );
+    let path = malformed.to_str().expect("UTF-8 path");
+    let output = run(&["lint", path, "--edition", "next"]);
+    assert_eq!(output.status.code(), Some(2));
+    let error = json(&output);
+    assert_eq!(error["result"], "error");
+    assert_eq!(error["kind"], "parse");
+    assert_eq!(error["file"], path);
+    assert_eq!(error["loc"]["file"], path);
+    assert!(error["loc"]["line"].as_u64().is_some());
+    assert!(error["loc"]["column"].as_u64().is_some());
+}
+
+#[test]
+fn safe_inline_maps_move_to_the_single_local_implements_block() {
+    let directory = FixtureDir::new();
+    let abstraction = directory.write(
+        "abstract.fsl",
+        r"spec Abstract {
+  type Id = 0..1
+  state { done: Map<Id, Bool> }
+  init { forall i: Id { done[i] = false } }
+  action finish(i: Id) { done[i] = true }
+  invariant Typed { forall i: Id { done[i] == true or done[i] == false } }
+}
+",
+    );
+    assert!(abstraction.exists());
+    let requirements = directory.write(
+        "requirements.fsl",
+        r#"requirements Concrete {
+  type Id = 0..1
+  state { done: Map<Id, Bool> }
+  init { forall i: Id { done[i] = false } }
+  implements Abstract from "abstract.fsl" {
+    map done[i: Id] = done[i]
+  }
+  action complete(i: Id) maps finish(i) { done[i] = true }
+  invariant Typed { forall i: Id { done[i] == true or done[i] == false } }
+}
+"#,
+    );
+    let path = requirements.to_str().expect("UTF-8 path");
+    let before_verify = run(&["verify", path, "--depth", "2"]);
+    assert!(
+        before_verify.status.success(),
+        "{}",
+        String::from_utf8_lossy(&before_verify.stdout)
+    );
+    let output = run(&["migrate", path, "--edition", "next", "--write"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let source = text(&requirements);
+    assert!(!source.contains("maps finish"));
+    assert!(source.contains("action complete(i: Id) -> finish(i)"));
+    assert_eq!(source.matches("action complete").count(), 2);
+
+    let after_verify = run(&["verify", path, "--depth", "2"]);
+    assert!(
+        after_verify.status.success(),
+        "{}",
+        String::from_utf8_lossy(&after_verify.stdout)
+    );
+    let before = json(&before_verify);
+    let after = json(&after_verify);
+    assert_eq!(before["result"], after["result"]);
+    assert_eq!(before["implements"], after["implements"]);
+}
+
+#[test]
+fn inline_maps_with_parameter_comments_are_refused_without_source_changes() {
+    let directory = FixtureDir::new();
+    directory.write(
+        "abstract.fsl",
+        r"spec Abstract {
+  type Id = 0..1
+  state { done: Map<Id, Bool> }
+  init { forall i: Id { done[i] = false } }
+  action finish(i: Id) { done[i] = true }
+  invariant Typed { forall i: Id { done[i] == true or done[i] == false } }
+}
+",
+    );
+    let original = r#"requirements Concrete {
+  type Id = 0..1
+  state { done: Map<Id, Bool> }
+  init { forall i: Id { done[i] = false } }
+  implements Abstract from "abstract.fsl" {
+    map done[i: Id] = done[i]
+  }
+  action complete(
+    i: Id // entity id
+  ) maps finish(i) { done[i] = true }
+  invariant Typed { forall i: Id { done[i] == true or done[i] == false } }
+}
+"#;
+    let requirements = directory.write("requirements.fsl", original);
+    let path = requirements.to_str().expect("UTF-8 path");
+    let output = run(&["migrate", path, "--edition", "next", "--write"]);
+    assert_eq!(output.status.code(), Some(2));
+    let finding = &json(&output)["files"][0]["findings"][0];
+    assert_eq!(finding["taxonomy"], "ambiguous_intent");
+    assert_eq!(finding["machine_applicable"], false);
+    assert_eq!(text(&requirements), original);
+}
+
+#[test]
+fn multi_file_refusal_leaves_every_input_unchanged() {
+    let directory = FixtureDir::new();
+    let safe_source = "domain Safe { type E = A | B }\n";
+    let refused_source = "domain Refused { aggregate A { invariant bad { true && false } } }\n";
+    let safe = directory.write("safe.fsl", safe_source);
+    let refused = directory.write("refused.fsl", refused_source);
+    let output = run(&[
+        "migrate",
+        safe.to_str().expect("UTF-8 path"),
+        refused.to_str().expect("UTF-8 path"),
+        "--edition",
+        "next",
+        "--write",
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(text(&safe), safe_source);
+    assert_eq!(text(&refused), refused_source);
+}
+
+#[cfg(unix)]
+#[test]
+fn multi_file_prepare_io_failure_leaves_every_input_unchanged() {
+    let directory = FixtureDir::new();
+    let writable = directory.0.join("writable");
+    let locked = directory.0.join("locked");
+    std::fs::create_dir(&writable).expect("writable directory");
+    std::fs::create_dir(&locked).expect("locked directory");
+    let first = writable.join("first.fsl");
+    let second = locked.join("second.fsl");
+    let first_source = "domain First { type E = A | B }\n";
+    let second_source = "domain Second { type E = A | B }\n";
+    std::fs::write(&first, first_source).expect("first fixture");
+    std::fs::write(&second, second_source).expect("second fixture");
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555))
+        .expect("lock directory");
+
+    let output = run(&[
+        "migrate",
+        first.to_str().expect("UTF-8 path"),
+        second.to_str().expect("UTF-8 path"),
+        "--edition",
+        "next",
+        "--write",
+    ]);
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755))
+        .expect("unlock directory");
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(text(&first), first_source);
+    assert_eq!(text(&second), second_source);
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -217,7 +217,9 @@ Use `enum Name { Member, ... }` for finite domain variants and
 `type Name = A | B` spelling is accepted by the current 2.x edition with the
 stable `deprecated_domain_enum_union` warning and a canonical replacement.
 Pass `--edition next` to `check`, `verify`, or `domain check` to reject legacy
-enum unions during migration.
+enum unions. Use `fslc lint <path>... --edition next` for stable non-mutating
+edition diagnostics and `fslc migrate <path>... --edition next` to review
+machine edits; add `--write` only after reviewing the complete validated set.
 
 ```fsl
 domain <Name> {
@@ -781,6 +783,8 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 
 ```
 fslc check <f>                                  # syntax / names / types only
+fslc lint <path>... [--edition current|next]    # stable edition findings; never mutates
+fslc migrate <path>... --edition next [--write] # dry run by default; atomic validated write set
 fslc fmt <f|-> [--edition current|next]         # canonical source on stdout; input is never mutated
 fslc fmt <path>... --check                      # JSON; exit 0 clean, 1 changed, 2 error
 fslc kernel <f> [--kernel-version 1|2]          # normalized typed Kernel JSON (default v1)

--- a/src/fslc/lsp/server.py
+++ b/src/fslc/lsp/server.py
@@ -106,6 +106,7 @@ def check_source(
                 if type_def.source_form != "legacy_enum_union":
                     continue
                 replacement = f"enum {type_def.name} {{ {', '.join(type_def.members)} }}"
+                suggestion = _legacy_enum_suggestion(source, type_def.name, replacement)
                 domain_warnings.append({
                     "kind": "deprecated_domain_enum_union",
                     "code": "deprecated_domain_enum_union",
@@ -117,6 +118,10 @@ def check_source(
                     "loc": type_def.loc,
                     "canonical_replacement": replacement,
                     "hint": f"replace the declaration with `{replacement}`",
+                    "taxonomy": "deprecated",
+                    "edition": "current",
+                    "machine_applicable": suggestion is not None,
+                    "suggestion": suggestion,
                 })
         ast, display_names = parse_src(source, base_dir)
         if ast[0] == "refinement":
@@ -334,6 +339,13 @@ def _create_server():
         )
         items = [_to_completion_item(types, c) for c in candidates]
         return types.CompletionList(is_incomplete=False, items=items)
+
+    @server.feature(
+        types.TEXT_DOCUMENT_CODE_ACTION,
+        types.CodeActionOptions(code_action_kinds=[types.CodeActionKind.QuickFix]),
+    )
+    def code_action(ls, params):
+        return _migration_code_actions(types, params.text_document.uri, params.context.diagnostics)
 
     @server.feature(
         types.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
@@ -680,8 +692,89 @@ def _make_diagnostic(types, source: str, item: Dict[str, Any], severity, index: 
         message=message,
         severity=severity,
         source="fslc",
-        code=item.get("kind"),
+        code=item.get("code") or item.get("kind"),
+        data={
+            key: item.get(key)
+            for key in (
+                "taxonomy",
+                "edition",
+                "canonical_replacement",
+                "machine_applicable",
+                "suggestion",
+            )
+            if item.get(key) is not None
+        } or None,
     )
+
+
+def _legacy_enum_suggestion(source: str, name: str, replacement: str) -> Optional[Dict[str, Any]]:
+    member = r"[A-Za-z_][A-Za-z0-9_]*"
+    pattern = re.compile(
+        rf"\btype\s+{re.escape(name)}\s*=\s*{member}(?:\s*\|\s*{member})+"
+    )
+    match = pattern.search(source)
+    if match is None:
+        return None
+    return {
+        "kind": "replace",
+        "replacement": replacement,
+        "machine_applicable": True,
+        "loc": _offset_range(source, match.start(), match.end()),
+    }
+
+
+def _offset_range(source: str, start: int, end: int) -> Dict[str, int]:
+    def point(offset: int) -> Tuple[int, int]:
+        prefix = source[:offset]
+        return prefix.count("\n") + 1, len(prefix.rsplit("\n", 1)[-1]) + 1
+
+    line, column = point(start)
+    end_line, end_column = point(end)
+    return {
+        "line": line,
+        "column": column,
+        "end_line": end_line,
+        "end_column": end_column,
+    }
+
+
+def _migration_code_actions(types, uri: str, diagnostics: List[Any]) -> List[Any]:
+    actions = []
+    for diagnostic in diagnostics:
+        data = diagnostic.data or {}
+        suggestion = data.get("suggestion") or {}
+        loc = suggestion.get("loc") or {}
+        if not data.get("machine_applicable") or not suggestion.get("replacement") or not loc:
+            continue
+        edit_range = types.Range(
+            start=types.Position(
+                line=max(int(loc.get("line", 1)) - 1, 0),
+                character=max(int(loc.get("column", 1)) - 1, 0),
+            ),
+            end=types.Position(
+                line=max(int(loc.get("end_line", loc.get("line", 1))) - 1, 0),
+                character=max(int(loc.get("end_column", loc.get("column", 1))) - 1, 0),
+            ),
+        )
+        actions.append(
+            types.CodeAction(
+                title=f"Replace with {data.get('canonical_replacement', 'canonical syntax')}",
+                kind=types.CodeActionKind.QuickFix,
+                diagnostics=[diagnostic],
+                edit=types.WorkspaceEdit(
+                    changes={
+                        uri: [
+                            types.TextEdit(
+                                range=edit_range,
+                                new_text=suggestion["replacement"],
+                            )
+                        ]
+                    }
+                ),
+                is_preferred=True,
+            )
+        )
+    return actions
 
 
 def _range_from_finding_nodes(finding: Dict[str, Any], index: Optional[DocumentIndex]) -> Optional[Range]:

--- a/tests/rust_only_surface.json
+++ b/tests/rust_only_surface.json
@@ -381,6 +381,98 @@
         }
       ],
       "commands": []
+    },
+    {
+      "path": [
+        "lint"
+      ],
+      "parent_index": 23,
+      "prog": "fslc lint",
+      "help_sha256": "d0f4839d59c145f0c426fe1fe2937a7430b5956c2ad85c6f3a3c03146f62319e",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "path",
+          "required": true,
+          "positional": true,
+          "nargs": "+",
+          "action": "store"
+        },
+        {
+          "dest": "edition",
+          "required": false,
+          "flags": [
+            "--edition"
+          ],
+          "choices": [
+            "current",
+            "next"
+          ],
+          "default": "current",
+          "action": "store"
+        }
+      ],
+      "commands": []
+    },
+    {
+      "path": [
+        "migrate"
+      ],
+      "parent_index": 24,
+      "prog": "fslc migrate",
+      "help_sha256": "ec4e87d743a3cd19d8be891064a9c5f6bb5ce9fa66ae92816f21de6bffc821ee",
+      "actions": [
+        {
+          "dest": "help",
+          "required": false,
+          "flags": [
+            "-h",
+            "--help"
+          ],
+          "nargs": 0,
+          "action": "store"
+        },
+        {
+          "dest": "path",
+          "required": true,
+          "positional": true,
+          "nargs": "+",
+          "action": "store"
+        },
+        {
+          "dest": "edition",
+          "required": false,
+          "flags": [
+            "--edition"
+          ],
+          "choices": [
+            "current",
+            "next"
+          ],
+          "default": "next",
+          "action": "store"
+        },
+        {
+          "dest": "write",
+          "required": false,
+          "flags": [
+            "--write"
+          ],
+          "nargs": 0,
+          "default": false,
+          "action": "store_true"
+        }
+      ],
+      "commands": []
     }
   ],
   "rust_only_actions": [
@@ -470,7 +562,7 @@
     {
       "path": [],
       "python_sha256": "731a3fd77cc65de2bd63dbf5fe84d72edd9361089f618aa0998fd294bd6f4392",
-      "rust_sha256": "0f31a4e2140917ea26fbc2505158bb2bffdcb48b3d52935b0ef87c1d6a88d899"
+      "rust_sha256": "c1adcda68a995fcadc1e061323fceca5aba2b2d0a3d24d652a3fb05d0e103b6b"
     },
     {
       "path": [

--- a/tests/test_lsp_server.py
+++ b/tests/test_lsp_server.py
@@ -25,6 +25,7 @@ from fslc.lsp.server import (  # noqa: E402
     _create_server,
     _definition_target,
     _path_to_uri,
+    _migration_code_actions,
     _result_to_diagnostics,
     _to_completion_item,
     _to_lsp_range,
@@ -376,3 +377,27 @@ def test_analysis_diagnostics_no_findings_file_adds_no_information_diagnostics()
     diagnostics = _result_to_diagnostics(types, source, result, index)
 
     assert not [d for d in diagnostics if d.source == "fslc analyze"]
+
+
+def test_legacy_enum_diagnostic_exposes_a_machine_applicable_code_action():
+    source = """domain Legacy {
+  type Status = Pending | Done
+  aggregate Job { state { status: Status = Pending; } }
+}
+"""
+    result = check_source(source, "legacy.fsl")
+    diagnostics = _result_to_diagnostics(types, source, result, None)
+    diagnostic = next(d for d in diagnostics if d.code == "deprecated_domain_enum_union")
+    assert diagnostic.data["taxonomy"] == "deprecated"
+    assert diagnostic.data["machine_applicable"] is True
+
+    uri = "file:///tmp/legacy.fsl"
+    actions = _migration_code_actions(types, uri, [diagnostic])
+    assert len(actions) == 1
+    edit = actions[0].edit.changes[uri][0]
+    assert edit.new_text == "enum Status { Pending, Done }"
+    lines = source.splitlines()
+    replaced = lines[edit.range.start.line][
+        edit.range.start.character:edit.range.end.character
+    ]
+    assert replaced == "type Status = Pending | Done"


### PR DESCRIPTION
## Problem

FSL has canonical next-edition spellings, but no single safe way to inventory or apply migrations. Hand edits can lose comments, change checked meaning, or partially update a multi-file invocation.

## Contract change

- add `fslc lint FILE... --edition current|next` and dry-run-by-default `fslc migrate FILE... --edition next [--write]`
- share canonical enum/operator/quantifier edits with the lossless formatter
- migrate legacy string metadata, implicit defaults, and safe inline action maps; explicitly refuse ambiguous or comment-unsafe cases
- validate parse/check, location-free Public Kernel, typed annotations, and requirements correspondence before writing
- make multi-file writes atomic and idempotent
- expose machine-applicable migration diagnostics as retained Python LSP quick fixes
- publish the CLI contract, accepted design, language/reference docs, generated site pages, and changelog entry

## Test evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `.venv/bin/python -m pytest -q` (1456 passed, 81 skipped)
- `.venv/bin/python -m pytest tests/test_lsp_server.py tests/test_rust_cli_contract.py -q` (24 passed)
- independent review: no blockers

Closes #249