### PR TITLE
fix(refine): reject ambiguous enum members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
+  implementation and abstraction enums, preventing checked and evaluation
+  merge order from assigning different nominal identities. Existing identifier
+  shadowing by implementation inputs is preserved, unevaluable abstraction
+  constants are excluded, bijective mappings use the explicit typed conversion,
+  and the separate many-to-one contract remains tracked by #455 (#454).
 - Refinement mappings can now declare an exhaustive, type-safe member-wise
   conversion between distinct nominal enums and invoke it from state maps or
   action arguments. This includes requirements `process` stage enums, rejects

--- a/docs/DESIGN-enum-member-identity.md
+++ b/docs/DESIGN-enum-member-identity.md
@@ -1,0 +1,111 @@
+# Checked-Kernel enum-member identity and lookup
+
+Status: accepted design decision for issue #454.
+
+## Decision
+
+FSL keeps bare enum-member source syntax, but an unshadowed bare member in a checked context
+must resolve to exactly one nominal enum. When implementation and abstraction models are combined
+for refinement and two enum types publish the same spelling, that spelling is ambiguous and the
+frontend rejects its use with a located type error. Existing mapping identifier precedence is
+unchanged: implementation state and constant names plus mapping parameters and binders shadow enum
+members. Abstraction constants are not mapping inputs and are not imported into the checked
+expression environment. A refinement can cross an enum boundary only through a construct that has
+already established the source and target nominal types. The current `enum conversion` and its
+checked `Expr::EnumMember` elaboration cover bijections; the source-total many-to-one case remains
+unsupported until issue #455 is implemented.
+
+This is a staged **go** for nominal lookup at the checked refinement boundary and a **no-go**
+for replacing `KernelModel.enum_members` with a tuple-keyed public field in the current Kernel
+contract. The flat map remains a compatibility index for unambiguous bare syntax inside one
+checked model. `KernelModel.types` is the canonical inventory for nominal membership, and
+`Expr::EnumMember { type_name, member }` is the canonical checked expression when identity
+must survive a merge.
+
+## Context and local rationale
+
+The flat `BTreeMap<String, Value>` is locally useful. It makes legacy bare expressions cheap to
+type and evaluate, preserves the accepted source grammar, feeds duplicate-write detection, and
+supports document/CLI catalogs without adding a second surface spelling. Model construction also
+rejects duplicate member spellings inside one Kernel model, so the index is unambiguous there.
+
+The boundary changes when refinement combines two independently valid models. Before this
+decision, `typecheck::base_env` derived a first-wins owner from the merged type inventory, while
+runtime and symbolic refinement helpers separately merged flat value maps. Their insertion order
+could choose a different owner. The local convenience therefore externalized nominal identity to
+each consumer and could turn a checked bare member into a different enum value at evaluation time.
+
+## Consumer and compatibility inventory
+
+| Consumer | Existing purpose | Decision |
+|---|---|---|
+| `fsl-core::model::ModelBuilder` | Reject duplicate bare members in one model and build the legacy lookup index | Retain; one-model bare syntax stays compatible. |
+| `fsl-core::typecheck::base_env` | Assign types to bare members | Publish only members with one owner in the checked type inventory; diagnose multiple owners. |
+| `fsl-core::refinement::refinement_type_context` | Combine impl/abs types for mapping checks | Keep both nominal type definitions, but only impl constants; ambiguity is detected from the complete type inventory without admitting unevaluable abs constants. |
+| `fsl-runtime::eval` and `fsl-verifier::eval` | Evaluate ordinary bare variables | Retain for unambiguous checked expressions; typed `Expr::EnumMember` bypasses the flat map. |
+| runtime/verifier refinement model assembly | Combine impl/abs models | May retain the flat compatibility index because an ambiguous bare expression can no longer pass the shared frontend. Typed literals resolve through `types`. |
+| duplicate-write detection | Evaluate static indices while building one model | Retain the flat one-model index. |
+| Public Kernel v1/v2 projection | Publish checked expressions | No schema change: a typed member remains `kind:"var"` plus its named type. Importers must use the `(type, name)` pair. |
+| document renderer and glossary | Recognize/display members | Continue using the one-model index; glossary targets already carry `Type.Member` and validate the nominal owner. |
+| CLI catalog and raw mapping evaluator | Completion/catalog or untyped external mappings | Continue exposing unambiguous model members. Raw production/causal replay still rejects typed enum conversions because no typed implementation model exists. |
+| frozen Python reference | Compatibility reference | No change; this decision concerns the authoritative native Rust checked boundary. |
+
+Bare-member source behavior is unchanged for every model that was valid by itself. The only newly
+rejected case is a refinement expression whose combined impl/abs inventory gives an unshadowed
+referenced bare spelling more than one nominal owner. Implementation state and constant entries are
+installed before enum members, and expression-local parameter/binder bindings are installed
+afterward; those ordinary identifiers therefore retain their established precedence. Abstraction
+constants are excluded because §1 mapping expressions range over implementation state and constants,
+and neither concrete nor symbolic evaluation supplies abstraction constants. The rejected enum
+expression had no stable interpretation across the checked and evaluation boundaries. Public Kernel
+v1/v2, JSON envelopes, exit codes, and replay schemas are unchanged.
+
+## Negative control and positive path
+
+`rust/fsl-core/tests/enum_conversion.rs` constructs independently valid `AImplStage.Shared` and
+`ZAbsStage.Shared` enums. Their names deliberately make the implementation owner win the former
+first-wins type environment while the abstraction flat value would overwrite it at runtime. The
+test asserts that a bare `Shared` in a refinement conditional is rejected and names both owners.
+This is the required wrong-nominal negative control: an expression that the old typecheck order
+accepted cannot reach the disagreeing runtime merge. A second negative control prevents an
+abstraction constant from masking the collision during checking when that constant is unavailable
+to evaluation. Adjacent positive controls preserve implementation state/constant and local-binder
+shadowing.
+
+The adjacent exhaustive-conversion test is the positive path. It checks that same-spelled members
+are elaborated as both `ImplStage.Shared`-style and `AbsStage.Shared`-style typed literals and that
+the existing Public Kernel expression shape retains both named types. Runtime and verifier
+agreement tests for `enum conversion` remain the execution-level anchors.
+
+## Alternatives and migration
+
+### A. Keep first-wins/overwrite flat lookup
+
+This has no migration cost but leaves ownership dependent on insertion order. It is rejected at the
+refinement boundary because typechecking and evaluation have separate merge implementations.
+
+### B. Reject ambiguous bare members and use typed checked literals
+
+This is the selected state. It is a small, reversible compatibility tightening, requires no schema
+version, and centralizes the safety decision in the shared frontend. Authors migrate an ambiguous
+conditional to the checked bijective conversion when it fits, rather than renaming enums or relying
+on declaration order. A colliding many-to-one mapping has an explicit temporary unsupported gap;
+issue #455 owns its separate source-total, non-injective contract.
+
+### C. Replace the Kernel field with `(type_name, member)` keys
+
+This may become useful if FSL accepts general qualified member syntax or publishes a versioned
+nominal-literal Kernel node. Doing it now would require coordinated changes to ordinary evaluation,
+duplicate-write analysis, documents, CLI catalogs, downstream Rust consumers, and compatibility
+policy while still needing a separate rule for bare syntax. The migration cost is not justified by
+additional safety after option B, so this issue does not authorize it.
+
+## Future gate for canonical storage migration
+
+Reconsider option C only with all of the following evidence:
+
+- an accepted source or Kernel contract for qualified enum-member lookup outside refinement;
+- an inventory of downstream users of the public `KernelModel` field;
+- byte/schema compatibility or an explicit Public Kernel version transition;
+- positive and rejecting concrete/symbolic/replay agreement controls; and
+- a measured reduction in consumer compensation beyond the ambiguity rejection established here.

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -254,6 +254,11 @@ refinement SeatImplRefinesBooking {
 
 ## 2.6 Exhaustive nominal-enum conversion (issue #450)
 
+The checked-boundary ownership and flat-index compatibility decision is recorded in
+[DESIGN-enum-member-identity.md](DESIGN-enum-member-identity.md). In particular, a bare
+member shared by the implementation and abstraction inventories is rejected rather than
+resolved by merge order.
+
 Refinement preserves nominal enum identity. Distinct impl/abs enums are never
 assignment-compatible and are never converted by ordinal. A refinement that needs a
 member-wise representation change declares a named conversion and calls it from a state

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -654,9 +654,6 @@ fn validate_refinement_expressions(
 
 fn refinement_type_context(implementation: &KernelModel, abstraction: &KernelModel) -> KernelModel {
     let mut context = implementation.clone();
-    for (name, value) in &abstraction.consts {
-        context.consts.entry(name.clone()).or_insert(value.clone());
-    }
     for (name, definition) in &abstraction.types {
         context
             .types

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -63,15 +63,37 @@ pub(crate) fn base_env(model: &KernelModel) -> TypeEnv {
         };
         env.entry(name.clone()).or_insert(ty);
     }
+    let mut enum_members = BTreeMap::<&str, Option<&str>>::new();
     for (type_name, definition) in &model.types {
         if let TypeDef::Enum { members, .. } = definition {
             for member in members {
-                env.entry(member.clone())
-                    .or_insert_with(|| TypeRef::Named(type_name.clone()));
+                enum_members
+                    .entry(member)
+                    .and_modify(|owner| *owner = None)
+                    .or_insert(Some(type_name));
             }
         }
     }
+    for (member, owner) in enum_members {
+        if let Some(type_name) = owner {
+            env.entry(member.to_owned())
+                .or_insert_with(|| TypeRef::Named(type_name.to_owned()));
+        }
+    }
     env
+}
+
+fn enum_member_owners(model: &KernelModel, member: &str) -> Vec<String> {
+    model
+        .types
+        .iter()
+        .filter_map(|(type_name, definition)| match definition {
+            TypeDef::Enum { members, .. } if members.iter().any(|item| item == member) => {
+                Some(type_name.clone())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 pub(crate) fn resolve(model: &KernelModel, ty: &TypeRef) -> Result<TypeRef, TypecheckError> {
@@ -173,10 +195,17 @@ pub(crate) fn infer_type(
             ))
         }
         Expr::Struct { name, .. } => Ok(TypeRef::Named(name.clone())),
-        Expr::Var(name) => env
-            .get(name)
-            .cloned()
-            .ok_or_else(|| error(format!("public Kernel cannot type identifier '{name}'"))),
+        Expr::Var(name) => env.get(name).cloned().ok_or_else(|| {
+            let owners = enum_member_owners(model, name);
+            if owners.len() > 1 {
+                error(format!(
+                    "ambiguous enum member '{name}' belongs to [{}]; use a bijective enum conversion when applicable (many-to-one: issue #455)",
+                    owners.join(", ")
+                ))
+            } else {
+                error(format!("public Kernel cannot type identifier '{name}'"))
+            }
+        }),
         Expr::EnumMember { type_name, member } => match model.types.get(type_name) {
             Some(TypeDef::Enum { members, .. }) if members.contains(member) => {
                 Ok(TypeRef::Named(type_name.clone()))

--- a/rust/fsl-core/tests/enum_conversion.rs
+++ b/rust/fsl-core/tests/enum_conversion.rs
@@ -172,6 +172,93 @@ fn conversion_calls_are_checked_in_action_arguments() {
 }
 
 #[test]
+fn merged_context_rejects_a_bare_member_shared_by_distinct_nominal_enums() {
+    let implementation = build(
+        "spec Impl { enum AImplStage { Shared, Left } state { stage: AImplStage } init { stage = Shared } }",
+    );
+    let abstraction = build(
+        "spec Abs { enum ZAbsStage { Shared, Zero, One } state { status: ZAbsStage } init { status = Zero } }",
+    );
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs map status = if stage == Shared then Zero else One }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("a merge must not reinterpret a checked impl member as an abs member");
+
+    assert!(
+        error.message.contains("ambiguous enum member 'Shared'"),
+        "{}",
+        error.message
+    );
+    assert!(error.message.contains("AImplStage"), "{}", error.message);
+    assert!(error.message.contains("ZAbsStage"), "{}", error.message);
+    assert!(error.message.contains("bijective enum conversion"));
+    assert!(error.message.contains("issue #455"));
+    assert!(
+        error.span.is_some(),
+        "diagnostic must retain the map location"
+    );
+}
+
+#[test]
+fn abstraction_constants_cannot_shadow_a_merged_enum_collision() {
+    let implementation = build(
+        "spec Impl { enum AImplStage { Shared, Left } state { stage: AImplStage } init { stage = Shared } }",
+    );
+    let abstraction = build(
+        "spec Abs { const Shared = 0 enum ZAbsStage { Shared, Zero, One } state { status: ZAbsStage } init { status = One } }",
+    );
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs map status = if Shared == 0 then Zero else One }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("mapping expressions may use implementation constants, not abstraction constants");
+
+    assert!(
+        error.message.contains("ambiguous enum member 'Shared'"),
+        "{}",
+        error.message
+    );
+    assert!(error.message.contains("AImplStage"), "{}", error.message);
+    assert!(error.message.contains("ZAbsStage"), "{}", error.message);
+    assert!(error.span.is_some());
+}
+
+#[test]
+fn ordinary_identifiers_keep_precedence_over_ambiguous_enum_members() {
+    let abstraction = build(
+        "spec Abs { type Key = 0..1 enum ZAbsStage { Shared, Zero } state { ready: Bool, flags: Map<Key, Key> } init { ready = false forall k: Key { flags[k] = 0 } } }",
+    );
+
+    for (implementation, mapping) in [
+        (
+            build(
+                "spec Impl { enum AImplStage { Shared, Left } state { Shared: Bool } init { Shared = true } }",
+            ),
+            "refinement R { impl Impl abs Abs map ready = Shared map flags[b: Key] = b }",
+        ),
+        (
+            build(
+                "spec Impl { const Shared = true enum AImplStage { Shared, Left } state { ready: Bool } init { ready = false } }",
+            ),
+            "refinement R { impl Impl abs Abs map ready = Shared map flags[b: Key] = b }",
+        ),
+        (
+            build(
+                "spec Impl { enum AImplStage { Shared, Left } state { ready: Bool } init { ready = false } }",
+            ),
+            "refinement R { impl Impl abs Abs map ready = ready map flags[Shared: Key] = Shared }",
+        ),
+    ] {
+        parse_refinement(mapping, &implementation, &abstraction).expect(
+            "implementation state/const and local bindings keep precedence over enum members",
+        );
+    }
+}
+
+#[test]
 fn empty_enum_conversion_fails_closed_before_call_elaboration() {
     let implementation = build(
         "spec Impl { enum EmptyImpl {} state { ready: Bool } init { ready = false } action send(s: EmptyImpl) { requires false } }",


### PR DESCRIPTION
## Summary
- closes #454 with a go/no-go decision for nominal enum lookup at the checked refinement boundary
- rejects unshadowed bare members owned by both impl and abs enums before merge order can reinterpret them
- retains the flat one-model compatibility index and Public Kernel v1/v2/replay shapes

## Changes
- make `base_env` publish only uniquely owned enum members and emit a located ambiguity diagnostic
- exclude abstraction constants from mapping inputs, matching the accepted impl-state/const contract and concrete/symbolic evaluators
- add an accepted consumer inventory, compatibility plan, alternatives, and future migration gate
- add negative controls for the former typecheck/runtime merge false greens plus positive state/const/binder shadowing controls

## Verification
- `cargo test --manifest-path rust/Cargo.toml -p fsl-core --test enum_conversion --locked` (7 passed)
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `./tools/check-native-integration.sh` (passed, including 351 WASM/native parity cases)
- independent review: no remaining actionable findings
- post-implementation local-optima audit: `harmless-locality`, severity 3/15, confidence C2

## Risk / Review Notes
- the only new rejection is an unshadowed bare enum spelling with multiple nominal owners in a merged refinement context
- implementation state/constants and mapping parameters/binders keep their existing precedence
- the existing `enum conversion` remains bijective; #455 owns the separate source-total many-to-one contract
- no Public Kernel schema, JSON envelope, exit-code, replay schema, or frozen Python change

## Follow-Up / Post-Merge Checks
- implement #455 from updated `main` as a separate PR after this integration is CI-green

Closes #454