### PR TITLE
refactor(verifier): centralize shared liveness and trace helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- BMC and induction now share neutral private liveness and trace-projection
+  owners, preserving verdicts, evidence, trace output, and solver boundaries
+  (#421).
 - Checked-model type validation now has one private neutral `fsl-core` owner
   shared by model construction, refinement, and Public Kernel export, with
   unchanged Kernel schemas, ordering, diagnostics, and fail-closed controls

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -2,20 +2,19 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use fsl_core::{
-    FslValue, KernelBinder, KernelModel, LeadsToDef, TraceAction, TraceChange, TraceStep,
-    static_leadsto_bindings,
-};
-use fsl_solver::{ModelValue, SatResult, SmtSolver};
+use fsl_core::{FslValue, KernelModel, LeadsToDef, TraceStep};
+use fsl_solver::{SatResult, SmtSolver};
 
 use crate::VerifyError;
-use crate::eval::{binder_values, eval};
+use crate::eval::eval;
+use crate::liveness::{LeadstoBinding, leadsto_bindings, leadsto_condition};
+use crate::trace::project_trace;
 use crate::transition::{
     ActionInstance, action_guards, action_instances, init_constraints, transition_constraint,
 };
 use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, concrete_value, i64_index, logical_equal,
-    project_state, project_value, symbolic_state,
+    symbolic_state,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -558,135 +557,6 @@ async fn build_witness<S: SmtSolver>(
     let popped = solver.pop(1);
     popped?;
     projected
-}
-
-pub(crate) fn project_trace<S: SmtSolver>(
-    solver: &S,
-    model: &KernelModel,
-    states: &[SymbolicState<S::Term>],
-    choices: &[S::Term],
-    instances: &[ActionInstance<S::Term>],
-    upto: usize,
-) -> Result<Vec<TraceStep>, VerifyError> {
-    let mut trace = Vec::new();
-    for step in 0..=upto {
-        let state = project_state(solver, model, &states[step])?;
-        let action = if step == 0 {
-            None
-        } else {
-            Some(project_action(
-                solver,
-                model,
-                &choices[step - 1],
-                instances,
-            )?)
-        };
-        let changes = trace
-            .last()
-            .map_or_else(BTreeMap::new, |previous: &TraceStep| {
-                state
-                    .iter()
-                    .filter_map(|(name, value)| {
-                        let before = &previous.state[name];
-                        (before != value).then(|| {
-                            (
-                                name.clone(),
-                                TraceChange {
-                                    from: before.clone(),
-                                    to: value.clone(),
-                                },
-                            )
-                        })
-                    })
-                    .collect()
-            });
-        trace.push(TraceStep {
-            step,
-            state,
-            action,
-            changes,
-        });
-    }
-    Ok(trace)
-}
-
-fn project_action<S: SmtSolver>(
-    solver: &S,
-    model: &KernelModel,
-    choice: &S::Term,
-    instances: &[ActionInstance<S::Term>],
-) -> Result<TraceAction, VerifyError> {
-    let index = match solver.model_eval(choice)? {
-        Some(ModelValue::Int(value)) => usize::try_from(value)
-            .map_err(|_| VerifyError::new("negative action choice in model"))?,
-        Some(ModelValue::Bool(_)) => {
-            return Err(VerifyError::new("Boolean action choice in model"));
-        }
-        None => return Err(VerifyError::new("action choice is unavailable in model")),
-    };
-    let instance = instances
-        .get(index)
-        .ok_or_else(|| VerifyError::new("action choice outside instance range"))?;
-    Ok(TraceAction {
-        name: instance.action.clone(),
-        params: instance
-            .params
-            .iter()
-            .map(|(name, value)| Ok((name.clone(), project_value(solver, model, value)?)))
-            .collect::<Result<BTreeMap<String, FslValue>, VerifyError>>()?,
-    })
-}
-
-#[derive(Clone)]
-pub(crate) struct LeadstoBinding<T> {
-    pub concrete: BTreeMap<String, FslValue>,
-    pub symbolic: Bindings<T>,
-}
-
-pub(crate) fn leadsto_bindings<S: SmtSolver>(
-    solver: &S,
-    model: &KernelModel,
-    property: &LeadsToDef,
-) -> Result<Vec<LeadstoBinding<S::Term>>, VerifyError> {
-    let mut expanded = vec![Bindings::new()];
-    for binder in &property.binders {
-        let symbolic = binder_values(solver, model, binder)?;
-        let name = match binder {
-            KernelBinder::Typed { name, .. }
-            | KernelBinder::Range { name, .. }
-            | KernelBinder::Collection { name, .. } => name,
-        };
-        let mut next = Vec::new();
-        for binding in expanded {
-            for (_, term) in &symbolic {
-                let mut candidate = binding.clone();
-                candidate.insert(name.clone(), term.clone());
-                next.push(candidate);
-            }
-        }
-        expanded = next;
-    }
-    let concrete = static_leadsto_bindings(model, property)?;
-    if concrete.len() != expanded.len() {
-        return Err(VerifyError::new("leadsTo binder expansion mismatch"));
-    }
-    Ok(concrete
-        .into_iter()
-        .zip(expanded)
-        .map(|(concrete, symbolic)| LeadstoBinding { concrete, symbolic })
-        .collect())
-}
-
-pub(crate) fn leadsto_condition<S: SmtSolver>(
-    solver: &S,
-    model: &KernelModel,
-    expr: &fsl_core::KernelExpr,
-    state: &SymbolicState<S::Term>,
-    binding: &Bindings<S::Term>,
-) -> Result<S::Term, VerifyError> {
-    let mut binding = binding.clone();
-    let value = eval(solver, model, expr, state, &mut binding, None)?;
-    Ok(bool_term(&value)?.clone())
 }
 
 fn states_equal<S: SmtSolver>(

--- a/rust/fsl-verifier/src/induction.rs
+++ b/rust/fsl-verifier/src/induction.rs
@@ -6,8 +6,9 @@ use fsl_core::{FslValue, KernelModel, TypeDef, TypeRef};
 use fsl_solver::{ModelValue, SatResult, SmtSolver};
 
 use crate::VerifyError;
-use crate::bmc::{leadsto_bindings, leadsto_condition, project_trace};
 use crate::eval::eval;
+use crate::liveness::{leadsto_bindings, leadsto_condition};
+use crate::trace::project_trace;
 use crate::transition::{action_instances, transition_constraint};
 use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, i64_index, int_term, symbolic_state_with_suffix,

--- a/rust/fsl-verifier/src/lib.rs
+++ b/rust/fsl-verifier/src/lib.rs
@@ -6,7 +6,9 @@ mod agreement;
 mod bmc;
 mod eval;
 mod induction;
+mod liveness;
 mod refinement;
+mod trace;
 mod transition;
 mod value;
 

--- a/rust/fsl-verifier/src/liveness.rs
+++ b/rust/fsl-verifier/src/liveness.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared symbolic liveness constraints for verifier engines.
+
+use std::collections::BTreeMap;
+
+use fsl_core::{FslValue, KernelBinder, KernelModel, LeadsToDef, static_leadsto_bindings};
+use fsl_solver::SmtSolver;
+
+use crate::VerifyError;
+use crate::eval::{binder_values, eval};
+use crate::value::{Bindings, SymbolicState, bool_term};
+
+#[derive(Clone)]
+pub(crate) struct LeadstoBinding<T> {
+    pub(crate) concrete: BTreeMap<String, FslValue>,
+    pub(crate) symbolic: Bindings<T>,
+}
+
+pub(crate) fn leadsto_bindings<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    property: &LeadsToDef,
+) -> Result<Vec<LeadstoBinding<S::Term>>, VerifyError> {
+    let mut expanded = vec![Bindings::new()];
+    for binder in &property.binders {
+        let symbolic = binder_values(solver, model, binder)?;
+        let name = match binder {
+            KernelBinder::Typed { name, .. }
+            | KernelBinder::Range { name, .. }
+            | KernelBinder::Collection { name, .. } => name,
+        };
+        let mut next = Vec::new();
+        for binding in expanded {
+            for (_, term) in &symbolic {
+                let mut candidate = binding.clone();
+                candidate.insert(name.clone(), term.clone());
+                next.push(candidate);
+            }
+        }
+        expanded = next;
+    }
+    let concrete = static_leadsto_bindings(model, property)?;
+    if concrete.len() != expanded.len() {
+        return Err(VerifyError::new("leadsTo binder expansion mismatch"));
+    }
+    Ok(concrete
+        .into_iter()
+        .zip(expanded)
+        .map(|(concrete, symbolic)| LeadstoBinding { concrete, symbolic })
+        .collect())
+}
+
+pub(crate) fn leadsto_condition<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expr: &fsl_core::KernelExpr,
+    state: &SymbolicState<S::Term>,
+    binding: &Bindings<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    let mut binding = binding.clone();
+    let value = eval(solver, model, expr, state, &mut binding, None)?;
+    Ok(bool_term(&value)?.clone())
+}

