### PR TITLE
fix(refine): add exhaustive nominal enum conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Refinement mappings can now declare an exhaustive, type-safe member-wise
+  conversion between distinct nominal enums and invoke it from state maps or
+  action arguments. This includes requirements `process` stage enums, rejects
+  unknown/duplicate/non-total mappings and implicit ordinal conversion, and
+  fails closed in raw replay modes that lack a typed implementation model
+  (#450).
 - The embedded native CLI contract and exact help tree now include all six documented causal
   command leaves, while the deliberately absent `causal verify` path remains rejected (#442).
 - Verifier transition-outcome agreement now proves actual guard failure and

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -252,6 +252,108 @@ refinement SeatImplRefinesBooking {
   the node and its semantics already existed in both v1 and v2 schemas, this
   change does not alter either schema version.
 
+## 2.6 Exhaustive nominal-enum conversion (issue #450)
+
+Refinement preserves nominal enum identity. Distinct impl/abs enums are never
+assignment-compatible and are never converted by ordinal. A refinement that needs a
+member-wise representation change declares a named conversion and calls it from a state
+map or action argument:
+
+```fsl
+refinement ApplicationUnitOfWorkRefinesUseCase {
+  impl ApplicationUnitOfWorkDesign
+  abs ApplicationUseCaseRequirements
+
+  enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
+    Received  -> Received
+    Loaded    -> Loaded
+    Decided   -> Decided
+    Committed -> Committed
+    Rejected  -> Rejected
+    Conflict  -> Conflict
+  }
+
+  map command_stage[c: Command] = convert(use_case_stage, stage[c])
+  action load(c) -> load(c)
+}
+```
+
+The declaration is a refinement item, so the same syntax is accepted in a standalone
+`refinement` file and an inline requirements `implements { }` block. Its name is local to
+that refinement block. Invocation uses the dedicated
+`convert(<conversion-name>, <expression>)` form and is valid in both state-map expressions
+and abstract action arguments. The first argument is a syntactic conversion name, not a
+value expression; this keeps conversion names out of the namespace of special expression
+calls such as `stage`, `old`, and `abs`.
+
+The source and target names must resolve to enums in the merged impl/abs checked-Kernel
+type inventory. This includes requirements `process` stage enums, DB/domain generated
+enums, and compose-renamed enum types. Conversion rows use the checked-Kernel member
+spellings. Requirements stages retain their source spelling; domain lowering intentionally
+namespaces members (for example `OrderStatus_Pending`), so a mapping at the Kernel
+refinement boundary uses the names published by `fslc kernel`, not the shorter domain-source
+alias. Diagnostics point to the conversion row and list the checked members; they do not
+fabricate a source-level domain span after lowering. The declaration is a checked bijection:
+
+- every declared source member appears exactly once on the left;
+- every declared target member appears exactly once on the right;
+- unknown source/target types or members, duplicate source/target members, a missing
+  member on either side, and a non-enum endpoint are `kind:"type"` errors at the
+  declaration/member location;
+- the call argument must have the declared source nominal type and the call result has
+  the declared target nominal type; and
+- duplicate conversion names, unknown conversion calls, and wrong call arity fail
+  statically.
+
+Requiring both source-totality and target-totality deliberately makes this construct a
+one-to-one representation conversion. A genuine abstraction that collapses several impl
+states into one abs state remains expressible with an ordinary conditional mapping only
+when every referenced member spelling is unambiguous in the merged context; that form does
+not claim exhaustive/bijective assurance. A many-to-one conversion whose source/target
+member spellings collide remains outside this feature. It needs a separately designed
+source-total, non-injective conversion contract rather than weakening this fail-closed
+bijection.
+
+### Checked representation and evaluation
+
+The private checked expression IR gains an enum-member literal carrying both
+`type_name` and `member`; it is not surface `Type.Member` syntax and never consults the
+flat bare-member namespace. Before storing the checked `Refinement`, the frontend
+elaborates each conversion call to the existing nested conditional (`ite`) shape whose
+conditions and results use these typed literals. Repeating the pure argument expression in
+that tree has no observable evaluation-order effect. The last branch is safe as the
+fallback only because source coverage was proved complete.
+
+Concrete Monitor/refinement evaluation maps the selected source member to the declared
+target member. Symbolic evaluation uses the same conditional tree and the enums' own
+member encodings; reversing declaration order therefore cannot change the result.
+Preserved-progress substitution, semantic diff, and inline `implements` consume the
+already-elaborated expression through the shared refinement builder. Production-log and
+causal replay are different: their `impl` is an untyped external JSON schema, so no source
+enum can be resolved. Those raw-surface mapping paths must reject an `enum conversion`
+declaration or `convert(...)` call with a located `kind:"type"` error explaining that a
+typed impl model is required; they must never ignore or partially evaluate it.
+
+Public Kernel model contracts do not contain refinement mappings, and this change does not
+invent a standalone mapping schema. For sidecars that publish an already-checked mapping
+expression, `public_kernel_expression` projects the elaborated form using the existing
+typed `ite` and `var` shape: an internal enum-member literal becomes
+`{"kind":"var","name":<member>,"type":{"kind":"named","name":<type>},...}`.
+The `(type, name)` pair round-trips nominal identity even when impl and abs use identical
+member spelling; projection does not reconstruct it through `base_env`. Public Kernel v1
+and v2 therefore need no new expression kind or schema version. An unelaborated
+`convert(...)` call fails export instead of being omitted or emitted as an untyped call.
+
+### Migration
+
+A pre-3.1 conditional mapping with distinct, unambiguous member spellings remains valid.
+When member spellings collide across nominal enums, or when exhaustive conversion is the
+intended contract, replace the conditional with `enum conversion` plus
+`convert(<name>, <expr>)`.
+Do not rename both layers to one enum type and do not map by declaration order; those
+workarounds erase layer identity or recreate the ordinal false-green that nominal typing
+prevents.
+
 ## 3. CLI / JSON
 
 ```

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1229,6 +1229,33 @@ refinement のマップと action の引数は、`if <condition> then <expr> els
 含め、通常の spec と同じ式文法と型規則を使います。条件が定数であっても、両方の分岐
 が名前と型の検査を受けます。
 
+異なる名前付き enum の間では、明示的に名前を付けた変換が必要です。refinement 内で
+メンバーごとの全単射を宣言し、状態マップまたは action の引数から呼び出します:
+
+```fsl
+enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
+  Received -> Received
+  Validated -> Validated
+  Executing -> Executing
+  Completed -> Completed
+}
+map command_stage[c: Command] = convert(use_case_stage, stage[c])
+```
+
+両端は enum 型でなければなりません。source と target の全メンバーをそれぞれ正確に
+1 回ずつ指定する必要があり、未知・重複・欠落したメンバーは変換宣言の位置を伴う
+`kind: "type"`(exit 2)になります。宣言順や同じメンバー名から変換を推論することは
+なく、2 つの enum の直接代入は引き続き型エラーです。target には requirements の
+`process` lowering が生成した stage enum を指定できます。その場合は `fslc kernel`
+で確認できる checked Kernel 名(例: `CommandStage`)を使います。既存の raw
+`replay --from-log` と causal observation のマッピングには型付き impl model がないため、
+変換宣言/呼び出しを位置付き型エラーとして拒否します。`convert` を使う前に型付き
+refinement へ移行してください。
+
+抽象側の生成 enum が Map の binder で、実装側の Map が design enum をキーにするときは、
+binder を逆方向に変換します。例えば `column_key Column -> DesignColumn` に対して
+`map column_exists[c: Column] = design_exists[convert(column_key, c)]` と書きます。
+
 ```bash
 fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 ```

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1258,6 +1258,36 @@ Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including `if <condition> then <expr> else <expr>`.
 Both branches are name- and type-checked even when the condition is constant.
 
+Distinct nominal enums require an explicit, named conversion. Declare a
+member-wise bijection in the refinement and call it from a state map or action
+argument:
+
+```fsl
+enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
+  Received -> Received
+  Validated -> Validated
+  Executing -> Executing
+  Completed -> Completed
+}
+map command_stage[c: Command] = convert(use_case_stage, stage[c])
+```
+
+Both endpoints must be enum types. Every source and target member must appear
+exactly once; unknown, duplicate, or missing members are `kind: "type"`
+(exit 2) errors at the conversion site. Conversion is never inferred from
+declaration order or equal member spelling, so direct assignment between the
+two enums remains a type error. The target may be a requirements `process`
+stage enum synthesized by lowering; use its checked Kernel name (visible in
+`fslc kernel`), such as `CommandStage`. Existing raw `replay --from-log` and
+causal observation mappings have no typed impl model and reject conversion
+declarations/calls with a located type error; migrate those mappings to a typed
+refinement before using `convert`.
+
+When an abstract generated enum is the binder for a map whose implementation
+uses a design enum as its key, convert the binder in the reverse direction,
+for example `map column_exists[c: Column] =
+design_exists[convert(column_key, c)]` with `column_key Column -> DesignColumn`.
+
 ```bash
 fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 ```

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1306,6 +1306,31 @@ locations; explicit entries still take precedence over auto synthesis.</p>
 <p>Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
 Both branches are name- and type-checked even when the condition is constant.</p>
+<p>Distinct nominal enums require an explicit, named conversion. Declare a
+member-wise bijection in the refinement and call it from a state map or action
+argument:</p>
+<pre><code class="language-fsl">enum conversion use_case_stage UnitOfWorkStage -&gt; CommandStage {
+  Received -&gt; Received
+  Validated -&gt; Validated
+  Executing -&gt; Executing
+  Completed -&gt; Completed
+}
+map command_stage[c: Command] = convert(use_case_stage, stage[c])
+</code></pre>
+<p>Both endpoints must be enum types. Every source and target member must appear
+exactly once; unknown, duplicate, or missing members are <code>kind: "type"</code>
+(exit 2) errors at the conversion site. Conversion is never inferred from
+declaration order or equal member spelling, so direct assignment between the
+two enums remains a type error. The target may be a requirements <code>process</code>
+stage enum synthesized by lowering; use its checked Kernel name (visible in
+<code>fslc kernel</code>), such as <code>CommandStage</code>. Existing raw <code>replay --from-log</code> and
+causal observation mappings have no typed impl model and reject conversion
+declarations/calls with a located type error; migrate those mappings to a typed
+refinement before using <code>convert</code>.</p>
+<p>When an abstract generated enum is the binder for a map whose implementation
+uses a design enum as its key, convert the binder in the reverse direction,
+for example <code>map column_exists[c: Column] =
+design_exists[convert(column_key, c)]</code> with <code>column_key Column -&gt; DesignColumn</code>.</p>
 <pre><code class="language-bash">fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 </code></pre>
 <p>Success: <code>result: "refines"</code> (exit 0). Violation: <code>refinement_failed</code> (exit 1)

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1279,6 +1279,28 @@ action、requirement-action の <code>maps</code>、auto/恒等の合成 — は
 <p>refinement のマップと action の引数は、<code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code> を
 含め、通常の spec と同じ式文法と型規則を使います。条件が定数であっても、両方の分岐
 が名前と型の検査を受けます。</p>
+<p>異なる名前付き enum の間では、明示的に名前を付けた変換が必要です。refinement 内で
+メンバーごとの全単射を宣言し、状態マップまたは action の引数から呼び出します:</p>
+<pre><code class="language-fsl">enum conversion use_case_stage UnitOfWorkStage -&gt; CommandStage {
+  Received -&gt; Received
+  Validated -&gt; Validated
+  Executing -&gt; Executing
+  Completed -&gt; Completed
+}
+map command_stage[c: Command] = convert(use_case_stage, stage[c])
+</code></pre>
+<p>両端は enum 型でなければなりません。source と target の全メンバーをそれぞれ正確に
+1 回ずつ指定する必要があり、未知・重複・欠落したメンバーは変換宣言の位置を伴う
+<code>kind: "type"</code>(exit 2)になります。宣言順や同じメンバー名から変換を推論することは
+なく、2 つの enum の直接代入は引き続き型エラーです。target には requirements の
+<code>process</code> lowering が生成した stage enum を指定できます。その場合は <code>fslc kernel</code>
+で確認できる checked Kernel 名(例: <code>CommandStage</code>)を使います。既存の raw
+<code>replay --from-log</code> と causal observation のマッピングには型付き impl model がないため、
+変換宣言/呼び出しを位置付き型エラーとして拒否します。<code>convert</code> を使う前に型付き
+refinement へ移行してください。</p>
+<p>抽象側の生成 enum が Map の binder で、実装側の Map が design enum をキーにするときは、
+binder を逆方向に変換します。例えば <code>column_key Column -&gt; DesignColumn</code> に対して
+<code>map column_exists[c: Column] = design_exists[convert(column_key, c)]</code> と書きます。</p>
 <pre><code class="language-bash">fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
 </code></pre>
 <p>成功: <code>result: "refines"</code>(exit 0)。違反: <code>refinement_failed</code>(exit 1)で、

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -3280,7 +3280,7 @@ fn bind_expression_tree(
             bind_expression_tree(registry, &child("second"), second, origin);
             bind_expression_tree(registry, &child("third"), third, origin);
         }
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {}
     }
 }
 

--- a/rust/fsl-core/src/expr_text.rs
+++ b/rust/fsl-core/src/expr_text.rs
@@ -142,6 +142,9 @@ fn expr_text_with_origins(model: Option<&KernelModel>, expr: &Expr) -> String {
             .join(", ")
         ),
         Expr::Var(name) => display_name(name),
+        Expr::EnumMember { type_name, member } => {
+            format!("{}.{}", display_name(type_name), display_name(member))
+        }
         Expr::Call { name, args, .. } => format!(
             "{}({})",
             display_name(name),

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -1225,9 +1225,27 @@ pub(crate) fn visit_expr_children(
             visitor(second)?;
             visitor(third)?;
         }
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {}
     }
     Ok(())
+}
+
+/// Return the first source span of a named expression call, including nested calls.
+#[must_use]
+pub fn expression_call_span(expr: &Expr, call_name: &str) -> Option<fsl_syntax::Span> {
+    if let Expr::Call { name, span, .. } = expr
+        && name == call_name
+    {
+        return Some(*span);
+    }
+    let mut found = None;
+    let _ = visit_expr_children(expr, &mut |child| {
+        if found.is_none() {
+            found = expression_call_span(child, call_name);
+        }
+        Ok(())
+    });
+    found
 }
 
 fn visit_binder_exprs(

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -1528,7 +1528,9 @@ fn expr_children(expr: &Expr) -> Vec<&Expr> {
             third,
             ..
         } => vec![first, second, third],
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => Vec::new(),
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {
+            Vec::new()
+        }
     }
 }
 

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -312,6 +312,10 @@ fn expr_json(
             output.insert("kind".to_owned(), json!("var"));
             output.insert("name".to_owned(), json!(name));
         }
