### PR TITLE
chore(release): prepare v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-20
+
 ### Fixed
 - Native induction CTIs now emit the documented heuristic `suggested_invariants` for monotone
-  scalar and uniformly initialized Map counters without changing the proof verdict (#337).
-- Native induction lemma handling now proves each `--lemma` candidate without original user
-  properties, then uses and recommends only the first independently proved candidate excluding each
-  successive CTI (#336).
+  scalar and uniformly initialized Map counters without changing the proof verdict; quantified Map
+  suggestions choose a collision-free binder so the emitted expression remains reusable (#337).
+- Native induction lemma handling accepts candidates for selected invariant and `trans` properties,
+  proves each candidate without original user properties, then uses and recommends only the first
+  independently proved candidate excluding each successive CTI (#336).
 - `fslc scenarios` now emits the shortest replayable action-coverage trace even
   when the covered action reaches a terminal state before the requested depth,
   including requirements transitions guarded by `Bool` inputs (issue #405).
 - `fslc mutate --by-requirement` now attributes acceptance and forbidden kills
   through explicit requirement annotations on the failed trace declaration
   instead of reporting the linked requirement as `empty_formalization` (issue
-  #407). Duplicate acceptance or forbidden IDs are rejected so attribution is
-  unambiguous.
+  #407). Explicit requirement relations are preserved even when their ID equals
+  a trace-case ID, while synthetic case relations remain excluded. Duplicate
+  acceptance or forbidden IDs are rejected so attribution is unambiguous.
 - `fslc mutate` now adjudicates singleton bound mutants whose empty domain
   produces no action instances instead of panicking in bounded verification;
   overflowing integer and bound neighbors are omitted (issue #406).
@@ -26,7 +30,6 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   roles now override event-name heuristics, ambiguous cross-role assignments
   fail closed, and completion, retry eligibility, Monitor/BFS execution, and
   symbolic verification share the same lowered status (issue #409).
-
 - `fslc lint` now classifies business `policy`/`goal` `satisfies CTRL-*`
   operands as control references, recursively expands directory inputs into a
   sorted list of unique physical `.fsl` files even when operands repeat or alias
@@ -63,11 +66,6 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   stronger survivor claim from returning (issue #338).
 
 ### Changed
-- The requirements-document renderer now reprojects and exactly matches the
-  complete RCIR renderer role sidecar against its checked Kernel/Model/trace
-  and original source inputs, failing closed on any changed spec metadata,
-  claim classification, requirement attribution, trace data, undecided item,
-  analysis bound, coverage entry, or provenance field.
 - The native installer no longer clones the repository into `~/.fsl`. It now
   installs an exact-tag, checksummed CLI/LSP pair under the user data directory,
   atomically activates the complete payload, safely migrates recognized Python
@@ -153,8 +151,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   structural/temporal findings, all `formal_status: "not_a_violation"` with
   `do_not_assume`. `causal diff` compares stable claim IDs and content
   versions, flags missing version bumps, retired-claim reactivation, and
-  retired-hypothesis re-proposals, with `support_transition: "not_available"`
-  until #322's evidence exists. Evidence/plan scope comparison treats a
+  retired-hypothesis re-proposals. `causal-diff.v0` accepts no evidence inputs,
+  so `support_transition` remains `"not_available"`; evidence aggregation is a
+  separate analyze/ledger projection. Evidence/plan scope comparison treats a
   dimension present on only one side as `unassessable`, never universal. No
   output path attaches `proved`/`verified` to a causal claim and
   there is deliberately no `causal verify`; `fsl-runtime`, `fsl-solver*`,
@@ -349,15 +348,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   always "a scheduling assumption" and never "immediately", `acceptance`/`forbidden`
   always carry a non-generalization disclaimer, and a progress/reachability claim never
   claims established evidence (RCIR v1 carries none). The renderer verifies the embedded
-  Public Kernel and requires every semantic
-  target to resolve exactly once before emitting Markdown, rejecting mismatched models.
+  Public Kernel, reprojects and exactly matches the complete RCIR renderer role sidecar against
+  its checked Kernel/Model/trace and original source inputs, and requires every semantic target to
+  resolve exactly once before emitting Markdown, failing closed on any mismatched input.
   `fsl_core::expr_text`/
   `source_expr_text` (the `explain --readable` canonical-text renderer) moved from the
   `fslc` binary crate into `fsl_core` so `fsl-tools` could reuse it without a
   second implementation; `fslc` re-exports both names unchanged. CLI wiring is issue
   #327. See `docs/DESIGN-document-controlled-language-renderer.md`.
 - Added the Requirement Claim IR (RCIR) v1 schema and native projector (issue #325),
-  the foundation of the upcoming `fslc document` requirements-document generator.
+  the semantic foundation used by the `fslc document` requirements-document workflow.
   `fsl_tools::project_requirement_claims_from_source` compiles a checked `spec` or
   `requirements` dialect model into `schemas/fslc/document/requirement-claims.v1.schema.json`:
   nine claim kinds (`operation`, `state_rule`, `transition_rule`, `progress_rule`,
@@ -371,10 +371,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   a target). RCIR is not a second semantics: it embeds the schema-validated Public
   Kernel v2 artifact, while claims expose typed subjects and stable target references
   instead of a second, unconstrained Python-shaped AST. Trace-only expressions reuse
-  the Public Kernel expression contract.
-  CLI wiring, the controlled-language renderer, drift checking, the no-silent-omission
-  gate, glossary, evidence overlay, and approval integration are follow-up issues
-  #326-#334; this change ships schema + library projector only. See
+  the Public Kernel expression contract. The controlled-language renderer, CLI, drift
+  checking, no-silent-omission gate, glossary, evidence overlay, and approval integration
+  are included in the same release through issues #326-#334. See
   `docs/DESIGN-document-requirement-claim-ir.md`.
 - `fsl_tools::undecided` gains `undecided_records`, a typed variant of
   `undecided_declarations` (issue #189) that additionally carries the annotation's
@@ -2512,7 +2511,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/ymm-oss/fsl/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/ymm-oss/fsl/compare/v2.7.0...v3.0.0
 [2.7.0]: https://github.com/ymm-oss/fsl/compare/v2.6.3...v2.7.0
 [2.6.3]: https://github.com/ymm-oss/fsl/compare/v2.6.2...v2.6.3

--- a/docs/DESIGN-causal.md
+++ b/docs/DESIGN-causal.md
@@ -522,8 +522,9 @@ with claim-ID witnesses as first-class attributes (§6). The evidence artifact
 schema (`fsl-causal-evidence.v0`), the lifecycle record chain, and the
 deterministic support-aggregation table are defined by #322. `causal-diff.v0`
 (claim identity by ID, content by version and typed fields) is defined by
-#321; its support transitions stay `not_available` until #322's evidence
-inputs exist.
+#321. Version 0 accepts no evidence inputs and therefore reports every support
+transition as `not_available`; #322's evidence aggregation remains a separate
+analyze/ledger projection.
 
 ## 9. Authority surface and algorithm constraints
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2518,8 +2518,9 @@ feedback SCC を経由するペアの最大値は上界)。
 (計測 cadence が到達 claim の最小持続を超えるとき正確に発火します。unknown な
 持続は推測せず `not_evaluable` として報告)、`unknown_lag_blocks_timeline`。
 `fslc causal diff` は 2 つのモデルファイルを安定 claim ID と content version で
-比較します。`support_transition` は外部 evidence が存在するまで
-`not_available` のままです。version 対象フィールドを同じ version のまま変更すると
+比較します。`causal-diff.v0` は evidence 入力を受け取らないため、
+`support_transition` は `not_available` のままです。evidence 集約は analyze/ledger
+projection が別に報告します。version 対象フィールドを同じ version のまま変更すると
 `content_changed_without_version_bump`、terminal な retired claim を active に
 戻すと `retired_claim_reactivated`、新しい claim が retired claim と同じ source、
 target、polarity を繰り返すと `retired_hypothesis_reproposed` を報告します。

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2559,8 +2559,10 @@ maximum is an upper bound when the pair is connected through a feedback SCC).
 exceeds an arriving claim's minimum persistence; unknown persistence is
 reported as `not_evaluable`, never guessed), and `unknown_lag_blocks_timeline`.
 `fslc causal diff` compares two model files by stable claim ID and content
-version; its `support_transition` stays `not_available` until external
-evidence exists. It reports `content_changed_without_version_bump` when
+version. `causal-diff.v0` accepts no evidence inputs, so its
+`support_transition` stays `not_available`; evidence aggregation is reported
+separately by analyze/ledger projections. It reports
+`content_changed_without_version_bump` when
 version-relevant fields move under the same version,
 `retired_claim_reactivated` when a terminal retired claim returns to active,
 and `retired_hypothesis_reproposed` when a new claim repeats a retired claim's

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -2422,7 +2422,10 @@ DESIGN-*.md).</p>
   <code>--by-requirement</code> flags "a requirement that kills no behavior mutant" as an
   <code>empty_formalization</code> warning (the semantic-level extension of
   <code>--strict-tags</code>); per-requirement kill counts and this warning are observed
-  lower bounds within the chosen mutant set and depth.
+  lower bounds within the chosen mutant set and depth. Acceptance and forbidden
+  kills use explicit requirement annotations on the failed trace declaration;
+  AC/FB case IDs are not implicit requirements. Trace case IDs are unique
+  within each declaration kind.
   → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a></li>
 <li><strong><code>fslc explain --readable</code></strong> — a text view over skeleton enumeration (state,
   action who/when/what-changes, verification bounds, fairness, KPI projections,
@@ -2537,8 +2540,10 @@ maximum is an upper bound when the pair is connected through a feedback SCC).
 exceeds an arriving claim's minimum persistence; unknown persistence is
 reported as <code>not_evaluable</code>, never guessed), and <code>unknown_lag_blocks_timeline</code>.
 <code>fslc causal diff</code> compares two model files by stable claim ID and content
-version; its <code>support_transition</code> stays <code>not_available</code> until external
-evidence exists. It reports <code>content_changed_without_version_bump</code> when
+version. <code>causal-diff.v0</code> accepts no evidence inputs, so its
+<code>support_transition</code> stays <code>not_available</code>; evidence aggregation is reported
+separately by analyze/ledger projections. It reports
+<code>content_changed_without_version_bump</code> when
 version-relevant fields move under the same version,
 <code>retired_claim_reactivated</code> when a terminal retired claim returns to active,
 and <code>retired_hypothesis_reproposed</code> when a new claim repeats a retired claim's

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -2382,7 +2382,10 @@ DESIGN-*.md があります)。</p>
   <code>--by-requirement</code> は「どの振る舞いミュータントも殺さない要件」を
   <code>empty_formalization</code> 警告としてフラグします(<code>--strict-tags</code> の意味レベルの
   拡張)。要件ごとのキル数とこの警告は、選択されたミュータント集合と深さの中で
-  観測された下界です。→ <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a></li>
+  観測された下界です。acceptance と forbidden の kill は、失敗した trace 宣言の
+  明示的な requirement annotation を使います。AC/FB case ID は暗黙の requirement
+  ではなく、trace case ID は宣言種別ごとに一意です。→
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a></li>
 <li><strong><code>fslc explain --readable</code></strong> — 骨格の列挙(状態、action の誰が/いつ/何を変える
   か、検証の境界、公平性、KPI の射影、branch の lowering、合成された refinement
   マッピング、自動検査、タグ)+ counterfactual(「この規則がなければ、この手順で
@@ -2498,8 +2501,9 @@ feedback SCC を経由するペアの最大値は上界)。
 (計測 cadence が到達 claim の最小持続を超えるとき正確に発火します。unknown な
 持続は推測せず <code>not_evaluable</code> として報告)、<code>unknown_lag_blocks_timeline</code>。
 <code>fslc causal diff</code> は 2 つのモデルファイルを安定 claim ID と content version で
-比較します。<code>support_transition</code> は外部 evidence が存在するまで
-<code>not_available</code> のままです。version 対象フィールドを同じ version のまま変更すると
+比較します。<code>causal-diff.v0</code> は evidence 入力を受け取らないため、
+<code>support_transition</code> は <code>not_available</code> のままです。evidence 集約は analyze/ledger
+projection が別に報告します。version 対象フィールドを同じ version のまま変更すると
 <code>content_changed_without_version_bump</code>、terminal な retired claim を active に
 戻すと <code>retired_claim_reactivated</code>、新しい claim が retired claim と同じ source、
 target、polarity を繰り返すと <code>retired_hypothesis_reproposed</code> を報告します。</p>

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -364,14 +364,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/fsl-tools/src/causal_projection.rs
+++ b/rust/fsl-tools/src/causal_projection.rs
@@ -434,8 +434,8 @@ fn sanitize(id: &str) -> String {
 }
 
 /// `fslc causal diff` (`causal-diff.v0`): claim identity by ID, content by
-/// version and typed fields. Support transitions are `not_available` until
-/// evidence inputs exist (#322).
+/// version and typed fields. Version 0 accepts no evidence inputs, so support
+/// transitions are always `not_available`; evidence aggregation is separate.
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn causal_diff_json(before: &CausalModel, after: &CausalModel) -> Value {

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7857,11 +7857,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8013,11 +8013,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8038,11 +8038,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8094,11 +8094,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8119,11 +8119,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8158,11 +8158,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8189,11 +8189,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8213,11 +8213,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8239,11 +8239,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8263,11 +8263,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8289,11 +8289,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8313,11 +8313,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8339,11 +8339,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8363,11 +8363,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8394,11 +8394,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8418,11 +8418,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8449,11 +8449,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8473,11 +8473,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8499,11 +8499,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8523,11 +8523,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.0.0"
+              "version": "3.1.0"
             },
             "solver": {
               "name": "z3",


### PR DESCRIPTION
## Summary

- clarify the final `causal-diff.v0` evidence boundary across authoritative docs, generated site references, and the Rust API documentation
- bump the native Rust workspace and VS Code extension release unit from 3.0.0 to 3.1.0
- roll the complete post-v3.0.0 changelog into `3.1.0` dated 2026-07-20
- regenerate Cargo/npm locks and the domain characterization baseline through their supported generators

## Release rationale

This is a SemVer minor release: it adds backward-compatible language, verification, causal-analysis, requirements-document, editor, and distribution capabilities, together with fixes. The frozen Python compatibility package remains unchanged.

Candidate base: `099e7f5e56ddc7d7370fcbc1103233f5fe2456f8`

## Verification

- `./tools/check-native-integration.sh` (exit 0)
  - full Rust fmt/clippy/test/build gate
  - browser Z3/Worker parity: 351 cases
- `uv run --extra dev pytest -q tests/test_site_reference_snapshot.py` (3 passed)
- focused domain characterization test (3 passed)
- focused native release-unit contract test (passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `git diff --check`
- independent release-preparation review completed; finding about generated site drift was fixed

## Release boundary

This PR only prepares v3.1.0 on `main`. It does not merge to `production`, create or push a tag, publish a GitHub Release, or publish artifacts. Those steps require a fresh exact-SHA dry run and explicit authorization after this PR is merged.