### PR TITLE
chore(claude): connect Rust architecture rule

### DIFF
--- a/.claude/rules/rust-verifier.md
+++ b/.claude/rules/rust-verifier.md
@@ -2,20 +2,34 @@
 paths:
   - "rust/**/*.rs"
   - "rust/Cargo.toml"
+  - "rust/**/Cargo.toml"
   - "rust/Cargo.lock"
 ---
 
-# Native Rust verifier rules
+# Native Rust architecture rules
 
-- The Rust workspace is authoritative. Design a feature around the typed Rust boundaries rather than
-  porting Python implementation structure mechanically.
+- The Rust workspace is authoritative. Before changing it, read
+  [`DESIGN-rust-components.md`](../../docs/DESIGN-rust-components.md) and
+  [`DESIGN-rust-component-internals.md`](../../docs/DESIGN-rust-component-internals.md). They own
+  the accepted crate and in-crate responsibility boundaries; do not copy Python structure.
+- Preserve the owner map: `fsl-syntax` owns source fidelity; `fsl-core` owns checked models and
+  Public Kernel; `fsl-runtime` owns concrete Monitor/replay/BFS semantics; `fsl-solver` owns the
+  backend-neutral boundary; `fsl-solver-z3` and `fsl-solver-z3js` are native and browser adapters;
+  `fsl-verifier` owns symbolic engines; `fsl-tools` owns derived artifacts; and `fslc-rust`,
+  `fsl-wasm`, and `fsl-lsp` own native delivery, Worker delivery, and editor projection.
 - Keep dependency direction explicit: `fsl-runtime -> fsl-core -> fsl-syntax`, while
   `fsl-verifier -> fsl-solver` and `fsl-verifier -> fsl-core`.
 - `fsl-runtime` must not depend directly or transitively on solver or Z3 crates.
 - A semantic construct implemented symbolically must have matching concrete/explicit-state behavior.
   Add a negative case capable of exposing a false-green result.
+- Preserve raw-output modes as raw, JSON envelopes, exit codes, Public Kernel and replay contracts,
+  and native/Worker parity. Delivery adapters must not independently redefine semantic validity.
+- The accepted logical module tree is an ownership map, not permission for an eager rewrite. Every
+  source-changing C2 candidate requires its own issue and scope, an independently revertible change,
+  a positive oracle, and a negative control that rejects known contract drift.
+- Semantic and derived transforms receive filesystem data through explicit input or a resolver. The
+  existing `testgen::relative_spec_path` access is bounded debt owned by #423; do not copy it or add
+  another implicit filesystem dependency.
 - Preserve checked `i64` arithmetic and SMT-LIB Euclidean division/remainder behavior.
