### PR TITLE
fix(verifier): prove transition outcome agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- Verifier transition-outcome agreement now proves actual guard failure and
+  representable defined post-update failure phases in native evaluation order,
+  rejects malformed, relabelled, partial, or checked-arithmetic evidence, and
+  fails closed for `partial_op` or concrete evidence outside the bounded
+  symbolic representation (#428).
+
 ### Changed
 - The authoritative Rust workspace now has one evidence-backed component design
   record covering all eleven crates, their state and responsibility ownership,

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -234,10 +234,23 @@ Concrete/symbolic agreement is a separate mechanical gate:
 parameters, and successor into the symbolic transition relation. Tests require
 every checked successful Monitor transition to be satisfiable and a deliberately
 altered successor to be rejected. `transition_outcome_matches_step` additionally
-checks disabled actions, concrete partial-operation rollback, and the attempted
-symbolic successor plus unchanged committed state for type-bound, invariant,
-transition, and ensures failures. The solver-free `fsl-runtime` dependency
-boundary remains intact.
+checks that disabled actions have an actually false guard and distinguishes
+representable successful, type-bound, invariant, transition, and ensures
+outcomes in native evaluation order. It rejects malformed calls and state
+shapes, corrupted attempted/committed states, and substituted outcome kinds.
+Because the symbolic value evaluator totalizes partial operators and uses
+unbounded integer terms, agreement uses a separate typed definedness predicate
+that follows native short-circuit, statement-branch, guard, post-property, and
+checked-i64 evaluation order. A non-partial claim is rejected when its reached
+path is undefined; an untaken partial expression does not make a valid outcome
+unsupported. Agreement-only fallback values let zero-capacity sequence terms
+be constructed under those predicates; ordinary BMC and induction retain their
+existing fail-closed evaluation. Exact `partial_op` classification and concrete
+evidence that the bounded symbolic representation cannot retain, such as an
+over-capacity sequence suffix, return an error rather than green until an exact
+partial-evidence oracle is available. Concrete conformance vectors remain
+authoritative for `partial_op` rollback meanwhile.
+The solver-free `fsl-runtime` dependency boundary remains intact.
 
 ## CLI and API
 

--- a/docs/DESIGN-rust-components.md
+++ b/docs/DESIGN-rust-components.md
@@ -379,7 +379,7 @@ Existing fitness functions remain authoritative:
 |---|---|---|
 | Keep runtime solver-independent. | `tools/check-native-integration.sh` dependency inspection | No `fsl-solver` or Z3 in the normal `fsl-runtime` tree. |
 | Keep WASM free of native Z3. | Same dependency inspection | No normal `fsl-solver-z3` dependency. |
-| Keep semantic paths aligned. | verifier expression/transition agreement tests | Valid Monitor facts are accepted and deliberately altered facts are rejected. |
+| Keep semantic paths aligned. | verifier expression/transition agreement tests | Solver-supported Monitor facts are accepted, deliberately altered facts are rejected, and unsupported partial-operation paths or unrepresentable concrete evidence fail closed rather than returning green. |
 | Keep Public Kernel complete and fail closed. | Kernel schema, conformance coverage, and negative tests | Every registered semantic/outcome feature is covered; unsupported nodes fail. |
 | Keep replay evidence executable. | replay schema/goldens and Monitor replay tests | Complete typed observations conform; malformed input and wrong states fail with the contracted exit. |
 | Keep delivery projections stable. | native integration, LSP stdio/corpus, and browser parity tests | CLI, LSP, and Worker preserve their shared identities and transport-specific contracts. |

--- a/rust/fsl-verifier/src/agreement.rs
+++ b/rust/fsl-verifier/src/agreement.rs
@@ -2,15 +2,18 @@
 
 use std::collections::BTreeMap;
 
-use fsl_core::{FslValue, KernelExpr, KernelModel, ParamDef, TypeRef};
+use fsl_core::{FslValue, KernelExpr, KernelModel, ParamDef, TypeDef, TypeRef};
 use fsl_solver::{SatResult, SmtSolver, Sort};
 
 use crate::VerifyError;
-use crate::eval::eval;
-use crate::transition::{action_instances, transition_constraint};
+use crate::eval::{definedness, eval};
+use crate::transition::{
+    action_guard_definedness, action_guards, action_instances, action_statements_definedness,
+    transition_constraint,
+};
 use crate::value::{
-    Bindings, bool_term, bounds, concrete_value, logical_equal, project_state,
-    symbolic_state_with_suffix,
+    Bindings, SymbolicState, SymbolicValue, bool_term, bounds, concrete_value, logical_equal,
+    project_state, symbolic_state_with_suffix,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -35,6 +38,27 @@ pub async fn transition_matches_step<S: SmtSolver>(
     params: &BTreeMap<String, FslValue>,
     next: &BTreeMap<String, FslValue>,
 ) -> Result<bool, VerifyError> {
+    solver.push();
+    let checked = transition_matches_step_with_bounds(
+        model, solver, current, action, params, next, false, false,
+    )
+    .await;
+    let popped = solver.pop(1);
+    popped?;
+    checked
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn transition_matches_step_with_bounds<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    next: &BTreeMap<String, FslValue>,
+    allow_next_bound_violation: bool,
+    totalize_partial_values: bool,
+) -> Result<bool, VerifyError> {
     let definition = model
         .actions
         .iter()
@@ -51,10 +75,21 @@ pub async fn transition_matches_step<S: SmtSolver>(
         )));
     }
 
