### PR TITLE
perf(cli): eliminate verify fixed cache cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Changed
+- Native `fslc verify` cache keys now use a build-time implementation fingerprint instead of
+  hashing the full executable on every invocation, and CLI preparation reuses its validated
+  `KernelModel` across property selection and engine dispatch. Cache schema v2 invalidates old
+  entries fail-closed while removing the engine-independent fixed cost found in issue #349.
+
 ### Added
 - `docs/intro/language.ja.html` now renders from a new, section-aligned Japanese
   translation, `docs/LANGUAGE.ja.md`, instead of reusing the English `docs/LANGUAGE.md`

--- a/docs/DESIGN-incremental-verify.md
+++ b/docs/DESIGN-incremental-verify.md
@@ -49,6 +49,13 @@ kept in one place (`verify_cache.compute_key`); adding a semantics-affecting par
    (relative-path, bytes) of every `*.py` in the installed `fslc` package. The file-content
    fingerprint is what protects editable installs and dev worktrees, where the version string
    does not move when `bmc.py` does. Computed once per process (~1 MB of source; milliseconds).
+   The native Rust CLI embeds the equivalent fingerprint at compile time: SHA-256 over the
+   participating workspace crates, manifests/lockfile, enabled features, target/profile/Rust
+   flags, and `rustc -vV`. Runtime cache-key construction hashes that fixed digest rather than
+   rereading and hashing the complete executable. This preserves fail-closed invalidation for
+   rebuilt editable worktrees while avoiding an engine-independent cost proportional to a
+   debug binary's size; native entries using this layout are schema `fslc-rust-cache.v2` under
+   `verify/v2` (issue #349).
 3. **Kernel AST**: the `(ast, display_names)` pair returned by `parse_src` — i.e.
    *post*-desugaring (compose/requirements/business/governance/db/ai/domain) and *post*
    `--instances`/`--values` override application. Because `expand_compose` /
@@ -82,7 +89,8 @@ than hashing an under-specified representation).
 ## 3. Storage
 
 - Location: `$FSLC_CACHE_DIR`, else `$XDG_CACHE_HOME/fslc`, else `~/.cache/fslc`. Layout:
