### PR TITLE
refactor(tools): centralize Domain naming transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- The duplicated Domain naming transform now has one private neutral owner used
+  by analysis, Kernel grounding, and code generation, with mixed-case, digit,
+  consecutive-underscore, and one-sided divergence controls (#419).
 - Claude's path-scoped Rust rule now links the accepted component and internal
   architecture, names all crate owners and hard delivery boundaries, rejects
   eager or unscoped C2 rewrites, and has positive/negative loading controls for

--- a/rust/fsl-tools/src/domain.rs
+++ b/rust/fsl-tools/src/domain.rs
@@ -3,16 +3,8 @@
 use fsl_syntax::{DomainEffect, DomainSpec, SyntaxExpr};
 use serde_json::{Value, json};
 
-fn snake(value: &str) -> String {
-    let mut out = String::new();
-    for (i, c) in value.chars().enumerate() {
-        if c.is_ascii_uppercase() && i > 0 {
-            out.push('_');
-        }
-        out.push(c.to_ascii_lowercase());
-    }
-    out
-}
+use crate::domain_naming::snake;
+
 fn assumptions(domain: &DomainSpec) -> Vec<Value> {
     let mut values = vec![
         json!({"id":"DOMAIN-ASSUME-FINITE-DOMAIN-MODEL","text":"domain IDs and undeclared scalar input types are modeled as finite 0..1 ranges unless declared explicitly"}),

--- a/rust/fsl-tools/src/domain_codegen.rs
+++ b/rust/fsl-tools/src/domain_codegen.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::domain_naming::snake;
 use crate::public_kernel::{public_kernel_v1_root, required_array, required_object, required_str};
 
 pub(crate) const METADATA_SCHEMA_ID: &str =
@@ -385,17 +386,6 @@ pub(crate) fn generate(
         )])),
         _ => Err(format!("unsupported domain generation target: {target}")),
     }
-}
-
-fn snake(name: &str) -> String {
-    let mut output = String::new();
-    for (index, character) in name.chars().enumerate() {
-        if index > 0 && character.is_ascii_uppercase() {
-            output.push('_');
-        }
-        output.push(character.to_ascii_lowercase());
-    }
-    output
 }
 
 fn generate_python(domain: &DomainScaffoldMetadata) -> String {
@@ -1293,6 +1283,58 @@ mod tests {
         assert_eq!(
             generate(&kernel, &metadata, "typescript").expect_err("reject missing action"),
             "public Kernel is missing lowered domain action 'order_approve'"
+        );
+    }
+
+    #[test]
+    fn shared_naming_keeps_analysis_and_codegen_grounding_aligned() {
+        let source = r"
+domain Naming {
+  type Id = 0..0
+  type Status = New | Approved
+  aggregate Order2__Item {
+    id Id
+    state { status: Status = New; }
+    command Approve2__Now {}
+    event Approved2__Now {}
+    decide Approve2__Now { emits Approved2__Now }
+    evolve Approved2__Now { status = Approved }
+  }
+}
+";
+        let SurfaceDocument::Domain(domain) =
+            parse_surface_document(source).expect("parse naming fixture")
+        else {
+            panic!("expected domain fixture");
+        };
+        let kernel = parse_kernel_source(source, &FsResolver::new(Path::new(".")))
+            .expect("lower naming fixture");
+        let model = build_model(kernel.clone()).expect("check naming fixture");
+        let public = public_kernel_contract(&kernel, &model, "naming.fsl", "domain")
+            .expect("export naming fixture");
+        let metadata = crate::domain::domain_scaffold_metadata(&domain);
+        let expected_action = "order2___item_approve2___now";
+
+        let checked = crate::domain::check_domain(&domain, &public).expect("check domain");
+        assert_eq!(
+            checked["generated_actions"],
+            serde_json::json!([expected_action])
+        );
+
+        let generated = generate(&public, &metadata, "python").expect("generate scaffold");
+        assert!(generated["domain_scaffold.py"].contains("def decide_order2___item"));
+
+        let mut divergent = public;
+        let action = divergent["actions"]
+            .as_array_mut()
+            .expect("actions")
+            .iter_mut()
+            .find(|action| action["name"] == expected_action)
+            .expect("expected action");
+        action["name"] = Value::String("order2__item_approve2__now".to_owned());
+        assert_eq!(
+            generate(&divergent, &metadata, "python").expect_err("reject naming divergence"),
+            "public Kernel is missing lowered domain action 'order2___item_approve2___now'"
         );
     }
 

--- a/rust/fsl-tools/src/domain_naming.rs
+++ b/rust/fsl-tools/src/domain_naming.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared naming transforms for Domain-family projections and generators.
+
+pub(crate) fn snake(value: &str) -> String {
+    let mut output = String::new();
+    for (index, character) in value.chars().enumerate() {
+        if index > 0 && character.is_ascii_uppercase() {
+            output.push('_');
+        }
+        output.push(character.to_ascii_lowercase());
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::snake;
+
+    #[test]
+    fn preserves_uppercase_digit_and_consecutive_underscore_behavior() {
+        assert_eq!(snake("Order2__Item"), "order2___item");
+        assert_eq!(snake("HTTP2__API"), "h_t_t_p2___a_p_i");
+    }
+}

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -27,6 +27,7 @@ mod document_render;
 mod document_render_expr;
 mod domain;
 mod domain_codegen;
+mod domain_naming;
 mod html;
 mod ledger;
 mod mutate;


### PR DESCRIPTION
## Problem

Domain analysis and Domain code generation each owned an identical private `snake` transform. A one-sided edit could silently split generated action identities from Kernel grounding and emitted scaffold names.

Closes #419.

## Contract change

- Move the existing transform unchanged into one private neutral Domain-family module.
- Route analysis, Kernel grounding, and code generation through that owner.
- Add exact mixed-case/digit/consecutive-underscore coverage and a negative control that corrupts one lowered Kernel action and requires grounding to reject it.
- Preserve the public `fsl_tools` facade, all five target names, schemas, output bytes, and the intentionally distinct acronym-aware core lowering rule.

## Local-optima audit

The pre-change duplicate-owner pattern scored 9/15 (`E2 A2 F2 K2 T1`, confidence C3): local convenience externalized one-sided drift into downstream generated contracts. Assigning ownership to either caller would invert a sibling dependency, while a generic naming utility would falsely merge this rule with core lowering. The selected private neutral sibling removes the second policy owner without expanding the public boundary. Residual bypass risk is 2/15 (confidence C2) and is covered at observable boundaries by the rejecting control and existing byte digests.

Independent review found no regressions or missed sibling paths.

## Verification

- `cargo test --manifest-path rust/Cargo.toml -p fsl-tools --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test domain_codegen_contract --locked`
- `./tools/check-native-integration.sh rust`
- `git diff --check`
- source inventory confirms exactly one tools Domain `snake` implementation and both callers import it

The full native entrypoint passed both local WASM probes twice, but `test-browser.mjs` stalled under the installed Google Chrome CDP and was interrupted rather than reported as passing. The GitHub browser/WASM check is therefore a mandatory merge condition.
