### PR TITLE
fix(cli): deduplicate repeated lint paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ### Fixed
 - `fslc lint` now classifies business `policy`/`goal` `satisfies CTRL-*`
   operands as control references, recursively expands directory inputs into a
-  sorted, deduplicated list of `.fsl` files, and continues to report nested FSL
-  parse errors instead of silently skipping them (issues #385 and #386).
+  sorted list of unique physical `.fsl` files even when operands repeat or alias
+  one another, and continues to report nested FSL parse errors instead of silently
+  skipping them (issues #385 and #386).
 - `fslc fmt` now preserves canonical hyphenated IDs in business control,
   policy, goal, and `satisfies` positions while retaining normal spacing around
   arithmetic subtraction (issue #387).

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -478,9 +478,11 @@ fn parse_migration_options(
                 .to_owned()
         });
     }
-    let mut unique = std::collections::BTreeSet::new();
-    if paths.iter().any(|path| !unique.insert(path.clone())) {
-        return Err("the same migration path cannot be supplied twice".to_owned());
+    if migrate {
+        let mut unique = std::collections::BTreeSet::new();
+        if paths.iter().any(|path| !unique.insert(path.clone())) {
+            return Err("the same migration path cannot be supplied twice".to_owned());
+        }
     }
     Ok(MigrationOptions {
         paths,

--- a/rust/fslc/tests/edition_migrator.rs
+++ b/rust/fslc/tests/edition_migrator.rs
@@ -235,7 +235,7 @@ fn builtin_id_policy_reports_each_surface_kind_without_rewriting_ids() {
 }
 
 #[test]
-fn lint_recursively_expands_directories_and_accepts_canonical_control_references() {
+fn lint_deduplicates_recursive_alias_and_repeated_paths() {
     let directory = FixtureDir::new();
     let nested = directory.0.join("nested");
     std::fs::create_dir(&nested).expect("create nested fixture directory");
@@ -267,10 +267,13 @@ verify {
     std::fs::write(&nested_file, business).expect("write nested fixture");
     std::fs::write(nested.join("ignored.txt"), "not FSL").expect("write ignored fixture");
     let aliased_root_file = nested.join("..").join("z.fsl");
+    let root_file_text = root_file.to_str().expect("UTF-8 root path");
 
     let output = run(&[
         "lint",
         directory.0.to_str().expect("UTF-8 directory path"),
+        root_file_text,
+        root_file_text,
         aliased_root_file.to_str().expect("UTF-8 aliased root path"),
         "--edition",
         "next",
@@ -293,6 +296,15 @@ verify {
             nested_file.to_str().expect("UTF-8 nested path"),
             root_file.to_str().expect("UTF-8 root path"),
         ]
+    );
+
+    let migrate = run(&["migrate", root_file_text, root_file_text]);
+    assert_eq!(migrate.status.code(), Some(2));
+    let migrate = json(&migrate);
+    assert_eq!(migrate["kind"], "usage");
+    assert_eq!(
+        migrate["message"],
+        "the same migration path cannot be supplied twice"
     );
 }
 


### PR DESCRIPTION
## Problem

PR #401 documented that `fslc lint` combines its operands into a deduplicated physical-file set, but shared migration option parsing rejected a completely repeated path before lint expansion. The command therefore returned a usage error instead of linting the file once.

## Change

- apply the exact duplicate-path usage rejection only to `fslc migrate`
- let `fslc lint` use its existing canonical physical-file deduplication
- extend the existing integration test with repeated operands and retain a negative control proving that migrate still returns the usage envelope and exit 2
- clarify the existing `[Unreleased]` changelog entry

## Impact

Repeated or aliased lint operands now report each physical file once. Migration write planning and its duplicate-path refusal are unchanged.

## Verification

- RED then GREEN: `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test edition_migrator lint_deduplicates_recursive_alias_and_repeated_paths --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test edition_migrator --locked` (15 passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml -p fslc-rust --all-targets --locked -- -D warnings`
- independent review: no actionable findings
