### PR TITLE
fix(induction): emit native CTI suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Native induction CTIs now emit the documented heuristic `suggested_invariants` for monotone
+  scalar and uniformly initialized Map counters without changing the proof verdict (#337).
 - Explicit domain-effect `success_event`, `failure_event`, and `timeout_event`
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and

--- a/docs/DESIGN-induction.md
+++ b/docs/DESIGN-induction.md
@@ -179,16 +179,20 @@ JSON (the shape finalized in §9, generalized to multiple states):
   length 2). The JSON example in DESIGN-v1.md §9 should be updated to follow this document's shape.
 - **Monotone-counter suggestions (#74, post-processing only, no solver/engine
   change):** after the CTI trace is built for an invariant `unknown_cti`
-  (not `leadsTo_rank`), `_suggest_monotone_invariants` (`bmc.py`) scans it for
-  a state variable — scalar `Int`/domain, or a `Map<K, Int>` key-wise — that
+  (not `leadsTo_rank`), native `suggested_invariants` in
+  `rust/fslc/src/verification.rs` scans it for a state variable — scalar
+  `Int`/domain, or a `Map<K, Int>` key-wise — that
   moves in only one direction across the trace *and* starts on the
   unreachable side of the concrete initial value obtained from
-  `runtime.Monitor(spec).reset()`. When found, the result gains
+  `fsl_runtime::deterministic_initial_state`. Map candidates additionally
+  require every changed key to move in the same direction. When found, the
+  result gains
   `"suggested_invariants": ["<expr>", ...]` and one sentence is appended to
   `hint` per suggestion, e.g. `"audit >= 0"` or, for a uniformly-initialized
-  map, `"forall k: Case { audit[k] >= 0 }"`. If `reset()` fails, the relevant
-  variable's init isn't a concrete `Int`, or the CTI start does not actually
-  violate the would-be bound, no suggestion is added for it. This is
+  map, `"forall k: Case { audit[k] >= 0 }"`. If deterministic initial-state
+  construction fails, the relevant variable's init isn't a concrete `Int`, or
+  the CTI start does not actually violate the would-be bound, no suggestion is
+  added for it. This is
   trace-monotonicity, not a global-monotonicity proof, so it is phrased as a
   suggestion — see `docs/LANGUAGE.md` §9 "Auxiliary invariants from a CTI".
 - The exit code is **not 2, not 1 of a new kind, and not 0**, but reuses `1`

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -89,6 +89,17 @@ pub fn explicit_unsupported_reason(model: &KernelModel) -> Option<String> {
     None
 }
 
+/// Build the concrete initial state only when init definitely assigns every state component.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] when init is nondeterministic, partially assigned, or cannot be
+/// evaluated concretely.
+pub fn deterministic_initial_state(model: &KernelModel) -> Result<State, RuntimeError> {
+    check_deterministic_init(model)?;
+    Ok(Monitor::new(model.clone())?.state)
+}
+
 /// Verify with an optional set of selected implicit state-bound properties.
 ///
 /// # Errors

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -18,8 +18,8 @@ use serde_json::{Value as JsonValue, json};
 mod explicit;
 
 pub use explicit::{
-    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, explicit_unsupported_reason,
-    verify_explicit, verify_explicit_selected,
+    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, deterministic_initial_state,
+    explicit_unsupported_reason, verify_explicit, verify_explicit_selected,
 };
 
 pub type State = BTreeMap<String, Value>;

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -397,8 +397,9 @@ fn map_suggestion(
         "<="
     };
     let public_name = display(name);
+    let binder = if public_name == "k" { "key" } else { "k" };
     let expression = format!(
-        "forall k: {} {{ {public_name}[k] {operator} {initial} }}",
+        "forall {binder}: {} {{ {public_name}[{binder}] {operator} {initial} }}",
         display(key_name)
     );
     monotone_suggestion(&public_name, direction, start, *initial, &expression)

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -249,6 +249,184 @@ fn load_induction_model(
     Ok(model)
 }
 
