### PR TITLE
refactor(db): lower compatibility kernel directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   symbolic representation (#428).
 
 ### Changed
+- `dbsystem` executable lifecycle lowering now constructs typed Kernel surface IR
+  directly instead of rendering and re-parsing generated FSL. The migration preserves
+  types, state, action/property semantics, metadata, annotations, and deterministic
+  ordering, removes the obsolete public source generator, and binds generated targets
+  to authored DB declarations so diagnostics and Public Kernel v2 provenance no longer
+  cite fabricated generated-source lines (#410).
 - The `fsl-runtime` touch-driven extraction evaluation retains the current public facade and
   physical eval, Monitor, liveness, refinement, search, and replay owners. Evidence is insufficient
   to select a move-only slice after the short migration/feature burst, so no implementation child

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -243,30 +243,22 @@ rules changed shape instead of gaining a same-named field:
 `DbCheckRule { name, annotations, span }`; `DbCheck::python_ast()`
 reconstructs the original plain `Vec<String>` rule-name list.
 
-`db_kernel_source` (`rust/fsl-core/src/db.rs`) still synthesizes the
-dbsystem's executable kernel as FSL source text re-parsed through the shared
-spec grammar (`fsl_syntax::parse_surface_spec`) — issue #281 did not replace
-that architecture, which would have been a much larger change unrelated to
-annotations. What changed is *what floats through the text*: a migration's
-`decl_annotations` and a matching `DbCheckRule`'s `annotations` are rendered
-back to literal `@requirement(...)`/`@undecided(...)`/`@kind(...)`/custom
-`@ns.path(...)` source lines (`Annotation::render_source()`,
-`rust/fsl-syntax/src/annotation.rs`) immediately before the corresponding
-synthesized `action`/`invariant`, rather than being squeezed through the
-lossy `quote_meta("ID", "text")` single-`MetaTag` string convention the
-system-generated `DB-MIGRATION`/`DB-NOT-NULL`/`DB-COMPAT-READ`/
-`DB-COMPAT-WRITE` labels still use unchanged. Re-parsing then binds them as
-ordinary typed `Annotation`s through the exact same
-`collect_declaration_annotations` path every other dialect uses, so they
-reach `AnnotationRegistry`/`KernelModel`/TSG/the audit ledger with no new
-plumbing. Because the lexer has no string-escape syntax
-(`rust/fsl-syntax/src/lexer.rs::lex_string` stops at the first `"` or
-newline), `Annotation::render_source()` sanitizes backslash, `"`, and
-newline characters out of a `String` argument value before quoting it — the
-same character class `quote_meta` already sanitizes, extended to cover
-newlines too since this is a fresh code path rather than an existing one.
-This sanitization only affects a `String` value containing those characters;
-Integer, Boolean, and Symbol arguments round-trip exactly.
+Issue #410 supersedes the temporary text-transport detail from #281.
+`rust/fsl-core/src/db.rs` now constructs the dbsystem's typed `SurfaceSpec`
+directly. A migration's `decl_annotations` and a matching `DbCheckRule`'s
+`annotations` are cloned onto the generated `SpecItem::Action` or
+`SpecItem::Invariant`; they no longer pass through
+`Annotation::render_source()`, a generated FSL string, or a second parse.
+System-owned `DB-MIGRATION`/`DB-NOT-NULL`/`DB-COMPAT-READ`/
+`DB-COMPAT-WRITE` labels remain separate `MetaTag`s, as before. Typed
+annotations still reach `AnnotationRegistry`/`KernelModel`/TSG/the audit
+ledger through the ordinary direct-lowering collection path, and their values
+are no longer subject to generated-source quoting or sanitization.
+
+The direct builder also supplies an `OriginRegistry`. Annotation relations
+remain distinct from provenance: a rule annotation does not become an origin
+identity, while the generated invariant separately points to the authored rule,
+artifact/environment entry, and column declarations that caused it.
 
 `tools/check_rust_surface_parity.py`'s `SUPPORTED_SPECIALIZED_FRONTENDS`
 already includes `ai-component`/`db`/`domain`; since no new field was
@@ -342,8 +334,6 @@ suppression, and exact declaration matching—remain unchanged.
   dropping the annotation;
 - unifying the four duplicated `pending_annotations` parser state machines
   (`parser.rs`, `domain.rs`, `ai.rs`, `db.rs`) behind one shared trait;
-- replacing `db_kernel_source`'s text-synthesis-and-reparse architecture with
-  direct `KernelSpec`/`SpecItem` construction;
 - formatter or source migrator behavior;
 - macro execution or verifier semantics selected by an annotation;
 - publishing annotations by mutating Public Kernel v1/v2.

--- a/docs/DESIGN-db.md
+++ b/docs/DESIGN-db.md
@@ -25,6 +25,40 @@ unchanged and avoids unsupported state shapes such as
 `Map<ArtifactVersion, Set<Column>>`. Static artifact capabilities are represented
 by generated invariants and metadata, not by nested runtime state.
 
+### Direct lowering and provenance
+
+The executable lifecycle is constructed directly as typed `SurfaceSpec` IR in
+`fsl-core`; a `dbsystem` is never rendered as generated FSL text and re-parsed.
+The direct builder preserves the legacy semantic mapping and deterministic order:
+
+- `SchemaVersion` spans the minimum and maximum schema values declared by the
+  database, migrations, environments, and artifact windows;
+- `Column` members and initial column-map assignments use sorted `(table, column)`
+  order, while migration actions and their operations retain source order;
+- each migration guard precedes its operation guards and updates, and the schema
+  update remains the final statement;
+- read/write compatibility properties follow environment, artifact-entry,
+  capability, and column order; the terminal predicate uses the last migration's
+  target schema or the database's initial schema.
+
+The old generated-source line numbers and empty origin registry were not a
+compatibility contract. Generated Kernel targets now carry `dbsystem` origin
+chains whose primary site is the authored database, column, migration,
+migration operation, environment-artifact entry, or compatibility rule. A
+property may additionally cite the contributing artifact and column as secondary
+sites. This is an intentional diagnostic correction: counterexamples point to
+the source DB declaration instead of a fabricated generated-Kernel line.
+Public Kernel v1 and v2 schemas and versions are unchanged; v2 reports these
+lowered targets as `generated_from_source`. Source-backed DB origins do not
+replace the established generated action/property display names, which remain
+the executable and replay identities. DB-only compatibility validation continues
+to belong to `fsl-tools` and is not moved into the shared kernel.
+
+The conformance anchors are `rust/fslc/tests/db_direct_lowering.rs`: a positive
+catalog-order/model control, a Public Kernel v2 source-origin control, and a
+negative `DB-NOT-NULL` migration that must still fail at the authored rule and
+migration locations.
+
 ## Semantic Modes
 
 ### 1. Compatibility Snapshot

--- a/examples/annotations/annotated_dbsystem.fsl
+++ b/examples/annotations/annotated_dbsystem.fsl
@@ -4,10 +4,10 @@
 //
 // Demonstrates `@requirement(id, text?)` attached directly to a
 // `migration` and to a `rule` line inside `check compatibility { ... }`.
-// The typed annotation reaches the checked model through
-// `Annotation::render_source()` rather than the legacy `quote_meta`
-// string convention — see docs/DESIGN-annotations.md's "domain/db/ai
-// nested declaration syntax" section.
+// Direct DB lowering clones the typed annotation onto the generated action or
+// invariant without a generated-source/render/reparse round trip — see
+// docs/DESIGN-annotations.md's "domain/db/ai nested declaration syntax"
+// section.
 //
 // Native-only: the frozen Python reference does not parse `@...` before
 // a dbsystem nested declaration, so this file is excluded from the

--- a/rust/fsl-core/src/db.rs
+++ b/rust/fsl-core/src/db.rs
@@ -3,7 +3,16 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use fsl_syntax::{Annotations, DbColumnRef, DbEnvironmentArtifact, DbSystem};
+use fsl_syntax::{
+    ActionItem, Annotations, DbColumn, DbColumnRef, DbEnvironmentArtifact, DbSystem, Expr, LValue,
+    MetaTag, Span, SpecItem, StateField, Statement, SurfaceSpec, TypeExpr,
+};
+
+use crate::{
+    INIT_TARGET, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET,
+    TERMINAL_TARGET, action_guard_target, action_statement_target, action_target,
+    init_statement_target, property_target, state_target, type_target,
+};
 
 fn safe(name: &str) -> String {
     let mut output = name
@@ -62,37 +71,151 @@ fn entry_name_parts(entry: &DbEnvironmentArtifact) -> Vec<String> {
     parts
 }
 
-fn compatibility_expression(window: (i64, i64), member: &str) -> String {
-    format!(
-        "not ((schema_version >= {}) and (schema_version <= {})) or column_exists[{member}]",
-        window.0, window.1
+fn named(name: &str) -> TypeExpr {
+    TypeExpr::Name(name.to_owned())
+}
+
+fn binary(op: &str, left: Expr, right: Expr) -> Expr {
+    Expr::Binary {
+        op: op.to_owned(),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+fn indexed(name: &str, member: &str) -> Expr {
+    Expr::Index(
+        Box::new(Expr::Var(name.to_owned())),
+        Box::new(Expr::Var(member.to_owned())),
     )
 }
 
-fn quote_meta(id: &str, text: &str) -> String {
-    format!(
-        "\"{}: {}\"",
-        id.replace(['\\', '\"'], "_"),
-        text.replace(['\\', '\"'], "_")
+fn assignment(name: &str, member: &str, value: Expr, span: Span) -> ActionItem {
+    ActionItem::Statement(Statement::Assign {
+        target: LValue::Index(name.to_owned(), Expr::Var(member.to_owned())),
+        value,
+        span,
+    })
+}
+
+fn requirement(expression: Expr, span: Span) -> ActionItem {
+    ActionItem::Requires(expression, span)
+}
+
+fn metadata(id: &str, text: String, span: Span) -> MetaTag {
+    MetaTag {
+        id: id.to_owned(),
+        text: Some(text),
+        span: Some(span),
+    }
+}
+
+fn source_site(span: Span, path: Vec<String>) -> OriginSite {
+    OriginSite {
+        source_file: None,
+        span: Some(span),
+        dialect: "dbsystem".to_owned(),
+        declaration_path: path,
+    }
+}
+
+fn db_origin(
+    span: Span,
+    path: Vec<String>,
+    step: &str,
+    generated: bool,
+    secondary: Vec<OriginSite>,
+) -> OriginChain {
+    OriginChain {
+        id: OriginId(format!(
+            "db:{}:{}:{}:{}:{}",
+            path.join("/"),
+            span.start.offset,
+            span.end.offset,
+            span.start.line,
+            span.start.column
+        )),
+        dialect: "dbsystem".to_owned(),
+        primary: Some(source_site(span, path)),
+        secondary,
+        lowering_steps: vec![LoweringStep {
+            kind: step.to_owned(),
+            detail: None,
+        }],
+        generated,
+    }
+}
+
+fn column_path(system: &DbSystem, column: &DbColumn) -> Vec<String> {
+    vec![
+        system.name.clone(),
+        "database".to_owned(),
+        system.database.name.clone(),
+        "table".to_owned(),
+        column.table.clone(),
+        "column".to_owned(),
+        column.name.clone(),
+    ]
+}
+
+fn bind_action_origins(
+    registry: &mut OriginRegistry,
+    name: &str,
+    items: &[ActionItem],
+    action_origin: OriginChain,
+    item_origins: &[OriginChain],
+) {
+    registry.bind(action_target(name), action_origin);
+    let mut guard_index = 0;
+    let mut statement_index = 0;
+    for (item, origin) in items.iter().zip(item_origins) {
+        match item {
+            ActionItem::Requires(..) | ActionItem::Let(..) => {
+                registry.bind(action_guard_target(name, guard_index), origin.clone());
+                guard_index += 1;
+            }
+            ActionItem::Ensures(..) => {
+                registry.bind(
+                    format!("action:{name}:ensure:{guard_index}"),
+                    origin.clone(),
+                );
+                guard_index += 1;
+            }
+            ActionItem::Statement(..) => {
+                registry.bind(
+                    action_statement_target(name, statement_index),
+                    origin.clone(),
+                );
+                statement_index += 1;
+            }
+        }
+    }
+}
+
+fn compatibility_expr(window: (i64, i64), member: &str) -> Expr {
+    binary(
+        "or",
+        Expr::Not(Box::new(binary(
+            "and",
+            binary(
+                ">=",
+                Expr::Var("schema_version".to_owned()),
+                Expr::Num(window.0),
+            ),
+            binary(
+                "<=",
+                Expr::Var("schema_version".to_owned()),
+                Expr::Num(window.1),
+            ),
+        ))),
+        indexed("column_exists", member),
     )
 }
 
-/// Render a declaration's typed annotations back to `@name(args...)` source
-/// lines so the synthesized kernel source carries them through the shared
-/// grammar's own annotation parser, rather than through the lossy legacy
-/// `"ID: text"` meta-string convention.
-fn annotation_lines(annotations: &Annotations, indent: &str) -> Vec<String> {
-    annotations
-        .source_order()
-        .iter()
-        .map(|annotation| format!("{indent}{}", annotation.render_source()))
-        .collect()
-}
-
-/// Render the executable kernel used by generic check/verify for a dbsystem.
-#[must_use]
+/// Build the executable database catalog directly as typed surface IR plus
+/// source-backed origins. No generated FSL source is involved.
 #[allow(clippy::too_many_lines)]
-pub fn db_kernel_source(system: &DbSystem) -> String {
+pub(crate) fn lower_db_surface(system: &DbSystem) -> (SurfaceSpec, OriginRegistry) {
     let columns = system
         .database
         .tables
@@ -136,172 +259,440 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
             .map(|rule| rule.name.as_str())
             .collect()
     };
-    let rule_annotations = system
+    let rule_by_name = system
         .check
         .rules
         .iter()
-        .map(|rule| (rule.name.as_str(), &rule.annotations))
+        .map(|rule| (rule.name.as_str(), rule))
         .collect::<BTreeMap<_, _>>();
 
-    let mut lines = vec![format!(
-        "spec {} \"db: database multi-environment compatibility\" {{",
-        system.name
-    )];
-    lines.push(format!("  type SchemaVersion = {schema_lo}..{schema_hi}"));
-    lines.push(format!(
-        "  enum Column {{ {} }}",
-        columns
-            .keys()
-            .map(column_member)
-            .collect::<Vec<_>>()
-            .join(", ")
-    ));
-    lines.push("  state {".to_owned());
-    lines.push("    schema_version: SchemaVersion,".to_owned());
-    lines.push("    column_exists: Map<Column, Bool>,".to_owned());
-    lines.push("    column_backfilled: Map<Column, Bool>,".to_owned());
-    lines.push("    column_not_null: Map<Column, Bool>".to_owned());
-    lines.push("  }".to_owned());
-    lines.push("  init {".to_owned());
-    lines.push(format!(
-        "    schema_version = {}",
-        system.database.initial_schema
-    ));
+    let mut registry = OriginRegistry::default();
+    registry.bind(
+        SPEC_TARGET,
+        db_origin(
+            system.span,
+            vec![system.name.clone()],
+            "lower_db_system",
+            false,
+            Vec::new(),
+        ),
+    );
+    let database_path = vec![
+        system.name.clone(),
+        "database".to_owned(),
+        system.database.name.clone(),
+    ];
+    let database_origin = db_origin(
+        system.database.span,
+        database_path.clone(),
+        "lower_db_database",
+        true,
+        Vec::new(),
+    );
+    registry.bind(type_target("SchemaVersion"), database_origin.clone());
+    registry.bind(type_target("Column"), database_origin.clone());
+    registry.bind(state_target("schema_version"), database_origin.clone());
+    for name in ["column_exists", "column_backfilled", "column_not_null"] {
+        let target = state_target(name);
+        registry.bind(target, database_origin.clone());
+    }
+
+    let mut items = vec![
+        SpecItem::Type {
+            name: "SchemaVersion".to_owned(),
+            lo: Box::new(Expr::Num(schema_lo)),
+            hi: Box::new(Expr::Num(schema_hi)),
+            symmetric: false,
+        },
+        SpecItem::Enum {
+            name: "Column".to_owned(),
+            members: columns.keys().map(column_member).collect(),
+            symmetric: false,
+        },
+        SpecItem::State(vec![
+            StateField::generated(
+                "schema_version",
+                named("SchemaVersion"),
+                system.database.span,
+            ),
+            StateField::generated(
+                "column_exists",
+                TypeExpr::Map(Box::new(named("Column")), Box::new(TypeExpr::Bool)),
+                system.database.span,
+            ),
+            StateField::generated(
+                "column_backfilled",
+                TypeExpr::Map(Box::new(named("Column")), Box::new(TypeExpr::Bool)),
+                system.database.span,
+            ),
+            StateField::generated(
+                "column_not_null",
+                TypeExpr::Map(Box::new(named("Column")), Box::new(TypeExpr::Bool)),
+                system.database.span,
+            ),
+        ]),
+    ];
+
+    let mut init_statements = vec![Statement::Assign {
+        target: LValue::Var("schema_version".to_owned()),
+        value: Expr::Num(system.database.initial_schema),
+        span: system.database.span,
+    }];
+    let mut init_origins = vec![database_origin.clone()];
     for (key, column) in &columns {
         let member = column_member(key);
-        lines.push(format!("    column_exists[{member}] = {}", column.present));
-        lines.push(format!(
-            "    column_backfilled[{member}] = {}",
-            column.backfilled
-        ));
-        lines.push(format!(
-            "    column_not_null[{member}] = {}",
-            column.not_null
-        ));
+        let origin = db_origin(
+            column.span,
+            column_path(system, column),
+            "lower_db_column_initial_state",
+            true,
+            Vec::new(),
+        );
+        for (name, value) in [
+            ("column_exists", column.present),
+            ("column_backfilled", column.backfilled),
+            ("column_not_null", column.not_null),
+        ] {
+            init_statements.push(Statement::Assign {
+                target: LValue::Index(name.to_owned(), Expr::Var(member.clone())),
+                value: Expr::Bool(value),
+                span: column.span,
+            });
+            init_origins.push(origin.clone());
+        }
     }
-    lines.push("  }".to_owned());
+    registry.bind(INIT_TARGET, database_origin);
+    for (index, origin) in init_origins.into_iter().enumerate() {
+        registry.bind(init_statement_target(index), origin);
+    }
+    items.push(SpecItem::Init {
+        statements: init_statements,
+        meta: None,
+        annotations: Annotations::default(),
+    });
 
     for migration in &system.migrations {
-        let action = format!("migrate_{}", safe(&migration.name));
-        let metadata = quote_meta(
-            "DB-MIGRATION",
-            &format!(
-                "{}: schema {} -> {}",
-                migration.name, migration.from_schema, migration.to_schema
-            ),
+        let action_name = format!("migrate_{}", safe(&migration.name));
+        let migration_path = vec![
+            system.name.clone(),
+            "migration".to_owned(),
+            migration.name.clone(),
+        ];
+        let action_origin = db_origin(
+            migration.span,
+            migration_path.clone(),
+            "lower_db_migration",
+            true,
+            Vec::new(),
         );
-        lines.extend(annotation_lines(&migration.decl_annotations, "  "));
-        lines.push(format!("  action {action}() {metadata} {{"));
-        lines.push(format!(
-            "    requires schema_version == {}",
-            migration.from_schema
-        ));
-        for operation in &migration.ops {
+        let mut action_items = vec![requirement(
+            binary(
+                "==",
+                Expr::Var("schema_version".to_owned()),
+                Expr::Num(migration.from_schema),
+            ),
+            migration.span,
+        )];
+        let mut item_origins = vec![action_origin.clone()];
+        for (op_index, operation) in migration.ops.iter().enumerate() {
             let member = column_member(&operation.column);
+            let op_origin = db_origin(
+                operation.span,
+                vec![
+                    system.name.clone(),
+                    "migration".to_owned(),
+                    migration.name.clone(),
+                    "operation".to_owned(),
+                    op_index.to_string(),
+                    operation.op.clone(),
+                ],
+                "lower_db_migration_operation",
+                true,
+                Vec::new(),
+            );
+            let mut push = |item: ActionItem| {
+                action_items.push(item);
+                item_origins.push(op_origin.clone());
+            };
             match operation.op.as_str() {
                 "add" => {
-                    lines.push(format!("    column_exists[{member}] = true"));
-                    lines.push(format!("    column_backfilled[{member}] = false"));
-                    lines.push(format!(
-                        "    column_not_null[{member}] = {}",
-                        operation.nullability.as_deref() == Some("not_null")
+                    push(assignment(
+                        "column_exists",
+                        &member,
+                        Expr::Bool(true),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_backfilled",
+                        &member,
+                        Expr::Bool(false),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_not_null",
+                        &member,
+                        Expr::Bool(operation.nullability.as_deref() == Some("not_null")),
+                        operation.span,
                     ));
                 }
                 "backfill" => {
-                    lines.push(format!("    requires column_exists[{member}]"));
-                    lines.push(format!("    column_backfilled[{member}] = true"));
+                    push(requirement(
+                        indexed("column_exists", &member),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_backfilled",
+                        &member,
+                        Expr::Bool(true),
+                        operation.span,
+                    ));
                 }
                 "set_not_null" => {
-                    lines.push(format!("    requires column_exists[{member}]"));
-                    lines.push(format!("    requires column_backfilled[{member}]"));
-                    lines.push(format!("    column_not_null[{member}] = true"));
+                    push(requirement(
+                        indexed("column_exists", &member),
+                        operation.span,
+                    ));
+                    push(requirement(
+                        indexed("column_backfilled", &member),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_not_null",
+                        &member,
+                        Expr::Bool(true),
+                        operation.span,
+                    ));
                 }
                 "drop" => {
-                    lines.push(format!("    column_exists[{member}] = false"));
-                    lines.push(format!("    column_backfilled[{member}] = false"));
-                    lines.push(format!("    column_not_null[{member}] = false"));
+                    for name in ["column_exists", "column_backfilled", "column_not_null"] {
+                        push(assignment(name, &member, Expr::Bool(false), operation.span));
+                    }
                 }
                 "rename" => {
-                    if let Some(target) = operation.columns.first() {
-                        let target = column_member(target);
-                        lines.push(format!("    requires column_exists[{member}]"));
-                        lines.push(format!("    column_exists[{member}] = false"));
-                        lines.push(format!("    column_backfilled[{member}] = false"));
-                        lines.push(format!("    column_not_null[{member}] = false"));
-                        lines.push(format!("    column_exists[{target}] = true"));
-                        lines.push(format!("    column_backfilled[{target}] = true"));
-                        lines.push(format!(
-                            "    column_not_null[{target}] = column_not_null[{member}]"
+                    if let Some(target_column) = operation.columns.first() {
+                        let target = column_member(target_column);
+                        push(requirement(
+                            indexed("column_exists", &member),
+                            operation.span,
+                        ));
+                        for name in ["column_exists", "column_backfilled", "column_not_null"] {
+                            push(assignment(name, &member, Expr::Bool(false), operation.span));
+                        }
+                        push(assignment(
+                            "column_exists",
+                            &target,
+                            Expr::Bool(true),
+                            operation.span,
+                        ));
+                        push(assignment(
+                            "column_backfilled",
+                            &target,
+                            Expr::Bool(true),
+                            operation.span,
+                        ));
+                        push(assignment(
+                            "column_not_null",
+                            &target,
+                            indexed("column_not_null", &member),
+                            operation.span,
                         ));
                     }
                 }
                 "split" => {
-                    lines.push(format!("    requires column_exists[{member}]"));
-                    lines.push(format!("    column_exists[{member}] = false"));
-                    lines.push(format!("    column_backfilled[{member}] = false"));
-                    lines.push(format!("    column_not_null[{member}] = false"));
-                    for target in &operation.columns {
-                        let target = column_member(target);
-                        lines.push(format!("    column_exists[{target}] = true"));
-                        lines.push(format!("    column_backfilled[{target}] = true"));
-                        lines.push(format!("    column_not_null[{target}] = false"));
+                    push(requirement(
+                        indexed("column_exists", &member),
+                        operation.span,
+                    ));
+                    for name in ["column_exists", "column_backfilled", "column_not_null"] {
+                        push(assignment(name, &member, Expr::Bool(false), operation.span));
+                    }
+                    for target_column in &operation.columns {
+                        let target = column_member(target_column);
+                        push(assignment(
+                            "column_exists",
+                            &target,
+                            Expr::Bool(true),
+                            operation.span,
+                        ));
+                        push(assignment(
+                            "column_backfilled",
+                            &target,
+                            Expr::Bool(true),
+                            operation.span,
+                        ));
+                        push(assignment(
+                            "column_not_null",
+                            &target,
+                            Expr::Bool(false),
+                            operation.span,
+                        ));
                     }
                 }
                 "merge" => {
-                    for source in &operation.columns {
-                        let source = column_member(source);
-                        lines.push(format!("    requires column_exists[{source}]"));
-                        lines.push(format!("    column_exists[{source}] = false"));
-                        lines.push(format!("    column_backfilled[{source}] = false"));
-                        lines.push(format!("    column_not_null[{source}] = false"));
+                    for source_column in &operation.columns {
+                        let source = column_member(source_column);
+                        push(requirement(
+                            indexed("column_exists", &source),
+                            operation.span,
+                        ));
+                        for name in ["column_exists", "column_backfilled", "column_not_null"] {
+                            push(assignment(name, &source, Expr::Bool(false), operation.span));
+                        }
                     }
-                    lines.push(format!("    column_exists[{member}] = true"));
-                    lines.push(format!("    column_backfilled[{member}] = true"));
-                    lines.push(format!("    column_not_null[{member}] = false"));
+                    push(assignment(
+                        "column_exists",
+                        &member,
+                        Expr::Bool(true),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_backfilled",
+                        &member,
+                        Expr::Bool(true),
+                        operation.span,
+                    ));
+                    push(assignment(
+                        "column_not_null",
+                        &member,
+                        Expr::Bool(false),
+                        operation.span,
+                    ));
                 }
                 _ => {}
             }
         }
-        lines.push(format!("    schema_version = {}", migration.to_schema));
-        lines.push("  }".to_owned());
+        action_items.push(ActionItem::Statement(Statement::Assign {
+            target: LValue::Var("schema_version".to_owned()),
+            value: Expr::Num(migration.to_schema),
+            span: migration.span,
+        }));
+        item_origins.push(action_origin.clone());
+        bind_action_origins(
+            &mut registry,
+            &action_name,
+            &action_items,
+            action_origin,
+            &item_origins,
+        );
+        items.push(SpecItem::Action {
+            name: action_name,
+            params: Vec::new(),
+            items: action_items,
+            span: migration.span,
+            fair: false,
+            meta: Some(metadata(
+                "DB-MIGRATION",
+                format!(
+                    "{}: schema {} -> {}",
+                    migration.name, migration.from_schema, migration.to_schema
+                ),
+                migration.span,
+            )),
+            sync: false,
+            annotations: migration.decl_annotations.clone(),
+        });
     }
     if system.migrations.is_empty() {
-        lines.push(format!(
-            "  action observe_schema_{}() \"DB-SNAPSHOT: static compatibility snapshot\" {{",
-            system.database.initial_schema
-        ));
-        lines.push(format!(
-            "    requires schema_version == {}",
-            system.database.initial_schema
-        ));
-        lines.push(format!(
-            "    schema_version = {}",
-            system.database.initial_schema
-        ));
-        lines.push("  }".to_owned());
+        let action_name = format!("observe_schema_{}", system.database.initial_schema);
+        let origin = db_origin(
+            system.database.span,
+            database_path,
+            "lower_db_static_snapshot",
+            true,
+            Vec::new(),
+        );
+        let action_items = vec![
+            requirement(
+                binary(
+                    "==",
+                    Expr::Var("schema_version".to_owned()),
+                    Expr::Num(system.database.initial_schema),
+                ),
+                system.database.span,
+            ),
+            ActionItem::Statement(Statement::Assign {
+                target: LValue::Var("schema_version".to_owned()),
+                value: Expr::Num(system.database.initial_schema),
+                span: system.database.span,
+            }),
+        ];
+        bind_action_origins(
+            &mut registry,
+            &action_name,
+            &action_items,
+            origin.clone(),
+            &[origin.clone(), origin],
+        );
+        items.push(SpecItem::Action {
+            name: action_name,
+            params: Vec::new(),
+            items: action_items,
+            span: system.database.span,
+            fair: false,
+            meta: Some(metadata(
+                "DB-SNAPSHOT",
+                "static compatibility snapshot".to_owned(),
+                system.database.span,
+            )),
+            sync: false,
+            annotations: Annotations::default(),
+        });
     }
 
     if rules.contains("not_null_after_backfill") {
-        let annotations = rule_annotations
-            .get("not_null_after_backfill")
-            .map(|value| (*value).clone())
+        let rule = rule_by_name.get("not_null_after_backfill").copied();
+        let annotations = rule
+            .map(|rule| rule.annotations.clone())
             .unwrap_or_default();
-        for key in columns.keys() {
+        for (key, column) in &columns {
             let member = column_member(key);
             let name = invariant_name(&["db_not_null_after_backfill", &key.0, &key.1]);
-            lines.extend(annotation_lines(&annotations, "  "));
-            lines.push(format!(
-                "  invariant {name} {} {{ not column_not_null[{member}] or (column_exists[{member}] and column_backfilled[{member}]) }}",
-                quote_meta(
+            let span = rule.map_or(column.span, |rule| rule.span);
+            let mut secondary = Vec::new();
+            if rule.is_some() {
+                secondary.push(source_site(column.span, column_path(system, column)));
+            }
+            registry.bind(
+                property_target("invariant", &name),
+                db_origin(
+                    span,
+                    vec![
+                        system.name.clone(),
+                        "check".to_owned(),
+                        "not_null_after_backfill".to_owned(),
+                        key.0.clone(),
+                        key.1.clone(),
+                    ],
+                    "lower_db_not_null_rule",
+                    true,
+                    secondary,
+                ),
+            );
+            items.push(SpecItem::Invariant {
+                name,
+                expr: Box::new(binary(
+                    "or",
+                    Expr::Not(Box::new(indexed("column_not_null", &member))),
+                    binary(
+                        "and",
+                        indexed("column_exists", &member),
+                        indexed("column_backfilled", &member),
+                    ),
+                )),
+                span,
+                meta: Some(metadata(
                     "DB-NOT-NULL",
-                    &format!(
+                    format!(
                         "{} can be not_null only after it exists and is backfilled",
                         column_label(key)
-                    )
-                )
-            ));
+                    ),
+                    span,
+                )),
+                annotations: annotations.clone(),
+            });
         }
     }
+
     for environment in &system.environments {
         for entry in &environment.artifacts {
             let Some(artifact) = artifacts.get(entry.artifact.as_str()) else {
@@ -328,12 +719,12 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
                 if !rules.contains(rule) && !rules.contains("removed_only_after_unused") {
                     continue;
                 }
-                let mut annotations = rule_annotations
+                let mut annotations = rule_by_name
                     .get(rule)
-                    .map(|value| (*value).clone())
+                    .map(|rule| rule.annotations.clone())
                     .unwrap_or_default();
-                if let Some(extra) = rule_annotations.get("removed_only_after_unused") {
-                    annotations.extend(extra.source_order().iter().cloned());
+                if let Some(extra) = rule_by_name.get("removed_only_after_unused") {
+                    annotations.extend(extra.annotations.source_order().iter().cloned());
                 }
                 for column in artifact.capabilities.get(capability).into_iter().flatten() {
                     let mut parts = vec![
@@ -346,31 +737,114 @@ pub fn db_kernel_source(system: &DbSystem) -> String {
                     parts.extend([column.0.clone(), column.1.clone()]);
                     let refs = parts.iter().map(String::as_str).collect::<Vec<_>>();
                     let name = invariant_name(&refs);
-                    let text = format!(
-                        "{} artifact {} in {} must not {} missing column {}",
-                        entry.role,
-                        entry.artifact,
-                        environment.name,
-                        verb,
-                        column_label(column)
+                    let mut secondary = vec![source_site(
+                        artifact.span,
+                        vec![
+                            system.name.clone(),
+                            "artifact".to_owned(),
+                            artifact.name.clone(),
+                            capability.to_owned(),
+                        ],
+                    )];
+                    if let Some(column_decl) = columns.get(column) {
+                        secondary.push(source_site(
+                            column_decl.span,
+                            column_path(system, column_decl),
+                        ));
+                    }
+                    for rule_name in [rule, "removed_only_after_unused"] {
+                        if let Some(rule_decl) = rule_by_name.get(rule_name) {
+                            let site = source_site(
+                                rule_decl.span,
+                                vec![
+                                    system.name.clone(),
+                                    "check".to_owned(),
+                                    rule_name.to_owned(),
+                                ],
+                            );
+                            if !secondary.contains(&site) {
+                                secondary.push(site);
+                            }
+                        }
+                    }
+                    registry.bind(
+                        property_target("invariant", &name),
+                        db_origin(
+                            entry.span,
+                            vec![
+                                system.name.clone(),
+                                "environment".to_owned(),
+                                environment.name.clone(),
+                                entry.role.clone(),
+                                entry.artifact.clone(),
+                            ],
+                            "lower_db_artifact_compatibility",
+                            true,
+                            secondary,
+                        ),
                     );
-                    lines.extend(annotation_lines(&annotations, "  "));
-                    lines.push(format!(
-                        "  invariant {name} {} {{ {} }}",
-                        quote_meta(id, &text),
-                        compatibility_expression(window, &column_member(column))
-                    ));
+                    items.push(SpecItem::Invariant {
+                        name,
+                        expr: Box::new(compatibility_expr(window, &column_member(column))),
+                        span: entry.span,
+                        meta: Some(metadata(
+                            id,
+                            format!(
+                                "{} artifact {} in {} must not {} missing column {}",
+                                entry.role,
+                                entry.artifact,
+                                environment.name,
+                                verb,
+                                column_label(column)
+                            ),
+                            entry.span,
+                        )),
+                        annotations: annotations.clone(),
+                    });
                 }
             }
         }
     }
+
     let final_schema = system
         .migrations
         .last()
         .map_or(system.database.initial_schema, |migration| {
             migration.to_schema
         });
-    lines.push(format!("  terminal {{ schema_version == {final_schema} }}"));
-    lines.push("}".to_owned());
-    lines.join("\n")
+    let terminal_span = system
+        .migrations
+        .last()
+        .map_or(system.database.span, |migration| migration.span);
+    registry.bind(
+        TERMINAL_TARGET,
+        db_origin(
+            terminal_span,
+            vec![system.name.clone(), "terminal_schema".to_owned()],
+            "lower_db_terminal_schema",
+            true,
+            Vec::new(),
+        ),
+    );
+    items.push(SpecItem::Terminal {
+        expr: Box::new(binary(
+            "==",
+            Expr::Var("schema_version".to_owned()),
+            Expr::Num(final_schema),
+        )),
+        span: terminal_span,
+    });
+
+    (
+        SurfaceSpec {
+            name: system.name.clone(),
+            meta: Some(metadata(
+                "db",
+                "database multi-environment compatibility".to_owned(),
+                system.span,
+            )),
+            items,
+        },
+        registry,
+    )
 }

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -2251,11 +2251,10 @@ fn lower_catalog_sentinel(name: String, prefix: &str, id: &str) -> Result<Kernel
 ///
 /// # Errors
 ///
-/// Returns [`CoreError`] if the generated kernel catalog is invalid.
+/// Returns [`CoreError`] if the lowered kernel catalog is invalid.
 pub fn lower_db(system: &fsl_syntax::DbSystem) -> Result<KernelSpec, CoreError> {
-    let source = crate::db_kernel_source(system);
-    let spec = fsl_syntax::parse_surface_spec(&source)?;
-    lower_direct_spec(spec)
+    let (surface, origins) = crate::db::lower_db_surface(system);
+    crate::lower_direct_spec_with_origins(surface, origins)
 }
 
 /// Lower a Functional-DDD document to its executable catalog kernel.

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -38,7 +38,6 @@ mod typecheck;
 pub use compose::{
     FileResolver, FsResolver, lower_compose, parse_kernel_source, parse_kernel_source_with_file,
 };
-pub use db::db_kernel_source;
 pub use diagnostics::{
     insert_requirement_metadata, model_warnings, requirement_metadata, version_metadata,
 };

--- a/rust/fsl-core/src/trace_json.rs
+++ b/rust/fsl-core/src/trace_json.rs
@@ -51,6 +51,13 @@ pub fn internal_origin_json(origin: &OriginChain) -> Value {
 
 #[must_use]
 pub fn origin_display_name(origin: &OriginChain) -> Option<&str> {
+    // Database lowering now has truthful source origins, but its public action
+    // and property names predate source-backed display-name substitution. Keep
+    // those executable/replay identities stable while still publishing the
+    // origin chain and authored locations.
+    if origin.dialect == "dbsystem" {
+        return None;
+    }
     origin
         .primary
         .as_ref()

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6717,9 +6717,8 @@ fn model_skeleton(model: &KernelModel) -> Value {
             let origin = model.action_origin(&action.name);
             let mut value = json!({
                 "name": origin
-                    .and_then(|origin| origin.primary.as_ref())
-                    .and_then(|site| site.declaration_path.last())
-                    .map_or_else(|| fslc_rust::display_name(&action.name), String::clone),
+                    .and_then(fslc_rust::origin_display_name)
+                    .map_or_else(|| fslc_rust::display_name(&action.name), str::to_owned),
                 "params": action.params.iter().map(|param|param_skeleton(model,param)).collect::<Vec<_>>(),
                 "requires_text": action.requires.iter().map(|expr|format!("requires {}",fslc_rust::source_expr_text(model,expr))).collect::<Vec<_>>(),
                 "ensures_text": action.ensures.iter().map(|expr|format!("ensures {}",fslc_rust::source_expr_text(model,expr))).collect::<Vec<_>>(),
@@ -6758,9 +6757,8 @@ fn model_skeleton(model: &KernelModel) -> Value {
             let origin = model.property_origin(kind, &property.name);
             let mut value = json!({
                 "name": origin
-                    .and_then(|origin| origin.primary.as_ref())
-                    .and_then(|site| site.declaration_path.last())
-                    .map_or_else(|| fslc_rust::display_name(&property.name), String::clone),
+                    .and_then(fslc_rust::origin_display_name)
+                    .map_or_else(|| fslc_rust::display_name(&property.name), str::to_owned),
                 "kind":kind,
                 "body_text":fslc_rust::source_expr_text(model,&property.expr),
                 "requirement":Value::Null

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -1036,9 +1036,8 @@ fn render_violation(
     };
     let origin = model.property_origin(property_kind, &violation.name);
     let rendered_name = origin
-        .and_then(|origin| origin.primary.as_ref())
-        .and_then(|site| site.declaration_path.last())
-        .map_or_else(|| display_name(&violation.name), String::clone);
+        .and_then(origin_display_name)
+        .map_or_else(|| display_name(&violation.name), str::to_owned);
     if violation.kind == "trans" {
         output.insert("trans".to_owned(), json!(rendered_name));
     }
@@ -1090,9 +1089,8 @@ fn render_violation(
                 let origin = model.action_origin(&action.name);
                 let mut rendered = json!({
                     "name": origin
-                        .and_then(|origin| origin.primary.as_ref())
-                        .and_then(|site| site.declaration_path.last())
-                        .map_or_else(|| display_name(&action.name), String::clone),
+                        .and_then(origin_display_name)
+                        .map_or_else(|| display_name(&action.name), str::to_owned),
                     "params": action.params.iter().map(|(name, value)| (
                         name.clone(), fsl_value_json(value)
                     )).collect::<Map<_, _>>(),
@@ -1149,9 +1147,8 @@ fn render_reachable_failure(
                     let origin = model.property_origin("reachable", &property.name);
                     let mut item = json!({
                         "name": origin
-                            .and_then(|origin| origin.primary.as_ref())
-                            .and_then(|site| site.declaration_path.last())
-                            .map_or_else(|| display_name(&property.name), String::clone),
+                            .and_then(origin_display_name)
+                            .map_or_else(|| display_name(&property.name), str::to_owned),
                         "loc": property.span.python_loc(),
                         "classification": "insufficient_depth",
                         "hint": format!("not witnessed within depth {}; try a larger --depth", options.depth),

--- a/rust/fslc/tests/db_direct_lowering.rs
+++ b/rust/fslc/tests/db_direct_lowering.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+use fsl_core::{
+    FsResolver, PublicKernelVersion, build_model, parse_kernel_source_with_file,
+    public_kernel_contract_for_version,
+};
+use fsl_syntax::{ActionItem, Expr, LValue, SpecItem, Statement};
+
+const SAFE: &str =
+    include_str!("../../../examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl");
+const UNSAFE: &str = include_str!("../../../examples/db/unsafe_not_null_before_backfill.fsl");
+const RENAME: &str = include_str!("../../../examples/db/safe_rename_preservation.fsl");
+const SPLIT: &str = include_str!("../../../examples/db/unsafe_lossy_split_preservation.fsl");
+const MERGE: &str = include_str!("../../../examples/db/unsafe_lossy_merge_preservation.fsl");
+const SAFE_PATH: &str = "examples/db/safe_dual_write_backfill_switch_read_drop_old.fsl";
+const UNSAFE_PATH: &str = "examples/db/unsafe_not_null_before_backfill.fsl";
+
+fn run_cli(args: &[&str]) -> (serde_json::Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn expr_signature(expr: &Expr) -> String {
+    match expr {
+        Expr::Num(value) => value.to_string(),
+        Expr::Bool(value) => value.to_string(),
+        Expr::Var(name) => name.clone(),
+        Expr::Index(base, index) => {
+            format!("{}[{}]", expr_signature(base), expr_signature(index))
+        }
+        Expr::Binary { op, left, right } => {
+            format!("({} {op} {})", expr_signature(left), expr_signature(right))
+        }
+        other => panic!("unexpected DB expression: {other:?}"),
+    }
+}
+
+fn lvalue_signature(target: &LValue) -> String {
+    match target {
+        LValue::Var(name) => name.clone(),
+        LValue::Index(name, index) => format!("{name}[{}]", expr_signature(index)),
+        other @ LValue::Field(..) => panic!("unexpected DB lvalue: {other:?}"),
+    }
+}
+
+fn item_signature(item: &ActionItem) -> String {
+    match item {
+        ActionItem::Requires(expr, _) => format!("requires {}", expr_signature(expr)),
+        ActionItem::Statement(Statement::Assign { target, value, .. }) => {
+            format!("{} = {}", lvalue_signature(target), expr_signature(value))
+        }
+        other => panic!("unexpected DB action item: {other:?}"),
+    }
+}
+
+#[test]
+fn direct_lowering_preserves_catalog_shape_and_source_order() {
+    let kernel = parse_kernel_source_with_file(SAFE, &FsResolver::new("."), SAFE_PATH)
+        .expect("lower dbsystem directly");
+    let syntax = kernel.syntax();
+
+    let actions = syntax
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            SpecItem::Action { name, items, .. } => Some((name.as_str(), items.len())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actions,
+        [
+            ("migrate_add_display_name", 5),
+            ("migrate_backfill_display_name", 4),
+            ("migrate_require_display_name", 5),
+            ("migrate_drop_legacy_name", 5),
+        ]
+    );
+
+    let init = syntax
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SpecItem::Init { statements, .. } => Some(statements),
+            _ => None,
+        })
+        .expect("generated init");
+    assert_eq!(init.len(), 10);
+
+    let add = syntax
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SpecItem::Action { name, items, .. } if name == "migrate_add_display_name" => {
+                Some(items)
+            }
+            _ => None,
+        })
+        .expect("add migration");
+    assert!(matches!(add.first(), Some(ActionItem::Requires(..))));
+    assert!(matches!(add.last(), Some(ActionItem::Statement(..))));
+
+    let read_origin = kernel
+        .origins()
+        .targets()
+        .find(|(target, _)| target.starts_with("property:invariant:db_readQqDbSepqQ"))
+        .and_then(|(_, origins)| origins.first())
+        .expect("read compatibility origin");
+    let secondary_names = read_origin
+        .secondary
+        .iter()
+        .filter_map(|site| site.declaration_path.last().map(String::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(secondary_names.contains("all_active_reads_exist"));
+    assert!(secondary_names.contains("removed_only_after_unused"));
+
+    let terminal = syntax.items.last().expect("terminal item");
+    assert!(matches!(terminal, SpecItem::Terminal { .. }));
+    build_model(kernel).expect("directly lowered catalog builds a checked model");
+}
+
+#[test]
+fn direct_lowering_preserves_structural_transform_shapes() {
+    for (source, path, expected_name, expected) in [
+        (
+            RENAME,
+            "examples/db/safe_rename_preservation.fsl",
+            "migrate_rename_legacy_name",
+            &[
+                "requires (schema_version == 0)",
+                "requires column_exists[col_users_legacy_name]",
+                "column_exists[col_users_legacy_name] = false",
+                "column_backfilled[col_users_legacy_name] = false",
+                "column_not_null[col_users_legacy_name] = false",
+                "column_exists[col_users_display_name] = true",
+                "column_backfilled[col_users_display_name] = true",
+                "column_not_null[col_users_display_name] = column_not_null[col_users_legacy_name]",
+                "schema_version = 1",
+            ][..],
+        ),
+        (
+            SPLIT,
+            "examples/db/unsafe_lossy_split_preservation.fsl",
+            "migrate_split_full_name",
+            &[
+                "requires (schema_version == 0)",
+                "requires column_exists[col_users_full_name]",
+                "column_exists[col_users_full_name] = false",
+                "column_backfilled[col_users_full_name] = false",
+                "column_not_null[col_users_full_name] = false",
+                "column_exists[col_users_first_name] = true",
+                "column_backfilled[col_users_first_name] = true",
+                "column_not_null[col_users_first_name] = false",
+                "column_exists[col_users_last_name] = true",
+                "column_backfilled[col_users_last_name] = true",
+                "column_not_null[col_users_last_name] = false",
+                "schema_version = 1",
+            ][..],
+        ),
+        (
+            MERGE,
+            "examples/db/unsafe_lossy_merge_preservation.fsl",
+            "migrate_merge_name",
+            &[
+                "requires (schema_version == 0)",
+                "requires column_exists[col_users_first_name]",
+                "column_exists[col_users_first_name] = false",
+                "column_backfilled[col_users_first_name] = false",
+                "column_not_null[col_users_first_name] = false",
+                "requires column_exists[col_users_last_name]",
+                "column_exists[col_users_last_name] = false",
+                "column_backfilled[col_users_last_name] = false",
+                "column_not_null[col_users_last_name] = false",
+                "column_exists[col_users_display_name] = true",
+                "column_backfilled[col_users_display_name] = true",
+                "column_not_null[col_users_display_name] = false",
+                "schema_version = 1",
+            ][..],
+        ),
+    ] {
+        let kernel = parse_kernel_source_with_file(source, &FsResolver::new("."), path)
+            .expect("lower structural migration directly");
+        let actions = kernel
+            .syntax()
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                SpecItem::Action { name, items, .. } => Some((name.as_str(), items)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actions.len(), 1, "{path}");
+        assert_eq!(actions[0].0, expected_name, "{path}");
+        assert_eq!(
+            actions[0].1.iter().map(item_signature).collect::<Vec<_>>(),
+            expected,
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn direct_lowering_publishes_authored_db_origins() {
+    let kernel = parse_kernel_source_with_file(UNSAFE, &FsResolver::new("."), UNSAFE_PATH)
+        .expect("lower dbsystem directly");
+    let model = build_model(kernel.clone()).expect("build dbsystem model");
+    let contract = public_kernel_contract_for_version(
+        &kernel,
+        &model,
+        UNSAFE_PATH,
+        "db",
+        PublicKernelVersion::V2,
+    )
+    .expect("publish v2");
+
+    let action_origin = kernel
+        .origins()
+        .primary_for("action:migrate_add_required_email")
+        .expect("migration action origin");
+    let action_site = action_origin
+        .primary
+        .as_ref()
+        .expect("migration source site");
+    assert_eq!(action_site.source_file.as_deref(), Some(UNSAFE_PATH));
+    assert_eq!(action_site.span.expect("migration span").start.line, 10);
+    assert!(action_origin.generated);
+
+    let property_target =
+        "property:invariant:db_not_null_after_backfillQqDbSepqQusersQqDbSepqQemail";
+    let property_origin = kernel
+        .origins()
+        .primary_for(property_target)
+        .expect("not-null property origin");
+    assert_eq!(
+        property_origin
+            .primary
+            .as_ref()
+            .and_then(|site| site.span)
+            .expect("rule span")
+            .start
+            .line,
+        28
+    );
+    assert!(property_origin.secondary.iter().any(|site| {
+        site.span
+            .is_some_and(|span| span.start.line == 6 && span.start.column == 7)
+    }));
+
+    let origins = contract["provenance"]["origins"]
+        .as_array()
+        .expect("published origins");
+    assert!(origins.iter().any(|origin| {
+        origin["assurance"] == "generated_from_source"
+            && origin["primary"]["source"]["value"] == UNSAFE_PATH
+    }));
+}
+
+#[test]
+fn direct_lowering_negative_control_rejects_not_null_before_backfill() {
+    let (value, status) = run_cli(&["verify", UNSAFE_PATH, "--depth", "2", "--no-cache"]);
+
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    assert_eq!(value["violation_kind"], "invariant");
+    assert_eq!(
+        value["invariant"],
+        "db_not_null_after_backfill__users__email"
+    );
+    assert_eq!(value["requirement"]["id"], "DB-NOT-NULL");
+    assert_eq!(value["loc"], serde_json::json!({"line": 28, "column": 5}));
+    assert_eq!(
+        value["last_action"]["loc"],
+        serde_json::json!({"line": 10, "column": 3})
+    );
+    assert_eq!(value["last_action"]["name"], "migrate_add_required_email");
+    assert_eq!(
+        value["trace"][1]["action"]["name"],
+        "migrate_add_required_email"
+    );
+    assert_eq!(value["violated_at_step"], 1);
+}
+
+#[test]
+fn direct_lowering_keeps_explain_names_replayable() {
+    let (value, status) = run_cli(&["explain", UNSAFE_PATH, "--depth", "2"]);
+
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "explained");
+    let action_names = value["skeleton"]["actions"]
+        .as_array()
+        .expect("actions")
+        .iter()
+        .map(|action| action["name"].as_str().expect("action name"))
+        .collect::<Vec<_>>();
+    assert_eq!(action_names, ["migrate_add_required_email"]);
+    let property_names = value["skeleton"]["properties"]
+        .as_array()
+        .expect("properties")
+        .iter()
+        .map(|property| property["name"].as_str().expect("property name"))
+        .collect::<Vec<_>>();
+    assert!(property_names.contains(&"db_not_null_after_backfill__users__email"));
+    assert_eq!(
+        property_names
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        property_names.len(),
+        "display names must remain unique"
+    );
+}


### PR DESCRIPTION
## Problem

`DbSystem` lowering generated synthetic FSL source, parsed it again, and then lowered that surface model. The round trip obscured authored DB provenance, coupled core lowering to text rendering, and retained an obsolete intermediate representation.

## Contract change

- Build the equivalent surface AST and origin registry directly from `DbSystem`.
- Preserve types, state/init, action guards and statements, properties, annotations, deterministic ordering, verdicts, Public Kernel schemas, and established action/property display identities.
- Bind generated Kernel targets to truthful authored DB declarations and locations instead of synthetic generated-text spans.
- Delete `db_kernel_source` and its public re-export; no compatibility fallback remains.

## Evidence

- Temporary legacy/direct equivalence harness covered safe dual-write, rename, feature-flag, split, merge, and static-snapshot catalogs before the legacy path was removed.
- Permanent direct-lowering tests cover exact catalog/action shape and order, Public Kernel v2 origins, explain/replay identity, and a DB-NOT-NULL violating negative control.
- Existing Python-driven native CLI DB compatibility contract passes.
- `./tools/check-native-integration.sh` passes, including native/WASM parity across 351 cases.
- Independent review found no remaining actionable issue.

## Local-optimum audit

The former text round trip was a cross-boundary local optimum: function-local rendering convenience externalized parser coupling and fabricated provenance. Direct structural lowering removes that boundary. The larger private builder is not currently an actionable local optimum because it has one semantic owner, no reverse dependency, no fallback, and no demonstrated preference inversion; reassess if consumers or change amplification appear.

Closes #410