-  `<root>/verify/v1/<key[:2]>/<key>.json`. Content-addressed keys make a machine-global cache
+  Python uses `<root>/verify/v1/<key[:2]>/<key>.json`; native Rust schema v2 uses the same
+  layout under `<root>/verify/v2/`. Content-addressed keys make a machine-global cache
   safe across projects/worktrees; entries embed no absolute paths (results carry spec names,
   not file paths).
 - Entry: `{"schema": 1, "created": iso8601, "fslc": version, "key_inputs": {component
@@ -133,8 +141,9 @@ failed at depth k last time is answered from depth k first" without a heuristic 
 No other cross-depth reuse in v1: a `verified`-at-depth-10 entry is *not* served for a
 depth-8 request, because verified payloads embed the depth in `depth`/`checked_to_depth`/
 warning text; rewriting cached payloads is exactly the kind of cleverness this design bans.
-(Index: a small `<root>/verify/v1/xdepth/<depth-agnostic-key>.json` pointer to the violated
-entry; same atomicity rules.)
+(Index: a small `<root>/verify/v1/xdepth/<depth-agnostic-key>.json` pointer for Python, or
+`<root>/verify/v2/xdepth/<depth-agnostic-key>.json` for native Rust, to the violated entry;
+same atomicity rules.)
 
 ## 6. Property-level differential re-verification (staged; BMC only)
 

--- a/rust/fslc/Cargo.toml
+++ b/rust/fslc/Cargo.toml
@@ -36,5 +36,8 @@ serde.workspace = true
 serde_json.workspace = true
 sha2 = { workspace = true, optional = true }
 
+[build-dependencies]
+sha2.workspace = true
+
 [lints]
 workspace = true

--- a/rust/fslc/build.rs
+++ b/rust/fslc/build.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+const IMPLEMENTATION_CRATES: &[&str] = &[
+    "fsl-core",
+    "fsl-runtime",
+    "fsl-solver",
+    "fsl-solver-z3",
+    "fsl-syntax",
+    "fsl-tools",
+    "fsl-verifier",
+    "fslc",
+];
+
+fn collect_files(path: &Path, files: &mut Vec<PathBuf>) {
+    if path.is_file() {
+        files.push(path.to_path_buf());
+        return;
+    }
+    let mut entries = std::fs::read_dir(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+        .map(|entry| entry.expect("read implementation entry").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+    for entry in entries {
+        collect_files(&entry, files);
+    }
+}
+
+fn main() {
+    let manifest = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let workspace = manifest.parent().expect("Rust workspace root");
+    let mut files = vec![workspace.join("Cargo.toml"), workspace.join("Cargo.lock")];
+    for package in IMPLEMENTATION_CRATES {
+        collect_files(&workspace.join(package), &mut files);
+    }
+    files.sort();
+
+    let mut digest = Sha256::new();
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file.display());
+        let relative = file
+            .strip_prefix(workspace)
+            .expect("workspace-relative input");
+        digest.update(relative.as_os_str().as_encoded_bytes());
+        digest.update(b"\0");
+        digest.update(
+            std::fs::read(&file)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", file.display())),
+        );
+        digest.update(b"\0");
+    }
+    for name in ["PROFILE", "TARGET", "CARGO_ENCODED_RUSTFLAGS"] {
+        println!("cargo:rerun-if-env-changed={name}");
+        digest.update(name.as_bytes());
+        digest.update(b"=");
+        digest.update(std::env::var(name).unwrap_or_default().as_bytes());
+        digest.update(b"\0");
+    }
+    let mut features = std::env::vars()
+        .filter(|(name, _)| name.starts_with("CARGO_FEATURE_"))
+        .collect::<Vec<_>>();
+    features.sort();
+    for (name, value) in features {
+        digest.update(name.as_bytes());
+        digest.update(b"=");
+        digest.update(value.as_bytes());
+        digest.update(b"\0");
+    }
+    println!("cargo:rerun-if-env-changed=RUSTC");
+    let rustc = std::process::Command::new(std::env::var_os("RUSTC").expect("rustc path"))
+        .arg("-vV")
+        .output()
+        .expect("run rustc -vV");
+    assert!(rustc.status.success(), "rustc -vV failed");
+    digest.update(&rustc.stdout);
+    println!(
+        "cargo:rustc-env=FSLC_IMPLEMENTATION_FINGERPRINT={:x}",
+        digest.finalize()
+    );
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -12261,6 +12261,7 @@ fn run_verify(
     };
     let selection = ModelSelection {
         path,
+        model: None,
         scope: None,
         property: None,
         excluded: &[],

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -28,6 +28,7 @@ pub(super) use fslc_rust::verification_output::DeadlockMode;
 #[derive(Clone, Copy)]
 pub(super) struct ModelSelection<'a> {
     pub(super) path: &'a Path,
+    pub(super) model: Option<&'a KernelModel>,
     pub(super) scope: Option<&'a ScopeBounds>,
     pub(super) property: Option<&'a str>,
     pub(super) excluded: &'a [String],
@@ -149,16 +150,15 @@ fn finish_verification(
 }
 
 fn load_selected_model(selection: ModelSelection<'_>) -> Result<KernelModel, String> {
-    selection
-        .scope
-        .map_or_else(
+    let mut model = match selection.model {
+        Some(model) => model.clone(),
+        None => selection.scope.map_or_else(
             || load_model(selection.path),
             |scope| load_model_scoped(selection.path, scope),
-        )
-        .and_then(|mut model| {
-            select_properties(&mut model, selection.property, selection.excluded)?;
-            Ok(model)
-        })
+        )?,
+    };
+    select_properties(&mut model, selection.property, selection.excluded)?;
+    Ok(model)
 }
 
 pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i32) {
@@ -1520,6 +1520,7 @@ pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions)
     };
     let selection = ModelSelection {
         path,
+        model: None,
         scope: None,
         property: options.property.as_deref(),
         excluded: &options.exclude_properties,
@@ -1744,13 +1745,29 @@ fn verify_cache_keys_with_solver_version(
     engine: &str,
     solver_version: &str,
 ) -> Result<(String, String), String> {
+    verify_cache_keys_with_fingerprints(
+        path,
+        options,
+        engine,
+        solver_version,
+        env!("FSLC_IMPLEMENTATION_FINGERPRINT"),
+    )
+}
+
+fn verify_cache_keys_with_fingerprints(
+    path: &Path,
+    options: &CliVerifyOptions,
+    engine: &str,
+    solver_version: &str,
+    implementation_fingerprint: &str,
+) -> Result<(String, String), String> {
     let canonical = cache_identity(path)?;
     let base = canonical.parent().unwrap_or_else(|| Path::new("."));
     let mut sources = Vec::new();
     collect_fsl_sources(base, &mut sources).map_err(|error| error.to_string())?;
     sources.sort();
     let mut digest = Sha256::new();
-    digest.update(b"fslc-rust-verify-cache-v1\0");
+    digest.update(b"fslc-rust-verify-cache-v2\0");
     digest.update(env!("CARGO_PKG_VERSION").as_bytes());
     if engine == "explicit" {
         digest.update(b"\0backend=native-explicit\0");
@@ -1759,9 +1776,8 @@ fn verify_cache_keys_with_solver_version(
         digest.update(solver_version.as_bytes());
         digest.update(b"\0");
     }
-    let executable = std::env::current_exe().map_err(|error| error.to_string())?;
-    digest.update(b"executable\0");
-    digest.update(std::fs::read(executable).map_err(|error| error.to_string())?);
+    digest.update(b"implementation\0");
+    digest.update(implementation_fingerprint.as_bytes());
     digest.update(b"\0");
     for source in sources {
         digest.update(
@@ -1804,7 +1820,7 @@ fn verify_cache_keys_with_solver_version(
 fn verify_cache_path(key: &str) -> Option<PathBuf> {
     Some(
         cache_root()?
-            .join("verify/v1")
+            .join("verify/v2")
             .join(&key[..2])
             .join(format!("{key}.json")),
     )
@@ -1822,7 +1838,7 @@ fn verify_cache_lookup_with_fallback(
     let path = verify_cache_path(key)?;
     if let Ok(bytes) = std::fs::read(path)
         && let Ok(entry) = serde_json::from_slice::<Value>(&bytes)
-        && entry.get("schema").and_then(Value::as_str) == Some("fslc-rust-cache.v1")
+        && entry.get("schema").and_then(Value::as_str) == Some("fslc-rust-cache.v2")
         && entry.get("key").and_then(Value::as_str) == Some(key)
     {
         let mut output = entry.get("output")?.clone();
@@ -1833,7 +1849,7 @@ fn verify_cache_lookup_with_fallback(
         return Some((output, entry.get("engine_fallback").cloned()));
     }
     let pointer_path = cache_root()?
-        .join("verify/v1/xdepth")
+        .join("verify/v2/xdepth")
         .join(format!("{xdepth}.json"));
     let pointer: Value = serde_json::from_slice(&std::fs::read(pointer_path).ok()?).ok()?;
     let violation_step = usize::try_from(pointer.get("violated_at_step")?.as_u64()?).ok()?;
@@ -1877,7 +1893,7 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value, engine_fallback: 
     let temporary = parent.join(format!(".{}.{}.tmp", key, std::process::id()));
     let explicit = output.get("engine").and_then(Value::as_str) == Some("explicit");
     let mut entry = json!({
-        "schema": "fslc-rust-cache.v1",
+        "schema": "fslc-rust-cache.v2",
         "key": key,
         "backend": if explicit { "native-explicit" } else { "native-z3" },
         "solver_version": if explicit {
@@ -1903,7 +1919,7 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value, engine_fallback: 
         && let Some(step) = output.get("violated_at_step").and_then(Value::as_u64)
         && let Some(root) = cache_root()
     {
-        let directory = root.join("verify/v1/xdepth");
+        let directory = root.join("verify/v2/xdepth");
         if std::fs::create_dir_all(&directory).is_ok() {
             let pointer = directory.join(format!("{xdepth}.json"));
             let temporary = directory.join(format!(".{xdepth}.{}.tmp", std::process::id()));
@@ -1920,7 +1936,10 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value, engine_fallback: 
 
 struct PreparedCliVerification {
     has_scope: bool,
+    is_agent_document: bool,
+    model: Result<KernelModel, String>,
     initial_state: Option<std::collections::BTreeMap<String, FslValue>>,
+    has_trace_contract: bool,
 }
 
 pub(super) fn run_verify_cli(path: &Path, options: &CliVerifyOptions) -> CommandResult {
@@ -1983,11 +2002,15 @@ fn prepare_cli_verification(
     path: &Path,
     options: &CliVerifyOptions,
 ) -> Result<PreparedCliVerification, CommandResult> {
-    if let Ok(source) = std::fs::read_to_string(path)
-        && let Err(error) = fsl_syntax::parse_surface_document(&source)
-    {
-        return Err((error_output("parse", &error.to_string()), 2));
-    }
+    let is_agent_document = if let Ok(source) = std::fs::read_to_string(path) {
+        match fsl_syntax::parse_surface_document(&source) {
+            Ok(fsl_syntax::SurfaceDocument::Agent(_)) => true,
+            Ok(_) => false,
+            Err(error) => return Err((error_output("parse", &error.to_string()), 2)),
+        }
+    } else {
+        false
+    };
     let has_scope = !options.scope.instances.is_empty() || !options.scope.values.is_empty();
     if let Err(error) = validate_specialized_document(path) {
         return Err((semantic_error_output(&error), 2));
@@ -2008,17 +2031,21 @@ fn prepare_cli_verification(
     } else {
         None
     };
+    let mut has_trace_contract = false;
     if !has_scope && let Ok(model) = &snapshot_model {
         match validate_requirement_traces(path, model) {
             Ok((Some(failure), _)) => return Err((failure, 2)),
-            Ok((None, _)) => {}
+            Ok((None, has_contract)) => has_trace_contract = has_contract,
             Err(error) => return Err((semantic_error_output(&error), 2)),
         }
     }
-    validate_cli_property_selection(path, options, has_scope)?;
+    validate_cli_property_selection(path, options, has_scope, snapshot_model.as_ref().ok())?;
     Ok(PreparedCliVerification {
         has_scope,
+        is_agent_document,
+        model: snapshot_model,
         initial_state,
+        has_trace_contract,
     })
 }
 
@@ -2026,14 +2053,15 @@ fn validate_cli_property_selection(
     path: &Path,
     options: &CliVerifyOptions,
     has_scope: bool,
+    prepared_model: Option<&KernelModel>,
 ) -> Result<(), CommandResult> {
     if options.property.is_none() && options.exclude_properties.is_empty() {
         return Ok(());
     }
-    let mut model = if has_scope {
-        load_model_scoped(path, &options.scope)
-    } else {
-        load_model(path)
+    let mut model = match prepared_model {
+        Some(model) => Ok(model.clone()),
+        None if has_scope => load_model_scoped(path, &options.scope),
+        None => load_model(path),
     }
     .map_err(|error| (semantic_error_output(&error), 2))?;
     if options.engine == "induction"
@@ -2154,58 +2182,97 @@ fn execute_cli_verification(
     options: &CliVerifyOptions,
     prepared: &PreparedCliVerification,
 ) -> CommandResult {
-    if prepared.has_scope
+    let filtered = prepared.has_scope
         || options.property.is_some()
         || !options.exclude_properties.is_empty()
-        || prepared.initial_state.is_some()
-    {
-        let deadlock = match DeadlockMode::parse(&options.deadlock) {
-            Ok(mode) => mode,
-            Err(error) => return (error_output("usage", &error), 2),
-        };
-        let selection = ModelSelection {
-            path,
-            scope: prepared.has_scope.then_some(&options.scope),
-            property: options.property.as_deref(),
-            excluded: &options.exclude_properties,
-        };
-        return match VerificationEngine::parse(&options.engine) {
-            Ok(VerificationEngine::Bmc) => run_bmc_filtered(BmcRequest {
-                selection,
-                depth: options.depth,
-                deadlock,
-                initial_state: prepared.initial_state.as_ref(),
-            }),
-            Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {
-                selection,
-                depth: options.depth,
-                deadlock,
-                k: options.k_ind,
-                auxiliary: &[],
-            }),
-            Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
-                selection,
-                depth: options.depth,
-                deadlock,
-                budget: options.explicit_budget,
-            }),
-            Ok(VerificationEngine::Auto) => run_auto_filtered(ExplicitRequest {
-                selection,
-                depth: options.depth,
-                deadlock,
-                budget: options.explicit_budget,
-            }),
-            Err(error) => (error_output("usage", &error), 2),
-        };
+        || prepared.initial_state.is_some();
+    if !filtered && prepared.is_agent_document {
+        return (
+            error_output(
+                "parse",
+                "agent documents cannot be verified as Kernel specs",
+            ),
+            2,
+        );
     }
-    run_verify(
+    let deadlock = match DeadlockMode::parse(&options.deadlock) {
+        Ok(mode) => mode,
+        Err(error) => return (error_output("usage", &error), 2),
+    };
+    let model = match &prepared.model {
+        Ok(model) => model,
+        Err(error) => return (semantic_error_output(error), 2),
+    };
+    let implements = if filtered {
+        None
+    } else {
+        match implements_result(path, model, options.depth) {
+            Ok(implements) => implements,
+            Err(error) => return (error_output("type", &error), 2),
+        }
+    };
+    let selection = ModelSelection {
         path,
-        options.depth,
-        &options.deadlock,
-        &options.engine,
-        options.explicit_budget,
-        options.k_ind,
-    )
+        model: Some(model),
+        scope: None,
+        property: options.property.as_deref(),
+        excluded: &options.exclude_properties,
+    };
+    let (mut output, status) = match VerificationEngine::parse(&options.engine) {
+        Ok(VerificationEngine::Bmc) => run_bmc_filtered(BmcRequest {
+            selection,
+            depth: options.depth,
+            deadlock,
+            initial_state: prepared.initial_state.as_ref(),
+        }),
+        Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {
+            selection,
+            depth: options.depth,
+            deadlock,
+            k: options.k_ind,
+            auxiliary: &[],
+        }),
+        Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
+            selection,
+            depth: options.depth,
+            deadlock,
+            budget: options.explicit_budget,
+        }),
+        Ok(VerificationEngine::Auto) => run_auto_filtered(ExplicitRequest {
+            selection,
+            depth: options.depth,
+            deadlock,
+            budget: options.explicit_budget,
+        }),
+        Err(error) => return (error_output("usage", &error), 2),
+    };
+    if !filtered {
+        decorate_default_cli_verification(&mut output, implements, prepared.has_trace_contract);
+    }
+    (output, status)
+}
+
+fn decorate_default_cli_verification(
+    output: &mut Value,
+    implements: Option<Value>,
+    has_trace_contract: bool,
+) {
+    let Value::Object(envelope) = output else {
+        return;
+    };
+    if envelope.get("result").and_then(Value::as_str) != Some("error")
+        && let Some(implements) = implements
+    {
+        envelope.insert("implements".to_owned(), implements);
+    }
+    if (envelope.contains_key("implements") || has_trace_contract)
+        && let Some(Value::Array(warnings)) = envelope.get_mut("warnings")
+    {
+        warnings.retain(|warning| {
+            warning.get("message").and_then(Value::as_str)
+                != Some("spec declares no user invariants (only implicit type bounds are checked)")
+        });
+    }
 }
 
 fn finalize_cli_verification(
@@ -2326,6 +2393,7 @@ mod tests {
         let (output, status) = run_bmc_filtered(BmcRequest {
             selection: ModelSelection {
                 path: &path,
+                model: None,
                 scope: None,
                 property: None,
                 excluded: &excluded,
@@ -2346,6 +2414,7 @@ mod tests {
         let (output, status) = run_induction_filtered(InductionRequest {
             selection: ModelSelection {
                 path: &path,
+                model: None,
                 scope: None,
                 property: None,
                 excluded: &excluded,
@@ -2411,6 +2480,31 @@ mod tests {
             .expect("current solver cache keys");
         let updated = verify_cache_keys_with_solver_version(&path, &options, "bmc", "Z3 4.17.0.0")
             .expect("updated solver cache keys");
+
+        assert_ne!(current, updated);
+    }
+
+    #[test]
+    fn cache_keys_include_the_compiled_implementation_fingerprint() {
+        let path = repository_path("examples/gallery/valid/tiny_turnstile.fsl");
+        let options = CliVerifyOptions::default();
+
+        let current = verify_cache_keys_with_fingerprints(
+            &path,
+            &options,
+            "bmc",
+            "Z3 4.16.0.0",
+            "implementation-a",
+        )
+        .expect("current implementation cache keys");
+        let updated = verify_cache_keys_with_fingerprints(
+            &path,
+            &options,
+            "bmc",
+            "Z3 4.16.0.0",
+            "implementation-b",
+        )
+        .expect("updated implementation cache keys");
 
         assert_ne!(current, updated);
     }

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -48,6 +48,23 @@ fn native_cli_checks_a_repository_spec_without_python() {
 }
 
 #[test]
+fn native_verify_preserves_the_agent_document_boundary_error() {
+    let (value, status) = run_cli(&[
+        "verify",
+        "examples/ai/recursive_support_agent.fsl",
+        "--no-cache",
+    ]);
+
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "parse");
+    assert_eq!(
+        value["message"],
+        "agent documents cannot be verified as Kernel specs"
+    );
+}
+
+#[test]
 fn native_check_and_verify_share_the_core_duplicate_write_gate() {
     let fixture = "rust/fslc/tests/fixtures/duplicate_write.fsl";
 


### PR DESCRIPTION
## Summary

Eliminates the engine-independent fixed cost in native `fslc verify` while preserving fail-closed cache identity and verification semantics.

Closes #349.

## Why

- **Root cause:** cache-key construction SHA-256 hashed the complete 52 MiB debug executable on every invocation. This dominated the listed parse/validation/model stages and could repeat three times for `--engine auto`.
- **Decision:** embed a cryptographic implementation fingerprint at build time instead of weakening identity to mtime/size or moving lookup ahead of validation.
- **Secondary cleanup:** reuse the already validated `KernelModel` across property validation and engine dispatch, removing feasible duplicate model loads requested by the issue.

## What Changed

- Added a build-time SHA-256 fingerprint over participating Rust sources, manifests/lockfile, features, target/profile/Rust flags, and `rustc -vV`.
- Bumped native cache entries and cross-depth pointers to fail-closed schema/path v2.
- Reused `PreparedCliVerification`'s model for BMC, induction, explicit, auto, scope/property, and snapshot dispatch.
- Preserved the agent-document error boundary with a negative regression test.
- Updated the incremental-verify design and changelog.

## Invariants

- Parse/model validation remains before cache lookup.
- Source/options/solver/implementation changes must invalidate cache entries; errors are never cached and cache failures remain misses.
- JSON verdict/evidence, exit codes, locations, `engine_fallback`, `--from-state`, and induction behavior remain unchanged.

## Evidence

Five-run instruction-count medians on the same native debug binary, `examples/gallery/valid/tiny_turnstile.fsl`, depth 8:

| Command | Instructions |
|---|---:|
| `check` | 94,167,834 |
| explicit `--no-cache` | 76,252,784 |
| explicit cold cache | 99,793,248 |
| explicit warm hit | 90,028,328 |
| BMC cold cache | 154,388,054 |

All paths are now in the same 10^8 order as `check`, versus the reported ~25B and locally reproduced 40.0B baseline.

Candidate-stage instrumentation showed each listed preprocessing stage completed in <=0.01s and <=86.6M cumulative process instructions; temporary instrumentation is not included in this PR.

- [x] `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- [x] `./tools/check-native-integration.sh` with pinned Z3 4.16.0
- [x] WASM browser native parity: 345 cases
- [x] Independent final review; no correctness/cache/engine blocker found

## Blast Radius and Failure Modes

- **Affected:** native verify-cache identity/storage and native CLI model preparation.
- **Compatibility:** old native cache entries intentionally miss under v2; no output/CLI compatibility change.
- A missing build input could stale the fingerprint; the build script hashes all participating workspace crates plus build configuration, and a negative key test proves fingerprint changes alter keys.
- Prepared-model drift could change verdicts; full BMC/explicit/auto corpus agreement and CLI regression suites cover this boundary.

## Rollout & Rollback

No migration is required; v2 cache entries populate lazily. Reverting this commit restores v1 behavior, with the expected cache miss between schemas.

## Review Focus

- `rust/fslc/build.rs`: completeness and reproducibility of implementation inputs.
- `rust/fslc/src/verification.rs`: cache v2 identity and prepared-model reuse.
- `docs/DESIGN-incremental-verify.md`: Python v1 versus native Rust v2 contract.