+fn integer_state_type(model: &KernelModel, ty: &fsl_core::TypeRef) -> bool {
+    match ty {
+        fsl_core::TypeRef::Int | fsl_core::TypeRef::Range(_, _) => true,
+        fsl_core::TypeRef::Named(name) => matches!(
+            model.types.get(name),
+            Some(fsl_core::TypeDef::Domain { .. })
+        ),
+        _ => false,
+    }
+}
+
+fn monotone_direction(values: &[i64]) -> Result<Option<std::cmp::Ordering>, ()> {
+    let mut direction = None;
+    for pair in values.windows(2) {
+        let current = pair[1].cmp(&pair[0]);
+        if current == std::cmp::Ordering::Equal {
+            continue;
+        }
+        if direction.is_some_and(|direction| direction != current) {
+            return Err(());
+        }
+        direction = Some(current);
+    }
+    Ok(direction)
+}
+
+fn monotone_qualifies(direction: std::cmp::Ordering, start: i64, initial: i64) -> bool {
+    match direction {
+        std::cmp::Ordering::Greater => start < initial,
+        std::cmp::Ordering::Less => start > initial,
+        std::cmp::Ordering::Equal => false,
+    }
+}
+
+fn monotone_suggestion(
+    name: &str,
+    direction: std::cmp::Ordering,
+    start: i64,
+    initial: i64,
+    expression: &str,
+) -> Option<(String, String)> {
+    let (motion, side) = match direction {
+        std::cmp::Ordering::Greater => ("increasing", "below"),
+        std::cmp::Ordering::Less => ("decreasing", "above"),
+        std::cmp::Ordering::Equal => return None,
+    };
+    monotone_qualifies(direction, start, initial).then(|| (
+        expression.to_owned(),
+        format!(
+            "'{name}' only {motion} in this CTI but starts {side} its initial value {initial}; adding invariant {expression} may exclude this unreachable start state"
+        ),
+    ))
+}
+
+fn scalar_suggestion(
+    initial_state: &std::collections::BTreeMap<String, FslValue>,
+    trace: &[fsl_core::TraceStep],
+    name: &str,
+) -> Option<(String, String)> {
+    let FslValue::Int(initial) = initial_state.get(name)? else {
+        return None;
+    };
+    let values = trace
+        .iter()
+        .map(|step| match step.state.get(name) {
+            Some(FslValue::Int(value)) => Some(*value),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let direction = monotone_direction(&values).ok()??;
+    let public_name = display(name);
+    let operator = if direction == std::cmp::Ordering::Greater {
+        ">="
+    } else {
+        "<="
+    };
+    let expression = format!("{public_name} {operator} {initial}");
+    monotone_suggestion(&public_name, direction, values[0], *initial, &expression)
+}
+
+fn map_suggestion(
+    model: &KernelModel,
+    initial_state: &std::collections::BTreeMap<String, FslValue>,
+    trace: &[fsl_core::TraceStep],
+    name: &str,
+    ty: &fsl_core::TypeRef,
+) -> Option<(String, String)> {
+    let fsl_core::TypeRef::Map(key_ty, value_ty) = ty else {
+        return None;
+    };
+    let fsl_core::TypeRef::Named(key_name) = key_ty.as_ref() else {
+        return None;
+    };
+    if !integer_state_type(model, value_ty) {
+        return None;
+    }
+    let FslValue::Map(initial_map) = initial_state.get(name)? else {
+        return None;
+    };
+    let mut initial_values = initial_map.values();
+    let FslValue::Int(initial) = initial_values.next()? else {
+        return None;
+    };
+    if initial_values.any(|value| value != &FslValue::Int(*initial)) {
+        return None;
+    }
+    let maps = trace
+        .iter()
+        .map(|step| match step.state.get(name) {
+            Some(FslValue::Map(map)) => Some(map),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let keys = maps
+        .iter()
+        .flat_map(|map| map.keys().cloned())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut directions = std::collections::BTreeSet::new();
+    let mut qualifying_start = None;
+    for key in keys {
+        let values = maps
+            .iter()
+            .map(|map| match map.get(&key) {
+                Some(FslValue::Int(value)) => Some(*value),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let direction = match monotone_direction(&values) {
+            Ok(Some(direction)) => direction,
+            Ok(None) => continue,
+            Err(()) => return None,
+        };
+        directions.insert(direction);
+        if monotone_qualifies(direction, values[0], *initial) {
+            qualifying_start.get_or_insert(values[0]);
+        }
+    }
+    if directions.len() != 1 {
+        return None;
+    }
+    let start = qualifying_start?;
+    let direction = directions.into_iter().next()?;
+    let operator = if direction == std::cmp::Ordering::Greater {
+        ">="
+    } else {
+        "<="
+    };
+    let public_name = display(name);
+    let expression = format!(
+        "forall k: {} {{ {public_name}[k] {operator} {initial} }}",
+        display(key_name)
+    );
+    monotone_suggestion(&public_name, direction, start, *initial, &expression)
+}
+
+fn suggested_invariants(
+    model: &KernelModel,
+    trace: &[fsl_core::TraceStep],
+) -> Vec<(String, String)> {
+    if trace.len() < 2 {
+        return Vec::new();
+    }
+    let Ok(initial_state) = fsl_runtime::deterministic_initial_state(model) else {
+        return Vec::new();
+    };
+    model
+        .state
+        .iter()
+        .filter_map(|(name, ty)| {
+            if integer_state_type(model, ty) {
+                scalar_suggestion(&initial_state, trace, name)
+            } else {
+                map_suggestion(model, &initial_state, trace, name, ty)
+            }
+        })
+        .collect()
+}
+
 fn render_induction_cti(
     model: &KernelModel,
     cti: &fsl_verifier::InductionCti,
@@ -280,10 +458,26 @@ fn render_induction_cti(
             "violated_at": cti.k,
         }),
     );
-    output.insert(
-        "hint".to_owned(),
-        json!("this state sequence satisfies all invariants but leads to a violation; the start state may be unreachable — add an auxiliary invariant that excludes it, then re-run"),
-    );
+    let mut hint = "this state sequence satisfies all invariants but leads to a violation; the start state may be unreachable — add an auxiliary invariant that excludes it, then re-run".to_owned();
+    if cti.kind == "invariant" {
+        let suggestions = suggested_invariants(model, &cti.trace);
+        if !suggestions.is_empty() {
+            for (_, sentence) in &suggestions {
+                hint.push(' ');
+                hint.push_str(sentence);
+            }
+            output.insert(
+                "suggested_invariants".to_owned(),
+                Value::Array(
+                    suggestions
+                        .into_iter()
+                        .map(|(expression, _)| Value::String(expression))
+                        .collect(),
+                ),
+            );
+        }
+    }
+    output.insert("hint".to_owned(), Value::String(hint));
     if cti.kind == "trans" {
         output.insert(
             "invariants_checked".to_owned(),

--- a/rust/fslc/tests/fixtures/induction_suggestion_bounded.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_bounded.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec BoundedCounter {
+  state { x: Int, y: Int }
+  init { x = 0  y = 0 }
+
+  action step() {
+    requires x >= 0 and x < 4
+    x = x + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_decreasing.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_decreasing.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec DecreasingGhostCounter {
+  state { audit: Int, y: Int }
+  init { audit = 0  y = 0 }
+
+  action step() {
+    requires audit > 100
+    audit = audit - 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_domain.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_domain.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec DomainGhostCounter {
+  type Counter = -200..200
+
+  state { audit: Counter, y: Int }
+  init { audit = 0  y = 0 }
+
+  action step() {
+    requires audit < -100
+    audit = audit + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_map.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_map.fsl
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec GhostMapCounter {
+  type Case = 0..1
+
+  state {
+    audit: Map<Case, Int>,
+    y: Int
+  }
+
+  init {
+    forall c: Case { audit[c] = 0 }
+    y = 0
+  }
+
+  action bump(c: Case) {
+    audit[c] = audit[c] + 1
+  }
+
+  action step(c: Case) {
+    requires audit[c] < -100
+    audit[c] = audit[c] + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_map_named_k.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_map_named_k.fsl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec MapNamedK {
+    type Case = 0..1
+    state {
+        k: Map<Case, Int>,
+        y: Int
+    }
+    init {
+        k[0] = 0
+        k[1] = 0
+        y = 0
+    }
+    action bump(c: Case) {
+        k[c] = k[c] + 1
+    }
+    action step(c: Case) {
+        requires k[c] < -100
+        k[c] = k[c] + 1
+        y = y + 1
+    }
+    invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_mixed_map.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_mixed_map.fsl
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec MixedMapCounter {
+  type Case = 0..1
+
+  state {
+    audit: Map<Case, Int>,
+    y: Int
+  }
+
+  init {
+    forall c: Case { audit[c] = 0 }
+    y = 0
+  }
+
+  action step() {
+    requires audit[0] < -100
+    audit[0] = audit[0] + 1
+    audit[1] = audit[1] - 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_nondeterministic_init.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_nondeterministic_init.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec NondeterministicInitCounter {
+  state { audit: Int, y: Int }
+  init { y = 0 }
+
+  action step() {
+    requires audit < -100
+    audit = 0
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_nonmonotone.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_nonmonotone.fsl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec NonmonotoneCounter {
+  state { audit: Int, y: Int, up: Bool }
+  init { audit = 0  y = 0  up = true }
+
+  action zigzag() {
+    requires audit < -99
+    if up {
+      audit = audit + 1
+      up = false
+    } else {
+      audit = audit - 1
+      up = true
+    }
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_nonuniform_map.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_nonuniform_map.fsl
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec NonuniformMapCounter {
+  type Case = 0..1
+
+  state {
+    audit: Map<Case, Int>,
+    y: Int
+  }
+
+  init {
+    audit[0] = 0
+    audit[1] = 1
+    y = 0
+  }
+
+  action step(c: Case) {
+    requires audit[c] < -100
+    audit[c] = audit[c] + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_scalar.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_scalar.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec GhostCounter {
+  state { audit: Int, y: Int }
+  init { audit = 0  y = 0 }
+
+  action bump() {
+    audit = audit + 1
+  }
+
+  action step() {
+    requires audit < -100
+    audit = audit + 1
+    y = y + 1
+  }
+
+  invariant Sync { y <= 4 }
+}

--- a/rust/fslc/tests/fixtures/induction_suggestion_trans.fsl
+++ b/rust/fslc/tests/fixtures/induction_suggestion_trans.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec TransGhostCounter {
+  state { audit: Int, y: Int }
+  init { audit = 0  y = 0 }
+
+  action step() {
+    requires audit < -100
+    audit = audit + 1
+    y = y + 1
+  }
+
+  trans NeverIncrease { y <= old(y) }
+}

--- a/rust/fslc/tests/induction_suggestions.rs
+++ b/rust/fslc/tests/induction_suggestions.rs
@@ -176,6 +176,20 @@ fn omits_suggestions_for_a_nonmonotone_cti() {
 }
 
 #[test]
+fn avoids_a_binder_collision_with_a_map_named_k() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_map_named_k.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(
+        output["suggested_invariants"],
+        serde_json::json!(["forall key: Case { k[key] >= 0 }"])
+    );
+}
+
+#[test]
 fn ranked_leadsto_failures_never_receive_suggestions() {
     let (output, status) = verify(
         "tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl",

--- a/rust/fslc/tests/induction_suggestions.rs
+++ b/rust/fslc/tests/induction_suggestions.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+const CTI_HINT: &str = "this state sequence satisfies all invariants but leads to a violation; the start state may be unreachable — add an auxiliary invariant that excludes it, then re-run";
+
+fn verify(fixture: &str, k: usize) -> (serde_json::Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            fixture,
+            "--engine",
+            "induction",
+            "--depth",
+            "8",
+            "--k",
+            &k.to_string(),
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ])
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn suggests_a_scalar_bound_without_changing_the_verdict() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_scalar.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["invariant"], "Sync");
+    assert_eq!(
+        output["suggested_invariants"],
+        serde_json::json!(["audit >= 0"])
+    );
+    assert!(output["hint"].as_str().unwrap().starts_with(CTI_HINT));
+    assert!(output["hint"].as_str().unwrap().contains("audit >= 0"));
+    assert!(output.get("auxiliary_invariant_recommendation").is_none());
+    assert!(
+        output["cti"]["states"][0]["state"]["audit"]
+            .as_i64()
+            .unwrap()
+            < 0
+    );
+}
+
+#[test]
+fn suggests_a_quantified_bound_for_a_uniform_map() {
+    let (output, status) = verify("rust/fslc/tests/fixtures/induction_suggestion_map.fsl", 1);
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(
+        output["suggested_invariants"],
+        serde_json::json!(["forall k: Case { audit[k] >= 0 }"])
+    );
+    assert!(output["hint"].as_str().unwrap().contains("audit"));
+}
+
+#[test]
+fn suggests_a_bound_for_a_domain_counter() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_domain.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(
+        output["suggested_invariants"],
+        serde_json::json!(["audit >= 0"])
+    );
+}
+
+#[test]
+fn suggests_an_upper_bound_for_a_decreasing_counter() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_decreasing.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(
+        output["suggested_invariants"],
+        serde_json::json!(["audit <= 0"])
+    );
+    assert!(
+        output["cti"]["states"][0]["state"]["audit"]
+            .as_i64()
+            .unwrap()
+            > 0
+    );
+}
+
+#[test]
+fn omits_suggestions_without_a_violated_initial_bound() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_bounded.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert!(output.get("suggested_invariants").is_none());
+    assert_eq!(output["hint"], CTI_HINT);
+}
+
+#[test]
+fn omits_suggestions_for_nondeterministic_initialization() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_nondeterministic_init.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert!(output.get("suggested_invariants").is_none());
+    assert_eq!(output["hint"], CTI_HINT);
+}
+
+#[test]
+fn omits_map_suggestions_for_nonuniform_initialization() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_nonuniform_map.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert!(output.get("suggested_invariants").is_none());
+    assert_eq!(output["hint"], CTI_HINT);
+}
+
+#[test]
+fn omits_map_suggestions_when_keys_move_in_opposite_directions() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_mixed_map.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert!(output.get("suggested_invariants").is_none());
+    assert_eq!(output["hint"], CTI_HINT);
+}
+
+#[test]
+fn omits_suggestions_for_a_nonmonotone_cti() {
+    let (output, status) = verify(
+        "rust/fslc/tests/fixtures/induction_suggestion_nonmonotone.fsl",
+        2,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["k"], 2);
+    assert!(output.get("suggested_invariants").is_none());
+    assert_eq!(output["hint"], CTI_HINT);
+}
+
+#[test]
+fn ranked_leadsto_failures_never_receive_suggestions() {
+    let (output, status) = verify(
+        "tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl",
+        1,
+    );
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["violation_kind"], "leadsTo_rank");
+    assert!(output.get("suggested_invariants").is_none());
+}
+
+#[test]
+fn trans_ctis_never_receive_invariant_suggestions() {
+    let (output, status) = verify("rust/fslc/tests/fixtures/induction_suggestion_trans.fsl", 1);
+
+    assert_eq!(status, 1, "{output}");
+    assert_eq!(output["result"], "unknown_cti");
+    assert_eq!(output["trans"], "NeverIncrease");
+    assert!(output.get("suggested_invariants").is_none());
+}


### PR DESCRIPTION
## Problem

The published induction contract documents heuristic suggested_invariants for monotone CTIs, but the authoritative native verifier emitted only the generic hint.

## Change

- post-process invariant CTIs for scalar, domain, and uniformly initialized Map counters
- require a deterministic fully assigned concrete init and a bound-violating CTI start
- suppress nonmonotone, mixed-direction Map, trans, and ranked-leadsTo cases
- keep the proof verdict, solver premises, CTI, and exit status unchanged
- align the native design reference and changelog

## Implementation local-optima audit

The audit identified the native migration omission as locally smaller but systemically costly at the documented agent-repair boundary. The selected minimal boundary keeps the heuristic in CLI rendering and reuses runtime initial-state semantics; it avoids adding proof-core dependencies, Worker induction scope, fallback behavior, or duplicated init evaluation.

## Verification

- focused native suggestion matrix: 11 tests passed
- cargo test for fsl-runtime and fslc-rust: passed
- focused Clippy with warnings denied: passed
- complete native integration gate: passed, including browser Z3 and 351 native/WASM parity cases
- independent review: no behavioral or contract findings; one documentation wording issue corrected

Closes #337