### PR TITLE
feat(parser): support literate Markdown FSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ tasks/active.md
 # Generated docs search index (bleve) — regenerable, not tracked
 docs/index.bleve/
 
+# fslc literate-Markdown materialization sibling (transient; leaked only on a crash)
+*.literate.fsl
+
 # Relational Design plugin local trace/session state — working scratch for the
 # design process, not a repo deliverable (the decisions land in docs/DESIGN-*.md)
 .relational-design/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
-- Literate Markdown FSL: `fslc check` and `fslc verify` now accept `.md` files
-  containing ` ```fsl ` fenced code blocks directly. Lines outside fsl blocks
-  are blanked in place so that diagnostic positions (line numbers, columns,
-  counterexample locs) point to the original Markdown document. Multiple fsl
-  blocks form one compilation unit; files without fsl fences are rejected with
-  a clear diagnostic (issue #193).
+- Literate Markdown FSL: `fslc check`, `fslc verify`, and `fslc scenarios` now
+  accept `.md` files containing ` ```fsl ` fenced code blocks directly. Lines
+  outside fsl blocks are blanked in place so that diagnostic positions (line
+  numbers, columns, counterexample locs) point to the original Markdown
+  document. Multiple fsl blocks form one compilation unit; files without fsl
+  fences are rejected with a clear diagnostic. Fence detection follows the
+  CommonMark grammar (backtick or tilde runs of length >= 3, matched by
+  character and length), so a non-fsl fence can safely contain a literal
+  ` ```fsl ` example. The verify cache key is stable across repeated runs of
+  the same document (issue #193).
 - `fslc-lsp` is now a native Rust language server backed directly by the authoritative
   syntax, core, and analysis implementation. Existing diagnostics, navigation, symbols,
   rename, semantic tokens, completion, hover, and code actions no longer require Python;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Literate Markdown FSL: `fslc check` and `fslc verify` now accept `.md` files
+  containing ` ```fsl ` fenced code blocks directly. Lines outside fsl blocks
+  are blanked in place so that diagnostic positions (line numbers, columns,
+  counterexample locs) point to the original Markdown document. Multiple fsl
+  blocks form one compilation unit; files without fsl fences are rejected with
+  a clear diagnostic (issue #193).
 - `fslc-lsp` is now a native Rust language server backed directly by the authoritative
   syntax, core, and analysis implementation. Existing diagnostics, navigation, symbols,
   rename, semantic tokens, completion, hover, and code actions no longer require Python;

--- a/docs/DESIGN-literate.md
+++ b/docs/DESIGN-literate.md
@@ -1,0 +1,110 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Literate Markdown FSL
+
+Issue: #193.
+
+## 1. Motivation
+
+FSL's default stance is spec-as-doc (`.fsl` files are the canonical source).
+In settings where natural-language Markdown is the canonical document —
+customer contracts, non-engineer-maintained requirements — a `.fsl` file
+becomes a secondary derivative and the doc↔spec drift surface grows.
+Literate Markdown FSL closes that gap by making the Markdown document itself
+the verification target: ` ```fsl ` fenced code blocks are extracted in place
+and verified as a single compilation unit.
+
+## 2. Design
+
+### In-place blanking
+
+Lines outside ` ```fsl ` fences are replaced with empty lines.  This
+preserves byte offsets, line numbers, and column positions so that every
+diagnostic — parse errors, type errors, counterexample locations — points
+to the Markdown document's own lines without any position remapping.
+
+The blanking function (`fsl_syntax::extract_literate_fsl`) returns `None`
+when no ` ```fsl ` fence is found, so non-literate `.md` files are never
+misidentified.
+
+### Materialization
+
+The native CLI (`fslc`) materializes the blanked text to a sibling
+`.literate.fsl` file next to the original `.md`, passes that path to the
+existing check/verify pipeline, and removes the sibling on completion
+(via a `Drop` guard).  This design avoids modifying every independent
+`read_to_string` call site in the CLI — the blanked file is read from disk
+by all existing code paths, and positions are correct because blanking
+preserves line structure.
+
+The sibling file requires write access to the source directory and is
+visible to concurrent processes during the CLI run.  This is acceptable
+for a local developer tool; a future design could use an in-memory buffer
+instead of a sibling file, but that would require a shared-source-loader
+refactoring across the ~8 independent `read_to_string` call sites in the
+CLI.
+
+### Multiple blocks
+
+Multiple ` ```fsl ` blocks in one document form one compilation unit.
+Definitions can be split across sections (e.g. state in one block, actions
+in another).  The parser sees the concatenated blanked text and applies
+its normal grammar.
+
+### Detection
+
+A `.md` file extension triggers literate mode.  If the file contains no
+` ```fsl ` fences, the CLI reports a clear error rather than feeding
+empty text to the parser.  Non-fsl fenced blocks (` ```python `, etc.)
+are ignored.
+
+### `use`/compose path resolution
+
+Import paths resolve relative to the Markdown file's parent directory,
+matching the existing behavior for `.fsl` files (via `FsResolver`).
+No code change was needed.
+
+### Cache key
+
+`collect_fsl_sources` (verify cache-key computation) includes `.md` files
+in directory walks so that edits to literate Markdown specs invalidate
+the verification cache.
+
+## 3. Scope boundaries
+
+### WASM / browser Worker
+
+The browser Worker receives source text directly from the application, not
+a file path.  Literate extraction is the application's responsibility:
+call `extract_literate_fsl` (exported by `fsl-syntax`) before passing the
+blanked text to the Worker.  The Worker does not inspect `source_file`
+extensions.
+
+### CLI contract
+
+The CLI contract's `file` positional argument accepts any file path and
+does not constrain extensions.  Literate support is a runtime behavior
+triggered by the `.md` extension, not a contract schema change.
+
+### Frozen Python reference
+
+The frozen Python implementation is not changed.  Literate Markdown is
+a Rust-only feature (same policy as `--engine explicit`, `--engine auto`,
+and `approval`).
+
+### LSP
+
+The current LSP is Python-based (#310 tracks its Rust migration).
+Literate Markdown support in the LSP is deferred until the Rust LSP
+exists; the `extract_literate_fsl` function in `fsl-syntax` is ready
+for it.
+
+## 4. Test evidence
+
+- `rust/fsl-syntax/src/literate.rs`: 6 unit tests (extraction, line-count
+  preservation, multi-block, no-fsl-fence rejection, non-fsl fence
+  isolation, mixed fences).
+- `rust/fslc/tests/literate_markdown.rs`: 8 CLI integration tests (check,
+  verify, scenarios, parse-error loc mapping, no-fsl rejection, non-fsl
+  rejection, multi-block = single-block verdict, materialized-file
+  cleanup).
+- `examples/literate/toggle.md`: canonical literate example.

--- a/docs/DESIGN-literate.md
+++ b/docs/DESIGN-literate.md
@@ -29,19 +29,31 @@ misidentified.
 ### Materialization
 
 The native CLI (`fslc`) materializes the blanked text to a sibling
-`.literate.fsl` file next to the original `.md`, passes that path to the
-existing check/verify pipeline, and removes the sibling on completion
-(via a `Drop` guard).  This design avoids modifying every independent
-`read_to_string` call site in the CLI — the blanked file is read from disk
-by all existing code paths, and positions are correct because blanking
-preserves line structure.
+`.{stem}.literate.fsl` file next to the original `.md` (e.g. `toggle.md`
+materializes to `.toggle.literate.fsl`), passes that path to the existing
+check/verify pipeline, and removes the sibling on completion (via a `Drop`
+guard).  This design avoids modifying every independent `read_to_string`
+call site in the CLI — the blanked file is read from disk by all existing
+code paths, and positions are correct because blanking preserves line
+structure.  The materialized path is used only to read source content;
+every user-visible label in the CLI's JSON output (`file` fields, migration
+and implicit-initial-value finding locations) is stamped with the original
+`.md` path instead, so machine-readable output never names the transient
+sibling.
 
-The sibling file requires write access to the source directory and is
-visible to concurrent processes during the CLI run.  This is acceptable
-for a local developer tool; a future design could use an in-memory buffer
-instead of a sibling file, but that would require a shared-source-loader
-refactoring across the ~8 independent `read_to_string` call sites in the
-CLI.
+The sibling filename is deterministic (no process ID component) so that the
+verify cache key — which is keyed in part on the canonicalized path passed
+to the check/verify pipeline — stays stable across repeated runs of the same
+document (see "Cache key" below). The sibling file requires write access to
+the source directory and is visible to concurrent processes during the CLI
+run: two concurrent runs on the same `.md` document write identical bytes
+(both blank from the same source), so a race is at worst a redundant write,
+never a wrong verdict; the only failure mode is one run's read losing to
+another process's deletion of the sibling mid-read, which errors loudly
+rather than silently misreading. This is acceptable for a local developer
+tool; a future design could use an in-memory buffer instead of a sibling
+file, but that would require a shared-source-loader refactoring across the
+~8 independent `read_to_string` call sites in the CLI.
 
 ### Multiple blocks
 
