### PR TITLE
fix(install): replace repository clone with native payload

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -112,9 +112,9 @@ a feature-flag system solely to accommodate this flow.
 4. Run `./tools/check-native-integration.sh` and dispatch the release workflow's
    manual artifact build. Verify the completed run's `head_sha` equals the
    recorded candidate SHA; discard and rerun evidence produced from a moving
-   branch after it advances. Confirm all four native targets, the VS Code
-   extension, and both Kernel bundles pass. `workflow_dispatch` is
-   non-publishing and must never attach Release assets, even for a tag ref. Add
+   branch after it advances. Confirm all four native targets, the Agent Skill
+   bundle, the VS Code extension, and both Kernel bundles pass.
+   `workflow_dispatch` is non-publishing and must never attach Release assets, even for a tag ref. Add
    focused formal, mutation, platform, or compatibility evidence when the
    changed contract requires it.
 5. Open `main -> production`. State the candidate SHA, version, included changes,
@@ -152,7 +152,8 @@ After the promotion is approved and merged:
    only the failed jobs; do not retag.
 9. Verify the Release body is non-empty and matches the changelog section.
 10. Verify exactly the four supported native `fslc`/`fslc-lsp` asset pairs and
-    checksums, the VS Code extension, and both Kernel bundles. Reject any
+    checksums, the Agent Skill bundle and checksum, the VS Code extension, and
+    both Kernel bundles. Reject any
     `macos-x64` asset. Download one supported binary, verify its checksum, and
     require `fslc --version` to equal the tag; the workflow performs the same
     tag/version assertion on every native runner.
@@ -199,7 +200,8 @@ path. Apply these design constraints when a change affects architecture:
 - Keep branch names out of product configuration, binaries, schemas, and runtime
   behavior. Git controls promotion; components implement one tested contract.
 - Treat all artifacts built from one tag as one atomic release unit. For FSL this
-  includes `fslc`, `fslc-lsp`, the VS Code extension, and published Kernel bundles.
+  includes `fslc`, `fslc-lsp`, the Agent Skills, the VS Code extension, and
+  published Kernel bundles.
   Build jobs upload private workflow artifacts; one final job uploads the complete
   unit to a draft, verifies the remote inventory, and only then makes it public.
 - Verify cross-component contracts at the promotion SHA. A component cannot be

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,9 +268,35 @@ jobs:
             dist/fsl-kernel-contract-v2.tar.gz
             dist/fsl-kernel-contract-v2.tar.gz.sha256
 
+  skills:
+    name: package Agent Skills
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Package the installable Agent Skills
+        run: |
+          mkdir -p dist
+          tar -czf dist/fsl-skills.tar.gz \
+            skills/fsl \
+            skills/fsl-business \
+            skills/fsl-requirements \
+            skills/fsl-design \
+            skills/fsl-design-review \
+            skills/fsl-delivery
+          ( cd dist && shasum -a 256 fsl-skills.tar.gz > fsl-skills.tar.gz.sha256 )
+
+      - name: Upload skill bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fsl-skills
+          path: |
+            dist/fsl-skills.tar.gz
+            dist/fsl-skills.tar.gz.sha256
+
   assemble:
     name: assemble complete release unit
-    needs: [build, vsix, kernel-contract]
+    needs: [build, vsix, kernel-contract, skills]
     runs-on: ubuntu-24.04
     steps:
       - name: Download the complete release unit
@@ -294,6 +320,7 @@ jobs:
             fsl-vscode.vsix
             fsl-kernel-contract-v1.tar.gz fsl-kernel-contract-v1.tar.gz.sha256
             fsl-kernel-contract-v2.tar.gz fsl-kernel-contract-v2.tar.gz.sha256
+            fsl-skills.tar.gz fsl-skills.tar.gz.sha256
           )
           test "$(find release-assets -maxdepth 1 -type f | wc -l | tr -d ' ')" = "${#expected[@]}"
           for asset in "${expected[@]}"; do test -f "release-assets/$asset"; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Changed
+- The native installer no longer clones the repository into `~/.fsl`. It now
+  installs an exact-tag, checksummed CLI/LSP pair under the user data directory,
+  atomically activates the complete payload, safely migrates recognized Python
+  2.7 links, and rejects binaries whose reported version differs from the
+  Release tag. Agent Skills are packaged as a checksummed Release asset; the
+  v3.0.0 compatibility path verifies a pinned tag-archive checksum and extracts
+  only the six installed skills.
+
 ## [3.0.0] - 2026-07-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ reading the verification results as it repairs it.
 1. **Install FSL and the skill**
 
    ```bash
-   git clone https://github.com/ymm-oss/fsl.git ~/.fsl
-   bash ~/.fsl/install.sh
+   curl -fsSL https://raw.githubusercontent.com/ymm-oss/fsl/main/install.sh | bash
    ```
 
    A standard install gives you the verifier `fslc` and the Claude Code skills
@@ -136,47 +135,49 @@ The Linux binaries target the Ubuntu 24.04 ABI baseline (glibc 2.39 or newer).
 
 ## Easy setup (for PMs, consultants, and non-engineers)
 
