### PR TITLE
fix(cli): publish causal command contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- The embedded native CLI contract and exact help tree now include all six documented causal
+  command leaves, while the deliberately absent `causal verify` path remains rejected (#442).
 - Verifier transition-outcome agreement now proves actual guard failure and
   representable defined post-update failure phases in native evaluation order,
   rejects malformed, relabelled, partial, or checked-arithmetic evidence, and

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -36,6 +36,23 @@ native tests instead compare every live help path with the checked-in embedded c
 validate the published result/schema contracts. Existing Python parity utilities remain historical
 or explicitly invoked compatibility evidence only.
 
+The checked-in `rust/fslc/cli-contract.json` is therefore native-authored authority, not a snapshot
+to regenerate from the frozen Python parser. It enumerates all 50 live native leaves, including the
+six Rust-only causal commands, and the native test fixes that leaf count plus the deliberately absent
+`causal verify` path. `tools/export_cli_contract.py` exports only the frozen Python compatibility
+subset and refuses to overwrite the authoritative native file.
+
+The #442 local-optimum audit found that retaining the old Python exporter as an apparent complete
+source was locally convenient when the Rust CLI still matched it, but became a `mixed`
+externalization/time-delayed defect once causal evolved only in Rust: documentation and 39 causal
+tests were green while every causal `--help` path returned a JSON error (usage or I/O, depending on
+which parser branch consumed `--help`) with exit 2. The observed runtime failure, contract omission,
+and false-negative path walker give severity 5/15
+(`E1 A1 F1 K1 T1`) at confidence C3. The selected intervention adds the missing native nodes and a
+50-leaf rejecting oracle while relabeling and guarding the compatibility exporter. Adding product
+behavior to frozen Python or introducing a shared parser framework is rejected; rollback is one
+contract/test/tooling commit with no data migration.
+
 The Claude/Codex environment tests execute Python repository hooks, not the FSL compiler product.
 They remain focused manual tooling checks and are deliberately outside the required native product
 gate; changes to those hooks must invoke the two named tests directly.

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -3,7 +3,7 @@
   "root": {
     "path": [],
     "prog": "fslc",
-    "help": "usage: fslc [-h] [-V] {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,document,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n\npositional arguments:\n  {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,document,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain}\n    version             show the version\n    lint                report edition migration diagnostics\n    migrate             plan or atomically apply edition migrations\n    fmt                 format one FSL source or check multiple paths\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    document            generate a requirements document (ja/en) or emit its\n                        RCIR claim set as JSON\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
+    "help": "usage: fslc [-h] [-V] {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,document,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain,causal}\n\npositional arguments:\n  {version,check,lint,migrate,fmt,kernel,conformance,verify,sweep,scenarios,replay,testgen,mutate,explain,html,ledger,document,approval,refine,diff,chain,typestate,analyze,db,compat,ai,domain,causal}\n    version             show the version\n    lint                report edition migration diagnostics\n    migrate             plan or atomically apply edition migrations\n    fmt                 format one FSL source or check multiple paths\n    kernel              emit the normalized public Kernel JSON contract\n    conformance         emit language-neutral concrete conformance vectors\n    sweep               run bounded verification across a scope grid\n    html                generate a self-contained HTML review report\n    ledger              generate a business audit ledger (markdown) by\n                        requirement id\n    document            generate a requirements document (ja/en) or emit its\n                        RCIR claim set as JSON\n    approval            create and check digest-bound approval records\n    diff                compare OLD and NEW specification semantics\n    chain               run a project manifest across business, requirements,\n                        design, and impl\n    typestate           decide whether typestate (ghost types) applies to a\n                        design spec and emit a TS template\n    analyze             emit structural analysis JSON for a spec\n    db                  database compatibility dialect commands\n    compat              shared compatibility commands\n    ai                  AI dialect commands\n    domain              Functional DDD / async effect dialect commands\n    causal              causal review, expectation, observation, and ledger commands\n\noptions:\n  -h, --help            show this help message and exit\n  -V, --version         show program's version number and exit\n",
     "actions": [
       {
         "dest": "help",
@@ -533,6 +533,103 @@
           }
         ],
         "commands": []
+      },
+      {
+        "path": ["causal"],
+        "prog": "fslc causal",
+        "help": "usage: fslc causal [-h] {check,analyze,verify-expectations,observe-expectations,diff,ledger}\n\npositional arguments:\n  {check,analyze,verify-expectations,observe-expectations,diff,ledger}\n    check               check a causal review model\n    analyze             project or review a causal model\n    verify-expectations\n                        bounded-check declared causal expectations\n    observe-expectations\n                        replay observations into causal expectation evidence\n    diff                compare causal models by stable claim identity\n    ledger              project claims, plans, and evidence into a causal ledger\n\noptions:\n  -h, --help            show this help message and exit\n",
+        "actions": [
+          {
+            "dest": "help",
+            "required": false,
+            "flags": ["-h", "--help"],
+            "nargs": 0,
+            "action": "store"
+          }
+        ],
+        "commands": [
+          {
+            "path": ["causal", "analyze"],
+            "prog": "fslc causal analyze",
+            "help": "usage: fslc causal analyze [-h] (--projection {causal_graph,causal_timeline,causal_traceability_graph,causal_evidence_graph} | --profile {causal-review}) [--format {json,dot,mermaid}] [--evidence EVIDENCE] [--lifecycle LIFECYCLE] [--as-of AS_OF] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --projection {causal_graph,causal_timeline,causal_traceability_graph,causal_evidence_graph}\n  --profile {causal-review}\n  --format {json,dot,mermaid}\n  --evidence EVIDENCE\n  --lifecycle LIFECYCLE\n  --as-of AS_OF\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "file", "required": true, "positional": true, "action": "store"},
+              {"dest": "projection", "required": false, "flags": ["--projection"], "choices": ["causal_graph", "causal_timeline", "causal_traceability_graph", "causal_evidence_graph"], "action": "store"},
+              {"dest": "profile", "required": false, "flags": ["--profile"], "choices": ["causal-review"], "action": "store"},
+              {"dest": "format", "required": false, "flags": ["--format"], "choices": ["json", "dot", "mermaid"], "default": "json", "action": "store"},
+              {"dest": "evidence", "required": false, "flags": ["--evidence"], "repeatable": true, "action": "store"},
+              {"dest": "lifecycle", "required": false, "flags": ["--lifecycle"], "repeatable": true, "action": "store"},
+              {"dest": "as_of", "required": false, "flags": ["--as-of"], "action": "store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["causal", "check"],
+            "prog": "fslc causal check",
+            "help": "usage: fslc causal check [-h] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help  show this help message and exit\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "file", "required": true, "positional": true, "action": "store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["causal", "diff"],
+            "prog": "fslc causal diff",
+            "help": "usage: fslc causal diff [-h] [--format {json}] before after\n\npositional arguments:\n  before\n  after\n\noptions:\n  -h, --help       show this help message and exit\n  --format {json}\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "before", "required": true, "positional": true, "action": "store"},
+              {"dest": "after", "required": true, "positional": true, "action": "store"},
+              {"dest": "format", "required": false, "flags": ["--format"], "choices": ["json"], "default": "json", "action": "store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["causal", "ledger"],
+            "prog": "fslc causal ledger",
+            "help": "usage: fslc causal ledger [-h] [--plans PLANS] [--evidence EVIDENCE] [--lifecycle LIFECYCLE] [--as-of AS_OF] [--format {json}] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --plans PLANS\n  --evidence EVIDENCE\n  --lifecycle LIFECYCLE\n  --as-of AS_OF\n  --format {json}\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "file", "required": true, "positional": true, "action": "store"},
+              {"dest": "plans", "required": false, "flags": ["--plans"], "repeatable": true, "action": "store"},
+              {"dest": "evidence", "required": false, "flags": ["--evidence"], "repeatable": true, "action": "store"},
+              {"dest": "lifecycle", "required": false, "flags": ["--lifecycle"], "repeatable": true, "action": "store"},
+              {"dest": "as_of", "required": false, "flags": ["--as-of"], "action": "store"},
+              {"dest": "format", "required": false, "flags": ["--format"], "choices": ["json"], "default": "json", "action": "store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["causal", "observe-expectations"],
+            "prog": "fslc causal observe-expectations",
+            "help": "usage: fslc causal observe-expectations [-h] --from-log FROM_LOG --mapping MAPPING --scope SCOPE --period-start PERIOD_START --period-end PERIOD_END [--out OUT] [--lifecycle-out LIFECYCLE_OUT] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --from-log FROM_LOG\n  --mapping MAPPING\n  --scope SCOPE\n  --period-start PERIOD_START\n  --period-end PERIOD_END\n  --out OUT\n  --lifecycle-out LIFECYCLE_OUT\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "file", "required": true, "positional": true, "action": "store"},
+              {"dest": "from_log", "required": true, "flags": ["--from-log"], "action": "store"},
+              {"dest": "mapping", "required": true, "flags": ["--mapping"], "action": "store"},
+              {"dest": "scope", "required": true, "flags": ["--scope"], "action": "store"},
+              {"dest": "period_start", "required": true, "flags": ["--period-start"], "action": "store"},
+              {"dest": "period_end", "required": true, "flags": ["--period-end"], "action": "store"},
+              {"dest": "out", "required": false, "flags": ["--out"], "action": "store"},
+              {"dest": "lifecycle_out", "required": false, "flags": ["--lifecycle-out"], "action": "store"}
+            ],
+            "commands": []
+          },
+          {
+            "path": ["causal", "verify-expectations"],
+            "prog": "fslc causal verify-expectations",
+            "help": "usage: fslc causal verify-expectations [-h] [--depth DEPTH] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help     show this help message and exit\n  --depth DEPTH\n",
+            "actions": [
+              {"dest": "help", "required": false, "flags": ["-h", "--help"], "nargs": 0, "action": "store"},
+              {"dest": "file", "required": true, "positional": true, "action": "store"},
+              {"dest": "depth", "required": false, "flags": ["--depth"], "default": 8, "action": "store"}
+            ],
+            "commands": []
+          }
+        ]
       },
       {
         "path": [

--- a/rust/fslc/tests/native_integration.rs
+++ b/rust/fslc/tests/native_integration.rs
@@ -115,6 +115,14 @@ fn native_cli_help_matches_the_embedded_contract_at_every_command_path() {
     assert_eq!(contract["schema"], "fsl-cli-contract.v1");
     let mut nodes = Vec::new();
     walk(&contract["root"], &mut nodes);
+    assert_eq!(
+        nodes
+            .iter()
+            .filter(|node| node["commands"].as_array().is_some_and(Vec::is_empty))
+            .count(),
+        50,
+        "the public contract must enumerate every live native leaf"
+    );
     let mut paths = BTreeSet::new();
 
     for node in nodes {
@@ -155,6 +163,22 @@ fn native_cli_help_matches_the_embedded_contract_at_every_command_path() {
             "help drift at {args:?}"
         );
     }
+
+    for path in [
+        vec!["causal"],
+        vec!["causal", "check"],
+        vec!["causal", "analyze"],
+        vec!["causal", "verify-expectations"],
+        vec!["causal", "observe-expectations"],
+        vec!["causal", "diff"],
+        vec!["causal", "ledger"],
+    ] {
+        assert!(paths.contains(&path), "missing public CLI path: {path:?}");
+    }
+    assert!(
+        !paths.contains(&vec!["causal", "verify"]),
+        "causal review must not acquire a proof-like verify command"
+    );
 
     let invalid_engine = run(&["verify", "specs/cart_v1.fsl", "--engine", "explict"]);
     assert_eq!(invalid_engine.status.code(), Some(2));

--- a/tools/export_cli_contract.py
+++ b/tools/export_cli_contract.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Export the complete public ``fslc`` argparse surface as canonical JSON."""
+"""Export the frozen Python compatibility CLI surface as canonical JSON.
+
+The authoritative native contract is ``rust/fslc/cli-contract.json`` and contains Rust-only
+commands. This compatibility exporter must never overwrite that native-owned artifact.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +19,7 @@ from fslc.cli_help import canonical_help
 
 
 ROOT = Path(__file__).resolve().parents[1]
+NATIVE_CONTRACT = ROOT / "rust" / "fslc" / "cli-contract.json"
 
 
 def _subparsers(parser: argparse.ArgumentParser) -> argparse._SubParsersAction | None:
@@ -76,7 +81,7 @@ def _parser_contract(parser: argparse.ArgumentParser, path: tuple[str, ...]) -> 
 
 
 def export_contract() -> dict[str, Any]:
-    """Return the deterministic public CLI contract."""
+    """Return the deterministic frozen-Python compatibility contract."""
     return {
         "schema": "fsl-cli-contract.v1",
         "root": _parser_contract(_build_arg_parser(), ()),
@@ -89,6 +94,11 @@ def main() -> None:
     parser = cli_argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-o", "--output", type=Path)
     args = parser.parse_args()
+    if args.output and args.output.resolve() == NATIVE_CONTRACT.resolve():
+        parser.error(
+            "refusing to overwrite the authoritative native CLI contract with the frozen "
+            "Python compatibility subset"
+        )
     rendered = json.dumps(export_contract(), ensure_ascii=False, indent=2) + "\n"
     if args.output:
         args.output.write_text(rendered, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Publish the six documented causal command leaves in the authoritative native CLI contract.
- Resolve the contract conflict that blocked #394: live Rust-only causal commands existed, but root/family/leaf help returned JSON errors because the embedded contract omitted them.
- Closes #442.

## Changes
- Add `causal` and its six leaves, options, defaults, and help text to `rust/fslc/cli-contract.json`.
- Fix native integration at 50 live leaves, require every causal path, and retain `causal verify` as a rejecting negative control.
- Reclassify `tools/export_cli_contract.py` as a frozen-Python compatibility exporter and refuse attempts to overwrite the native-owned contract.
- Record the authority boundary and implementation-local-optimum audit in the accepted Rust integration design and changelog.

## Verification
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test native_integration --locked` (6 passed)
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test causal_cli --test causal_ownership --locked` (39 + 2 passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml -p fslc-rust --all-targets --locked -- -D warnings`
- `PYTHONPATH=src python3 tools/export_cli_contract.py -o rust/fslc/cli-contract.json` (expected refusal, exit 2)
- `git diff --check`
- `./tools/check-native-integration.sh` (exit 0; browser/native parity 351 cases)
- Independent review completed with no actionable findings.

## Risk / Review Notes
- This changes the published help/contract surface to match already documented and tested native behavior; causal command arguments, JSON envelopes, locations/evidence, stderr, and exit statuses are unchanged.
- The frozen Python implementation gains no product behavior. Worker/LSP behavior and persisted data are outside the change.
- The audit selected the smallest reversible repair. A shared parser framework and Python causal implementation were explicitly rejected. Rollback is this single commit; no migration is required.

## Follow-Up / Post-Merge Checks
- Resume the command-outcome evaluation in #394 using the corrected 50-leaf inventory.