### PR TITLE
feat(replay): define observation correspondence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,9 @@ jobs:
           cp rust/fslc/tests/fixtures/replay_trace.valid.v1.json dist/fsl-kernel-contract-v1/fixtures/
           cp rust/fslc/tests/fixtures/replay_trace.state-mismatch.v1.json dist/fsl-kernel-contract-v1/fixtures/
           cp rust/fslc/tests/fixtures/replay_trace.bad-tick.v1.json dist/fsl-kernel-contract-v1/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.fsl dist/fsl-kernel-contract-v1/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.valid.v1.json dist/fsl-kernel-contract-v1/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json dist/fsl-kernel-contract-v1/fixtures/
           cp docs/DESIGN-replay-trace.md dist/fsl-kernel-contract-v1/
           cp docs/DESIGN-kernel-contract.md dist/fsl-kernel-contract-v1/README.md
           tar -czf dist/fsl-kernel-contract-v1.tar.gz -C dist fsl-kernel-contract-v1
@@ -183,6 +186,9 @@ jobs:
           cp rust/fslc/tests/fixtures/replay_trace.valid.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp rust/fslc/tests/fixtures/replay_trace.state-mismatch.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp rust/fslc/tests/fixtures/replay_trace.bad-tick.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.fsl dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.valid.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp docs/DESIGN-replay-trace.md dist/fsl-kernel-contract-v2/docs/
           cp docs/DESIGN-kernel-origin-v2.md dist/fsl-kernel-contract-v2/README.md
           cp docs/DESIGN-kernel-contract.md dist/fsl-kernel-contract-v2/docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Replay-trace schema `1.1.0` adds explicit `action: null` observation points.
