### PR TITLE
fix(mutate): attribute trace oracle kills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `fslc mutate --by-requirement` now attributes acceptance and forbidden kills
+  through explicit requirement annotations on the failed trace declaration
+  instead of reporting the linked requirement as `empty_formalization` (issue
+  #407). Duplicate acceptance or forbidden IDs are rejected so attribution is
+  unambiguous.
 - Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and

--- a/docs/DESIGN-mutate.md
+++ b/docs/DESIGN-mutate.md
@@ -90,6 +90,8 @@ mechanization is reversed: the kill oracle records each mutant's killer → aggr
 `killed_by` requirement tag. **A requirement that killed no behavior mutation = an empty
 formalization**, warned as `empty_formalization`. v1 records the first-killer and explicitly
 labels this "lower observation bound" (sole-killer redundancy analysis is future work).
+Acceptance and forbidden kills are attributed through explicit requirement annotations on the
+failed trace declaration; their AC/FB case IDs remain unique scenario identities, not requirements.
 
 ## 5. Output / ripple
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2390,7 +2390,10 @@ DESIGN-*.md があります)。
   `--by-requirement` は「どの振る舞いミュータントも殺さない要件」を
   `empty_formalization` 警告としてフラグします(`--strict-tags` の意味レベルの
   拡張)。要件ごとのキル数とこの警告は、選択されたミュータント集合と深さの中で
-  観測された下界です。→ [`DESIGN-mutate.md`](DESIGN-mutate.md)
+  観測された下界です。acceptance と forbidden の kill は、失敗した trace 宣言の
+  明示的な requirement annotation を使います。AC/FB case ID は暗黙の requirement
+  ではなく、trace case ID は宣言種別ごとに一意です。→
+  [`DESIGN-mutate.md`](DESIGN-mutate.md)
 - **`fslc explain --readable`** — 骨格の列挙(状態、action の誰が/いつ/何を変える
   か、検証の境界、公平性、KPI の射影、branch の lowering、合成された refinement
   マッピング、自動検査、タグ)+ counterfactual(「この規則がなければ、この手順で

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2432,7 +2432,10 @@ DESIGN-*.md).
   `--by-requirement` flags "a requirement that kills no behavior mutant" as an
   `empty_formalization` warning (the semantic-level extension of
   `--strict-tags`); per-requirement kill counts and this warning are observed
