### PR TITLE
fix(domain): honor explicit effect outcome roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
+  roles now override event-name heuristics, ambiguous cross-role assignments
+  fail closed, and completion, retry eligibility, Monitor/BFS execution, and
+  symbolic verification share the same lowered status (issue #409).
+
 ### Changed
 - The requirements-document renderer now reprojects and exactly matches the
   complete RCIR renderer role sidecar against its checked Kernel/Model/trace

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -161,6 +161,15 @@ boundary. The v0 implementation lowers the lifecycle to finite maps:
 - retry actions respect `max_attempts`
 - successful effect status is sticky
 
+`success_event`, `failure_event`, and `timeout_event` are authoritative outcome
+roles and lower to `Succeeded`, `Failed`, and `TimedOut` before any event-name
+heuristic is considered. A single event assigned to multiple explicit roles is
+rejected before Kernel lowering. Outcomes without an explicit role keep the v0
+heuristic (`timeout`/`timedout`, then `fail`, then `cancel`, otherwise success).
+The completion assignment is the single classification point; retry guards and
+the success-sticky transition consume its resulting status rather than
+reclassifying the event.
+
 The checker reports hard structural errors before running the kernel when an
 async effect has no `correlation_id`, or an irreversible effect lacks an
 `idempotency_key`.

--- a/docs/DESIGN-effect.md
+++ b/docs/DESIGN-effect.md
@@ -18,6 +18,14 @@ The v0 implementation lowers that lifecycle to kernel `Map<CorrelationId, Effect
 pending, retry actions require a failed/timed-out status and `attempts < max`,
 and successful completion is sticky.
 
+Explicit `success_event`, `failure_event`, and `timeout_event` declarations are
+authoritative and map to `Succeeded`, `Failed`, and `TimedOut` even when their
+event names suggest another outcome. Assigning one event to multiple explicit
+roles fails closed before Kernel lowering. Only outcomes without an explicit
+role use the v0 event-name heuristic (`timeout`/`timedout`, then `fail`, then
+`cancel`, otherwise success). Retry eligibility and success stickiness consume
+the resulting status and do not classify event names independently.
+
 Irreversible effects must declare `idempotency_key`; otherwise
 `fslc domain check` emits `irreversible_effect_without_idempotency_key` and does
 not run the formal kernel check. Missing timeout/retry/fallback and possible

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -208,6 +208,9 @@ domain <Name> {
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    success_event PaymentCaptured
+    failure_event PaymentFailed
+    timeout_event PaymentCaptureTimedOut
     retry { max_attempts 3 }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation { emits PaymentFailed }
@@ -243,6 +246,16 @@ lowering します。domain の enum メンバーは lowering 時に名前空間
 aggregate 内で解決され、そのコマンドの `requires` 節の連言と、各拒否条件の否定に
 なります。未知のシンボル、aggregate をまたぐコマンド、型の不一致、未対応の呼び出し
 は、元の domain 式の位置で報告されます。
+
+effect は `success_event`、`failure_event`、`timeout_event` により、完了イベントへ
+明示的な outcome role を割り当てられます。これらの宣言が分類の正規契約であり、
+イベント名に `fail`、`cancel`、`timeout` が含まれていても、それぞれ `Succeeded`、
+`Failed`、`TimedOut` へ lowering されます。同じイベントを複数の明示 role に
+割り当てると parse error になります。明示 role のない outcome には、v0 の名前
+ヒューリスティクスが次の優先順で残ります: `timeout`/`timedout` -> `TimedOut`、
+`fail` -> `Failed`、`cancel` -> `Cancelled`、それ以外 -> `Succeeded`。完了 action、
+`Failed | TimedOut` の retry guard、success-sticky transition property は、すべて
+この単一の lowering 済み status を利用します。
 
 domain 宣言では、有限のバリアントに `enum Name { Member, ... }` を、有界の数値範囲
 に `type Name = lo..hi` を使います。レガシーな書き方 `type Name = A | B` は現行の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -208,6 +208,9 @@ domain <Name> {
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    success_event PaymentCaptured
+    failure_event PaymentFailed
+    timeout_event PaymentCaptureTimedOut
     retry { max_attempts 3 }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation { emits PaymentFailed }
@@ -244,6 +247,17 @@ aggregate and becomes the conjunction of the command's `requires` clauses and
 the negation of each rejection condition. Unknown symbols, cross-aggregate
 commands, type mismatches, and unsupported calls are reported at the original
 domain expression.
+
+An effect can assign completion events explicit outcome roles with
+`success_event`, `failure_event`, and `timeout_event`. These declarations are the
+authoritative classification: they lower to `Succeeded`, `Failed`, and `TimedOut`
+respectively, even when an event name contains `fail`, `cancel`, or `timeout`.
+Assigning one event to more than one explicit role is a parse error. An outcome
+without an explicit role retains the v0 name heuristic, in priority order:
+`timeout`/`timedout` -> `TimedOut`, `fail` -> `Failed`, `cancel` -> `Cancelled`,
+and otherwise `Succeeded`. Completion actions, the `Failed | TimedOut` retry
+guard, and the success-sticky transition property all consume that one lowered
+status.
 
 Domain declarations use `enum Name { Member, ... }` for finite variants and
 `type Name = lo..hi` for bounded numeric ranges. The legacy spelling

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -246,6 +246,9 @@ reports stable fsl-domain findings):</p>
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    success_event PaymentCaptured
+    failure_event PaymentFailed
+    timeout_event PaymentCaptureTimedOut
     retry { max_attempts 3 }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation { emits PaymentFailed }
@@ -281,6 +284,16 @@ aggregate and becomes the conjunction of the command's <code>requires</code> cla
 the negation of each rejection condition. Unknown symbols, cross-aggregate
 commands, type mismatches, and unsupported calls are reported at the original
 domain expression.</p>
+<p>An effect can assign completion events explicit outcome roles with
+<code>success_event</code>, <code>failure_event</code>, and <code>timeout_event</code>. These declarations are the
+authoritative classification: they lower to <code>Succeeded</code>, <code>Failed</code>, and <code>TimedOut</code>
+respectively, even when an event name contains <code>fail</code>, <code>cancel</code>, or <code>timeout</code>.
+Assigning one event to more than one explicit role is a parse error. An outcome
+without an explicit role retains the v0 name heuristic, in priority order:
+<code>timeout</code>/<code>timedout</code> -&gt; <code>TimedOut</code>, <code>fail</code> -&gt; <code>Failed</code>, <code>cancel</code> -&gt; <code>Cancelled</code>,
+and otherwise <code>Succeeded</code>. Completion actions, the <code>Failed | TimedOut</code> retry
+guard, and the success-sticky transition property all consume that one lowered
+status.</p>
 <p>Domain declarations use <code>enum Name { Member, ... }</code> for finite variants and
 <code>type Name = lo..hi</code> for bounded numeric ranges. The legacy spelling
 <code>type Name = A | B</code> remains accepted in the current 2.x edition and produces the

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -248,6 +248,9 @@ fsl-domain findings を報告します):</p>
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    success_event PaymentCaptured
+    failure_event PaymentFailed
+    timeout_event PaymentCaptureTimedOut
     retry { max_attempts 3 }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation { emits PaymentFailed }
@@ -282,6 +285,15 @@ lowering します。domain の enum メンバーは lowering 時に名前空間
 aggregate 内で解決され、そのコマンドの <code>requires</code> 節の連言と、各拒否条件の否定に
 なります。未知のシンボル、aggregate をまたぐコマンド、型の不一致、未対応の呼び出し
 は、元の domain 式の位置で報告されます。</p>
+<p>effect は <code>success_event</code>、<code>failure_event</code>、<code>timeout_event</code> により、完了イベントへ
+明示的な outcome role を割り当てられます。これらの宣言が分類の正規契約であり、
+イベント名に <code>fail</code>、<code>cancel</code>、<code>timeout</code> が含まれていても、それぞれ <code>Succeeded</code>、
+<code>Failed</code>、<code>TimedOut</code> へ lowering されます。同じイベントを複数の明示 role に
+割り当てると parse error になります。明示 role のない outcome には、v0 の名前
+ヒューリスティクスが次の優先順で残ります: <code>timeout</code>/<code>timedout</code> -&gt; <code>TimedOut</code>、
+<code>fail</code> -&gt; <code>Failed</code>、<code>cancel</code> -&gt; <code>Cancelled</code>、それ以外 -&gt; <code>Succeeded</code>。完了 action、
+<code>Failed | TimedOut</code> の retry guard、success-sticky transition property は、すべて
+この単一の lowering 済み status を利用します。</p>
 <p>domain 宣言では、有限のバリアントに <code>enum Name { Member, ... }</code> を、有界の数値範囲
 に <code>type Name = lo..hi</code> を使います。レガシーな書き方 <code>type Name = A | B</code> は現行の
 2.x エディションでは引き続き受理され、宣言全体に対して安定した

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -8,6 +8,11 @@ use fsl_syntax::{
     SyntaxExprKind,
 };
 
+use crate::{
+    CoreError,
+    domain_lowering::{effect_outcome_member, validate_effect_outcome_roles},
+};
+
 fn synthetic_num(value: i64, loc: DomainLoc) -> SyntaxExpr {
     let position = SourcePos {
         offset: 0,
@@ -479,24 +484,6 @@ fn evolve_assignments(
     output
 }
 
-fn outcome_status(context: &Context<'_>, effect: &DomainEffect, event: &str) -> String {
-    let lowered = event.to_ascii_lowercase();
-    let member = if effect.timeout_event.as_deref() == Some(event)
-        || lowered.contains("timeout")
-        || lowered.contains("timedout")
-    {
-        "TimedOut"
-    } else if effect.failure_event.as_deref() == Some(event) || lowered.contains("fail") {
-        "Failed"
-    } else if lowered.contains("cancel") {
-        "Cancelled"
-    } else {
-        "Succeeded"
-    };
-    let _ = context;
-    Context::status_member(effect, member)
-}
-
 fn render_effect_actions(context: &Context<'_>, effect: &DomainEffect) -> Vec<String> {
     let Some(correlation) = Context::correlation_field(effect) else {
         return Vec::new();
@@ -540,7 +527,7 @@ fn render_effect_actions(context: &Context<'_>, effect: &DomainEffect) -> Vec<St
         );
         lines.push(format!(
             "  {status}[{correlation}] = {}",
-            outcome_status(context, effect, event_name)
+            Context::status_member(effect, effect_outcome_member(effect, event_name))
         ));
         let mut environment = aggregate
             .state
@@ -737,9 +724,13 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
 }
 
 /// Render the full executable kernel source for a Functional-DDD document.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns [`CoreError`] when an effect event has conflicting explicit outcome roles.
 #[allow(clippy::too_many_lines)]
-pub fn domain_kernel_source(domain: &DomainSpec) -> String {
+pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
+    validate_effect_outcome_roles(domain)?;
     let context = Context::new(domain);
     let mut lines = vec![format!(
         "spec {} \"domain: generated from fsl-domain/fsl-effect\" {{",
@@ -1032,5 +1023,5 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> String {
     lines.push("}".to_owned());
     let mut source = lines.join("\n");
     source.push('\n');
-    source
+    Ok(source)
 }

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -494,7 +494,7 @@ fn render_effect_actions(context: &Context<'_>, effect: &DomainEffect) -> Vec<St
     let mut lines = Vec::new();
     let status = Context::status_var(effect);
     let attempts = Context::attempt_var(effect);
-    for event_name in &effect.outcomes {
+    for event_name in effect.outcome_events() {
         let Some((aggregate, event)) = context.event(event_name) else {
             continue;
         };

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -141,6 +141,37 @@ fn attempt_var(effect: &DomainEffect) -> String {
     format!("{}_attempts", lower_name(&effect.name))
 }
 
+pub(crate) fn effect_outcome_member(effect: &DomainEffect, event: &str) -> &'static str {
+    if effect.success_event.as_deref() == Some(event) {
+        return "Succeeded";
+    }
+    if effect.failure_event.as_deref() == Some(event) {
+        return "Failed";
+    }
+    if effect.timeout_event.as_deref() == Some(event) {
+        return "TimedOut";
+    }
+    let lowered = event.to_ascii_lowercase();
+    if lowered.contains("timeout") || lowered.contains("timedout") {
+        "TimedOut"
+    } else if lowered.contains("fail") {
+        "Failed"
+    } else if lowered.contains("cancel") {
+        "Cancelled"
+    } else {
+        "Succeeded"
+    }
+}
+
+pub(crate) fn validate_effect_outcome_roles(domain: &DomainSpec) -> Result<(), CoreError> {
+    for effect in &domain.effects {
+        if let Some(message) = effect.outcome_role_conflict() {
+            return Err(error_at(message, span_at(effect.loc)));
+        }
+    }
+    Ok(())
+}
+
 fn and_all(mut values: Vec<Expr>) -> Expr {
     if values.is_empty() {
         return Expr::Bool(true);
@@ -2006,6 +2037,7 @@ fn field_params(resolver: &Resolver<'_>, fields: &[DomainField]) -> Result<Vec<P
 pub(crate) fn lower_domain_surface(
     domain: &DomainSpec,
 ) -> Result<(SurfaceSpec, OriginRegistry), CoreError> {
+    validate_effect_outcome_roles(domain)?;
     let resolver = Resolver::new(domain);
     resolver.validate_document_expressions()?;
     let mut items = Vec::new();
@@ -2394,23 +2426,6 @@ fn lower_aggregate_actions(
     Ok(())
 }
 
-fn outcome_status(effect: &DomainEffect, event: &str) -> String {
-    let lowered = event.to_ascii_lowercase();
-    let member = if effect.timeout_event.as_deref() == Some(event)
-        || lowered.contains("timeout")
-        || lowered.contains("timedout")
-    {
-        "TimedOut"
-    } else if effect.failure_event.as_deref() == Some(event) || lowered.contains("fail") {
-        "Failed"
-    } else if lowered.contains("cancel") {
-        "Cancelled"
-    } else {
-        "Succeeded"
-    };
-    status_member(effect, member)
-}
-
 #[allow(clippy::too_many_lines)]
 fn lower_effect_actions(
     resolver: &Resolver<'_>,
@@ -2464,7 +2479,10 @@ fn lower_effect_actions(
             );
             action_items.push(ActionItem::Statement(Statement::Assign {
                 target: LValue::Index(status_var(effect), Expr::Var(correlation.clone())),
-                value: Expr::Var(outcome_status(effect, event_name)),
+                value: Expr::Var(status_member(
+                    effect,
+                    effect_outcome_member(effect, event_name),
+                )),
                 span,
             }));
             action_items.extend(resolver.evolve_items(aggregate, event_name, &scope)?);

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -6,8 +6,8 @@ use fsl_syntax::{
     ActionItem, AggregateKind, Annotations, Binder, DomainAggregate, DomainDecide, DomainEffect,
     DomainField, DomainLoc, DomainSaga, DomainSagaStep, DomainSpec, DomainType,
     DomainTypeSourceForm, Expr, LValue, MetaTag, Param, Pattern, QualifiedName, Span, SpecItem,
-    StateField, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxLValue,
-    SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr, SyntaxTypeExprKind, TypeExpr,
+    StateField, Statement, SurfaceSpec, SyntaxBinder, SyntaxExpr, SyntaxExprKind, SyntaxIdent,
+    SyntaxLValue, SyntaxPattern, SyntaxQualifiedName, SyntaxTypeExpr, SyntaxTypeExprKind, TypeExpr,
 };
 
 use crate::CoreError;
@@ -167,6 +167,19 @@ pub(crate) fn validate_effect_outcome_roles(domain: &DomainSpec) -> Result<(), C
     for effect in &domain.effects {
         if let Some(message) = effect.outcome_role_conflict() {
             return Err(error_at(message, span_at(effect.loc)));
+        }
+        for event in effect.explicit_outcome_events() {
+            if !domain
+                .aggregates
+                .iter()
+                .flat_map(|aggregate| &aggregate.events)
+                .any(|candidate| candidate.name == *event)
+            {
+                return Err(error_at(
+                    format!("unknown domain event '{event}'"),
+                    span_at(effect.loc),
+                ));
+            }
         }
     }
     Ok(())
@@ -2434,7 +2447,7 @@ fn lower_effect_actions(
 ) -> Result<(), CoreError> {
     for effect in &domain.effects {
         let (correlation, correlation_type) = resolver.correlation(effect)?;
-        for event_name in &effect.outcomes {
+        for event_name in effect.outcome_events() {
             let (aggregate, event) = resolver.event(event_name, effect.loc)?;
             let span = span_at(event.loc);
             let mut scope = resolver.scope_for_aggregate(aggregate)?;
@@ -2450,14 +2463,19 @@ fn lower_effect_actions(
             }
             let mut params = event.fields.clone();
             if !params.iter().any(|field| field.name.text == correlation) {
-                let mut synthetic = event
-                    .fields
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| error_at("cannot synthesize correlation parameter", span))?;
-                synthetic.name.text.clone_from(&correlation);
-                synthetic.type_name = correlation_type.clone();
-                params.insert(0, synthetic);
+                params.insert(
+                    0,
+                    DomainField {
+                        name: SyntaxIdent {
+                            text: correlation.clone(),
+                            span,
+                        },
+                        type_name: correlation_type.clone(),
+                        default: None,
+                        span,
+                        loc: event.loc,
+                    },
+                );
             }
             let current = Expr::Index(
                 Box::new(Expr::Var(status_var(effect))),

--- a/rust/fsl-core/tests/domain_lowering.rs
+++ b/rust/fsl-core/tests/domain_lowering.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fsl_core::{
-    FsResolver, KernelExpr, KernelLValue, KernelStatement, build_model, parse_kernel_source,
+    FsResolver, KernelExpr, KernelLValue, KernelStatement, build_model, lower_domain,
+    parse_kernel_source,
 };
-use fsl_syntax::{ActionItem, SpecItem};
+use fsl_syntax::{ActionItem, SpecItem, SurfaceDocument, parse_surface_document};
 
 fn lower(source: &str) -> fsl_core::KernelSpec {
     parse_kernel_source(source, &FsResolver::new(".")).expect("lower domain directly")
@@ -575,4 +576,125 @@ fn canonical_domain_enum_rejects_empty_and_duplicate_members_at_source_spans() {
             .contains("duplicate enum member 'Pending'")
     );
     assert_eq!((duplicate.line, duplicate.column), (1, 43));
+}
+
+#[test]
+fn explicit_effect_outcome_roles_override_event_name_heuristics() {
+    let kernel = lower(
+        r"
+domain ExplicitEffectOutcomes {
+  type RequestId = 0..0
+  aggregate Request {
+    event Requested { id: RequestId }
+    event FailureRecovered { id: RequestId }
+    event RequestTimedOutPermanently { id: RequestId }
+    event FailureTimeout { id: RequestId }
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+    success_event FailureRecovered
+    failure_event RequestTimedOutPermanently
+    timeout_event FailureTimeout
+    retry { max_attempts 2 }
+  }
+}
+",
+    );
+    let surface = kernel.syntax();
+    for (action_name, expected_status) in [
+        (
+            "work_complete_failure_recovered",
+            "WorkEffectStatus_Succeeded",
+        ),
+        (
+            "work_complete_request_timed_out_permanently",
+            "WorkEffectStatus_Failed",
+        ),
+        ("work_complete_failure_timeout", "WorkEffectStatus_TimedOut"),
+    ] {
+        let assigned_status = surface
+            .items
+            .iter()
+            .find_map(|item| match item {
+                SpecItem::Action { name, items, .. } if name == action_name => {
+                    items.iter().find_map(|item| match item {
+                        ActionItem::Statement(KernelStatement::Assign {
+                            target: KernelLValue::Index(name, _),
+                            value: KernelExpr::Var(value),
+                            ..
+                        }) if name == "work_status" => Some(value),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .expect("completion status assignment");
+        assert_eq!(assigned_status, expected_status);
+    }
+}
+
+#[test]
+fn rejects_an_event_assigned_to_multiple_explicit_effect_roles() {
+    let error = lowering_error(
+        r"
+domain AmbiguousEffectOutcome {
+  type RequestId = 0..0
+  aggregate Request {
+    event Requested { id: RequestId }
+    event Finished { id: RequestId }
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+    success_event Finished
+    failure_event Finished
+  }
+}
+",
+    );
+    assert!(
+        error
+            .message
+            .contains("effect outcome event 'Finished' has multiple explicit roles"),
+        "{}",
+        error.message
+    );
+
+    let SurfaceDocument::Domain(mut domain) = parse_surface_document(
+        r"
+domain ProgrammaticConflict {
+  type RequestId = 0..0
+  aggregate Request {
+    event Requested { id: RequestId }
+    event Finished { id: RequestId }
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+    success_event Finished
+  }
+}
+",
+    )
+    .expect("parse valid domain") else {
+        panic!("expected domain document");
+    };
+    domain.effects[0].failure_event = Some("Finished".to_owned());
+    let error = lower_domain(&domain).expect_err("programmatic conflict must fail closed");
+    assert!(
+        error
+            .message
+            .contains("effect outcome event 'Finished' has multiple explicit roles")
+    );
+    let error = fsl_core::domain_kernel_source(&domain)
+        .expect_err("programmatic textual lowering conflict must fail closed");
+    assert!(
+        error
+            .message
+            .contains("effect outcome event 'Finished' has multiple explicit roles")
+    );
 }

--- a/rust/fsl-core/tests/domain_lowering.rs
+++ b/rust/fsl-core/tests/domain_lowering.rs
@@ -643,7 +643,7 @@ domain AmbiguousEffectOutcome {
   type RequestId = 0..0
   aggregate Request {
     event Requested { id: RequestId }
-    event Finished { id: RequestId }
+    event Finished {}
   }
   effect Work {
     async
@@ -697,4 +697,43 @@ domain ProgrammaticConflict {
             .message
             .contains("effect outcome event 'Finished' has multiple explicit roles")
     );
+}
+
+#[test]
+fn programmatic_explicit_effect_role_is_an_outcome_for_both_lowering_paths() {
+    let SurfaceDocument::Domain(mut domain) = parse_surface_document(
+        r"
+domain ProgrammaticRole {
+  type RequestId = 0..0
+  aggregate Request {
+    event Requested { id: RequestId }
+    event Finished {}
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+  }
+}
+",
+    )
+    .expect("parse valid domain") else {
+        panic!("expected domain document");
+    };
+    domain.effects[0].success_event = Some("Finished".to_owned());
+
+    let kernel = lower_domain(&domain).expect("lower programmatic explicit role");
+    assert!(kernel.syntax().items.iter().any(
+        |item| matches!(item, SpecItem::Action { name, .. } if name == "work_complete_finished")
+    ));
+    let source =
+        fsl_core::domain_kernel_source(&domain).expect("render programmatic explicit role");
+    assert!(source.contains("action work_complete_finished("));
+
+    domain.effects[0].success_event = Some("Missing".to_owned());
+    let error = lower_domain(&domain).expect_err("checked lowering must reject unknown role event");
+    assert!(error.message.contains("unknown domain event 'Missing'"));
+    let error = fsl_core::domain_kernel_source(&domain)
+        .expect_err("textual lowering must reject unknown role event");
+    assert!(error.message.contains("unknown domain event 'Missing'"));
 }

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -430,6 +430,29 @@ impl DomainEffect {
         None
     }
 
+    /// Iterate the events assigned to an explicit outcome role.
+    pub fn explicit_outcome_events(&self) -> impl Iterator<Item = &String> {
+        [
+            self.success_event.as_ref(),
+            self.failure_event.as_ref(),
+            self.timeout_event.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+    }
+
+    /// Return every completion event, including programmatically assigned roles.
+    #[must_use]
+    pub fn outcome_events(&self) -> Vec<&String> {
+        let mut events = self.outcomes.iter().collect::<Vec<_>>();
+        for event in self.explicit_outcome_events() {
+            if !events.contains(&event) {
+                events.push(event);
+            }
+        }
+        events
+    }
+
     fn python_ast(&self) -> Value {
         json!({
             "$type":"DomainEffect","name":self.name,"async_effect":self.async_effect,
@@ -1133,13 +1156,10 @@ impl DomainParser {
         if let Some(message) = effect.outcome_role_conflict() {
             return Err(ParseError::new(message, effect.loc.span()));
         }
-        for event in [
-            effect.success_event.clone(),
-            effect.failure_event.clone(),
-            effect.timeout_event.clone(),
-        ]
-        .into_iter()
-        .flatten()
+        for event in effect
+            .explicit_outcome_events()
+            .cloned()
+            .collect::<Vec<_>>()
         {
             push_unique(&mut effect.outcomes, event);
         }

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -402,6 +402,34 @@ impl DomainEffect {
         }
     }
 
+    /// Describe an event assigned to more than one explicit outcome role.
+    #[must_use]
+    pub fn outcome_role_conflict(&self) -> Option<String> {
+        for ((left_role, left_event), (right_role, right_event)) in [
+            (
+                ("success_event", self.success_event.as_deref()),
+                ("failure_event", self.failure_event.as_deref()),
+            ),
+            (
+                ("success_event", self.success_event.as_deref()),
+                ("timeout_event", self.timeout_event.as_deref()),
+            ),
+            (
+                ("failure_event", self.failure_event.as_deref()),
+                ("timeout_event", self.timeout_event.as_deref()),
+            ),
+        ] {
+            if let (Some(left_event), Some(right_event)) = (left_event, right_event)
+                && left_event == right_event
+            {
+                return Some(format!(
+                    "effect outcome event '{left_event}' has multiple explicit roles ({left_role}, {right_role})"
+                ));
+            }
+        }
+        None
+    }
+
     fn python_ast(&self) -> Value {
         json!({
             "$type":"DomainEffect","name":self.name,"async_effect":self.async_effect,
@@ -1101,6 +1129,9 @@ impl DomainParser {
             } else {
                 return Err(self.error("expected effect declaration"));
             }
+        }
+        if let Some(message) = effect.outcome_role_conflict() {
+            return Err(ParseError::new(message, effect.loc.span()));
         }
         for event in [
             effect.success_event.clone(),

--- a/rust/fsl-tools/src/domain.rs
+++ b/rust/fsl-tools/src/domain.rs
@@ -123,8 +123,11 @@ fn actions(domain: &DomainSpec) -> Vec<String> {
 }
 
 /// Build a specialized domain check envelope around the shared kernel result.
-#[must_use]
-pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Value {
+///
+/// # Errors
+///
+/// Returns an error when textual Kernel rendering rejects the domain AST.
+pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Result<Value, fsl_core::CoreError> {
     let assumptions = assumptions(domain);
     let findings = domain
         .effects
@@ -135,9 +138,13 @@ pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Value {
         .iter()
         .any(|finding| finding["severity"] == "error");
     if hard {
-        json!({"result":"violated","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"formal_result":"not_run","findings":findings,"assumptions":assumptions,"kernel_source":domain_kernel_source(domain)})
+        Ok(
+            json!({"result":"violated","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"formal_result":"not_run","findings":findings,"assumptions":assumptions,"kernel_source":domain_kernel_source(domain)?}),
+        )
     } else {
-        json!({"result":"verified_under_assumptions","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"spec":domain.name,"formal_result":"verified","kernel":kernel,"findings":findings,"assumptions":assumptions,"generated_actions":actions(domain)})
+        Ok(
+            json!({"result":"verified_under_assumptions","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"spec":domain.name,"formal_result":"verified","kernel":kernel,"findings":findings,"assumptions":assumptions,"generated_actions":actions(domain)}),
+        )
     }
 }
 
@@ -154,8 +161,11 @@ pub fn analyze_domain(domain: &DomainSpec) -> Value {
 }
 
 /// Render a compact executable kernel catalog used by expand and review tools.
-#[must_use]
-pub fn domain_kernel_source(domain: &DomainSpec) -> String {
+///
+/// # Errors
+///
+/// Returns an error when the domain AST has conflicting explicit outcome roles.
+pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, fsl_core::CoreError> {
     fsl_core::domain_kernel_source(domain)
 }
 

--- a/rust/fsl-tools/src/domain.rs
+++ b/rust/fsl-tools/src/domain.rs
@@ -79,7 +79,7 @@ fn actions(domain: &DomainSpec) -> Vec<String> {
         }
     }
     for effect in &domain.effects {
-        for outcome in &effect.outcomes {
+        for outcome in effect.outcome_events() {
             out.push(format!(
                 "{}_complete_{}",
                 snake(&effect.name),
@@ -128,6 +128,7 @@ fn actions(domain: &DomainSpec) -> Vec<String> {
 ///
 /// Returns an error when textual Kernel rendering rejects the domain AST.
 pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Result<Value, fsl_core::CoreError> {
+    let kernel_source = domain_kernel_source(domain)?;
     let assumptions = assumptions(domain);
     let findings = domain
         .effects
@@ -139,7 +140,7 @@ pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Result<Value, fsl_co
         .any(|finding| finding["severity"] == "error");
     if hard {
         Ok(
-            json!({"result":"violated","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"formal_result":"not_run","findings":findings,"assumptions":assumptions,"kernel_source":domain_kernel_source(domain)?}),
+            json!({"result":"violated","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"formal_result":"not_run","findings":findings,"assumptions":assumptions,"kernel_source":kernel_source}),
         )
     } else {
         Ok(
@@ -157,7 +158,7 @@ pub fn analyze_domain(domain: &DomainSpec) -> Value {
         .iter()
         .flat_map(|effect| effect_findings(domain, effect, &assumptions))
         .collect::<Vec<_>>();
-    json!({"result":"analyzed","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"profile":domain.implementation_profile,"aggregates":domain.aggregates.iter().map(|a|json!({"name":a.name,"id_type":a.id_type,"state":a.state.iter().map(|f|json!({"name":f.name.text,"type":f.type_name.render_source()})).collect::<Vec<_>>(),"commands":a.commands.iter().map(|x|&x.name).collect::<Vec<_>>(),"events":a.events.iter().map(|x|&x.name).collect::<Vec<_>>(),"errors":a.errors.iter().map(|x|&x.name).collect::<Vec<_>>(),"invariants":a.invariants.iter().map(|x|&x.name.text).collect::<Vec<_>>() })).collect::<Vec<_>>(),"effects":domain.effects.iter().map(|e|json!({"name":e.name,"async":e.async_effect,"reliable":e.reliable,"irreversible":e.irreversible,"handles":e.handles.as_ref().or(e.request_event.as_ref()),"outcomes":e.outcomes,"correlation_id":e.correlation_id.as_ref().map(SyntaxExpr::render_source),"idempotency_key":e.idempotency_key.as_ref().map(SyntaxExpr::render_source),"retry_max_attempts":e.retry.max_attempts,"timeout_event":e.timeout_event,"outbox":e.outbox,"inbox":e.inbox})).collect::<Vec<_>>(),"sagas":domain.sagas.iter().map(|s|json!({"name":s.name,"starts_on":s.starts_on,"steps":s.steps.iter().map(|x|json!({"name":x.name,"async":x.async_step,"requires":x.requires.iter().map(SyntaxExpr::render_source).collect::<Vec<_>>(),"emits":x.emits,"awaits_mode":x.awaits_mode,"awaits":x.awaits,"timeout_event":x.timeout_event})).collect::<Vec<_>>(),"compensations":s.compensations.iter().map(|x|json!({"trigger_event":x.trigger_event,"after_event":x.after_event,"emits":x.emits})).collect::<Vec<_>>(),"outboxes":s.outboxes,"inboxes":s.inboxes,"invariants":s.invariants.iter().map(|x|&x.name.text).collect::<Vec<_>>() })).collect::<Vec<_>>(),"findings":findings,"assumptions":assumptions})
+    json!({"result":"analyzed","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"profile":domain.implementation_profile,"aggregates":domain.aggregates.iter().map(|a|json!({"name":a.name,"id_type":a.id_type,"state":a.state.iter().map(|f|json!({"name":f.name.text,"type":f.type_name.render_source()})).collect::<Vec<_>>(),"commands":a.commands.iter().map(|x|&x.name).collect::<Vec<_>>(),"events":a.events.iter().map(|x|&x.name).collect::<Vec<_>>(),"errors":a.errors.iter().map(|x|&x.name).collect::<Vec<_>>(),"invariants":a.invariants.iter().map(|x|&x.name.text).collect::<Vec<_>>() })).collect::<Vec<_>>(),"effects":domain.effects.iter().map(|e|json!({"name":e.name,"async":e.async_effect,"reliable":e.reliable,"irreversible":e.irreversible,"handles":e.handles.as_ref().or(e.request_event.as_ref()),"outcomes":e.outcome_events(),"correlation_id":e.correlation_id.as_ref().map(SyntaxExpr::render_source),"idempotency_key":e.idempotency_key.as_ref().map(SyntaxExpr::render_source),"retry_max_attempts":e.retry.max_attempts,"timeout_event":e.timeout_event,"outbox":e.outbox,"inbox":e.inbox})).collect::<Vec<_>>(),"sagas":domain.sagas.iter().map(|s|json!({"name":s.name,"starts_on":s.starts_on,"steps":s.steps.iter().map(|x|json!({"name":x.name,"async":x.async_step,"requires":x.requires.iter().map(SyntaxExpr::render_source).collect::<Vec<_>>(),"emits":x.emits,"awaits_mode":x.awaits_mode,"awaits":x.awaits,"timeout_event":x.timeout_event})).collect::<Vec<_>>(),"compensations":s.compensations.iter().map(|x|json!({"trigger_event":x.trigger_event,"after_event":x.after_event,"emits":x.emits})).collect::<Vec<_>>(),"outboxes":s.outboxes,"inboxes":s.inboxes,"invariants":s.invariants.iter().map(|x|&x.name.text).collect::<Vec<_>>() })).collect::<Vec<_>>(),"findings":findings,"assumptions":assumptions})
 }
 
 /// Render a compact executable kernel catalog used by expand and review tools.
@@ -225,7 +226,7 @@ pub fn domain_scaffold_metadata(domain: &DomainSpec) -> Value {
             "name":value.name,
             "handles":value.handles,
             "request_event":value.request_event,
-            "outcomes":value.outcomes,
+            "outcomes":value.outcome_events(),
             "retry_max_attempts":value.retry.max_attempts
         })).collect::<Vec<_>>(),
         "sagas":domain.sagas.iter().map(|value|json!({

--- a/rust/fsl-tools/tests/domain_regression.rs
+++ b/rust/fsl-tools/tests/domain_regression.rs
@@ -31,3 +31,77 @@ domain Example {
     fsl_core::parse_kernel_source(&expanded, &fsl_core::FsResolver::new("."))
         .expect("expanded source remains valid FSL");
 }
+
+#[test]
+fn domain_check_rejects_programmatic_outcome_role_conflict() {
+    let source = r"
+domain ProgrammaticConflict {
+  type Id = 0..0
+  aggregate Item {
+    event Requested { id: Id }
+    event Finished { id: Id }
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+    success_event Finished
+  }
+}
+";
+    let fsl_syntax::SurfaceDocument::Domain(mut domain) =
+        fsl_syntax::parse_surface_document(source).expect("parse valid domain")
+    else {
+        panic!("expected domain document");
+    };
+    domain.effects[0].failure_event = Some("Finished".to_owned());
+
+    let error = fsl_tools::check_domain(&domain, &serde_json::json!({}))
+        .expect_err("domain check must reject conflicting roles");
+    assert!(
+        error
+            .message
+            .contains("effect outcome event 'Finished' has multiple explicit roles")
+    );
+}
+
+#[test]
+fn domain_outputs_normalize_programmatic_explicit_role() {
+    let source = r"
+domain ProgrammaticRole {
+  type Id = 0..0
+  aggregate Item {
+    event Requested { id: Id }
+    event Finished {}
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+  }
+}
+";
+    let fsl_syntax::SurfaceDocument::Domain(mut domain) =
+        fsl_syntax::parse_surface_document(source).expect("parse valid domain")
+    else {
+        panic!("expected domain document");
+    };
+    domain.effects[0].success_event = Some("Finished".to_owned());
+
+    let checked = fsl_tools::check_domain(&domain, &serde_json::json!({}))
+        .expect("check programmatic explicit role");
+    assert!(
+        checked["generated_actions"]
+            .as_array()
+            .expect("generated actions")
+            .contains(&serde_json::json!("work_complete_finished"))
+    );
+    assert_eq!(
+        fsl_tools::analyze_domain(&domain)["effects"][0]["outcomes"],
+        serde_json::json!(["Finished"])
+    );
+    assert_eq!(
+        fsl_tools::domain_scaffold_metadata(&domain)["effects"][0]["outcomes"],
+        serde_json::json!(["Finished"])
+    );
+}

--- a/rust/fsl-tools/tests/domain_regression.rs
+++ b/rust/fsl-tools/tests/domain_regression.rs
@@ -24,7 +24,7 @@ domain Example {
     let fsl_syntax::SurfaceDocument::Domain(domain) = document else {
         panic!("expected domain document");
     };
-    let expanded = fsl_tools::domain_kernel_source(&domain);
+    let expanded = fsl_tools::domain_kernel_source(&domain).expect("render domain kernel");
     assert!(expanded.contains("enum Status { Status_New, Status_Done }"));
     assert!(expanded.contains("action item_complete()"));
     assert!(expanded.contains("item_status = Status_Done"));

--- a/rust/fsl-verifier/tests/transition_agreement.rs
+++ b/rust/fsl-verifier/tests/transition_agreement.rs
@@ -94,7 +94,6 @@ spec Agreement {
   }
   invariant Bound { x <= 2 }
 }
-
 ";
     let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
     let model = build_model(kernel).expect("build model");
@@ -130,6 +129,101 @@ spec Agreement {
             &wrong,
         ))
         .expect("reject different successor")
+    );
+}
+
+#[test]
+fn explicit_effect_success_disables_retry_across_monitor_and_symbolic_semantics() {
+    let source = r"
+domain ExplicitEffectSuccess {
+  type RequestId = 0..0
+  aggregate Request {
+    command Start { id: RequestId }
+    event Requested { id: RequestId }
+    event FailureRecovered { id: RequestId }
+    decide Start { emits Requested }
+    evolve Requested {}
+    evolve FailureRecovered {}
+  }
+  effect Work {
+    async
+    correlation_id Requested.id
+    handles Requested
+    success_event FailureRecovered
+    retry { max_attempts 2 }
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower domain");
+    let model = build_model(kernel).expect("build model");
+    assert!(
+        model
+            .transitions
+            .iter()
+            .any(|property| property.name == "Work_SuccessSticky")
+    );
+
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let start = monitor
+        .enabled()
+        .expect("enumerate start")
+        .into_iter()
+        .find(|action| action.action == "request_start")
+        .expect("request start action");
+    monitor.step(&start).expect("start effect");
+
+    let completion = monitor
+        .enabled()
+        .expect("enumerate completion")
+        .into_iter()
+        .find(|action| action.action == "work_complete_failure_recovered")
+        .expect("explicit success completion");
+    let before = monitor.state.clone();
+    let result = monitor.step(&completion).expect("complete effect");
+    assert!(result.violation.is_none());
+    assert!(
+        monitor
+            .enabled()
+            .expect("enumerate after success")
+            .iter()
+            .all(|action| action.action != "work_retry")
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    assert!(
+        block_on(fsl_verifier::transition_matches_step(
+            &model,
+            &mut solver,
+            &before,
+            &completion.action,
+            &completion.params,
+            &result.state,
+        ))
+        .expect("accept Monitor successor")
+    );
+
+    let mut wrong = result.state;
+    let FslValue::Map(statuses) = wrong.get_mut("work_status").expect("effect status state") else {
+        panic!("effect status must be a map");
+    };
+    statuses.insert(
+        FslValue::Int(0),
+        FslValue::Enum {
+            type_name: "WorkEffectStatus".to_owned(),
+            member: "WorkEffectStatus_Failed".to_owned(),
+        },
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create rejection solver");
+    assert!(
+        !block_on(fsl_verifier::transition_matches_step(
+            &model,
+            &mut solver,
+            &before,
+            &completion.action,
+            &completion.params,
+            &wrong,
+        ))
+        .expect("reject name-heuristic failure successor")
     );
 }
 

--- a/rust/fsl-verifier/tests/transition_agreement.rs
+++ b/rust/fsl-verifier/tests/transition_agreement.rs
@@ -30,6 +30,26 @@ fn monitor_boundary_model() -> fsl_core::KernelModel {
     build_model(kernel).expect("build model")
 }
 
+fn assert_success_is_sticky(
+    model: &fsl_core::KernelModel,
+    succeeded: &BTreeMap<String, FslValue>,
+    violated: &BTreeMap<String, FslValue>,
+) {
+    let sticky = model
+        .transitions
+        .iter()
+        .find(|property| property.name == "Work_SuccessSticky")
+        .expect("success-sticky transition property");
+    for (state, expected) in [(succeeded, true), (violated, false)] {
+        let mut bindings = BTreeMap::new();
+        assert_eq!(
+            fsl_runtime::eval(&sticky.expr, state, &mut bindings, model, Some(succeeded),)
+                .expect("evaluate success-stickiness"),
+            FslValue::Bool(expected)
+        );
+    }
+}
+
 #[test]
 fn collection_and_option_transitions_agree_across_bounded_reachable_states() {
     let fixture =
@@ -156,12 +176,6 @@ domain ExplicitEffectSuccess {
 ";
     let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower domain");
     let model = build_model(kernel).expect("build model");
-    assert!(
-        model
-            .transitions
-            .iter()
-            .any(|property| property.name == "Work_SuccessSticky")
-    );
 
     let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
     let start = monitor
@@ -202,7 +216,7 @@ domain ExplicitEffectSuccess {
         .expect("accept Monitor successor")
     );
 
-    let mut wrong = result.state;
+    let mut wrong = result.state.clone();
     let FslValue::Map(statuses) = wrong.get_mut("work_status").expect("effect status state") else {
         panic!("effect status must be a map");
     };
@@ -213,6 +227,7 @@ domain ExplicitEffectSuccess {
             member: "WorkEffectStatus_Failed".to_owned(),
         },
     );
+    assert_success_is_sticky(&model, &result.state, &wrong);
     let mut solver = fsl_solver_z3::Z3Solver::new().expect("create rejection solver");
     assert!(
         !block_on(fsl_verifier::transition_matches_step(

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -7680,15 +7680,11 @@ fn run_domain_check(
     if status == 2 {
         return apply_domain_edition((kernel, status), path, path, edition);
     }
-    apply_domain_edition(
-        wrap_specialized(fsl_tools::check_domain(
-            &domain,
-            &stable_kernel_projection(kernel),
-        )),
-        path,
-        path,
-        edition,
-    )
+    let result = match fsl_tools::check_domain(&domain, &stable_kernel_projection(kernel)) {
+        Ok(result) => wrap_specialized(result),
+        Err(error) => (semantic_error_output(&error.to_string()), 2),
+    };
+    apply_domain_edition(result, path, path, edition)
 }
 
 fn run_domain_analyze(path: &Path) -> (Value, i32) {
@@ -7703,7 +7699,10 @@ fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
         Ok(domain) => domain,
         Err(error) => return (semantic_error_output(&error), 2),
     };
-    let source = fsl_tools::domain_kernel_source(&domain);
+    let source = match fsl_tools::domain_kernel_source(&domain) {
+        Ok(source) => source,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
     if let Some(output_path) = output_path
         && let Err(error) = std::fs::write(output_path, &source)
     {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -7889,7 +7889,7 @@ fn run_domain_testgen(
             format!("{}_attempts", snake_case(&effect.name)),
             format!("effect.{}.attempts", effect.name),
         ));
-        for event in &effect.outcomes {
+        for event in effect.outcome_events() {
             display_names.push((
                 format!(
                     "{}_complete_{}",

--- a/rust/fslc/tests/domain_expression_characterization.rs
+++ b/rust/fslc/tests/domain_expression_characterization.rs
@@ -335,7 +335,7 @@ fn public_projection(name: &str) -> Value {
 }
 
 fn generated_fragments(domain: &DomainSpec, needles: &[&str]) -> Value {
-    let source = fsl_core::domain_kernel_source(domain);
+    let source = fsl_core::domain_kernel_source(domain).expect("render domain kernel");
     Value::Array(
         needles
             .iter()

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -270,6 +270,9 @@ domain <Name> {
     correlation_id PaymentCaptureRequested.payment_request_id
     handles PaymentCaptureRequested
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+    success_event PaymentCaptured
+    failure_event PaymentFailed
+    timeout_event PaymentCaptureTimedOut
     retry { max_attempts 3 }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation { emits PaymentFailed }
@@ -315,6 +318,14 @@ missing lowered type/state/action counterparts fail closed; source expressions
 and effect/saga topology are authoritative in the companion because v1 has no
 equivalent nodes. Emitters never receive `DomainSpec`, never reparse source
 text, and the five targets preserve their pre-migration bytes.
+
+Effect completion classification first honors explicit roles:
+`success_event` -> `Succeeded`, `failure_event` -> `Failed`, and `timeout_event`
+-> `TimedOut`, regardless of event spelling. The same event in multiple explicit
+roles is a parse error. Outcomes without an explicit role retain the v0 name
+heuristic in priority order (`timeout`/`timedout`, `fail`, `cancel`, otherwise
+success). Completion status, retry eligibility, and success stickiness therefore
+share the one lowered status classification.
 
 The Rust frontend keeps an internal origin chain across direct domain lowering,
 checked-model construction, verification, counterexamples, and `explain`.


### PR DESCRIPTION
## Problem

Explicit effect outcome roles were not authoritative: event-name heuristics could classify an explicit success as failed, and conflicting explicit roles were not rejected.

## Contract and implementation

- Explicit success_event, failure_event, and timeout_event now override all name heuristics.
- Events assigned to multiple explicit roles fail closed in parsing, checked lowering, and textual Kernel rendering.
- Textual expansion and checked lowering share one outcome classifier and one role validator.
- Monitor/BFS and symbolic verification continue to consume the same checked Kernel; explicit success disables retry and satisfies success stickiness.
- Public Kernel JSON schema is unchanged.

## Evidence

- Added explicit-role priority and programmatic-AST conflict negative controls.
- Added Monitor/symbolic transition agreement coverage that rejects a mutated Failed successor after explicit success.
- Updated LANGUAGE.md, LANGUAGE.ja.md, domain/effect design notes, FSL skill reference, changelog, and generated language HTML.
- Applied implementation-local-optima-audit; corrected parser-only validation externalization and the sibling textual-renderer boundary found by independent review.
- Independent re-review: no remaining actionable findings.

## Verification

- Focused syntax/core/tools/verifier/CLI tests pass.
- Site reference snapshot: 3 passed.
- ./tools/check-native-integration.sh passes, including Clippy, full workspace tests/build, and browser native parity across 351 cases.

Closes #409