### PR TITLE
feat(runtime): monitor bounded liveness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,9 @@ jobs:
           cp rust/fslc/tests/fixtures/replay_observation.fsl dist/fsl-kernel-contract-v1/fixtures/
           cp rust/fslc/tests/fixtures/replay_observation.valid.v1.json dist/fsl-kernel-contract-v1/fixtures/
           cp rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json dist/fsl-kernel-contract-v1/fixtures/
+          cp examples/nfr/bounded_response.fsl dist/fsl-kernel-contract-v1/fixtures/
+          cp examples/nfr/bounded_response.within.v1.json dist/fsl-kernel-contract-v1/fixtures/
+          cp examples/nfr/bounded_response.overdue.v1.json dist/fsl-kernel-contract-v1/fixtures/
           cp docs/DESIGN-replay-trace.md dist/fsl-kernel-contract-v1/
           cp docs/DESIGN-kernel-contract.md dist/fsl-kernel-contract-v1/README.md
           tar -czf dist/fsl-kernel-contract-v1.tar.gz -C dist fsl-kernel-contract-v1
@@ -189,6 +192,9 @@ jobs:
           cp rust/fslc/tests/fixtures/replay_observation.fsl dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp rust/fslc/tests/fixtures/replay_observation.valid.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp rust/fslc/tests/fixtures/replay_observation.transient-observed.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp examples/nfr/bounded_response.fsl dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp examples/nfr/bounded_response.within.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
+          cp examples/nfr/bounded_response.overdue.v1.json dist/fsl-kernel-contract-v2/rust/fslc/tests/fixtures/
           cp docs/DESIGN-replay-trace.md dist/fsl-kernel-contract-v2/docs/
           cp docs/DESIGN-kernel-origin-v2.md dist/fsl-kernel-contract-v2/README.md
           cp docs/DESIGN-kernel-contract.md dist/fsl-kernel-contract-v2/docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Replay-trace schema `1.2.0` opts into solver-free bounded `leadsTo`