--- a/rust/fsl-verifier/src/trace.rs
+++ b/rust/fsl-verifier/src/trace.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared symbolic trace projection for verifier engines.
+
+use std::collections::BTreeMap;
+
+use fsl_core::{FslValue, KernelModel, TraceAction, TraceChange, TraceStep};
+use fsl_solver::{ModelValue, SmtSolver};
+
+use crate::VerifyError;
+use crate::transition::ActionInstance;
+use crate::value::{SymbolicState, project_state, project_value};
+
+pub(crate) fn project_trace<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    states: &[SymbolicState<S::Term>],
+    choices: &[S::Term],
+    instances: &[ActionInstance<S::Term>],
+    upto: usize,
+) -> Result<Vec<TraceStep>, VerifyError> {
+    let mut trace = Vec::new();
+    for step in 0..=upto {
+        let state = project_state(solver, model, &states[step])?;
+        let action = if step == 0 {
+            None
+        } else {
+            Some(project_action(
+                solver,
+                model,
+                &choices[step - 1],
+                instances,
+            )?)
+        };
+        let changes = trace
+            .last()
+            .map_or_else(BTreeMap::new, |previous: &TraceStep| {
+                state
+                    .iter()
+                    .filter_map(|(name, value)| {
+                        let before = &previous.state[name];
+                        (before != value).then(|| {
+                            (
+                                name.clone(),
+                                TraceChange {
+                                    from: before.clone(),
+                                    to: value.clone(),
+                                },
+                            )
+                        })
+                    })
+                    .collect()
+            });
+        trace.push(TraceStep {
+            step,
+            state,
+            action,
+            changes,
+        });
+    }
+    Ok(trace)
+}
+
+fn project_action<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    choice: &S::Term,
+    instances: &[ActionInstance<S::Term>],
+) -> Result<TraceAction, VerifyError> {
+    let index = match solver.model_eval(choice)? {
+        Some(ModelValue::Int(value)) => usize::try_from(value)
+            .map_err(|_| VerifyError::new("negative action choice in model"))?,
+        Some(ModelValue::Bool(_)) => {
+            return Err(VerifyError::new("Boolean action choice in model"));
+        }
+        None => return Err(VerifyError::new("action choice is unavailable in model")),
+    };
+    let instance = instances
+        .get(index)
+        .ok_or_else(|| VerifyError::new("action choice outside instance range"))?;
+    Ok(TraceAction {
+        name: instance.action.clone(),
+        params: instance
+            .params
+            .iter()
+            .map(|(name, value)| Ok((name.clone(), project_value(solver, model, value)?)))
+            .collect::<Result<BTreeMap<String, FslValue>, VerifyError>>()?,
+    })
+}