@@ -57,26 +69,59 @@ A `.md` file extension triggers literate mode.  If the file contains no
 empty text to the parser.  Non-fsl fenced blocks (` ```python `, etc.)
 are ignored.
 
+Fence recognition follows the CommonMark fenced-code-block grammar rather
+than a fixed triple-backtick check: an opening fence is a line whose
+trimmed form starts with a run of three or more backticks or tildes, and
+the block is an fsl block iff the first whitespace-separated token of the
+info string (the text after that run) is exactly `fsl`. A closing fence is
+a line whose trimmed form is a run of the *same* character, at least as
+long as the opening run, followed by nothing else — so a shorter or
+differently-charactered run, or a run followed by trailing text (e.g.
+` ``` foo `), does not close the block and is ordinary content instead.
+While inside a fence, lines are checked only for closing; a line that looks
+like an opening fence is content of the current block, never a nested
+fence — this is what lets a non-fsl four-backtick (or `~~~~`) fence safely
+contain a literal ` ```fsl ` example without corrupting extraction. An
+unterminated fence runs to end of file.
+
 ### `use`/compose path resolution
 
 Import paths resolve relative to the Markdown file's parent directory,
 matching the existing behavior for `.fsl` files (via `FsResolver`).
-No code change was needed.
+No code change was needed.  A literate `.md` may `use`/compose `.fsl` files
+relative to its own directory; using another `.md` file as a compose target
+is not supported.
 
 ### Cache key
 
 `collect_fsl_sources` (verify cache-key computation) includes `.md` files
-in directory walks so that edits to literate Markdown specs invalidate
-the verification cache.
+in directory walks so that edits to literate Markdown specs invalidate the
+verification cache. The transient `.{stem}.literate.fsl` materialization
+(see "Materialization" above) is excluded from that walk by filename suffix
+— its content is already represented by the `.md` file itself through this
+same function's Markdown branch, so including it too would double-count it
+and, before the sibling's filename was made deterministic, made every run's
+cache key unique (the walk picked up the run-local sibling as if it were an
+independent dependency). The cache key's `path` field is the canonicalized
+path passed to the check/verify pipeline (the materialized sibling for a
+literate `.md`), which is why the sibling's filename must be deterministic
+rather than PID-suffixed — otherwise the key would never repeat across runs
+of the same document.
 
 ## 3. Scope boundaries
 
 ### WASM / browser Worker
 
 The browser Worker receives source text directly from the application, not
-a file path.  Literate extraction is the application's responsibility:
-call `extract_literate_fsl` (exported by `fsl-syntax`) before passing the
-blanked text to the Worker.  The Worker does not inspect `source_file`
+a file path, and `fsl-wasm` exports only `run` and `internal_error` via
+`wasm_bindgen` — `extract_literate_fsl` is a plain Rust function on
+`fsl-syntax`, not reachable from JavaScript.  Literate extraction is
+therefore the embedding application's responsibility, performed in JS (or by
+any tool that strips non-fsl lines while preserving line positions) before
+the blanked text is passed to the Worker.  `extract_literate_fsl` is
+available as-is to Rust embedders of `fsl-syntax`; exposing an equivalent
+through `fsl-wasm` for JS callers is possible future work, not something
+this design relies on today.  The Worker does not inspect `source_file`
 extensions.
 
 ### CLI contract
@@ -93,18 +138,24 @@ and `approval`).
 
 ### LSP
 
-The current LSP is Python-based (#310 tracks its Rust migration).
-Literate Markdown support in the LSP is deferred until the Rust LSP
-exists; the `extract_literate_fsl` function in `fsl-syntax` is ready
-for it.
+The native Rust language server (`rust/fsl-lsp`, issue #310) does not yet
+handle `.md` documents — its document index and
+diagnostics pipeline are wired to `.fsl` sources only. Literate Markdown
+support in `fsl-lsp` is deferred follow-up work; `extract_literate_fsl` in
+`fsl-syntax` is ready for it (the same blanking function the CLI uses would
+let the LSP index a `.md` document's fsl fences with correct line positions
+without a separate code path).
 
 ## 4. Test evidence
 
-- `rust/fsl-syntax/src/literate.rs`: 6 unit tests (extraction, line-count
+- `rust/fsl-syntax/src/literate.rs`: 10 unit tests (extraction, line-count
   preservation, multi-block, no-fsl-fence rejection, non-fsl fence
-  isolation, mixed fences).
-- `rust/fslc/tests/literate_markdown.rs`: 8 CLI integration tests (check,
+  isolation, mixed fences, four-backtick fence containing a literal
+  ` ```fsl ` example, tilde-fenced non-fsl block, `~~~fsl` fence, backtick
+  run with trailing text staying content inside an fsl block).
+- `rust/fslc/tests/literate_markdown.rs`: 11 CLI integration tests (check,
   verify, scenarios, parse-error loc mapping, no-fsl rejection, non-fsl
-  rejection, multi-block = single-block verdict, materialized-file
-  cleanup).
+  rejection, multi-block = single-block verdict, materialized-file cleanup,
+  verify-cache hit on a second run, edition-finding `file` field naming the
+  `.md` document, four-backtick fence repro verifying as `violated`).
 - `examples/literate/toggle.md`: canonical literate example.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -986,12 +986,12 @@ or, when the target predicate is unsatisfiable under type bounds/invariants:
 ### Literate Markdown FSL
 
 Markdown files (`.md`) containing ` ```fsl ` fenced code blocks are accepted
-directly by `fslc check` and `fslc verify` — no flags or extraction step
-needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
-that all diagnostic positions (line numbers, columns in error messages and
-counterexamples) point to the original Markdown document. Multiple fsl blocks
-in one document are treated as one compilation unit, so definitions can be
-split across sections:
+directly by `fslc check`, `fslc verify`, and `fslc scenarios` — no flags or
+extraction step needed. Lines outside fsl blocks are blanked (replaced with
+empty lines) so that all diagnostic positions (line numbers, columns in error
+messages and counterexamples) point to the original Markdown document.
+Multiple fsl blocks in one document are treated as one compilation unit, so
+definitions can be split across sections:
 
     # Cart invariant
 
@@ -1011,7 +1011,9 @@ split across sections:
 
 A `.md` file with no ` ```fsl ` fences is rejected with a clear diagnostic.
 Non-fsl fenced blocks (` ```python `, etc.) are ignored. `use`/compose paths
-resolve relative to the Markdown file's directory (same as for `.fsl` files).
+resolve relative to the Markdown file's directory (same as for `.fsl` files);
+a literate `.md` may `use`/compose `.fsl` files this way, but using another
+`.md` file as a compose target is not supported.
 
 ## 8. Recommended workflow: make proved the standard
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -665,14 +665,14 @@ variable.
 ## 7. The verifier `fslc`
 
 ```
-fslc check     <file.fsl>                        # syntax / names / types only (fast)
+fslc check     <file.fsl|file.md>                  # syntax / names / types only (fast; .md = literate FSL)
 fslc lint      <path>... [--edition current|next] # stable edition diagnostics; never mutates
 fslc migrate   <path>... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       <file.fsl|-> [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       <path>... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    <file.fsl> [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance <file.fsl> [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
-fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexample is shortest)
+fslc verify    <file.fsl|file.md> [--depth K]     # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
                [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
@@ -690,7 +690,7 @@ fslc verify    <file.fsl> [--depth K]            # BMC (default K=8, counterexam
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc sweep     <file.fsl> --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
-fslc scenarios <file.fsl> [--depth K]            # generate integration-test scaffold JSON
+fslc scenarios <file.fsl|file.md> [--depth K]     # generate integration-test scaffold JSON
 fslc replay    <file.fsl> --trace <events.json>  # spec-action trace conformance (§12)
 fslc replay    <file.fsl> --from-log <events.jsonl> --mapping <mapping.fsl>
                                                  # production log mapping + conformance (§12)
@@ -982,6 +982,36 @@ or, when the target predicate is unsatisfiable under type bounds/invariants:
   "hint": "target predicate is unsatisfiable under type bounds/invariants (_bounds_x); ..."
 }
 ```
+
+### Literate Markdown FSL
+
+Markdown files (`.md`) containing ` ```fsl ` fenced code blocks are accepted
+directly by `fslc check` and `fslc verify` — no flags or extraction step
+needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
+that all diagnostic positions (line numbers, columns in error messages and
+counterexamples) point to the original Markdown document. Multiple fsl blocks
+in one document are treated as one compilation unit, so definitions can be
+split across sections:
+
+    # Cart invariant
+
+    ```fsl
+    spec Cart {
+      state { count: 0..3 }
+      init  { count = 0 }
+    ```
+
+    ## Actions (continued in a second fsl block)
+
+    ```fsl
+      action inc() { requires count < 3  count = count + 1 }
+      invariant Bounded { count >= 0 and count <= 3 }
+    }
+    ```
+
+A `.md` file with no ` ```fsl ` fences is rejected with a clear diagnostic.
+Non-fsl fenced blocks (` ```python `, etc.) are ignored. `use`/compose paths
+resolve relative to the Markdown file's directory (same as for `.fsl` files).
 
 ## 8. Recommended workflow: make proved the standard
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |
 | [`DESIGN-explicit-engine.md`](DESIGN-explicit-engine.md) | `verify --engine explicit` (Rust-native): Z3-free concrete-state BFS, closure ⇒ `proved`, `unknown_budget` truncation, deterministic-init and binder-domain fail-closed gates; plus the `--engine auto` composite (explicit first, transparent BMC fallback, `engine`/`engine_fallback` tracking) |
+| [`DESIGN-literate.md`](DESIGN-literate.md) | Literate Markdown FSL: in-place blanking extraction of ` ```fsl ` fenced blocks, materialization, position-preserving diagnostics, scope boundaries (WASM waiver, LSP deferral) |
 | [`DESIGN-from-state.md`](DESIGN-from-state.md) | Predictive BMC from a complete Monitor/replay logical-state snapshot (`verify --from-state`), including type validation, faithfulness metadata, cache/symmetry boundaries, and induction exclusion |
 | [`DESIGN-trans.md`](DESIGN-trans.md) | `trans` (transition invariant / two-state safety) |
 | [`DESIGN-temporal.md`](DESIGN-temporal.md) | leadsTo, weak fairness (lasso counterexamples), and respond scenarios |

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1068,12 +1068,12 @@ internal split-action <code>name</code> and adds <code>display_name</code>.</p>
 </code></pre>
 <h3 id="literate-markdown-fsl">Literate Markdown FSL</h3>
 <p>Markdown files (<code>.md</code>) containing <code>```fsl</code> fenced code blocks are accepted
-directly by <code>fslc check</code> and <code>fslc verify</code> — no flags or extraction step
-needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
-that all diagnostic positions (line numbers, columns in error messages and
-counterexamples) point to the original Markdown document. Multiple fsl blocks
-in one document are treated as one compilation unit, so definitions can be
-split across sections:</p>
+directly by <code>fslc check</code>, <code>fslc verify</code>, and <code>fslc scenarios</code> — no flags or
+extraction step needed. Lines outside fsl blocks are blanked (replaced with
+empty lines) so that all diagnostic positions (line numbers, columns in error
+messages and counterexamples) point to the original Markdown document.
+Multiple fsl blocks in one document are treated as one compilation unit, so
+definitions can be split across sections:</p>
 <pre><code># Cart invariant
 
 ```fsl
@@ -1092,7 +1092,9 @@ spec Cart {
 </code></pre>
 <p>A <code>.md</code> file with no <code>```fsl</code> fences is rejected with a clear diagnostic.
 Non-fsl fenced blocks (<code>```python</code>, etc.) are ignored. <code>use</code>/compose paths
-resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files).</p></div></details>
+resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files);
+a literate <code>.md</code> may <code>use</code>/compose <code>.fsl</code> files this way, but using another
+<code>.md</code> file as a compose target is not supported.</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. Recommended workflow: make proved the standard<span class="tree-blurb"> — The recommended BMC-to-induction workflow toward proved.</span></summary><div class="tree-body"><ol>
 <li>Write the spec → <code>fslc check</code> (the fast syntax/type loop)</li>
 <li><code>fslc verify --depth 8</code> → if violated, fix using the trace.

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -745,14 +745,14 @@ variable.</p></div></details>
 <li>A full <code>push</code> into a Seq is also detected automatically as <code>type_bound</code>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
-<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — The fslc CLI surface, result kinds, exit codes, coverage diagnosis.</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl|file.md&gt;                  # syntax / names / types only (fast; .md = literate FSL)
 fslc lint      &lt;path&gt;... [--edition current|next] # stable edition diagnostics; never mutates
 fslc migrate   &lt;path&gt;... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance &lt;file.fsl&gt; [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
-fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
+fslc verify    &lt;file.fsl|file.md&gt; [--depth K]     # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
                [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
@@ -770,7 +770,7 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
-fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
+fslc scenarios &lt;file.fsl|file.md&gt; [--depth K]     # generate integration-test scaffold JSON
 fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # spec-action trace conformance (§12)
 fslc replay    &lt;file.fsl&gt; --from-log &lt;events.jsonl&gt; --mapping &lt;mapping.fsl&gt;
                                                  # production log mapping + conformance (§12)
@@ -1065,7 +1065,34 @@ internal split-action <code>name</code> and adds <code>display_name</code>.</p>
   &quot;blocking_requires&quot;: [{&quot;kind&quot;: &quot;type_bound&quot;, &quot;name&quot;: &quot;_bounds_x&quot;}],
   &quot;hint&quot;: &quot;target predicate is unsatisfiable under type bounds/invariants (_bounds_x); ...&quot;
 }
-</code></pre></div></details>
+</code></pre>
+<h3 id="literate-markdown-fsl">Literate Markdown FSL</h3>
+<p>Markdown files (<code>.md</code>) containing <code>```fsl</code> fenced code blocks are accepted
+directly by <code>fslc check</code> and <code>fslc verify</code> — no flags or extraction step
+needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
+that all diagnostic positions (line numbers, columns in error messages and
+counterexamples) point to the original Markdown document. Multiple fsl blocks
+in one document are treated as one compilation unit, so definitions can be
+split across sections:</p>
+<pre><code># Cart invariant
+
+```fsl
+spec Cart {
+  state { count: 0..3 }
+  init  { count = 0 }
+```
+
+## Actions (continued in a second fsl block)
+
+```fsl
+  action inc() { requires count &lt; 3  count = count + 1 }
+  invariant Bounded { count &gt;= 0 and count &lt;= 3 }
+}
+```
+</code></pre>
+<p>A <code>.md</code> file with no <code>```fsl</code> fences is rejected with a clear diagnostic.
+Non-fsl fenced blocks (<code>```python</code>, etc.) are ignored. <code>use</code>/compose paths
+resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files).</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. Recommended workflow: make proved the standard<span class="tree-blurb"> — The recommended BMC-to-induction workflow toward proved.</span></summary><div class="tree-body"><ol>
 <li>Write the spec → <code>fslc check</code> (the fast syntax/type loop)</li>
 <li><code>fslc verify --depth 8</code> → if violated, fix using the trace.

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1068,12 +1068,12 @@ internal split-action <code>name</code> and adds <code>display_name</code>.</p>
 </code></pre>
 <h3 id="literate-markdown-fsl">Literate Markdown FSL</h3>
 <p>Markdown files (<code>.md</code>) containing <code>```fsl</code> fenced code blocks are accepted
-directly by <code>fslc check</code> and <code>fslc verify</code> — no flags or extraction step
-needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
-that all diagnostic positions (line numbers, columns in error messages and
-counterexamples) point to the original Markdown document. Multiple fsl blocks
-in one document are treated as one compilation unit, so definitions can be
-split across sections:</p>
+directly by <code>fslc check</code>, <code>fslc verify</code>, and <code>fslc scenarios</code> — no flags or
+extraction step needed. Lines outside fsl blocks are blanked (replaced with
+empty lines) so that all diagnostic positions (line numbers, columns in error
+messages and counterexamples) point to the original Markdown document.
+Multiple fsl blocks in one document are treated as one compilation unit, so
+definitions can be split across sections:</p>
 <pre><code># Cart invariant
 
 ```fsl
@@ -1092,7 +1092,9 @@ spec Cart {
 </code></pre>
 <p>A <code>.md</code> file with no <code>```fsl</code> fences is rejected with a clear diagnostic.
 Non-fsl fenced blocks (<code>```python</code>, etc.) are ignored. <code>use</code>/compose paths
-resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files).</p></div></details>
+resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files);
+a literate <code>.md</code> may <code>use</code>/compose <code>.fsl</code> files this way, but using another
+<code>.md</code> file as a compose target is not supported.</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. Recommended workflow: make proved the standard<span class="tree-blurb"> — BMC から帰納法へ、proved を標準にする推奨ワークフロー。</span></summary><div class="tree-body"><ol>
 <li>Write the spec → <code>fslc check</code> (the fast syntax/type loop)</li>
 <li><code>fslc verify --depth 8</code> → if violated, fix using the trace.

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -745,14 +745,14 @@ variable.</p></div></details>
 <li>A full <code>push</code> into a Seq is also detected automatically as <code>type_bound</code>
   (to guard it, write <code>requires q.size() &lt; N</code>).</li>
 </ul></div></details>
