### PR TITLE
fix(scenarios): keep terminal action cover traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `fslc scenarios` now emits the shortest replayable action-coverage trace even
+  when the covered action reaches a terminal state before the requested depth,
+  including requirements transitions guarded by `Bool` inputs (issue #405).
 - Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1985,7 +1985,6 @@ pub fn action_cover_traces(
         changes: BTreeMap::new(),
     }];
     let mut covered = BTreeMap::new();
-    let mut first_enabled_seen = BTreeSet::new();
     let mut visited = BTreeSet::from([initial.state.clone()]);
     let mut queue = VecDeque::from([(initial, initial_trace, 0_usize)]);
     while let Some((monitor, trace, step)) = queue.pop_front() {
@@ -2003,33 +2002,17 @@ pub fn action_cover_traces(
                 &instance,
                 &result,
             ));
-            if first_enabled_seen.insert(instance.action.clone())
-                && can_extend_exactly(&child, depth - step - 1)?
-            {
+            if result.violation.is_none() {
                 covered
                     .entry(instance.action.clone())
                     .or_insert_with(|| child_trace.clone());
-            }
-            if result.violation.is_none() && visited.insert(child.state.clone()) {
-                queue.push_back((child, child_trace, step + 1));
+                if visited.insert(child.state.clone()) {
+                    queue.push_back((child, child_trace, step + 1));
+                }
             }
         }
     }
     Ok(covered)
