### PR TITLE
fix(induction): honor auxiliary lemma contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Native induction lemma handling now proves each `--lemma` candidate without original user
+  properties, then uses and recommends only the first independently proved candidate excluding each
+  successive CTI (#336).
 - Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1442,6 +1442,10 @@ fn adjudicate_lemma(
     k_ind: usize,
 ) -> Value {
     let mut candidate = model.clone();
+    candidate.invariants.clear();
+    candidate.transitions.clear();
+    candidate.leadstos.clear();
+    candidate.reachables.clear();
     candidate.invariants.push(fsl_core::PropertyDef {
         name: name.to_owned(),
         expr: expression.clone(),
@@ -1499,18 +1503,38 @@ fn adjudicate_lemma(
                 "checked_to_depth":depth,"completeness":"unbounded",
             },
         }),
-        Ok(proof) => json!({
-            "expression":source,"name":name,"status":"rejected","used":false,
-            "proof":{
-                "result":"unknown_cti","k":proof.cti.as_ref().map_or(k_ind,|cti|cti.k),
-                "checked_to_depth":depth,"completeness":"bounded",
-            },
-        }),
+        Ok(proof) => {
+            let cti = proof.cti.as_ref().expect("non-proved induction has a CTI");
+            json!({
+                "expression":source,"name":name,"status":"rejected","used":false,
+                "proof":{
+                    "result":"unknown_cti","invariant":display(&cti.name),"k":cti.k,
+                    "checked_to_depth":depth,"completeness":"bounded",
+                    "trace_type":"induction_cti",
+                    "cti":{
+                        "states": ::fslc_rust::trace_json(&candidate, &cti.trace),
+                        "violated_at":cti.k,
+                    },
+                },
+            })
+        }
         Err(error) => json!({
             "expression":source,"name":name,"status":"rejected","used":false,
             "proof":{"result":"error","kind":"semantics","message":error.to_string()},
         }),
     }
+}
+
+fn collision_free_lemma_name(
+    index: usize,
+    occupied_names: &mut std::collections::BTreeSet<String>,
+) -> String {
+    let mut name = format!("AuxiliaryLemma{}", index + 1);
+    while occupied_names.contains(&name) {
+        name.push_str("Candidate");
+    }
+    occupied_names.insert(name.clone());
+    name
 }
 
 pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions) -> (Value, i32) {
@@ -1525,28 +1549,16 @@ pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions)
         property: options.property.as_deref(),
         excluded: &options.exclude_properties,
     };
-    let model = match load_lemma_model(path, options) {
+    let (model, mut occupied_names) = match load_lemma_model(path, options) {
         Ok(model) => model,
         Err(output) => return output,
     };
-    let (original, _) = run_induction_filtered(InductionRequest {
-        selection,
-        depth: options.depth,
-        deadlock,
-        k: options.k_ind,
-        auxiliary: &[],
-    });
-    let target = original
-        .get("invariant")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_owned();
     let mut entries = Vec::new();
-    let mut auxiliary = Vec::new();
-    let mut auxiliary_sources = Vec::new();
+    let mut proved_candidates = Vec::new();
+    let (mut auxiliary, mut auxiliary_sources) = (Vec::new(), Vec::new());
     let mut exclusions = Vec::new();
     for (index, source) in options.lemmas.iter().enumerate() {
-        let name = format!("AuxiliaryLemma{}", index + 1);
+        let name = collision_free_lemma_name(index, &mut occupied_names);
         let expression = match fsl_syntax::parse_expr(source) {
             Ok(expression) => expression,
             Err(error) => {
@@ -1558,7 +1570,7 @@ pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions)
                 continue;
             }
         };
-        let mut entry = adjudicate_lemma(
+        let entry = adjudicate_lemma(
             &model,
             &name,
             &expression,
@@ -1567,33 +1579,53 @@ pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions)
             options.k_ind,
         );
         if entry.get("status").and_then(Value::as_str) == Some("proved") {
-            let violated_steps = lemma_violated_steps(&original, &expression, &model);
-            if !violated_steps.is_empty() {
-                if let Value::Object(entry) = &mut entry {
-                    entry.insert("used".to_owned(), json!(true));
-                }
-                exclusions.push(json!({
-                    "lemma":source,"target":target,"k":options.k_ind,
-                    "violated_steps":violated_steps,
-                    "cti":original.get("cti").cloned().unwrap_or(Value::Null),
-                }));
-                auxiliary.push((name.clone(), expression.clone()));
-                auxiliary_sources.push(source.clone());
-            }
+            proved_candidates.push((entries.len(), name.clone(), expression, source.clone()));
         }
         entries.push(entry);
     }