+  Equal-state stutters preserve the projected action trace; reported transient
+  implementation states are nonconformant while unreported intermediates are
+  outside invariant judgment. Replay now delegates action outcomes, partial
+  guards, and rollback to `Monitor::attempt`, with differential fixtures in both
+  Public Kernel release bundles (issue #224).
 - `fslc replay --trace` now consumes the closed `replay-trace.v1` external
   compiler contract: trace/Kernel versions, exact spec action/parameters,
   canonical ticks, complete typed initial and post-action state, and optional

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -290,6 +290,13 @@ values; its complete tick/state contract is defined by
 golden vectors, Rust tests, this document, `docs/LANGUAGE.md`, the shared skill,
 and `CHANGELOG.md`.
 
+Replay observation actions execute through `Monitor::attempt`. Solver-free BFS
+also uses Monitor transitions, while
+`fsl-verifier/src/agreement.rs::{transition_matches_step,transition_outcome_matches_step}`
+checks Monitor successors and failures against symbolic transition semantics.
+Stutter performs no transition and requires full equality with the current
+Monitor state, so it introduces no second runtime or solver semantics.
+
 Public Kernel v2 is the separately negotiated provenance publication contract
 defined by [`DESIGN-kernel-origin-v2.md`](DESIGN-kernel-origin-v2.md). Use
 `fslc kernel SPEC --kernel-version 2`; omission remains v1. Its companion

--- a/docs/DESIGN-log-replay.md
+++ b/docs/DESIGN-log-replay.md
@@ -17,7 +17,9 @@ fsl-ai, and fsl-domain evidence commands.
 Normalized generated-code traces whose names already match Public Kernel use
 the versioned complete-state contract in
 [`DESIGN-replay-trace.md`](DESIGN-replay-trace.md). This mapping path remains
-for production records with external names and schemas.
+for production records with external names and schemas. Its mapping target
+`-> stutter` is separate syntax; public replay traces encode an observation
+stutter as JSON `action:null` and never reserve the action name `stutter`.
 
 ## 2. Record and mapping contracts
 

--- a/docs/DESIGN-replay-trace.md
+++ b/docs/DESIGN-replay-trace.md
@@ -1,6 +1,6 @@
 # Public Replay Trace Contract
 
-Status: accepted and implemented for issue #221.
+Status: accepted and implemented for issues #221 and #224.
 
 ## Goal and authority
 
@@ -19,13 +19,19 @@ wall-clock time, or replace production-log refinement mappings.
 ```json
 {
   "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "kernel_schema_version": "1.0.0",
   "spec": "ReplayTrace",
   "initial": {"phase": "Idle", "selected": null},
   "events": [
     {
       "tick": 1,
+      "action": null,
+      "params": {},
+      "state": {"phase": "Idle", "selected": null}
+    },
+    {
+      "tick": 2,
       "timestamp": "producer-sequence-42",
       "action": "select",
       "params": {"i": 0},
@@ -36,22 +42,52 @@ wall-clock time, or replace production-log refinement mappings.
 ```
 
 The root and each event are closed objects. `initial` is the complete logical
-state at tick 0. Every event is exactly one transition: ticks are the canonical
-sequence `1..N`, `action` is the exact Public Kernel action name, `params` has
-the exact parameter set, and `state` is the complete post-action logical state.
+state at tick 0. Every event is exactly one logical transition: ticks are the
+canonical sequence `1..N`, `action` is either an exact Public Kernel action name
+or the v1.1 stutter value `null`, and `state` is the complete resulting logical
+state. Action parameters are exact; stutter requires the empty object `{}`.
 State values use the ordinary Monitor/Public Kernel representation: enum member
 strings, `null`/value for Option, objects for struct and complete Map values,
 arrays for Set/Seq, and pair arrays for relations.
 
 `timestamp` is optional, non-empty, opaque producer metadata. Replay ignores it;
 it has no ordering, deadline, or formal-time meaning. Consumers use `tick` for
-the logical transition order.
+the logical transition order, including stutter steps.
+
+## Observation-point correspondence
+
+Let `S0` be the Monitor initial state and `O0` the reported `initial`; they must
+be equal and `Monitor::current_violation` must be empty. For event `i`, replay
+applies exactly one of these rules:
+
+- **Action** `a(p)`: `Monitor::attempt(a, p)` must commit without a violation,
+  producing `Si`, and the reported complete state `Oi` must equal `Si`.
+- **Stutter**: no Monitor action is executed, `Si = S(i-1)`, the current
+  violation must be empty, and `Oi` must equal that unchanged state.
+
+Deleting or inserting any number of equal-state stutter observations therefore
+preserves the projected action trace and final logical state. A string action
+literally named `stutter` remains an ordinary action; only JSON `null` denotes
+the stutter rule.
+
+Invariants, bounds, and transition semantics are judged only on these reported
+logical states and atomic Monitor action successors. Concrete implementation
+states between two observations are absent from the trace and are not checked.
+This permits an implementation to pass through a transient state that violates
+an FSL invariant while implementing one atomic action, but reporting that same
+state as an observation is nonconformant because it cannot equal the required
+logical state. Replay does not infer or synthesize unreported intermediates.
 
 Replay-trace v1 accepts `kernel_schema_version` `1.0.0` and `2.0.0`. Kernel v2
 adds provenance but does not change action/state execution values. Trace schema
 SemVer is independent: changing required fields, tick meaning, or value encoding
 requires a trace major; adding support for a Kernel version without changing
 trace values is additive.
+
+Trace schema `1.0.0` accepts action events only. `1.1.0` additively permits
+`action: null` with empty params for stutter observations. Replay reports the
+input trace version in `trace_schema_version` and rejects null actions under
+`1.0.0`.
 
 ## Validation and verdicts
 
@@ -66,6 +102,12 @@ divergence is `state_mismatch` with deterministic leaf `mismatches`. Rejected
 actions and invariant/type/partial-operation failures keep their existing
 nonconformant verdict (exit 1). `failed_at_event` remains zero-based; `tick` is
 one-based. Conformance exits 0.
+
+All versioned parameters and states are decoded before Monitor execution, so a
+malformed later observation is always exit 2 even if an earlier logical step
+would be nonconformant. Action execution uses the same `Monitor::attempt`
+conformance entry point as the public harness; replay does not reimplement
+guard, partial-operation, update, or rollback semantics.
 
 Snapshots are decoded with the same complete typed state loader used by
 `--from-state` and mapped log replay, then compared after canonical rendering.
@@ -87,8 +129,9 @@ for external names and schemas.
 
 ## Fixtures and distribution
 
-The positive, state-mismatch, and malformed-tick goldens plus their FSL spec
-live under `rust/fslc/tests/fixtures/replay_trace*`. Release packaging copies the
+The action, state-mismatch, malformed-tick, stuttering, and transient-observation
+goldens plus their FSL specs live under `rust/fslc/tests/fixtures/replay_*`.
+Release packaging copies the
 schema and all fixtures into both independently checksummed Public Kernel v1
 and v2 bundles together with this contract, so an external compiler can
 implement and test the backward contract from release artifacts alone.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1417,15 +1417,21 @@ External compilers emit the native replay contract as a closed versioned JSON
 object (`schemas/fslc/kernel/replay-trace.v1.schema.json`):
 
 ```json
-{"$schema":"https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json","schema_version":"1.0.0","kernel_schema_version":"1.0.0","spec":"ShoppingCart","initial":{"stock":{"0":1},"cart":{"0":0}},"events":[{"tick":1,"action":"add_to_cart","params":{"u":0,"i":0},"state":{"stock":{"0":0},"cart":{"0":1}}}]}
+{"$schema":"https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json","schema_version":"1.1.0","kernel_schema_version":"1.0.0","spec":"ShoppingCart","initial":{"stock":{"0":1},"cart":{"0":0}},"events":[{"tick":1,"action":null,"params":{},"state":{"stock":{"0":1},"cart":{"0":0}}},{"tick":2,"action":"add_to_cart","params":{"u":0,"i":0},"state":{"stock":{"0":0},"cart":{"0":1}}}]}
 ```
 
 `initial` is the complete tick-0 state and every event has the exact Public
-Kernel action/parameter names plus its complete post-state. Ticks are exactly
-`1..N`. Optional non-empty `timestamp` is ignored opaque producer metadata, not
+Kernel action/parameter names plus its complete post-state. Since trace schema
+1.1, `action:null` with `{}` params is an explicit stutter observation whose
+complete state must equal the current logical state; 1.0 remains action-only.
+Inserting or deleting equal-state stutters preserves the projected action trace
+and final state. Ticks are exactly `1..N`, including stutters. Optional non-empty
+`timestamp` is ignored opaque producer metadata, not
 formal time. Trace v1 accepts Kernel `1.0.0` and `2.0.0`. Malformed contracts
 fail as input errors; typed initial/post-state divergence is nonconformant with
-leaf mismatch evidence. Bare arrays and `{events:[...]}` remain the explicit
+leaf mismatch evidence. Invariants apply to observation points and atomic
+Monitor successors, not to unreported implementation intermediates. Bare arrays
+and `{events:[...]}` remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See `docs/DESIGN-replay-trace.md`.
 

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1457,14 +1457,20 @@ fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # se
 </code></pre>
 <p>External compilers emit the native replay contract as a closed versioned JSON
 object (<code>schemas/fslc/kernel/replay-trace.v1.schema.json</code>):</p>
-<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.0.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
+<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.1.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
 </code></pre>
 <p><code>initial</code> is the complete tick-0 state and every event has the exact Public
-Kernel action/parameter names plus its complete post-state. Ticks are exactly
-<code>1..N</code>. Optional non-empty <code>timestamp</code> is ignored opaque producer metadata, not
+Kernel action/parameter names plus its complete post-state. Since trace schema
+1.1, <code>action:null</code> with <code>{}</code> params is an explicit stutter observation whose
+complete state must equal the current logical state; 1.0 remains action-only.
+Inserting or deleting equal-state stutters preserves the projected action trace
+and final state. Ticks are exactly <code>1..N</code>, including stutters. Optional non-empty
+<code>timestamp</code> is ignored opaque producer metadata, not
 formal time. Trace v1 accepts Kernel <code>1.0.0</code> and <code>2.0.0</code>. Malformed contracts
 fail as input errors; typed initial/post-state divergence is nonconformant with
-leaf mismatch evidence. Bare arrays and <code>{events:[...]}</code> remain the explicit
+leaf mismatch evidence. Invariants apply to observation points and atomic
+Monitor successors, not to unreported implementation intermediates. Bare arrays
+and <code>{events:[...]}</code> remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See <code>docs/DESIGN-replay-trace.md</code>.</p>
 <p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1457,14 +1457,20 @@ fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # se
 </code></pre>
 <p>External compilers emit the native replay contract as a closed versioned JSON
 object (<code>schemas/fslc/kernel/replay-trace.v1.schema.json</code>):</p>
-<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.0.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
+<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.1.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
 </code></pre>
 <p><code>initial</code> is the complete tick-0 state and every event has the exact Public
-Kernel action/parameter names plus its complete post-state. Ticks are exactly
-<code>1..N</code>. Optional non-empty <code>timestamp</code> is ignored opaque producer metadata, not
+Kernel action/parameter names plus its complete post-state. Since trace schema
+1.1, <code>action:null</code> with <code>{}</code> params is an explicit stutter observation whose
+complete state must equal the current logical state; 1.0 remains action-only.
+Inserting or deleting equal-state stutters preserves the projected action trace
+and final state. Ticks are exactly <code>1..N</code>, including stutters. Optional non-empty
+<code>timestamp</code> is ignored opaque producer metadata, not
 formal time. Trace v1 accepts Kernel <code>1.0.0</code> and <code>2.0.0</code>. Malformed contracts
 fail as input errors; typed initial/post-state divergence is nonconformant with
-leaf mismatch evidence. Bare arrays and <code>{events:[...]}</code> remain the explicit
+leaf mismatch evidence. Invariants apply to observation points and atomic
+Monitor successors, not to unreported implementation intermediates. Bare arrays
+and <code>{events:[...]}</code> remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See <code>docs/DESIGN-replay-trace.md</code>.</p>
 <p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -59,8 +59,9 @@ pub use origin::{
 pub use public_kernel::{
     KERNEL_SCHEMA_ID, KERNEL_SCHEMA_VERSION, KERNEL_V1_SCHEMA_ID, KERNEL_V1_SCHEMA_VERSION,
     KERNEL_V2_SCHEMA_ID, KERNEL_V2_SCHEMA_VERSION, PublicKernelError, PublicKernelVersion,
-    REPLAY_TRACE_V1_SCHEMA_ID, REPLAY_TRACE_V1_SCHEMA_VERSION, TESTGEN_TRACE_V1_SCHEMA_ID,
-    TESTGEN_TRACE_V1_SCHEMA_VERSION, public_kernel_contract, public_kernel_contract_for_version,
+    REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION, REPLAY_TRACE_V1_SCHEMA_ID,
+    REPLAY_TRACE_V1_SCHEMA_VERSION, TESTGEN_TRACE_V1_SCHEMA_ID, TESTGEN_TRACE_V1_SCHEMA_VERSION,
+    public_kernel_contract, public_kernel_contract_for_version,
 };
 pub use refinement::{
     ActionCorrespondence, ActionCorrespondenceTarget, ActionRef, ImplementsContract, ProgressMap,

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -23,7 +23,8 @@ pub const KERNEL_V2_SCHEMA_ID: &str = "https://fsl.dev/schemas/fslc/kernel/kerne
 pub const TESTGEN_TRACE_V1_SCHEMA_VERSION: &str = "1.0.0";
 pub const TESTGEN_TRACE_V1_SCHEMA_ID: &str =
     "https://fsl.dev/schemas/fslc/kernel/testgen-trace.v1.schema.json";
-pub const REPLAY_TRACE_V1_SCHEMA_VERSION: &str = "1.0.0";
+pub const REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION: &str = "1.0.0";
+pub const REPLAY_TRACE_V1_SCHEMA_VERSION: &str = "1.1.0";
 pub const REPLAY_TRACE_V1_SCHEMA_ID: &str =
     "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json";
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2716,88 +2716,115 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                 expected,
             );
         }
+        match monitor.current_violation() {
+            Ok(Some(violation)) => {
+                return replay_failure_with_state(
+                    &model,
+                    None,
+                    json!({
+                        "kind":violation.kind,
+                        "name":display(&violation.name),
+                        "tick":0,
+                    }),
+                    expected,
+                );
+            }
+            Ok(None) => {}
+            Err(error) => return (error_output("internal", &error.to_string()), 3),
+        }
     }
     for (index, event) in trace.events.iter().enumerate() {
-        let action_name = &event.action;
-        let params = &event.params;
         let state_before = fslc_rust::state_json(&monitor.state);
-        let Some(action) = model.actions.iter().find(|action| {
-            action.name == *action_name || !versioned && display(&action.name) == *action_name
-        }) else {
-            return replay_failure(
-                &model,
-                &monitor,
-                index,
-                json!({
-                    "kind": "bad_call",
-                    "message": format!("unknown action '{action_name}'"),
-                    "action": action_name,
-                    "params": params,
-                }),
-            );
-        };
-        let parsed = if versioned {
-            validated_events[index]
-                .0
-                .clone()
-                .expect("known versioned action was validated")
-        } else {
-            match parse_params(&model, action, params) {
-                Ok(params) => params,
-                Err(message) => {
+        let (action_evidence, transition) = match &event.step {
+            fslc_rust::replay_trace::ReplayStep::Stutter => {
+                match monitor.current_violation() {
+                    Ok(Some(violation)) => {
+                        return replay_failure(
+                            &model,
+                            &monitor,
+                            index,
+                            json!({
+                                "kind":violation.kind,
+                                "name":display(&violation.name),
+                                "action":Value::Null,
+                                "params":{},
+                                "transition":"stutter",
+                            }),
+                        );
+                    }
+                    Ok(None) => {}
+                    Err(error) => return (error_output("internal", &error.to_string()), 3),
+                }
+                (Value::Null, "stutter")
+            }
+            fslc_rust::replay_trace::ReplayStep::Action {
+                name: action_name,
+                params,
+            } => {
+                let Some(action) = model.actions.iter().find(|action| {
+                    action.name == *action_name
+                        || !versioned && display(&action.name) == *action_name
+                }) else {
                     return replay_failure(
                         &model,
                         &monitor,
                         index,
                         json!({
                             "kind": "bad_call",
-                            "message": message,
+                            "message": format!("unknown action '{action_name}'"),
                             "action": action_name,
                             "params": params,
                         }),
                     );
+                };
+                let parsed = if versioned {
+                    let ValidatedReplayStep::Action(parsed) = &validated_events[index].step else {
+                        unreachable!("parsed replay step changed during validation")
+                    };
+                    parsed
+                        .clone()
+                        .expect("known versioned action was validated")
+                } else {
+                    match parse_params(&model, action, params) {
+                        Ok(params) => params,
+                        Err(message) => {
+                            return replay_failure(
+                                &model,
+                                &monitor,
+                                index,
+                                json!({
+                                    "kind": "bad_call",
+                                    "message": message,
+                                    "action": action_name,
+                                    "params": params,
+                                }),
+                            );
+                        }
+                    }
+                };
+                let stepped = match monitor.attempt(&action.name, &parsed) {
+                    Ok(stepped) => stepped,
+                    Err(error) => return (error_output("internal", &error.to_string()), 3),
+                };
+                if let Some(violation) = stepped.violation {
+                    return replay_failure(
+                        &model,
+                        &monitor,
+                        index,
+                        json!({
+                            "kind": violation.kind,
+                            "name": display(&violation.name),
+                            "action": display(&action.name),
+                            "params": params,
+                        }),
+                    );
                 }
+                (json!(action.name), "action")
             }
         };
-        let enabled = match monitor.enabled() {
-            Ok(enabled) => enabled,
-            Err(error) => return (error_output("internal", &error.to_string()), 3),
-        };
-        let Some(instance) = enabled
-            .iter()
-            .find(|instance| instance.action == action.name && instance.params == parsed)
-        else {
-            return replay_failure(
-                &model,
-                &monitor,
-                index,
-                json!({
-                    "kind": "requires_failed",
-                    "action": display(&action.name),
-                    "params": params,
-                }),
-            );
-        };
-        let stepped = match monitor.step(instance) {
-            Ok(stepped) => stepped,
-            Err(error) => return (error_output("internal", &error.to_string()), 3),
-        };
-        if let Some(violation) = stepped.violation {
-            return replay_failure(
-                &model,
-                &monitor,
-                index,
-                json!({
-                    "kind": violation.kind,
-                    "name": display(&violation.name),
-                    "action": display(&action.name),
-                    "params": params,
-                }),
-            );
-        }
         if let Some(state) = &event.state {
             let observed = if versioned {
-                validated_events[index].1.clone()
+                validated_events[index].state.clone()
             } else {
                 match replay_snapshot_json(state, &model) {
                     Ok(observed) => observed,
@@ -2813,7 +2840,8 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                     json!({
                         "kind":"state_mismatch",
                         "tick":event.tick,
-                        "action":action.name,
+                        "action":action_evidence,
+                        "transition":transition,
                         "expected_state":expected,
                         "observed_state":observed,
                         "mismatches":mismatches,
@@ -2836,14 +2864,12 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         json!("leadsTo properties are not checked by replay (finite logs only)"),
     );
     if let fslc_rust::replay_trace::ReplayTraceContract::V1 {
+        schema_version,
         kernel_schema_version,
         ..
     } = trace.contract
     {
-        output.insert(
-            "trace_schema_version".to_owned(),
-            json!(fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION),
-        );
+        output.insert("trace_schema_version".to_owned(), json!(schema_version));
         output.insert(
             "kernel_schema_version".to_owned(),
             json!(kernel_schema_version),
@@ -3349,7 +3375,7 @@ fn replay_failure_with_state(
     output.insert(
         "hint".to_owned(),
         json!(if index.is_none() {
-            "the implementation initial state does not match the specification init"
+            "the implementation initial state is not a valid specification state"
         } else {
             "the implementation performed an action the spec forbids at this state (or reached a state violating an invariant)"
         }),
@@ -12516,7 +12542,15 @@ fn has_bounds(model: &KernelModel, ty: &TypeRef) -> bool {
     }
 }
 
-type ValidatedReplayEvent = (Option<std::collections::BTreeMap<String, FslValue>>, Value);
+enum ValidatedReplayStep {
+    Action(Option<std::collections::BTreeMap<String, FslValue>>),
+    Stutter,
+}
+
+struct ValidatedReplayEvent {
+    step: ValidatedReplayStep,
+    state: Value,
+}
 
 fn validate_versioned_replay_events(
     model: &KernelModel,
@@ -12533,13 +12567,19 @@ fn validate_versioned_replay_events(
                     .expect("versioned replay event requires state"),
                 model,
             )?;
-            let params = model
-                .actions
-                .iter()
-                .find(|action| action.name == event.action)
-                .map(|action| parse_versioned_params(model, action, &event.params, index))
-                .transpose()?;
-            Ok((params, state))
+            let step = match &event.step {
+                fslc_rust::replay_trace::ReplayStep::Stutter => ValidatedReplayStep::Stutter,
+                fslc_rust::replay_trace::ReplayStep::Action { name, params } => {
+                    let params = model
+                        .actions
+                        .iter()
+                        .find(|action| action.name == *name)
+                        .map(|action| parse_versioned_params(model, action, params, index))
+                        .transpose()?;
+                    ValidatedReplayStep::Action(params)
+                }
+            };
+            Ok(ValidatedReplayEvent { step, state })
         })
         .collect()
 }

--- a/rust/fslc/src/replay_trace.rs
+++ b/rust/fslc/src/replay_trace.rs
@@ -10,6 +10,7 @@ use serde_json::{Map, Value};
 pub enum ReplayTraceContract {
     Legacy,
     V1 {
+        schema_version: String,
         kernel_schema_version: String,
         spec: String,
         initial: Map<String, Value>,
@@ -20,9 +21,17 @@ pub enum ReplayTraceContract {
 pub struct ReplayEvent {
     pub tick: Option<u64>,
     pub timestamp: Option<String>,
-    pub action: String,
-    pub params: Map<String, Value>,
+    pub step: ReplayStep,
     pub state: Option<Map<String, Value>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReplayStep {
+    Action {
+        name: String,
+        params: Map<String, Value>,
+    },
+    Stutter,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -49,7 +58,7 @@ struct ReplayEventV1 {
     tick: u64,
     #[serde(default)]
     timestamp: Option<String>,
-    action: String,
+    action: Value,
     params: Map<String, Value>,
     state: Map<String, Value>,
 }
@@ -108,10 +117,14 @@ fn parse_v1(data: Value) -> Result<ReplayTraceInput, String> {
             fsl_core::REPLAY_TRACE_V1_SCHEMA_ID
         ));
     }
-    if trace.schema_version != fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION {
+    if !matches!(
+        trace.schema_version.as_str(),
+        fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION | fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+    ) {
         return Err(format!(
-            "unsupported replay trace schema_version '{}'; expected '{}'",
+            "unsupported replay trace schema_version '{}'; expected '{}' or '{}'",
             trace.schema_version,
+            fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION,
             fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
         ));
     }
@@ -139,11 +152,7 @@ fn parse_v1(data: Value) -> Result<ReplayTraceInput, String> {
                     event.tick
                 ));
             }
-            if event.action.is_empty() {
-                return Err(format!(
-                    "replay trace event {index} action must not be empty"
-                ));
-            }
+            let step = parse_v1_step(event.action, event.params, index, &trace.schema_version)?;
             if event.timestamp.as_ref().is_some_and(String::is_empty) {
                 return Err(format!(
                     "replay trace event {index} timestamp must not be empty"
@@ -152,20 +161,54 @@ fn parse_v1(data: Value) -> Result<ReplayTraceInput, String> {
             Ok(ReplayEvent {
                 tick: Some(event.tick),
                 timestamp: event.timestamp,
-                action: event.action,
-                params: event.params,
+                step,
                 state: Some(event.state),
             })
         })
         .collect::<Result<_, _>>()?;
     Ok(ReplayTraceInput {
         contract: ReplayTraceContract::V1 {
+            schema_version: trace.schema_version,
             kernel_schema_version: trace.kernel_schema_version,
             spec: trace.spec,
             initial: trace.initial,
         },
         events,
     })
+}
+
+fn parse_v1_step(
+    action: Value,
+    params: Map<String, Value>,
+    index: usize,
+    schema_version: &str,
+) -> Result<ReplayStep, String> {
+    match action {
+        Value::String(action) if !action.is_empty() => Ok(ReplayStep::Action {
+            name: action,
+            params,
+        }),
+        Value::String(_) => Err(format!(
+            "replay trace event {index} action must not be empty"
+        )),
+        Value::Null
+            if schema_version == fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION && params.is_empty() =>
+        {
+            Ok(ReplayStep::Stutter)
+        }
+        Value::Null if schema_version == fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION => {
+            Err(format!(
+                "replay trace event {index} stutter requires schema_version '{}'",
+                fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+            ))
+        }
+        Value::Null => Err(format!(
+            "replay trace event {index} stutter params must be empty"
+        )),
+        _ => Err(format!(
+            "replay trace event {index} action must be a string or null"
+        )),
+    }
 }
 
 fn parse_legacy_event(event: Value) -> Result<ReplayEvent, String> {
@@ -184,8 +227,10 @@ fn parse_legacy_event(event: Value) -> Result<ReplayEvent, String> {
     Ok(ReplayEvent {
         tick: None,
         timestamp: None,
-        action,
-        params,
+        step: ReplayStep::Action {
+            name: action,
+            params,
+        },
         state: None,
     })
 }
@@ -194,7 +239,7 @@ fn parse_legacy_event(event: Value) -> Result<ReplayEvent, String> {
 mod tests {
     use serde_json::{Value, json};
 
-    use super::{ReplayTraceContract, parse_replay_trace};
+    use super::{ReplayStep, ReplayTraceContract, parse_replay_trace};
 
     fn versioned() -> Value {
         json!({
@@ -216,7 +261,10 @@ mod tests {
             let parsed = parse_replay_trace(input).expect("legacy trace");
             assert_eq!(parsed.contract, ReplayTraceContract::Legacy);
             assert_eq!(parsed.events.len(), 1);
-            assert_eq!(parsed.events[0].action, "advance");
+            assert!(matches!(
+                &parsed.events[0].step,
+                ReplayStep::Action { name, .. } if name == "advance"
+            ));
         }
         assert!(
             parse_replay_trace(json!({"spec":"S","events":[]}))
@@ -280,5 +328,29 @@ mod tests {
             let parsed = parse_replay_trace(input).expect("supported Kernel version");
             assert!(matches!(parsed.contract, ReplayTraceContract::V1 { .. }));
         }
+    }
+
+    #[test]
+    fn v1_1_adds_explicit_stutter_without_reserving_an_action_name() {
+        let mut stutter = versioned();
+        stutter["events"][0]["action"] = Value::Null;
+        let parsed = parse_replay_trace(stutter.clone()).expect("v1.1 stutter");
+        assert_eq!(parsed.events[0].step, ReplayStep::Stutter);
+
+        stutter["schema_version"] = json!(fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION);
+        assert!(parse_replay_trace(stutter).is_err());
+
+        let mut params = versioned();
+        params["events"][0]["action"] = Value::Null;
+        params["events"][0]["params"] = json!({"unexpected":true});
+        assert!(parse_replay_trace(params).is_err());
+
+        let mut named = versioned();
+        named["events"][0]["action"] = json!("stutter");
+        let parsed = parse_replay_trace(named).expect("ordinary action name");
+        assert!(matches!(
+            &parsed.events[0].step,
+            ReplayStep::Action { name, .. } if name == "stutter"
+        ));
     }
 }

--- a/rust/fslc/tests/fixtures/replay_observation.fsl
+++ b/rust/fslc/tests/fixtures/replay_observation.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ReplayObservation {
+  state { value: Int }
+  init { value = 0 }
+
+  action commit() {
+    value = 2
+  }
+
+  invariant NoTransientState { value != 1 }
+}

--- a/rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json
+++ b/rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "ReplayObservation",
+  "initial": {"value": 0},
+  "events": [
+    {"tick": 1, "action": null, "params": {}, "state": {"value": 1}},
+    {"tick": 2, "action": "commit", "params": {}, "state": {"value": 2}}
+  ]
+}

--- a/rust/fslc/tests/fixtures/replay_observation.valid.v1.json
+++ b/rust/fslc/tests/fixtures/replay_observation.valid.v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "ReplayObservation",
+  "initial": {"value": 0},
+  "events": [
+    {"tick": 1, "action": null, "params": {}, "state": {"value": 0}},
+    {"tick": 2, "action": "commit", "params": {}, "state": {"value": 2}},
+    {"tick": 3, "action": null, "params": {}, "state": {"value": 2}}
+  ]
+}

--- a/rust/fslc/tests/fixtures/replay_trace.fsl
+++ b/rust/fslc/tests/fixtures/replay_trace.fsl
@@ -23,5 +23,11 @@ spec ReplayTrace {
     requires selected is some(i)
     phase = Done
   }
+  action partial(i: Id) {
+    requires 1 / i > 0
+  }
+  action stutter() {
+    phase = Done
+  }
   invariant Nonnegative { forall i: Id { count[i] >= 0 } }
 }

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -590,8 +590,11 @@ fn published_schema_ids_match_the_rust_api_constants() {
     assert_eq!(testgen_trace["$id"], fsl_core::TESTGEN_TRACE_V1_SCHEMA_ID);
     assert_eq!(replay_trace["$id"], fsl_core::REPLAY_TRACE_V1_SCHEMA_ID);
     assert_eq!(
-        replay_trace["properties"]["schema_version"]["const"],
-        fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+        replay_trace["properties"]["schema_version"]["enum"],
+        json!([
+            fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION,
+            fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+        ])
     );
     assert_eq!(
         replay_trace["properties"]["kernel_schema_version"]["enum"],
@@ -599,6 +602,18 @@ fn published_schema_ids_match_the_rust_api_constants() {
             fsl_core::KERNEL_V1_SCHEMA_VERSION,
             fsl_core::KERNEL_V2_SCHEMA_VERSION
         ])
+    );
+    assert_eq!(
+        replay_trace["$defs"]["event"]["properties"]["action"]["type"],
+        json!(["string", "null"])
+    );
+    assert_eq!(
+        replay_trace["$defs"]["event"]["allOf"][0]["then"]["properties"]["params"]["maxProperties"],
+        0
+    );
+    assert_eq!(
+        replay_trace["allOf"][0]["then"]["properties"]["events"]["items"]["properties"]["action"]["type"],
+        "string"
     );
     let kinds = kernel["$defs"]["expression"]["properties"]["kind"]["enum"]
         .as_array()

--- a/rust/fslc/tests/replay_trace_contract.rs
+++ b/rust/fslc/tests/replay_trace_contract.rs
@@ -19,10 +19,14 @@ fn replay(trace: &str) -> Output {
 }
 
 fn replay_path(trace: &Path) -> Output {
+    replay_spec_path(&fixture("replay_trace.fsl"), trace)
+}
+
+fn replay_spec_path(spec: &Path, trace: &Path) -> Output {
     Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args([
             "replay",
-            fixture("replay_trace.fsl").to_str().expect("spec path"),
+            spec.to_str().expect("spec path"),
             "--trace",
             trace.to_str().expect("trace path"),
         ])
@@ -30,7 +34,55 @@ fn replay_path(trace: &Path) -> Output {
         .expect("run replay")
 }
 
+#[test]
+fn observation_points_are_stuttering_equivalent_and_unobserved_intermediates_are_ignored() {
+    let with_stutters = replay_spec_path(
+        &fixture("replay_observation.fsl"),
+        &fixture("replay_observation.valid.v1.json"),
+    );
+    assert!(with_stutters.status.success());
+    let with_stutters = json(&with_stutters);
+    assert_eq!(with_stutters["trace_schema_version"], "1.1.0");
+    assert_eq!(with_stutters["steps_checked"], 3);
+    assert_eq!(with_stutters["final_state"]["value"], 2);
+
+    let mut without_stutters: Value = serde_json::from_str(
+        &std::fs::read_to_string(fixture("replay_observation.valid.v1.json")).expect("fixture"),
+    )
+    .expect("trace JSON");
+    let action = without_stutters["events"][1].clone();
+    without_stutters["events"] = json!([action]);
+    without_stutters["events"][0]["tick"] = json!(1);
+    let path = write_trace(&without_stutters);
+    let output = replay_spec_path(&fixture("replay_observation.fsl"), &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert!(output.status.success());
+    assert_eq!(json(&output)["final_state"], with_stutters["final_state"]);
+}
+
+#[test]
+fn reporting_a_transient_intermediate_as_an_observation_is_nonconformant() {
+    let output = replay_spec_path(
+        &fixture("replay_observation.fsl"),
+        &fixture("replay_observation.transient-observed.v1.json"),
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let value = json(&output);
+    assert_eq!(value["failed_at_event"], 0);
+    assert_eq!(value["violation"]["kind"], "state_mismatch");
+    assert_eq!(value["violation"]["action"], Value::Null);
+    assert_eq!(value["violation"]["transition"], "stutter");
+    assert_eq!(value["violation"]["mismatches"][0]["path"], "value");
+}
+
 fn replay_value(value: &Value) -> Output {
+    let path = write_trace(value);
+    let output = replay_path(&path);
+    std::fs::remove_file(path).expect("remove trace");
+    output
+}
+
+fn write_trace(value: &Value) -> PathBuf {
     let path = std::env::temp_dir().join(format!(
         "fsl-replay-trace-{}-{}.json",
         std::process::id(),
@@ -38,9 +90,7 @@ fn replay_value(value: &Value) -> Output {
     ));
     std::fs::write(&path, serde_json::to_vec(value).expect("serialize trace"))
         .expect("write trace");
-    let output = replay_path(&path);
-    std::fs::remove_file(path).expect("remove trace");
-    output
+    path
 }
 
 fn json(output: &Output) -> Value {
@@ -120,6 +170,29 @@ fn versioned_parameter_type_errors_are_input_errors_but_rejected_calls_are_nonco
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(json(&output)["violation"]["kind"], "requires_failed");
 
+    let mut partial = valid.clone();
+    partial["events"]
+        .as_array_mut()
+        .expect("events")
+        .truncate(1);
+    partial["events"][0]["action"] = json!("partial");
+    partial["events"][0]["params"] = json!({"i":0});
+    partial["events"][0]["state"] = partial["initial"].clone();
+    let output = replay_value(&partial);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(json(&output)["violation"]["kind"], "partial_op");
+
+    let mut named_stutter = valid.clone();
+    named_stutter["events"]
+        .as_array_mut()
+        .expect("events")
+        .truncate(1);
+    named_stutter["events"][0]["action"] = json!("stutter");
+    named_stutter["events"][0]["params"] = json!({});
+    named_stutter["events"][0]["state"] = named_stutter["initial"].clone();
+    named_stutter["events"][0]["state"]["phase"] = json!("Done");
+    assert!(replay_value(&named_stutter).status.success());
+
     let mut malformed_after_rejection = valid;
     malformed_after_rejection["events"][0]["action"] = json!("finish");
     malformed_after_rejection["events"][0]["params"] = json!({});
@@ -185,6 +258,9 @@ fn release_bundles_include_the_schema_spec_and_positive_and_negative_goldens() {
         "replay_trace.valid.v1.json",
         "replay_trace.state-mismatch.v1.json",
         "replay_trace.bad-tick.v1.json",
+        "replay_observation.fsl",
+        "replay_observation.valid.v1.json",
+        "replay_observation.transient-observed.v1.json",
     ] {
         assert_eq!(workflow.matches(artifact).count(), 2, "{artifact}");
     }

--- a/schemas/fslc/kernel/replay-trace.v1.schema.json
+++ b/schemas/fslc/kernel/replay-trace.v1.schema.json
@@ -7,7 +7,7 @@
   "required": ["$schema", "schema_version", "kernel_schema_version", "spec", "initial", "events"],
   "properties": {
     "$schema": { "const": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json" },
-    "schema_version": { "const": "1.0.0" },
+    "schema_version": { "enum": ["1.0.0", "1.1.0"] },
     "kernel_schema_version": { "enum": ["1.0.0", "2.0.0"] },
     "spec": { "type": "string", "minLength": 1 },
     "initial": { "$ref": "#/$defs/state" },
@@ -25,10 +25,36 @@
       "properties": {
         "tick": { "type": "integer", "minimum": 1 },
         "timestamp": { "type": "string", "minLength": 1 },
-        "action": { "type": "string", "minLength": 1 },
+        "action": { "type": ["string", "null"], "minLength": 1 },
         "params": { "type": "object" },
         "state": { "$ref": "#/$defs/state" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "action": { "type": "null" } },
+            "required": ["action"]
+          },
+          "then": { "properties": { "params": { "maxProperties": 0 } } }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "schema_version": { "const": "1.0.0" } },
+        "required": ["schema_version"]
+      },
+      "then": {
+        "properties": {
+          "events": {
+            "items": {
+              "properties": { "action": { "type": "string" } }
+            }
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -854,8 +854,11 @@ fslc compat check <f> [--include-ai]                    # dbsystem compatibility
 Native generated-code replay uses `replay-trace.v1`: a closed root carrying
 trace and Kernel versions, exact spec identity, complete tick-0 `initial`, and
 events with exact Public Kernel `action`/`params`, canonical ticks `1..N`, and
-complete post-action `state`. Optional `timestamp` is opaque and ignored. Trace
-v1 accepts Kernel 1.0.0/2.0.0. Ill-shaped/incomplete input is exit 2; typed
+complete post-transition `state`. Trace schema 1.1 adds explicit stutter as
+`action:null` plus empty params; its state must equal the unchanged Monitor
+state. Equal-state stutters may be inserted/deleted, while unreported concrete
+intermediates are outside invariant judgment. Optional `timestamp` is opaque
+and ignored. Trace v1 accepts Kernel 1.0.0/2.0.0. Ill-shaped/incomplete input is exit 2; typed
 state divergence is exit 1 with leaf mismatches. Bare arrays/`{events}` are the
 unversioned action-only compatibility adapter; testgen/verifier traces are not
 replay input. See `docs/DESIGN-replay-trace.md`.


### PR DESCRIPTION
## Problem

Kernel transitions are atomic while generated implementations may pass through concrete intermediate states. Replay therefore needs an OSS-owned rule for deciding only reported observation points without treating unreported intermediates as logical states.

## Contract change

- add replay-trace schema 1.1 with explicit stutter observations encoded as `action: null`, empty params, and a complete unchanged state; schema 1.0 remains action-only
- define stuttering equivalence formally: inserting/deleting equal-state stutters preserves the projected action trace and final state
- apply invariants/bounds only to initial/action/stutter logical observations, never to absent implementation intermediates
- consolidate replay action execution through `Monitor::attempt`, sharing requires/partial/update/rollback semantics with the conformance harness and existing Monitor↔symbolic agreement gates
- ship differential fixtures showing an omitted transient invariant violation conforms while reporting it as an observation is nonconformant
- include observation fixtures in both Public Kernel release bundles and update the accepted contract, LANGUAGE/generated site, shared skill, and CHANGELOG

## Test evidence

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fsl-verifier --test transition_agreement`
- `.venv/bin/python -m pytest tests/test_rust_cli_contract.py tests/test_site_reference_snapshot.py -q` (15 passed)
- external Draft 2020-12 schema validation: 1.1 null accepted; 1.0 null and null+params rejected
- independent review: no blockers

Closes #224