-}
-
-fn can_extend_exactly(monitor: &Monitor, remaining: usize) -> Result<bool, RuntimeError> {
-    if remaining == 0 {
-        return Ok(true);
-    }
-    for instance in monitor.enabled()? {
-        let mut child = monitor.clone();
-        let result = child.step(&instance)?;
-        if result.violation.is_none() && can_extend_exactly(&child, remaining - 1)? {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/fsl-runtime/tests/monitor_regression.rs
+++ b/rust/fsl-runtime/tests/monitor_regression.rs
@@ -82,6 +82,47 @@ fn replay_rejects_a_trace_that_is_not_enabled() {
 }
 
 #[test]
+fn action_cover_trace_uses_the_enabling_bool_value_and_may_end_at_terminal() {
+    let model = model(
+        "spec BoolGuard { state { done: Bool } init { done = false } ".to_owned()
+            + "action accept(allowed: Bool) { requires not done requires allowed done = true } "
+            + "terminal { done } }",
+    );
+
+    let traces = fsl_runtime::action_cover_traces(model.clone(), 8).expect("cover traces");
+    let trace = &traces["accept"];
+    assert_eq!(trace.len(), 2, "{trace:?}");
+    assert_eq!(
+        trace[1].action.as_ref().expect("covered action").params["allowed"],
+        FslValue::Bool(true)
+    );
+    fsl_runtime::replay_trace(model.clone(), trace).expect("replay cover trace");
+
+    let mut monitor = fsl_runtime::Monitor::new(model).expect("initialize monitor");
+    let rejected = monitor
+        .attempt(
+            "accept",
+            &BTreeMap::from([("allowed".to_owned(), FslValue::Bool(false))]),
+        )
+        .expect("observe disabled Bool binding");
+    assert_eq!(
+        rejected.violation.expect("false must be rejected").kind,
+        "requires_failed"
+    );
+}
+
+#[test]
+fn action_cover_traces_exclude_violating_steps() {
+    let model = model(
+        "spec UnsafeCover { state { safe: Bool } init { safe = true } ".to_owned()
+            + "action break_safety() { safe = false } invariant Safe { safe } }",
+    );
+
+    let traces = fsl_runtime::action_cover_traces(model, 1).expect("cover traces");
+    assert!(!traces.contains_key("break_safety"), "{traces:?}");
+}
+
+#[test]
 fn failed_steps_leave_the_monitor_state_unchanged() {
     for (suffix, expected_kind) in [
         ("invariant Safe { x == 0 }", "invariant"),

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -513,6 +513,40 @@ fn typed_requirement_relations_reach_strict_tags_scenarios_and_diagnostics() {
 }
 
 #[test]
+fn scenarios_cover_a_bool_guarded_transition_into_a_terminal_state() {
+    let (scenarios, status) = run_cli(&[
+        "scenarios",
+        "rust/fslc/tests/fixtures/scenario_bool_guard_terminal.fsl",
+        "--depth",
+        "8",
+    ]);
+
+    assert_eq!(status, 0, "{scenarios}");
+    let generated = scenarios["scenarios"].as_array().expect("scenarios");
+    let cover = generated
+        .iter()
+        .find(|scenario| scenario["name"] == "cover_accept")
+        .expect("accept coverage scenario");
+    let steps = cover["steps"].as_array().expect("coverage steps");
+    assert_eq!(steps.len(), 1, "{cover}");
+    assert_eq!(steps[0]["action"], "accept", "{cover}");
+    assert_eq!(steps[0]["params"]["c"], 0, "{cover}");
+    assert_eq!(steps[0]["params"]["allowed"], true, "{cover}");
+    assert_eq!(
+        cover["expected_states"][0]["item_stage"]["0"], "Accepted",
+        "{cover}"
+    );
+    assert_eq!(cover["requirement"]["id"], "REQ-SCENARIO-001", "{cover}");
+    assert!(
+        generated
+            .iter()
+            .any(|scenario| scenario["name"] == "acceptance_AC-SCENARIO-001"),
+        "{scenarios}"
+    );
+    assert_eq!(scenarios["warnings"], serde_json::json!([]), "{scenarios}");
+}
+
+#[test]
 fn native_cli_replays_witnesses_from_partially_initialized_state() {
     let (violated, status) = run_cli(&[
         "verify",

--- a/rust/fslc/tests/fixtures/scenario_bool_guard_terminal.fsl
+++ b/rust/fslc/tests/fixtures/scenario_bool_guard_terminal.fsl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements ScenarioBoolGuardTerminal {
+  process Item {
+    stages Ready, Accepted
+    initial Ready
+    transition accept Ready -> Accepted by System
+      with allowed: Bool
+      when allowed
+      covers REQ-SCENARIO-001 "An allowed item can be accepted"
+  }
+
+  acceptance AC-SCENARIO-001 "Allowed item is accepted" {
+    accept(0, true)
+    expect Item 0 in Accepted
+  }
+
+  terminal { forall i: Item { stage(i) == Accepted } }
+}
+
+verify {
+  instances Item = 1
+}

--- a/tests/snapshots/approval_ledger.md
+++ b/tests/snapshots/approval_ledger.md
@@ -2,7 +2,7 @@
 
 | 要件ID | 業務目的 | 状態 | 承認状態 | 保証クラス | 検出種別 | リスク | 判断者 | 次アクション |
 |---|---|---|---|---|---|---|---|---|
-| REQ-190 | an approved review remains approved | 🟢 反例なし | ✅ approved (unsigned) | bounded(BMC depth 2) | — | — | — | — |
+| REQ-190 | an approved review remains approved | 🟢 確認済（承認可） | ✅ approved (unsigned) | bounded(BMC depth 2) | — | — | — | — |
 
 ## 承認照合
 


### PR DESCRIPTION
Closes #405.

## Problem

`action_cover_traces` discarded a successfully executed action unless its resulting state could extend to exactly the requested depth. A one-step Bool-guarded transition into a terminal state therefore produced no action-coverage scenario.

## Contract and implementation

The maintained scenario contract requires the shortest replayable trace within the depth bound. This change removes the exact-depth extension search and records the first non-violating execution reached by the existing BFS. The fix is shared by all native scenario consumers and does not change verification semantics or the JSON shape.

## Regression evidence

- Runtime regression proves `allowed=true` yields a replayable one-step trace at depth 8.
- Negative controls prove `allowed=false` is rejected and invariant-violating steps are excluded.
- CLI regression reproduces the requirements-process/Bool/terminal-state case and checks requirement attribution.
- The approval-ledger snapshot was regenerated from its workflow; the newly covered one-shot `approve` action changes REQ-190 to confirmed/approvable.

## Local-optima audit

Rejected warning suppression, terminal-only special casing, and trace padding because each leaves shared consumers inconsistent or invents non-replayable evidence. Deleting the exact-depth predicate is the smallest systemic repair.

## Verification

- `cargo test -p fsl-runtime --locked`
- `cargo test -p fslc-rust --test cli_regression --locked`
- focused Clippy with `-D warnings`
- `./tools/check-native-integration.sh` (browser Z3 and 351 native/WASM parity cases)
- independent final review: no actionable findings