-- Preserve native/Worker envelope semantics and replay witnesses rather than comparing unstable solver
-  model bytes.
 - Run the smallest affected crate tests first, then formatting, Clippy, and wider workspace gates.
 - New Rust source files require `// SPDX-License-Identifier: Apache-2.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- Claude's path-scoped Rust rule now links the accepted component and internal
+  architecture, names all crate owners and hard delivery boundaries, rejects
+  eager or unscoped C2 rewrites, and has positive/negative loading controls for
+  Rust versus frozen-Python paths (#392).
 - Migration-era porting, Python bridge, and sequence design text now marks its
   historical authority explicitly and links to the maintained native Rust
   contracts. The Kernel contract now records native outcome priority, while

--- a/tests/test_claude_environment.py
+++ b/tests/test_claude_environment.py
@@ -2,6 +2,7 @@
 # Copyright 2026 Ryoichi Izumita
 """Contract tests for the checked-in Claude Code environment."""
 
+from fnmatch import fnmatchcase
 import json
 import os
 from pathlib import Path
@@ -47,6 +48,66 @@ def test_required_environment_files_exist() -> None:
         "hooks/session_context.py",
     ]
     assert all((CLAUDE / path).is_file() for path in required)
+
+
+def test_normal_entrypoint_triggers_rust_architecture_rule_for_rust_only() -> None:
+    entrypoint = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    assert entrypoint.startswith("@AGENTS.md\n")
+    assert (
+        "Inspect `git status --short` and the relevant implementation before editing."
+        in entrypoint
+    )
+
+    rule = (CLAUDE / "rules" / "rust-verifier.md").read_text(encoding="utf-8")
+    front_matter = rule.split("---", 2)[1]
+    patterns = [
+        line.removeprefix('- "').removesuffix('"')
+        for line in map(str.strip, front_matter.splitlines())
+        if line.startswith('- "')
+    ]
+
+    def applies_to(path: str) -> bool:
+        return any(fnmatchcase(path, pattern) for pattern in patterns)
+
+    assert applies_to("rust/fsl-runtime/src/lib.rs")
+    assert applies_to("rust/fslc/src/main.rs")
+    assert applies_to("rust/Cargo.toml")
+    assert applies_to("rust/fsl-runtime/Cargo.toml")
+    assert not applies_to("src/fslc/runtime.py")
+    assert not applies_to("pyproject.toml")
+    assert not applies_to("docs/DESIGN-rust-components.md")
+
+
+def test_rust_architecture_rule_carries_the_accepted_contract() -> None:
+    rule = (CLAUDE / "rules" / "rust-verifier.md").read_text(encoding="utf-8")
+    normalized_rule = " ".join(rule.split())
+    required_contracts = [
+        "DESIGN-rust-components.md",
+        "DESIGN-rust-component-internals.md",
+        "`fsl-syntax` owns source fidelity",
+        "`fsl-core` owns checked models and Public Kernel",
+        "`fsl-runtime` owns concrete Monitor/replay/BFS semantics",
+        "`fsl-solver` owns the backend-neutral boundary",
+        "`fsl-solver-z3` and `fsl-solver-z3js` are native and browser adapters",
+        "`fsl-verifier` owns symbolic engines",
+        "`fsl-tools` owns derived artifacts",
+        "`fslc-rust`, `fsl-wasm`, and `fsl-lsp` own native delivery, Worker delivery, and "
+        "editor projection",
+        "`fsl-runtime` must not depend directly or transitively on solver or Z3 crates",
+        "raw-output",
+        "JSON envelopes",
+        "exit codes",
+        "Public Kernel",
+        "replay contracts",
+        "native/Worker parity",
+        "not permission for an eager rewrite",
+        "source-changing C2",
+        "negative control",
+        "testgen::relative_spec_path",
+        "#423",
+        "implicit filesystem dependency",
+    ]
+    assert all(contract in normalized_rule for contract in required_contracts)
 
 
 def test_settings_use_project_root_and_protect_snapshot() -> None:


### PR DESCRIPTION
## Problem

The checked-in Claude Rust rule covered only part of the accepted architecture and did not mechanically prove that normal repository startup leads to the rule for Rust work while excluding the frozen Python reference. Crate-local manifest changes could also bypass the runtime/solver boundary guidance.

## Change

- Connect `.claude/rules/rust-verifier.md` to the accepted component and internal design records and name all eleven crate owners.
- Preserve runtime/solver independence, semantic agreement, raw output, JSON/exit, Kernel/replay, and native/Worker contracts.
- Make the logical module map explicitly non-authorizing: each source-changing C2 needs its own issue, reversible scope, positive oracle, and rejecting negative control.
- Keep `testgen::relative_spec_path` as #423 bounded debt and prohibit new implicit filesystem input.
- Add static positive/negative controls for the normal `CLAUDE.md` entrypoint, Rust source, workspace and crate manifests, and excluded Python/docs paths. Assert exact owner relationships so swapped ownership cannot pass.

## Local-optima audit

Ran `implementation-local-optima-audit` before PR creation using both the three-file delivery boundary and the twelve-month repository/M1 boundary. Extending the existing path rule was selected over always-on duplication, a second overlapping rule, or a live Claude hook/CLI framework. Independent review found and drove repairs for crate-local manifest coverage and an unordered-token false-green oracle; independent re-review found no remaining actionable issue. Residual future client/glob drift is low and bounded by the documented `paths` form plus representative positive/negative cases.

## Verification

- `python3 -m pytest tests/test_claude_environment.py -q` — 12 passed
- `git diff --check` — passed
- `./tools/check-native-integration.sh` — passed, including Rust format/Clippy/tests/build, dependency checks, browser probes, and 351 native/Worker parity cases

Closes #392