### PR TITLE
fix(mutate): adjudicate singleton bound mutants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `fslc mutate` now adjudicates singleton bound mutants whose empty domain
+  produces no action instances instead of panicking in bounded verification;
+  overflowing integer and bound neighbors are omitted (issue #406).
 - Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and

--- a/docs/DESIGN-mutate.md
+++ b/docs/DESIGN-mutate.md
@@ -26,7 +26,7 @@ before checking. Reasons:
    `build_spec` produces** — directly mutating the spec dict leaves them stale and the mutation
    has no effect.
 2. Derived consistency such as `phys_vars` can be left to build_spec.
-3. Dialects are handled uniformly. The grammar and verification engine are untouched.
+3. Dialects are handled uniformly without mutation-specific grammar or verification semantics.
 
 ### Mutation operators (deterministic enumeration, no randomness)
 
@@ -39,6 +39,10 @@ before checking. Reasons:
 | integer/bound ±1 | off-by-one | `("num", n)`±1, `("type", n, lo, hi)`'s lo/hi ±1 |
 | then/else swap | mistaken branch | swap an `if` whose both branches are non-empty |
 | fair removal | missing leadsTo fairness assumption | flip the action's fair True→False |
+
+Integer and numeric type-bound mutations that would overflow are omitted. Empty
+numeric domains remain materializable kernel inputs and are adjudicated by the
+ordinary oracle, including its zero-action-instance behavior.
 
 ### External JSONL contract
 
@@ -111,7 +115,8 @@ generation-quality evidence (an `invalid` record says nothing about the spec's
 constraint strength — it failed before reaching the kill oracle, so counting it
 either way would distort the score). Built-in entries have `source:"builtin"`;
 external entries add `id`, `source:"external"`, `input_kind`, and JSONL `line`.
-**The verification engine is unmodified.**
+Mutation uses the ordinary bounded verifier, including its normal termination
+after the initial state when a model has no action instances.
 
 ### What the score means (and does not)
 

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -59,6 +59,19 @@ fn rebuild_one<T: Clone>(values: &[T], index: usize, replacement: T) -> Vec<T> {
     result
 }
 
+fn adjacent_integers(value: i64) -> impl Iterator<Item = (i64, &'static str, &'static str)> {
+    [
+        (-1, "minus1", "integer_literal_minus1"),
+        (1, "plus1", "integer_literal_plus1"),
+    ]
+    .into_iter()
+    .filter_map(move |(delta, suffix, literal_op)| {
+        value
+            .checked_add(delta)
+            .map(|candidate| (candidate, suffix, literal_op))
+    })
+}
+
 fn mutate_binder(
     binder: &Binder,
     enums: &BTreeMap<String, Vec<String>>,
@@ -162,16 +175,13 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
     let mut output = Vec::new();
     match expr {
         Expr::Num(value) => {
-            output.push(ExprMutation {
-                expr: Expr::Num(value - 1),
-                op: "integer_literal_minus1",
-                enum_swap: None,
-            });
-            output.push(ExprMutation {
-                expr: Expr::Num(value + 1),
-                op: "integer_literal_plus1",
-                enum_swap: None,
-            });
+            for (candidate, _, op) in adjacent_integers(*value) {
+                output.push(ExprMutation {
+                    expr: Expr::Num(candidate),
+                    op,
+                    enum_swap: None,
+                });
+            }
         }
         Expr::Var(name) if enums.contains_key(name) => {
             for sibling in &enums[name] {
@@ -739,12 +749,12 @@ pub fn enumerate_builtin_mutants(spec: &SurfaceSpec) -> Vec<BuiltinMutant> {
                     let Expr::Num(value) = value else {
                         continue;
                     };
-                    for (delta, suffix) in [(-1, "minus1"), (1, "plus1")] {
+                    for (candidate, suffix, _) in adjacent_integers(*value) {
                         let mut mutated = spec.clone();
                         mutated.items[item_index] = if bound == "lo" {
                             SpecItem::Type {
                                 name: name.clone(),
-                                lo: Box::new(Expr::Num(value + delta)),
+                                lo: Box::new(Expr::Num(candidate)),
                                 hi: hi.clone(),
                                 symmetric: *symmetric,
                             }
@@ -752,7 +762,7 @@ pub fn enumerate_builtin_mutants(spec: &SurfaceSpec) -> Vec<BuiltinMutant> {
                             SpecItem::Type {
                                 name: name.clone(),
                                 lo: lo.clone(),
-                                hi: Box::new(Expr::Num(value + delta)),
+                                hi: Box::new(Expr::Num(candidate)),
                                 symmetric: *symmetric,
                             }
                         };

--- a/rust/fsl-tools/tests/binder_aggregates.rs
+++ b/rust/fsl-tools/tests/binder_aggregates.rs
@@ -27,3 +27,24 @@ spec AggregateMutation {
             >= 6
     );
 }
+
+#[test]
+fn integer_literal_mutation_omits_overflowing_neighbor() {
+    let source = r"
+spec MaximumIntegerMutation {
+  const MAX = 9223372036854775807
+  state { flag: Bool }
+  init { flag = false }
+  action stay() { flag = flag }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower source");
+    let mutants = enumerate_builtin_mutants(kernel.syntax());
+    let operations = mutants
+        .iter()
+        .filter(|mutant| mutant.target.starts_with("const MAX"))
+        .map(|mutant| mutant.op.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(operations, ["integer_literal_minus1"]);
+}

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -238,8 +238,11 @@ async fn verify_bounded_config<S: SmtSolver>(
                 check_leadsto_deadlines(solver, model, &states, &choices, &instances, step).await?;
         }
 
-        if step == depth || instances.is_empty() {
+        if step == depth {
             continue;
+        }
+        if instances.is_empty() {
+            break;
         }
         let next = symbolic_state(solver, model, step + 1)?;
         let choice = solver.constant(&format!("__choice@{step}"), &fsl_solver::Sort::Int)?;
@@ -254,8 +257,9 @@ async fn verify_bounded_config<S: SmtSolver>(
         choices.push(choice);
     }
     if result.leadsto_violation.is_none() {
+        let unrolled_depth = states.len() - 1;
         result.leadsto_violation =
-            check_leadstos(solver, model, &states, &choices, &instances, depth).await?;
+            check_leadstos(solver, model, &states, &choices, &instances, unrolled_depth).await?;
     }
     Ok(result)
 }

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -118,6 +118,70 @@ spec NestedOptionEquality {
 }
 
 #[test]
+fn bounded_verification_stops_after_initial_state_without_action_instances() {
+    let source = r"
+spec EmptyActionDomain {
+  type Empty = 1..0
+  state { done: Bool }
+  init { done = false }
+  action finish(item: Empty) { done = true }
+  invariant InitiallyPending { not done }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect("verify initial state");
+
+    assert!(result.violation.is_none(), "{result:?}");
+    assert_eq!(result.deadlock_step, Some(0));
+}
+
+#[test]
+fn bounded_verification_checks_liveness_at_the_actual_zero_action_depth() {
+    let source = r"
+spec EmptyActionLiveness {
+  type Empty = 1..0
+  state { done: Bool }
+  init { done = false }
+  action finish(item: Empty) { done = true }
+  leadsTo NeverTriggered { done ~> not done }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect("verify initial state");
+
+    assert!(result.leadsto_violation.is_none(), "{result:?}");
+    assert_eq!(result.deadlock_step, Some(0));
+}
+
+#[test]
+fn bounded_verification_rejects_initial_violation_without_action_instances() {
+    let source = r"
+spec EmptyActionInitialViolation {
+  type Empty = 1..0
+  state { done: Bool }
+  init { done = false }
+  action finish(item: Empty) { done = true }
+  invariant MustBeDone { done }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect("verify initial state");
+
+    let violation = result.violation.expect("initial invariant violation");
+    assert_eq!(violation.name, "MustBeDone");
+    assert_eq!(violation.step, 0);
+}
+
+#[test]
 fn binder_aggregates_agree_for_ranges_sets_and_duplicate_sequences() {
     let source = r"
 spec BinderAggregateAgreement {

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -219,6 +219,31 @@ fn monitor_boundary_self_spec_is_proved_and_mutation_sensitive() {
 }
 
 #[test]
+fn mutate_rebuilds_singleton_domain_bound_expansions_without_panicking() {
+    let (mutated, status) = run_cli(&[
+        "mutate",
+        "rust/fslc/tests/fixtures/mutate_singleton_domain.fsl",
+        "--depth",
+        "8",
+        "--max-mutants",
+        "2",
+    ]);
+
+    assert_eq!(status, 0, "{mutated}");
+    assert_eq!(mutated["result"], "mutated");
+    let operations = mutated["mutants"]
+        .as_array()
+        .expect("mutants")
+        .iter()
+        .map(|mutant| mutant["op"].as_str().expect("mutation operation"))
+        .collect::<Vec<_>>();
+    assert_eq!(operations, ["type_bound_lo_minus1", "type_bound_lo_plus1"]);
+    let empty_domain = &mutated["mutants"][1];
+    assert_eq!(empty_domain["status"], "survived", "{mutated}");
+    assert!(empty_domain["killed_by"].is_null(), "{mutated}");
+}
+
+#[test]
 fn native_check_and_verify_reject_duplicate_correspondence_origins() {
     let fixture = "rust/fslc/tests/fixtures/action_correspondence_duplicate.fsl";
 

--- a/rust/fslc/tests/fixtures/mutate_singleton_domain.fsl
+++ b/rust/fslc/tests/fixtures/mutate_singleton_domain.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements SingletonDomainMutation {
+  process Item {
+    stages Ready, Done
+    initial Ready
+    transition finish Ready -> Done by System
+  }
+}
+verify { instances Item = 1 }


### PR DESCRIPTION
## Problem

`fslc mutate` panicked on the second bound mutant of a singleton requirements entity. The mutant produced an empty numeric domain, so BMC had zero action instances but continued indexing states at the requested depth.

## Contract and implementation

- keep empty-domain mutants as ordinary mutation-sensitivity probes
- stop BMC after the initial state when no action instances exist
- run liveness checks at the actually unrolled depth
- share checked adjacent-integer generation across literal and type-bound mutation paths
- document zero-instance adjudication and overflow omission

## Audit

The implementation-local-optima audit rejected filtering empty domains from the catalog because that would hide a valid vacuity probe and distort mutation sensitivity. Independent review found and verified the liveness sibling path, integer-literal overflow path, and step-zero invariant negative control. Final re-review reported no actionable findings.

## Verification

- focused RED reproduction: panic at `rust/fsl-verifier/src/bmc.rs` before the fix
- `cargo test --manifest-path rust/Cargo.toml -p fsl-tools --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fsl-verifier --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test cli_regression --locked`
- focused Clippy for `fsl-tools`, `fsl-verifier`, and `fslc-rust` with `-D warnings`
- `./tools/check-native-integration.sh` including browser Z3 and 351 native/WASM parity cases

Closes #406