### PR TITLE
fix(release): align Rust MSRV with locked dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Build native Rust binary
         working-directory: rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   VSIX, and Kernel bundles before one tag-only publication step. Release actions,
   the Rust toolchain, and the VSIX packager are pinned; publication verifies a
   remote draft inventory before making it public, and manual dry runs validate
-  the same assembled unit without publishing it.
+  the same assembled unit without publishing it. Native crates and release
+  builds require Rust 1.88 or newer.
 - The installer rejects unsupported Intel macOS, pins repository content and
   binaries to the same latest Release tag, and stages both checksummed native
   binaries before replacing either installed command. Linux artifacts now have

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 version = "3.0.0"
 edition = "2024"
 license = "Apache-2.0"
-rust-version = "1.85"
+rust-version = "1.88"
 publish = false
 
 [workspace.dependencies]

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -341,19 +341,19 @@ impl<'a> Context<'a> {
             }
         }
         for (variable, ty) in type_env {
-            if self.ty(ty).is_some_and(|ty| ty.kind == "enum") {
-                if let Some(definition) = self.ty(ty) {
-                    for member in &definition.members {
-                        let value = self.enum_value(ty, member);
-                        output = output.replace(
-                            &format!("{variable} == {member}"),
-                            &format!("{variable} == {value}"),
-                        );
-                        output = output.replace(
-                            &format!("{variable} != {member}"),
-                            &format!("{variable} != {value}"),
-                        );
-                    }
+            if self.ty(ty).is_some_and(|ty| ty.kind == "enum")
+                && let Some(definition) = self.ty(ty)
+            {
+                for member in &definition.members {
+                    let value = self.enum_value(ty, member);
+                    output = output.replace(
+                        &format!("{variable} == {member}"),
+                        &format!("{variable} == {value}"),
+                    );
+                    output = output.replace(
+                        &format!("{variable} != {member}"),
+                        &format!("{variable} != {value}"),
+                    );
                 }
             }
             let marker = format!("{variable} in [");

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -1361,10 +1361,10 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
     expr: Expr,
     replacements: &HashMap<String, Expr, S>,
 ) -> Expr {
-    if let Expr::Var(name) = &expr {
-        if let Some(replacement) = replacements.get(name) {
-            return replacement.clone();
-        }
+    if let Expr::Var(name) = &expr
+        && let Some(replacement) = replacements.get(name)
+    {
+        return replacement.clone();
     }
     match expr {
         Expr::Some(expr) => Expr::Some(Box::new(substitute(*expr, replacements))),

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -247,20 +247,20 @@ fn infer_type(
             _ => Err(error("public Kernel cannot infer uncontextualized none")),
         },
         Expr::Some(item) => {
-            if let Some(expected) = expected {
-                if matches!(resolve(model, expected)?, TypeRef::Option(_)) {
-                    return Ok(expected.clone());
-                }
+            if let Some(expected) = expected
+                && matches!(resolve(model, expected)?, TypeRef::Option(_))
+            {
+                return Ok(expected.clone());
             }
             Ok(TypeRef::Option(Box::new(infer_type(
                 item, env, model, None,
             )?)))
         }
         Expr::Set(items) => {
-            if let Some(expected) = expected {
-                if matches!(resolve(model, expected)?, TypeRef::Set(_)) {
-                    return Ok(expected.clone());
-                }
+            if let Some(expected) = expected
+                && matches!(resolve(model, expected)?, TypeRef::Set(_))
+            {
+                return Ok(expected.clone());
             }
             let first = items
                 .first()
@@ -268,10 +268,10 @@ fn infer_type(
             Ok(TypeRef::Set(Box::new(infer_type(first, env, model, None)?)))
         }
         Expr::Seq(items) => {
-            if let Some(expected) = expected {
-                if matches!(resolve(model, expected)?, TypeRef::Seq(_, _)) {
-                    return Ok(expected.clone());
-                }
+            if let Some(expected) = expected
+                && matches!(resolve(model, expected)?, TypeRef::Seq(_, _))
+            {
+                return Ok(expected.clone());
             }
             let first = items
                 .first()

--- a/rust/fsl-syntax/src/db.rs
+++ b/rust/fsl-syntax/src/db.rs
@@ -590,11 +590,11 @@ impl DbParser {
             } else {
                 None
             };
-            if capability == "emits_offline" {
-                if let Some(ttl) = ttl {
-                    for reference in &refs {
-                        offline_ttls.insert(reference.clone(), ttl);
-                    }
+            if capability == "emits_offline"
+                && let Some(ttl) = ttl
+            {
+                for reference in &refs {
+                    offline_ttls.insert(reference.clone(), ttl);
                 }
             }
             capabilities.entry(capability).or_default().extend(refs);

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -1346,11 +1346,11 @@ impl DomainParser {
             return Err(ParseError::new("expected time value", token.span));
         };
         let mut output = value.to_string();
-        if let TokenKind::Ident(unit) = &self.peek().kind {
-            if token.span.end.offset == self.peek().span.start.offset {
-                output.push_str(unit);
-                self.bump();
-            }
+        if let TokenKind::Ident(unit) = &self.peek().kind
+            && token.span.end.offset == self.peek().span.start.offset
+        {
+            output.push_str(unit);
+            self.bump();
         }
         Ok(output)
     }

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1585,12 +1585,12 @@ impl<'a> Parser<'a> {
                 return Ok(result);
             }
         }
-        if let TokenKind::Ident(name) = &self.peek().kind {
-            if self.next_is_type_delimiter() {
-                let name = name.clone();
-                self.bump();
-                return Ok(TypeExpr::Name(name));
-            }
+        if let TokenKind::Ident(name) = &self.peek().kind
+            && self.next_is_type_delimiter()
+        {
+            let name = name.clone();
+            self.bump();
+            return Ok(TypeExpr::Name(name));
         }
         let lo = self.expression(0)?;
         self.expect_symbol("..")?;

--- a/rust/fsl-tools/src/analysis_graph.rs
+++ b/rust/fsl-tools/src/analysis_graph.rs
@@ -325,14 +325,16 @@ fn action_state(tsg: &Value) -> (Vec<Value>, Vec<Value>) {
     for edge in tsg["edges"].as_array().into_iter().flatten() {
         let from = edge["from"].as_str().unwrap_or_default();
         let to = edge["to"].as_str().unwrap_or_default();
-        if edge["kind"] == "writes" && state_ids.contains(to) {
-            if let Some(action) = owner(from) {
-                edges.push(projection_edge(&action, "writes", to));
-            }
-        } else if edge["kind"] == "reads" && state_ids.contains(to) {
-            if let Some(action) = owner(from) {
-                edges.push(projection_edge(to, "read_by", &action));
-            }
+        if edge["kind"] == "writes"
+            && state_ids.contains(to)
+            && let Some(action) = owner(from)
+        {
+            edges.push(projection_edge(&action, "writes", to));
+        } else if edge["kind"] == "reads"
+            && state_ids.contains(to)
+            && let Some(action) = owner(from)
+        {
+            edges.push(projection_edge(to, "read_by", &action));
         }
     }
     select(tsg, &action_ids.union(&state_ids).cloned().collect(), edges)

--- a/rust/fsl-verifier/src/value.rs
+++ b/rust/fsl-verifier/src/value.rs
@@ -1027,22 +1027,22 @@ fn project_scalar<S: SmtSolver>(
         return Ok(FslValue::Bool(project_bool(solver, term)?));
     }
     let value = project_int(solver, term)?;
-    if let TypeRef::Named(name) = ty {
-        if let Some(TypeDef::Enum { members, .. }) = model.types.get(name) {
-            let index = usize::try_from(value)
-                .map_err(|_| VerifyError::new("negative enum ordinal in solver model"))?;
-            let Some(member) = members.get(index) else {
-                // A type-bound counterexample deliberately assigns an invalid
-                // ordinal. Preserve that raw value so the verifier can emit the
-                // witness instead of turning a valid finding into a projection
-                // error.
-                return Ok(FslValue::Int(value));
-            };
-            return Ok(FslValue::Enum {
-                type_name: name.clone(),
-                member: member.clone(),
-            });
-        }
+    if let TypeRef::Named(name) = ty
+        && let Some(TypeDef::Enum { members, .. }) = model.types.get(name)
+    {
+        let index = usize::try_from(value)
+            .map_err(|_| VerifyError::new("negative enum ordinal in solver model"))?;
+        let Some(member) = members.get(index) else {
+            // A type-bound counterexample deliberately assigns an invalid
+            // ordinal. Preserve that raw value so the verifier can emit the
+            // witness instead of turning a valid finding into a projection
+            // error.
+            return Ok(FslValue::Int(value));
+        };
+        return Ok(FslValue::Enum {
+            type_name: name.clone(),
+            member: member.clone(),
+        });
     }
     Ok(FslValue::Int(value))
 }

--- a/rust/fslc/src/coverage.rs
+++ b/rust/fslc/src/coverage.rs
@@ -606,15 +606,15 @@ fn walk_value_kinds(
         },
         TypeRef::Option(inner) => {
             tags.insert("value_option");
-            if value.get("kind").and_then(Value::as_str) == Some("some") {
-                if let Some(inner_value) = value.get("value") {
-                    if matches!(inner.as_ref(), TypeRef::Option(_))
-                        && inner_value.get("kind").and_then(Value::as_str) == Some("none")
-                    {
-                        *nested_option = true;
-                    }
-                    walk_value_kinds(inner, inner_value, model, tags, nested_option);
+            if value.get("kind").and_then(Value::as_str) == Some("some")
+                && let Some(inner_value) = value.get("value")
+            {
+                if matches!(inner.as_ref(), TypeRef::Option(_))
+                    && inner_value.get("kind").and_then(Value::as_str) == Some("none")
+                {
+                    *nested_option = true;
                 }
+                walk_value_kinds(inner, inner_value, model, tags, nested_option);
             }
         }
         TypeRef::Map(_, item) => {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3795,13 +3795,13 @@ fn run_scenarios_mode(
         insert_requirement_metadata(&mut scenario, &action.annotations, action.meta.as_ref());
         scenarios.push(Value::Object(scenario));
     }
-    if let Some(trace) = &result.deadlock_trace {
-        if deadlock_mode != "ignore" {
-            let mut scenario = scenario_from_trace(trace);
-            scenario.insert("name".to_owned(), json!("deadlock_terminal"));
-            scenario.insert("kind".to_owned(), json!("deadlock"));
-            scenarios.push(Value::Object(scenario));
-        }
+    if let Some(trace) = &result.deadlock_trace
+        && deadlock_mode != "ignore"
+    {
+        let mut scenario = scenario_from_trace(trace);
+        scenario.insert("name".to_owned(), json!("deadlock_terminal"));
+        scenario.insert("kind".to_owned(), json!("deadlock"));
+        scenarios.push(Value::Object(scenario));
     }
     match requirement_trace_scenarios(path, &model) {
         Ok(requirement_scenarios) => scenarios.extend(requirement_scenarios),

--- a/rust/fslc/tests/native_integration.rs
+++ b/rust/fslc/tests/native_integration.rs
@@ -346,7 +346,7 @@ fn native_release_unit_is_atomic_pinned_and_platform_closed() {
             "mutable release action: {mutable}"
         );
     }
-    assert!(workflow.contains("toolchain: 1.85.0"));
+    assert!(workflow.contains("toolchain: 1.88.0"));
 
     let installer = std::fs::read_to_string(root.join("install.sh")).expect("installer");
     assert!(!installer.contains("echo \"macos-x64\""));


### PR DESCRIPTION
## Problem
The exact-main release dry-run failed on all four native targets because the pinned Rust 1.85.0 toolchain cannot build locked dependencies requiring Rust 1.88.

## Contract change
- Declare Rust 1.88 as the workspace MSRV.
- Pin release builds to Rust 1.88.0.
- Apply behavior-preserving let-chain consolidations required by the newly effective Clippy MSRV.

## Evidence
- `cargo +1.88.0 check --manifest-path rust/Cargo.toml --workspace --locked`
- `Z3_SYS_Z3_VERSION=4.16.0 cargo +1.88.0 build --manifest-path rust/Cargo.toml --release --locked -p fslc-rust -p fsl-lsp`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `./tools/check-native-integration.sh` (345 native/WASM parity cases)

## Release evidence
Failed non-publishing dry-run: https://github.com/ymm-oss/fsl/actions/runs/29551023546
No tag or GitHub Release was created.