-No programming knowledge is required. Git is used to keep every installed file
-on one published Release tag.
+No programming knowledge or Git installation is required. The installer keeps
+the native commands and Agent Skills on one published Release tag.
 
-1. **Install Git** from [git-scm.com](https://git-scm.com/) if `git --version`
-   does not work in your terminal.
-2. **Open a terminal** (on Mac, "Terminal.app"; search your apps for "terminal").
-3. **Run the install commands**:
+1. **Open a terminal** (on Mac, "Terminal.app"; search your apps for "terminal").
+2. **Run the install command**:
 
    ```bash
-   git clone https://github.com/ymm-oss/fsl.git ~/.fsl
-   bash ~/.fsl/install.sh
+   curl -fsSL https://raw.githubusercontent.com/ymm-oss/fsl/main/install.sh | bash
    ```
 
-This places FSL itself in `~/.fsl`, the `fslc` command in `~/.local/bin/fslc`, and
-the Claude Code skills in `~/.claude/skills/`.
-The installer checks out the latest published Release tag in `~/.fsl`, so the
-skills, examples, `fslc`, and `fslc-lsp` always come from the same release.
-
-> If you use the GitHub CLI, `gh repo clone ymm-oss/fsl ~/.fsl` can replace the
-> `git clone` command above.
+This places only the versioned release payload under `~/.local/share/fsl`, links
+the commands from `~/.local/bin`, and links the Claude Code skills from
+`~/.claude/skills/`. It does not clone the repository or install examples,
+documentation, Python sources, or Rust sources. `FSL_DATA_DIR` overrides the
+release-payload location and `FSL_BIN_DIR` overrides the command-link location.
 
 What gets installed:
 
 - the native Rust `fslc` and `fslc-lsp` commands (used from `~/.local/bin`; Python is not required)
-  — the VSCode extension in `editors/vscode/` launches `fslc-lsp` from `PATH`
+  — the VSCode extension launches `fslc-lsp` from `PATH`
 - the Claude Code skills (`~/.claude/skills/fsl*`)
-- samples for PMs and consultants (`examples/pm/`, `examples/consulting/`)
+
+The installer verifies both native checksums and rejects a binary whose reported
+version differs from the latest Release tag. It also migrates recognized links
+to the old Python 2.7 or `~/.fsl` installations. Use `--no-skill` to skip creating
+the Claude Code skill links.
 
 Windows users should use WSL or refer to the developer instructions (PowerShell).
 
 Uninstall:
 
 ```bash
-rm -rf ~/.fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
+rm -rf ~/.local/share/fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
 ```
 
-Official releases are the checksummed native binaries, VSCode extension, and
-Kernel bundles attached to GitHub Releases. The retained Python compatibility
-reference is installed from this repository and is not published to PyPI; the
-Rust workspace crates are not published to crates.io. Publishing either surface
-requires an explicit manifest, workflow, and documentation change.
+Official releases contain checksummed native binaries, VSCode extension, and
+Kernel bundles. Releases after v3.0.0 also contain the checksummed Agent Skill
+bundle; the installer verifies a pinned source-archive checksum for the v3.0.0
+compatibility path. The Python
+compatibility reference remains in this repository at version 2.7.0, but this
+installer does not install it and it is not published to PyPI. The Rust workspace
+crates are not published to crates.io. Publishing either surface requires an
+explicit manifest, workflow, and documentation change.
 Maintainers cut releases using the documented [`docs/RELEASE.md`](docs/RELEASE.md)
 procedure and the internal [`release` Agent Skill](.claude/skills/release/SKILL.md).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,11 +32,14 @@ binary.
 | Linux arm64 | `ubuntu-24.04-arm` | `linux-arm64` |
 | Windows x64 | `windows-latest` | `windows-x64.exe` |
 
-Intel macOS (`macos-x64`) is not supported. Releases also contain the VS Code
-extension and the Public Kernel contract bundles produced by
-`.github/workflows/release.yml`.
+Intel macOS (`macos-x64`) is not supported. Releases also contain the
+checksummed Agent Skill bundle, VS Code extension, and Public Kernel contract
+bundles produced by `.github/workflows/release.yml`.
 `install.sh` resolves the latest published tag once and uses that same tag for
-the repository content and both native binaries.
+the skill bundle and both native binaries. It installs only those payloads into
+the user's data directory; it does not clone the repository. The v3.0.0
+compatibility path extracts only the skills from that exact tag's source archive
+because the first native release predates the checksummed skill bundle.
 
 Linux artifacts target glibc 2.39 or newer. The release workflow pins both Linux
 runners to Ubuntu 24.04 and rejects binaries that require a newer GLIBC symbol.
@@ -85,8 +88,9 @@ It also rejects a dynamic dependency on `libz3`.
    `workflow_dispatch` run builds and smoke-tests every artifact but cannot
    attach files to a GitHub Release, even when the selected ref is a tag.
 2. Verify the completed run's `head_sha` equals the recorded candidate SHA and
-   all four native targets, the VS Code extension, and both Kernel bundles
-   pass. Do not reuse evidence from a moving branch after its SHA changes.
+   all four native targets, the Agent Skill bundle, VS Code extension, and both
+   Kernel bundles pass. Do not reuse evidence from a moving branch after its SHA
+   changes.
 3. Open the release-promotion pull request from `main` to `production`, stating
    the candidate SHA, version, changes, residual risk, gate results, and dry-run
    URL.
@@ -125,7 +129,8 @@ It also rejects a dynamic dependency on `libz3`.
    section.
 2. Confirm `fslc`, `fslc-lsp`, and their checksum files exist for exactly the
    four supported suffixes. Confirm no `macos-x64` asset exists. Also confirm
-   the VS Code extension and both Kernel bundle/checksum pairs are present.
+   the Agent Skill bundle/checksum pair, VS Code extension, and both Kernel
+   bundle/checksum pairs are present.
 3. Download the current machine's supported binary and checksum, verify the
    checksum, and run `fslc --version`. It must print `fslc X.Y.Z`.
 4. Report the promotion pull request, production SHA, tag SHA, release URL,

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,26 @@
 set -euo pipefail
 
 INSTALL_SKILL=1
-CLONE_URL="https://github.com/ymm-oss/fsl.git"
-INSTALL_DIR="${FSL_INSTALL_DIR:-$HOME/.fsl}"
+DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+if [ -n "${FSL_DATA_DIR:-}" ]; then
+  INSTALL_DIR="$FSL_DATA_DIR"
+elif [ -n "${FSL_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$FSL_INSTALL_DIR"
+  echo "Warning: FSL_INSTALL_DIR is deprecated; use FSL_DATA_DIR instead."
+else
+  INSTALL_DIR="$DATA_HOME/fsl"
+fi
+case "$INSTALL_DIR" in
+  /*) ;;
+  *) fail_message="FSL_DATA_DIR must be an absolute path: $INSTALL_DIR" ;;
+esac
 
 fail() {
   echo "Error: $*" >&2
   exit 1
 }
+
+[ -z "${fail_message:-}" ] || fail "$fail_message"
 
 usage() {
   echo "Usage: bash install.sh [--no-skill]"
@@ -30,41 +43,28 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+download_file() {
+  local url="$1"
+  local destination="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$destination"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$destination"
+  else
+    fail "curl or wget is required to install FSL."
+  fi
+}
+
 latest_release_tag() {
   local api metadata tag
   api="https://api.github.com/repos/ymm-oss/fsl/releases/latest"
-  if command -v curl >/dev/null 2>&1; then
-    metadata=$(curl -fsSL "$api")
-  elif command -v wget >/dev/null 2>&1; then
-    metadata=$(wget -qO- "$api")
-  else
-    fail "curl or wget is required to resolve the latest FSL release."
-  fi
-  tag=$(printf '%s\n' "$metadata" | sed -n 's/^[[:space:]]*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p')
+  metadata=$(mktemp)
+  download_file "$api" "$metadata" || fail "Failed to resolve the latest FSL release."
+  tag=$(sed -n 's/^[[:space:]]*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' "$metadata")
+  rm -f "$metadata"
   [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "The latest GitHub Release has an invalid tag: $tag"
   printf '%s\n' "$tag"
 }
-
-command -v git >/dev/null 2>&1 || fail "git is required. Install it from https://git-scm.com/."
-RELEASE_TAG=$(latest_release_tag)
-
-if [ -e "$INSTALL_DIR" ]; then
-  [ -d "$INSTALL_DIR/.git" ] || fail "$INSTALL_DIR already exists but is not a Git repository. Remove or move it and re-run."
-  unexpected=$(git -C "$INSTALL_DIR" status --porcelain --untracked-files=all | awk '$0 !~ /^\?\? \.native\//')
-  [ -z "$unexpected" ] || fail "$INSTALL_DIR has local changes. Move them or remove the directory and re-run."
-  echo "Updating the FSL repository to $RELEASE_TAG: $INSTALL_DIR"
-  git -C "$INSTALL_DIR" fetch --force --depth 1 origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG" || fail "Failed to fetch $RELEASE_TAG."
-  git -C "$INSTALL_DIR" checkout --detach "$RELEASE_TAG" || fail "Failed to check out $RELEASE_TAG."
-else
-  echo "Fetching FSL $RELEASE_TAG: $INSTALL_DIR"
-  git clone --branch "$RELEASE_TAG" --depth 1 "$CLONE_URL" "$INSTALL_DIR" || fail "Failed to fetch $RELEASE_TAG. Check your network connection."
-fi
-REPO_DIR=$(cd "$INSTALL_DIR" && pwd -P)
-
-NATIVE_DIR="$REPO_DIR/.native/bin"
-FSL_BIN="$NATIVE_DIR/fslc"
-FSL_LSP_BIN="$NATIVE_DIR/fslc-lsp"
-mkdir -p "$NATIVE_DIR"
 
 native_target() {
   local os arch
@@ -78,52 +78,154 @@ native_target() {
   esac
 }
 
-download_file() {
-  local url="$1"
-  local destination="$2"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$destination"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$url" -O "$destination"
+hash_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
   else
-    fail "curl or wget is required to download the native FSL binaries."
+    fail "shasum or sha256sum is required to verify FSL release assets."
   fi
 }
 
-RELEASE_URL="https://github.com/ymm-oss/fsl/releases/download/$RELEASE_TAG"
 stage_release_asset() {
   local asset="$1"
   local destination="$2"
   local expected_hash actual_hash
-  echo "Installing native Rust binary: $asset"
-  download_file "$RELEASE_URL/$asset" "$destination.download" || fail "Failed to download $asset from $RELEASE_TAG."
-  download_file "$RELEASE_URL/$asset.sha256" "$destination.sha256.download" || fail "Failed to download the checksum for $asset."
+  echo "Downloading release asset: $asset"
+  download_file "$RELEASE_URL/$asset" "$destination.download" || return 1
+  download_file "$RELEASE_URL/$asset.sha256" "$destination.sha256.download" || return 1
   expected_hash=$(awk '{print $1}' "$destination.sha256.download")
-  if command -v shasum >/dev/null 2>&1; then
-    actual_hash=$(shasum -a 256 "$destination.download" | awk '{print $1}')
-  elif command -v sha256sum >/dev/null 2>&1; then
-    actual_hash=$(sha256sum "$destination.download" | awk '{print $1}')
-  else
-    fail "shasum or sha256sum is required to verify the native binaries."
-  fi
+  actual_hash=$(hash_file "$destination.download")
   [ "$expected_hash" = "$actual_hash" ] || fail "Checksum verification failed for $asset."
   rm -f "$destination.sha256.download"
-  chmod +x "$destination.download"
 }
 
-TARGET=$(native_target)
-STAGING_DIR=$(mktemp -d "$NATIVE_DIR/.install.XXXXXX")
-trap 'rm -rf "$STAGING_DIR"' EXIT
-stage_release_asset "fslc-$TARGET" "$STAGING_DIR/fslc"
-stage_release_asset "fslc-lsp-$TARGET" "$STAGING_DIR/fslc-lsp"
+stage_skills() {
+  local archive source_root skill_name
+  archive="$STAGING_DIR/fsl-skills.tar.gz"
+  mkdir -p "$STAGING_DIR/skills"
+  if [ "$RELEASE_TAG" != "v3.0.0" ]; then
+    stage_release_asset "fsl-skills.tar.gz" "$archive" \
+      || fail "Failed to download the checksummed skill bundle from $RELEASE_TAG."
+    tar -xzf "$archive.download" -C "$STAGING_DIR"
+    rm -f "$archive.download"
+    return
+  fi
 
-mv "$STAGING_DIR/fslc.download" "$FSL_BIN"
-mv "$STAGING_DIR/fslc-lsp.download" "$FSL_LSP_BIN"
-rm -rf "$STAGING_DIR"
+  # v3.0.0 predates the checksummed skill bundle. Keep compatibility by
+  # extracting only the skills from the immutable release tag archive.
+  rm -f "$archive.download" "$archive.sha256.download"
+  echo "The release has no skill bundle; extracting skills from source tag $RELEASE_TAG."
+  archive="$STAGING_DIR/source.tar.gz"
+  download_file "https://github.com/ymm-oss/fsl/archive/refs/tags/$RELEASE_TAG.tar.gz" "$archive" \
+    || fail "Failed to download the source archive for $RELEASE_TAG."
+  [ "$(hash_file "$archive")" = "d2d691a98af28f4aaa77ded08b35978539a0d1e3c65e8b7f29783f143a447598" ] \
+    || fail "Checksum verification failed for the v3.0.0 source archive."
+  mkdir -p "$STAGING_DIR/source"
+  tar -xzf "$archive" -C "$STAGING_DIR/source"
+  source_root=$(find "$STAGING_DIR/source" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+  [ -n "$source_root" ] || fail "The source archive for $RELEASE_TAG is empty."
+  for skill_name in fsl fsl-business fsl-requirements fsl-design fsl-design-review fsl-delivery; do
+    [ -d "$source_root/skills/$skill_name" ] || fail "The $skill_name skill is missing from $RELEASE_TAG."
+    cp -R "$source_root/skills/$skill_name" "$STAGING_DIR/skills/$skill_name"
+  done
+  rm -rf "$STAGING_DIR/source" "$archive"
+}
+
+RELEASE_TAG=$(latest_release_tag)
+RELEASE_URL="https://github.com/ymm-oss/fsl/releases/download/$RELEASE_TAG"
+TARGET=$(native_target)
+RELEASES_DIR="$INSTALL_DIR/releases"
+mkdir -p "$RELEASES_DIR"
+STAGING_DIR=$(mktemp -d "$RELEASES_DIR/.install.XXXXXX")
+trap 'rm -rf "$STAGING_DIR"' EXIT
+mkdir -p "$STAGING_DIR/bin"
+
+# Download and verify the complete native pair before changing the active install.
+stage_release_asset "fslc-$TARGET" "$STAGING_DIR/bin/fslc" \
+  || fail "Failed to download fslc-$TARGET from $RELEASE_TAG."
+stage_release_asset "fslc-lsp-$TARGET" "$STAGING_DIR/bin/fslc-lsp" \
+  || fail "Failed to download fslc-lsp-$TARGET from $RELEASE_TAG."
+mv "$STAGING_DIR/bin/fslc.download" "$STAGING_DIR/bin/fslc"
+mv "$STAGING_DIR/bin/fslc-lsp.download" "$STAGING_DIR/bin/fslc-lsp"
+chmod +x "$STAGING_DIR/bin/fslc" "$STAGING_DIR/bin/fslc-lsp"
+stage_skills
+
+EXPECTED_VERSION="fslc ${RELEASE_TAG#v}"
+ACTUAL_VERSION=$("$STAGING_DIR/bin/fslc" --version) \
+  || fail "The downloaded native fslc did not start."
+[ "$ACTUAL_VERSION" = "$EXPECTED_VERSION" ] \
+  || fail "The downloaded binary reports '$ACTUAL_VERSION'; expected '$EXPECTED_VERSION'."
+
+CLI_HASH=$(hash_file "$STAGING_DIR/bin/fslc")
+RELEASE_NAME="$RELEASE_TAG-${CLI_HASH:0:12}"
+RELEASE_DIR="$RELEASES_DIR/$RELEASE_NAME"
+if [ -e "$RELEASE_DIR" ]; then
+  [ -x "$RELEASE_DIR/bin/fslc" ] && [ -x "$RELEASE_DIR/bin/fslc-lsp" ] \
+    || fail "$RELEASE_DIR does not contain an executable native pair."
+  diff -qr "$STAGING_DIR" "$RELEASE_DIR" >/dev/null \
+    || fail "$RELEASE_DIR differs from the verified $RELEASE_TAG payload. Move it and re-run."
+  rm -rf "$STAGING_DIR"
+else
+  mv "$STAGING_DIR" "$RELEASE_DIR"
+fi
 trap - EXIT
 
-LOCAL_BIN="$HOME/.local/bin"
+CURRENT_LINK="$INSTALL_DIR/current"
+if [ -e "$CURRENT_LINK" ] && [ ! -L "$CURRENT_LINK" ]; then
+  fail "$CURRENT_LINK exists and is not a symbolic link. Move it and re-run."
+fi
+FSL_BIN="$CURRENT_LINK/bin/fslc"
+FSL_LSP_BIN="$CURRENT_LINK/bin/fslc-lsp"
+
+LOCAL_BIN="${FSL_BIN_DIR:-$HOME/.local/bin}"
+case "$LOCAL_BIN" in
+  /*) ;;
+  *) fail "FSL_BIN_DIR must be an absolute path: $LOCAL_BIN" ;;
+esac
 mkdir -p "$LOCAL_BIN"
+
+preflight_command_link() {
+  local cmd_name="$1"
+  local target="$2"
+  local link_path="$LOCAL_BIN/$cmd_name"
+  local link_target
+  if [ -L "$link_path" ]; then
+    link_target=$(readlink "$link_path" || true)
+    case "$link_target" in
+      "$target"|"$HOME/.fsl/.venv/bin/$cmd_name"|"$HOME/.fsl/.native/bin/$cmd_name") return ;;
+    esac
+    [ ! -e "$link_path" ] \
+      || fail "$link_path points to a different installation ($link_target). Move it and re-run."
+  elif [ -e "$link_path" ]; then
+    fail "$link_path already exists and is not managed by FSL. Move it and re-run."
+  fi
+}
+
+preflight_skill_link() {
+  local skill_name="$1"
+  local source="$CURRENT_LINK/skills/$skill_name"
+  local destination="$HOME/.claude/skills/$skill_name"
+  local backup="$destination.pre-native-v3"
+  [ -d "$RELEASE_DIR/skills/$skill_name" ] \
+    || fail "$RELEASE_DIR is missing the $skill_name skill."
+  if [ -L "$destination" ] && [ "$(readlink "$destination")" = "$source" ]; then
+    return
+  fi
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    [ ! -e "$backup" ] && [ ! -L "$backup" ] \
+      || fail "$backup already exists. Move it and re-run."
+  fi
+}
+
+preflight_command_link fslc "$FSL_BIN"
+preflight_command_link fslc-lsp "$FSL_LSP_BIN"
+if [ "$INSTALL_SKILL" -eq 1 ]; then
+  for SKILL_NAME in fsl fsl-business fsl-requirements fsl-design fsl-design-review fsl-delivery; do
+    preflight_skill_link "$SKILL_NAME"
+  done
+fi
 
 link_command() {
   local cmd_name="$1"
@@ -133,15 +235,24 @@ link_command() {
   if [ -L "$link_path" ]; then
     link_target=$(readlink "$link_path" || true)
     if [ "$link_target" = "$target" ]; then
-      echo "The $cmd_name command link is already set up: $link_path"
-    elif [ "$link_target" = "$REPO_DIR/.venv/bin/$cmd_name" ]; then
-      ln -sfn "$target" "$link_path"
-      echo "Migrated the $cmd_name command link from Python to the native binary: $link_path"
-    else
-      echo "Warning: $link_path points to a different location (${link_target}). Not overwriting."
+      echo "The $cmd_name command link is current: $link_path"
+      return
     fi
+    case "$link_target" in
+      "$HOME/.fsl/.venv/bin/$cmd_name"|"$HOME/.fsl/.native/bin/$cmd_name")
+        ln -sfn "$target" "$link_path"
+        echo "Migrated the $cmd_name command link to the native $RELEASE_TAG binary: $link_path"
+        return
+        ;;
+    esac
+    [ -e "$link_path" ] || {
+      ln -sfn "$target" "$link_path"
+      echo "Replaced a broken $cmd_name command link: $link_path"
+      return
+    }
+    fail "$link_path points to a different installation ($link_target). Move it and re-run."
   elif [ -e "$link_path" ]; then
-    echo "Warning: $link_path already exists. Not overwriting. If needed, remove it manually and re-run."
+    fail "$link_path already exists and is not managed by FSL. Move it and re-run."
   else
     ln -s "$target" "$link_path"
     echo "Created the $cmd_name command link: $link_path"
@@ -149,36 +260,35 @@ link_command() {
 }
 
 link_command fslc "$FSL_BIN"
-# The VS Code extension launches `fslc-lsp` from PATH.
 link_command fslc-lsp "$FSL_LSP_BIN"
 
 case ":$PATH:" in
-  *":$LOCAL_BIN:"*)
-    ;;
+  *":$LOCAL_BIN:"*) ;;
   *)
     SHELL_NAME=$(basename "${SHELL:-}")
     if [ "$SHELL_NAME" = "zsh" ]; then
-      echo "$LOCAL_BIN is not on your PATH. If needed, add this line to ~/.zshrc: export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo "$LOCAL_BIN is not on your PATH. Add this line to ~/.zshrc: export PATH=\"\$HOME/.local/bin:\$PATH\""
     elif [ "$SHELL_NAME" = "bash" ]; then
-      echo "$LOCAL_BIN is not on your PATH. If needed, add this line to ~/.bashrc: export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo "$LOCAL_BIN is not on your PATH. Add this line to ~/.bashrc: export PATH=\"\$HOME/.local/bin:\$PATH\""
     else
-      echo "$LOCAL_BIN is not on your PATH. If needed, add this line to your shell config file: export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo "$LOCAL_BIN is not on your PATH. Add it in your shell configuration."
     fi
     ;;
 esac
 
 if [ "$INSTALL_SKILL" -eq 1 ]; then
-  SKILL_NAMES="fsl fsl-business fsl-requirements fsl-design fsl-design-review fsl-delivery"
   mkdir -p "$HOME/.claude/skills"
-  for SKILL_NAME in $SKILL_NAMES; do
-    SKILL_SRC="$REPO_DIR/skills/$SKILL_NAME"
+  for SKILL_NAME in fsl fsl-business fsl-requirements fsl-design fsl-design-review fsl-delivery; do
+    SKILL_SRC="$CURRENT_LINK/skills/$SKILL_NAME"
     SKILL_DST="$HOME/.claude/skills/$SKILL_NAME"
-    [ -d "$SKILL_SRC" ] || fail "$SKILL_SRC not found. Check that the repository was fetched correctly and re-run."
+    [ -d "$RELEASE_DIR/skills/$SKILL_NAME" ] \
+      || fail "$RELEASE_DIR is missing the $SKILL_NAME skill."
     if [ -L "$SKILL_DST" ] && [ "$(readlink "$SKILL_DST")" = "$SKILL_SRC" ]; then
       echo "The Claude Code skill link is current: $SKILL_DST"
     elif [ -e "$SKILL_DST" ] || [ -L "$SKILL_DST" ]; then
       SKILL_BACKUP="$SKILL_DST.pre-native-v3"
-      [ ! -e "$SKILL_BACKUP" ] && [ ! -L "$SKILL_BACKUP" ] || fail "$SKILL_BACKUP already exists. Move it and re-run."
+      [ ! -e "$SKILL_BACKUP" ] && [ ! -L "$SKILL_BACKUP" ] \
+        || fail "$SKILL_BACKUP already exists. Move it and re-run."
       mv "$SKILL_DST" "$SKILL_BACKUP"
       ln -s "$SKILL_SRC" "$SKILL_DST"
       echo "Linked Claude Code skill: $SKILL_DST (previous copy preserved at $SKILL_BACKUP)"
@@ -191,15 +301,31 @@ else
   echo "Skipped linking the Claude Code skills."
 fi
 
-echo "Running a smoke test."
-CHECK_OUTPUT=$("$FSL_BIN" check "$REPO_DIR/specs/cart_v1.fsl") || fail "Smoke test failed. Check the result of $FSL_BIN check $REPO_DIR/specs/cart_v1.fsl."
-case "$CHECK_OUTPUT" in
-  *'"result": "ok"'*|*'"result":"ok"'*)
-    echo "Smoke test ok: fslc check specs/cart_v1.fsl"
-    ;;
-  *)
-    fail "Smoke test was not ok. Check the output of $FSL_BIN check $REPO_DIR/specs/cart_v1.fsl."
-    ;;
+# Every destination has been checked and prepared. Rename a same-filesystem
+# temporary link over current to activate the complete payload atomically.
+ACTIVATION_DIR=$(mktemp -d "$INSTALL_DIR/.activate.XXXXXX")
+trap 'rm -rf "$ACTIVATION_DIR"' EXIT
+ACTIVATION_LINK="$ACTIVATION_DIR/current"
+ln -s "releases/$RELEASE_NAME" "$ACTIVATION_LINK"
+case "$(uname -s)" in
+  Darwin) mv -fh "$ACTIVATION_LINK" "$CURRENT_LINK" ;;
+  Linux) mv -fT "$ACTIVATION_LINK" "$CURRENT_LINK" ;;
+  *) fail "Atomic activation is unsupported on this operating system." ;;
 esac
+rm -rf "$ACTIVATION_DIR"
+trap - EXIT
+[ "$("$FSL_BIN" --version)" = "$EXPECTED_VERSION" ] \
+  || fail "The active native binary does not report $EXPECTED_VERSION."
+if command -v fslc >/dev/null 2>&1; then
+  RESOLVED_FSL=$(command -v fslc)
+  RESOLVED_VERSION=$(fslc --version 2>/dev/null || true)
+  if [ "$RESOLVED_VERSION" != "$EXPECTED_VERSION" ]; then
+    echo "Warning: PATH resolves fslc to $RESOLVED_FSL reporting '$RESOLVED_VERSION'." >&2
+    echo "Put $LOCAL_BIN before the old Python installation to use $EXPECTED_VERSION." >&2
+  fi
+fi
 
-echo "Done. Open Claude Code and try saying: \"Use \$fsl-requirements to formalize and verify these cancellation requirements.\" Examples: $REPO_DIR/examples/pm/ (PMs), $REPO_DIR/examples/consulting/ (consultants)"
+if [ -d "$HOME/.fsl/.git" ]; then
+  echo "Legacy repository detected at $HOME/.fsl. It is no longer used; remove it after preserving any local changes."
+fi
+echo "Installed native FSL $RELEASE_TAG without a repository clone: $INSTALL_DIR"

--- a/rust/fslc/tests/native_integration.rs
+++ b/rust/fslc/tests/native_integration.rs
@@ -32,6 +32,54 @@ fn assert_windows_release_smoke(workflow: &str) {
     assert!(workflow.contains("$verifyResult.result -ne \"verified\""));
 }
 
+fn assert_installer_release_contract(root: &Path) {
+    let installer = std::fs::read_to_string(root.join("install.sh")).expect("installer");
+    assert!(!installer.contains("echo \"macos-x64\""));
+    assert!(installer.contains("RELEASE_TAG=$(latest_release_tag)"));
+    assert!(!installer.contains("git clone"));
+    assert!(!installer.contains("command -v git"));
+    assert!(installer.contains("releases/download/$RELEASE_TAG"));
+    assert!(!installer.contains("releases/latest/download"));
+    assert!(installer.contains("$DATA_HOME/fsl"));
+    assert!(installer.contains("RELEASE_NAME=\"$RELEASE_TAG-${CLI_HASH:0:12}\""));
+    assert!(installer.contains("mktemp -d \"$INSTALL_DIR/.activate.XXXXXX\""));
+    assert!(installer.contains("mv -fh \"$ACTIVATION_LINK\" \"$CURRENT_LINK\""));
+    assert!(installer.contains("mv -fT \"$ACTIVATION_LINK\" \"$CURRENT_LINK\""));
+    assert!(installer.contains("stage_release_asset \"fsl-skills.tar.gz\""));
+    assert!(installer.contains("[ \"$RELEASE_TAG\" != \"v3.0.0\" ]"));
+    assert!(installer.contains("archive/refs/tags/$RELEASE_TAG.tar.gz"));
+    assert!(installer.contains("d2d691a98af28f4aaa77ded08b35978539a0d1e3c65e8b7f29783f143a447598"));
+    assert!(installer.contains("EXPECTED_VERSION=\"fslc ${RELEASE_TAG#v}\""));
+    assert!(installer.contains("RESOLVED_VERSION=$(fslc --version"));
+    assert!(installer.contains("diff -qr \"$STAGING_DIR\" \"$RELEASE_DIR\""));
+    assert!(installer.contains("FSL_DATA_DIR must be an absolute path"));
+    assert!(installer.contains("$HOME/.fsl/.venv/bin/$cmd_name"));
+    assert!(!installer.contains("*\"/.venv/bin/$cmd_name\""));
+    assert!(installer.contains("ln -s \"$SKILL_SRC\" \"$SKILL_DST\""));
+    assert!(installer.contains("$SKILL_DST.pre-native-v3"));
+    let stage_cli = installer
+        .find("stage_release_asset \"fslc-$TARGET\"")
+        .unwrap();
+    let stage_lsp = installer
+        .find("stage_release_asset \"fslc-lsp-$TARGET\"")
+        .unwrap();
+    let activate = installer
+        .find("mv -fh \"$ACTIVATION_LINK\" \"$CURRENT_LINK\"")
+        .unwrap();
+    let preflight = installer
+        .find("preflight_command_link fslc \"$FSL_BIN\"")
+        .unwrap();
+    let prepare_lsp = installer
+        .find("link_command fslc-lsp \"$FSL_LSP_BIN\"")
+        .unwrap();
+    assert!(
+        stage_cli < stage_lsp
+            && stage_lsp < preflight
+            && preflight < prepare_lsp
+            && prepare_lsp < activate
+    );
+}
+
 fn run(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args(args)
@@ -327,7 +375,7 @@ fn native_release_unit_is_atomic_pinned_and_platform_closed() {
         .replace("\r\n", "\n");
     assert_eq!(workflow.matches("softprops/action-gh-release@").count(), 1);
     assert!(workflow.contains("name: assemble complete release unit"));
-    assert!(workflow.contains("needs: [build, vsix, kernel-contract]"));
+    assert!(workflow.contains("needs: [build, vsix, kernel-contract, skills]"));
     assert!(workflow.contains("name: release-unit"));
     assert!(workflow.contains("name: publish atomic release unit"));
     assert!(workflow.contains("needs: [assemble]"));
@@ -340,6 +388,8 @@ fn native_release_unit_is_atomic_pinned_and_platform_closed() {
     assert!(workflow.contains("npm ci"));
     assert!(workflow.contains("cp ../../LICENSE LICENSE"));
     assert!(workflow.contains("npm exec -- vsce package"));
+    assert!(workflow.contains("tar -czf dist/fsl-skills.tar.gz"));
+    assert!(workflow.contains("fsl-skills.tar.gz fsl-skills.tar.gz.sha256"));
     assert!(!workflow.contains("npx --yes @vscode/vsce"));
     assert_eq!(workflow.matches("            target: ").count(), 4);
     for target in ["macos-arm64", "linux-x64", "linux-arm64", "windows-x64"] {
@@ -365,25 +415,7 @@ fn native_release_unit_is_atomic_pinned_and_platform_closed() {
     }
     assert!(workflow.contains("toolchain: 1.88.0"));
     assert_vendored_z3(&root, &workflow);
-
-    let installer = std::fs::read_to_string(root.join("install.sh")).expect("installer");
-    assert!(!installer.contains("echo \"macos-x64\""));
-    assert!(installer.contains("RELEASE_TAG=$(latest_release_tag)"));
-    assert!(installer.contains("git clone --branch \"$RELEASE_TAG\" --depth 1"));
-    assert!(installer.contains("releases/download/$RELEASE_TAG"));
-    assert!(!installer.contains("releases/latest/download"));
-    assert!(installer.contains("ln -s \"$SKILL_SRC\" \"$SKILL_DST\""));
-    assert!(installer.contains("$SKILL_DST.pre-native-v3"));
-    let stage_cli = installer
-        .find("stage_release_asset \"fslc-$TARGET\"")
-        .unwrap();
-    let stage_lsp = installer
-        .find("stage_release_asset \"fslc-lsp-$TARGET\"")
-        .unwrap();
-    let install_cli = installer
-        .find("mv \"$STAGING_DIR/fslc.download\" \"$FSL_BIN\"")
-        .unwrap();
-    assert!(stage_cli < stage_lsp && stage_lsp < install_cli);
+    assert_installer_release_contract(&root);
 
     let package: Value = serde_json::from_str(
         &std::fs::read_to_string(root.join("editors/vscode/package.json"))


### PR DESCRIPTION
## Summary

- stop cloning the full repository into `~/.fsl`
- install the exact-tag native CLI/LSP pair and Agent Skills under the user data directory
- activate the complete payload through an atomic `current` switch
- migrate recognized legacy Python/native links and warn when PATH still selects Python 2.7
- add a checksummed Agent Skill bundle to the atomic Release unit

## Root cause

The native v3 installer retained the Python-era repository-as-installation
layout. It also left some stale command links untouched, allowing
`fslc --version` to resolve to the frozen Python 2.7 compatibility entry point
even though the released Rust binary reports 3.0.0.

## Compatibility and safety

- v3.0.0 predates the skill Release asset, so its exact tag archive is accepted only with a pinned SHA-256 and only the six skills are extracted.
- future releases fail closed unless the checksummed skill bundle is present.
- CLI and LSP are checksum-verified and staged together; the downloaded CLI must report the Release tag version before activation.
- unrelated command links are preserved and cause an actionable preflight error.

## Validation

- `./tools/check-native-integration.sh` — passed outside the sandbox, including browser Z3, Worker cancellation, and 345 native/WASM parity cases
- native release contract integration tests — passed
- real temporary-home install and reinstall from public v3.0.0 assets — `fslc 3.0.0`, no repository clone
- default six-skill linking and `--no-skill` paths — passed
- legacy-link migration, unrelated-link preservation, and PATH-shadow warning paths — passed
- `bash -n install.sh`, `cargo fmt --all --check`, workflow YAML parse, and `git diff --check` — passed