-    let symbolic_current = symbolic_state_with_suffix(solver, model, "agreement_current")?;
-    let symbolic_next = symbolic_state_with_suffix(solver, model, "agreement_next")?;
-    pin_state(solver, model, &symbolic_current, current, "current")?;
-    pin_state(solver, model, &symbolic_next, next, "next")?;
+    let mut symbolic_current = symbolic_state_with_suffix(solver, model, "agreement_current")?;
+    let mut symbolic_next = symbolic_state_with_suffix(solver, model, "agreement_next")?;
+    pin_state(solver, model, &symbolic_current, current, "current", false)?;
+    pin_state(
+        solver,
+        model,
+        &symbolic_next,
+        next,
+        "next",
+        allow_next_bound_violation,
+    )?;
+    if totalize_partial_values {
+        totalize_agreement_state(solver, model, &mut symbolic_current)?;
+        totalize_agreement_state(solver, model, &mut symbolic_next)?;
+    }
     let instances = action_instances(solver, model)?;
     let choice = solver.constant("agreement_action_choice", &Sort::Int)?;
     let transition = transition_constraint(
@@ -97,9 +132,9 @@ pub async fn transition_matches_step<S: SmtSolver>(
             solver.pop(1)?;
             return Err(error);
         }
-        let result = solver.check().await?;
+        let result = solver.check().await;
         solver.pop(1)?;
-        match result {
+        match result? {
             SatResult::Sat => return Ok(true),
             SatResult::Unsat => {}
             SatResult::Unknown => {
@@ -112,11 +147,14 @@ pub async fn transition_matches_step<S: SmtSolver>(
     Ok(false)
 }
 
-/// Check a complete concrete outcome, including disabled calls and rollback.
-/// Successful outcomes must be admitted by the symbolic transition relation.
-/// Post-update failures must expose a symbolic attempted successor while the
-/// committed state remains the pre-state. Partial operations are concrete-only
-/// because SMT integer and collection operators are totalized.
+/// Check the solver-provable parts of a concrete outcome, including disabled
+/// calls, rollback, and the exact non-partial post-update failure phase.
+/// Successful outcomes must be admitted by the symbolic transition relation
+/// and pass bounds, invariants, transition properties, and ensures. Evidence
+/// A non-partial claim whose reached path is undefined is rejected. A claimed
+/// partial outcome, or concrete identity that cannot be retained by the bounded
+/// symbolic representation, fails closed with [`VerifyError`] until an exact
+/// partial-evidence oracle is available.
 ///
 /// # Errors
 ///
@@ -133,20 +171,77 @@ pub async fn transition_outcome_matches_step<S: SmtSolver>(
     attempted: Option<&BTreeMap<String, FslValue>>,
     outcome_kind: &str,
 ) -> Result<bool, VerifyError> {
+    solver.push();
+    let checked = transition_outcome_matches_step_scoped(
+        model,
+        solver,
+        current,
+        action,
+        params,
+        committed,
+        attempted,
+        outcome_kind,
+    )
+    .await;
+    let popped = solver.pop(1);
+    popped?;
+    checked
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn transition_outcome_matches_step_scoped<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    committed: &BTreeMap<String, FslValue>,
+    attempted: Option<&BTreeMap<String, FslValue>>,
+    outcome_kind: &str,
+) -> Result<bool, VerifyError> {
     match outcome_kind {
         "ok" => {
             if attempted.is_some() {
                 return Ok(false);
             }
-            transition_matches_step(model, solver, current, action, params, committed).await
+            if !transition_is_admitted(model, solver, current, action, params, committed, false)
+                .await?
+            {
+                return Ok(false);
+            }
+            if !action_execution_is_defined(model, solver, current, action, params).await? {
+                return Ok(false);
+            }
+            post_outcome_matches(
+                model,
+                solver,
+                current,
+                action,
+                params,
+                committed,
+                outcome_kind,
+            )
+            .await
         }
         "requires_failed" => {
             if committed != current || attempted.is_some() {
                 return Ok(false);
             }
-            Ok(!transition_matches_step(model, solver, current, action, params, current).await?)
+            action_is_disabled_and_defined(model, solver, current, action, params).await
         }
-        "partial_op" => Ok(committed == current && attempted.is_none()),
+        "partial_op" => {
+            if committed != current {
+                return Ok(false);
+            }
+            validate_action_parameters(model, action, params)?;
+            pin_concrete_state(model, current, "current", false)?;
+            if let Some(attempted) = attempted {
+                pin_concrete_state(model, attempted, "attempted", true)?;
+            }
+            Err(VerifyError::new(
+                "exact partial-operation agreement is not implemented",
+            ))
+        }
         "type_bound" | "invariant" | "trans" | "ensures" => {
             let Some(attempted) = attempted else {
                 return Ok(false);
@@ -154,11 +249,552 @@ pub async fn transition_outcome_matches_step<S: SmtSolver>(
             if committed != current {
                 return Ok(false);
             }
-            transition_matches_step(model, solver, current, action, params, attempted).await
+            if !transition_is_admitted(
+                model,
+                solver,
+                current,
+                action,
+                params,
+                attempted,
+                outcome_kind == "type_bound",
+            )
+            .await?
+            {
+                return Ok(false);
+            }
+            if !action_execution_is_defined(model, solver, current, action, params).await? {
+                return Ok(false);
+            }
+            post_outcome_matches(
+                model,
+                solver,
+                current,
+                action,
+                params,
+                attempted,
+                outcome_kind,
+            )
+            .await
         }
         other => Err(VerifyError::new(format!(
             "unknown transition agreement outcome '{other}'"
         ))),
+    }
+}
+
+async fn transition_is_admitted<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    next: &BTreeMap<String, FslValue>,
+    allow_next_bound_violation: bool,
+) -> Result<bool, VerifyError> {
+    solver.push();
+    let checked = transition_matches_step_with_bounds(
+        model,
+        solver,
+        current,
+        action,
+        params,
+        next,
+        allow_next_bound_violation,
+        true,
+    )
+    .await;
+    let popped = solver.pop(1);
+    popped?;
+    checked
+}
+
+#[derive(Clone, Copy)]
+enum ActionCondition {
+    EnabledAndDefined,
+    DisabledAndDefined,
+}
+
+async fn action_execution_is_defined<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+) -> Result<bool, VerifyError> {
+    action_condition_is_implied(
+        model,
+        solver,
+        current,
+        action,
+        params,
+        ActionCondition::EnabledAndDefined,
+    )
+    .await
+}
+
+async fn action_is_disabled_and_defined<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+) -> Result<bool, VerifyError> {
+    action_condition_is_implied(
+        model,
+        solver,
+        current,
+        action,
+        params,
+        ActionCondition::DisabledAndDefined,
+    )
+    .await
+}
+
+async fn action_condition_is_implied<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    expected: ActionCondition,
+) -> Result<bool, VerifyError> {
+    solver.push();
+    let assertions = (|| -> Result<S::Term, VerifyError> {
+        let definition = validate_action_parameters(model, action, params)?;
+        let mut symbolic_current =
+            symbolic_state_with_suffix(solver, model, "agreement_action_current")?;
+        pin_state(solver, model, &symbolic_current, current, "current", false)?;
+        totalize_agreement_state(solver, model, &mut symbolic_current)?;
+        let symbolic_params = symbolic_action_parameters(solver, model, definition, params)?;
+        let status = action_guard_definedness(
+            solver,
+            model,
+            definition,
+            &symbolic_current,
+            &symbolic_params,
+        )?;
+        let condition = match expected {
+            ActionCondition::EnabledAndDefined => {
+                let statements_defined = action_statements_definedness(
+                    solver,
+                    model,
+                    definition,
+                    &symbolic_current,
+                    &status.bindings,
+                )?;
+                solver.and(&[status.defined, status.enabled, statements_defined])?
+            }
+            ActionCondition::DisabledAndDefined => {
+                solver.and(&[status.defined, solver.not(&status.enabled)?])?
+            }
+        };
+        solver.assert(&solver.not(&condition)?)?;
+        Ok(condition)
+    })();
+    if let Err(error) = assertions {
+        solver.pop(1)?;
+        return Err(error);
+    }
+    let result = solver.check().await;
+    solver.pop(1)?;
+    match result? {
+        SatResult::Unsat => Ok(true),
+        SatResult::Sat => Ok(false),
+        SatResult::Unknown => Err(VerifyError::new(
+            "solver returned unknown in action-outcome agreement",
+        )),
+    }
+}
+
+async fn post_outcome_matches<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    next: &BTreeMap<String, FslValue>,
+    outcome_kind: &str,
+) -> Result<bool, VerifyError> {
+    let definition = validate_action_parameters(model, action, params)?;
+    let mut symbolic_current =
+        symbolic_state_with_suffix(solver, model, "agreement_outcome_current")?;
+    let mut symbolic_next = symbolic_state_with_suffix(solver, model, "agreement_outcome_next")?;
+    pin_state(solver, model, &symbolic_current, current, "current", false)?;
+    pin_state(
+        solver,
+        model,
+        &symbolic_next,
+        next,
+        "next",
+        outcome_kind == "type_bound",
+    )?;
+    totalize_agreement_state(solver, model, &mut symbolic_current)?;
+    totalize_agreement_state(solver, model, &mut symbolic_next)?;
+
+    let bound_terms = model
+        .state
+        .iter()
+        .map(|(name, _)| {
+            bounds(
+                solver,
+                model,
+                symbolic_next.get(name).ok_or_else(|| {
+                    VerifyError::new(format!("symbolic next state is missing '{name}'"))
+                })?,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let bounds_hold = solver.and(&bound_terms)?;
+
+    let (invariants_hold, invariant_fails) = ordered_property_phase(
+        solver,
+        model,
+        &model.invariants,
+        &symbolic_next,
+        &symbolic_current,
+    )?;
+    let (transitions_hold, transition_fails) = ordered_property_phase(
+        solver,
+        model,
+        &model.transitions,
+        &symbolic_next,
+        &symbolic_current,
+    )?;
+
+    let symbolic_params = symbolic_action_parameters(solver, model, definition, params)?;
+    let (_, mut bindings) = action_guards(
+        solver,
+        model,
+        definition,
+        &symbolic_current,
+        &symbolic_params,
+    )?;
+    let (ensures_hold, ensure_fails) = ordered_expression_phase(
+        solver,
+        model,
+        &definition.ensures,
+        &symbolic_next,
+        &mut bindings,
+        Some(&symbolic_current),
+    )?;
+
+    let condition = match outcome_kind {
+        "ok" => solver.and(&[bounds_hold, invariants_hold, transitions_hold, ensures_hold])?,
+        "type_bound" => solver.not(&bounds_hold)?,
+        "invariant" => solver.and(&[bounds_hold, invariant_fails])?,
+        "trans" => solver.and(&[bounds_hold, invariants_hold, transition_fails])?,
+        "ensures" => solver.and(&[bounds_hold, invariants_hold, transitions_hold, ensure_fails])?,
+        _ => unreachable!("post outcome kind was matched by the caller"),
+    };
+    solver.assert(&solver.not(&condition)?)?;
+    match solver.check().await? {
+        SatResult::Unsat => Ok(true),
+        SatResult::Sat => Ok(false),
+        SatResult::Unknown => Err(VerifyError::new(
+            "solver returned unknown in post-outcome agreement",
+        )),
+    }
+}
+
+fn ordered_property_phase<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    properties: &[fsl_core::PropertyDef],
+    next: &SymbolicState<S::Term>,
+    current: &SymbolicState<S::Term>,
+) -> Result<(S::Term, S::Term), VerifyError> {
+    let mut prefix = solver.bool_value(true);
+    let mut failures = Vec::new();
+    for property in properties {
+        let mut bindings = Bindings::new();
+        let expression_defined = definedness(
+            solver,
+            model,
+            &property.expr,
+            next,
+            &bindings,
+            Some(current),
+        )?;
+        let value = eval(
+            solver,
+            model,
+            &property.expr,
+            next,
+            &mut bindings,
+            Some(current),
+        )?;
+        let value = bool_term(&value)?.clone();
+        failures.push(solver.and(&[
+            prefix.clone(),
+            expression_defined.clone(),
+            solver.not(&value)?,
+        ])?);
+        prefix = solver.and(&[prefix, expression_defined, value])?;
+    }
+    Ok((prefix, solver.or(&failures)?))
+}
+
+fn ordered_expression_phase<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expressions: &[fsl_core::KernelExpr],
+    state: &SymbolicState<S::Term>,
+    bindings: &mut Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<(S::Term, S::Term), VerifyError> {
+    let mut prefix = solver.bool_value(true);
+    let mut failures = Vec::new();
+    for expression in expressions {
+        let expression_defined =
+            definedness(solver, model, expression, state, bindings, old_state)?;
+        let value = eval(solver, model, expression, state, bindings, old_state)?;
+        let value = bool_term(&value)?.clone();
+        failures.push(solver.and(&[
+            prefix.clone(),
+            expression_defined.clone(),
+            solver.not(&value)?,
+        ])?);
+        prefix = solver.and(&[prefix, expression_defined, value])?;
+    }
+    Ok((prefix, solver.or(&failures)?))
+}
+
+fn symbolic_action_parameters<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    definition: &fsl_core::ActionDef,
+    params: &BTreeMap<String, FslValue>,
+) -> Result<Bindings<S::Term>, VerifyError> {
+    definition
+        .params
+        .iter()
+        .map(|parameter| {
+            let name = parameter.name();
+            let value = params.get(name).ok_or_else(|| {
+                VerifyError::new(format!("agreement parameter '{name}' is missing"))
+            })?;
+            let ty = match parameter {
+                ParamDef::Typed { ty, .. } => ty.clone(),
+                ParamDef::Range { lo, hi, .. } => TypeRef::Range(*lo, *hi),
+            };
+            Ok((name.to_owned(), concrete_value(solver, model, &ty, value)?))
+        })
+        .collect()
+}
+
+fn validate_action_parameters<'a>(
+    model: &'a KernelModel,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+) -> Result<&'a fsl_core::ActionDef, VerifyError> {
+    let definition = model
+        .actions
+        .iter()
+        .find(|definition| definition.name == action)
+        .ok_or_else(|| VerifyError::new(format!("unknown agreement action '{action}'")))?;
+    if definition.params.len() != params.len()
+        || definition
+            .params
+            .iter()
+            .any(|parameter| !params.contains_key(parameter.name()))
+    {
+        return Err(VerifyError::new(format!(
+            "agreement parameters do not match action '{action}'"
+        )));
+    }
+    for parameter in &definition.params {
+        let name = parameter.name();
+        let value = params
+            .get(name)
+            .ok_or_else(|| VerifyError::new(format!("agreement parameter '{name}' is missing")))?;
+        let domain = match parameter {
+            ParamDef::Typed { ty, .. } => model.domain_values(ty)?,
+            ParamDef::Range { lo, hi, .. } => (*lo..=*hi).map(FslValue::Int).collect(),
+        };
+        if !domain.contains(value) {
+            return Err(VerifyError::new(format!(
+                "agreement parameter '{name}' is outside the action domain"
+            )));
+        }
+    }
+    Ok(definition)
+}
+
+fn pin_concrete_state(
+    model: &KernelModel,
+    state: &BTreeMap<String, FslValue>,
+    label: &str,
+    allow_bound_violation: bool,
+) -> Result<(), VerifyError> {
+    if state.len() != model.state.len() {
+        return Err(VerifyError::new(format!(
+            "agreement {label} state has the wrong number of variables"
+        )));
+    }
+    for (name, ty) in &model.state {
+        let value = state.get(name).ok_or_else(|| {
+            VerifyError::new(format!("agreement {label} state is missing '{name}'"))
+        })?;
+        validate_concrete_value_shape(model, ty, value, allow_bound_violation)?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+fn validate_concrete_value_shape(
+    model: &KernelModel,
+    ty: &TypeRef,
+    value: &FslValue,
+    allow_bound_violation: bool,
+) -> Result<(), VerifyError> {
+    match (ty, value) {
+        (TypeRef::Bool, FslValue::Bool(_))
+        | (TypeRef::Int, FslValue::Int(_))
+        | (TypeRef::Option(_), FslValue::None) => Ok(()),
+        (TypeRef::Range(lo, hi), FslValue::Int(value)) => {
+            if allow_bound_violation || lo <= value && value <= hi {
+                Ok(())
+            } else {
+                Err(VerifyError::new("agreement value is outside its range"))
+            }
+        }
+        (TypeRef::Named(name), FslValue::Int(value)) => {
+            let Some(TypeDef::Domain { lo, hi, .. }) = model.types.get(name) else {
+                return Err(VerifyError::new(format!("'{name}' is not a domain")));
+            };
+            if allow_bound_violation || lo <= value && value <= hi {
+                Ok(())
+            } else {
+                Err(VerifyError::new(format!(
+                    "agreement value is outside domain '{name}'"
+                )))
+            }
+        }
+        (TypeRef::Named(name), FslValue::Enum { type_name, member }) if name == type_name => {
+            let Some(TypeDef::Enum { members, .. }) = model.types.get(name) else {
+                return Err(VerifyError::new(format!("'{name}' is not an enum")));
+            };
+            if members.contains(member) {
+                Ok(())
+            } else {
+                Err(VerifyError::new(format!("unknown enum member '{member}'")))
+            }
+        }
+        (TypeRef::Named(name), FslValue::Struct { type_name, fields }) if name == type_name => {
+            let Some(TypeDef::Struct { fields: expected }) = model.types.get(name) else {
+                return Err(VerifyError::new(format!("'{name}' is not a struct")));
+            };
+            if fields.len() != expected.len() {
+                return Err(VerifyError::new(format!(
+                    "agreement struct '{name}' has the wrong number of fields"
+                )));
+            }
+            for (field, field_ty) in expected {
+                let field_value = fields.get(field).ok_or_else(|| {
+                    VerifyError::new(format!("agreement struct '{name}' is missing '{field}'"))
+                })?;
+                validate_concrete_value_shape(model, field_ty, field_value, allow_bound_violation)?;
+            }
+            Ok(())
+        }
+        (TypeRef::Option(inner), FslValue::Some(value)) => {
+            validate_concrete_value_shape(model, inner, value, allow_bound_violation)
+        }
+        (TypeRef::Map(key_ty, value_ty), FslValue::Map(values)) => {
+            let expected = model.map_key_values(key_ty)?;
+            if values.len() != expected.len()
+                || expected.iter().any(|key| !values.contains_key(key))
+            {
+                return Err(VerifyError::new(
+                    "agreement map keys do not match the finite key domain",
+                ));
+            }
+            values.values().try_for_each(|value| {
+                validate_concrete_value_shape(model, value_ty, value, allow_bound_violation)
+            })
+        }
+        (TypeRef::Set(element_ty), FslValue::Set(values)) => {
+            let domain = model.domain_values(element_ty)?;
+            if values.iter().any(|value| !domain.contains(value)) {
+                return Err(VerifyError::new(
+                    "agreement set contains a value outside its finite domain",
+                ));
+            }
+            Ok(())
+        }
+        (TypeRef::Seq(element_ty, capacity), FslValue::Seq(values)) => {
+            if values.len() > *capacity {
+                return Err(VerifyError::new(
+                    "exact agreement cannot represent an over-capacity sequence",
+                ));
+            }
+            values.iter().try_for_each(|value| {
+                validate_concrete_value_shape(model, element_ty, value, allow_bound_violation)
+            })
+        }
+        (TypeRef::Relation(source_ty, target_ty), FslValue::Relation(values)) => {
+            let sources = model.domain_values(source_ty)?;
+            let targets = model.domain_values(target_ty)?;
+            if values
+                .iter()
+                .any(|(source, target)| !sources.contains(source) || !targets.contains(target))
+            {
+                return Err(VerifyError::new(
+                    "agreement relation contains a pair outside its finite domains",
+                ));
+            }
+            Ok(())
+        }
+        _ => Err(VerifyError::new(format!(
+            "agreement value does not match type {ty:?}"
+        ))),
+    }
+}
+
+fn totalize_agreement_state<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    state: &mut SymbolicState<S::Term>,
+) -> Result<(), VerifyError> {
+    state
+        .values_mut()
+        .try_for_each(|value| totalize_agreement_value(solver, model, value))
+}
+
+fn totalize_agreement_value<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    value: &mut SymbolicValue<S::Term>,
+) -> Result<(), VerifyError> {
+    match value {
+        SymbolicValue::Option { value, .. } => totalize_agreement_value(solver, model, value),
+        SymbolicValue::Struct { fields, .. } => fields
+            .values_mut()
+            .try_for_each(|value| totalize_agreement_value(solver, model, value)),
+        SymbolicValue::Map { entries, .. } => entries
+            .iter_mut()
+            .try_for_each(|(_, value)| totalize_agreement_value(solver, model, value)),
+        SymbolicValue::Seq { ty, slots, .. } => {
+            let TypeRef::Seq(element_ty, capacity) = ty else {
+                unreachable!();
+            };
+            if *capacity == 0 && slots.is_empty() {
+                let mut fallback =
+                    concrete_value(solver, model, element_ty, &model.default_value(element_ty)?)?;
+                totalize_agreement_value(solver, model, &mut fallback)?;
+                slots.push(fallback);
+            }
+            slots
+                .iter_mut()
+                .try_for_each(|value| totalize_agreement_value(solver, model, value))
+        }
+        SymbolicValue::SetLiteral(values) | SymbolicValue::SeqLiteral(values) => values
+            .iter_mut()
+            .try_for_each(|value| totalize_agreement_value(solver, model, value)),
+        SymbolicValue::Scalar { .. }
+        | SymbolicValue::None
+        | SymbolicValue::Set { .. }
+        | SymbolicValue::Relation { .. } => Ok(()),
     }
 }
 
@@ -168,12 +804,9 @@ fn pin_state<S: SmtSolver>(
     symbolic: &crate::value::SymbolicState<S::Term>,
     concrete: &BTreeMap<String, FslValue>,
     label: &str,
+    allow_bound_violation: bool,
 ) -> Result<(), VerifyError> {
-    if concrete.len() != model.state.len() {
-        return Err(VerifyError::new(format!(
-            "agreement {label} state has the wrong number of variables"
-        )));
-    }
+    pin_concrete_state(model, concrete, label, allow_bound_violation)?;
     for (name, ty) in &model.state {
         let value = concrete.get(name).ok_or_else(|| {
             VerifyError::new(format!("agreement {label} state is missing '{name}'"))

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -194,6 +194,427 @@ pub(crate) fn eval<S: SmtSolver>(
     }
 }
 
+/// Build the condition under which concrete evaluation of `expr` completes
+/// without a partial operation, checked integer overflow, or invalid finite
+/// lookup. Unlike [`eval`], this preserves native short-circuit and conditional
+/// evaluation paths.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(crate) fn definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expr: &Expr,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    match expr {
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => Ok(solver.bool_value(true)),
+        Expr::UnaryNamed {
+            name, expr: inner, ..
+        } if name == "old" => definedness(
+            solver,
+            model,
+            inner,
+            old_state.ok_or_else(|| VerifyError::new("old() used without old state"))?,
+            bindings,
+            None,
+        ),
+        Expr::Neg(inner) => {
+            let mut local = bindings.clone();
+            let inner_defined = definedness(solver, model, inner, state, &local, old_state)?;
+            let inner = eval(solver, model, inner, state, &mut local, old_state)?;
+            Ok(solver.and(&[
+                inner_defined,
+                solver.not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
+            ])?)
+        }
+        Expr::UnaryNamed {
+            name, expr: inner, ..
+        } if name == "abs" => {
+            let mut local = bindings.clone();
+            let inner_defined = definedness(solver, model, inner, state, &local, old_state)?;
+            let inner = eval(solver, model, inner, state, &mut local, old_state)?;
+            Ok(solver.and(&[
+                inner_defined,
+                solver.not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
+            ])?)
+        }
+        Expr::Some(inner)
+        | Expr::Not(inner)
+        | Expr::Field(inner, _)
+        | Expr::Is { expr: inner, .. }
+        | Expr::Stage { entity: inner, .. }
+        | Expr::UnaryNamed { expr: inner, .. } => {
+            definedness(solver, model, inner, state, bindings, old_state)
+        }
+        Expr::Set(items) | Expr::Seq(items) | Expr::Call { args: items, .. } => {
+            ordered_definedness(solver, model, items, state, bindings, old_state)
+        }
+        Expr::Struct { name, fields } => {
+            let TypeDef::Struct {
+                fields: expected, ..
+            } = model
+                .types
+                .get(name)
+                .ok_or_else(|| VerifyError::new(format!("unknown struct type '{name}'")))?
+            else {
+                return Err(VerifyError::new(format!("'{name}' is not a struct")));
+            };
+            let expressions = fields
+                .iter()
+                .map(|(field, expression)| (field.as_str(), expression))
+                .collect::<BTreeMap<_, _>>();
+            let items = expected
+                .iter()
+                .map(|(field, _)| {
+                    expressions
+                        .get(field.as_str())
+                        .copied()
+                        .ok_or_else(|| VerifyError::new(format!("missing struct field '{field}'")))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if expressions.len() != expected.len() {
+                return Err(VerifyError::new(format!(
+                    "struct '{name}' has the wrong number of fields"
+                )));
+            }
+            ordered_definedness_refs(solver, model, &items, state, bindings, old_state)
+        }
+        Expr::Index(base, index) => {
+            let mut local = bindings.clone();
+            let base_defined = definedness(solver, model, base, state, &local, old_state)?;
+            let base_value = eval(solver, model, base, state, &mut local, old_state)?;
+            let index_defined = definedness(solver, model, index, state, &local, old_state)?;
+            let index_value = eval(solver, model, index, state, &mut local, old_state)?;
+            let accessible = index_accessible(solver, model, &base_value, &index_value)?;
+            Ok(solver.and(&[base_defined, index_defined, accessible])?)
+        }
+        Expr::Method {
+            receiver,
+            name,
+            args,
+        } => {
+            let mut local = bindings.clone();
+            let receiver_defined = definedness(solver, model, receiver, state, &local, old_state)?;
+            let receiver_value = eval(solver, model, receiver, state, &mut local, old_state)?;
+            let arguments_defined =
+                ordered_definedness(solver, model, args, state, &local, old_state)?;
+            let argument_values = args
+                .iter()
+                .map(|argument| eval(solver, model, argument, state, &mut local, old_state))
+                .collect::<Result<Vec<_>, _>>()?;
+            let operation_defined =
+                method_definedness(solver, name, &receiver_value, argument_values.as_slice())?;
+            Ok(solver.and(&[receiver_defined, arguments_defined, operation_defined])?)
+        }
+        Expr::Binary { op, left, right } => {
+            let mut local = bindings.clone();
+            let left_defined = definedness(solver, model, left, state, &local, old_state)?;
+            let left_value = eval(solver, model, left, state, &mut local, old_state)?;
+            let right_defined = definedness(solver, model, right, state, &local, old_state)?;
+            let right_value = eval(solver, model, right, state, &mut local, old_state)?;
+            let reached_right = match op.as_str() {
+                "and" | "=>" => bool_term(&left_value)?.clone(),
+                "or" => solver.not(bool_term(&left_value)?)?,
+                _ => solver.bool_value(true),
+            };
+            let mut parts = vec![
+                left_defined,
+                solver.implies(&reached_right, &right_defined)?,
+            ];
+            if matches!(op.as_str(), "/" | "%") {
+                parts.push(
+                    solver.not(&solver.equal(int_term(&right_value)?, &solver.int_value(0))?)?,
+                );
+                let overflow = solver.and(&[
+                    solver.equal(int_term(&left_value)?, &solver.int_value(i64::MIN))?,
+                    solver.equal(int_term(&right_value)?, &solver.int_value(-1))?,
+                ])?;
+                parts.push(solver.not(&overflow)?);
+            } else if matches!(op.as_str(), "+" | "-" | "*") {
+                let result = match op.as_str() {
+                    "+" => solver.add(int_term(&left_value)?, int_term(&right_value)?)?,
+                    "-" => solver.sub(int_term(&left_value)?, int_term(&right_value)?)?,
+                    "*" => solver.mul(int_term(&left_value)?, int_term(&right_value)?)?,
+                    _ => unreachable!(),
+                };
+                parts.push(i64_term_is_in_range(solver, &result)?);
+            }
+            Ok(solver.and(&parts)?)
+        }
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            let mut local = bindings.clone();
+            let condition_defined =
+                definedness(solver, model, condition, state, &local, old_state)?;
+            let condition_value = eval(solver, model, condition, state, &mut local, old_state)?;
+            let then_defined = definedness(solver, model, then_expr, state, &local, old_state)?;
+            let else_defined = definedness(solver, model, else_expr, state, &local, old_state)?;
+            Ok(solver.and(&[
+                condition_defined,
+                solver.ite(bool_term(&condition_value)?, &then_defined, &else_defined)?,
+            ])?)
+        }
+        Expr::Quantified {
+            quantifier,
+            binder,
+            body,
+        } => quantified_definedness(
+            solver, model, quantifier, binder, body, state, bindings, old_state,
+        ),
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => aggregate_definedness(
+            solver,
+            model,
+            *kind,
+            binder,
+            value.as_deref(),
+            state,
+            bindings,
+            old_state,
+        ),
+        Expr::BinaryNamed { left, right, .. } => ordered_definedness_refs(
+            solver,
+            model,
+            &[left.as_ref(), right.as_ref()],
+            state,
+            bindings,
+            old_state,
+        ),
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => ordered_definedness_refs(
+            solver,
+            model,
+            &[first.as_ref(), second.as_ref(), third.as_ref()],
+            state,
+            bindings,
+            old_state,
+        ),
+    }
+}
+
+fn ordered_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expressions: &[Expr],
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    let expressions = expressions.iter().collect::<Vec<_>>();
+    ordered_definedness_refs(solver, model, &expressions, state, bindings, old_state)
+}
+
+fn ordered_definedness_refs<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expressions: &[&Expr],
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    let mut local = bindings.clone();
+    let mut terms = Vec::new();
+    for expression in expressions {
+        terms.push(definedness(
+            solver, model, expression, state, &local, old_state,
+        )?);
+        let _ = eval(solver, model, expression, state, &mut local, old_state)?;
+    }
+    Ok(solver.and(&terms)?)
+}
+
+pub(crate) fn index_accessible<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    base: &SymbolicValue<S::Term>,
+    index: &SymbolicValue<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    match base {
+        SymbolicValue::Map { ty, entries } => {
+            let TypeRef::Map(key_ty, _) = ty else {
+                unreachable!();
+            };
+            let terms = entries
+                .iter()
+                .map(|(key, _)| {
+                    let key = concrete_value(solver, model, key_ty, key)?;
+                    logical_equal(solver, model, index, &key)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(solver.or(&terms)?)
+        }
+        SymbolicValue::Seq { len, .. } => Ok(solver.and(&[
+            solver.ge(int_term(index)?, &solver.int_value(0))?,
+            solver.lt(int_term(index)?, len)?,
+        ])?),
+        _ => Err(VerifyError::new("indexing requires a map or sequence")),
+    }
+}
+
+fn method_definedness<S: SmtSolver>(
+    solver: &S,
+    name: &str,
+    receiver: &SymbolicValue<S::Term>,
+    arguments: &[SymbolicValue<S::Term>],
+) -> Result<S::Term, VerifyError> {
+    let SymbolicValue::Seq { len, .. } = receiver else {
+        return Ok(solver.bool_value(true));
+    };
+    match (name, arguments) {
+        ("head" | "pop", []) => solver
+            .gt(len, &solver.int_value(0))
+            .map_err(VerifyError::from),
+        ("at", [index]) => Ok(solver.and(&[
+            solver.ge(int_term(index)?, &solver.int_value(0))?,
+            solver.lt(int_term(index)?, len)?,
+        ])?),
+        _ => Ok(solver.bool_value(true)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn quantified_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    quantifier: &str,
+    binder: &Binder,
+    body: &Expr,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    let mut terms = vec![binder_source_definedness(
+        solver, model, binder, state, bindings, old_state,
+    )?];
+    let mut reaches_candidate = solver.bool_value(true);
+    for (name, value, membership) in
+        binder_candidates(solver, model, binder, state, bindings, old_state)?
+    {
+        let mut local = bindings.clone();
+        local.insert(name, value);
+        let membership = membership.unwrap_or_else(|| solver.bool_value(true));
+        let where_defined = binder_where_expression(binder).map_or_else(
+            || Ok(solver.bool_value(true)),
+            |where_expr| definedness(solver, model, where_expr, state, &local, old_state),
+        )?;
+        terms.push(solver.implies(
+            &solver.and(&[reaches_candidate.clone(), membership.clone()])?,
+            &where_defined,
+        )?);
+        let where_term = binder_where(solver, model, binder, state, &mut local, old_state)?
+            .unwrap_or_else(|| solver.bool_value(true));
+        let selected = solver.and(&[membership, where_term])?;
+        let body_defined = definedness(solver, model, body, state, &local, old_state)?;
+        terms.push(solver.implies(
+            &solver.and(&[reaches_candidate.clone(), selected.clone()])?,
+            &body_defined,
+        )?);
+        let body_value = eval(solver, model, body, state, &mut local, old_state)?;
+        let continues = if quantifier == "forall" {
+            solver.or(&[solver.not(&selected)?, bool_term(&body_value)?.clone()])?
+        } else {
+            solver.or(&[solver.not(&selected)?, solver.not(bool_term(&body_value)?)?])?
+        };
+        reaches_candidate = solver.and(&[reaches_candidate, continues])?;
+    }
+    Ok(solver.and(&terms)?)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn aggregate_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    kind: AggregateKind,
+    binder: &Binder,
+    value: Option<&Expr>,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    let mut terms = vec![binder_source_definedness(
+        solver, model, binder, state, bindings, old_state,
+    )?];
+    let mut sum = solver.int_value(0);
+    for (name, candidate, membership) in
+        binder_candidates(solver, model, binder, state, bindings, old_state)?
+    {
+        let mut local = bindings.clone();
+        local.insert(name, candidate);
+        let membership = membership.unwrap_or_else(|| solver.bool_value(true));
+        let where_defined = binder_where_expression(binder).map_or_else(
+            || Ok(solver.bool_value(true)),
+            |where_expr| definedness(solver, model, where_expr, state, &local, old_state),
+        )?;
+        terms.push(solver.implies(&membership, &where_defined)?);
+        let where_term = binder_where(solver, model, binder, state, &mut local, old_state)?
+            .unwrap_or_else(|| solver.bool_value(true));
+        if let Some(value) = value {
+            let value_defined = definedness(solver, model, value, state, &local, old_state)?;
+            let selected = solver.and(&[membership, where_term])?;
+            terms.push(solver.implies(&selected, &value_defined)?);
+            if kind == AggregateKind::Sum {
+                let value = eval(solver, model, value, state, &mut local, old_state)?;
+                let next_sum = solver.add(&sum, int_term(&value)?)?;
+                terms.push(solver.implies(&selected, &i64_term_is_in_range(solver, &next_sum)?)?);
+                sum = solver.ite(&selected, &next_sum, &sum)?;
+            }
+        }
+    }
+    Ok(solver.and(&terms)?)
+}
+
+fn i64_term_is_in_range<S: SmtSolver>(solver: &S, term: &S::Term) -> Result<S::Term, VerifyError> {
+    Ok(solver.and(&[
+        solver.ge(term, &solver.int_value(i64::MIN))?,
+        solver.le(term, &solver.int_value(i64::MAX))?,
+    ])?)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn binder_source_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    binder: &Binder,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<S::Term, VerifyError> {
+    match binder {
+        Binder::Typed { .. } => Ok(solver.bool_value(true)),
+        Binder::Range { lo, hi, .. } => ordered_definedness_refs(
+            solver,
+            model,
+            &[lo.as_ref(), hi.as_ref()],
+            state,
+            bindings,
+            old_state,
+        ),
+        Binder::Collection { collection, .. } => {
+            definedness(solver, model, collection, state, bindings, old_state)
+        }
+    }
+}
+
+fn binder_where_expression(binder: &Binder) -> Option<&Expr> {
+    match binder {
+        Binder::Typed { where_expr, .. }
+        | Binder::Range { where_expr, .. }
+        | Binder::Collection { where_expr, .. } => where_expr.as_deref(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn eval_struct_literal<S: SmtSolver>(
     solver: &S,

--- a/rust/fsl-verifier/src/transition.rs
+++ b/rust/fsl-verifier/src/transition.rs
@@ -7,7 +7,7 @@ use fsl_core::{
 use fsl_solver::SmtSolver;
 
 use crate::VerifyError;
-use crate::eval::{binder_values, binder_where, eval};
+use crate::eval::{binder_values, binder_where, definedness, eval, index_accessible};
 use crate::value::{
     Bindings, SymbolicState, SymbolicValue, bool_term, coerce, i64_index, ite_value, logical_equal,
     select_finite, store_finite,
@@ -20,6 +20,12 @@ pub(crate) struct ActionInstance<T> {
     pub action_index: usize,
     pub action: String,
     pub params: Bindings<T>,
+}
+
+pub(crate) struct ActionGuardDefinedness<T> {
+    pub enabled: T,
+    pub defined: T,
+    pub bindings: Bindings<T>,
 }
 
 pub(crate) fn action_instances<S: SmtSolver>(
@@ -82,6 +88,172 @@ pub(crate) fn action_guards<S: SmtSolver>(
         }
     }
     Ok((guards, bindings))
+}
+
+pub(crate) fn action_guard_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    action: &ActionDef,
+    state: &SymbolicState<S::Term>,
+    params: &Bindings<S::Term>,
+) -> Result<ActionGuardDefinedness<S::Term>, VerifyError> {
+    let mut bindings = params.clone();
+    let mut reaches_guard = solver.bool_value(true);
+    let mut guard_terms = Vec::new();
+    for guard in &action.guards {
+        let expression = match guard {
+            ActionGuard::Let(_, expression) | ActionGuard::Requires(expression) => expression,
+        };
+        let expression_defined = definedness(solver, model, expression, state, &bindings, None)?;
+        guard_terms.push(solver.implies(&reaches_guard, &expression_defined)?);
+        let value = eval(solver, model, expression, state, &mut bindings, None)?;
+        match guard {
+            ActionGuard::Let(name, _) => {
+                reaches_guard = solver.and(&[reaches_guard, expression_defined])?;
+                bindings.insert(name.clone(), value);
+            }
+            ActionGuard::Requires(_) => {
+                reaches_guard = solver.and(&[
+                    reaches_guard,
+                    expression_defined,
+                    bool_term(&value)?.clone(),
+                ])?;
+            }
+        }
+    }
+    Ok(ActionGuardDefinedness {
+        enabled: reaches_guard,
+        defined: solver.and(&guard_terms)?,
+        bindings,
+    })
+}
+
+pub(crate) fn action_statements_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    action: &ActionDef,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    statements_definedness(
+        solver,
+        model,
+        &action.statements,
+        state,
+        &mut bindings.clone(),
+    )
+}
+
+fn statements_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    statements: &[Statement],
+    read_state: &SymbolicState<S::Term>,
+    bindings: &mut Bindings<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    let terms = statements
+        .iter()
+        .map(|statement| statement_definedness(solver, model, statement, read_state, bindings))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(solver.and(&terms)?)
+}
+
+fn statement_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    statement: &Statement,
+    read_state: &SymbolicState<S::Term>,
+    bindings: &mut Bindings<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    match statement {
+        Statement::Assign { target, value, .. } => {
+            let value_defined = definedness(solver, model, value, read_state, bindings, None)?;
+            let _ = eval(solver, model, value, read_state, bindings, None)?;
+            let target_defined = lvalue_definedness(solver, model, target, read_state, bindings)?;
+            Ok(solver.and(&[value_defined, target_defined])?)
+        }
+        Statement::If {
+            condition,
+            then_statements,
+            else_statements,
+            ..
+        } => {
+            let condition_defined =
+                definedness(solver, model, condition, read_state, bindings, None)?;
+            let condition = eval(solver, model, condition, read_state, bindings, None)?;
+            let then_defined = statements_definedness(
+                solver,
+                model,
+                then_statements,
+                read_state,
+                &mut bindings.clone(),
+            )?;
+            let else_defined = statements_definedness(
+                solver,
+                model,
+                else_statements,
+                read_state,
+                &mut bindings.clone(),
+            )?;
+            Ok(solver.and(&[
+                condition_defined,
+                solver.ite(bool_term(&condition)?, &then_defined, &else_defined)?,
+            ])?)
+        }
+        Statement::ForAll {
+            binder, statements, ..
+        } => {
+            let mut terms = Vec::new();
+            for (name, value) in binder_values(solver, model, binder)? {
+                let mut local = bindings.clone();
+                local.insert(name, value);
+                let where_defined = match binder {
+                    fsl_core::KernelBinder::Typed { where_expr, .. }
+                    | fsl_core::KernelBinder::Range { where_expr, .. }
+                    | fsl_core::KernelBinder::Collection { where_expr, .. } => {
+                        where_expr.as_deref().map_or_else(
+                            || Ok(solver.bool_value(true)),
+                            |expression| {
+                                definedness(solver, model, expression, read_state, &local, None)
+                            },
+                        )?
+                    }
+                };
+                let where_term = binder_where(solver, model, binder, read_state, &mut local, None)?
+                    .unwrap_or_else(|| solver.bool_value(true));
+                let body_defined =
+                    statements_definedness(solver, model, statements, read_state, &mut local)?;
+                terms.push(
+                    solver.and(&[where_defined, solver.implies(&where_term, &body_defined)?])?,
+                );
+            }
+            Ok(solver.and(&terms)?)
+        }
+    }
+}
+
+fn lvalue_definedness<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    target: &LValue,
+    read_state: &SymbolicState<S::Term>,
+    bindings: &mut Bindings<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    match target {
+        LValue::Var(_) => Ok(solver.bool_value(true)),
+        LValue::Index(name, index) => {
+            let index_defined = definedness(solver, model, index, read_state, bindings, None)?;
+            let index_value = eval(solver, model, index, read_state, bindings, None)?;
+            let root = read_state
+                .get(name)
+                .ok_or_else(|| VerifyError::new(format!("unknown state variable '{name}'")))?;
+            Ok(solver.and(&[
+                index_defined,
+                index_accessible(solver, model, root, &index_value)?,
+            ])?)
+        }
+        LValue::Field(base, _) => lvalue_definedness(solver, model, base, read_state, bindings),
+    }
 }
 
 pub(crate) fn init_constraints<S: SmtSolver>(

--- a/rust/fsl-verifier/tests/transition_agreement.rs
+++ b/rust/fsl-verifier/tests/transition_agreement.rs
@@ -50,6 +50,136 @@ fn assert_success_is_sticky(
     }
 }
 
+fn assert_post_failure_kind_rejections(
+    model: &fsl_core::KernelModel,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    result: &fsl_runtime::StepResult,
+    actual_kind: &str,
+) {
+    let Some(attempted) = result.attempted_state.as_ref() else {
+        return;
+    };
+    for substituted_kind in ["type_bound", "invariant", "trans", "ensures"] {
+        if substituted_kind == actual_kind {
+            continue;
+        }
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create substitution solver");
+        let substituted = block_on(fsl_verifier::transition_outcome_matches_step(
+            model,
+            &mut solver,
+            current,
+            action,
+            params,
+            &result.state,
+            Some(attempted),
+            substituted_kind,
+        ));
+        assert_ne!(
+            substituted,
+            Ok(true),
+            "{action} {actual_kind} accepted as {substituted_kind}"
+        );
+    }
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create success mutant solver");
+    assert_ne!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            model,
+            &mut solver,
+            current,
+            action,
+            params,
+            attempted,
+            None,
+            "ok",
+        )),
+        Ok(true),
+        "{action} {actual_kind} accepted as ok"
+    );
+}
+
+fn assert_failure_outcome_agreement(
+    model: &fsl_core::KernelModel,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    result: &fsl_runtime::StepResult,
+    kind: &str,
+) {
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create failure solver");
+    let agreement = block_on(fsl_verifier::transition_outcome_matches_step(
+        model,
+        &mut solver,
+        current,
+        action,
+        params,
+        &result.state,
+        result.attempted_state.as_ref(),
+        kind,
+    ));
+    if kind == "partial_op" {
+        assert!(
+            agreement
+                .expect_err("partial outcome must fail closed without an exact oracle")
+                .message
+                .contains("partial-operation")
+        );
+    } else if kind == "type_bound" {
+        match agreement {
+            Ok(true) => {}
+            Err(error) if error.message.contains("over-capacity sequence") => {}
+            other => panic!("{action} {kind} disagreed: {other:?}"),
+        }
+    } else {
+        assert!(
+            agreement.expect("check failure agreement"),
+            "{action} {kind} disagreed"
+        );
+        assert_post_failure_kind_rejections(model, current, action, params, result, kind);
+    }
+}
+
+fn assert_attempted_presence_corruption_rejected(
+    model: &fsl_core::KernelModel,
+    current: &BTreeMap<String, FslValue>,
+    action: &str,
+    params: &BTreeMap<String, FslValue>,
+    result: &fsl_runtime::StepResult,
+    kind: &str,
+) {
+    let corrupted_attempted = if result.attempted_state.is_some() {
+        None
+    } else {
+        Some(current)
+    };
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create corruption solver");
+    let corrupted = block_on(fsl_verifier::transition_outcome_matches_step(
+        model,
+        &mut solver,
+        current,
+        action,
+        params,
+        &result.state,
+        corrupted_attempted,
+        kind,
+    ));
+    if kind == "partial_op" {
+        assert!(
+            corrupted
+                .expect_err("partial corruption must fail closed")
+                .message
+                .contains("partial-operation")
+        );
+    } else {
+        assert!(
+            !corrupted.expect("reject corrupted failure evidence"),
+            "{action} {kind} accepted the wrong attempted-state presence"
+        );
+    }
+}
+
 #[test]
 fn collection_and_option_transitions_agree_across_bounded_reachable_states() {
     let fixture =
@@ -89,6 +219,22 @@ fn collection_and_option_transitions_agree_across_bounded_reachable_states() {
                 ))
                 .expect("check transition agreement"),
                 "{} disagreed from {current:?}",
+                enabled.action
+            );
+            let mut solver = fsl_solver_z3::Z3Solver::new().expect("create outcome solver");
+            assert!(
+                block_on(fsl_verifier::transition_outcome_matches_step(
+                    &model,
+                    &mut solver,
+                    &current,
+                    &enabled.action,
+                    &enabled.params,
+                    &result.state,
+                    None,
+                    "ok",
+                ))
+                .expect("check successful outcome agreement"),
+                "{} outcome disagreed from {current:?}",
                 enabled.action
             );
             checked += 1;
@@ -276,46 +422,21 @@ fn disabled_and_failed_monitor_outcomes_agree_and_rollback() {
                 "{} committed a failed step",
                 action.name
             );
-            let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
-            assert!(
-                block_on(fsl_verifier::transition_outcome_matches_step(
-                    &model,
-                    &mut solver,
-                    &current,
-                    &action.name,
-                    &params,
-                    &result.state,
-                    result.attempted_state.as_ref(),
-                    &violation.kind,
-                ))
-                .expect("check failure agreement"),
-                "{} {} disagreed",
-                action.name,
-                violation.kind
+            assert_failure_outcome_agreement(
+                &model,
+                &current,
+                &action.name,
+                &params,
+                &result,
+                &violation.kind,
             );
-
-            let mut rejection_solver =
-                fsl_solver_z3::Z3Solver::new().expect("create rejection solver");
-            let corrupted_attempted = if result.attempted_state.is_some() {
-                None
-            } else {
-                Some(&current)
-            };
-            assert!(
-                !block_on(fsl_verifier::transition_outcome_matches_step(
-                    &model,
-                    &mut rejection_solver,
-                    &current,
-                    &action.name,
-                    &params,
-                    &result.state,
-                    corrupted_attempted,
-                    &violation.kind,
-                ))
-                .expect("reject corrupted failure evidence"),
-                "{} {} accepted the wrong attempted-state presence",
-                action.name,
-                violation.kind
+            assert_attempted_presence_corruption_rejected(
+                &model,
+                &current,
+                &action.name,
+                &params,
+                &result,
+                &violation.kind,
             );
         } else {
             let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
@@ -332,8 +453,756 @@ fn disabled_and_failed_monitor_outcomes_agree_and_rollback() {
                 "{} disagreed from {current:?}",
                 action.name
             );
+            if action.name == "flip" {
+                let mut solver = fsl_solver_z3::Z3Solver::new().expect("create outcome solver");
+                assert!(
+                    block_on(fsl_verifier::transition_outcome_matches_step(
+                        &model,
+                        &mut solver,
+                        &current,
+                        &action.name,
+                        &params,
+                        &result.state,
+                        None,
+                        "ok",
+                    ))
+                    .expect("check successful outcome agreement")
+                );
+            }
         }
     }
+}
+
+#[test]
+fn enabled_non_stuttering_success_cannot_be_relabelled_as_a_failure() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fslc/tests/fixtures/conformance_failures.fsl");
+    let source = std::fs::read_to_string(&fixture).expect("read failure fixture");
+    let kernel = parse_kernel_source(
+        &source,
+        &FsResolver::new(fixture.parent().expect("fixture directory")),
+    )
+    .expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("flip", &BTreeMap::new())
+        .expect("execute enabled success");
+    assert!(result.violation.is_none());
+    assert_ne!(result.state, current, "negative control must not stutter");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create rejection solver");
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "flip",
+            &BTreeMap::new(),
+            &current,
+            None,
+            "requires_failed",
+        ))
+        .expect("reject fabricated requires failure")
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create fail-closed solver");
+    let error = block_on(fsl_verifier::transition_outcome_matches_step(
+        &model,
+        &mut solver,
+        &current,
+        "flip",
+        &BTreeMap::new(),
+        &current,
+        None,
+        "partial_op",
+    ))
+    .expect_err("partial-operation evidence must not pass without an exact oracle");
+    assert!(error.message.contains("partial-operation agreement"));
+}
+
+#[test]
+fn agreement_queries_do_not_contaminate_a_reused_solver() {
+    let source = r"
+spec ReusedAgreementSolver {
+  type Bit = 0..1
+  state { x: Bit }
+  init { x = 0 }
+  action flip() { x = 1 }
+  action blocked() { requires false  x = 1 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let initial = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = initial.state.clone();
+    let params = BTreeMap::new();
+    let mut flip = initial.clone();
+    let success = flip.attempt("flip", &params).expect("execute flip");
+    let mut blocked = initial.clone();
+    let rejected = blocked
+        .attempt("blocked", &params)
+        .expect("execute blocked");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create reused solver");
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "flip",
+            &params,
+            &current,
+            None,
+            "requires_failed",
+        ))
+        .expect("reject fabricated guard failure")
+    );
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "blocked",
+            &params,
+            &rejected.state,
+            None,
+            "requires_failed",
+        ))
+        .expect("accept genuine guard failure")
+    );
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "flip",
+            &params,
+            &success.state,
+            None,
+            "ok",
+        ))
+        .expect("accept success after failure queries")
+    );
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "flip",
+            &params,
+            &current,
+            None,
+            "ok",
+        ))
+        .expect("reject wrong successor after successful query")
+    );
+}
+
+fn reached_partial_paths_model() -> fsl_core::KernelModel {
+    let source = r"
+spec ReachedPartialPaths {
+  type Bit = 0..1
+  state {
+    x: Bit,
+    queue: Seq<Bit, 0>,
+    values: Map<Bit, Bit>
+  }
+  init {
+    x = 0
+    queue = Seq {}
+    forall i: Bit { values[i] = i }
+  }
+  action skipped_guard() {
+    requires false
+    requires queue.head() == 0
+    x = 1
+  }
+  action skipped_quantified_guard() {
+    requires false
+    requires forall i in 0..0 { queue.head() == i }
+    x = 1
+  }
+  action reached_guard() {
+    requires queue.head() == 0
+    x = 1
+  }
+  action safe_branch() {
+    if false { x = queue.head() } else { x = 1 }
+  }
+  action reached_branch() {
+    if true { x = queue.head() } else { x = 1 }
+  }
+  action map_read() { x = values[1] }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    build_model(kernel).expect("build model")
+}
+
+#[test]
+fn agreement_accepts_unreached_partial_operation_paths() {
+    let model = reached_partial_paths_model();
+    let initial = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let params = BTreeMap::new();
+
+    for action in ["skipped_guard", "skipped_quantified_guard"] {
+        let mut skipped = initial.clone();
+        let rejected = skipped
+            .attempt(action, &params)
+            .expect("short-circuit later guard");
+        assert_eq!(
+            rejected
+                .violation
+                .as_ref()
+                .map(|violation| violation.kind.as_str()),
+            Some("requires_failed")
+        );
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create guard solver");
+        assert!(
+            block_on(fsl_verifier::transition_outcome_matches_step(
+                &model,
+                &mut solver,
+                &initial.state,
+                action,
+                &params,
+                &rejected.state,
+                None,
+                "requires_failed",
+            ))
+            .expect("accept short-circuited guard failure")
+        );
+    }
+
+    for action in ["safe_branch", "map_read"] {
+        let mut monitor = initial.clone();
+        let result = monitor
+            .attempt(action, &params)
+            .expect("execute defined operation path");
+        assert!(result.violation.is_none(), "{action} must succeed");
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create success solver");
+        assert!(
+            block_on(fsl_verifier::transition_outcome_matches_step(
+                &model,
+                &mut solver,
+                &initial.state,
+                action,
+                &params,
+                &result.state,
+                None,
+                "ok",
+            ))
+            .expect("accept reached defined operation path"),
+            "{action} outcome disagreed"
+        );
+    }
+}
+
+#[test]
+fn disabled_guard_does_not_evaluate_an_unreachable_body() {
+    let source = r"
+spec DisabledPartialBody {
+  type Bit = 0..1
+  state { x: Bit, dead: Seq<Bit, 0> }
+  init { x = 0  dead = Seq {} }
+  action disabled() {
+    requires false
+    x = dead.head()
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let current = fsl_runtime::Monitor::new(model.clone())
+        .expect("create monitor")
+        .state;
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create disabled solver");
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "disabled",
+            &BTreeMap::new(),
+            &current,
+            None,
+            "requires_failed",
+        ))
+        .expect("accept disabled guard without evaluating its body")
+    );
+}
+
+#[test]
+fn ordinary_bmc_remains_fail_closed_for_reached_zero_capacity_access() {
+    let source = r"
+spec ZeroCapacityBmc {
+  type Bit = 0..1
+  state { x: Bit, queue: Seq<Bit, 0> }
+  init { x = 0  queue = Seq {} }
+  action bad() { x = queue.head() }
+  invariant Stay { x == 0 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let concrete = monitor
+        .attempt("bad", &BTreeMap::new())
+        .expect("classify concrete partial operation");
+    assert_eq!(
+        concrete
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("partial_op")
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create BMC solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect_err("ordinary BMC must not consume agreement-only fallback values");
+    assert!(
+        error.message.contains("zero-capacity sequence"),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn agreement_rejects_reached_partial_operation_paths() {
+    let model = reached_partial_paths_model();
+    let initial = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let params = BTreeMap::new();
+
+    let mut reached_guard = initial.clone();
+    let partial_guard = reached_guard
+        .attempt("reached_guard", &params)
+        .expect("classify reached partial guard");
+    assert_eq!(
+        partial_guard
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("partial_op")
+    );
+    let mut fabricated_success = initial.state.clone();
+    fabricated_success.insert("x".to_owned(), FslValue::Int(1));
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create partial-guard solver");
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &initial.state,
+            "reached_guard",
+            &params,
+            &fabricated_success,
+            None,
+            "ok",
+        ))
+        .expect("reject reached partial guard as success")
+    );
+
+    let mut reached_branch = initial.clone();
+    let partial_branch = reached_branch
+        .attempt("reached_branch", &params)
+        .expect("classify reached partial branch");
+    assert_eq!(
+        partial_branch
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("partial_op")
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create partial-branch solver");
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &initial.state,
+            "reached_branch",
+            &params,
+            &initial.state,
+            None,
+            "ok",
+        ))
+        .expect("reject reached partial branch as success")
+    );
+}
+
+#[test]
+fn earlier_post_phase_failure_dominates_later_partial_syntax() {
+    let source = r"
+spec OrderedPostFailure {
+  type Bit = 0..1
+  state { x: Bit, queue: Seq<Bit, 0> }
+  init { x = 0  queue = Seq {} }
+  action overflow() { x = 2 }
+  action fail_invariant() { x = 1 }
+  invariant FirstFailure { x == 0 }
+  invariant LaterPartial { queue.head() == 0 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("overflow", &BTreeMap::new())
+        .expect("execute bound failure before invariant");
+    assert_eq!(
+        result
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("type_bound")
+    );
+    let attempted = result
+        .attempted_state
+        .as_ref()
+        .expect("bound failure preserves attempted state");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create ordered-phase solver");
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "overflow",
+            &BTreeMap::new(),
+            &result.state,
+            Some(attempted),
+            "type_bound",
+        ))
+        .expect("accept first reached post failure")
+    );
+
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("fail_invariant", &BTreeMap::new())
+        .expect("execute invariant failure before later partial invariant");
+    assert_eq!(
+        result
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("invariant")
+    );
+    let attempted = result
+        .attempted_state
+        .as_ref()
+        .expect("invariant failure preserves attempted state");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create invariant-phase solver");
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "fail_invariant",
+            &BTreeMap::new(),
+            &result.state,
+            Some(attempted),
+            "invariant",
+        ))
+        .expect("accept earlier invariant failure")
+    );
+}
+
+#[test]
+fn old_expression_definedness_uses_the_pre_state() {
+    let source = r"
+spec OldDefinedness {
+  type Bit = 0..1
+  state { queue: Seq<Bit, 1> }
+  init { queue = Seq {} }
+  action fill() { queue = queue.push(0) }
+  trans OldHead { old(queue.head()) == 0 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("fill", &BTreeMap::new())
+        .expect("classify partial old-state expression");
+    assert_eq!(
+        result
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("partial_op")
+    );
+    let attempted = result
+        .attempted_state
+        .as_ref()
+        .expect("post-update partial preserves attempted state");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create old-state solver");
+    assert!(
+        !block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "fill",
+            &BTreeMap::new(),
+            attempted,
+            None,
+            "ok",
+        ))
+        .expect("reject partial old-state expression as success")
+    );
+}
+
+#[test]
+fn checked_integer_overflow_cannot_be_relabelled_as_success() {
+    let source = r"
+spec CheckedIntegerAgreement {
+  state { minimum: Int, maximum: Int, values: Seq<Int, 3> }
+  init {
+    minimum = -9223372036854775807 - 1
+    maximum = 9223372036854775807
+    values = Seq { 9223372036854775807, 1, -1 }
+  }
+  action abs_overflow() {
+    minimum = minimum
+    values = values
+    ensures abs(minimum) > 0
+  }
+  action sum_overflow() {
+    minimum = minimum
+    values = values
+    ensures sum(item in values of item) > 0
+  }
+  action negation_overflow() {
+    ensures -minimum > 0
+  }
+  action addition_overflow() {
+    ensures maximum + 1 > maximum
+  }
+  action subtraction_overflow() {
+    ensures minimum - 1 < minimum
+  }
+  action multiplication_overflow() {
+    ensures maximum * 2 > maximum
+  }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let initial = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+
+    for (action, expected_error) in [
+        ("abs_overflow", "integer overflow in abs"),
+        ("sum_overflow", "integer overflow in sum"),
+        ("negation_overflow", "integer overflow in negation"),
+        ("addition_overflow", "integer overflow in addition"),
+        ("subtraction_overflow", "integer overflow in subtraction"),
+        (
+            "multiplication_overflow",
+            "integer overflow in multiplication",
+        ),
+    ] {
+        let mut monitor = initial.clone();
+        let error = monitor
+            .attempt(action, &BTreeMap::new())
+            .expect_err("native checked arithmetic must reject the action");
+        assert!(error.message.contains(expected_error), "{error:?}");
+
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create overflow solver");
+        assert!(
+            !block_on(fsl_verifier::transition_outcome_matches_step(
+                &model,
+                &mut solver,
+                &initial.state,
+                action,
+                &BTreeMap::new(),
+                &initial.state,
+                None,
+                "ok",
+            ))
+            .expect("reject fabricated checked-arithmetic success"),
+            "{action} overflow was accepted as success"
+        );
+    }
+}
+
+#[test]
+fn representable_scalar_type_bound_outcome_agrees() {
+    let source = r"
+spec ScalarTypeBoundAgreement {
+  type Bit = 0..1
+  state { x: Bit }
+  init { x = 0 }
+  action overflow() { x = 2 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("overflow", &BTreeMap::new())
+        .expect("execute overflowing assignment");
+    assert_eq!(
+        result
+            .violation
+            .as_ref()
+            .map(|violation| violation.kind.as_str()),
+        Some("type_bound")
+    );
+    let attempted = result
+        .attempted_state
+        .as_ref()
+        .expect("type-bound failure preserves attempted state");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create type-bound solver");
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "overflow",
+            &BTreeMap::new(),
+            &result.state,
+            Some(attempted),
+            "type_bound",
+        ))
+        .expect("check representable type-bound agreement")
+    );
+}
+
+#[test]
+fn over_capacity_sequence_suffix_cannot_pass_exact_agreement() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fslc/tests/fixtures/conformance_failures.fsl");
+    let source = std::fs::read_to_string(&fixture).expect("read failure fixture");
+    let kernel = parse_kernel_source(
+        &source,
+        &FsResolver::new(fixture.parent().expect("fixture directory")),
+    )
+    .expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+    let current = monitor.state.clone();
+    let result = monitor
+        .attempt("type_bound", &BTreeMap::new())
+        .expect("execute sequence overflow");
+    let mut altered = result
+        .attempted_state
+        .expect("sequence overflow preserves attempted state");
+    let FslValue::Seq(values) = altered.get_mut("queue").expect("queue state") else {
+        panic!("queue must be a sequence");
+    };
+    assert!(
+        values.len() > 1,
+        "negative control needs an overflow suffix"
+    );
+    values[1] = FslValue::Int(1);
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create overflow-suffix solver");
+    let error = block_on(fsl_verifier::transition_outcome_matches_step(
+        &model,
+        &mut solver,
+        &current,
+        "type_bound",
+        &BTreeMap::new(),
+        &result.state,
+        Some(&altered),
+        "type_bound",
+    ))
+    .expect_err("unrepresentable overflow suffix must fail closed");
+    assert!(error.message.contains("over-capacity sequence"));
+}
+
+#[test]
+fn outcome_agreement_rejects_malformed_calls_and_state_shapes() {
+    let source = r"
+spec MalformedAgreement {
+  type Bit = 0..1
+  struct Pair { value: Bit }
+  state { x: Bit, pair: Pair }
+  init { x = 0  pair = Pair { value: 0 } }
+  action set(v: Bit) { requires false  x = v }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let current = fsl_runtime::Monitor::new(model.clone())
+        .expect("create monitor")
+        .state;
+
+    for malformed_params in [
+        BTreeMap::new(),
+        BTreeMap::from([("v".to_owned(), FslValue::Int(2))]),
+        BTreeMap::from([("wrong".to_owned(), FslValue::Int(0))]),
+    ] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create malformed-call solver");
+        assert!(
+            block_on(fsl_verifier::transition_outcome_matches_step(
+                &model,
+                &mut solver,
+                &current,
+                "set",
+                &malformed_params,
+                &current,
+                None,
+                "requires_failed",
+            ))
+            .is_err()
+        );
+    }
+
+    let good_params = BTreeMap::from([("v".to_owned(), FslValue::Int(0))]);
+    let mut missing_state = current.clone();
+    missing_state.remove("x");
+    let mut extra_state = current.clone();
+    extra_state.insert("extra".to_owned(), FslValue::Bool(false));
+    let mut wrong_state_type = current.clone();
+    wrong_state_type.insert("x".to_owned(), FslValue::Bool(false));
+    let mut out_of_bound_state = current.clone();
+    out_of_bound_state.insert("x".to_owned(), FslValue::Int(2));
+    let mut extra_struct_field = current.clone();
+    let FslValue::Struct { fields, .. } = extra_struct_field.get_mut("pair").expect("pair state")
+    else {
+        panic!("pair must be a struct");
+    };
+    fields.insert("extra".to_owned(), FslValue::Int(0));
+
+    for malformed_state in [
+        missing_state,
+        extra_state,
+        wrong_state_type,
+        out_of_bound_state,
+        extra_struct_field,
+    ] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create malformed-state solver");
+        assert!(
+            block_on(fsl_verifier::transition_outcome_matches_step(
+                &model,
+                &mut solver,
+                &malformed_state,
+                "set",
+                &good_params,
+                &malformed_state,
+                None,
+                "requires_failed",
+            ))
+            .is_err()
+        );
+    }
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create unknown-action solver");
+    assert!(
+        block_on(fsl_verifier::transition_outcome_matches_step(
+            &model,
+            &mut solver,
+            &current,
+            "missing",
+            &BTreeMap::new(),
+            &current,
+            None,
+            "partial_op",
+        ))
+        .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Close #428 by replacing shape-only transition-outcome agreement with exact, fail-closed symbolic checks.
- Reject enabled non-stuttering successes relabeled as `requires_failed`, outcome-kind substitutions, malformed calls/states, checked-arithmetic overflow, and evidence the bounded encoding cannot represent exactly.

## Changes
- Validate the exact action instance, parameter domain, concrete state shape, rollback/attempted-state shape, successor, and native failure-phase order.
- Add path-sensitive symbolic definedness for guards, statements, properties, short-circuiting, collection access, and checked `i64` arithmetic.
- Keep `partial_op` evidence explicitly unsupported instead of returning a shape-only green result; reject over-capacity sequence evidence whose suffix is not symbolically represented.
- Scope zero-capacity sequence fallback values to agreement-only queries after concrete pins, preserving strict ordinary BMC and induction behavior.
- Add 18 focused agreement tests, including positive outcomes, classification mutants, malformed evidence, partial-path reachability, solver reuse, and a negative control proving the fallback does not leak into BMC.
- Update the accepted Kernel/component agreement wording and `[Unreleased]` changelog entry.

## Verification
- `cargo test --manifest-path rust/Cargo.toml -p fsl-verifier --test transition_agreement --locked` (18/18 passed)
- `cargo test --manifest-path rust/Cargo.toml -p fsl-verifier --locked` (passed)
- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-verifier --all-targets --locked -- -D warnings` (passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all` (passed)
- `git diff --check` (passed)
- `./tools/check-native-integration.sh` (passed)
- `./tools/check-native-integration.sh wasm` (passed; 351 native/Worker parity cases)

## Risk / Review Notes
- Specification interpretation: native Rust Monitor order is authoritative for this verifier boundary: guards/body, then bounds, invariants, transition properties, and ensures. A separate documentation-only change will mark conflicting migration-era wording as historical.
- This does not change FSL language/runtime semantics, runtime solver independence, CLI/Worker/LSP envelopes, Kernel/replay schemas, exit codes, or frozen Python behavior.
- The pre-PR `implementation-local-optima-audit` found no correctness blocker. It classifies the verifier-local definedness traversal and agreement-private zero-capacity phantom slot as bounded C2 follow-up debt, not scope to fold into this repair.
- Rollback is isolated to this commit; no migration, persisted-data change, rollout order, or manual production step is involved.

## Follow-Up / Post-Merge Checks
- Correct the stale migration-authority and C2-authorization wording in a separate audited documentation PR before resuming #392.
- Consider a shared paired value/definedness abstraction only under a separately accepted design; do not pre-empt M1 ownership moves here.
