### PR TITLE
refactor(tools): centralize requirements document locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- Requirements-document locale parsing and selection now has one private
+  neutral presentation owner shared by rendering, markers, glossary, and
+  document checking, while preserving the `fsl_tools::Locale` facade and
+  generated output bytes (#422).
 - BMC and induction now share neutral private liveness and trace-projection
   owners, preserving verdicts, evidence, trace output, and solver boundaries
   (#421).

--- a/rust/fsl-tools/src/document_check.rs
+++ b/rust/fsl-tools/src/document_check.rs
@@ -17,7 +17,7 @@ use crate::document_markers::{
     DOCUMENT_RENDERER, DOCUMENT_RENDERER_VERSION, DOCUMENT_SCHEMA, MarkerIssue, NORMATIVE_SCOPE,
     SLOT_NAMES, Segment, parse_body, parse_frontmatter,
 };
-use crate::document_render::Locale;
+use crate::document_presentation::Locale;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct DriftReason {

--- a/rust/fsl-tools/src/document_glossary.rs
+++ b/rust/fsl-tools/src/document_glossary.rs
@@ -19,7 +19,7 @@ use fsl_core::{FslValue, KernelModel};
 use serde::Deserialize;
 use serde::de::{Deserializer, MapAccess, Visitor};
 
-use crate::document_render::Locale;
+use crate::document_presentation::Locale;
 
 pub const GLOSSARY_SCHEMA: &str = "fslc.document-glossary.v1";
 

--- a/rust/fsl-tools/src/document_markers.rs
+++ b/rust/fsl-tools/src/document_markers.rs
@@ -13,7 +13,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::document_render::Locale;
+use crate::document_presentation::Locale;
 
 /// Versions the *artifact format* (frontmatter key set + marker grammar) —
 /// distinct from `RCIR_SCHEMA_VERSION`, which versions the claims JSON, not

--- a/rust/fsl-tools/src/document_presentation.rs
+++ b/rust/fsl-tools/src/document_presentation.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared presentation values for requirements-document generation and checking.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Locale {
+    Ja,
+    En,
+}
+
+impl Locale {
+    /// The short code recorded in a generated document's `lang` frontmatter
+    /// key (issue #329) and accepted by `fslc document generate --lang`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ja => "ja",
+            Self::En => "en",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "ja" => Some(Self::Ja),
+            "en" => Some(Self::En),
+            _ => None,
+        }
+    }
+}

--- a/rust/fsl-tools/src/document_render.rs
+++ b/rust/fsl-tools/src/document_render.rs
@@ -28,35 +28,9 @@ use serde_json::Value;
 use crate::document::{Claim, ClaimKind, RequirementClaimSet};
 use crate::document_evidence::{AppliedEvidence, requirement_assurance};
 use crate::document_glossary::AppliedGlossary;
+use crate::document_presentation::Locale;
 use crate::document_project::project_renderer_contract;
 use crate::document_render_expr;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Locale {
-    Ja,
-    En,
-}
-
-impl Locale {
-    /// The short code recorded in a generated document's `lang` frontmatter
-    /// key (issue #329) and accepted by `fslc document generate --lang`.
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Ja => "ja",
-            Self::En => "en",
-        }
-    }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "ja" => Some(Self::Ja),
-            "en" => Some(Self::En),
-            _ => None,
-        }
-    }
-}
 
 #[derive(Debug)]
 pub struct RenderedDocument {

--- a/rust/fsl-tools/src/document_render_expr.rs
+++ b/rust/fsl-tools/src/document_render_expr.rs
@@ -21,7 +21,7 @@ use fsl_core::{
     Pattern, source_binder_text,
 };
 
-use crate::document_render::Locale;
+use crate::document_presentation::Locale;
 
 /// Longest canonical code-span text allowed inside a natural-language atom
 /// before the whole enclosing proposition falls back (issue #326 §4.0).

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -22,6 +22,7 @@ mod document_digest;
 mod document_evidence;
 mod document_glossary;
 mod document_markers;
+mod document_presentation;
 mod document_project;
 mod document_render;
 mod document_render_expr;
@@ -91,12 +92,13 @@ pub use document_markers::{
     NORMATIVE_SCOPE, ParsedDocument, SLOT_NAMES, Segment, parse_frontmatter_only,
     parse_generated_document,
 };
+pub use document_presentation::Locale;
 pub use document_project::{
     DocumentDialect, DocumentInput, DocumentProjectionError, RCIR_SUPPORTED_DIALECTS,
     project_requirement_claims, project_requirement_claims_from_source,
 };
 pub use document_render::{
-    AppliedApproval, AppliedApprovals, Locale, RenderedDocument, render_requirements_document,
+    AppliedApproval, AppliedApprovals, RenderedDocument, render_requirements_document,
 };
 pub use domain::{
     analyze_domain, check_domain, domain_adapter_files, domain_kernel_source, domain_scaffold,

--- a/rust/fsl-tools/tests/document_render.rs
+++ b/rust/fsl-tools/tests/document_render.rs
@@ -248,18 +248,20 @@ fn renderer_rejects_a_state_rule_reclassified_as_a_deadline() {
         fsl_core::parse_kernel_source(&fixture.source, &fsl_core::FsResolver::new(&fixture.root))
             .expect("parse model");
     let model = fsl_core::build_model(kernel.clone()).expect("build model");
-    let error = fsl_tools::render_requirements_document(
-        &claims,
-        &kernel,
-        &model,
-        &fixture.source,
-        Locale::En,
-        None,
-        None,
-        None,
-    )
-    .expect_err("mismatched claim kind must fail closed");
-    assert!(error.contains("does not match the paired"));
+    for locale in [Locale::Ja, Locale::En] {
+        let error = fsl_tools::render_requirements_document(
+            &claims,
+            &kernel,
+            &model,
+            &fixture.source,
+            locale,
+            None,
+            None,
+            None,
+        )
+        .expect_err("mismatched claim kind must fail closed independently of presentation locale");
+        assert!(error.contains("does not match the paired"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`Locale` was owned by `document_render`, forcing document checking, glossary parsing, marker
generation, and expression rendering to depend upward on the terminal renderer merely to carry a
shared presentation input.

## Contract change

- Move `Locale` and its unchanged `as_str`/`parse` behavior to one private neutral
  `document_presentation` owner.
- Preserve the existing `fsl_tools::Locale` root re-export, variants, accepted spellings, Markdown,
  frontmatter, marker, glossary, check, JSON, and CLI contracts.
- Keep renderer-owned result/approval values and ledger assurance classification in their existing
  semantic owners.

## Changes

- Add the focused private `document_presentation` module.
- Route renderer, expression rendering, markers, glossary, and document check through that owner.
- Strengthen the RCIR semantic-role mutation control so the same invalid role is rejected under
  both Japanese and English presentation locales.
- Record the ownership correction in the changelog.

## Verification

- `cargo test --manifest-path rust/Cargo.toml -p fsl-tools --locked --test document_render --test document_markers --test document_glossary --test document_evidence --test document_approval` — 79 passed.
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked --test document_cli --test document_check_cli --test document_glossary_cli --test document_evidence_cli --test document_approval_cli` — 67 passed.
- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-tools --all-targets --locked -- -D warnings` — passed.
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — passed.
- `git diff --check` — passed.
- `./tools/check-native-integration.sh` — passed, including final browser parity with 351 cases.

## Local-optima audit

Deep-dive C2 audit classified the old renderer-owned shared input as externalization, 8/15
(`E2 A2 F1 K2 T1`, C2). Leave-in-place, forwarding-alias, generic shared-module, and focused-owner
counterfactuals were compared. The focused private presentation owner was selected because it moves
the complete five-consumer closure without adding a dependency, wrapper, trait, service, schema,
state, or copied policy. Residual navigation cost is harmless locality, 2/15
(`E0 A1 F0 K0 T1`, C2); no audit blocker remains.

## Review

Independent final review found no actionable issues and confirmed the complete move, root API
compatibility, unchanged assurance ownership, and the dual-locale semantic-role negative control.

Closes #422
