### PR TITLE
refactor(tools): make testgen path context explicit

### DIFF
--- a/.claude/rules/rust-verifier.md
+++ b/.claude/rules/rust-verifier.md
@@ -27,9 +27,9 @@ paths:
 - The accepted logical module tree is an ownership map, not permission for an eager rewrite. Every
   source-changing C2 candidate requires its own issue and scope, an independently revertible change,
   a positive oracle, and a negative control that rejects known contract drift.
-- Semantic and derived transforms receive filesystem data through explicit input or a resolver. The
-  existing `testgen::relative_spec_path` access is bounded debt owned by #423; do not copy it or add
-  another implicit filesystem dependency.
+- Semantic and derived transforms receive filesystem data through explicit input or a resolver.
+  `fslc-rust` owns the explicit testgen path context resolved by #423;
+  `testgen::relative_spec_path` must remain a filesystem- and CWD-free lexical projection.
 - Preserve checked `i64` arithmetic and SMT-LIB Euclidean division/remainder behavior.
 - Run the smallest affected crate tests first, then formatting, Clippy, and wider workspace gates.
 - New Rust source files require `// SPDX-License-Identifier: Apache-2.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- Test generation now receives an explicit delivery-normalized path context,
+  removing filesystem and CWD observation from the pure generator while
+  preserving existing, missing, and symlinked pytest paths and every other
+  target's output bytes (#423).
 - Requirements-document locale parsing and selection now has one private
   neutral presentation owner shared by rendering, markers, glossary, and
   document checking, while preserving the `fsl_tools::Locale` facade and

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -81,7 +81,7 @@ inference), and E0 (assumption).
 | E-06 | E2 | Runtime rollback, explicit search, symbolic agreement, Public Kernel, document rendering, CLI, browser parity, and LSP tests contain rejecting cases. | Supplies existing fitness functions. |
 | E-07 | E3 | Focused syntax/core/runtime/solver/native-Z3/verifier tests passed 219 tests, and `cargo check -p fsl-solver-z3js --locked` passed at the baseline. | Confirms the semantic internals used as design evidence are reproducible. |
 | E-08 | E0 | Production load, third-party Rust API use, team ownership, and future feature frequency. | Limits eager restructuring and API-removal claims. |
-| E-09 | E2 | `fmt`, readable explain, and TypeScript modes emit raw output; the accepted port contract requires raw modes to remain raw. `testgen::relative_spec_path` directly canonicalizes paths. | Bounds the CLI output design and records the existing tool-I/O exception. |
+| E-09 | E2 | `fmt`, readable explain, and TypeScript modes emit raw output; the accepted port contract requires raw modes to remain raw. Test generation receives one delivery-normalized path context, and `testgen::relative_spec_path` is a lexical projection. | Bounds the CLI output design and records the resolved testgen I/O boundary. |
 
 Scoped classifications are:
 
@@ -96,9 +96,8 @@ Scoped classifications are:
 - **accidental:** current filenames, flat versus nested modules, private helper placement,
   root-module implementation bodies, and per-call accumulator shapes;
 - **defect:** checked type validation owned by `public_kernel`, shared induction policy owned by
-  `bmc`, document locale owned by its renderer, duplicated domain `snake` transforms, the native
-  verification module's glob dependency on its parent, and test-generation path normalization
-  performed inside the derived transform;
+  `bmc`, document locale owned by its renderer, duplicated domain `snake` transforms, and the native
+  verification module's glob dependency on its parent;
 - **unknown:** external use of the public legacy runtime BFS and compatibility binaries, operational
   importance of those paths, and whether current change clusters will persist.
 
@@ -135,9 +134,9 @@ implementations or state ownership require one.
 Parsers, lowerers, engines, and tool families return their native error/result type. The CLI,
 Worker, or LSP converts that result once at its boundary. Filesystem access is either an explicit
 delivery operation, a named resolver, or a declared path-presentation adapter; writes never occur
-inside semantic or derived-artifact transforms. `testgen::relative_spec_path` is the current bounded
-exception that canonicalizes paths inside a transform. No sibling tool may copy that pattern, and
-its caller must supply normalized path context before test-generation path semantics are changed.
+inside semantic or derived-artifact transforms. `fslc-rust` constructs test generation's explicit
+normalized path context, including independent spec and output-parent canonicalization/fallback;
+`testgen::relative_spec_path` remains a filesystem- and CWD-free lexical projection.
 
 Move-only refactors must retain both a successful oracle and a rejecting oracle. A successful build
 or unchanged positive snapshot alone does not establish semantic preservation.
@@ -302,12 +301,11 @@ builders/contexts are per-call accumulators. No family owns process lifecycle or
   names in both paths.
 - Retain the fail-closed `public_kernel` adapter shared by typestate, test generation, and Domain
   code generation. Do not merge those distinct tools merely because they share input validation.
-- Treat `testgen::relative_spec_path` as a bounded I/O debt. A candidate triggered by its next path
-  behavior change would move canonicalization to the caller and pass normalized path context into
-  the pure generator, preserving generated pytest output and embedded paths byte-for-byte for
-  existing, missing, and symlinked path inputs.
+- **Resolved C2 slice (#423):** `fslc-rust` owns test-generation path canonicalization and passes an
+  explicit normalized path context into the pure generator. Preserve generated pytest output and
+  embedded paths byte-for-byte for existing, missing, and symlinked path inputs.
 - **Candidate inventory (not authorization):** the future structural candidates are the locale
-  owner, duplicated Domain naming helper, and test-generation path input. Decide and verify each
+  owner and duplicated Domain naming helper. Decide and verify each
   independently under its own issue, accepted scope/design, positive and rejecting oracle,
   pre-PR audit, and independently revertible pull request. Do not replace the flat root API or
   create subcrates; family directories are optional presentation after the dependency graph is
@@ -419,8 +417,9 @@ revertible slices in this order of evidence, not as one pre-authorized migration
 1. **Exact duplication:** consolidate the Domain naming transform.
 2. **Neutral-policy slices:** move core checked-type validation, verifier liveness/trace helpers, or
    document locale ownership one at a time. Preserve root re-exports and accepted feature contracts.
-3. **Path-input slice:** move test-generation canonicalization to the delivery caller and preserve
-   generated pytest output and paths byte-for-byte for existing, missing, and symlinked inputs.
+3. **Path-input slice (completed by #423):** test-generation canonicalization is owned by the
+   delivery caller; generated pytest output and paths remain byte-identical for existing, missing,
+   and symlinked inputs.
 4. **Dependency slice:** replace `fslc/src/verification.rs`'s parent glob with explicit imports and
    remove forwarding/duplicate policy only after proving identical callers.
 5. **CLI experiment:** extract the causal command family without changing arguments, JSON envelopes,

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -109,7 +109,8 @@ pub use ledger::{render_ledger, render_ledger_with_approvals};
 pub use mutate::{BuiltinMutant, enumerate_builtin_mutants};
 pub use refinement_analysis::analyze_refinement;
 pub use testgen::{
-    TestgenInput, compose_testgen_input, generate_testgen, public_kernel_testgen_input,
+    TestgenInput, TestgenPathContext, compose_testgen_input, generate_testgen,
+    public_kernel_testgen_input,
 };
 pub use typestate::analyze_typestate;
 pub use undecided::{UndecidedRecord, undecided_declarations, undecided_records};

--- a/rust/fsl-tools/src/testgen.rs
+++ b/rust/fsl-tools/src/testgen.rs
@@ -20,13 +20,67 @@ struct TestgenAction {
     params: Vec<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TestgenOutputContext {
+    WithoutOutput,
+    WithOutput { parent: Option<PathBuf> },
+}
+
+/// Explicit, delivery-normalized path input for generated test presentation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TestgenPathContext {
+    source_name: String,
+    spec_path: PathBuf,
+    output: TestgenOutputContext,
+}
+
+impl TestgenPathContext {
+    /// Build context for content returned without an output file.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a raw source path without a UTF-8 file name.
+    pub fn without_output(source_path: &Path, spec_path: PathBuf) -> Result<Self, String> {
+        Ok(Self {
+            source_name: testgen_source_name(source_path)?,
+            spec_path,
+            output: TestgenOutputContext::WithoutOutput,
+        })
+    }
+
+    /// Build context for content written to a caller-selected output file.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a raw source path without a UTF-8 file name.
+    pub fn with_output(
+        source_path: &Path,
+        spec_path: PathBuf,
+        output_parent: Option<PathBuf>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            source_name: testgen_source_name(source_path)?,
+            spec_path,
+            output: TestgenOutputContext::WithOutput {
+                parent: output_parent,
+            },
+        })
+    }
+}
+
+fn testgen_source_name(source_path: &Path) -> Result<String, String> {
+    source_path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .map(str::to_owned)
+        .ok_or_else(|| "testgen spec path must have a UTF-8 file name".to_owned())
+}
+
 /// Normalized, target-independent input consumed by every test generator.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TestgenInput {
     spec_name: String,
-    source_name: String,
-    spec_path: PathBuf,
-    output_path: Option<PathBuf>,
+    path: TestgenPathContext,
     state_order: Vec<String>,
     actions: Vec<TestgenAction>,
     scenarios: Vec<Value>,
@@ -341,8 +395,7 @@ fn normalize_step(step: &mut Value, actions: &[TestgenAction]) {
 
 fn build_input(
     spec_name: String,
-    spec_path: &Path,
-    output_path: Option<&Path>,
+    path: &TestgenPathContext,
     state_order: Vec<String>,
     actions: Vec<TestgenAction>,
     scenarios: &Value,
@@ -370,11 +423,6 @@ fn build_input(
         })
         .collect::<BTreeMap<_, _>>();
     validate_walk(walk, &spec_name, &state_names, &action_params)?;
-    let source_name = spec_path
-        .file_name()
-        .and_then(std::ffi::OsStr::to_str)
-        .ok_or_else(|| "testgen spec path must have a UTF-8 file name".to_owned())?
-        .to_owned();
     let scenarios = normalize_scenarios(
         validate_scenarios(scenarios, &spec_name, &state_names, &action_params)?,
         &state_order,
@@ -382,9 +430,7 @@ fn build_input(
     );
     Ok(TestgenInput {
         spec_name,
-        source_name,
-        spec_path: spec_path.to_owned(),
-        output_path: output_path.map(Path::to_owned),
+        path: path.clone(),
         state_order,
         actions,
         scenarios,
@@ -399,8 +445,7 @@ fn build_input(
 /// Rejects incompatible or malformed contracts and mismatched specification names.
 pub fn public_kernel_testgen_input(
     kernel: &Value,
-    spec_path: &Path,
-    output_path: Option<&Path>,
+    path: &TestgenPathContext,
     scenarios: &Value,
     walk: &Value,
 ) -> Result<TestgenInput, String> {
@@ -457,15 +502,7 @@ pub fn public_kernel_testgen_input(
         .collect::<Result<Vec<_>, String>>()?;
     actions.sort_by_key(|(order, _)| *order);
     let actions = actions.into_iter().map(|(_, action)| action).collect();
-    build_input(
-        spec_name,
-        spec_path,
-        output_path,
-        state_order,
-        actions,
-        scenarios,
-        walk,
-    )
+    build_input(spec_name, path, state_order, actions, scenarios, walk)
 }
 
 /// Explicit compose bridge while Public Kernel rejects multi-file provenance.
@@ -479,8 +516,7 @@ pub fn public_kernel_testgen_input(
 #[doc(hidden)]
 pub fn compose_testgen_input(
     spec_name: &str,
-    spec_path: &Path,
-    output_path: Option<&Path>,
+    path: &TestgenPathContext,
     state_order: Vec<String>,
     actions: Vec<(String, Vec<String>)>,
     scenarios: &Value,
@@ -488,8 +524,7 @@ pub fn compose_testgen_input(
 ) -> Result<TestgenInput, String> {
     build_input(
         spec_name.to_owned(),
-        spec_path,
-        output_path,
+        path,
         state_order,
         actions
             .into_iter()
@@ -566,14 +601,15 @@ fn portable_path(path: &Path) -> String {
         .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
-fn relative_spec_path(spec: &Path, output: Option<&Path>) -> String {
-    let absolute = std::fs::canonicalize(spec).unwrap_or_else(|_| spec.to_path_buf());
-    let Some(parent) = output.and_then(Path::parent) else {
-        return portable_path(&absolute);
+fn relative_spec_path(path: &TestgenPathContext) -> String {
+    let TestgenOutputContext::WithOutput {
+        parent: Some(parent),
+    } = &path.output
+    else {
+        return portable_path(&path.spec_path);
     };
-    let base = std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
-    let left = base.components().collect::<Vec<_>>();
-    let right = absolute.components().collect::<Vec<_>>();
+    let left = parent.components().collect::<Vec<_>>();
+    let right = path.spec_path.components().collect::<Vec<_>>();
     let common = left
         .iter()
         .zip(&right)
@@ -591,18 +627,14 @@ fn relative_spec_path(spec: &Path, output: Option<&Path>) -> String {
 
 #[allow(clippy::too_many_lines)]
 fn emit_pytest(input: &TestgenInput) -> String {
-    let path_expr = if input.output_path.is_some() {
-        format!(
+    let path_expr = match input.path.output {
+        TestgenOutputContext::WithoutOutput => python_string(&relative_spec_path(&input.path)),
+        TestgenOutputContext::WithOutput { .. } => format!(
             "Path(__file__).resolve().parent / {}",
-            python_string(&relative_spec_path(
-                &input.spec_path,
-                input.output_path.as_deref()
-            ))
-        )
-    } else {
-        python_string(&relative_spec_path(&input.spec_path, None))
+            python_string(&relative_spec_path(&input.path))
+        ),
     };
-    let source_name = &input.source_name;
+    let source_name = &input.path.source_name;
     let mut text = format!(
         r#""""Auto-generated conformance tests for FSL spec.
 Source: {source_name}
@@ -1324,17 +1356,17 @@ fn emit_phpunit(source_name: &str, spec_name: &str, scenarios: &[Value], walk: &
 pub fn generate_testgen(input: &TestgenInput, target: &str) -> Result<String, String> {
     let content = match target {
         "pytest" => emit_pytest(input),
-        "vitest" => emit_vitest(&input.source_name, &input.scenarios, &input.walk),
-        "swift" => emit_swift(&input.source_name, &input.scenarios, &input.walk),
+        "vitest" => emit_vitest(&input.path.source_name, &input.scenarios, &input.walk),
+        "swift" => emit_swift(&input.path.source_name, &input.scenarios, &input.walk),
         "kotlin" => emit_kotlin(
-            &input.source_name,
+            &input.path.source_name,
             &input.spec_name,
             &input.scenarios,
             &input.walk,
         ),
-        "dart" => emit_dart(&input.source_name, &input.scenarios, &input.walk),
+        "dart" => emit_dart(&input.path.source_name, &input.scenarios, &input.walk),
         "phpunit" => emit_phpunit(
-            &input.source_name,
+            &input.path.source_name,
             &input.spec_name,
             &input.scenarios,
             &input.walk,
@@ -1382,16 +1414,19 @@ mod tests {
         (kernel, scenarios, walk)
     }
 
+    fn path_context() -> TestgenPathContext {
+        TestgenPathContext::without_output(Path::new("demo.fsl"), PathBuf::from("demo.fsl"))
+            .expect("build test path context")
+    }
+
     #[test]
     fn public_and_explicit_compose_metadata_normalize_to_one_input() {
         let (kernel, scenarios, walk) = contracts();
-        let public =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect("adapt public Kernel");
+        let public = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect("adapt public Kernel");
         let compose = compose_testgen_input(
             "Demo",
-            Path::new("demo.fsl"),
-            None,
+            &path_context(),
             vec!["zeta".to_owned(), "alpha".to_owned()],
             vec![
                 ("begin".to_owned(), vec!["id".to_owned()]),
@@ -1403,6 +1438,96 @@ mod tests {
         .expect("adapt explicit compose metadata");
 
         assert_eq!(public, compose);
+    }
+
+    #[test]
+    fn explicit_path_context_is_the_only_generated_path_input() {
+        let (kernel, scenarios, walk) = contracts();
+        let first_context = TestgenPathContext::with_output(
+            Path::new("demo.fsl"),
+            PathBuf::from("/workspace/first/demo.fsl"),
+            Some(PathBuf::from("/workspace/generated")),
+        )
+        .expect("build first path context");
+        let second_context = TestgenPathContext::with_output(
+            Path::new("demo.fsl"),
+            PathBuf::from("/workspace/second/demo.fsl"),
+            Some(PathBuf::from("/workspace/generated")),
+        )
+        .expect("build second path context");
+        let first = public_kernel_testgen_input(&kernel, &first_context, &scenarios, &walk)
+            .expect("adapt first path context");
+        let second = public_kernel_testgen_input(&kernel, &second_context, &scenarios, &walk)
+            .expect("adapt second path context");
+
+        let first_pytest = generate_testgen(&first, "pytest").expect("emit first pytest");
+        let second_pytest = generate_testgen(&second, "pytest").expect("emit second pytest");
+        assert!(
+            first_pytest
+                .contains("SPEC_PATH = Path(__file__).resolve().parent / '../first/demo.fsl'")
+        );
+        assert!(
+            second_pytest
+                .contains("SPEC_PATH = Path(__file__).resolve().parent / '../second/demo.fsl'")
+        );
+        assert_ne!(first_pytest, second_pytest);
+        for target in ["vitest", "swift", "kotlin", "dart", "phpunit"] {
+            assert_eq!(
+                generate_testgen(&first, target).expect("emit first non-pytest target"),
+                generate_testgen(&second, target).expect("emit second non-pytest target"),
+                "{target} must not observe path-context changes"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_and_parentless_paths_keep_the_explicit_fallback_spelling() {
+        let (kernel, scenarios, walk) = contracts();
+        let missing = TestgenPathContext::without_output(
+            Path::new("missing.fsl"),
+            PathBuf::from("missing/spec.fsl"),
+        )
+        .expect("build missing path context");
+        let input = public_kernel_testgen_input(&kernel, &missing, &scenarios, &walk)
+            .expect("adapt missing path context");
+        let pytest = generate_testgen(&input, "pytest").expect("emit missing-path pytest");
+        assert!(pytest.contains("Source: missing.fsl"));
+        assert!(pytest.contains("SPEC_PATH = 'missing/spec.fsl'"));
+
+        let parentless = TestgenPathContext::with_output(
+            Path::new("demo.fsl"),
+            PathBuf::from("/workspace/demo.fsl"),
+            None,
+        )
+        .expect("build parentless path context");
+        let input = public_kernel_testgen_input(&kernel, &parentless, &scenarios, &walk)
+            .expect("adapt parentless output context");
+        let pytest = generate_testgen(&input, "pytest").expect("emit parentless-path pytest");
+        assert!(
+            pytest.contains("SPEC_PATH = Path(__file__).resolve().parent / '/workspace/demo.fsl'")
+        );
+    }
+
+    #[test]
+    fn generator_source_has_no_filesystem_or_canonicalization_dependency() {
+        let source = include_str!("testgen.rs");
+        let filesystem_api = ["std", "::", "fs"].concat();
+        let canonicalization_api = ["canonical", "ize"].concat();
+        let cwd_api = ["current", "_dir"].concat();
+        assert!(!source.contains(&filesystem_api));
+        assert!(!source.contains(&canonicalization_api));
+        assert!(!source.contains(&cwd_api));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_context_preserves_non_utf8_source_name_rejection() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let source = PathBuf::from(std::ffi::OsString::from_vec(vec![0xff]));
+        let error = TestgenPathContext::without_output(&source, source.clone())
+            .expect_err("reject a non-UTF-8 source name");
+        assert_eq!(error, "testgen spec path must have a UTF-8 file name");
     }
 
     #[test]
@@ -1423,30 +1548,26 @@ mod tests {
     fn public_adapter_fails_closed_on_schema_version_and_spec_mismatch() {
         let (mut kernel, scenarios, walk) = contracts();
         kernel["$schema"] = json!("https://example.com/kernel.schema.json");
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject unsupported schema identifier");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject unsupported schema identifier");
         assert!(error.contains("unsupported public Kernel $schema"));
 
         let (mut kernel, scenarios, walk) = contracts();
         kernel["schema_version"] = json!("2.0.0");
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject unsupported version");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject unsupported version");
         assert!(error.contains("unsupported public Kernel schema_version"));
 
         let (kernel, scenarios, mut walk) = contracts();
         walk["schema_version"] = json!("2.0.0");
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject unsupported trace version");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject unsupported trace version");
         assert!(error.contains("concrete vector.schema_version"));
 
         let (kernel, mut scenarios, walk) = contracts();
         scenarios["spec"] = json!("Other");
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject mismatched spec");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject mismatched spec");
         assert!(error.contains("does not match public Kernel spec"));
     }
 
@@ -1454,26 +1575,16 @@ mod tests {
     fn testgen_rejects_malformed_vectors_and_unknown_targets() {
         let (kernel, scenarios, mut malformed_walk) = contracts();
         malformed_walk["steps"] = json!([{"action":"begin"}]);
-        let error = public_kernel_testgen_input(
-            &kernel,
-            Path::new("demo.fsl"),
-            None,
-            &scenarios,
-            &malformed_walk,
-        )
-        .expect_err("reject malformed vector");
+        let error =
+            public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &malformed_walk)
+                .expect_err("reject malformed vector");
         assert!(error.contains("steps[0].params must be an object"));
 
         let (_, _, mut malformed_walk) = contracts();
         malformed_walk["extra"] = json!(true);
-        let error = public_kernel_testgen_input(
-            &kernel,
-            Path::new("demo.fsl"),
-            None,
-            &scenarios,
-            &malformed_walk,
-        )
-        .expect_err("reject unknown trace field");
+        let error =
+            public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &malformed_walk)
+                .expect_err("reject unknown trace field");
         assert!(error.contains("unknown field 'extra'"));
 
         let (_, _, mut malformed_walk) = contracts();
@@ -1483,14 +1594,9 @@ mod tests {
             "expected":{"zeta":0,"alpha":0},
             "extra":true
         }]);
-        let error = public_kernel_testgen_input(
-            &kernel,
-            Path::new("demo.fsl"),
-            None,
-            &scenarios,
-            &malformed_walk,
-        )
-        .expect_err("reject unknown trace step field");
+        let error =
+            public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &malformed_walk)
+                .expect_err("reject unknown trace step field");
         assert!(error.contains("steps[0] has unknown field 'extra'"));
 
         let malformed_scenarios = json!({
@@ -1503,14 +1609,9 @@ mod tests {
             }]
         });
         let (_, _, walk) = contracts();
-        let error = public_kernel_testgen_input(
-            &kernel,
-            Path::new("demo.fsl"),
-            None,
-            &malformed_scenarios,
-            &walk,
-        )
-        .expect_err("reject inconsistent scenario vector");
+        let error =
+            public_kernel_testgen_input(&kernel, &path_context(), &malformed_scenarios, &walk)
+                .expect_err("reject inconsistent scenario vector");
         assert!(error.contains("must have equal lengths"));
 
         let (_, _, mut walk) = contracts();
@@ -1519,9 +1620,8 @@ mod tests {
             "params":{},
             "expected":{"zeta":0,"alpha":0}
         }]);
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject unknown vector action");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject unknown vector action");
         assert!(error.contains("unknown action 'missing'"));
 
         let (_, _, mut walk) = contracts();
@@ -1530,15 +1630,13 @@ mod tests {
             "params":{},
             "expected":{"zeta":0,"alpha":0}
         }]);
-        let error =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect_err("reject mismatched vector parameters");
+        let error = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect_err("reject mismatched vector parameters");
         assert!(error.contains("must match public Kernel parameters"));
 
         let (_, _, walk) = contracts();
-        let input =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect("adapt valid input");
+        let input = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect("adapt valid input");
         assert!(generate_testgen(&input, "unknown").is_err());
     }
 
@@ -1559,9 +1657,8 @@ mod tests {
                 "expected_states":[]
             }
         ]);
-        let input =
-            public_kernel_testgen_input(&kernel, Path::new("demo.fsl"), None, &scenarios, &walk)
-                .expect("adapt valid scenarios");
+        let input = public_kernel_testgen_input(&kernel, &path_context(), &scenarios, &walk)
+            .expect("adapt valid scenarios");
 
         let output = generate_testgen(&input, "pytest").expect("emit pytest");
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -10841,11 +10841,14 @@ fn run_testgen(
         Ok(walk) => walk,
         Err(error) => return (semantic_error_output(&error), 2),
     };
+    let path_context = match testgen_path_context(path, output_path) {
+        Ok(context) => context,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
     let input = if source_dialect(&source) == "compose" {
         fsl_tools::compose_testgen_input(
             &model.name,
-            path,
-            output_path,
+            &path_context,
             model.state.iter().map(|(name, _)| name.clone()).collect(),
             model
                 .actions
@@ -10873,7 +10876,7 @@ fn run_testgen(
         )
         .map_err(|error| error.to_string())
         .and_then(|contract| {
-            fsl_tools::public_kernel_testgen_input(&contract, path, output_path, &scenarios, &walk)
+            fsl_tools::public_kernel_testgen_input(&contract, &path_context, &scenarios, &walk)
         })
     };
     let input = match input {
@@ -10916,6 +10919,23 @@ fn run_testgen(
         }
     }
     (result, status)
+}
+
+fn testgen_path_context(
+    spec_path: &Path,
+    output_path: Option<&Path>,
+) -> Result<fsl_tools::TestgenPathContext, String> {
+    let normalized_spec =
+        std::fs::canonicalize(spec_path).unwrap_or_else(|_| spec_path.to_path_buf());
+    match output_path {
+        None => fsl_tools::TestgenPathContext::without_output(spec_path, normalized_spec),
+        Some(output) => {
+            let output_parent = output.parent().map(|parent| {
+                std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf())
+            });
+            fsl_tools::TestgenPathContext::with_output(spec_path, normalized_spec, output_parent)
+        }
+    }
 }
 
 fn run_html_report(

--- a/rust/fslc/tests/testgen_contract.rs
+++ b/rust/fslc/tests/testgen_contract.rs
@@ -91,3 +91,51 @@ fn compose_bridge_preserves_pytest_and_baked_target_goldens() {
         );
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn symlink_source_name_and_canonical_pytest_path_remain_distinct() {
+    use std::os::unix::fs::symlink;
+
+    let root = root();
+    let fixture_root = root.join("rust/target/testgen-contract");
+    let directory = fixture_root.join("path-context");
+    let real_output_parent = fixture_root.join("path-output-real");
+    if directory.exists() {
+        std::fs::remove_dir_all(&directory).expect("clear path-context fixture");
+    }
+    if real_output_parent.exists() {
+        std::fs::remove_dir_all(&real_output_parent).expect("clear real output fixture");
+    }
+    std::fs::create_dir_all(&directory).expect("create path-context fixture");
+    std::fs::create_dir_all(&real_output_parent).expect("create real output directory");
+    let generated = directory.join("generated-link");
+    symlink(&real_output_parent, &generated).expect("create output-parent symlink");
+    let alias = directory.join("cart-alias.fsl");
+    symlink(root.join("specs/cart_v1.fsl"), &alias).expect("create spec symlink");
+    let output_path = generated.join("cart.py");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .arg("testgen")
+        .arg(&alias)
+        .args(["--depth", "3", "--target", "pytest", "-o"])
+        .arg(&output_path)
+        .current_dir(&root)
+        .output()
+        .expect("run symlinked native testgen");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let generated = std::fs::read_to_string(&output_path).expect("read symlink pytest output");
+    assert!(generated.contains("Source: cart-alias.fsl"));
+    assert!(
+        generated.contains(
+            "SPEC_PATH = Path(__file__).resolve().parent / '../../../../specs/cart_v1.fsl'"
+        )
+    );
+
+    std::fs::remove_dir_all(&directory).expect("clear path-context fixture");
+    std::fs::remove_dir_all(&real_output_parent).expect("clear real output fixture");
+}

--- a/tests/test_claude_environment.py
+++ b/tests/test_claude_environment.py
@@ -104,8 +104,9 @@ def test_rust_architecture_rule_carries_the_accepted_contract() -> None:
         "source-changing C2",
         "negative control",
         "testgen::relative_spec_path",
+        "explicit testgen path context",
         "#423",
-        "implicit filesystem dependency",
+        "filesystem- and CWD-free lexical projection",
     ]
     assert all(contract in normalized_rule for contract in required_contracts)
 


### PR DESCRIPTION
## Summary
- Move testgen path canonicalization and CWD/filesystem observation from `fsl-tools` into the native CLI delivery boundary.
- Preserve pytest path spelling for existing, missing, and symlinked inputs while keeping every non-pytest target byte-identical.
- Close the bounded path-I/O debt recorded in the accepted Rust component design.

## Changes
- Add an explicit `TestgenPathContext` consumed by both Public Kernel and compose adapters, with no legacy forwarding API.
- Canonicalize the spec and output parent independently in `fslc-rust`, preserving the raw alias filename and fail-closed non-UTF-8 behavior.
- Keep `relative_spec_path` lexical and add negative controls for filesystem, canonicalization, and CWD reintroduction.
- Cover spec and output-parent symlinks, missing/parentless paths, and path-only invariance across Vitest, Swift, Kotlin, Dart, and PHPUnit.
- Update the accepted design, architecture rule, contract test, and changelog to reflect the resolved ownership boundary.

## Verification
- `cargo test --manifest-path rust/Cargo.toml -p fsl-tools --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked --test testgen_contract --test domain_codegen_contract`
- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-tools -p fslc-rust --all-targets --locked -- -D warnings`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `python3 -m pytest tests/test_claude_environment.py`
- `./tools/check-native-integration.sh` passed once end-to-end, including browser cancellation/native parity and 351/351 parity cases.
- After independent-review test/document corrections, a second full run passed all Rust tests/build and Node/WASM/browser probes; its final `test:browser` session stopped producing a verdict and was terminated. The product implementation was unchanged from the complete first run; CI remains the final Windows/browser check.

## Risk / Review Notes
- This intentionally changes the public Rust testgen adapter signatures and does not retain compatibility wrappers, as required by #423. Repository production has one native delivery caller.
- The pre-PR local-optima audit classified generator-owned filesystem observation as `externalization`, severity 9/15, confidence C2. It also caught and repaired an initial weakening of non-UTF-8 fail-closed behavior.
- Independent review found four coverage/authority gaps; all were repaired, and the final re-review found no remaining issue.
- No CLI flags, JSON envelopes, exit codes, templates, target set, or generated output bytes change.

## Follow-Up / Post-Merge Checks
- Require all GitHub CI checks, including Windows portable-path coverage, before merge.
- Rollback is a single commit revert; there is no persisted-data migration or rollout step.

Closes #423