-  lower bounds within the chosen mutant set and depth.
+  lower bounds within the chosen mutant set and depth. Acceptance and forbidden
+  kills use explicit requirement annotations on the failed trace declaration;
+  AC/FB case IDs are not implicit requirements. Trace case IDs are unique
+  within each declaration kind.
   → [`DESIGN-mutate.md`](DESIGN-mutate.md)
 - **`fslc explain --readable`** — a text view over skeleton enumeration (state,
   action who/when/what-changes, verification bounds, fairness, KPI projections,

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -2296,6 +2296,8 @@ pub fn requirements_trace_contract(
     let stage_resolver = StageResolver::new(&stage_processes);
     let mut acceptance = Vec::new();
     let mut forbidden = Vec::new();
+    let mut acceptance_ids = BTreeSet::new();
+    let mut forbidden_ids = BTreeSet::new();
     for item in requirements.items {
         let convert_steps = |steps: Vec<fsl_syntax::AcceptanceStep>| {
             steps
@@ -2317,6 +2319,9 @@ pub fn requirements_trace_contract(
                 span,
                 annotations: surface_annotations,
             } => {
+                if !acceptance_ids.insert(id.clone()) {
+                    return Err(core_error(format!("duplicate acceptance id '{id}'"), span));
+                }
                 let annotations = trace_case_annotations(&id, &text, span, &surface_annotations)?;
                 let expectation = match expectation {
                     fsl_syntax::AcceptanceExpectation::Expr(mut expr, _) => {
@@ -2351,6 +2356,9 @@ pub fn requirements_trace_contract(
                 span,
                 annotations: surface_annotations,
             } => {
+                if !forbidden_ids.insert(id.clone()) {
+                    return Err(core_error(format!("duplicate forbidden id '{id}'"), span));
+                }
                 let annotations = trace_case_annotations(&id, &text, span, &surface_annotations)?;
                 forbidden.push(RequirementsTraceCase {
                     annotations,

--- a/rust/fsl-core/tests/typed_annotations.rs
+++ b/rust/fsl-core/tests/typed_annotations.rs
@@ -345,6 +345,31 @@ requirements TraceCases {
 }
 
 #[test]
+fn trace_case_ids_are_unique_within_each_kind() {
+    for keyword in ["acceptance", "forbidden"] {
+        let expectation = if keyword == "acceptance" {
+            "expect ready"
+        } else {
+            "expect rejected"
+        };
+        let source = format!(
+            r#"
+requirements DuplicateTraceCase {{
+  state {{ ready: Bool }}
+  init {{ ready = false }}
+  action publish() {{ ready = true }}
+  {keyword} CASE-1 "first" {{ publish() {expectation} }}
+  {keyword} CASE-1 "second" {{ publish() {expectation} }}
+}}
+"#
+        );
+        let error = requirements_trace_contract(&source).expect_err("duplicate trace case id");
+        assert_eq!(error.message, format!("duplicate {keyword} id 'CASE-1'"));
+        assert_eq!(error.line, 7);
+    }
+}
+
+#[test]
 fn nested_annotation_syntax_reaches_the_checked_model() {
     let source = r#"
 spec NestedAnnotations {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -9715,6 +9715,13 @@ fn annotation_requirement_ids(annotations: &Annotations) -> Vec<String> {
         .collect()
 }
 
+fn trace_case_requirement_ids(case: &fsl_core::RequirementsTraceCase) -> Vec<String> {
+    annotation_requirement_ids(&case.annotations)
+        .into_iter()
+        .filter(|requirement| requirement != &case.id)
+        .collect()
+}
+
 fn property_requirements(model: &KernelModel, name: &str) -> Vec<String> {
     model
         .invariants
@@ -9835,6 +9842,32 @@ fn mutation_oracle_for_model(model: KernelModel, depth: usize) -> MutationOracle
     mutation_model_oracle(model, depth)
 }
 
+fn requirement_trace_failure_requirements(
+    source: &str,
+    failure: &Value,
+) -> Result<Vec<String>, String> {
+    let id = failure
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "requirement trace failure has no declaration id".to_owned())?;
+    let kind = failure
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "requirement trace failure has no kind".to_owned())?;
+    let contract = fsl_core::requirements_trace_contract(source)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "requirement trace failure has no trace contract".to_owned())?;
+    let cases = match kind {
+        "acceptance" => &contract.acceptance,
+        "forbidden" | "forbidden_setup" => &contract.forbidden,
+        _ => return Err(format!("unknown requirement trace failure kind '{kind}'")),
+    };
+    let case = cases.iter().find(|case| case.id == id).ok_or_else(|| {
+        format!("requirement trace failure references unknown declaration '{id}'")
+    })?;
+    Ok(trace_case_requirement_ids(case))
+}
+
 fn apply_requirement_mutation_oracle(
     source: &str,
     model: &KernelModel,
@@ -9858,7 +9891,7 @@ fn apply_requirement_mutation_oracle(
                 }
                 .to_owned(),
             ),
-            killer_requirements: Vec::new(),
+            killer_requirements: requirement_trace_failure_requirements(source, &failure)?,
         };
     }
     Ok(())
@@ -9953,7 +9986,10 @@ fn mutation_summary(mutants: &[Value]) -> Value {
     json!({"total":mutants.len(),"killed":killed,"survived":survived,"invalid":invalid,"kill_rate":mutation_kill_rate(killed,survived),"by_source":{"builtin":builtin,"external":external}})
 }
 
-fn requirement_kill_index(model: &KernelModel) -> Map<String, Value> {
+fn requirement_kill_index(
+    model: &KernelModel,
+    trace_contract: Option<&fsl_core::RequirementsTraceContract>,
+) -> Map<String, Value> {
     let mut result = Map::new();
     for annotations in model
         .actions
@@ -9970,6 +10006,16 @@ fn requirement_kill_index(model: &KernelModel) -> Map<String, Value> {
         .chain(model.leadstos.iter().map(|item| &item.annotations))
     {
         for requirement in annotation_requirement_ids(annotations) {
+            result.entry(requirement).or_insert(json!({"kills":0}));
+        }
+    }
+    if let Some(contract) = trace_contract {
+        for requirement in contract
+            .acceptance
+            .iter()
+            .chain(&contract.forbidden)
+            .flat_map(trace_case_requirement_ids)
+        {
             result.entry(requirement).or_insert(json!({"kills":0}));
         }
     }
@@ -10426,6 +10472,10 @@ fn run_mutate(
         Ok(source) => source,
         Err(error) => return (error_output("io", &error.to_string()), 0),
     };
+    let trace_contract = match fsl_core::requirements_trace_contract(&source) {
+        Ok(contract) => contract,
+        Err(error) => return (semantic_error_output(&error.to_string()), 0),
+    };
     let document = match parse_surface_document(path) {
         Ok(document) => document,
         Err(error) => return (semantic_error_output(&error), 0),
@@ -10461,7 +10511,7 @@ fn run_mutate(
         .map(|(name, _)| name.clone())
         .collect::<std::collections::BTreeSet<_>>();
     let mut by_req = if by_requirement {
-        requirement_kill_index(&model)
+        requirement_kill_index(&model, trace_contract.as_ref())
     } else {
         Map::new()
     };

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -9716,10 +9716,9 @@ fn annotation_requirement_ids(annotations: &Annotations) -> Vec<String> {
 }
 
 fn trace_case_requirement_ids(case: &fsl_core::RequirementsTraceCase) -> Vec<String> {
-    annotation_requirement_ids(&case.annotations)
-        .into_iter()
-        .filter(|requirement| requirement != &case.id)
-        .collect()
+    let mut explicit = Annotations::default();
+    explicit.extend(case.annotations.source_order().iter().skip(1).cloned());
+    annotation_requirement_ids(&explicit)
 }
 
 fn property_requirements(model: &KernelModel, name: &str) -> Vec<String> {

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -244,7 +244,11 @@ fn mutate_attributes_trace_oracle_kills_to_attached_requirements() {
     let requirement = &mutated["by_requirement"]["REQ-TEST-001"];
     assert_eq!(requirement["kills"], 3, "{mutated}");
     assert!(requirement.get("warning").is_none(), "{mutated}");
-    for case_id in ["AC-TEST-001", "FB-TEST-001", "FB-SETUP-001"] {
+    assert_eq!(
+        mutated["by_requirement"]["AC-TEST-001"]["kills"], 1,
+        "{mutated}"
+    );
+    for case_id in ["FB-TEST-001", "FB-SETUP-001"] {
         assert!(
             mutated["by_requirement"].get(case_id).is_none(),
             "{mutated}"

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -219,6 +219,72 @@ fn monitor_boundary_self_spec_is_proved_and_mutation_sensitive() {
 }
 
 #[test]
+fn mutate_attributes_trace_oracle_kills_to_attached_requirements() {
+    let (mutated, status) = run_cli(&[
+        "mutate",
+        "rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl",
+        "--depth",
+        "8",
+        "--by-requirement",
+        "--max-mutants",
+        "0",
+        "--from",
+        "rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.jsonl",
+    ]);
+
+    assert_eq!(status, 0, "{mutated}");
+    let mutants = mutated["mutants"].as_array().expect("mutants");
+    assert_eq!(mutants.len(), 3, "{mutated}");
+    assert_eq!(mutants[0]["status"], "killed", "{mutated}");
+    assert_eq!(mutants[0]["killed_by"], "acceptance", "{mutated}");
+    assert_eq!(mutants[1]["status"], "killed", "{mutated}");
+    assert_eq!(mutants[1]["killed_by"], "forbidden", "{mutated}");
+    assert_eq!(mutants[2]["status"], "killed", "{mutated}");
+    assert_eq!(mutants[2]["killed_by"], "forbidden", "{mutated}");
+    let requirement = &mutated["by_requirement"]["REQ-TEST-001"];
+    assert_eq!(requirement["kills"], 3, "{mutated}");
+    assert!(requirement.get("warning").is_none(), "{mutated}");
+    for case_id in ["AC-TEST-001", "FB-TEST-001", "FB-SETUP-001"] {
+        assert!(
+            mutated["by_requirement"].get(case_id).is_none(),
+            "{mutated}"
+        );
+    }
+
+    let (builtin, builtin_status) = run_cli(&[
+        "mutate",
+        "rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl",
+        "--depth",
+        "8",
+        "--by-requirement",
+        "--max-mutants",
+        "100",
+    ]);
+    assert_eq!(builtin_status, 0, "{builtin}");
+    let prepare_guard = builtin["mutants"]
+        .as_array()
+        .expect("builtin mutants")
+        .iter()
+        .find(|mutant| {
+            mutant["op"] == "requires_negate"
+                && mutant["target"]
+                    .as_str()
+                    .is_some_and(|target| target.starts_with("prepare requires"))
+        })
+        .expect("prepare guard mutant");
+    assert_eq!(prepare_guard["status"], "killed", "{builtin}");
+    assert_eq!(prepare_guard["killed_by"], "forbidden", "{builtin}");
+    let builtin_requirement = &builtin["by_requirement"]["REQ-TEST-001"];
+    assert!(
+        builtin_requirement["kills"]
+            .as_u64()
+            .is_some_and(|kills| kills > 0),
+        "{builtin}"
+    );
+    assert!(builtin_requirement.get("warning").is_none(), "{builtin}");
+}
+
+#[test]
 fn native_check_and_verify_reject_duplicate_correspondence_origins() {
     let fixture = "rust/fslc/tests/fixtures/action_correspondence_duplicate.fsl";
 

--- a/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl
+++ b/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements MutateRequirementAttribution {
+  process Case {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by User
+    with allowed: Bool
+    when allowed
+  }
+
+  state { blocked: Bool }
+  init { blocked = false }
+  action prepare() { requires not blocked  blocked = blocked }
+  action deny() { requires blocked  blocked = blocked }
+
+  @requirement("REQ-TEST-001", "only allowed cases finish")
+  acceptance AC-TEST-001 "allowed cases finish" {
+    finish(0, true)
+    expect Case 0 in Done
+  }
+
+  @requirement("REQ-TEST-001", "only allowed cases finish")
+  forbidden FB-TEST-001 "disallowed cases cannot finish" {
+    finish(0, false)
+    expect rejected
+  }
+
+  @requirement("REQ-TEST-001", "only allowed cases finish")
+  forbidden FB-SETUP-001 "forbidden setup must remain executable" {
+    prepare()
+    deny()
+    expect rejected
+  }
+}
+verify { instances Case = 2 }

--- a/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl
+++ b/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.fsl
@@ -14,6 +14,7 @@ requirements MutateRequirementAttribution {
   action prepare() { requires not blocked  blocked = blocked }
   action deny() { requires blocked  blocked = blocked }
 
+  @requirement("AC-TEST-001", "allowed cases finish")
   @requirement("REQ-TEST-001", "only allowed cases finish")
   acceptance AC-TEST-001 "allowed cases finish" {
     finish(0, true)

--- a/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.jsonl
+++ b/rust/fslc/tests/fixtures/mutate_trace_requirement_attribution.jsonl
@@ -1,0 +1,3 @@
+{"id":"acceptance","replace":{"target":"when allowed","replacement":"when false"}}
+{"id":"forbidden","replace":{"target":"when allowed","replacement":"when true"}}
+{"id":"forbidden-setup","replace":{"target":"requires not blocked","replacement":"requires blocked"}}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1145,8 +1145,11 @@ first failed layer and later layers are marked `skipped`.
   dead at baseline, a beyond-depth effect, or genuine under-constraint —
   triage it as a review queue. If the baseline is not clean at depth K, no mutation is done and
   the baseline result is returned. `--by-requirement` aggregates by the requirement
-  tag of the "killed property" and warns on zero kills as `empty_formalization`
-  (a lower bound observed for this mutant set and depth).
+  tag of the killed property or failed acceptance/forbidden trace declaration
+  and warns on zero kills as `empty_formalization` (a lower bound observed for
+  this mutant set and depth). Trace attribution uses explicit requirement
+  annotations; AC/FB case IDs are not implicit requirements and are unique
+  within each declaration kind.
   `--from` appends external JSONL mutants. Each line supplies either full
   `mutated_spec` source (`spec` alias accepted) or an exact
   `replace:{target,replacement,occurrence?}` instruction. Valid records use the


### PR DESCRIPTION
Closes #407

## Problem

Acceptance and forbidden trace-oracle kills changed mutant verdicts but discarded the attached requirement relations, so `--by-requirement` reported zero kills and `empty_formalization`.

## Contract and implementation

- attribute trace-oracle kills only through explicit checked `@requirement` relations
- keep acceptance/forbidden case IDs as scenario identities, not implicit requirement IDs
- reject duplicate IDs within each trace kind so attribution remains unambiguous
- share trace-relation extraction between index construction and failure attribution
- document the contract in the language references and mutation design

## Local-optima audit

Rejected expanding public trace-failure JSON and putting scenario declarations into `KernelModel`; both externalized an internal aggregation concern. Also rejected the first ID-only lookup repair because it omitted trace-only relations and duplicate-ID ambiguity. The selected change centralizes uniqueness and relation extraction without changing verdicts or envelope shape.

## Verification

- `cargo test --manifest-path rust/Cargo.toml -p fsl-core --test typed_annotations --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test cli_regression --locked`
- focused Clippy for `fsl-core` and `fslc-rust` with `-D warnings`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `git diff --check`
- `./tools/check-native-integration.sh` (browser Z3 and 351 native/WASM parity cases)
- independent review: no actionable findings