+  monitoring over initial, action, and stutter observations. Inclusive deadline
+  failures carry property/binding/timing evidence; successful output separates
+  safety from bounded liveness, preserves finite-prefix `pending`, and names
+  unchecked unbounded properties. Native BMC and a test-only Python oracle
+  cross-check the monitor, and positive/overdue NFR fixtures ship in both Public
+  Kernel release bundles (issue #225).
 - Replay-trace schema `1.1.0` adds explicit `action: null` observation points.
   Equal-state stutters preserve the projected action trace; reported transient
   implementation states are nonconformant while unreported intermediates are

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -296,6 +296,10 @@ also uses Monitor transitions, while
 checks Monitor successors and failures against symbolic transition semantics.
 Stutter performs no transition and requires full equality with the current
 Monitor state, so it introduces no second runtime or solver semantics.
+Replay schema 1.2 additionally runs the solver-free `BoundedLivenessMonitor` on
+the same observations. Its inclusive `leadsTo ... within` deadline is
+differentially checked against the native BMC deadline probe; requirements
+`deadline` remains an ordinary lowered safety invariant.
 
 Public Kernel v2 is the separately negotiated provenance publication contract
 defined by [`DESIGN-kernel-origin-v2.md`](DESIGN-kernel-origin-v2.md). Use

--- a/docs/DESIGN-nfr.md
+++ b/docs/DESIGN-nfr.md
@@ -179,3 +179,18 @@ disproportionate cost or a kernel-semantics change the architecture forbids
 
 The guidance above (verify a timed property at the clock-owning layer; share the
 clock to carry it across a refinement) is the supported approach.
+
+## 7. Runtime evidence for bounded responses (issue #225)
+
+There are two intentionally different runtime-visible deadline forms:
+
+- requirements `deadline age <= K` lowers to an invariant and is checked as
+  safety by Monitor/replay;
+- `leadsTo P ~> within K Q` is a bounded response and trace schema 1.2 checks it
+  with the solver-free bounded-liveness monitor.
+
+Both count logical observations, not timestamps. For bounded `leadsTo`, the
+trigger observation is `p`, the inclusive deadline is `p + K`, and both action
+and stutter events advance time. Finite prefixes may end with pending
+obligations; unbounded response claims still require verifier evidence. See
+`examples/nfr/bounded_response.fsl` and its positive/overdue replay traces.

--- a/docs/DESIGN-replay-trace.md
+++ b/docs/DESIGN-replay-trace.md
@@ -1,6 +1,6 @@
 # Public Replay Trace Contract
 
-Status: accepted and implemented for issues #221 and #224.
+Status: accepted and implemented for issues #221, #224, and #225.
 
 ## Goal and authority
 
@@ -11,15 +11,16 @@ is `schemas/fslc/kernel/replay-trace.v1.schema.json`; the native Rust CLI is the
 authoritative consumer.
 
 Replay is finite runtime evidence. It checks concrete actions, safety
-properties, and complete observed states. It does not prove `leadsTo`, interpret
-wall-clock time, or replace production-log refinement mappings.
+properties, complete observed states, and (since trace schema 1.2) bounded
+`leadsTo` deadlines. It does not prove unbounded liveness, interpret wall-clock
+time, or replace production-log refinement mappings.
 
 ## Versioned v1 envelope
 
 ```json
 {
   "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
-  "schema_version": "1.1.0",
+  "schema_version": "1.2.0",
   "kernel_schema_version": "1.0.0",
   "spec": "ReplayTrace",
   "initial": {"phase": "Idle", "selected": null},
@@ -87,7 +88,33 @@ trace values is additive.
 Trace schema `1.0.0` accepts action events only. `1.1.0` additively permits
 `action: null` with empty params for stutter observations. Replay reports the
 input trace version in `trace_schema_version` and rejects null actions under
-`1.0.0`.
+`1.0.0`. Schema `1.2.0` opts into the bounded-liveness semantics below; earlier
+minor versions retain safety-only replay rather than changing meaning in place.
+
+## Bounded liveness at observation points
+
+For each `leadsTo L { P ~> within K Q }` and each supported static binder
+assignment, replay 1.2 maintains the oldest unsatisfied trigger. At observation
+`p`, `P` starts an obligation unless `Q` already holds. `Q` may satisfy that
+obligation at any observation through the inclusive deadline `p + K`; if it is
+still false there, replay exits 1 with `check:"bounded_liveness"`, `property`,
+`bindings`, `pending_since`, `deadline`, `within`, and `tick`. This is the same
+deadline rule as native BMC. Tick 0 and every action or stutter event are
+observations, so stutters advance the bounded response clock.
+
+Safety is checked before liveness at each observation. A state mismatch or
+safety violation at a deadline is therefore reported as safety evidence rather
+than being hidden by a liveness result. Successful replay reports separate
+`checks.safety` and `checks.bounded_liveness` objects. A finite prefix ending
+before a deadline reports liveness `status:"pending"`; this is not a proof or a
+failure. Unbounded `leadsTo` declarations are listed in
+`unbounded_properties` and remain unchecked.
+
+The runtime monitor is solver-free and consumes the checked Kernel model. It
+enumerates typed and static integer-range binders. Collection binders and
+`where` filters fail closed instead of silently checking a weaker property.
+Requirements `deadline` is already lowered to a safety invariant and stays in
+the safety check; only explicit `leadsTo ... within K` uses this monitor.
 
 ## Validation and verdicts
 
@@ -129,8 +156,9 @@ for external names and schemas.
 
 ## Fixtures and distribution
 
-The action, state-mismatch, malformed-tick, stuttering, and transient-observation
-goldens plus their FSL specs live under `rust/fslc/tests/fixtures/replay_*`.
+The action, state-mismatch, malformed-tick, stuttering, transient-observation,
+and bounded-liveness goldens plus their FSL specs live under
+`rust/fslc/tests/fixtures/replay_*` and `examples/nfr/bounded_response*`.
 Release packaging copies the
 schema and all fixtures into both independently checksummed Public Kernel v1
 and v2 bundles together with this contract, so an external compiler can

--- a/docs/DESIGN-temporal.md
+++ b/docs/DESIGN-temporal.md
@@ -322,6 +322,24 @@ failure is a transition-progress failure.
 - **scenarios**: leadsTo is out of scope (future: leave a comment about the
   possibility of turning a pending→achieved trace into a scenario).
 
+## 5.1 Solver-free bounded runtime monitoring (issue #225)
+
+Public replay trace 1.2 evaluates `leadsTo P ~> within K Q` without Z3. The
+runtime monitor consumes the same checked `LeadsToDef` as the verifier and
+tracks the oldest outstanding trigger per static binder assignment. For a
+trigger at observation `p`, `Q` may become true through observation `p + K`;
+otherwise that deadline is the violating observation. `within 0` therefore
+requires `Q` in the same observation as `P`.
+
+This is deliberately only bounded prefix monitoring. A trace that ends early
+reports pending obligations, and declarations without `within` are reported as
+unchecked rather than inferred from a finite prefix. Action and stutter
+observations both advance the logical clock. Unsupported collection binders or
+`where` filters fail closed. Differential tests feed a native BMC
+counterexample into the monitor and require identical property, binding,
+trigger, and deadline evidence. The external contract and JSON fields are
+specified in `DESIGN-replay-trace.md`.
+
 ## 6. Test Plan (tests/test_temporal.py)
 
 1. **stutter counterexample**: a spec that deadlocks after becoming P so Q never

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1417,7 +1417,7 @@ External compilers emit the native replay contract as a closed versioned JSON
 object (`schemas/fslc/kernel/replay-trace.v1.schema.json`):
 
 ```json
-{"$schema":"https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json","schema_version":"1.1.0","kernel_schema_version":"1.0.0","spec":"ShoppingCart","initial":{"stock":{"0":1},"cart":{"0":0}},"events":[{"tick":1,"action":null,"params":{},"state":{"stock":{"0":1},"cart":{"0":0}}},{"tick":2,"action":"add_to_cart","params":{"u":0,"i":0},"state":{"stock":{"0":0},"cart":{"0":1}}}]}
+{"$schema":"https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json","schema_version":"1.2.0","kernel_schema_version":"1.0.0","spec":"ShoppingCart","initial":{"stock":{"0":1},"cart":{"0":0}},"events":[{"tick":1,"action":null,"params":{},"state":{"stock":{"0":1},"cart":{"0":0}}},{"tick":2,"action":"add_to_cart","params":{"u":0,"i":0},"state":{"stock":{"0":0},"cart":{"0":1}}}]}
 ```
 
 `initial` is the complete tick-0 state and every event has the exact Public
@@ -1434,6 +1434,14 @@ Monitor successors, not to unreported implementation intermediates. Bare arrays
 and `{events:[...]}` remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See `docs/DESIGN-replay-trace.md`.
+
+Trace schema 1.2 additionally checks every `leadsTo P ~> within K Q` at the
+initial state and each action/stutter observation. The deadline `p + K` is
+inclusive: `Q` there succeeds, while absence of `Q` fails with bounded-liveness
+evidence. Safety is evaluated first. Successful output separates
+`checks.safety` from `checks.bounded_liveness`; an unfinished finite obligation
+is `pending`, and unbounded `leadsTo` properties are named but not claimed as
+checked. Schemas 1.0/1.1 retain their earlier safety-only meaning.
 
 The `--from-log` form reuses the exact refinement mapping grammar to translate
 external JSONL records into spec actions and logical state; it does not add a

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1457,7 +1457,7 @@ fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # se
 </code></pre>
 <p>External compilers emit the native replay contract as a closed versioned JSON
 object (<code>schemas/fslc/kernel/replay-trace.v1.schema.json</code>):</p>
-<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.1.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
+<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.2.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
 </code></pre>
 <p><code>initial</code> is the complete tick-0 state and every event has the exact Public
 Kernel action/parameter names plus its complete post-state. Since trace schema
@@ -1473,6 +1473,13 @@ Monitor successors, not to unreported implementation intermediates. Bare arrays
 and <code>{events:[...]}</code> remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See <code>docs/DESIGN-replay-trace.md</code>.</p>
+<p>Trace schema 1.2 additionally checks every <code>leadsTo P ~&gt; within K Q</code> at the
+initial state and each action/stutter observation. The deadline <code>p + K</code> is
+inclusive: <code>Q</code> there succeeds, while absence of <code>Q</code> fails with bounded-liveness
+evidence. Safety is evaluated first. Successful output separates
+<code>checks.safety</code> from <code>checks.bounded_liveness</code>; an unfinished finite obligation
+is <code>pending</code>, and unbounded <code>leadsTo</code> properties are named but not claimed as
+checked. Schemas 1.0/1.1 retain their earlier safety-only meaning.</p>
 <p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate
 external JSONL records into spec actions and logical state; it does not add a
 second mapping language. Each non-empty line is

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1457,7 +1457,7 @@ fslc testgen specs/cart_v1.fsl --target phpunit -o CartConformanceTest.php  # se
 </code></pre>
 <p>External compilers emit the native replay contract as a closed versioned JSON
 object (<code>schemas/fslc/kernel/replay-trace.v1.schema.json</code>):</p>
-<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.1.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
+<pre><code class="language-json">{&quot;$schema&quot;:&quot;https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json&quot;,&quot;schema_version&quot;:&quot;1.2.0&quot;,&quot;kernel_schema_version&quot;:&quot;1.0.0&quot;,&quot;spec&quot;:&quot;ShoppingCart&quot;,&quot;initial&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}},&quot;events&quot;:[{&quot;tick&quot;:1,&quot;action&quot;:null,&quot;params&quot;:{},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:1},&quot;cart&quot;:{&quot;0&quot;:0}}},{&quot;tick&quot;:2,&quot;action&quot;:&quot;add_to_cart&quot;,&quot;params&quot;:{&quot;u&quot;:0,&quot;i&quot;:0},&quot;state&quot;:{&quot;stock&quot;:{&quot;0&quot;:0},&quot;cart&quot;:{&quot;0&quot;:1}}}]}
 </code></pre>
 <p><code>initial</code> is the complete tick-0 state and every event has the exact Public
 Kernel action/parameter names plus its complete post-state. Since trace schema
@@ -1473,6 +1473,13 @@ Monitor successors, not to unreported implementation intermediates. Bare arrays
 and <code>{events:[...]}</code> remain the explicit
 unversioned action-only adapter. Testgen and verifier trace JSON are not replay
 input. See <code>docs/DESIGN-replay-trace.md</code>.</p>
+<p>Trace schema 1.2 additionally checks every <code>leadsTo P ~&gt; within K Q</code> at the
+initial state and each action/stutter observation. The deadline <code>p + K</code> is
+inclusive: <code>Q</code> there succeeds, while absence of <code>Q</code> fails with bounded-liveness
+evidence. Safety is evaluated first. Successful output separates
+<code>checks.safety</code> from <code>checks.bounded_liveness</code>; an unfinished finite obligation
+is <code>pending</code>, and unbounded <code>leadsTo</code> properties are named but not claimed as
+checked. Schemas 1.0/1.1 retain their earlier safety-only meaning.</p>
 <p>The <code>--from-log</code> form reuses the exact refinement mapping grammar to translate
 external JSONL records into spec actions and logical state; it does not add a
 second mapping language. Each non-empty line is

--- a/examples/nfr/README.md
+++ b/examples/nfr/README.md
@@ -13,6 +13,10 @@ refinement.
   **refines** `sla_worker.fsl`, plus the mapping.
 - `support_sla.fsl`: a second requirements-dialect SLA fixture (the non-vacuous
   deadline-urgency pattern from DOGFOOD-8).
+- `bounded_response.fsl`: a solver-free replay fixture with one bounded and one
+  unbounded `leadsTo`; `bounded_response.within.v1.json` responds at the
+  inclusive deadline and `bounded_response.overdue.v1.json` misses it through
+  stutter observations.
 
 The modeled SLA is: once a request is submitted, it is finished within 4 discrete
 ticks. `urgent start, finish` means `tick` is disabled whenever work can start or
@@ -25,6 +29,10 @@ fslc verify examples/nfr/sla_worker.fsl --depth 10 --deadlock ignore
 fslc verify examples/nfr/sla_worker.fsl --depth 10 --deadlock ignore --engine induction
 fslc refine examples/nfr/sla_worker_design.fsl examples/nfr/sla_worker.fsl \
             examples/nfr/sla_worker_refines.fsl --depth 6        # => refines
+fslc replay examples/nfr/bounded_response.fsl \
+             --trace examples/nfr/bounded_response.within.v1.json   # => conformant
+fslc replay examples/nfr/bounded_response.fsl \
+             --trace examples/nfr/bounded_response.overdue.v1.json  # => bounded liveness failure
 ```
 
 Removing `urgent start, finish` leaves `tick` unconstrained by runnable work and

--- a/examples/nfr/bounded_response.fsl
+++ b/examples/nfr/bounded_response.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec BoundedResponse {
+  type Stage = 0..3
+  state { stage: Stage }
+  init { stage = 0 }
+
+  action advance() {
+    requires stage < 3
+    stage = stage + 1
+  }
+
+  leadsTo RespondsInTwo { stage == 1 ~> within 2 stage == 3 }
+  leadsTo EventuallyResponds { stage == 1 ~> stage == 3 }
+}

--- a/examples/nfr/bounded_response.overdue.v1.json
+++ b/examples/nfr/bounded_response.overdue.v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.2.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "BoundedResponse",
+  "initial": {"stage": 0},
+  "events": [
+    {"tick": 1, "action": "advance", "params": {}, "state": {"stage": 1}},
+    {"tick": 2, "action": null, "params": {}, "state": {"stage": 1}},
+    {"tick": 3, "action": null, "params": {}, "state": {"stage": 1}}
+  ]
+}

