### PR TITLE
ci: bootstrap production source policy

### DIFF
--- a/.github/workflows/production-policy.yml
+++ b/.github/workflows/production-policy.yml
@@ -1,0 +1,28 @@
+name: production-policy
+
+on:
+  pull_request_target:
+    branches: [production]
+
+permissions:
+  contents: read
+
+jobs:
+  source-policy:
+    name: production source policy
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Accept only reviewed promotion branches
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REPO" != "$REPOSITORY" ]; then
+            echo "production accepts branches only from $REPOSITORY; got: $HEAD_REPO" >&2
+            exit 1
+          fi
+          if [[ ! "$HEAD_REF" =~ ^main$|^release/v[0-9]+\.[0-9]+$|^hotfix/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "production accepts only main, release/vX.Y, or hotfix/vX.Y.Z; got: $HEAD_REF" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Purpose

One-time bootstrap of the reviewed production source policy onto the latest published baseline. The `pull_request_target` workflow cannot validate its own first installation because it is absent from the `production` base branch.

## Exact baseline

- production: `6668457c888641b92edea33685687590e73c16f8` (`v2.7.0`)
- bootstrap head: `bc8ed15063dff08bca31775ca3150b4ea5530ad2`
- only added path: `.github/workflows/production-policy.yml`
- policy blob: `6374195aa178d14acc9d120c0f29f0f6be28b154`, byte-identical to reviewed `main`

## Manual bootstrap verification

- allowed source branch: `release/v2.7`
- same-repository head: `ymm-oss/fsl`
- no product or release artifact changes

After this PR is explicitly approved and merged, the production ruleset will require `production source policy` on future promotion PRs.