-<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl&gt;                        # syntax / names / types only (fast)
+<details id="7-the-verifier-fslc"><summary>7. The verifier `fslc`<span class="tree-blurb"> — fslc コマンド一覧、結果種別、終了コード、カバレッジ診断。</span></summary><div class="tree-body"><pre><code>fslc check     &lt;file.fsl|file.md&gt;                  # syntax / names / types only (fast; .md = literate FSL)
 fslc lint      &lt;path&gt;... [--edition current|next] # stable edition diagnostics; never mutates
 fslc migrate   &lt;path&gt;... --edition next [--write] # dry-run edits; --write applies validated set
 fslc fmt       &lt;file.fsl|-&gt; [--edition current|next] # canonical FSL to stdout; never mutates input
 fslc fmt       &lt;path&gt;... --check                 # JSON format_check; exit 0 clean, 1 changed, 2 error
 fslc kernel    &lt;file.fsl&gt; [--kernel-version 1|2] # normalized typed Kernel JSON (default v1)
 fslc conformance &lt;file.fsl&gt; [--depth K] [--kernel-version 1|2] # matching vectors (default v1)
-fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, counterexample is shortest)
+fslc verify    &lt;file.fsl|file.md&gt; [--depth K]     # BMC (default K=8, counterexample is shortest)
                [--engine induction] [--k N]      # k-induction: unbounded-depth proof
                [--engine explicit]               # concrete-state BFS (native fslc): closure ⇒ proved
                [--explicit-budget N]             #   max visited states (default 1000000); over ⇒ unknown_budget
@@ -770,7 +770,7 @@ fslc verify    &lt;file.fsl&gt; [--depth K]            # BMC (default K=8, count
                [--strict-tags] [--requirements ids.txt]  # tag matching (§15)
 fslc sweep     &lt;file.fsl&gt; --instances E=lo..hi --depth lo..hi [--property Name]
                                                  # opt-in scope sweep over bounded verification