+        Expr::EnumMember { member, .. } => {
+            output.insert("kind".to_owned(), json!("var"));
+            output.insert("name".to_owned(), json!(member));
+        }
         Expr::Call { name, .. } => {
             return Err(error(format!(
                 "unlowered predicate call '{name}' in public Kernel"
@@ -829,7 +833,12 @@ fn walk_partial(
             third,
             ..
         } => children.extend([first.as_ref(), second.as_ref(), third.as_ref()]),
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::Call { .. } => {}
+        Expr::Num(_)
+        | Expr::Bool(_)
+        | Expr::None
+        | Expr::Var(_)
+        | Expr::EnumMember { .. }
+        | Expr::Call { .. } => {}
     }
     for child in children {
         walk_partial(child, env, model, path, span, path_condition, output)?;

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -1,17 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use fsl_syntax::{
-    ActionTarget, Binder, CorrespondenceOrigin, Expr, MetaTag, QualifiedName, RefinementItem,
-    RefinementParam, RequirementAction, RequirementActionItem, RequirementBlockItem,
-    RequirementsItem, Span, SurfaceDocument, SurfaceRefinement,
+    ActionTarget, Binder, ConditionalSpans, CorrespondenceOrigin, Expr, MetaTag, QualifiedName,
+    RefinementItem, RefinementParam, RequirementAction, RequirementActionItem,
+    RequirementBlockItem, RequirementsItem, Span, SurfaceDocument, SurfaceRefinement,
 };
 
 use crate::{
-    ActionDef, FileResolver, KernelModel, ParamDef, TypeRef, build_model, parse_kernel_source,
+    ActionDef, FileResolver, KernelModel, ParamDef, TypeDef, TypeRef, build_model,
+    parse_kernel_source,
 };
+
+#[derive(Clone, Debug)]
+struct EnumConversion {
+    source: String,
+    target: String,
+    members: Vec<(String, String)>,
+    span: Span,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateMap {
@@ -109,6 +118,7 @@ fn build_refinement(
     let mut abs_name = None;
     let mut maps_auto = None;
     let mut state_maps = BTreeMap::new();
+    let mut enum_conversion_items = Vec::new();
     let mut action_correspondences = BTreeMap::new();
     let mut action_sources = Vec::new();
     let mut progress = Vec::new();
@@ -118,6 +128,13 @@ fn build_refinement(
             RefinementItem::Impl(name) => impl_name = Some(name),
             RefinementItem::Abs(name) => abs_name = Some(name),
             RefinementItem::MapsAuto(span) => maps_auto = Some(span),
+            RefinementItem::EnumConversion {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => enum_conversion_items.push((name, source, target, members, span)),
             RefinementItem::Map {
                 name,
                 binder,
@@ -193,6 +210,17 @@ fn build_refinement(
             ),
             None,
         ));
+    }
+    let enum_conversions = build_enum_conversions(enum_conversion_items, &type_context)?;
+    for state_map in state_maps.values_mut() {
+        state_map.expr = elaborate_enum_conversions(state_map.expr.clone(), &enum_conversions)?;
+    }
+    for source in &mut action_sources {
+        if let ActionTarget::Action(_, args) = &mut source.target {
+            for argument in args {
+                *argument = elaborate_enum_conversions(argument.clone(), &enum_conversions)?;
+            }
+        }
     }
     validate_correspondence_duplicates(&action_sources)?;
     for source in action_sources {
@@ -272,6 +300,344 @@ fn build_refinement(
         state_maps,
         action_correspondences,
         progress,
+    })
+}
+
+type SurfaceEnumConversion = (String, String, String, Vec<(String, String, Span)>, Span);
+
+fn build_enum_conversions(
+    items: Vec<SurfaceEnumConversion>,
+    context: &KernelModel,
+) -> Result<BTreeMap<String, EnumConversion>, RefinementError> {
+    let mut conversions = BTreeMap::new();
+    for (name, source, target, rows, span) in items {
+        let source_members = enum_type_members(context, &source, span)?;
+        let target_members = enum_type_members(context, &target, span)?;
+        let mut seen_source = BTreeSet::new();
+        let mut seen_target = BTreeSet::new();
+        let mut members = Vec::new();
+        for (source_member, target_member, row_span) in rows {
+            if !source_members.contains(&source_member) {
+                return Err(refinement_error(
+                    format!("unknown enum member '{source}.{source_member}'"),
+                    Some(row_span),
+                ));
+            }
+            if !target_members.contains(&target_member) {
+                return Err(refinement_error(
+                    format!("unknown enum member '{target}.{target_member}'"),
+                    Some(row_span),
+                ));
+            }
+            if !seen_source.insert(source_member.clone()) {
+                return Err(refinement_error(
+                    format!(
+                        "enum conversion '{name}' maps source member '{source_member}' more than once"
+                    ),
+                    Some(row_span),
+                ));
+            }
+            if !seen_target.insert(target_member.clone()) {
+                return Err(refinement_error(
+                    format!(
+                        "enum conversion '{name}' maps target member '{target_member}' more than once"
+                    ),
+                    Some(row_span),
+                ));
+            }
+            members.push((source_member, target_member));
+        }
+        let missing_source = source_members
+            .iter()
+            .filter(|member| !seen_source.contains(*member))
+            .cloned()
+            .collect::<Vec<_>>();
+        let missing_target = target_members
+            .iter()
+            .filter(|member| !seen_target.contains(*member))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_source.is_empty() || !missing_target.is_empty() {
+            return Err(refinement_error(
+                format!(
+                    "enum conversion '{name}' must cover every source and target member exactly once; missing source: [{}]; missing target: [{}]",
+                    missing_source.join(", "),
+                    missing_target.join(", ")
+                ),
+                Some(span),
+            ));
+        }
+        if conversions
+            .insert(
+                name.clone(),
+                EnumConversion {
+                    source,
+                    target,
+                    members,
+                    span,
+                },
+            )
+            .is_some()
+        {
+            return Err(refinement_error(
+                format!("duplicate enum conversion '{name}'"),
+                Some(span),
+            ));
+        }
+    }
+    Ok(conversions)
+}
+
+fn enum_type_members(
+    context: &KernelModel,
+    type_name: &str,
+    span: Span,
+) -> Result<Vec<String>, RefinementError> {
+    match context.types.get(type_name) {
+        Some(TypeDef::Enum { members, .. }) if members.is_empty() => Err(refinement_error(
+            format!("enum conversion endpoint '{type_name}' has no members"),
+            Some(span),
+        )),
+        Some(TypeDef::Enum { members, .. }) => Ok(members.clone()),
+        Some(_) => Err(refinement_error(
+            format!("enum conversion endpoint '{type_name}' is not an enum"),
+            Some(span),
+        )),
+        None => Err(refinement_error(
+            format!("unknown enum conversion type '{type_name}'"),
+            Some(span),
+        )),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn elaborate_enum_conversions(
+    expr: Expr,
+    conversions: &BTreeMap<String, EnumConversion>,
+) -> Result<Expr, RefinementError> {
+    Ok(match expr {
+        Expr::Call { name, args, span } if name == "convert" => {
+            let [conversion_name, argument] = args.as_slice() else {
+                return Err(refinement_error(
+                    "convert expects exactly two arguments: convert(name, expression)",
+                    Some(span),
+                ));
+            };
+            let Expr::Var(conversion_name) = conversion_name else {
+                return Err(refinement_error(
+                    "convert first argument must be an enum conversion name",
+                    Some(span),
+                ));
+            };
+            let conversion = conversions.get(conversion_name).ok_or_else(|| {
+                refinement_error(
+                    format!("unknown enum conversion '{conversion_name}'"),
+                    Some(span),
+                )
+            })?;
+            let argument = elaborate_enum_conversions(argument.clone(), conversions)?;
+            let (_, fallback_member) = conversion
+                .members
+                .last()
+                .expect("validated enum conversions are non-empty");
+            let mut expanded = Expr::EnumMember {
+                type_name: conversion.target.clone(),
+                member: fallback_member.clone(),
+            };
+            for (source_member, target_member) in conversion.members.iter().rev() {
+                expanded = Expr::Conditional {
+                    condition: Box::new(Expr::Binary {
+                        op: "==".to_owned(),
+                        left: Box::new(argument.clone()),
+                        right: Box::new(Expr::EnumMember {
+                            type_name: conversion.source.clone(),
+                            member: source_member.clone(),
+                        }),
+                    }),
+                    then_expr: Box::new(Expr::EnumMember {
+                        type_name: conversion.target.clone(),
+                        member: target_member.clone(),
+                    }),
+                    else_expr: Box::new(expanded),
+                    spans: Box::new(ConditionalSpans {
+                        condition: span,
+                        then_expr: span,
+                        else_expr: conversion.span,
+                    }),
+                };
+            }
+            expanded
+        }
+        Expr::Call { name, args, span } => Expr::Call {
+            name,
+            args: args
+                .into_iter()
+                .map(|expr| elaborate_enum_conversions(expr, conversions))
+                .collect::<Result<_, _>>()?,
+            span,
+        },
+        Expr::Some(expr) => Expr::Some(Box::new(elaborate_enum_conversions(*expr, conversions)?)),
+        Expr::Set(items) => Expr::Set(
+            items
+                .into_iter()
+                .map(|expr| elaborate_enum_conversions(expr, conversions))
+                .collect::<Result<_, _>>()?,
+        ),
+        Expr::Seq(items) => Expr::Seq(
+            items
+                .into_iter()
+                .map(|expr| elaborate_enum_conversions(expr, conversions))
+                .collect::<Result<_, _>>()?,
+        ),
+        Expr::Struct { name, fields } => Expr::Struct {
+            name,
+            fields: fields
+                .into_iter()
+                .map(|(name, expr)| Ok((name, elaborate_enum_conversions(expr, conversions)?)))
+                .collect::<Result<_, RefinementError>>()?,
+        },
+        Expr::Index(base, index) => Expr::Index(
+            Box::new(elaborate_enum_conversions(*base, conversions)?),
+            Box::new(elaborate_enum_conversions(*index, conversions)?),
+        ),
+        Expr::Field(base, field) => Expr::Field(
+            Box::new(elaborate_enum_conversions(*base, conversions)?),
+            field,
+        ),
+        Expr::Method {
+            receiver,
+            name,
+            args,
+        } => Expr::Method {
+            receiver: Box::new(elaborate_enum_conversions(*receiver, conversions)?),
+            name,
+            args: args
+                .into_iter()
+                .map(|expr| elaborate_enum_conversions(expr, conversions))
+                .collect::<Result<_, _>>()?,
+        },
+        Expr::Binary { op, left, right } => Expr::Binary {
+            op,
+            left: Box::new(elaborate_enum_conversions(*left, conversions)?),
+            right: Box::new(elaborate_enum_conversions(*right, conversions)?),
+        },
+        Expr::Neg(expr) => Expr::Neg(Box::new(elaborate_enum_conversions(*expr, conversions)?)),
+        Expr::Not(expr) => Expr::Not(Box::new(elaborate_enum_conversions(*expr, conversions)?)),
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            spans,
+        } => Expr::Conditional {
+            condition: Box::new(elaborate_enum_conversions(*condition, conversions)?),
+            then_expr: Box::new(elaborate_enum_conversions(*then_expr, conversions)?),
+            else_expr: Box::new(elaborate_enum_conversions(*else_expr, conversions)?),
+            spans,
+        },
+        Expr::Is { expr, pattern } => Expr::Is {
+            expr: Box::new(elaborate_enum_conversions(*expr, conversions)?),
+            pattern,
+        },
+        Expr::Quantified {
+            quantifier,
+            binder,
+            body,
+        } => Expr::Quantified {
+            quantifier,
+            binder: elaborate_conversion_binder(binder, conversions)?,
+            body: Box::new(elaborate_enum_conversions(*body, conversions)?),
+        },
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => Expr::Aggregate {
+            kind,
+            binder: elaborate_conversion_binder(binder, conversions)?,
+            value: value
+                .map(|expr| elaborate_enum_conversions(*expr, conversions).map(Box::new))
+                .transpose()?,
+        },
+        Expr::Stage {
+            process,
+            entity,
+            entity_span,
+            span,
+        } => Expr::Stage {
+            process,
+            entity: Box::new(elaborate_enum_conversions(*entity, conversions)?),
+            entity_span,
+            span,
+        },
+        Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
+            name,
+            expr: Box::new(elaborate_enum_conversions(*expr, conversions)?),
+            span,
+        },
+        Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
+            name,
+            left: Box::new(elaborate_enum_conversions(*left, conversions)?),
+            right: Box::new(elaborate_enum_conversions(*right, conversions)?),
+        },
+        Expr::TernaryNamed {
+            name,
+            first,
+            second,
+            third,
+        } => Expr::TernaryNamed {
+            name,
+            first: Box::new(elaborate_enum_conversions(*first, conversions)?),
+            second: Box::new(elaborate_enum_conversions(*second, conversions)?),
+            third: Box::new(elaborate_enum_conversions(*third, conversions)?),
+        },
+        expr @ (Expr::Num(_)
+        | Expr::Bool(_)
+        | Expr::None
+        | Expr::Var(_)
+        | Expr::EnumMember { .. }) => expr,
+    })
+}
+
+fn elaborate_conversion_binder(
+    binder: Binder,
+    conversions: &BTreeMap<String, EnumConversion>,
+) -> Result<Binder, RefinementError> {
+    Ok(match binder {
+        Binder::Typed {
+            name,
+            type_name,
+            where_expr,
+        } => Binder::Typed {
+            name,
+            type_name,
+            where_expr: where_expr
+                .map(|expr| elaborate_enum_conversions(*expr, conversions).map(Box::new))
+                .transpose()?,
+        },
+        Binder::Range {
+            name,
+            lo,
+            hi,
+            where_expr,
+        } => Binder::Range {
+            name,
+            lo: Box::new(elaborate_enum_conversions(*lo, conversions)?),
+            hi: Box::new(elaborate_enum_conversions(*hi, conversions)?),
+            where_expr: where_expr
+                .map(|expr| elaborate_enum_conversions(*expr, conversions).map(Box::new))
+                .transpose()?,
+        },
+        Binder::Collection {
+            name,
+            collection,
+            where_expr,
+        } => Binder::Collection {
+            name,
+            collection: Box::new(elaborate_enum_conversions(*collection, conversions)?),
+            where_expr: where_expr
+                .map(|expr| elaborate_enum_conversions(*expr, conversions).map(Box::new))
+                .transpose()?,
+        },
     })
 }
 

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -177,6 +177,16 @@ pub(crate) fn infer_type(
             .get(name)
             .cloned()
             .ok_or_else(|| error(format!("public Kernel cannot type identifier '{name}'"))),
+        Expr::EnumMember { type_name, member } => match model.types.get(type_name) {
+            Some(TypeDef::Enum { members, .. }) if members.contains(member) => {
+                Ok(TypeRef::Named(type_name.clone()))
+            }
+            Some(TypeDef::Enum { .. }) => {
+                Err(error(format!("unknown enum member '{type_name}.{member}'")))
+            }
+            Some(_) => Err(error(format!("'{type_name}' is not an enum"))),
+            None => Err(error(format!("unknown enum type '{type_name}'"))),
+        },
         Expr::Call { name, .. } => Err(error(format!(
             "unlowered predicate call '{name}' in public Kernel"
         ))),
@@ -642,7 +652,7 @@ fn value_expression(value: crate::FslValue) -> Result<Expr, TypecheckError> {
     Ok(match value {
         crate::FslValue::Int(value) => Expr::Num(value),
         crate::FslValue::Bool(value) => Expr::Bool(value),
-        crate::FslValue::Enum { member, .. } => Expr::Var(member),
+        crate::FslValue::Enum { type_name, member } => Expr::EnumMember { type_name, member },
         crate::FslValue::None => Expr::None,
         crate::FslValue::Some(value) => Expr::Some(Box::new(value_expression(*value)?)),
         crate::FslValue::Struct { type_name, fields } => Expr::Struct {
@@ -732,6 +742,7 @@ fn validate_expression(
         | Expr::Bool(_)
         | Expr::None
         | Expr::Var(_)
+        | Expr::EnumMember { .. }
         | Expr::Call { .. }
         | Expr::Stage { .. } => {}
         Expr::Some(item) => {

--- a/rust/fsl-core/tests/enum_conversion.rs
+++ b/rust/fsl-core/tests/enum_conversion.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use fsl_core::{
+    FsResolver, TypeRef, build_model, parse_kernel_source, parse_refinement,
+    public_kernel_expression,
+};
+use fsl_syntax::{SourcePos, Span};
+
+fn build(source: &str) -> fsl_core::KernelModel {
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
+    build_model(kernel).expect("build model")
+}
+
+fn models() -> (fsl_core::KernelModel, fsl_core::KernelModel) {
+    (
+        build(
+            "spec Impl { enum ImplStage { Conflict, Loaded, Received } state { stage: ImplStage } init { stage = Received } action load() { requires stage == Received stage = Loaded } }",
+        ),
+        build(
+            "spec Abs { enum AbsStage { Received, Loaded, Conflict } state { status: AbsStage } init { status = Received } action load() { requires status == Received status = Loaded } }",
+        ),
+    )
+}
+
+const MAPPING: &str = r"refinement R {
+  impl Impl
+  abs Abs
+  enum conversion stage ImplStage -> AbsStage {
+    Received -> Received
+    Loaded -> Loaded
+    Conflict -> Conflict
+  }
+  map status = convert(stage, stage)
+  action load() -> load()
+}";
+
+#[test]
+fn exhaustive_conversion_keeps_nominal_identity_in_checked_and_public_expressions() {
+    let (implementation, abstraction) = models();
+    let refinement = parse_refinement(MAPPING, &implementation, &abstraction)
+        .expect("same-spelled members convert explicitly");
+    let expression = &refinement.state_maps["status"].expr;
+    let rendered = fsl_core::expr_text(expression);
+    assert!(rendered.contains("ImplStage.Received"), "{rendered}");
+    assert!(rendered.contains("AbsStage.Received"), "{rendered}");
+
+    let mut context = implementation.clone();
+    context.types.extend(abstraction.types.clone());
+    let position = SourcePos {
+        offset: 0,
+        line: 1,
+        column: 1,
+    };
+    let public = public_kernel_expression(
+        expression,
+        &context,
+        "mapping.fsl",
+        Span {
+            start: position,
+            end: position,
+        },
+        Some(&TypeRef::Named("AbsStage".to_owned())),
+    )
+    .expect("elaborated conversion has an existing Public Kernel representation");
+    let public = public.to_string();
+    assert!(public.contains(r#""name":"ImplStage""#), "{public}");
+    assert!(public.contains(r#""name":"AbsStage""#), "{public}");
+    assert!(!public.contains("enum_convert"), "{public}");
+}
+
+#[test]
+fn conversion_declaration_fails_closed_for_incomplete_unknown_and_duplicate_members() {
+    let (implementation, abstraction) = models();
+    for (source, expected) in [
+        (
+            MAPPING.replace("    Conflict -> Conflict\n", ""),
+            "missing source: [Conflict]; missing target: [Conflict]",
+        ),
+        (
+            MAPPING.replace("Conflict -> Conflict", "Missing -> Conflict"),
+            "unknown enum member 'ImplStage.Missing'",
+        ),
+        (
+            MAPPING.replace("Conflict -> Conflict", "Conflict -> Missing"),
+            "unknown enum member 'AbsStage.Missing'",
+        ),
+        (
+            MAPPING.replace("Conflict -> Conflict", "Received -> Conflict"),
+            "maps source member 'Received' more than once",
+        ),
+        (
+            MAPPING.replace("Conflict -> Conflict", "Conflict -> Loaded"),
+            "maps target member 'Loaded' more than once",
+        ),
+    ] {
+        let error = parse_refinement(&source, &implementation, &abstraction)
+            .expect_err("invalid conversion must fail statically");
+        assert!(error.message.contains(expected), "{}", error.message);
+        assert!(error.span.is_some(), "diagnostic must retain a location");
+    }
+
+    let implicit = parse_refinement(
+        "refinement R { impl Impl abs Abs map status = stage action load() -> load() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("distinct nominal enums remain incompatible without conversion");
+    assert!(implicit.message.contains("is not assignable"));
+
+    for (implementation, abstraction, rows, expected) in [
+        (
+            build(
+                "spec Impl { enum ImplStage { A, B, C } state { stage: ImplStage } init { stage = A } }",
+            ),
+            build(
+                "spec Abs { enum AbsStage { X, Y } state { status: AbsStage } init { status = X } }",
+            ),
+            "A -> X B -> Y",
+            "missing source: [C]; missing target: []",
+        ),
+        (
+            build(
+                "spec Impl { enum ImplStage { A, B } state { stage: ImplStage } init { stage = A } }",
+            ),
+            build(
+                "spec Abs { enum AbsStage { X, Y, Z } state { status: AbsStage } init { status = X } }",
+            ),
+            "A -> X B -> Y",
+            "missing source: []; missing target: [Z]",
+        ),
+    ] {
+        let source = format!(
+            "refinement R {{ impl Impl abs Abs enum conversion stage ImplStage -> AbsStage {{ {rows} }} }}"
+        );
+        let error = parse_refinement(&source, &implementation, &abstraction)
+            .expect_err("source-only and target-only omissions must fail closed");
+        assert!(error.message.contains(expected), "{}", error.message);
+        assert!(error.span.is_some());
+    }
+
+    for (source, expected) in [
+        (
+            MAPPING.replace("convert(stage, stage)", "convert(stage)"),
+            "convert expects exactly two arguments",
+        ),
+        (
+            MAPPING.replace("convert(stage, stage)", "convert(missing, stage)"),
+            "unknown enum conversion 'missing'",
+        ),
+    ] {
+        let error = parse_refinement(&source, &implementation, &abstraction)
+            .expect_err("malformed conversion calls must fail statically");
+        assert!(error.message.contains(expected), "{}", error.message);
+        assert!(error.span.is_some());
+    }
+}
+
+#[test]
+fn conversion_calls_are_checked_in_action_arguments() {
+    let implementation = build(
+        "spec Impl { enum ImplStage { A, B } state { stage: ImplStage } init { stage = A } action send(s: ImplStage) { stage = s } }",
+    );
+    let abstraction = build(
+        "spec Abs { enum AbsStage { A, B } state { status: AbsStage } init { status = A } action send(s: AbsStage) { status = s } }",
+    );
+    parse_refinement(
+        "refinement R { impl Impl abs Abs enum conversion stage ImplStage -> AbsStage { A -> A B -> B } map status = convert(stage, stage) action send(s) -> send(convert(stage, s)) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("action argument uses the shared checked conversion");
+}
+
+#[test]
+fn empty_enum_conversion_fails_closed_before_call_elaboration() {
+    let implementation = build(
+        "spec Impl { enum EmptyImpl {} state { ready: Bool } init { ready = false } action send(s: EmptyImpl) { requires false } }",
+    );
+    let abstraction = build(
+        "spec Abs { enum EmptyAbs {} state { ready: Bool } init { ready = false } action send(s: EmptyAbs) { requires false } }",
+    );
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs enum conversion empty EmptyImpl -> EmptyAbs {} action send(s) -> send(convert(empty, s)) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("empty conversions must not reach an infallible elaboration branch");
+    assert!(error.message.contains("EmptyImpl' has no members"));
+    assert!(error.span.is_some());
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -736,7 +736,7 @@ fn collect_state_references(
                 output.insert(name.clone());
             }
         }
-        Expr::Num(_) | Expr::Bool(_) | Expr::None => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::EnumMember { .. } => {}
         Expr::Some(value)
         | Expr::Neg(value)
         | Expr::Not(value)

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -102,6 +102,20 @@ pub fn eval(
             .or_else(|| model.enum_members.get(name))
             .cloned()
             .ok_or_else(|| runtime_error(format!("unknown identifier '{name}'"))),
+        Expr::EnumMember { type_name, member } => {
+            let Some(TypeDef::Enum { members, .. }) = model.types.get(type_name) else {
+                return Err(runtime_error(format!("unknown enum type '{type_name}'")));
+            };
+            if !members.contains(member) {
+                return Err(runtime_error(format!(
+                    "unknown enum member '{type_name}.{member}'"
+                )));
+            }
+            Ok(Value::Enum {
+                type_name: type_name.clone(),
+                member: member.clone(),
+            })
+        }
         Expr::Call { name, .. } => {
             Err(runtime_error(format!("unexpanded predicate call '{name}'")))
         }

--- a/rust/fsl-runtime/tests/action_correspondence.rs
+++ b/rust/fsl-runtime/tests/action_correspondence.rs
@@ -72,3 +72,79 @@ fn explicit_and_auto_correspondences_have_the_same_concrete_verdict() {
         assert_eq!(explicit_result, routed_result);
     }
 }
+
+#[test]
+fn enum_conversion_agrees_across_concrete_refinement_routes_without_ordinal_coercion() {
+    const ABS: &str = "spec Abs { enum AbsStage { A, B, C } state { status: AbsStage } init { status = A } action step() { requires status == A status = B } }";
+    let implementation = build(
+        "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } action step() { requires stage == A stage = B } }",
+    );
+    let abstraction = build(ABS);
+    let mapping = "refinement R { impl Impl abs Abs enum conversion stage ImplStage -> AbsStage { A -> A B -> B C -> C } map status = convert(stage, stage) action step() -> step() }";
+    let refinement =
+        parse_refinement(mapping, &implementation, &abstraction).expect("explicit enum conversion");
+    let result = check_refinement(&implementation, &abstraction, &refinement, 2)
+        .expect("concrete refinement check");
+    assert!(result.failure.is_none(), "{result:?}");
+
+    let wrong = parse_refinement(
+        "refinement R { impl Impl abs Abs enum conversion stage ImplStage -> AbsStage { A -> B B -> A C -> C } map status = convert(stage, stage) action step() -> step() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("a complete but wrong bijection is statically well typed");
+    let wrong = check_refinement(&implementation, &abstraction, &wrong, 2)
+        .expect("negative control executes");
+    assert!(
+        wrong.failure.is_some(),
+        "wrong member mapping must not refine"
+    );
+
+    let argument_implementation = build(
+        "spec Impl { enum ImplStage { A, B } state { stage: ImplStage } init { stage = A } action send(s: ImplStage) { stage = s } }",
+    );
+    let argument_abstraction = build(
+        "spec Abs { enum AbsStage { A, B } state { status: AbsStage } init { status = A } action send(s: AbsStage) { status = s } }",
+    );
+    let wrong_argument = parse_refinement(
+        "refinement R { impl Impl abs Abs enum conversion state_stage ImplStage -> AbsStage { A -> A B -> B } enum conversion argument_stage ImplStage -> AbsStage { A -> B B -> A } map status = convert(state_stage, stage) action send(s) -> send(convert(argument_stage, s)) }",
+        &argument_implementation,
+        &argument_abstraction,
+    )
+    .expect("wrong action-argument bijection remains statically complete");
+    let wrong_argument = check_refinement(
+        &argument_implementation,
+        &argument_abstraction,
+        &wrong_argument,
+        1,
+    )
+    .expect("action-argument negative control executes");
+    assert!(
+        wrong_argument.failure.is_some(),
+        "member-swapped action argument must not produce a false-green refinement"
+    );
+
+    let inline = r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum conversion stage ImplStage -> AbsStage { A -> A B -> B C -> C }
+    map status = convert(stage, stage)
+    action step() -> step()
+  }
+  enum ImplStage { C, B, A }
+  state { stage: ImplStage }
+  init { stage = A }
+  action step() { requires stage == A stage = B }
+}"#;
+    let inline_implementation = build(inline);
+    let contract = requirements_implements(inline, &Resolver(ABS), &inline_implementation)
+        .expect("inline enum conversion builds")
+        .expect("implements contract");
+    let inline_result = check_refinement(
+        &inline_implementation,
+        &contract.abstraction,
+        &contract.refinement,
+        2,
+    )
+    .expect("inline concrete refinement check");
+    assert!(inline_result.failure.is_none(), "{inline_result:?}");
+}

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -98,6 +98,10 @@ pub enum Expr {
         fields: Vec<(String, Expr)>,
     },
     Var(String),
+    EnumMember {
+        type_name: String,
+        member: String,
+    },
     Call {
         name: String,
         args: Vec<Expr>,
@@ -235,6 +239,9 @@ impl Expr {
                 json!(["struct_lit", name, object])
             }
             Self::Var(name) => json!(["var", name]),
+            Self::EnumMember { type_name, member } => {
+                json!(["enum_member", type_name, member])
+            }
             Self::Call { name, args, span } => {
                 json!(["call", name, ast_list(args), span.python_loc()])
             }

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1252,6 +1252,32 @@ impl<'a> Parser<'a> {
             || self.peek_symbol("{")
     }
 
+    fn enum_conversion_item(&mut self) -> Result<RefinementItem, ParseError> {
+        let span = self.bump().span;
+        self.expect_ident_value("conversion")?;
+        let name = self.expect_ident()?;
+        let source = self.expect_ident()?;
+        self.expect_symbol("->")?;
+        let target = self.expect_ident()?;
+        self.expect_symbol("{")?;
+        let mut members = Vec::new();
+        while !self.eat_symbol("}") {
+            let member_span = self.peek().span;
+            let source_member = self.expect_ident()?;
+            self.expect_symbol("->")?;
+            let target_member = self.expect_ident()?;
+            members.push((source_member, target_member, member_span));
+            self.eat_symbol(",");
+        }
+        Ok(RefinementItem::EnumConversion {
+            name,
+            source,
+            target,
+            members,
+            span,
+        })
+    }
+
     fn refinement_item(
         &mut self,
         origin: CorrespondenceOrigin,
@@ -1266,6 +1292,9 @@ impl<'a> Parser<'a> {
             let span = self.bump().span;
             self.expect_ident_value("auto")?;
             return Ok(RefinementItem::MapsAuto(span));
+        }
+        if self.peek_ident("enum") {
+            return self.enum_conversion_item();
         }
         if self.peek_ident("map") {
             let span = self.bump().span;

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -252,6 +252,13 @@ pub enum RefinementItem {
     Impl(String),
     Abs(String),
     MapsAuto(Span),
+    EnumConversion {
+        name: String,
+        source: String,
+        target: String,
+        members: Vec<(String, String, Span)>,
+        span: Span,
+    },
     Map {
         name: String,
         binder: Option<Binder>,
@@ -1045,6 +1052,23 @@ impl RefinementItem {
             Self::Impl(name) => json!(["impl", name]),
             Self::Abs(name) => json!(["abs", name]),
             Self::MapsAuto(span) => json!(["maps_auto", span.python_loc()]),
+            Self::EnumConversion {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => json!([
+                "enum_conversion",
+                name,
+                source,
+                target,
+                members
+                    .iter()
+                    .map(|(source, target, span)| { json!([source, target, span.python_loc()]) })
+                    .collect::<Vec<_>>(),
+                span.python_loc()
+            ]),
             Self::Map {
                 name,
                 binder,

--- a/rust/fsl-tools/src/analysis.rs
+++ b/rust/fsl-tools/src/analysis.rs
@@ -565,7 +565,7 @@ fn expr_reads_bound(
             reads.extend(expr_reads_bound(second, state, bound));
             reads.extend(expr_reads_bound(third, state, bound));
         }
-        Expr::Num(_) | Expr::Bool(_) | Expr::None => {}
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::EnumMember { .. } => {}
     }
     reads
 }

--- a/rust/fsl-tools/src/mutate.rs
+++ b/rust/fsl-tools/src/mutate.rs
@@ -192,6 +192,18 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                 });
             }
         }
+        Expr::EnumMember { type_name, member } if enums.contains_key(member) => {
+            for sibling in &enums[member] {
+                output.push(ExprMutation {
+                    expr: Expr::EnumMember {
+                        type_name: type_name.clone(),
+                        member: sibling.clone(),
+                    },
+                    op: "enum_constant_swap",
+                    enum_swap: None,
+                });
+            }
+        }
         Expr::Some(value) => {
             for mutation in expr_mutations(value, enums) {
                 output.push(ExprMutation {
@@ -555,7 +567,7 @@ fn expr_mutations(expr: &Expr, enums: &BTreeMap<String, Vec<String>>) -> Vec<Exp
                 });
             }
         }
-        Expr::Bool(_) | Expr::None | Expr::Var(_) => {}
+        Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {}
     }
     output
 }

--- a/rust/fsl-tools/src/refinement_analysis.rs
+++ b/rust/fsl-tools/src/refinement_analysis.rs
@@ -98,6 +98,31 @@ pub fn analyze_refinement(refinement: &SurfaceRefinement) -> Value {
                 insert_node(&mut nodes, node(id.clone(), "maps_auto", "maps auto"));
                 insert_edge(&mut edges, edge(&ref_id, "declares", &id));
             }
+            RefinementItem::EnumConversion {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => {
+                let id = format!("enum_conversion:{name}");
+                let mut value = located_node(id.clone(), "enum_conversion", name, *span);
+                if let Value::Object(object) = &mut value {
+                    object.insert("source_type".to_owned(), json!(source));
+                    object.insert("target_type".to_owned(), json!(target));
+                    object.insert(
+                        "members".to_owned(),
+                        json!(
+                            members
+                                .iter()
+                                .map(|(source, target, _)| json!({"source":source,"target":target}))
+                                .collect::<Vec<_>>()
+                        ),
+                    );
+                }
+                insert_node(&mut nodes, value);
+                insert_edge(&mut edges, edge(&ref_id, "declares", &id));
+            }
             RefinementItem::Map {
                 name,
                 binder,

--- a/rust/fsl-tools/src/undecided.rs
+++ b/rust/fsl-tools/src/undecided.rs
@@ -75,7 +75,10 @@ fn expression_roots(model: &KernelModel, expr: &KernelExpr) -> BTreeSet<String> 
                     collect(value, roots);
                 }
             }
-            KernelExpr::Num(_) | KernelExpr::Bool(_) | KernelExpr::None => {}
+            KernelExpr::Num(_)
+            | KernelExpr::Bool(_)
+            | KernelExpr::None
+            | KernelExpr::EnumMember { .. } => {}
         }
     }
 

--- a/rust/fsl-tools/tests/refinement_correspondence.rs
+++ b/rust/fsl-tools/tests/refinement_correspondence.rs
@@ -6,7 +6,7 @@ use fsl_tools::analyze_refinement;
 #[test]
 fn refinement_graph_exposes_correspondence_origin_and_shared_progress_identity() {
     let document = parse_surface_document(
-        "refinement R { impl Impl abs Abs action step(v: N) -> run(v) preserve progress { respond Eventually by step } }",
+        "refinement R { impl Impl abs Abs enum conversion status ImplStatus -> AbsStatus { Open -> Ready Closed -> Done } action step(v: N) -> run(v) preserve progress { respond Eventually by step } }",
     )
     .expect("parse refinement");
     let SurfaceDocument::Refinement(refinement) = document else {
@@ -20,6 +20,21 @@ fn refinement_graph_exposes_correspondence_origin_and_shared_progress_identity()
         .find(|node| node["id"] == "action_map:step")
         .expect("action node");
     assert_eq!(action["origin"], "refinement_file");
+    let conversion = graph["nodes"]
+        .as_array()
+        .expect("nodes")
+        .iter()
+        .find(|node| node["id"] == "enum_conversion:status")
+        .expect("enum conversion node");
+    assert_eq!(conversion["source_type"], "ImplStatus");
+    assert_eq!(conversion["target_type"], "AbsStatus");
+    assert_eq!(
+        conversion["members"],
+        serde_json::json!([
+            {"source": "Open", "target": "Ready"},
+            {"source": "Closed", "target": "Done"}
+        ])
+    );
     assert!(
         graph["edges"]
             .as_array()

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -64,6 +64,15 @@ pub(crate) fn eval<S: SmtSolver>(
             eval_struct_literal(solver, model, name, fields, state, bindings, old_state)
         }
         Expr::Var(name) => lookup(solver, model, name, state, bindings),
+        Expr::EnumMember { type_name, member } => concrete_value(
+            solver,
+            model,
+            &TypeRef::Named(type_name.clone()),
+            &FslValue::Enum {
+                type_name: type_name.clone(),
+                member: member.clone(),
+            },
+        ),
         Expr::Call { name, .. } => Err(VerifyError::new(format!(
             "unexpanded predicate call '{name}'"
         ))),
@@ -208,7 +217,9 @@ pub(crate) fn definedness<S: SmtSolver>(
     old_state: Option<&SymbolicState<S::Term>>,
 ) -> Result<S::Term, VerifyError> {
     match expr {
-        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) => Ok(solver.bool_value(true)),
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {
+            Ok(solver.bool_value(true))
+        }
         Expr::UnaryNamed {
             name, expr: inner, ..
         } if name == "old" => definedness(

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use fsl_core::{FsResolver, build_model, parse_kernel_source};
+use fsl_core::{FsResolver, build_model, parse_kernel_source, parse_refinement};
 
 fn block_on<F: Future>(future: F) -> F::Output {
     let mut future = pin!(future);
@@ -93,6 +93,69 @@ spec Agreement {
     let explicit = fsl_runtime::verify_explicit(model, 8, 100).expect("verify explicitly");
     assert!(explicit.violation.is_none(), "{explicit:?}");
     assert!(explicit.closure, "{explicit:?}");
+}
+
+#[test]
+fn elaborated_enum_conversion_agrees_concretely_symbolically_and_in_preserved_progress() {
+    let resolver = FsResolver::new(".");
+    let implementation = build_model(
+        parse_kernel_source(
+            "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } fair action step() { requires stage == A stage = B } }",
+            &resolver,
+        )
+        .expect("parse implementation"),
+    )
+    .expect("build implementation");
+    let abstraction = build_model(
+        parse_kernel_source(
+            "spec Abs { enum AbsStage { A, B, C } state { status: AbsStage } init { status = A } fair action step() { requires status == A status = B } leadsTo Advances { status == A ~> status == B } }",
+            &resolver,
+        )
+        .expect("parse abstraction"),
+    )
+    .expect("build abstraction");
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs enum conversion stage ImplStage -> AbsStage { A -> A B -> B C -> C } map status = convert(stage, stage) action step() -> step() preserve progress { respond Advances by step } }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("build conversion mapping");
+
+    let expression = &mapping.state_maps["status"].expr;
+    let mut merged = implementation.clone();
+    merged.types.extend(abstraction.types.clone());
+    merged.enum_members.extend(abstraction.enum_members.clone());
+    let mut monitor = fsl_runtime::Monitor::new(implementation.clone()).expect("monitor");
+    let mut states = vec![monitor.state.clone()];
+    let action = monitor.enabled().expect("enabled")[0].clone();
+    monitor.step(&action).expect("step");
+    states.push(monitor.state.clone());
+    for state in states {
+        let expected = fsl_runtime::eval(expression, &state, &mut BTreeMap::new(), &merged, None)
+            .expect("concrete conversion");
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("solver");
+        assert!(
+            block_on(fsl_verifier::expression_matches_value(
+                &merged,
+                &mut solver,
+                expression,
+                &state,
+                &expected,
+            ))
+            .expect("symbolic conversion agreement")
+        );
+    }
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("solver");
+    let progress = block_on(fsl_verifier::check_refinement_progress(
+        &implementation,
+        &abstraction,
+        &mapping,
+        &mut solver,
+        2,
+    ))
+    .expect("preserved progress check");
+    assert!(progress.violation.is_none(), "{progress:?}");
 }
 
 #[test]

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -94,6 +94,20 @@ fn error(solver_version: &str, kind: &str, message: impl AsRef<str>) -> Value {
     Value::Object(output)
 }
 
+fn implements_error(
+    solver_version: &str,
+    failure: &fslc_rust::verification_output::RequirementsImplementsError,
+) -> Value {
+    let mut output = error(solver_version, "type", &failure.message);
+    if let Some(span) = failure.span
+        && let Some(object) = output.as_object_mut()
+    {
+        object.insert("loc".to_owned(), span.python_loc());
+        object.insert("span".to_owned(), json!(span));
+    }
+    output
+}
+
 fn build(request: &Request, solver_version: &str) -> Result<KernelModel, Value> {
     let resolver = MemoryResolver {
         files: request.files.clone(),
@@ -292,7 +306,7 @@ fn add_frontend_metadata(
             remove_generic_invariant_warning(&mut output);
         }
         Ok(None) => {}
-        Err(failure) => return error(solver_version, "semantics", failure),
+        Err(failure) => return implements_error(solver_version, &failure),
     }
     let additions = fslc_rust::frontend_output::implicit_initial_value_warnings(
         &request.source,
@@ -560,6 +574,44 @@ mod tests {
             error["message"]
                 .as_str()
                 .is_some_and(|message| message.contains("missing-before.fsl"))
+        );
+    }
+
+    #[test]
+    fn check_keeps_inline_enum_conversion_error_location() {
+        let request = Request {
+            cmd: "check".to_owned(),
+            source: r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum conversion stage ImplStage -> AbsStage { A -> A }
+    map status = convert(stage, stage)
+    action step() -> step()
+  }
+  enum ImplStage { A, B }
+  state { stage: ImplStage }
+  init { stage = A }
+  action step() { stage = B }
+}
+"#
+            .to_owned(),
+            source_file: "impl.fsl".to_owned(),
+            files: BTreeMap::from([(
+                "abs.fsl".to_owned(),
+                "spec Abs { enum AbsStage { A, B } state { status: AbsStage } init { status = A } action step() { status = B } }".to_owned(),
+            )]),
+            options: Options::default(),
+        };
+
+        let failure = block_on(check(&request, TEST_SOLVER_VERSION));
+
+        assert_eq!(failure["result"], "error");
+        assert_eq!(failure["kind"], "type");
+        assert_eq!(failure["loc"], json!({"line": 3, "column": 5}));
+        assert!(failure["span"].is_object());
+        assert!(
+            failure["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("missing source: [B]"))
         );
     }
 

--- a/rust/fslc/src/causal.rs
+++ b/rust/fslc/src/causal.rs
@@ -672,6 +672,16 @@ fn run_causal_observe_expectations(
         Ok(_) => return (error_output("type", "expected refinement mapping file"), 2),
         Err(error) => return (error_output("parse", &error.to_string()), 2),
     };
+    if let Some(span) = crate::untyped_replay_enum_conversion_span(&mapping) {
+        return (
+            crate::located_error_output(
+                "type",
+                "enum conversion requires a typed impl model and is not supported by causal --from-log mappings",
+                span,
+            ),
+            2,
+        );
+    }
     let records = match read_jsonl_records(log_path) {
         Ok(records) => records,
         Err(error) => return (error_output("io", &error), 2),

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -4389,6 +4389,43 @@ fn read_jsonl_records(path: &Path) -> Result<Vec<(usize, Value)>, String> {
         .collect()
 }
 
+pub(crate) fn untyped_replay_enum_conversion_span(
+    mapping: &fsl_syntax::SurfaceRefinement,
+) -> Option<fsl_syntax::Span> {
+    for item in &mapping.items {
+        match item {
+            fsl_syntax::RefinementItem::EnumConversion { span, .. } => return Some(*span),
+            fsl_syntax::RefinementItem::Map { expr, .. } => {
+                if let Some(span) = fsl_core::expression_call_span(expr, "convert") {
+                    return Some(span);
+                }
+            }
+            fsl_syntax::RefinementItem::Action {
+                target: fsl_syntax::ActionTarget::Action(_, args),
+                ..
+            } => {
+                if let Some(span) = args
+                    .iter()
+                    .find_map(|expr| fsl_core::expression_call_span(expr, "convert"))
+                {
+                    return Some(span);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+pub(crate) fn located_error_output(kind: &str, message: &str, span: fsl_syntax::Span) -> Value {
+    let mut output = error_output(kind, message);
+    output.as_object_mut().expect("error envelope").extend([
+        ("loc".to_owned(), span.python_loc()),
+        ("span".to_owned(), json!(span)),
+    ]);
+    output
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_log_replay(path: &Path, log_path: &Path, mapping_path: &Path) -> (Value, i32) {
     const NOTE: &str = "leadsTo properties are not checked by replay (finite logs only)";
@@ -4405,6 +4442,16 @@ fn run_log_replay(path: &Path, log_path: &Path, mapping_path: &Path) -> (Value, 
         Ok(_) => return (error_output("type", "expected refinement mapping file"), 2),
         Err(error) => return (error_output("parse", &error.to_string()), 2),
     };
+    if let Some(span) = untyped_replay_enum_conversion_span(&mapping) {
+        return (
+            located_error_output(
+                "type",
+                "enum conversion requires a typed impl model and is not supported by --from-log mappings",
+                span,
+            ),
+            2,
+        );
+    }
     let records = match read_jsonl_records(log_path) {
         Ok(records) => records,
         Err(error) => return (error_output("io", &error), 2),
@@ -5115,7 +5162,7 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
             output.insert("spec".to_owned(), json!(model.name));
             let implements = match implements_result(path, &model, 8) {
                 Ok(implements) => implements,
-                Err(error) => return (error_output("type", &error), 2),
+                Err(error) => return (implements_error_output(&error), 2),
             };
             let warnings = if implements.is_some() || has_trace_contract {
                 model_warnings(&model)
@@ -7340,7 +7387,10 @@ fn expression_state_roots(
                     collect(value, roots);
                 }
             }
-            KernelExpr::Num(_) | KernelExpr::Bool(_) | KernelExpr::None => {}
+            KernelExpr::Num(_)
+            | KernelExpr::Bool(_)
+            | KernelExpr::None
+            | KernelExpr::EnumMember { .. } => {}
         }
     }
     fn collect_binder(
@@ -7996,6 +8046,9 @@ fn expression_mutant_count(
     match expr {
         KernelExpr::Num(_) => 2,
         KernelExpr::Var(name) => enum_siblings.get(name).copied().unwrap_or_default(),
+        KernelExpr::EnumMember { member, .. } => {
+            enum_siblings.get(member).copied().unwrap_or_default()
+        }
         KernelExpr::Some(value)
         | KernelExpr::Neg(value)
         | KernelExpr::Not(value)
@@ -12897,10 +12950,24 @@ fn implements_result(
     path: &Path,
     model: &KernelModel,
     depth: usize,
-) -> Result<Option<Value>, String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+) -> Result<Option<Value>, fslc_rust::verification_output::RequirementsImplementsError> {
+    let source = std::fs::read_to_string(path).map_err(|error| {
+        fslc_rust::verification_output::RequirementsImplementsError {
+            message: error.to_string(),
+            span: None,
+        }
+    })?;
     let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
     fslc_rust::verification_output::requirements_implements_output(&source, &resolver, model, depth)
+}
+
+fn implements_error_output(
+    error: &fslc_rust::verification_output::RequirementsImplementsError,
+) -> Value {
+    error.span.map_or_else(
+        || error_output("type", &error.message),
+        |span| located_error_output("type", &error.message, span),
+    )
 }
 
 fn mismatch_paths(
@@ -12997,7 +13064,15 @@ fn run_refine(
     };
     let mapping = match fsl_core::parse_refinement(&source, &implementation, &abstraction) {
         Ok(mapping) => mapping,
-        Err(error) => return (error_output("type", &error.message), 2),
+        Err(error) => {
+            return (
+                error.span.map_or_else(
+                    || error_output("type", &error.message),
+                    |span| located_error_output("type", &error.message, span),
+                ),
+                2,
+            );
+        }
     };
     let checked =
         match fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, depth) {
@@ -13445,7 +13520,7 @@ fn run_verify(
         }
         implements = match implements_result(path, &model, depth) {
             Ok(implements) => implements,
-            Err(error) => return (error_output("type", &error), 2),
+            Err(error) => return (implements_error_output(&error), 2),
         };
     }
     let deadlock = match DeadlockMode::parse(deadlock_mode) {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -9,10 +9,10 @@ use sha2::{Digest, Sha256};
 
 use super::{
     CliVerifyOptions, ScopeBounds, add_strict_tag_warnings, apply_vacuity_mode, block_on_native,
-    display, envelope, error_output, implements_result, invariant_names, load_model,
-    load_model_scoped, load_snapshot_value_object, load_state_snapshot, select_properties,
-    selected_implicit_bounds, semantic_error_output, validate_requirement_traces,
-    validate_specialized_document,
+    display, envelope, error_output, implements_error_output, implements_result, invariant_names,
+    load_model, load_model_scoped, load_snapshot_value_object, load_state_snapshot,
+    select_properties, selected_implicit_bounds, semantic_error_output,
+    validate_requirement_traces, validate_specialized_document,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1918,7 +1918,7 @@ fn execute_cli_verification(
     } else {
         match implements_result(path, model, options.depth) {
             Ok(implements) => implements,
-            Err(error) => return (error_output("type", &error), 2),
+            Err(error) => return (implements_error_output(&error), 2),
         }
     };
     let selection = ModelSelection {

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -3,6 +3,7 @@
 //! Backend-neutral JSON rendering for bounded verification results.
 
 use std::collections::BTreeSet;
+use std::fmt;
 use std::future::Future;
 
 use fsl_core::{
@@ -20,6 +21,21 @@ pub enum DeadlockMode {
     Error,
     Ignore,
 }
+
+/// A requirements `implements` failure with its refinement source location.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RequirementsImplementsError {
+    pub message: String,
+    pub span: Option<fsl_syntax::Span>,
+}
+
+impl fmt::Display for RequirementsImplementsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RequirementsImplementsError {}
 
 impl DeadlockMode {
     /// Parse the public CLI/Worker spelling.
@@ -131,15 +147,23 @@ pub fn requirements_implements_output(
     resolver: &dyn fsl_core::FileResolver,
     model: &KernelModel,
     depth: usize,
-) -> Result<Option<Value>, String> {
-    let Some(contract) = fsl_core::requirements_implements(source, resolver, model)
-        .map_err(|error| error.to_string())?
+) -> Result<Option<Value>, RequirementsImplementsError> {
+    let Some(contract) =
+        fsl_core::requirements_implements(source, resolver, model).map_err(|error| {
+            RequirementsImplementsError {
+                message: error.message,
+                span: error.span,
+            }
+        })?
     else {
         return Ok(None);
     };
     let checked =
         fsl_runtime::check_refinement(model, &contract.abstraction, &contract.refinement, depth)
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| RequirementsImplementsError {
+                message: error.to_string(),
+                span: None,
+            })?;
     Ok(Some(if let Some(failure) = checked.failure {
         json!({
             "abs": contract.abstraction.name,

--- a/rust/fslc/tests/causal_cli.rs
+++ b/rust/fslc/tests/causal_cli.rs
@@ -913,6 +913,51 @@ fn observe_expectations_fails_without_scope() {
 }
 
 #[test]
+fn observe_expectations_rejects_enum_conversion_without_typed_impl_model() {
+    let scratch = tempfile_dir();
+    let mapping = scratch.join("enum-conversion-mapping.fsl");
+    std::fs::write(
+        &mapping,
+        r"refinement ExternalRefinesIncident {
+  impl External
+  abs IncidentResponse
+
+  enum conversion status ExternalStatus -> IncidentStatus {
+    Open -> Open
+  }
+}
+",
+    )
+    .expect("write mapping");
+
+    let (output, status) = run_cli(&[
+        "causal",
+        "observe-expectations",
+        INCIDENT,
+        "--from-log",
+        OBS_LOG,
+        "--mapping",
+        mapping.to_str().expect("utf-8 mapping path"),
+        "--scope",
+        OBS_SCOPE,
+        "--period-start",
+        "2026-01-01",
+        "--period-end",
+        "2026-03-31",
+    ]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "type");
+    assert_eq!(output["loc"], serde_json::json!({"line": 5, "column": 3}));
+    assert!(
+        output["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("typed impl model")
+    );
+}
+
+#[test]
 fn observe_expectations_fails_without_period() {
     let (output, status) = run_cli(&[
         "causal",

--- a/rust/fslc/tests/fixtures/issue_450_design.fsl
+++ b/rust/fslc/tests/fixtures/issue_450_design.fsl
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ApplicationUnitOfWorkDesign {
+  entity Command
+  enum UnitOfWorkStage {
+    Conflict, Rejected, Committed, Decided, Loaded, Received
+  }
+
+  state {
+    stage: Map<Command, UnitOfWorkStage>
+  }
+
+  init {
+    forall c: Command {
+      stage[c] = Received
+    }
+  }
+
+  action load(c: Command) {
+    requires stage[c] == Received
+    stage[c] = Loaded
+  }
+}
+
+verify {
+  instances Command = 1
+}

--- a/rust/fslc/tests/fixtures/issue_450_mapping.fsl
+++ b/rust/fslc/tests/fixtures/issue_450_mapping.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+refinement ApplicationUnitOfWorkRefinesUseCase {
+  impl ApplicationUnitOfWorkDesign
+  abs ApplicationUseCaseRequirements
+  enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
+    Received -> Received
+    Loaded -> Loaded
+    Decided -> Decided
+    Committed -> Committed
+    Rejected -> Rejected
+    Conflict -> Conflict
+  }
+
+  map command_stage[c: Command] = convert(use_case_stage, stage[c])
+  action load(c) -> load(c)
+}

--- a/rust/fslc/tests/fixtures/issue_450_mapping_incomplete.fsl
+++ b/rust/fslc/tests/fixtures/issue_450_mapping_incomplete.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+refinement ApplicationUnitOfWorkRefinesUseCase {
+  impl ApplicationUnitOfWorkDesign
+  abs ApplicationUseCaseRequirements
+  enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
+    Received -> Received
+    Loaded -> Loaded
+    Decided -> Decided
+    Committed -> Committed
+    Rejected -> Rejected
+  }
+
+  map command_stage[c: Command] = convert(use_case_stage, stage[c])
+  action load(c) -> load(c)
+}

--- a/rust/fslc/tests/fixtures/issue_450_requirements.fsl
+++ b/rust/fslc/tests/fixtures/issue_450_requirements.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+requirements ApplicationUseCaseRequirements {
+  process Command {
+    stages Received, Loaded, Decided, Committed, Rejected, Conflict
+    initial Received
+    transition load Received -> Loaded by Application
+  }
+}
+
+verify {
+  instances Command = 1
+}

--- a/rust/fslc/tests/issue_450_enum_conversion.rs
+++ b/rust/fslc/tests/issue_450_enum_conversion.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+#[test]
+fn process_stage_refinement_accepts_explicit_conversion_and_rejects_non_total_mapping() {
+    let design = fixture("issue_450_design.fsl").display().to_string();
+    let requirements = fixture("issue_450_requirements.fsl").display().to_string();
+    let mapping = fixture("issue_450_mapping.fsl").display().to_string();
+    let (success, status) = run(&[
+        "refine".to_owned(),
+        design.clone(),
+        requirements.clone(),
+        mapping.clone(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{success}");
+    assert_eq!(success["result"], "refines");
+
+    let incomplete = fixture("issue_450_mapping_incomplete.fsl")
+        .display()
+        .to_string();
+    let (failure, status) = run(&[
+        "refine".to_owned(),
+        design,
+        requirements.clone(),
+        incomplete,
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ]);
+    assert_eq!(status, 2, "{failure}");
+    assert_eq!(failure["kind"], "type");
+    assert!(failure["loc"].is_object(), "{failure}");
+    assert!(failure["span"].is_object(), "{failure}");
+    assert!(failure["message"].as_str().is_some_and(|message| {
+        message.contains("missing source: [Conflict]; missing target: [Conflict]")
+    }));
+
+    let (replay, status) = run(&[
+        "replay".to_owned(),
+        requirements,
+        "--from-log".to_owned(),
+        "not-read.jsonl".to_owned(),
+        "--mapping".to_owned(),
+        mapping,
+    ]);
+    assert_eq!(status, 2, "{replay}");
+    assert_eq!(replay["kind"], "type");
+    assert!(replay["loc"].is_object(), "{replay}");
+    assert!(
+        replay["message"]
+            .as_str()
+            .is_some_and(|message| { message.contains("typed impl model") })
+    );
+}
+
+#[test]
+fn inline_implements_enum_conversion_errors_keep_their_location() {
+    let scratch =
+        std::env::temp_dir().join(format!("fslc-issue-450-inline-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    std::fs::write(
+        scratch.join("abs.fsl"),
+        "spec Abs { enum AbsStage { A, B } state { status: AbsStage } init { status = A } action step() { status = B } }",
+    )
+    .expect("write abstraction");
+    let implementation = scratch.join("impl.fsl");
+    std::fs::write(
+        &implementation,
+        r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum conversion stage ImplStage -> AbsStage {
+      A -> A
+    }
+    map status = convert(stage, stage)
+    action step() -> step()
+  }
+  enum ImplStage { A, B }
+  state { stage: ImplStage }
+  init { stage = A }
+  action step() { stage = B }
+}
+"#,
+    )
+    .expect("write implementation");
+
+    let (failure, status) = run(&["check".to_owned(), implementation.display().to_string()]);
+    assert_eq!(status, 2, "{failure}");
+    assert_eq!(failure["kind"], "type");
+    assert_eq!(failure["loc"], serde_json::json!({"line": 3, "column": 5}));
+    assert!(failure["span"].is_object(), "{failure}");
+    assert!(
+        failure["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("missing source: [B]"))
+    );
+}
+
+#[test]
+fn empty_enum_conversion_is_a_located_type_error_not_a_panic() {
+    let scratch = std::env::temp_dir().join(format!("fslc-issue-450-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    let implementation = scratch.join("impl.fsl");
+    let abstraction = scratch.join("abs.fsl");
+    let mapping = scratch.join("mapping.fsl");
+    std::fs::write(
+        &implementation,
+        "spec Impl { enum EmptyImpl {} state { ready: Bool } init { ready = false } action send(s: EmptyImpl) { requires false } }",
+    )
+    .expect("write implementation");
+    std::fs::write(
+        &abstraction,
+        "spec Abs { enum EmptyAbs {} state { ready: Bool } init { ready = false } action send(s: EmptyAbs) { requires false } }",
+    )
+    .expect("write abstraction");
+    std::fs::write(
+        &mapping,
+        "refinement R { impl Impl abs Abs enum conversion empty EmptyImpl -> EmptyAbs {} map ready = ready action send(s) -> send(convert(empty, s)) }",
+    )
+    .expect("write mapping");
+
+    let (failure, status) = run(&[
+        "refine".to_owned(),
+        implementation.display().to_string(),
+        abstraction.display().to_string(),
+        mapping.display().to_string(),
+    ]);
+    assert_eq!(status, 2, "{failure}");
+    assert_eq!(failure["kind"], "type");
+    assert!(failure["loc"].is_object(), "{failure}");
+    assert!(failure["span"].is_object(), "{failure}");
+    assert!(
+        failure["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("EmptyImpl' has no members"))
+    );
+}

--- a/rust/fslc/tests/issue_450_sibling_enum_conversion.rs
+++ b/rust/fslc/tests/issue_450_sibling_enum_conversion.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn scratch(name: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("fslc-issue-450-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&path).expect("create scratch directory");
+    path
+}
+
+fn write(directory: &Path, name: &str, source: &str) -> PathBuf {
+    let path = directory.join(name);
+    std::fs::write(&path, source).expect("write fixture");
+    path
+}
+
+fn refine(implementation: &Path, abstraction: &Path, mapping: &Path) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "refine",
+            implementation.to_str().expect("utf-8 implementation path"),
+            abstraction.to_str().expect("utf-8 abstraction path"),
+            mapping.to_str().expect("utf-8 mapping path"),
+            "--depth",
+            "1",
+        ])
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).expect("native JSON output");
+    (value, output.status.code().expect("exit status"))
+}
+
+fn assert_positive_and_missing_row(
+    name: &str,
+    files: &[(&str, &str)],
+    implementation_name: &str,
+    abstraction_name: &str,
+    mapping_source: &str,
+    removed_row: &str,
+) {
+    let directory = scratch(name);
+    for (path, source) in files {
+        write(&directory, path, source);
+    }
+    let implementation = directory.join(implementation_name);
+    let abstraction = directory.join(abstraction_name);
+    let mapping = write(&directory, "mapping.fsl", mapping_source);
+    let (success, status) = refine(&implementation, &abstraction, &mapping);
+    assert_eq!(status, 0, "{name}: {success}");
+    assert_eq!(success["result"], "refines", "{name}: {success}");
+
+    let incomplete_source = mapping_source.replacen(removed_row, "", 1);
+    assert_ne!(
+        incomplete_source, mapping_source,
+        "row must exist in fixture"
+    );
+    let incomplete = write(&directory, "mapping-incomplete.fsl", &incomplete_source);
+    let (failure, status) = refine(&implementation, &abstraction, &incomplete);
+    assert_eq!(status, 2, "{name}: {failure}");
+    assert_eq!(failure["kind"], "type", "{name}: {failure}");
+    assert!(failure["loc"].is_object(), "{name}: {failure}");
+    assert!(
+        failure["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("missing source"))
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn generated_and_renamed_enum_paths_use_the_same_checked_conversion() {
+    assert_positive_and_missing_row(
+        "db-column",
+        &[
+            (
+                "impl.fsl",
+                r"spec DbDesign {
+  type DesignVersion = 0..0
+  enum DesignColumn { col_users_id }
+  state {
+    version: DesignVersion,
+    d_exists: Map<DesignColumn, Bool>,
+    d_backfilled: Map<DesignColumn, Bool>,
+    d_not_null: Map<DesignColumn, Bool>
+  }
+  init {
+    version = 0
+    forall c: DesignColumn {
+      d_exists[c] = true
+      d_backfilled[c] = true
+      d_not_null[c] = true
+    }
+  }
+  action observe_schema_0() { version = 0 }
+}",
+            ),
+            (
+                "abs.fsl",
+                r"dbsystem DbAbs {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; }
+  }
+}",
+            ),
+        ],
+        "impl.fsl",
+        "abs.fsl",
+        r"refinement DbR {
+  impl DbDesign
+  abs DbAbs
+  enum conversion column_key Column -> DesignColumn {
+    col_users_id -> col_users_id
+  }
+  map schema_version = version
+  map column_exists[c: Column] = d_exists[convert(column_key, c)]
+  map column_backfilled[c: Column] = d_backfilled[convert(column_key, c)]
+  map column_not_null[c: Column] = d_not_null[convert(column_key, c)]
+  action observe_schema_0() -> observe_schema_0()
+}",
+        "    col_users_id -> col_users_id\n",
+    );
+
+    assert_positive_and_missing_row(
+        "domain-effect",
+        &[
+            (
+                "impl.fsl",
+                r"spec DomainDesign {
+  type RequestId = 0..0
+  type DesignAttempt = 0..1
+  enum DesignCaptureStatus {
+    CaptureEffectStatus_NotStarted,
+    CaptureEffectStatus_Pending,
+    CaptureEffectStatus_Succeeded,
+    CaptureEffectStatus_Failed,
+    CaptureEffectStatus_TimedOut,
+    CaptureEffectStatus_Cancelled,
+    CaptureEffectStatus_Compensated
+  }
+  state {
+    status: Map<RequestId, DesignCaptureStatus>,
+    attempts: Map<RequestId, DesignAttempt>,
+    requested: Bool
+  }
+  init {
+    forall r: RequestId {
+      status[r] = CaptureEffectStatus_NotStarted
+      attempts[r] = 0
+    }
+    requested = false
+  }
+  action request(r: RequestId) {
+    status[r] = CaptureEffectStatus_Pending
+    attempts[r] = attempts[r] + 1
+    requested = true
+  }
+}",
+            ),
+            (
+                "abs.fsl",
+                r"domain DomainAbs {
+  implementation_profile functional_ddd
+  type OrderId = 0..0
+  type RequestId = 0..0
+  enum Status { Draft, Done, Failed }
+  aggregate Order {
+    id OrderId
+    state { status: Status = Draft; }
+    command Request { request_id: RequestId }
+    event Requested { request_id: RequestId }
+    event Captured { request_id: RequestId }
+    event Failed { request_id: RequestId }
+    decide Request { requires status == Draft emits Requested }
+    evolve Requested { status = Draft }
+    evolve Captured { status = Done }
+    evolve Failed { status = Failed }
+  }
+  effect Capture {
+    async
+    idempotency_key Order.id
+    correlation_id Requested.request_id
+    handles Requested
+    emits one_of [Captured, Failed]
+    retry { max_attempts 1 }
+  }
+}",
+            ),
+        ],
+        "impl.fsl",
+        "abs.fsl",
+        r"refinement DomainR {
+  impl DomainDesign
+  abs DomainAbs
+  enum conversion capture_status DesignCaptureStatus -> CaptureEffectStatus {
+    CaptureEffectStatus_NotStarted -> CaptureEffectStatus_NotStarted
+    CaptureEffectStatus_Pending -> CaptureEffectStatus_Pending
+    CaptureEffectStatus_Succeeded -> CaptureEffectStatus_Succeeded
+    CaptureEffectStatus_Failed -> CaptureEffectStatus_Failed
+    CaptureEffectStatus_TimedOut -> CaptureEffectStatus_TimedOut
+    CaptureEffectStatus_Cancelled -> CaptureEffectStatus_Cancelled
+    CaptureEffectStatus_Compensated -> CaptureEffectStatus_Compensated
+  }
+  map capture_attempts[r: RequestId] = attempts[r]
+  map capture_status[r: RequestId] = convert(capture_status, status[r])
+  map event_Captured = false
+  map event_Failed = false
+  map event_Requested = requested
+  map order_status = Status_Draft
+  action request(r) -> order_request(r)
+}",
+        "    CaptureEffectStatus_Compensated -> CaptureEffectStatus_Compensated\n",
+    );
+
+    assert_positive_and_missing_row(
+        "compose-renamed",
+        &[
+            (
+                "pay_component.fsl",
+                r"spec PayComponent {
+  type PayId = 0..0
+  enum PSt { Created, Captured }
+  state { payment: Map<PayId, PSt> }
+  init { forall p: PayId { payment[p] = Created } }
+  action capture(p: PayId) {
+    requires payment[p] == Created
+    payment[p] = Captured
+  }
+}",
+            ),
+            (
+                "impl.fsl",
+                r#"compose PayCompose {
+  use PayComponent as pay from "pay_component.fsl"
+  action do(p: pay.PayId) = pay.capture(p) { }
+  internal pay.capture
+}"#,
+            ),
+            (
+                "abs.fsl",
+                r"spec PayAbs {
+  type PayId = 0..0
+  enum AbsPSt { Created, Captured }
+  state { status: Map<PayId, AbsPSt> }
+  init { forall p: PayId { status[p] = Created } }
+  action do(p: PayId) {
+    requires status[p] == Created
+    status[p] = Captured
+  }
+}",
+            ),
+        ],
+        "impl.fsl",
+        "abs.fsl",
+        r"refinement PayR {
+  impl PayCompose
+  abs PayAbs
+  enum conversion payment_status pay__PSt -> AbsPSt {
+    Created -> Created
+    Captured -> Captured
+  }
+  map status[p: PayId] = convert(payment_status, pay__payment[p])
+  action do(p) -> do(p)
+}",
+        "    Captured -> Captured\n",
+    );
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -605,9 +605,13 @@ refinement <Name> {
   impl <ImplSpecName>
   abs  <AbsSpecName>
   maps auto                                      // optional identity defaults for same-named compatible state/actions
+  enum conversion <name> <ImplEnum> -> <AbsEnum> {
+    <ImplMember> -> <AbsMember>                  // exhaustive bijection; every member exactly once
+  }
   map <abs_var> = <expr over impl state>          // scalar abstract variable
   map <abs_var>[<x>: <KeyType>] = <expr>          // per-element mapping of a Map
-  // map and action arguments use the same expressions as specs, including if <c> then <a> else <b>
+  // use convert(<name>, <expr>) in a map or action argument
+  // map and action arguments otherwise use the same expressions as specs, including if <c> then <a> else <b>
   action <impl_act>(<formal params>...) -> <abs_act>(<expr>...) | stutter
   // formal params may be bare names or name: Type annotations matching the impl action
   // explicit map/action entries override maps auto; incompatible same-name candidates are type errors
@@ -631,6 +635,18 @@ merged (merging would let an impl-only member get reinterpreted as whichever
 abs member sits at the same ordinal index). Same-named domain types
 (`lo..hi`) with different bounds are fine — an out-of-range value there is
 still caught as `map_out_of_bounds`/`abs_state_mismatch`.
+
+Distinct nominal enums stay incompatible unless an `enum conversion` is
+declared and invoked with `convert(name, expr)`. Both endpoints must be enums;
+unknown, duplicate, or missing source/target members fail as a located type
+error. Conversion is member-wise and never inferred from ordinal position.
+For a requirements `process` stage target, use the checked Kernel enum name
+reported by `fslc kernel` (for example `CommandStage`). Raw production-log and
+causal replay mappings have no typed impl model and therefore reject enum
+conversion declarations/calls; use a typed refinement mapping instead.
+For a generated abstract Map key such as DB `Column`, the conversion direction
+is abstract-to-implementation: convert the abstract binder before indexing the
+implementation Map (for example `Column -> DesignColumn`).
 
 ## 2. Types
 


### PR DESCRIPTION
## Problem

Requirements `process` stages and design enums are distinct nominal types. Before this change,
refinement could not safely express their member-wise conversion when member spellings collided;
bare-member lookup could also be reinterpreted after impl/abs model merge.

## Contract and implementation

- Add refinement-local `enum conversion Name Source -> Target { ... }` declarations and
  `convert(Name, expr)` calls for state maps and action arguments.
- Check a complete bijection: nominal endpoints, every source/target exactly once, no unknown or
  duplicate members, and no ordinal/declaration-order conversion.
- Elaborate calls to existing conditional IR with private typed enum-member literals so concrete,
  explicit, symbolic, progress, tooling, inline `implements`, CLI, and Worker paths agree.
- Preserve Public Kernel v1/v2 expression schemas by projecting checked typed literals through the
  existing typed `var` shape.
- Reject raw production-log and causal replay with located type errors because those surfaces have no
  typed implementation model.
- Cover requirements stage, DB `Column`, domain effect status, compose-renamed enums, and action
  arguments with positive and rejecting controls.
- Update the accepted refinement design, English/Japanese language references, generated site
  reference, FSL skill reference, migration guidance, and changelog.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `./tools/check-native-integration.sh`
- `.venv/bin/python -m pytest -q tests/test_site_reference_snapshot.py` (3 passed)
- Issue fixtures pass native `fslc fmt --check` with `changed:false`.

Independent review found and then verified fixes for empty-enum fallback panic, lost CLI/Worker
locations, and missing sibling-path durable tests; the re-review has no actionable findings.

## Local-optima audit

The audit combined 24-month Git signals with source/runtime behavior. It separated required
semantic-agreement fanout from boundary debt:

- #454 tracks a no-commitment spike for the flat bare-member namespace and a nominal Kernel lookup
  migration; this PR uses the smallest typed escape hatch instead of changing versioned boundaries.
- #455 tracks a separate source-total, non-injective conversion contract; this PR retains the
  stronger bijective assurance.
- Public Kernel compatibility projection and fail-closed raw replay are intentional localities, not
  silently accepted gaps. Collection lifting did not have enough usage/runtime evidence to open an
  issue.

Fixes #450