--- a/rust/fsl-verifier/tests/leadsto_within_deadline.rs
+++ b/rust/fsl-verifier/tests/leadsto_within_deadline.rs
@@ -94,10 +94,10 @@ fn within_deadline_met_stays_verified_beyond_the_deadlock_step() {
 }
 
 #[test]
-fn bounded_leadsto_where_filters_fail_closed_in_bmc() {
+fn bounded_and_ranked_leadsto_where_filters_fail_closed_through_one_owner() {
     let source = LATE_Q.replace(
         "leadsTo Progress { x == 1 ~> within 1 x == 3 }",
-        "leadsTo Progress { forall i: Count where i > 0 { x == 1 ~> within 1 x == 3 } }",
+        "leadsTo Progress { forall i: Count where i > 0 { x == 1 ~> within 1 x == 3 } decreases 3 - x }",
     );
     let kernel =
         parse_kernel_source(&source, &FsResolver::new(std::env::temp_dir())).expect("parse");
@@ -106,4 +106,9 @@ fn bounded_leadsto_where_filters_fail_closed_in_bmc() {
     let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
         .expect_err("where filters must fail closed");
     assert!(error.message.contains("where filters"), "{error}");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create ranked solver");
+    let ranked_error = block_on(fsl_verifier::prove_ranked_leadstos(&model, &mut solver))
+        .expect_err("ranked where filters must fail closed through the same owner");
+    assert_eq!(ranked_error.message, error.message);
 }


### PR DESCRIPTION
## Summary

- Move liveness binding/condition helpers and symbolic trace projection out of the BMC engine into focused private neutral owners.
- Remove the production `induction -> bmc` dependency while preserving verifier semantics, evidence, traces, and solver boundaries.
- Keep the public crate facade and all CLI/Worker output contracts unchanged.

Closes #421.

## Changes

- Add private `liveness` ownership for `LeadstoBinding`, binder expansion, and P/Q condition evaluation.
- Add private `trace` ownership for state/action/change projection, including the subordinate action projector.
- Route both BMC and induction through those owners without changing helper bodies, ordering, query context, or error strings.
- Extend the filtered-binder negative control so the same deadline/ranked property must fail through both BMC and ranked induction with an identical diagnostic.

## Verification

- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-verifier --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml -p fsl-verifier --locked` (28 integration tests)
- Focused CLI BMC/induction, stagnation, deadline, and replay suites (42 tests)
- Existing altered-successor and corrupt-failed-evidence controls (18 transition-agreement tests)
- `git diff --check`
- Independent final review: no actionable findings.
- `./tools/check-native-integration.sh`: Rust/workspace lint, tests, build, native integration, Node/WASM probe, and browser probe passed. The final local `test:browser` runner remained alive but idle at 0% CPU for Node, esbuild, and Chrome after about twelve minutes, so only that wait was interrupted and is not represented as a fully passing local gate.

## Risk / Review Notes

- The accepted design assigns separate neutral liveness and trace responsibilities. A single generic support module was rejected because it would couple independent dependency closures and invite unrelated engine policy.
- `static_leadsto_bindings` remains in `fsl-core` as the solver-independent authority shared with the runtime monitor.
- No public API, schema, dependency, solver relation, migration, persisted data, CLI flag, or rollout change is intended.
- The local-optima audit scored the original BMC-owned shared policy at 9/15 externalization; the selected focused owners leave only a 2/15 private-module navigation cost and no blocker.

## Follow-Up / Post-Merge Checks

- Require the PR WASM/browser check to pass, covering the local browser runner limitation.