-fslc scenarios &lt;file.fsl&gt; [--depth K]            # generate integration-test scaffold JSON
+fslc scenarios &lt;file.fsl|file.md&gt; [--depth K]     # generate integration-test scaffold JSON
 fslc replay    &lt;file.fsl&gt; --trace &lt;events.json&gt;  # spec-action trace conformance (§12)
 fslc replay    &lt;file.fsl&gt; --from-log &lt;events.jsonl&gt; --mapping &lt;mapping.fsl&gt;
                                                  # production log mapping + conformance (§12)
@@ -1065,7 +1065,34 @@ internal split-action <code>name</code> and adds <code>display_name</code>.</p>
   &quot;blocking_requires&quot;: [{&quot;kind&quot;: &quot;type_bound&quot;, &quot;name&quot;: &quot;_bounds_x&quot;}],
   &quot;hint&quot;: &quot;target predicate is unsatisfiable under type bounds/invariants (_bounds_x); ...&quot;
 }
-</code></pre></div></details>
+</code></pre>
+<h3 id="literate-markdown-fsl">Literate Markdown FSL</h3>
+<p>Markdown files (<code>.md</code>) containing <code>```fsl</code> fenced code blocks are accepted
+directly by <code>fslc check</code> and <code>fslc verify</code> — no flags or extraction step
+needed. Lines outside fsl blocks are blanked (replaced with empty lines) so
+that all diagnostic positions (line numbers, columns in error messages and
+counterexamples) point to the original Markdown document. Multiple fsl blocks
+in one document are treated as one compilation unit, so definitions can be
+split across sections:</p>
+<pre><code># Cart invariant
+
+```fsl
+spec Cart {
+  state { count: 0..3 }
+  init  { count = 0 }
+```
+
+## Actions (continued in a second fsl block)
+
+```fsl
+  action inc() { requires count &lt; 3  count = count + 1 }
+  invariant Bounded { count &gt;= 0 and count &lt;= 3 }
+}
+```
+</code></pre>
+<p>A <code>.md</code> file with no <code>```fsl</code> fences is rejected with a clear diagnostic.
+Non-fsl fenced blocks (<code>```python</code>, etc.) are ignored. <code>use</code>/compose paths
+resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files).</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. Recommended workflow: make proved the standard<span class="tree-blurb"> — BMC から帰納法へ、proved を標準にする推奨ワークフロー。</span></summary><div class="tree-body"><ol>
 <li>Write the spec → <code>fslc check</code> (the fast syntax/type loop)</li>
 <li><code>fslc verify --depth 8</code> → if violated, fix using the trace.

--- a/examples/literate/toggle.md
+++ b/examples/literate/toggle.md
@@ -1,0 +1,46 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Toggle — a literate FSL example
+
+This document demonstrates **literate Markdown FSL**: a Markdown file whose
+` ```fsl ` fenced code blocks are extracted and verified as a single
+compilation unit by `fslc check` and `fslc verify`.
+
+## Model
+
+The toggle has a single Boolean state variable.
+
+```fsl
+spec Toggle {
+  state { active: Bool }
+  init  { active = false }
+```
+
+## Behavior
+
+A single action flips the state.
+
+```fsl
+  action toggle() {
+    active = not active
+  }
+```
+
+## Invariant
+
+The invariant is trivially true — it exists to demonstrate that verification
+results (line numbers, counterexample locations) point to the Markdown
+document's own lines.
+
+```fsl
+  invariant AlwaysBool {
+    active or not active
+  }
+}
+```
+
+## Verification
+
+```sh
+fslc check  examples/literate/toggle.md
+fslc verify examples/literate/toggle.md --depth 4
+```

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -16,6 +16,7 @@ mod db;
 mod dispatch;
 mod domain;
 mod lexer;
+mod literate;
 mod lossless;
 mod parser;
 mod surface;
@@ -48,6 +49,7 @@ pub use domain::{
     DomainSagaStep, DomainSpec, DomainStalePolicy, DomainType, DomainTypeSourceForm, parse_domain,
 };
 pub use lexer::{LexError, Token, TokenKind, lex};
+pub use literate::extract_literate_fsl;
 pub use lossless::{
     CanonicalRewrite, CanonicalRewriteKind, FormatEdition, FormatError, LosslessDocument,
     LosslessKind, LosslessNode, SourceEdit, apply_source_edits, canonical_rewrites, format_source,

--- a/rust/fsl-syntax/src/literate.rs
+++ b/rust/fsl-syntax/src/literate.rs
@@ -8,13 +8,33 @@
 /// correspond 1:1 to the original document.  Multiple fsl blocks are treated as
 /// one compilation unit (definitions can be split across sections).
 ///
+/// Fence detection follows the `CommonMark` fenced-code-block grammar: an opening
+/// fence is a line whose trimmed form starts with a run of three or more
+/// backticks or tildes; the block is an fsl block iff the first
+/// whitespace-separated token of the info string (the text after the run) is
+/// exactly `fsl`. A closing fence is a line whose trimmed form is a run of the
+/// same character, at least as long as the opening run, followed by nothing
+/// else. While inside a fence, lines are only checked for closing — a line
+/// that looks like an opening fence is ordinary content of the current block,
+/// never a nested fence. An unterminated fence runs to end of file.
+///
 /// Returns `None` when the source contains no ` ```fsl ` fences, meaning it is
 /// not a literate FSL document — the caller should reject it or treat it as
 /// plain text rather than feeding an empty string to the parser.
 #[must_use]
 pub fn extract_literate_fsl(source: &str) -> Option<String> {
-    let mut inside_fsl = false;
-    let mut inside_other_fence = false;
+    enum FenceKind {
+        Fsl,
+        Other,
+    }
+
+    struct OpenFence {
+        ch: char,
+        len: usize,
+        kind: FenceKind,
+    }
+
+    let mut open: Option<OpenFence> = None;
     let mut found_fsl_fence = false;
     let mut output = String::with_capacity(source.len());
 
@@ -23,21 +43,27 @@ pub fn extract_literate_fsl(source: &str) -> Option<String> {
     for (i, line) in lines_iter.into_iter().enumerate() {
         let trimmed = line.trim();
         let is_last = i + 1 == line_count;
-        if inside_fsl {
-            if trimmed == "```" || trimmed.starts_with("``` ") {
-                inside_fsl = false;
-            } else {
+        if let Some(fence) = &open {
+            let closes = closing_fence_len(trimmed, fence.ch).is_some_and(|len| len >= fence.len);
+            if closes {
+                open = None;
+            } else if matches!(fence.kind, FenceKind::Fsl) {
                 output.push_str(line);
             }
-        } else if inside_other_fence {
-            if trimmed == "```" || trimmed.starts_with("``` ") {
-                inside_other_fence = false;
+        } else if let Some((ch, len, info)) = opening_fence(trimmed) {
+            let is_fsl = info.split_whitespace().next() == Some("fsl");
+            if is_fsl {
+                found_fsl_fence = true;
             }
-        } else if is_fsl_fence(trimmed) {
-            found_fsl_fence = true;
-            inside_fsl = true;
-        } else if trimmed.starts_with("```") {
-            inside_other_fence = true;
+            open = Some(OpenFence {
+                ch,
+                len,
+                kind: if is_fsl {
+                    FenceKind::Fsl
+                } else {
+                    FenceKind::Other
+                },
+            });
         }
         if !is_last {
             output.push('\n');
@@ -47,8 +73,34 @@ pub fn extract_literate_fsl(source: &str) -> Option<String> {
     if found_fsl_fence { Some(output) } else { None }
 }
 
-fn is_fsl_fence(trimmed: &str) -> bool {
-    trimmed == "```fsl" || trimmed.starts_with("```fsl ")
+/// Detect an opening fence: a run of three or more identical backtick or tilde
+/// characters at the start of the trimmed line. Returns the fence character,
+/// the run length, and the info string (the remainder of the trimmed line).
+fn opening_fence(trimmed: &str) -> Option<(char, usize, &str)> {
+    let ch = trimmed.chars().next()?;
+    if ch != '`' && ch != '~' {
+        return None;
+    }
+    let len = trimmed
+        .chars()
+        .take_while(|&candidate| candidate == ch)
+        .count();
+    if len < 3 {
+        return None;
+    }
+    // `ch` is single-byte ASCII, so the byte offset equals the char count above.
+    Some((ch, len, &trimmed[len..]))
+}
+
+/// Detect a closing fence for the given fence character: the trimmed line
+/// (already stripped of surrounding whitespace by the caller) consists
+/// entirely of that character, with no info string. Returns the run length so
+/// the caller can compare it against the opening run length.
+fn closing_fence_len(trimmed: &str, ch: char) -> Option<usize> {
+    if trimmed.is_empty() || !trimmed.chars().all(|candidate| candidate == ch) {
+        return None;
+    }
+    Some(trimmed.chars().count())
 }
 
 #[cfg(test)]
@@ -146,5 +198,88 @@ spec S {}
         // Python block lines are blank.
         let lines: Vec<&str> = blanked.lines().collect();
         assert_eq!(lines[1], "", "python code should be blanked");
+    }
+
+    #[test]
+    fn four_backtick_fence_containing_a_triple_backtick_fsl_example_extracts_only_real_fsl_blocks()
+    {
+        // A four-backtick "other" fence whose body demonstrates a ```fsl example must
+        // not let that inner triple-backtick text terminate the four-backtick fence
+        // early, and must not treat the inner ` ```fsl ` line as a real opening fence.
+        let doc = "\
+# Spec
+
+```fsl
+spec Counter {
+  state { n: 0..3 }
+  init { n = 0 }
+  action inc() { n = n + 1 }
+```
+
+Example (four-backtick fence, inner three backticks are literal):
+
+````text
+```fsl
+example only
+```
+````
+
+```fsl
+  invariant Low { n < 2 }
+}
+```
+";
+        let blanked = extract_literate_fsl(doc).expect("should detect fsl fences");
+        assert!(!blanked.contains("example only"));
+        assert!(!blanked.contains("````text"));
+        let extracted = blanked
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            extracted,
+            "spec Counter {\n  state { n: 0..3 }\n  init { n = 0 }\n  action inc() { n = n + 1 }\n  invariant Low { n < 2 }\n}"
+        );
+    }
+
+    #[test]
+    fn tilde_fenced_non_fsl_block_is_ignored_and_does_not_treat_an_inner_fsl_line_as_opening() {
+        let doc = "\
+~~~
+```fsl
+spec Ignored {}
+```
+~~~
+
+```fsl
+spec Real {}
+```
+";
+        let blanked = extract_literate_fsl(doc).expect("should detect the real fsl fence");
+        assert!(!blanked.contains("Ignored"));
+        assert!(blanked.contains("spec Real {}"));
+    }
+
+    #[test]
+    fn tilde_fsl_fence_is_recognized() {
+        let doc = "~~~fsl\nspec Tilde {}\n~~~\n";
+        let blanked = extract_literate_fsl(doc).expect("~~~fsl should open an fsl fence");
+        assert!(blanked.contains("spec Tilde {}"));
+    }
+
+    #[test]
+    fn backtick_run_with_trailing_text_inside_an_fsl_block_stays_content() {
+        let doc = "\
+```fsl
+spec S {
+``` foo
+}
+```
+";
+        let blanked = extract_literate_fsl(doc).expect("should detect fsl fence");
+        assert!(blanked.contains("``` foo"));
+        assert!(blanked.contains("spec S {"));
+        assert!(blanked.contains('}'));
     }
 }

--- a/rust/fsl-syntax/src/literate.rs
+++ b/rust/fsl-syntax/src/literate.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+/// Extract FSL source from a Markdown document by in-place blanking.
+///
+/// Lines outside ` ```fsl ` fenced code blocks are replaced with empty lines so
+/// that byte offsets, line numbers, and column positions in the blanked output
+/// correspond 1:1 to the original document.  Multiple fsl blocks are treated as
+/// one compilation unit (definitions can be split across sections).
+///
+/// Returns `None` when the source contains no ` ```fsl ` fences, meaning it is
+/// not a literate FSL document — the caller should reject it or treat it as
+/// plain text rather than feeding an empty string to the parser.
+#[must_use]
+pub fn extract_literate_fsl(source: &str) -> Option<String> {
+    let mut inside_fsl = false;
+    let mut inside_other_fence = false;
+    let mut found_fsl_fence = false;
+    let mut output = String::with_capacity(source.len());
+
+    let lines_iter: Vec<&str> = source.split('\n').collect();
+    let line_count = lines_iter.len();
+    for (i, line) in lines_iter.into_iter().enumerate() {
+        let trimmed = line.trim();
+        let is_last = i + 1 == line_count;
+        if inside_fsl {
+            if trimmed == "```" || trimmed.starts_with("``` ") {
+                inside_fsl = false;
+            } else {
+                output.push_str(line);
+            }
+        } else if inside_other_fence {
+            if trimmed == "```" || trimmed.starts_with("``` ") {
+                inside_other_fence = false;
+            }
+        } else if is_fsl_fence(trimmed) {
+            found_fsl_fence = true;
+            inside_fsl = true;
+        } else if trimmed.starts_with("```") {
+            inside_other_fence = true;
+        }
+        if !is_last {
+            output.push('\n');
+        }
+    }
+
+    if found_fsl_fence { Some(output) } else { None }
+}
+
+fn is_fsl_fence(trimmed: &str) -> bool {
+    trimmed == "```fsl" || trimmed.starts_with("```fsl ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_a_single_fsl_block() {
+        let doc = "\
+# Title
+
+Some prose.
+
+```fsl
+spec Toggle {
+  state active: Bool = false
+}
+```
+
+More prose.
+";
+        let blanked = extract_literate_fsl(doc).expect("should detect fsl fence");
+        assert!(blanked.contains("spec Toggle {"));
+        assert!(blanked.contains("state active: Bool = false"));
+        // Prose lines are blank.
+        let lines: Vec<&str> = blanked.lines().collect();
+        assert_eq!(lines[0], "", "title line should be blank");
+        assert_eq!(lines[2], "", "prose line should be blank");
+        // The fsl content lines have the same line numbers as in the doc.
+        let doc_lines: Vec<&str> = doc.lines().collect();
+        let spec_line = doc_lines
+            .iter()
+            .position(|line| line.contains("spec Toggle"))
+            .unwrap();
+        assert_eq!(lines[spec_line], doc_lines[spec_line]);
+    }
+
+    #[test]
+    fn preserves_line_count() {
+        let doc = "# H1\n\n```fsl\nspec S {}\n```\n\n# H2\n";
+        let blanked = extract_literate_fsl(doc).unwrap();
+        assert_eq!(
+            blanked.lines().count(),
+            doc.lines().count(),
+            "line count must be identical"
+        );
+    }
+
+    #[test]
+    fn multiple_blocks_form_one_compilation_unit() {
+        let doc = "\
+# States
+
+```fsl
+spec Multi {
+  state x: Int = 0
+```
+
+# Actions
+
+```fsl
+  action inc { x' = x + 1 }
+}
+```
+";
+        let blanked = extract_literate_fsl(doc).unwrap();
+        assert!(blanked.contains("state x: Int = 0"));
+        assert!(blanked.contains("action inc"));
+    }
+
+    #[test]
+    fn returns_none_without_fsl_fences() {
+        assert!(extract_literate_fsl("# Just a readme\n\nNo fsl here.\n").is_none());
+    }
+
+    #[test]
+    fn ignores_non_fsl_fenced_blocks() {
+        let doc = "```python\nprint('hello')\n```\n";
+        assert!(extract_literate_fsl(doc).is_none());
+    }
+
+    #[test]
+    fn non_fsl_fence_does_not_interfere_with_fsl_fence() {
+        let doc = "\
+```python
+print('hello')
+```
+
+```fsl
+spec S {}
+```
+";
+        let blanked = extract_literate_fsl(doc).unwrap();
+        assert!(blanked.contains("spec S {}"));
+        // Python block lines are blank.
+        let lines: Vec<&str> = blanked.lines().collect();
+        assert_eq!(lines[1], "", "python code should be blanked");
+    }
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -27,6 +27,36 @@ use verification::{
 const CLI_CONTRACT: &str = include_str!("../cli-contract.json");
 const DEFAULT_EXPLICIT_BUDGET: usize = 1_000_000;
 
+struct LiterateState {
+    path: PathBuf,
+}
+
+impl Drop for LiterateState {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn materialize_literate(path: &Path) -> Result<Option<LiterateState>, String> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) != Some("md") {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let blanked = fsl_syntax::extract_literate_fsl(&raw).ok_or_else(|| {
+        format!(
+            "{}: Markdown file does not contain any ```fsl fenced code blocks",
+            path.display()
+        )
+    })?;
+    let stem = path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("literate");
+    let materialized = path.with_file_name(format!(".{stem}.{}.literate.fsl", std::process::id()));
+    std::fs::write(&materialized, &blanked).map_err(|error| error.to_string())?;
+    Ok(Some(LiterateState { path: materialized }))
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ScopeBounds {
     instances: std::collections::BTreeMap<String, i64>,
@@ -808,6 +838,8 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| "usage: fslc check SPEC [options]".to_owned())?,
             );
+            let literate_guard = materialize_literate(&path)?;
+            let path = literate_guard.as_ref().map_or(&path, |state| &state.path);
             let mut strict_tags = false;
             let mut requirements = None;
             let mut edition = "current".to_owned();
@@ -825,7 +857,7 @@ fn command() -> Result<(Value, i32), String> {
                 }
             }
             Ok(with_version_metadata(run_check_with_tags(
-                &path,
+                path,
                 strict_tags,
                 requirements.as_deref(),
                 &edition,
@@ -1445,10 +1477,12 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| format!("usage: fslc {command} SPEC [options]"))?,
             );
+            let literate_guard = materialize_literate(&path)?;
+            let path = literate_guard.as_ref().map_or(&path, |state| &state.path);
             let options = parse_verify_options(&mut args)?;
             Ok(if command == "verify" {
-                let result = run_verify_cli(&path, &options);
-                with_version_metadata(apply_domain_edition(result, &path, &options.edition))
+                let result = run_verify_cli(path, &options);
+                with_version_metadata(apply_domain_edition(result, path, &options.edition))
             } else {
                 if options.engine != "bmc"
                     || options.explicit_budget != DEFAULT_EXPLICIT_BUDGET
@@ -1467,7 +1501,7 @@ fn command() -> Result<(Value, i32), String> {
                 {
                     return Err("scenarios accepts only --depth and --deadlock".to_owned());
                 }
-                run_scenarios(&path, options.depth, &options.deadlock)
+                run_scenarios(path, options.depth, &options.deadlock)
             })
         }
         _ => Err(format!("unknown command '{command}'")),

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -41,7 +41,8 @@ fn materialize_literate(path: &Path) -> Result<Option<LiterateState>, String> {
     if path.extension().and_then(std::ffi::OsStr::to_str) != Some("md") {
         return Ok(None);
     }
-    let raw = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let raw =
+        std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
     let blanked = fsl_syntax::extract_literate_fsl(&raw).ok_or_else(|| {
         format!(
             "{}: Markdown file does not contain any ```fsl fenced code blocks",
@@ -52,7 +53,13 @@ fn materialize_literate(path: &Path) -> Result<Option<LiterateState>, String> {
         .file_stem()
         .and_then(std::ffi::OsStr::to_str)
         .unwrap_or("literate");
-    let materialized = path.with_file_name(format!(".{stem}.{}.literate.fsl", std::process::id()));
+    // Deterministic (no PID): the same `.md` must materialize to the same sibling
+    // path across runs so the verify cache key is stable. Concurrent runs on the
+    // same document write identical bytes (both blank from the same source), so a
+    // race only ever produces a harmless duplicate write, never a wrong verdict;
+    // worst case a run's mid-read sees the file mid-write-or-delete by a sibling
+    // process and errors loudly rather than silently misreading.
+    let materialized = path.with_file_name(format!(".{stem}.literate.fsl"));
     std::fs::write(&materialized, &blanked).map_err(|error| error.to_string())?;
     Ok(Some(LiterateState { path: materialized }))
 }
@@ -834,12 +841,14 @@ fn command() -> Result<(Value, i32), String> {
             std::process::exit(0);
         }
         "check" => {
-            let path = PathBuf::from(
+            let display_path = PathBuf::from(
                 args.next()
                     .ok_or_else(|| "usage: fslc check SPEC [options]".to_owned())?,
             );
-            let literate_guard = materialize_literate(&path)?;
-            let path = literate_guard.as_ref().map_or(&path, |state| &state.path);
+            let literate_guard = materialize_literate(&display_path)?;
+            let path = literate_guard
+                .as_ref()
+                .map_or(&display_path, |state| &state.path);
             let mut strict_tags = false;
             let mut requirements = None;
             let mut edition = "current".to_owned();
@@ -858,6 +867,7 @@ fn command() -> Result<(Value, i32), String> {
             }
             Ok(with_version_metadata(run_check_with_tags(
                 path,
+                &display_path,
                 strict_tags,
                 requirements.as_deref(),
                 &edition,
@@ -1473,16 +1483,23 @@ fn command() -> Result<(Value, i32), String> {
             ))
         }
         "verify" | "scenarios" => {
-            let path = PathBuf::from(
+            let display_path = PathBuf::from(
                 args.next()
                     .ok_or_else(|| format!("usage: fslc {command} SPEC [options]"))?,
             );
-            let literate_guard = materialize_literate(&path)?;
-            let path = literate_guard.as_ref().map_or(&path, |state| &state.path);
+            let literate_guard = materialize_literate(&display_path)?;
+            let path = literate_guard
+                .as_ref()
+                .map_or(&display_path, |state| &state.path);
             let options = parse_verify_options(&mut args)?;
             Ok(if command == "verify" {
                 let result = run_verify_cli(path, &options);
-                with_version_metadata(apply_domain_edition(result, path, &options.edition))
+                with_version_metadata(apply_domain_edition(
+                    result,
+                    path,
+                    &display_path,
+                    &options.edition,
+                ))
             } else {
                 if options.engine != "bmc"
                     || options.explicit_budget != DEFAULT_EXPLICIT_BUDGET
@@ -2426,7 +2443,7 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
                         );
                         (detail, status, "verify", Some(depth))
                     } else {
-                        let (detail, status) = run_check(&file_path);
+                        let (detail, status) = run_check(&file_path, &file_path);
                         (detail, status, "check", None)
                     };
                 let passed = chain_layer_passes(&detail, status);
@@ -3903,11 +3920,17 @@ fn display_binding(value: &fsl_core::FslValue) -> String {
     }
 }
 
-fn run_check(path: &Path) -> (Value, i32) {
+/// `path` is read for source content (for a literate `.md` input, this is the
+/// materialized, blanked `.literate.fsl` sibling — its line positions match
+/// the original document). `display_path` is stamped into every user-visible
+/// label (`file` fields, embedded `at file:line:col` text) so the machine-
+/// readable output always names the document the caller actually passed in,
+/// never the transient materialization.
+fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     if let Ok(source) = std::fs::read_to_string(path) {
         if let Some(output) = fslc_rust::frontend_output::ai_project_check_output(
             &source,
-            &path.to_string_lossy(),
+            &display_path.to_string_lossy(),
             envelope(),
         ) {
             return (output, 0);
@@ -3930,10 +3953,13 @@ fn run_check(path: &Path) -> (Value, i32) {
             Err(error) => return (surface_parse_error_output(&error), 2),
         }
         let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-        if let Some(diagnostic) =
-            fslc_rust::source_diagnostic::diagnostics(&source, &path.to_string_lossy(), &resolver)
-                .into_iter()
-                .find(|diagnostic| diagnostic.kind != "migration")
+        if let Some(diagnostic) = fslc_rust::source_diagnostic::diagnostics(
+            &source,
+            &display_path.to_string_lossy(),
+            &resolver,
+        )
+        .into_iter()
+        .find(|diagnostic| diagnostic.kind != "migration")
         {
             return (semantic_error_output(&diagnostic.message), 2);
         }
@@ -4211,13 +4237,17 @@ fn add_strict_tag_warnings(
     Ok(())
 }
 
+/// `path` is read for source content (the materialized `.literate.fsl` sibling
+/// for a literate `.md` input); `display_path` is stamped into user-visible
+/// labels. See `run_check` for the same split.
 fn run_check_with_tags(
     path: &Path,
+    display_path: &Path,
     strict_tags: bool,
     requirements: Option<&Path>,
     edition: &str,
 ) -> (Value, i32) {
-    let (mut output, status) = run_check(path);
+    let (mut output, status) = run_check(path, display_path);
     if status == 0 && strict_tags {
         let model = match load_model(path) {
             Ok(model) => model,
@@ -4227,12 +4257,20 @@ fn run_check_with_tags(
             return (error_output("io", &error), 2);
         }
     }
-    apply_domain_edition((output, status), path, edition)
+    apply_domain_edition((output, status), path, display_path, edition)
 }
 
+/// `path` is read for source content (the materialized `.literate.fsl`
+/// sibling for a literate `.md` input, so parsing sees the correctly blanked,
+/// position-preserving text); `display_path` is stamped into every
+/// user-visible label (migration/edition finding `file` fields, implicit-
+/// initial-value warning `file` fields) so machine-readable output always
+/// names the document the caller passed on the command line, never the
+/// transient materialization.
 fn apply_domain_edition(
     (mut output, status): (Value, i32),
     path: &Path,
+    display_path: &Path,
     edition: &str,
 ) -> (Value, i32) {
     let Ok(source) = std::fs::read_to_string(path) else {
@@ -4243,21 +4281,23 @@ fn apply_domain_edition(
     } else {
         fslc_rust::migration::Edition::Current
     };
-    let Ok(plan) =
-        fslc_rust::migration::plan_migration(&source, &path.to_string_lossy(), migration_edition)
-    else {
+    let Ok(plan) = fslc_rust::migration::plan_migration(
+        &source,
+        &display_path.to_string_lossy(),
+        migration_edition,
+    ) else {
         return (output, status);
     };
     let mut additions = plan
         .diagnostics
         .iter()
         .filter(|finding| edition == "next" || finding.code == "deprecated_domain_enum_union")
-        .map(|finding| finding.json(&path.to_string_lossy(), migration_edition))
+        .map(|finding| finding.json(&display_path.to_string_lossy(), migration_edition))
         .collect::<Vec<_>>();
     if edition != "next" {
         additions.extend(fslc_rust::frontend_output::implicit_initial_value_warnings(
             &source,
-            &path.to_string_lossy(),
+            &display_path.to_string_lossy(),
         ));
     }
     if edition == "next" && !additions.is_empty() {
@@ -5034,18 +5074,19 @@ fn run_domain_check(
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
         Err(error) => {
-            return apply_domain_edition((semantic_error_output(&error), 2), path, edition);
+            return apply_domain_edition((semantic_error_output(&error), 2), path, path, edition);
         }
     };
     let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
     if status == 2 {
-        return apply_domain_edition((kernel, status), path, edition);
+        return apply_domain_edition((kernel, status), path, path, edition);
     }
     apply_domain_edition(
         wrap_specialized(fsl_tools::check_domain(
             &domain,
             &stable_kernel_projection(kernel),
         )),
+        path,
         path,
         edition,
     )

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1655,7 +1655,7 @@ fn cache_root() -> Option<PathBuf> {
 
 fn collect_fsl_sources(path: &Path, output: &mut Vec<PathBuf>) -> std::io::Result<()> {
     if path.is_file() {
-        if is_fsl_source(path) {
+        if is_fsl_source(path) && !is_literate_materialization(path) {
             output.push(path.to_path_buf());
         }
         return Ok(());
@@ -1682,6 +1682,17 @@ fn is_fsl_source(path: &Path) -> bool {
             .is_some(),
         _ => false,
     }
+}
+
+/// True for the transient sibling `fslc` materializes next to a literate `.md`
+/// file (see `materialize_literate` in `main.rs`). This file's content is
+/// already represented by the `.md` file itself via `is_fsl_source`'s Markdown
+/// branch above, so it must be excluded from the cache-key directory walk —
+/// otherwise a run-local artifact would spuriously appear as a dependency.
+fn is_literate_materialization(path: &Path) -> bool {
+    path.file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|name| name.ends_with(".literate.fsl"))
 }
 
 fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String, String), String> {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1655,7 +1655,7 @@ fn cache_root() -> Option<PathBuf> {
 
 fn collect_fsl_sources(path: &Path, output: &mut Vec<PathBuf>) -> std::io::Result<()> {
     if path.is_file() {
-        if path.extension().and_then(std::ffi::OsStr::to_str) == Some("fsl") {
+        if is_fsl_source(path) {
             output.push(path.to_path_buf());
         }
         return Ok(());
@@ -1671,6 +1671,17 @@ fn collect_fsl_sources(path: &Path, output: &mut Vec<PathBuf>) -> std::io::Resul
         }
     }
     Ok(())
+}
+
+fn is_fsl_source(path: &Path) -> bool {
+    match path.extension().and_then(std::ffi::OsStr::to_str) {
+        Some("fsl") => true,
+        Some("md") => std::fs::read_to_string(path)
+            .ok()
+            .and_then(|source| fsl_syntax::extract_literate_fsl(&source))
+            .is_some(),
+        _ => false,
+    }
 }
 
 fn verify_cache_keys(path: &Path, options: &CliVerifyOptions) -> Result<(String, String), String> {

--- a/rust/fslc/tests/fixtures/literate_toggle.md
+++ b/rust/fslc/tests/fixtures/literate_toggle.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Toggle Spec
+
+A simple toggle modeled in FSL.
+
+## Model
+
+```fsl
+spec Toggle {
+  state { active: Bool }
+  init  { active = false }
+```
+
+## Actions
+
+```fsl
+  action toggle() {
+    active = not active
+  }
+```
+
+## Properties
+
+```fsl
+  invariant AlwaysBool {
+    active or not active
+  }
+}
+```
+
+That's the whole spec.

--- a/rust/fslc/tests/literate_markdown.rs
+++ b/rust/fslc/tests/literate_markdown.rs
@@ -211,3 +211,187 @@ fn literate_scenarios_produces_output() {
         "scenarios should produce structured output: {output:#}"
     );
 }
+
+/// Isolates the verify cache in a fresh, per-test directory (same pattern as
+/// `issue_226_auto_engine.rs`'s `CacheDir`).
+struct LiterateCacheDir {
+    path: PathBuf,
+}
+
+impl LiterateCacheDir {
+    fn new(name: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "fslc-literate-cachedir-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        Self { path }
+    }
+
+    fn run(&self, arguments: &[&str]) -> (Value, i32) {
+        let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+            .args(arguments)
+            .current_dir(repository_root())
+            .env("FSLC_CACHE_DIR", &self.path)
+            .output()
+            .expect("run native fslc");
+        let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "invalid JSON: {error}; args={arguments:?}; stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+        (value, output.status.code().expect("native exit status"))
+    }
+}
+
+impl Drop for LiterateCacheDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[test]
+fn literate_verify_cache_hits_on_the_second_run() {
+    // Root cause this guards: the materialized sibling used to embed
+    // `std::process::id()` in its filename, so the canonicalized "path" baked
+    // into the cache key (and the sibling's own entry in the cache-key
+    // directory walk) changed on every single run — the cache could never
+    // hit for a `.md` spec. The fsl content below embeds a fresh nonce so
+    // this test's cache entry cannot collide with any other test's.
+    let cache = LiterateCacheDir::new("hit");
+    let dir = std::env::temp_dir().join(format!("fslc-literate-cache-doc-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let doc = dir.join("cache_toggle.md");
+    std::fs::write(
+        &doc,
+        format!(
+            "\
+# Cache toggle
+
+```fsl
+// nonce: {nonce}
+spec CacheToggle {{
+  state {{ active: Bool }}
+  init {{ active = false }}
+  action toggle() {{ active = not active }}
+  invariant AlwaysBool {{ active or not active }}
+}}
+```
+"
+        ),
+    )
+    .expect("write cache-key test doc");
+    let doc_str = doc.to_str().expect("UTF-8 path");
+
+    let (first, status) = cache.run(&["verify", doc_str, "--depth", "4"]);
+    assert_eq!(status, 0, "first run failed: {first:#}");
+    assert!(
+        first.get("cache").is_none(),
+        "first run should not report a cache hit: {first:#}"
+    );
+
+    let (second, status) = cache.run(&["verify", doc_str, "--depth", "4"]);
+    assert_eq!(status, 0, "second run failed: {second:#}");
+    assert_eq!(
+        second["cache"]["hit"], true,
+        "second run should hit the verify cache: {second:#}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn literate_check_edition_finding_names_the_markdown_file_not_the_materialization() {
+    // Wraps `tests/fixtures/domain_legacy_enum_union.fsl` (which produces a
+    // `deprecated_domain_enum_union` warning under the default "current"
+    // edition — see `issue_244_domain_enum.rs`) in a literate `.md` fence and
+    // asserts the finding's `loc.file` names the `.md` path, never the
+    // transient `.literate.fsl` materialization `apply_domain_edition` reads
+    // from.
+    let dir = std::env::temp_dir().join(format!("fslc-literate-edition-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let inner = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/domain_legacy_enum_union.fsl"),
+    )
+    .expect("read domain enum-union fixture");
+    let doc = dir.join("legacy_enum.md");
+    std::fs::write(&doc, format!("# Legacy enum\n\n```fsl\n{inner}```\n")).expect("write doc");
+    let doc_str = doc.to_str().expect("UTF-8 path");
+
+    let (output, status) = run_cli(&["check", doc_str]);
+    assert_eq!(status, 0, "check failed: {output:#}");
+    let warning = output["warnings"]
+        .as_array()
+        .and_then(|warnings| {
+            warnings
+                .iter()
+                .find(|warning| warning["code"] == "deprecated_domain_enum_union")
+        })
+        .unwrap_or_else(|| panic!("missing deprecation warning: {output:#}"));
+    assert_eq!(
+        warning["loc"]["file"], doc_str,
+        "finding file field should name the .md document: {output:#}"
+    );
+    let file_field = warning["loc"]["file"].as_str().expect("file field");
+    assert!(
+        !file_field.contains("literate.fsl"),
+        "finding file field must not leak the materialized sibling: {output:#}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn four_backtick_fence_around_a_triple_backtick_fsl_example_verifies_correctly() {
+    // Regression for the CommonMark fence-length bug: a four-backtick "other"
+    // fence containing a literal ```fsl example used to be mis-tracked (the
+    // old code only ever recognized exactly-3-backtick closers), corrupting
+    // extraction and producing a confusing parse error instead of the real
+    // verdict. Per CommonMark, the final fsl block below is real spec code:
+    // `n` can reach 2 via repeated `inc()`, violating `Low`.
+    let dir = std::env::temp_dir().join(format!("fslc-literate-fourtick-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let doc = dir.join("four_backtick.md");
+    std::fs::write(
+        &doc,
+        "\
+# Spec
+
+```fsl
+spec Counter {
+  state { n: 0..3 }
+  init { n = 0 }
+  action inc() { n = n + 1 }
+```
+
+Example (four-backtick fence, inner three backticks are literal):
+
+````text
+```fsl
+example only
+```
+````
+
+```fsl
+  invariant Low { n < 2 }
+}
+```
+",
+    )
+    .expect("write four-backtick repro doc");
+    let doc_str = doc.to_str().expect("UTF-8 path");
+
+    let (output, status) = run_cli(&["verify", doc_str, "--depth", "6", "--no-cache"]);
+    assert_eq!(
+        output["result"], "violated",
+        "expected violated: {output:#}"
+    );
+    assert_eq!(status, 1, "{output:#}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/rust/fslc/tests/literate_markdown.rs
+++ b/rust/fslc/tests/literate_markdown.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn run_cli(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn fixture_path(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .to_owned()
+}
+
+#[test]
+fn literate_check_succeeds_on_valid_spec() {
+    let path = fixture_path("literate_toggle.md");
+    let (output, status) = run_cli(&["check", &path]);
+    assert_eq!(status, 0, "check failed: {output:#}");
+    assert_eq!(output["result"], "ok");
+    assert_eq!(output["spec"], "Toggle");
+}
+
+#[test]
+fn literate_verify_produces_a_bounded_verdict() {
+    let path = fixture_path("literate_toggle.md");
+    let (output, status) = run_cli(&["verify", &path, "--depth", "4", "--no-cache"]);
+    assert_eq!(status, 0, "verify failed: {output:#}");
+    assert_eq!(output["result"], "verified");
+    assert_eq!(output["completeness"], "bounded");
+}
+
+#[test]
+fn literate_parse_error_loc_points_to_the_markdown_line() {
+    let dir = std::env::temp_dir().join(format!("fslc-literate-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let bad = dir.join("bad.md");
+    std::fs::write(
+        &bad,
+        "# Bad spec\n\n```fsl\nspec Bad {\n  state { x: Bool\n}\n```\n",
+    )
+    .unwrap();
+    let (output, status) = run_cli(&["check", bad.to_str().unwrap()]);
+    assert_eq!(status, 2);
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "parse");
+    // The closing brace is at md line 6, the ``` at 7, EOF at 8 — the parser
+    // should report an error on a line >= 4 (inside or past the fsl block),
+    // not on line 1 (which would mean position mapping is broken).
+    let line = output["loc"]["line"].as_u64().expect("error loc line");
+    assert!(
+        line >= 4,
+        "error loc should point into the fsl block: {output:#}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn markdown_without_fsl_fences_is_rejected() {
+    let dir = std::env::temp_dir().join(format!("fslc-literate-nofsl-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let readme = dir.join("readme.md");
+    std::fs::write(&readme, "# Just a readme\n\nNo fsl here.\n").unwrap();
+    let (output, status) = run_cli(&["check", readme.to_str().unwrap()]);
+    assert_eq!(status, 2);
+    assert_eq!(output["result"], "error");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not contain any")),
+        "expected fsl-fence-missing error: {output:#}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn non_fsl_fenced_blocks_are_ignored() {
+    let dir = std::env::temp_dir().join(format!("fslc-literate-other-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let doc = dir.join("python_only.md");
+    std::fs::write(&doc, "# Python example\n\n```python\nprint('hello')\n```\n").unwrap();
+    let (output, status) = run_cli(&["check", doc.to_str().unwrap()]);
+    assert_eq!(status, 2);
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not contain any")),
+        "python-only doc should be rejected: {output:#}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn multi_block_spec_matches_single_block_verification() {
+    let multi_path = fixture_path("literate_toggle.md");
+
+    let single_dir =
+        std::env::temp_dir().join(format!("fslc-literate-single-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&single_dir);
+    let single = single_dir.join("toggle_single.md");
+    std::fs::write(
+        &single,
+        "\
+# Toggle
+
+```fsl
+spec Toggle {
+  state { active: Bool }
+  init  { active = false }
+  action toggle() {
+    active = not active
+  }
+  invariant AlwaysBool {
+    active or not active
+  }
+}
+```
+",
+    )
+    .unwrap();
+
+    let (multi, multi_status) = run_cli(&["verify", &multi_path, "--depth", "4", "--no-cache"]);
+    let (single, single_status) = run_cli(&[
+        "verify",
+        single.to_str().unwrap(),
+        "--depth",
+        "4",
+        "--no-cache",
+    ]);
+
+    assert_eq!(multi_status, single_status);
+    assert_eq!(multi["result"], single["result"]);
+    assert_eq!(multi["completeness"], single["completeness"]);
+    let _ = std::fs::remove_dir_all(&single_dir);
+}
+
+#[test]
+fn materialized_file_is_cleaned_up_after_check_and_verify() {
+    let dir = std::env::temp_dir().join(format!("fslc-literate-cleanup-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let doc = dir.join("cleanup_test.md");
+    std::fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/literate_toggle.md"),
+        &doc,
+    )
+    .expect("copy fixture");
+    let doc_str = doc.to_str().expect("UTF-8 path");
+
+    let _ = run_cli(&["check", doc_str]);
+    assert!(
+        !has_literate_sibling(&dir),
+        "materialized file leaked after check"
+    );
+
+    let _ = run_cli(&["verify", doc_str, "--depth", "2", "--no-cache"]);
+    assert!(
+        !has_literate_sibling(&dir),
+        "materialized file leaked after verify"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+fn has_literate_sibling(directory: &Path) -> bool {
+    std::fs::read_dir(directory)
+        .into_iter()
+        .flatten()
+        .any(|entry| {
+            entry.is_ok_and(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.contains("literate.fsl"))
+            })
+        })
+}
+
+#[test]
+fn literate_scenarios_produces_output() {
+    let path = fixture_path("literate_toggle.md");
+    let (output, status) = run_cli(&["scenarios", &path, "--depth", "4"]);
+    assert_eq!(status, 0, "scenarios failed: {output:#}");
+    assert!(
+        output.get("scenarios").is_some() || output.get("result").is_some(),
+        "scenarios should produce structured output: {output:#}"
+    );
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -782,7 +782,7 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 ## 7. CLI and JSON essentials
 
 ```
-fslc check <f>                                  # syntax / names / types only
+fslc check <f>                                  # syntax / names / types only; f = .fsl or .md (literate)
 fslc lint <path>... [--edition current|next]    # stable edition findings; never mutates
 fslc migrate <path>... --edition next [--write] # dry run by default; atomic validated write set
 fslc fmt <f|-> [--edition current|next]         # canonical source on stdout; input is never mutated
@@ -924,6 +924,13 @@ clear. `auto` shares its cache entries with plain `--engine explicit`/`bmc`
 runs of the same spec (the cache key is always the engine that actually
 decided, never `auto` itself), does not change the default engine, and is
 Rust-only.
+
+**Literate Markdown FSL.** `fslc check` and `fslc verify` accept `.md` files
+containing ` ```fsl ` fenced code blocks directly — no extraction step or
+flag needed. Non-fsl lines are blanked in place so all diagnostic positions
+point to the Markdown document's own line numbers. Multiple fsl blocks form
+one compilation unit (split definitions across sections). Files without fsl
+fences are rejected; non-fsl fences (` ```python ` etc.) are ignored.
 
 `diff` uses bidirectional bounded refinement for behavior changes, implication
 between the OLD/NEW user-invariant conjunctions, and replay of OLD `forbidden`

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -925,12 +925,15 @@ runs of the same spec (the cache key is always the engine that actually
 decided, never `auto` itself), does not change the default engine, and is
 Rust-only.
 
-**Literate Markdown FSL.** `fslc check` and `fslc verify` accept `.md` files
-containing ` ```fsl ` fenced code blocks directly — no extraction step or
-flag needed. Non-fsl lines are blanked in place so all diagnostic positions
-point to the Markdown document's own line numbers. Multiple fsl blocks form
-one compilation unit (split definitions across sections). Files without fsl
-fences are rejected; non-fsl fences (` ```python ` etc.) are ignored.
+**Literate Markdown FSL.** `fslc check`, `fslc verify`, and `fslc scenarios`
+accept `.md` files containing ` ```fsl ` fenced code blocks directly — no
+extraction step or flag needed. Non-fsl lines are blanked in place so all
+diagnostic positions point to the Markdown document's own line numbers.
+Multiple fsl blocks form one compilation unit (split definitions across
+sections). Files without fsl fences are rejected; non-fsl fences
+(` ```python ` etc.) are ignored. A literate `.md` may `use`/compose `.fsl`
+files relative to its own directory; using another `.md` as a compose target
+is not supported.
 
 `diff` uses bidirectional bounded refinement for behavior changes, implication
 between the OLD/NEW user-invariant conjunctions, and replay of OLD `forbidden`


### PR DESCRIPTION
## Problem

Markdown documents with FSL specifications embedded in fenced code blocks required manual extraction before `fslc check`/`fslc verify` could process them. This friction pushed literate-style documentation (where the Markdown IS the canonical spec) into a second-class workflow with a drift surface between the doc and a separate `.fsl` file (issue #193).

## Contract change

`fslc check doc.md` and `fslc verify doc.md` now accept `.md` files directly:

1. ` ```fsl ` fenced code blocks are extracted via **in-place blanking** — lines outside fsl blocks are replaced with empty lines so that all diagnostic positions (line numbers, columns, counterexample locs) point to the original Markdown document's own lines.
2. Multiple fsl blocks in one document form **one compilation unit** — definitions can be split across sections (state in one block, actions in another).
3. **No new flags** — `.md` extension triggers literate mode automatically.
4. Files without ` ```fsl ` fences are rejected with a clear diagnostic. Non-fsl fences (` ```python `, etc.) are ignored.
5. `use`/compose paths resolve relative to the Markdown file's directory (same as `.fsl`).
6. `fslc scenarios doc.md` also works (shares the verify dispatch path).

The default `.fsl` behavior is unchanged. This is a Rust-only feature (same policy as `--engine explicit`/`auto`).

## Implementation

- **`fsl_syntax::extract_literate_fsl`** (`rust/fsl-syntax/src/literate.rs`): blanking function that preserves line count and byte positions. Returns `None` for non-literate `.md` files.
- **`materialize_literate`** (`rust/fslc/src/main.rs`): for `.md` paths, writes blanked text to a sibling `.literate.fsl` file, passes that to the existing pipeline, removes on `Drop`. This avoids modifying the ~8 independent `read_to_string` call sites.
- **Cache-key collection** (`rust/fslc/src/verification.rs`): `collect_fsl_sources` includes `.md` files only when they contain fsl fences (checked via `extract_literate_fsl`).
- **WASM**: The browser Worker receives source text directly; literate extraction is the application's responsibility (documented waiver in `DESIGN-literate.md` §3).

## Test evidence

- `rust/fsl-syntax/src/literate.rs`: 6 unit tests (extraction, line-count preservation, multi-block, no-fsl rejection, non-fsl isolation, mixed fences).
- `rust/fslc/tests/literate_markdown.rs`: 8 CLI integration tests (check ok, verify bounded, scenarios output, parse-error loc mapping to MD lines, no-fsl rejection, non-fsl rejection, multi-block = single-block verdict, materialized-file cleanup).
- `examples/literate/toggle.md`: canonical literate example (check → ok, verify → verified).
- `cargo fmt --check` / `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test --workspace --locked`: 76 suites ok.

## Docs

- `docs/DESIGN-literate.md` (new): motivation, blanking design, materialization, scope boundaries (WASM waiver, LSP deferral, CLI contract).
- `docs/LANGUAGE.md` §7: check/verify/scenarios usage updated for `.md`, literate subsection with example.
- `skills/fsl/reference.md`: check signature note, literate paragraph.
- `docs/README.md`: design-doc index entry.
- `docs/intro/language.{en,ja}.html`: regenerated.
- `CHANGELOG.md` [Unreleased].

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)