--- a/examples/nfr/bounded_response.within.v1.json
+++ b/examples/nfr/bounded_response.within.v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.2.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "BoundedResponse",
+  "initial": {"stage": 0},
+  "events": [
+    {"tick": 1, "action": "advance", "params": {}, "state": {"stage": 1}},
+    {"tick": 2, "action": "advance", "params": {}, "state": {"stage": 2}},
+    {"tick": 3, "action": "advance", "params": {}, "state": {"stage": 3}}
+  ]
+}

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -49,7 +49,7 @@ pub use dialect::{
 pub use domain::domain_kernel_source;
 pub use model::{
     ActionDef, ActionGuard, KernelModel, LeadsToDef, ModelError, ParamDef, PropertyDef, TypeDef,
-    TypeRef, Value as FslValue, build_model,
+    TypeRef, Value as FslValue, build_model, static_leadsto_bindings,
 };
 pub use origin::{
     INIT_TARGET, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET,
@@ -60,8 +60,9 @@ pub use public_kernel::{
     KERNEL_SCHEMA_ID, KERNEL_SCHEMA_VERSION, KERNEL_V1_SCHEMA_ID, KERNEL_V1_SCHEMA_VERSION,
     KERNEL_V2_SCHEMA_ID, KERNEL_V2_SCHEMA_VERSION, PublicKernelError, PublicKernelVersion,
     REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION, REPLAY_TRACE_V1_SCHEMA_ID,
-    REPLAY_TRACE_V1_SCHEMA_VERSION, TESTGEN_TRACE_V1_SCHEMA_ID, TESTGEN_TRACE_V1_SCHEMA_VERSION,
-    public_kernel_contract, public_kernel_contract_for_version,
+    REPLAY_TRACE_V1_SCHEMA_VERSION, REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION,
+    TESTGEN_TRACE_V1_SCHEMA_ID, TESTGEN_TRACE_V1_SCHEMA_VERSION, public_kernel_contract,
+    public_kernel_contract_for_version,
 };
 pub use refinement::{
     ActionCorrespondence, ActionCorrespondenceTarget, ActionRef, ImplementsContract, ProgressMap,

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -294,6 +294,74 @@ impl KernelModel {
     }
 }
 
+/// Enumerate the solver-independent static bindings of a `leadsTo` property.
+///
+/// # Errors
+///
+/// Returns [`ModelError`] for dynamic/filtering binders or unsupported
+/// collection domains.
+pub fn static_leadsto_bindings(
+    model: &KernelModel,
+    property: &LeadsToDef,
+) -> Result<Vec<BTreeMap<String, Value>>, ModelError> {
+    let mut expanded = vec![BTreeMap::new()];
+    for binder in &property.binders {
+        if match binder {
+            Binder::Typed { where_expr, .. }
+            | Binder::Range { where_expr, .. }
+            | Binder::Collection { where_expr, .. } => where_expr.is_some(),
+        } {
+            return Err(model_error(
+                "where filters are not implemented in bounded leadsTo",
+            ));
+        }
+        let (name, values) = match binder {
+            Binder::Typed {
+                name, type_name, ..
+            } => (
+                name,
+                model.domain_values(&TypeRef::Named(type_name.name.clone()))?,
+            ),
+            Binder::Range { name, lo, hi, .. } => {
+                let lo = static_leadsto_int(lo, model)?;
+                let hi = static_leadsto_int(hi, model)?;
+                (name, (lo..=hi).map(Value::Int).collect())
+            }
+            Binder::Collection { .. } => {
+                return Err(model_error(
+                    "collection binders are not implemented in bounded leadsTo",
+                ));
+            }
+        };
+        let mut next = Vec::new();
+        for binding in expanded {
+            for value in &values {
+                let mut candidate = binding.clone();
+                candidate.insert(name.clone(), value.clone());
+                next.push(candidate);
+            }
+        }
+        expanded = next;
+    }
+    Ok(expanded)
+}
+
+fn static_leadsto_int(expr: &Expr, model: &KernelModel) -> Result<i64, ModelError> {
+    match expr {
+        Expr::Num(value) => Ok(*value),
+        Expr::Var(name) => match model.consts.get(name) {
+            Some(Value::Int(value)) => Ok(*value),
+            _ => Err(model_error(format!("'{name}' is not an integer constant"))),
+        },
+        Expr::Neg(value) => static_leadsto_int(value, model)?
+            .checked_neg()
+            .ok_or_else(|| model_error("integer overflow in leadsTo binder")),
+        _ => Err(model_error(
+            "leadsTo range binder must use static integer bounds",
+        )),
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelError {
     pub message: String,

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -24,7 +24,8 @@ pub const TESTGEN_TRACE_V1_SCHEMA_VERSION: &str = "1.0.0";
 pub const TESTGEN_TRACE_V1_SCHEMA_ID: &str =
     "https://fsl.dev/schemas/fslc/kernel/testgen-trace.v1.schema.json";
 pub const REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION: &str = "1.0.0";
-pub const REPLAY_TRACE_V1_SCHEMA_VERSION: &str = "1.1.0";
+pub const REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION: &str = "1.1.0";
+pub const REPLAY_TRACE_V1_SCHEMA_VERSION: &str = "1.2.0";
 pub const REPLAY_TRACE_V1_SCHEMA_ID: &str =
     "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json";
 

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -11,7 +11,7 @@ use fsl_core::{
     KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
     KernelLValue as LValue, KernelModel, KernelStatement as Statement, ModelError, ParamDef,
     Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
-    insert_requirement_metadata, model_warnings, state_summary,
+    insert_requirement_metadata, model_warnings, state_summary, static_leadsto_bindings,
 };
 use serde_json::{Value as JsonValue, json};
 
@@ -689,6 +689,48 @@ pub struct StepResult {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedLivenessViolation {
+    pub property: String,
+    pub bindings: Bindings,
+    pub pending_since: usize,
+    pub deadline: usize,
+    pub within: usize,
+    pub step: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedLivenessPending {
+    pub property: String,
+    pub bindings: Bindings,
+    pub pending_since: usize,
+    pub deadline: usize,
+    pub within: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedLivenessStatus {
+    pub checked_properties: Vec<String>,
+    pub unbounded_properties: Vec<String>,
+    pub pending: Vec<BoundedLivenessPending>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BoundedLivenessProperty {
+    definition: fsl_core::LeadsToDef,
+    within: usize,
+    bindings: Vec<Bindings>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BoundedLivenessMonitor {
+    model: KernelModel,
+    properties: Vec<BoundedLivenessProperty>,
+    unbounded_properties: Vec<String>,
+    pending: BTreeMap<(usize, Bindings), (usize, usize)>,
+    next_step: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Monitor {
     pub model: KernelModel,
     pub state: State,
@@ -1009,6 +1051,147 @@ impl Monitor {
         checked_bounds: Option<&BTreeSet<String>>,
     ) -> Result<Option<Violation>, RuntimeError> {
         check_state_selected(&self.state, None, &self.model, self.step, checked_bounds)
+    }
+}
+
+impl BoundedLivenessMonitor {
+    /// Build a solver-free monitor for every `leadsTo ... within K` property.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] for negative deadlines, overflow, dynamic range
+    /// bounds, `where` filters, or collection binders unsupported by the
+    /// symbolic deadline checker.
+    pub fn new(model: KernelModel) -> Result<Self, RuntimeError> {
+        let mut properties = Vec::new();
+        let mut unbounded_properties = Vec::new();
+        for property in &model.leadstos {
+            let Some(within) = property.within else {
+                unbounded_properties.push(property.name.clone());
+                continue;
+            };
+            let within = usize::try_from(within)
+                .map_err(|_| runtime_error("leadsTo within must be non-negative"))?;
+            properties.push(BoundedLivenessProperty {
+                definition: property.clone(),
+                within,
+                bindings: static_leadsto_bindings(&model, property)?,
+            });
+        }
+        Ok(Self {
+            model,
+            properties,
+            unbounded_properties,
+            pending: BTreeMap::new(),
+            next_step: 0,
+        })
+    }
+
+    /// Observe one consecutive logical trace state.
+    ///
+    /// `step` counts every action and stutter observation. A response is valid
+    /// on its deadline state; failure is reported only when Q is still false.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeError`] for non-consecutive steps or concrete expression
+    /// evaluation failures.
+    pub fn observe(
+        &mut self,
+        state: &State,
+        step: usize,
+    ) -> Result<Option<BoundedLivenessViolation>, RuntimeError> {
+        if step != self.next_step {
+            return Err(runtime_error(format!(
+                "bounded liveness expected step {}, got {step}",
+                self.next_step
+            )));
+        }
+        for (property_index, property) in self.properties.iter().enumerate() {
+            for binding in &property.bindings {
+                let key = (property_index, binding.clone());
+                let mut after_binding = binding.clone();
+                let after = as_bool(eval(
+                    &property.definition.after,
+                    state,
+                    &mut after_binding,
+                    &self.model,
+                    None,
+                )?)?;
+                if after {
+                    self.pending.remove(&key);
+                    continue;
+                }
+                if let Some((pending_since, deadline)) = self.pending.get(&key).copied() {
+                    if step >= deadline {
+                        return Ok(Some(BoundedLivenessViolation {
+                            property: property.definition.name.clone(),
+                            bindings: binding.clone(),
+                            pending_since,
+                            deadline,
+                            within: property.within,
+                            step,
+                        }));
+                    }
+                    continue;
+                }
+                let mut before_binding = binding.clone();
+                let before = as_bool(eval(
+                    &property.definition.before,
+                    state,
+                    &mut before_binding,
+                    &self.model,
+                    None,
+                )?)?;
+                if before {
+                    let deadline = step
+                        .checked_add(property.within)
+                        .ok_or_else(|| runtime_error("bounded liveness deadline exceeds usize"))?;
+                    self.pending.insert(key, (step, deadline));
+                    if property.within == 0 {
+                        return Ok(Some(BoundedLivenessViolation {
+                            property: property.definition.name.clone(),
+                            bindings: binding.clone(),
+                            pending_since: step,
+                            deadline: step,
+                            within: 0,
+                            step,
+                        }));
+                    }
+                }
+            }
+        }
+        self.next_step = step
+            .checked_add(1)
+            .ok_or_else(|| runtime_error("bounded liveness step exceeds usize"))?;
+        Ok(None)
+    }
+
+    #[must_use]
+    pub fn status(&self) -> BoundedLivenessStatus {
+        let pending = self
+            .pending
+            .iter()
+            .map(|((property_index, bindings), (pending_since, deadline))| {
+                let property = &self.properties[*property_index];
+                BoundedLivenessPending {
+                    property: property.definition.name.clone(),
+                    bindings: bindings.clone(),
+                    pending_since: *pending_since,
+                    deadline: *deadline,
+                    within: property.within,
+                }
+            })
+            .collect();
+        BoundedLivenessStatus {
+            checked_properties: self
+                .properties
+                .iter()
+                .map(|property| property.definition.name.clone())
+                .collect(),
+            unbounded_properties: self.unbounded_properties.clone(),
+            pending,
+        }
     }
 }
 

--- a/rust/fsl-runtime/tests/bounded_liveness.rs
+++ b/rust/fsl-runtime/tests/bounded_liveness.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use fsl_core::{FsResolver, FslValue, KernelBinder, KernelExpr, build_model, parse_kernel_source};
+use fsl_runtime::{BoundedLivenessMonitor, Monitor};
+
+fn checked_model(source: &str) -> fsl_core::KernelModel {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse kernel");
+    build_model(kernel).expect("build model")
+}
+
+fn step(monitor: &mut Monitor, action: &str, params: &BTreeMap<String, FslValue>) {
+    let result = monitor.attempt(action, params).expect("attempt action");
+    assert!(result.violation.is_none(), "{result:?}");
+}
+
+const LATE_Q: &str = r"
+spec LateQ {
+  type Count = 0..3
+  state { x: Count }
+  init { x = 0 }
+  action step() {
+    requires x < 3
+    x = x + 1
+  }
+  leadsTo Progress { x == 1 ~> within 1 x == 3 }
+}
+";
+
+#[test]
+fn deadline_is_inclusive_and_a_late_response_is_reported_at_the_deadline() {
+    let model = checked_model(LATE_Q);
+    let mut state = Monitor::new(model.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(model).expect("liveness monitor");
+    assert!(
+        liveness
+            .observe(&state.state, 0)
+            .expect("initial")
+            .is_none()
+    );
+
+    step(&mut state, "step", &BTreeMap::new());
+    assert!(
+        liveness
+            .observe(&state.state, 1)
+            .expect("trigger")
+            .is_none()
+    );
+    let pending = liveness.status().pending;
+    assert_eq!(pending[0].pending_since, 1);
+    assert_eq!(pending[0].deadline, 2);
+
+    step(&mut state, "step", &BTreeMap::new());
+    let violation = liveness
+        .observe(&state.state, 2)
+        .expect("deadline")
+        .expect("missed deadline");
+    assert_eq!(violation.property, "Progress");
+    assert_eq!(violation.pending_since, 1);
+    assert_eq!(violation.deadline, 2);
+    assert_eq!(violation.within, 1);
+}
+
+#[test]
+fn response_on_the_deadline_and_simultaneous_zero_window_response_satisfy() {
+    let model = checked_model(&LATE_Q.replace("within 1", "within 2"));
+    let mut state = Monitor::new(model.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(model).expect("liveness monitor");
+    liveness.observe(&state.state, 0).expect("initial");
+    for observation in 1..=3 {
+        step(&mut state, "step", &BTreeMap::new());
+        assert!(
+            liveness
+                .observe(&state.state, observation)
+                .expect("observation")
+                .is_none()
+        );
+    }
+    assert!(liveness.status().pending.is_empty());
+
+    let simultaneous = checked_model(
+        r"
+spec Simultaneous {
+  state { ready: Bool }
+  init { ready = true }
+  leadsTo Already { ready ~> within 0 ready }
+}
+",
+    );
+    let state = Monitor::new(simultaneous.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(simultaneous).expect("liveness monitor");
+    assert!(
+        liveness
+            .observe(&state.state, 0)
+            .expect("initial")
+            .is_none()
+    );
+}
+
+#[test]
+fn zero_window_failure_and_each_static_binding_are_checked() {
+    let zero = checked_model(
+        r"
+spec ZeroWindow {
+  state { ready: Bool }
+  init { ready = false }
+  leadsTo Immediate { not ready ~> within 0 ready }
+}
+",
+    );
+    let state = Monitor::new(zero.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(zero).expect("liveness monitor");
+    let violation = liveness
+        .observe(&state.state, 0)
+        .expect("initial")
+        .expect("zero-window failure");
+    assert_eq!(violation.deadline, 0);
+
+    let bound = checked_model(
+        r"
+spec Bound {
+  type Id = 0..1
+  state { done: Map<Id, Bool> }
+  init { forall i: Id { done[i] = false } }
+  action complete(i: Id) { done[i] = true }
+  leadsTo Each { forall i: Id { not done[i] ~> within 1 done[i] } }
+}
+",
+    );
+    let mut state = Monitor::new(bound.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(bound).expect("liveness monitor");
+    liveness.observe(&state.state, 0).expect("initial");
+    step(
+        &mut state,
+        "complete",
+        &BTreeMap::from([("i".to_owned(), FslValue::Int(0))]),
+    );
+    let violation = liveness
+        .observe(&state.state, 1)
+        .expect("deadline")
+        .expect("binding failure");
+    assert_eq!(violation.bindings["i"], FslValue::Int(1));
+}
+
+#[test]
+fn finite_prefix_reports_pending_and_unbounded_properties_separately() {
+    let model = checked_model(&LATE_Q.replace(
+        "leadsTo Progress { x == 1 ~> within 1 x == 3 }",
+        "leadsTo Progress { x == 1 ~> within 3 x == 3 }\n  leadsTo Eventually { x == 0 ~> x == 3 }",
+    ));
+    let mut state = Monitor::new(model.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(model).expect("liveness monitor");
+    liveness.observe(&state.state, 0).expect("initial");
+    step(&mut state, "step", &BTreeMap::new());
+    liveness.observe(&state.state, 1).expect("trigger");
+    let status = liveness.status();
+    assert_eq!(status.checked_properties, ["Progress"]);
+    assert_eq!(status.unbounded_properties, ["Eventually"]);
+    assert_eq!(status.pending[0].deadline, 4);
+}
+
+#[test]
+fn static_range_binders_use_the_shared_concrete_expansion() {
+    let mut model = checked_model(LATE_Q);
+    model.leadstos[0].binders = vec![KernelBinder::Range {
+        name: "i".to_owned(),
+        lo: Box::new(KernelExpr::Num(0)),
+        hi: Box::new(KernelExpr::Num(1)),
+        where_expr: None,
+    }];
+    let mut state = Monitor::new(model.clone()).expect("state monitor");
+    let mut liveness = BoundedLivenessMonitor::new(model).expect("liveness monitor");
+    liveness.observe(&state.state, 0).expect("initial");
+    step(&mut state, "step", &BTreeMap::new());
+    liveness.observe(&state.state, 1).expect("trigger");
+    step(&mut state, "step", &BTreeMap::new());
+    let violation = liveness
+        .observe(&state.state, 2)
+        .expect("deadline")
+        .expect("binding failure");
+    assert_eq!(violation.bindings["i"], FslValue::Int(0));
+}
+
+#[test]
+fn unsupported_deadline_shapes_fail_closed() {
+    let mut negative = checked_model(LATE_Q);
+    negative.leadstos[0].within = Some(-1);
+    assert!(BoundedLivenessMonitor::new(negative).is_err());
+
+    let mut collection = checked_model(LATE_Q);
+    collection.leadstos[0].binders = vec![KernelBinder::Collection {
+        name: "item".to_owned(),
+        collection: Box::new(KernelExpr::Var("x".to_owned())),
+        where_expr: None,
+    }];
+    assert!(BoundedLivenessMonitor::new(collection).is_err());
+
+    let mut filtered = checked_model(LATE_Q);
+    filtered.leadstos[0].binders = vec![KernelBinder::Range {
+        name: "i".to_owned(),
+        lo: Box::new(KernelExpr::Num(0)),
+        hi: Box::new(KernelExpr::Num(1)),
+        where_expr: Some(Box::new(KernelExpr::Bool(true))),
+    }];
+    assert!(BoundedLivenessMonitor::new(filtered).is_err());
+}

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use fsl_core::{
     FslValue, KernelBinder, KernelModel, LeadsToDef, TraceAction, TraceChange, TraceStep,
+    static_leadsto_bindings,
 };
 use fsl_solver::{ModelValue, SatResult, SmtSolver};
 
@@ -643,30 +644,9 @@ pub(crate) fn leadsto_bindings<S: SmtSolver>(
     model: &KernelModel,
     property: &LeadsToDef,
 ) -> Result<Vec<LeadstoBinding<S::Term>>, VerifyError> {
-    let mut expanded = vec![LeadstoBinding {
-        concrete: BTreeMap::new(),
-        symbolic: Bindings::new(),
-    }];
+    let mut expanded = vec![Bindings::new()];
     for binder in &property.binders {
         let symbolic = binder_values(solver, model, binder)?;
-        let concrete = match binder {
-            KernelBinder::Typed { type_name, .. } => {
-                model.domain_values(&fsl_core::TypeRef::Named(type_name.name.clone()))?
-            }
-            KernelBinder::Range { lo, hi, .. } => {
-                let lo = static_int(lo, model)?;
-                let hi = static_int(hi, model)?;
-                (lo..=hi).map(FslValue::Int).collect()
-            }
-            KernelBinder::Collection { .. } => {
-                return Err(VerifyError::new(
-                    "collection binders are not implemented in bounded leadsTo",
-                ));
-            }
-        };
-        if concrete.len() != symbolic.len() {
-            return Err(VerifyError::new("leadsTo binder expansion mismatch"));
-        }
         let name = match binder {
             KernelBinder::Typed { name, .. }
             | KernelBinder::Range { name, .. }
@@ -674,34 +654,23 @@ pub(crate) fn leadsto_bindings<S: SmtSolver>(
         };
         let mut next = Vec::new();
         for binding in expanded {
-            for (value, (_, term)) in concrete.iter().zip(&symbolic) {
+            for (_, term) in &symbolic {
                 let mut candidate = binding.clone();
-                candidate.concrete.insert(name.clone(), value.clone());
-                candidate.symbolic.insert(name.clone(), term.clone());
+                candidate.insert(name.clone(), term.clone());
                 next.push(candidate);
             }
         }
         expanded = next;
     }
-    Ok(expanded)
-}
-
-fn static_int(expr: &fsl_core::KernelExpr, model: &KernelModel) -> Result<i64, VerifyError> {
-    match expr {
-        fsl_core::KernelExpr::Num(value) => Ok(*value),
-        fsl_core::KernelExpr::Var(name) => match model.consts.get(name) {
-            Some(FslValue::Int(value)) => Ok(*value),
-            _ => Err(VerifyError::new(format!(
-                "'{name}' is not an integer constant"
-            ))),
-        },
-        fsl_core::KernelExpr::Neg(value) => static_int(value, model)?
-            .checked_neg()
-            .ok_or_else(|| VerifyError::new("integer overflow in leadsTo binder")),
-        _ => Err(VerifyError::new(
-            "leadsTo range binder must use static integer bounds",
-        )),
+    let concrete = static_leadsto_bindings(model, property)?;
+    if concrete.len() != expanded.len() {
+        return Err(VerifyError::new("leadsTo binder expansion mismatch"));
     }
+    Ok(concrete
+        .into_iter()
+        .zip(expanded)
+        .map(|(concrete, symbolic)| LeadstoBinding { concrete, symbolic })
+        .collect())
 }
 
 pub(crate) fn leadsto_condition<S: SmtSolver>(

--- a/rust/fsl-verifier/tests/leadsto_within_deadline.rs
+++ b/rust/fsl-verifier/tests/leadsto_within_deadline.rs
@@ -51,6 +51,23 @@ fn within_deadline_miss_is_detected_at_every_depth_at_or_beyond_the_deadline() {
         assert_eq!(details.pending_since, 1, "depth {depth}: {leadsto:?}");
         assert_eq!(details.deadline, Some(2), "depth {depth}: {leadsto:?}");
         assert!(!details.stutter, "depth {depth}: {leadsto:?}");
+
+        let mut runtime = fsl_runtime::BoundedLivenessMonitor::new(model.clone())
+            .expect("runtime liveness monitor");
+        let mut runtime_violation = None;
+        for (step, observation) in leadsto.trace.iter().enumerate() {
+            runtime_violation = runtime
+                .observe(&observation.state, step)
+                .expect("runtime observation");
+            if runtime_violation.is_some() {
+                break;
+            }
+        }
+        let runtime = runtime_violation.expect("runtime deadline violation");
+        assert_eq!(runtime.property, leadsto.name);
+        assert_eq!(runtime.bindings, details.bindings);
+        assert_eq!(runtime.pending_since, details.pending_since);
+        assert_eq!(Some(runtime.deadline), details.deadline);
     }
 }
 
@@ -74,4 +91,19 @@ fn within_deadline_met_stays_verified_beyond_the_deadlock_step() {
             "depth {depth}: {result:?}"
         );
     }
+}
+
+#[test]
+fn bounded_leadsto_where_filters_fail_closed_in_bmc() {
+    let source = LATE_Q.replace(
+        "leadsTo Progress { x == 1 ~> within 1 x == 3 }",
+        "leadsTo Progress { forall i: Count where i > 0 { x == 1 ~> within 1 x == 3 } }",
+    );
+    let kernel =
+        parse_kernel_source(&source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect_err("where filters must fail closed");
+    assert!(error.message.contains("where filters"), "{error}");
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2699,6 +2699,18 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         Ok(monitor) => monitor,
         Err(error) => return (semantic_error_output(&error.to_string()), 2),
     };
+    let mut bounded_liveness = if matches!(
+        &trace.contract,
+        fslc_rust::replay_trace::ReplayTraceContract::V1 { schema_version, .. }
+            if schema_version == fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+    ) {
+        match fsl_runtime::BoundedLivenessMonitor::new(model.clone()) {
+            Ok(monitor) => Some(monitor),
+            Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        }
+    } else {
+        None
+    };
     if let Some(observed) = observed_initial {
         let expected = fslc_rust::state_json(&monitor.state);
         let mismatches = json_mismatches(&expected, &observed, "");
@@ -2708,6 +2720,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                 None,
                 json!({
                     "kind":"initial_state_mismatch",
+                    "check":"safety",
                     "tick":0,
                     "expected_state":expected,
                     "observed_state":observed,
@@ -2723,6 +2736,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                     None,
                     json!({
                         "kind":violation.kind,
+                        "check":"safety",
                         "name":display(&violation.name),
                         "tick":0,
                     }),
@@ -2731,6 +2745,20 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
             }
             Ok(None) => {}
             Err(error) => return (error_output("internal", &error.to_string()), 3),
+        }
+        if let Some(liveness) = &mut bounded_liveness {
+            match liveness.observe(&monitor.state, 0) {
+                Ok(Some(violation)) => {
+                    return replay_bounded_liveness_failure(
+                        &model,
+                        None,
+                        &violation,
+                        fslc_rust::state_json(&monitor.state),
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => return (error_output("internal", &error.to_string()), 3),
+            }
         }
     }
     for (index, event) in trace.events.iter().enumerate() {
@@ -2745,6 +2773,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                             index,
                             json!({
                                 "kind":violation.kind,
+                                "check":"safety",
                                 "name":display(&violation.name),
                                 "action":Value::Null,
                                 "params":{},
@@ -2771,6 +2800,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                         index,
                         json!({
                             "kind": "bad_call",
+                            "check":"safety",
                             "message": format!("unknown action '{action_name}'"),
                             "action": action_name,
                             "params": params,
@@ -2794,6 +2824,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                                 index,
                                 json!({
                                     "kind": "bad_call",
+                                    "check":"safety",
                                     "message": message,
                                     "action": action_name,
                                     "params": params,
@@ -2813,6 +2844,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                         index,
                         json!({
                             "kind": violation.kind,
+                            "check":"safety",
                             "name": display(&violation.name),
                             "action": display(&action.name),
                             "params": params,
@@ -2839,6 +2871,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                     Some(index),
                     json!({
                         "kind":"state_mismatch",
+                        "check":"safety",
                         "tick":event.tick,
                         "action":action_evidence,
                         "transition":transition,
@@ -2850,6 +2883,20 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                 );
             }
         }
+        if let Some(liveness) = &mut bounded_liveness {
+            match liveness.observe(&monitor.state, index + 1) {
+                Ok(Some(violation)) => {
+                    return replay_bounded_liveness_failure(
+                        &model,
+                        Some(index),
+                        &violation,
+                        state_before,
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => return (error_output("internal", &error.to_string()), 3),
+            }
+        }
     }
     let mut output = envelope();
     output.insert("result".to_owned(), json!("conformant"));
@@ -2859,9 +2906,16 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         "final_state".to_owned(),
         fslc_rust::state_json(&monitor.state),
     );
+    let bounded_status = bounded_liveness
+        .as_ref()
+        .map(fsl_runtime::BoundedLivenessMonitor::status);
     output.insert(
         "note".to_owned(),
-        json!("leadsTo properties are not checked by replay (finite logs only)"),
+        json!(if bounded_status.is_some() {
+            "bounded leadsTo deadlines were checked over this finite observation prefix; unbounded leadsTo properties remain unchecked"
+        } else {
+            "leadsTo properties are not checked by replay (finite logs only)"
+        }),
     );
     if let fslc_rust::replay_trace::ReplayTraceContract::V1 {
         schema_version,
@@ -2869,13 +2923,90 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
         ..
     } = trace.contract
     {
-        output.insert("trace_schema_version".to_owned(), json!(schema_version));
+        output.insert(
+            "trace_schema_version".to_owned(),
+            json!(schema_version.clone()),
+        );
         output.insert(
             "kernel_schema_version".to_owned(),
             json!(kernel_schema_version),
         );
+        output.insert(
+            "checks".to_owned(),
+            json!({
+                "safety":{
+                    "status":"passed",
+                    "observations_checked":trace.events.len() + 1,
+                },
+                "bounded_liveness":bounded_status.as_ref().map_or_else(
+                    || json!({
+                        "status":"not_checked",
+                        "reason":format!(
+                            "trace schema_version '{}' requires '{}' for bounded liveness",
+                            schema_version,
+                            fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION,
+                        ),
+                    }),
+                    bounded_liveness_status_json,
+                ),
+            }),
+        );
     }
     (Value::Object(output), 0)
+}
+
+fn bounded_liveness_status_json(status: &fsl_runtime::BoundedLivenessStatus) -> Value {
+    json!({
+        "status":if status.pending.is_empty() { "passed" } else { "pending" },
+        "checked_properties":status.checked_properties,
+        "unbounded_properties":status.unbounded_properties,
+        "pending":status.pending.iter().map(|pending| json!({
+            "property":pending.property,
+            "bindings":replay_liveness_bindings_json(&pending.bindings),
+            "pending_since":pending.pending_since,
+            "deadline":pending.deadline,
+            "within":pending.within,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn replay_liveness_bindings_json(bindings: &fsl_runtime::Bindings) -> Value {
+    Value::Object(
+        bindings
+            .iter()
+            .map(|(name, value)| (name.clone(), fslc_rust::fsl_value_json(value)))
+            .collect(),
+    )
+}
+
+fn replay_bounded_liveness_failure(
+    model: &KernelModel,
+    index: Option<usize>,
+    violation: &fsl_runtime::BoundedLivenessViolation,
+    state_before: Value,
+) -> (Value, i32) {
+    let (mut output, code) = replay_failure_with_state(
+        model,
+        index,
+        json!({
+            "kind":"leadsTo",
+            "check":"bounded_liveness",
+            "property":violation.property,
+            "bindings":replay_liveness_bindings_json(&violation.bindings),
+            "pending_since":violation.pending_since,
+            "deadline":violation.deadline,
+            "within":violation.within,
+            "tick":violation.step,
+        }),
+        state_before,
+    );
+    output["note"] = json!(
+        "a bounded leadsTo deadline was missed on this finite observation prefix; unbounded leadsTo properties remain unchecked"
+    );
+    output["hint"] = json!(
+        "the implementation did not reach the leadsTo response by its inclusive observation deadline"
+    );
+    (output, code)
 }
 
 fn replay_snapshot_json(

--- a/rust/fslc/src/replay_trace.rs
+++ b/rust/fslc/src/replay_trace.rs
@@ -119,12 +119,15 @@ fn parse_v1(data: Value) -> Result<ReplayTraceInput, String> {
     }
     if !matches!(
         trace.schema_version.as_str(),
-        fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION | fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+        fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION
+            | fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION
+            | fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
     ) {
         return Err(format!(
-            "unsupported replay trace schema_version '{}'; expected '{}' or '{}'",
+            "unsupported replay trace schema_version '{}'; expected '{}', '{}', or '{}'",
             trace.schema_version,
             fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION,
+            fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION,
             fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
         ));
     }
@@ -192,14 +195,18 @@ fn parse_v1_step(
             "replay trace event {index} action must not be empty"
         )),
         Value::Null
-            if schema_version == fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION && params.is_empty() =>
+            if matches!(
+                schema_version,
+                fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION
+                    | fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+            ) && params.is_empty() =>
         {
             Ok(ReplayStep::Stutter)
         }
         Value::Null if schema_version == fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION => {
             Err(format!(
                 "replay trace event {index} stutter requires schema_version '{}'",
-                fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
+                fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION
             ))
         }
         Value::Null => Err(format!(
@@ -333,9 +340,14 @@ mod tests {
     #[test]
     fn v1_1_adds_explicit_stutter_without_reserving_an_action_name() {
         let mut stutter = versioned();
+        stutter["schema_version"] = json!(fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION);
         stutter["events"][0]["action"] = Value::Null;
         let parsed = parse_replay_trace(stutter.clone()).expect("v1.1 stutter");
         assert_eq!(parsed.events[0].step, ReplayStep::Stutter);
+
+        let mut current = stutter.clone();
+        current["schema_version"] = json!(fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION);
+        assert!(parse_replay_trace(current).is_ok());
 
         stutter["schema_version"] = json!(fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION);
         assert!(parse_replay_trace(stutter).is_err());

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -593,6 +593,7 @@ fn published_schema_ids_match_the_rust_api_constants() {
         replay_trace["properties"]["schema_version"]["enum"],
         json!([
             fsl_core::REPLAY_TRACE_V1_INITIAL_SCHEMA_VERSION,
+            fsl_core::REPLAY_TRACE_V1_STUTTER_SCHEMA_VERSION,
             fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION
         ])
     );

--- a/rust/fslc/tests/replay_trace_contract.rs
+++ b/rust/fslc/tests/replay_trace_contract.rs
@@ -14,6 +14,15 @@ fn fixture(name: &str) -> PathBuf {
         .join(name)
 }
 
+fn nfr_example(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .join("examples/nfr")
+        .join(name)
+}
+
 fn replay(trace: &str) -> Output {
     replay_path(&fixture(trace))
 }
@@ -73,6 +82,96 @@ fn reporting_a_transient_intermediate_as_an_observation_is_nonconformant() {
     assert_eq!(value["violation"]["action"], Value::Null);
     assert_eq!(value["violation"]["transition"], "stutter");
     assert_eq!(value["violation"]["mismatches"][0]["path"], "value");
+}
+
+#[test]
+fn trace_v1_2_checks_bounded_liveness_and_reports_finite_prefix_status() {
+    let spec = nfr_example("bounded_response.fsl");
+    let within = replay_spec_path(&spec, &nfr_example("bounded_response.within.v1.json"));
+    assert!(within.status.success());
+    let within = json(&within);
+    assert_eq!(within["checks"]["safety"]["status"], "passed");
+    assert_eq!(within["checks"]["bounded_liveness"]["status"], "passed");
+    assert_eq!(
+        within["checks"]["bounded_liveness"]["checked_properties"],
+        json!(["RespondsInTwo"])
+    );
+    assert_eq!(
+        within["checks"]["bounded_liveness"]["unbounded_properties"],
+        json!(["EventuallyResponds"])
+    );
+
+    let mut prefix: Value = serde_json::from_str(
+        &std::fs::read_to_string(nfr_example("bounded_response.within.v1.json")).expect("fixture"),
+    )
+    .expect("trace JSON");
+    prefix["events"].as_array_mut().expect("events").truncate(1);
+    let path = write_trace(&prefix);
+    let output = replay_spec_path(&spec, &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert!(output.status.success());
+    let output = json(&output);
+    assert_eq!(output["checks"]["bounded_liveness"]["status"], "pending");
+    assert_eq!(
+        output["checks"]["bounded_liveness"]["pending"][0]["pending_since"],
+        1
+    );
+    assert_eq!(
+        output["checks"]["bounded_liveness"]["pending"][0]["deadline"],
+        3
+    );
+}
+
+#[test]
+fn overdue_bounded_response_is_liveness_nonconformance_after_safety() {
+    let spec = nfr_example("bounded_response.fsl");
+    let overdue_path = nfr_example("bounded_response.overdue.v1.json");
+    let overdue = replay_spec_path(&spec, &overdue_path);
+    assert_eq!(overdue.status.code(), Some(1));
+    let overdue = json(&overdue);
+    assert_eq!(overdue["failed_at_event"], 2);
+    assert_eq!(overdue["violation"]["kind"], "leadsTo");
+    assert_eq!(overdue["violation"]["check"], "bounded_liveness");
+    assert_eq!(overdue["violation"]["property"], "RespondsInTwo");
+    assert_eq!(overdue["violation"]["pending_since"], 1);
+    assert_eq!(overdue["violation"]["deadline"], 3);
+    assert_eq!(overdue["violation"]["tick"], 3);
+
+    let mut action_at_deadline: Value =
+        serde_json::from_str(&std::fs::read_to_string(&overdue_path).expect("fixture"))
+            .expect("trace JSON");
+    action_at_deadline["events"][2] =
+        json!({"tick":3,"action":"advance","params":{},"state":{"stage":2}});
+    let path = write_trace(&action_at_deadline);
+    let output = replay_spec_path(&spec, &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert_eq!(output.status.code(), Some(1));
+    let action_at_deadline = json(&output);
+    assert_eq!(action_at_deadline["violation"]["check"], "bounded_liveness");
+    assert_eq!(action_at_deadline["state_before"]["stage"], 1);
+
+    let mut mismatch: Value =
+        serde_json::from_str(&std::fs::read_to_string(&overdue_path).expect("fixture"))
+            .expect("trace JSON");
+    mismatch["events"][2]["state"]["stage"] = json!(2);
+    let path = write_trace(&mismatch);
+    let output = replay_spec_path(&spec, &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(json(&output)["violation"]["check"], "safety");
+
+    let mut old_semantics: Value =
+        serde_json::from_str(&std::fs::read_to_string(overdue_path).expect("fixture"))
+            .expect("trace JSON");
+    old_semantics["schema_version"] = json!("1.1.0");
+    let path = write_trace(&old_semantics);
+    let output = replay_spec_path(&spec, &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert!(output.status.success());
+    assert_eq!(
+        json(&output)["checks"]["bounded_liveness"]["status"],
+        "not_checked"
+    );
 }
 
 fn replay_value(value: &Value) -> Output {
@@ -261,6 +360,9 @@ fn release_bundles_include_the_schema_spec_and_positive_and_negative_goldens() {
         "replay_observation.fsl",
         "replay_observation.valid.v1.json",
         "replay_observation.transient-observed.v1.json",
+        "bounded_response.fsl",
+        "bounded_response.within.v1.json",
+        "bounded_response.overdue.v1.json",
     ] {
         assert_eq!(workflow.matches(artifact).count(), 2, "{artifact}");
     }

--- a/schemas/fslc/kernel/replay-trace.v1.schema.json
+++ b/schemas/fslc/kernel/replay-trace.v1.schema.json
@@ -7,7 +7,7 @@
   "required": ["$schema", "schema_version", "kernel_schema_version", "spec", "initial", "events"],
   "properties": {
     "$schema": { "const": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json" },
-    "schema_version": { "enum": ["1.0.0", "1.1.0"] },
+    "schema_version": { "enum": ["1.0.0", "1.1.0", "1.2.0"] },
     "kernel_schema_version": { "enum": ["1.0.0", "2.0.0"] },
     "spec": { "type": "string", "minLength": 1 },
     "initial": { "$ref": "#/$defs/state" },

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -863,6 +863,12 @@ state divergence is exit 1 with leaf mismatches. Bare arrays/`{events}` are the
 unversioned action-only compatibility adapter; testgen/verifier traces are not
 replay input. See `docs/DESIGN-replay-trace.md`.
 
+Schema 1.2 opts into solver-free bounded-liveness replay. Every
+`leadsTo P ~> within K Q` is observed at tick 0 and after each action/stutter;
+`Q` at the inclusive deadline succeeds and absence of `Q` fails. Safety is
+reported first and separately. A finite unfinished obligation is `pending`, and
+unbounded `leadsTo` is listed as unchecked. Schema 1.0/1.1 stays safety-only.
+
 Use native `fslc kernel` as the stable compiler boundary after dialect lowering
 and type checking. Do not consume the frozen Python AST JSON or reparse expression
 strings: every exported expression has a structural type and span, actions and

--- a/tests/oracle.py
+++ b/tests/oracle.py
@@ -17,7 +17,7 @@ import subprocess
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from fslc.cli import exit_code, run_verify
 from fslc.model import FslError, domain_range
@@ -54,6 +54,69 @@ class OracleResult:
 
 class UnsupportedOracle(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class BoundedPropertyOracle:
+    name: str
+    before: Callable[[dict[str, Any]], bool]
+    after: Callable[[dict[str, Any]], bool]
+    within: int
+
+
+def bounded_liveness_oracle(
+    observations: list[dict[str, Any]],
+    properties: list[BoundedPropertyOracle],
+) -> dict[str, Any]:
+    """Independent finite-prefix oracle for unbound ``leadsTo ... within``.
+
+    Observation index is the logical tick, including stutters. Q may hold on
+    the deadline observation. A remaining obligation is pending, not proof of
+    either satisfaction or failure.
+    """
+    pending: dict[str, int] = {}
+    for step, state in enumerate(observations):
+        for prop in properties:
+            if prop.within < 0:
+                raise UnsupportedOracle("leadsTo within must be non-negative")
+            if prop.after(state):
+                pending.pop(prop.name, None)
+                continue
+            pending_since = pending.get(prop.name)
+            if pending_since is not None:
+                deadline = pending_since + prop.within
+                if step >= deadline:
+                    return {
+                        "status": "violated",
+                        "property": prop.name,
+                        "pending_since": pending_since,
+                        "deadline": deadline,
+                        "within": prop.within,
+                        "tick": step,
+                    }
+                continue
+            if prop.before(state):
+                pending[prop.name] = step
+                if prop.within == 0:
+                    return {
+                        "status": "violated",
+                        "property": prop.name,
+                        "pending_since": step,
+                        "deadline": step,
+                        "within": 0,
+                        "tick": step,
+                    }
+    obligations = [
+        {
+            "property": prop.name,
+            "pending_since": pending[prop.name],
+            "deadline": pending[prop.name] + prop.within,
+            "within": prop.within,
+        }
+        for prop in properties
+        if prop.name in pending
+    ]
+    return {"status": "pending" if obligations else "passed", "pending": obligations}
 
 
 def normalize(value: Any) -> Any:

--- a/tests/snapshots/corpus_snapshot.json
+++ b/tests/snapshots/corpus_snapshot.json
@@ -1160,6 +1160,12 @@
       "warnings": []
     }
   },
+  "examples/nfr/bounded_response.fsl": {
+    "check": {
+      "result": "ok",
+      "warnings": []
+    }
+  },
   "examples/nfr/sla_worker.fsl": {
     "check": {
       "result": "ok",

--- a/tests/test_bounded_liveness_oracle.py
+++ b/tests/test_bounded_liveness_oracle.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from oracle import BoundedPropertyOracle, bounded_liveness_oracle
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUST = ROOT / "rust" / "target" / "debug" / "fslc"
+SPEC = ROOT / "examples" / "nfr" / "bounded_response.fsl"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_native_cli():
+    subprocess.run(
+        ["cargo", "build", "--quiet", "--locked", "-p", "fslc-rust"],
+        cwd=ROOT / "rust",
+        check=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["bounded_response.within.v1.json", "bounded_response.overdue.v1.json"],
+)
+def test_native_bounded_liveness_matches_the_z3_free_oracle(fixture: str):
+    trace_path = ROOT / "examples" / "nfr" / fixture
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    states = [trace["initial"], *(event["state"] for event in trace["events"])]
+    oracle = bounded_liveness_oracle(
+        states,
+        [
+            BoundedPropertyOracle(
+                name="RespondsInTwo",
+                before=lambda state: state["stage"] == 1,
+                after=lambda state: state["stage"] == 3,
+                within=2,
+            )
+        ],
+    )
+    completed = subprocess.run(
+        [str(RUST), "replay", str(SPEC), "--trace", str(trace_path)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    native = json.loads(completed.stdout)
+
+    if oracle["status"] == "violated":
+        assert completed.returncode == 1
+        assert native["violation"]["check"] == "bounded_liveness"
+        for key in ["property", "pending_since", "deadline", "within", "tick"]:
+            assert native["violation"][key] == oracle[key]
+    else:
+        assert completed.returncode == 0
+        assert native["checks"]["bounded_liveness"]["status"] == oracle["status"]


### PR DESCRIPTION
## Problem

Replay could validate observation-point safety, but finite external traces could not mechanically reject missed bounded `leadsTo` deadlines.

## Contract change

- add replay-trace schema `1.2.0` as an explicit bounded-liveness opt-in
- monitor `leadsTo P ~> within K Q` at tick 0 and every action/stutter observation, with an inclusive deadline
- report safety and bounded liveness separately; preserve finite-prefix `pending` and identify unchecked unbounded properties
- share static binder expansion between runtime and BMC and fail closed for unsupported collection/`where` binders
- keep trace schemas 1.0/1.1 safety-only

## Evidence

- focused runtime, verifier, replay-contract, and Python oracle tests
- native BMC counterexample/runtime monitor differential check
- positive, overdue, action-at-deadline, `within 0`, typed/range binding, stutter, safety-precedence, and fail-closed regressions
- full Rust workspace fmt, Clippy, test, and build gates
- Python Rust CLI compatibility and oracle tests; full Python suite
- independent review completed; one diagnostic `state_before` issue found and fixed

## Documentation and distribution

Updated the accepted replay/temporal/NFR/kernel designs, language guide, shared FSL reference, generated language pages, NFR examples, release bundles, and changelog.

Closes #225