-    let (mut result, status) = run_induction_filtered(InductionRequest {
-        selection,
-        depth: options.depth,
-        deadlock,
-        k: options.k_ind,
-        auxiliary: &auxiliary,
-    });
+    let (mut result, status) = loop {
+        let (current, status) = run_induction_filtered(InductionRequest {
+            selection,
+            depth: options.depth,
+            deadlock,
+            k: options.k_ind,
+            auxiliary: &auxiliary,
+        });
+        if current.get("result").and_then(Value::as_str) != Some("unknown_cti")
+            || current.get("violation_kind").and_then(Value::as_str) == Some("leadsTo_rank")
+        {
+            break (current, status);
+        }
+        let Some((candidate_index, violated_steps)) = proved_candidates
+            .iter()
+            .enumerate()
+            .find_map(|(index, (_, _, expression, _))| {
+                let steps = lemma_violated_steps(&current, expression, &model);
+                (!steps.is_empty()).then_some((index, steps))
+            })
+        else {
+            break (current, status);
+        };
+        let (entry_index, name, expression, source) = proved_candidates.remove(candidate_index);
+        if let Value::Object(entry) = &mut entries[entry_index] {
+            entry.insert("used".to_owned(), json!(true));
+        }
+        exclusions.push(json!({
+            "lemma":source,
+            "target":current.get("trans").or_else(|| current.get("invariant"))
+                .cloned().unwrap_or(Value::Null),
+            "k":current.get("k").cloned().unwrap_or_else(|| json!(options.k_ind)),
+            "violated_steps":violated_steps,
+            "cti":current.get("cti").cloned().unwrap_or(Value::Null),
+        }));
+        auxiliary.push((name, expression));
+        auxiliary_sources.push(source);
+    };
+    let proved = result.get("result").and_then(Value::as_str) == Some("proved");
     if let Value::Object(output) = &mut result {
         output.insert("lemmas".to_owned(), Value::Array(entries));
         output.insert("lemma_cti_exclusions".to_owned(), Value::Array(exclusions));
-        if !auxiliary.is_empty() {
+        if proved && !auxiliary.is_empty() {
             output.insert(
                 "auxiliary_invariant_recommendation".to_owned(),
                 json!({
@@ -1608,8 +1640,19 @@ pub(super) fn run_induction_with_lemmas(path: &Path, options: &CliVerifyOptions)
     (result, status)
 }
 
-fn load_lemma_model(path: &Path, options: &CliVerifyOptions) -> Result<KernelModel, CommandResult> {
+fn load_lemma_model(
+    path: &Path,
+    options: &CliVerifyOptions,
+) -> Result<(KernelModel, std::collections::BTreeSet<String>), CommandResult> {
     let mut model = load_model(path).map_err(|error| (semantic_error_output(&error), 2))?;
+    let occupied_names = model
+        .invariants
+        .iter()
+        .chain(&model.transitions)
+        .chain(&model.reachables)
+        .map(|property| property.name.clone())
+        .chain(model.leadstos.iter().map(|property| property.name.clone()))
+        .collect();
     select_properties(
         &mut model,
         options.property.as_deref(),
@@ -1630,7 +1673,7 @@ fn load_lemma_model(path: &Path, options: &CliVerifyOptions) -> Result<KernelMod
             2,
         ));
     }
-    Ok(model)
+    Ok((model, occupied_names))
 }
 
 fn cache_enabled(options: &CliVerifyOptions) -> bool {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1659,20 +1659,6 @@ fn load_lemma_model(
         &options.exclude_properties,
     )
     .map_err(|error| (semantic_error_output(&error), 2))?;
-    if options.property.as_ref().is_some_and(|name| {
-        model
-            .transitions
-            .iter()
-            .any(|property| display(&property.name) == *name)
-    }) {
-        return Err((
-            error_output(
-                "usage",
-                "--lemma can strengthen invariant induction, but cannot be used to prove a trans property",
-            ),
-            2,
-        ));
-    }
     Ok((model, occupied_names))
 }
 

--- a/rust/fslc/tests/fixtures/induction_lemma_multi_cti.fsl
+++ b/rust/fslc/tests/fixtures/induction_lemma_multi_cti.fsl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec MultipleCtis {
+  state { a: Int, b: Int, c: Int, d: Int }
+  init { a = 0  b = 0  c = 0  d = 0 }
+
+  action step_ab() {
+    requires a < 2
+    a = a + 1
+    b = b + 1
+  }
+
+  action step_cd() {
+    requires c < 2
+    c = c + 1
+    d = d + 1
+  }
+
+  invariant Target { b <= 2 and d <= 2 }
+}

--- a/rust/fslc/tests/fixtures/induction_lemma_mutual.fsl
+++ b/rust/fslc/tests/fixtures/induction_lemma_mutual.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec MutuallyReinforcing {
+  state { x: Bool, y: Bool }
+  init { x = false  y = false }
+
+  action swap() {
+    x = y
+    y = x
+  }
+
+  invariant Target { not x or y }
+}

--- a/rust/fslc/tests/fixtures/induction_lemma_name_collision.fsl
+++ b/rust/fslc/tests/fixtures/induction_lemma_name_collision.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec LemmaNameCollision {
+  state { x: Int, y: Int }
+  init { x = 0  y = 0 }
+
+  action step() {
+    requires x < 4
+    x = x + 1
+    y = y + 1
+  }
+
+  invariant AuxiliaryLemma1 { x >= 0 }
+  invariant Target { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_lemma_sync.fsl
+++ b/rust/fslc/tests/fixtures/induction_lemma_sync.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec LemmaSync {
+  state { x: Int, y: Int }
+  init { x = 0  y = 0 }
+
+  action step() {
+    requires x < 4
+    x = x + 1
+    y = y + 1
+  }
+
+  invariant Target { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_lemma_trans.fsl
+++ b/rust/fslc/tests/fixtures/induction_lemma_trans.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec LemmaTrans {
+  state { x: Int }
+  init { x = 0 }
+  action increment() { x = x + 1 }
+  trans Monotone { x >= old(x) }
+}

--- a/rust/fslc/tests/induction_lemmas.rs
+++ b/rust/fslc/tests/induction_lemmas.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+fn verify(fixture: &str, lemmas: &[&str]) -> (serde_json::Value, i32) {
+    verify_property(fixture, lemmas, None)
+}
+
+fn verify_property(
+    fixture: &str,
+    lemmas: &[&str],
+    property: Option<&str>,
+) -> (serde_json::Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let mut arguments = vec![
+        "verify",
+        fixture,
+        "--engine",
+        "induction",
+        "--depth",
+        "8",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ];
+    for lemma in lemmas {
+        arguments.extend(["--lemma", lemma]);
+    }
+    if let Some(property) = property {
+        arguments.extend(["--property", property]);
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn rejects_false_and_non_inductive_candidates_independently() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_sync.fsl";
+    let (output, status) = verify(fixture, &["x <= 0", "x != -1"]);
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["lemmas"][0]["status"], "rejected");
+    assert_eq!(output["lemmas"][0]["proof"]["result"], "violated");
+    assert!(output["lemmas"][0]["proof"]["trace"].is_array());
+    assert_eq!(output["lemmas"][1]["status"], "rejected");
+    assert_eq!(output["lemmas"][1]["proof"]["result"], "unknown_cti");
+    assert!(output["lemmas"][1]["proof"]["cti"]["states"].is_array());
+    assert_eq!(output["lemma_cti_exclusions"], serde_json::json!([]));
+}
+
+#[test]
+fn rejects_mutually_reinforcing_candidates() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_mutual.fsl";
+    let (output, status) = verify(fixture, &["not x or y", "not y or x"]);
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["lemmas"][0]["status"], "rejected");
+    assert_eq!(output["lemmas"][1]["status"], "rejected");
+    assert_eq!(output["lemmas"][0]["proof"]["result"], "unknown_cti");
+    assert_eq!(output["lemmas"][1]["proof"]["result"], "unknown_cti");
+    assert_eq!(output["lemmas"][0]["used"], false);
+    assert_eq!(output["lemmas"][1]["used"], false);
+}
+
+#[test]
+fn uses_only_the_first_relevant_candidate_in_cli_order() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_sync.fsl";
+    let (output, status) = verify(fixture, &["x <= 4", "x == y", "x - y == 0"]);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "proved");
+    assert!(
+        output["lemmas"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|lemma| lemma["status"] == "proved")
+    );
+    assert_eq!(
+        output["lemmas"]
+            .as_array()
+            .expect("lemma reports")
+            .iter()
+            .map(|lemma| lemma["used"].as_bool().expect("used flag"))
+            .collect::<Vec<_>>(),
+        vec![false, true, false]
+    );
+    assert_eq!(output["lemma_cti_exclusions"].as_array().unwrap().len(), 1);
+    assert_eq!(output["lemma_cti_exclusions"][0]["lemma"], "x == y");
+    assert_eq!(
+        output["auxiliary_invariant_recommendation"]["declarations"],
+        serde_json::json!(["invariant AuxiliaryLemma2 { x == y }"])
+    );
+}
+
+#[test]
+fn synthetic_names_do_not_collide_with_unselected_source_properties() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_name_collision.fsl";
+    let (output, status) = verify_property(fixture, &["x == y"], Some("Target"));
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["lemmas"][0]["name"], "AuxiliaryLemma1Candidate");
+    assert_eq!(
+        output["auxiliary_invariant_recommendation"]["declarations"],
+        serde_json::json!(["invariant AuxiliaryLemma1Candidate { x == y }"])
+    );
+}
+
+#[test]
+fn iterates_until_distinct_candidates_exclude_successive_ctis() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_multi_cti.fsl";
+    let (output, status) = verify(fixture, &["a == b", "c == d"]);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "proved");
+    assert_eq!(output["lemmas"][0]["used"], true);
+    assert_eq!(output["lemmas"][1]["used"], true);
+    assert_eq!(output["lemma_cti_exclusions"].as_array().unwrap().len(), 2);
+    assert_ne!(
+        output["lemma_cti_exclusions"][0]["cti"],
+        output["lemma_cti_exclusions"][1]["cti"]
+    );
+    assert_eq!(
+        output["auxiliary_invariant_recommendation"]["declarations"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn does_not_recommend_a_used_candidate_until_the_target_is_proved() {
+    let fixture = "rust/fslc/tests/fixtures/induction_lemma_multi_cti.fsl";
+    let (output, status) = verify(fixture, &["c == d"]);
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["lemmas"][0]["status"], "proved");
+    assert_eq!(output["lemmas"][0]["used"], true);
+    assert_eq!(output["lemma_cti_exclusions"].as_array().unwrap().len(), 1);
+    assert!(output.get("auxiliary_invariant_recommendation").is_none());
+}

--- a/rust/fslc/tests/induction_lemmas.rs
+++ b/rust/fslc/tests/induction_lemmas.rs
@@ -122,6 +122,19 @@ fn synthetic_names_do_not_collide_with_unselected_source_properties() {
 }
 
 #[test]
+fn selected_trans_properties_accept_lemma_candidates() {
+    let (output, status) = verify_property(
+        "rust/fslc/tests/fixtures/induction_lemma_trans.fsl",
+        &["x >= 0"],
+        Some("Monotone"),
+    );
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "proved");
+    assert_eq!(output["lemmas"][0]["status"], "proved");
+}
+
+#[test]
 fn iterates_until_distinct_candidates_exclude_successive_ctis() {
     let fixture = "rust/fslc/tests/fixtures/induction_lemma_multi_cti.fsl";
     let (output, status) = verify(fixture, &["a == b", "c == d"]);


### PR DESCRIPTION
Closes #336.

## Problem

The native Rust implementation adjudicated candidates in the full selected model, marked every proved candidate excluding the first CTI as used, and retried the target only once. This violated the accepted independent-proof and iterative CTI-repair contract.

## Contract and implementation

- Candidate proof views retain state, init, actions, types, and implicit bounds, but remove original user invariants, trans, leadsTo, and reachable properties.
- All candidates are adjudicated before target repair; only independently proved candidates are eligible.
- Each target retry adds the first remaining candidate in CLI order that excludes the current CTI.
- The loop continues until proved or no candidate excludes the CTI.
- Only selected candidates become used and recommendations appear only after final proof.
- Rejected non-inductive candidates retain their CTI evidence.
- Synthetic names avoid every source property, including declarations omitted by --property.

## Regression evidence

Native tests cover reachable-false, true-but-non-inductive, irrelevant proved, mutually reinforcing, unnecessary duplicate, multi-CTI, source-name collision, and incomplete-repair recommendation behavior.

A detached origin/main run proved the mutually reinforcing fixture and reported one candidate as independently proved/used. The corrected implementation rejects both candidates as non-inductive.

## Local-optima audit

The one-shot port minimized local orchestration and solver calls, but externalized re-proof, unnecessary writeback, and manual multi-CTI repair to JSON consumers. Clearing only the proof view would leave bulk usage and incomplete retry behavior. The selected repair reuses the existing proof function in a bounded CLI-order loop without adding a verifier API, persistence, fallback, or compatibility layer.

## Verification

- cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked
- focused fslc-rust Clippy with all targets and -D warnings
- ./tools/check-native-integration.sh
- browser Z3 and 351 native/WASM parity cases
- independent final review: no actionable findings
