### PR TITLE
ci: split Rust and WASM verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  rust-workspace-wasm:
-    name: rust workspace and WASM
+  rust-workspace:
+    name: rust workspace
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -28,6 +28,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy,rustfmt
+
+      - name: Check Rust workspace
+        run: ./tools/check-native-integration.sh rust
+
+  wasm:
+    name: WASM
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      Z3_SYS_Z3_VERSION: "4.16.0"
+      READ_ONLY_GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
           targets: wasm32-unknown-unknown
 
       - uses: actions/setup-node@v4
@@ -38,11 +54,22 @@ jobs:
             rust/spikes/z3js-worker/package-lock.json
             rust/fsl-wasm/package-lock.json
 
+      - name: Cache pinned wasm-bindgen CLI
+        id: wasm-bindgen-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/wasm-bindgen
+            ~/.cargo/bin/wasm-bindgen-test-runner
+            ~/.cargo/bin/wasm2es6js
+          key: ${{ runner.os }}-wasm-bindgen-cli-0.2.126
+
       - name: Install pinned wasm-bindgen CLI
+        if: steps.wasm-bindgen-cache.outputs.cache-hit != 'true'
         run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
-      - name: Check native integration suite
-        run: ./tools/check-native-integration.sh
+      - name: Check WASM integration
+        run: ./tools/check-native-integration.sh wasm
 
   rust-native-z3:
     name: native Z3 4.16 (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   #278).
 
 ### Changed
+- Required product CI now runs the Rust workspace and WASM integration phases in parallel while
+  preserving `tools/check-native-integration.sh` as the complete local gate. The pinned
+  `wasm-bindgen-cli` binaries are cached by runner OS and version instead of being rebuilt on every
+  run.
 - The internal `release` Skill now operates a GitLab Flow-inspired
   `short-lived branch -> main -> production -> vX.Y.Z` lifecycle. It separates
   integration evidence from release readiness, omits permanent `develop` and

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -6,14 +6,6 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
-cargo fmt --manifest-path rust/Cargo.toml --all -- --check
-cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
-cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --lib --locked
-cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --test stdio --locked
-cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --test corpus --locked
-cargo test --manifest-path rust/Cargo.toml --workspace --exclude fsl-lsp --locked
-cargo build --manifest-path rust/Cargo.toml --workspace --locked
-
 assert_dependency_absent() {
   local package="$1" pattern="$2" message="$3" tree
   tree="$(cargo tree --manifest-path rust/Cargo.toml -p "$package" --edges normal)"
@@ -23,11 +15,41 @@ assert_dependency_absent() {
   fi
 }
 
-assert_dependency_absent fsl-runtime 'fsl-solver|z3' 'fsl-runtime must remain solver-independent'
-assert_dependency_absent fsl-wasm 'fsl-solver-z3 v' 'fsl-wasm must not depend on the native Z3 backend'
+check_rust() {
+  cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+  cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
+  cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --lib --locked
+  cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --test stdio --locked
+  cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --test corpus --locked
+  cargo test --manifest-path rust/Cargo.toml --workspace --exclude fsl-lsp --locked
+  cargo build --manifest-path rust/Cargo.toml --workspace --locked
 
-npm --prefix rust/spikes/z3js-worker ci
-npm --prefix rust/spikes/z3js-worker run probe
-npm --prefix rust/spikes/z3js-worker run probe:browser
-npm --prefix rust/fsl-wasm ci
-npm --prefix rust/fsl-wasm run test:browser
+  assert_dependency_absent fsl-runtime 'fsl-solver|z3' 'fsl-runtime must remain solver-independent'
+  assert_dependency_absent fsl-wasm 'fsl-solver-z3 v' 'fsl-wasm must not depend on the native Z3 backend'
+}
+
+check_wasm() {
+  npm --prefix rust/spikes/z3js-worker ci
+  npm --prefix rust/spikes/z3js-worker run probe
+  npm --prefix rust/spikes/z3js-worker run probe:browser
+  cargo build --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc --locked
+  npm --prefix rust/fsl-wasm ci
+  npm --prefix rust/fsl-wasm run test:browser
+}
+
+case "${1:-all}" in
+  rust)
+    check_rust
+    ;;
+  wasm)
+    check_wasm
+    ;;
+  all)
+    check_rust
+    check_wasm
+    ;;
+  *)
+    echo "usage: $0 [all|rust|wasm]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## What changed

- split the required product CI into parallel `rust workspace` and `WASM` jobs
- add `rust` and `wasm` phases to `tools/check-native-integration.sh` while keeping the no-argument complete gate
- make the WASM phase self-contained by building its required native `fslc` binary
- cache the pinned `wasm-bindgen-cli` binaries by runner OS and version

## Why

The combined Rust workspace and WASM job was the CI critical path. In [run 29535948977](https://github.com/ymm-oss/fsl/actions/runs/29535948977/job/87747187393), the job took 10m22s, including 8m36s in the serial integration step and 1m27s installing `wasm-bindgen-cli`.

Running the unchanged Rust and WASM verification surfaces in parallel shortens the critical path without removing checks. Exact CI timing will be measured by this PR; the first run will populate the wasm-bindgen cache.

## Validation

- `./tools/check-native-integration.sh rust`
- `./tools/check-native-integration.sh wasm` — native parity passed for 345 cases
- `bash -n tools/check-native-integration.sh`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`
