### PR TITLE
feat(refine): add source-total enum abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- Refinement mappings can declare a source-total `enum abstraction` and invoke
+  it with `abstract(name, expr)` for nominal many-to-one mappings. Repeated and
+  unused targets are allowed, while missing, duplicate, unknown, or
+  wrong-nominal sources fail closed; concrete, symbolic, progress, CLI, Worker,
+  Public Kernel projection, and raw-replay guards share the checked semantics
+  without weakening bijective `enum conversion` (#455).
+
 ### Fixed
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier
   shadowing by implementation inputs is preserved, unevaluable abstraction
-  constants are excluded, bijective mappings use the explicit typed conversion,
-  and the separate many-to-one contract remains tracked by #455 (#454).
+  constants are excluded, bijections use explicit typed conversion, and
+  many-to-one mappings use explicit source-total abstraction (#454, #455).
 - Refinement mappings can now declare an exhaustive, type-safe member-wise
   conversion between distinct nominal enums and invoke it from state maps or
   action arguments. This includes requirements `process` stage enums, rejects

--- a/docs/DESIGN-enum-member-identity.md
+++ b/docs/DESIGN-enum-member-identity.md
@@ -11,9 +11,9 @@ frontend rejects its use with a located type error. Existing mapping identifier 
 unchanged: implementation state and constant names plus mapping parameters and binders shadow enum
 members. Abstraction constants are not mapping inputs and are not imported into the checked
 expression environment. A refinement can cross an enum boundary only through a construct that has
-already established the source and target nominal types. The current `enum conversion` and its
-checked `Expr::EnumMember` elaboration cover bijections; the source-total many-to-one case remains
-unsupported until issue #455 is implemented.
+already established the source and target nominal types. `enum conversion` covers bijections, while
+`enum abstraction` covers source-total many-to-one mappings; both elaborate to checked
+`Expr::EnumMember` expressions.
 
 This is a staged **go** for nominal lookup at the checked refinement boundary and a **no-go**
 for replacing `KernelModel.enum_members` with a tuple-keyed public field in the current Kernel
@@ -47,7 +47,7 @@ each consumer and could turn a checked bare member into a different enum value a
 | duplicate-write detection | Evaluate static indices while building one model | Retain the flat one-model index. |
 | Public Kernel v1/v2 projection | Publish checked expressions | No schema change: a typed member remains `kind:"var"` plus its named type. Importers must use the `(type, name)` pair. |
 | document renderer and glossary | Recognize/display members | Continue using the one-model index; glossary targets already carry `Type.Member` and validate the nominal owner. |
-| CLI catalog and raw mapping evaluator | Completion/catalog or untyped external mappings | Continue exposing unambiguous model members. Raw production/causal replay still rejects typed enum conversions because no typed implementation model exists. |
+| CLI catalog and raw mapping evaluator | Completion/catalog or untyped external mappings | Continue exposing unambiguous model members. Raw production/causal replay rejects typed enum conversions and abstractions because no typed implementation model exists. |
 | frozen Python reference | Compatibility reference | No change; this decision concerns the authoritative native Rust checked boundary. |
 
 Bare-member source behavior is unchanged for every model that was valid by itself. The only newly
@@ -72,10 +72,10 @@ abstraction constant from masking the collision during checking when that consta
 to evaluation. Adjacent positive controls preserve implementation state/constant and local-binder
 shadowing.
 
-The adjacent exhaustive-conversion test is the positive path. It checks that same-spelled members
+The adjacent enum-mapping tests are the positive paths. They check that same-spelled members
 are elaborated as both `ImplStage.Shared`-style and `AbsStage.Shared`-style typed literals and that
 the existing Public Kernel expression shape retains both named types. Runtime and verifier
-agreement tests for `enum conversion` remain the execution-level anchors.
+agreement tests for `enum conversion` and `enum abstraction` are the execution-level anchors.
 
 ## Alternatives and migration
 
@@ -88,9 +88,9 @@ refinement boundary because typechecking and evaluation have separate merge impl
 
 This is the selected state. It is a small, reversible compatibility tightening, requires no schema
 version, and centralizes the safety decision in the shared frontend. Authors migrate an ambiguous
-conditional to the checked bijective conversion when it fits, rather than renaming enums or relying
-on declaration order. A colliding many-to-one mapping has an explicit temporary unsupported gap;
-issue #455 owns its separate source-total, non-injective contract.
+conditional to checked `enum conversion` plus `convert` for a bijection, or to source-total
+`enum abstraction` plus `abstract` for a many-to-one mapping, rather than renaming enums or relying
+on declaration order.
 
 ### C. Replace the Kernel field with `(type_name, member)` keys
 

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -312,12 +312,8 @@ fabricate a source-level domain span after lowering. The declaration is a checke
 
 Requiring both source-totality and target-totality deliberately makes this construct a
 one-to-one representation conversion. A genuine abstraction that collapses several impl
-states into one abs state remains expressible with an ordinary conditional mapping only
-when every referenced member spelling is unambiguous in the merged context; that form does
-not claim exhaustive/bijective assurance. A many-to-one conversion whose source/target
-member spellings collide remains outside this feature. It needs a separately designed
-source-total, non-injective conversion contract rather than weakening this fail-closed
-bijection.
+states into one abs state uses the separate source-total contract in section 2.7 rather
+than weakening this fail-closed bijection.
 
 ### Checked representation and evaluation
 
@@ -352,12 +348,51 @@ and v2 therefore need no new expression kind or schema version. An unelaborated
 ### Migration
 
 A pre-3.1 conditional mapping with distinct, unambiguous member spellings remains valid.
-When member spellings collide across nominal enums, or when exhaustive conversion is the
-intended contract, replace the conditional with `enum conversion` plus
-`convert(<name>, <expr>)`.
+For a bijection, replace a colliding or exhaustively intended conditional with
+`enum conversion` plus `convert(<name>, <expr>)`. For a source-total many-to-one
+mapping, use the abstraction contract in section 2.7.
 Do not rename both layers to one enum type and do not map by declaration order; those
 workarounds erase layer identity or recreate the ordinal false-green that nominal typing
 prevents.
+
+## 2.7 Source-total nominal-enum abstraction (issue #455)
+
+A many-to-one representation boundary declares a distinct `enum abstraction` and invokes
+it with `abstract(<name>, <expr>)`:
+
+```fsl
+enum abstraction lifecycle ImplStage -> AbsStage {
+  Received  -> Pending
+  Validated -> Pending
+  Completed -> Done
+  Rejected  -> Failed
+}
+map status = abstract(lifecycle, stage)
+```
+
+This declaration is a source-total function, not a bijection. Both endpoint enums must be
+non-empty so the total mapping has a representable result and the checked conditional has
+a fallback. Every source member must appear exactly once. Unknown endpoint types or members, non-enum endpoints, duplicate
+source rows, missing source rows, wrong call arity, unknown names, and a call argument of
+the wrong nominal source type are located type errors. Multiple source rows may select the
+same target. Target members absent from all rows are intentionally unused by this
+abstraction and require no separate declaration. An injective table is accepted, but
+authors should use `enum conversion` when target-totality and target uniqueness are part of
+the intended assurance.
+
+Conversion and abstraction names share one refinement-local namespace, while their call
+forms are not interchangeable. Keeping both declaration and invocation distinct prevents
+a call site from silently claiming bijective assurance for a source-total mapping. Both
+forms lower through the same typed enum-member conditional representation, so concrete
+refinement, symbolic expression agreement, preserved progress, inline `implements`, CLI,
+Worker, and Public Kernel expression projection retain one evaluation path. Reversing
+either enum's declaration order cannot change the result.
+
+Raw production and causal replay lack a typed implementation model and therefore reject
+either an abstraction declaration or `abstract(...)` call with a located type error. They
+must not infer endpoint types from JSON values. Migrate an ambiguous conditional that
+collapses nominal members to `enum abstraction` plus `abstract`; migrate a one-to-one table
+to `enum conversion` plus `convert` so its stronger target guarantees remain executable.
 
 ## 3. CLI / JSON
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1229,8 +1229,9 @@ refinement のマップと action の引数は、`if <condition> then <expr> els
 含め、通常の spec と同じ式文法と型規則を使います。条件が定数であっても、両方の分岐
 が名前と型の検査を受けます。
 
-異なる名前付き enum の間では、明示的に名前を付けた変換が必要です。refinement 内で
-メンバーごとの全単射を宣言し、状態マップまたは action の引数から呼び出します:
+異なる名前付き enum の間では、明示的に名前を付けた enum mapping が必要です。
+メンバーごとの全単射には、refinement 内で conversion を宣言し、状態マップまたは
+action の引数から呼び出します:
 
 ```fsl
 enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
@@ -1251,6 +1252,28 @@ map command_stage[c: Command] = convert(use_case_stage, stage[c])
 `replay --from-log` と causal observation のマッピングには型付き impl model がないため、
 変換宣言/呼び出しを位置付き型エラーとして拒否します。`convert` を使う前に型付き
 refinement へ移行してください。
+
+多対一の境界では、source-total な abstraction を宣言し、専用の呼び出し形式を
+使います:
+
+```fsl
+enum abstraction lifecycle ImplStage -> AbsStage {
+  Received  -> Pending
+  Validated -> Pending
+  Completed -> Done
+}
+map status = abstract(lifecycle, stage)
+```
+
+両端の enum は空であってはならず、source の全メンバーを正確に 1 回ずつ指定する
+必要があります。source の重複や欠落、
+未知または異なる nominal 型のメンバーは、位置付き型エラーになります。target の
+重複は許可され、どの行にも現れない target メンバーは、この abstraction では意図的に
+未使用です。`enum conversion` は引き続き全単射であり、target の重複や欠落を拒否します。
+conversion と abstraction の名前は refinement ローカルの名前空間を共有し、
+`convert` と `abstract` を取り違えることはできません。どちらも enum の宣言順に依存
+しません。raw production-log と causal のマッピングには型付き impl model がないため、
+abstraction も拒否します。
 
 抽象側の生成 enum が Map の binder で、実装側の Map が design enum をキーにするときは、
 binder を逆方向に変換します。例えば `column_key Column -> DesignColumn` に対して

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1258,9 +1258,9 @@ Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including `if <condition> then <expr> else <expr>`.
 Both branches are name- and type-checked even when the condition is constant.
 
-Distinct nominal enums require an explicit, named conversion. Declare a
-member-wise bijection in the refinement and call it from a state map or action
-argument:
+Distinct nominal enums require an explicit, named enum mapping. For a
+member-wise bijection, declare a conversion in the refinement and call it from
+a state map or action argument:
 
 ```fsl
 enum conversion use_case_stage UnitOfWorkStage -> CommandStage {
@@ -1282,6 +1282,29 @@ stage enum synthesized by lowering; use its checked Kernel name (visible in
 causal observation mappings have no typed impl model and reject conversion
 declarations/calls with a located type error; migrate those mappings to a typed
 refinement before using `convert`.
+
+For a many-to-one boundary, declare a source-total abstraction and use its
+distinct call form:
+
+```fsl
+enum abstraction lifecycle ImplStage -> AbsStage {
+  Received  -> Pending
+  Validated -> Pending
+  Completed -> Done
+}
+map status = abstract(lifecycle, stage)
+```
+
+Both endpoint enums must be non-empty, and every source member must appear
+exactly once. Duplicate or missing source
+members and unknown or wrong-nominal members are located type errors. Repeated
+targets are allowed; target members omitted from all rows are intentionally
+unused by this abstraction. `enum conversion` remains a bijection and still
+rejects duplicate or missing targets. Conversion and abstraction names share
+one refinement-local namespace, and `convert`/`abstract` cannot be
+interchanged. Both forms are independent of enum declaration order. Raw
+production-log and causal mappings reject abstractions too because they have
+no typed implementation model.
 
 When an abstract generated enum is the binder for a map whose implementation
 uses a design enum as its key, convert the binder in the reverse direction,

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1306,9 +1306,9 @@ locations; explicit entries still take precedence over auto synthesis.</p>
 <p>Refinement maps and action arguments use the same expression grammar and type
 rules as ordinary specs, including <code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code>.
 Both branches are name- and type-checked even when the condition is constant.</p>
-<p>Distinct nominal enums require an explicit, named conversion. Declare a
-member-wise bijection in the refinement and call it from a state map or action
-argument:</p>
+<p>Distinct nominal enums require an explicit, named enum mapping. For a
+member-wise bijection, declare a conversion in the refinement and call it from
+a state map or action argument:</p>
 <pre><code class="language-fsl">enum conversion use_case_stage UnitOfWorkStage -&gt; CommandStage {
   Received -&gt; Received
   Validated -&gt; Validated
@@ -1327,6 +1327,25 @@ stage enum synthesized by lowering; use its checked Kernel name (visible in
 causal observation mappings have no typed impl model and reject conversion
 declarations/calls with a located type error; migrate those mappings to a typed
 refinement before using <code>convert</code>.</p>
+<p>For a many-to-one boundary, declare a source-total abstraction and use its
+distinct call form:</p>
+<pre><code class="language-fsl">enum abstraction lifecycle ImplStage -&gt; AbsStage {
+  Received  -&gt; Pending
+  Validated -&gt; Pending
+  Completed -&gt; Done
+}
+map status = abstract(lifecycle, stage)
+</code></pre>
+<p>Both endpoint enums must be non-empty, and every source member must appear
+exactly once. Duplicate or missing source
+members and unknown or wrong-nominal members are located type errors. Repeated
+targets are allowed; target members omitted from all rows are intentionally
+unused by this abstraction. <code>enum conversion</code> remains a bijection and still
+rejects duplicate or missing targets. Conversion and abstraction names share
+one refinement-local namespace, and <code>convert</code>/<code>abstract</code> cannot be
+interchanged. Both forms are independent of enum declaration order. Raw
+production-log and causal mappings reject abstractions too because they have
+no typed implementation model.</p>
 <p>When an abstract generated enum is the binder for a map whose implementation
 uses a design enum as its key, convert the binder in the reverse direction,
 for example <code>map column_exists[c: Column] =

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1279,8 +1279,9 @@ action、requirement-action の <code>maps</code>、auto/恒等の合成 — は
 <p>refinement のマップと action の引数は、<code>if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;</code> を
 含め、通常の spec と同じ式文法と型規則を使います。条件が定数であっても、両方の分岐
 が名前と型の検査を受けます。</p>
-<p>異なる名前付き enum の間では、明示的に名前を付けた変換が必要です。refinement 内で
-メンバーごとの全単射を宣言し、状態マップまたは action の引数から呼び出します:</p>
+<p>異なる名前付き enum の間では、明示的に名前を付けた enum mapping が必要です。
+メンバーごとの全単射には、refinement 内で conversion を宣言し、状態マップまたは
+action の引数から呼び出します:</p>
 <pre><code class="language-fsl">enum conversion use_case_stage UnitOfWorkStage -&gt; CommandStage {
   Received -&gt; Received
   Validated -&gt; Validated
@@ -1298,6 +1299,24 @@ map command_stage[c: Command] = convert(use_case_stage, stage[c])
 <code>replay --from-log</code> と causal observation のマッピングには型付き impl model がないため、
 変換宣言/呼び出しを位置付き型エラーとして拒否します。<code>convert</code> を使う前に型付き
 refinement へ移行してください。</p>
+<p>多対一の境界では、source-total な abstraction を宣言し、専用の呼び出し形式を
+使います:</p>
+<pre><code class="language-fsl">enum abstraction lifecycle ImplStage -&gt; AbsStage {
+  Received  -&gt; Pending
+  Validated -&gt; Pending
+  Completed -&gt; Done
+}
+map status = abstract(lifecycle, stage)
+</code></pre>
+<p>両端の enum は空であってはならず、source の全メンバーを正確に 1 回ずつ指定する
+必要があります。source の重複や欠落、
+未知または異なる nominal 型のメンバーは、位置付き型エラーになります。target の
+重複は許可され、どの行にも現れない target メンバーは、この abstraction では意図的に
+未使用です。<code>enum conversion</code> は引き続き全単射であり、target の重複や欠落を拒否します。
+conversion と abstraction の名前は refinement ローカルの名前空間を共有し、
+<code>convert</code> と <code>abstract</code> を取り違えることはできません。どちらも enum の宣言順に依存
+しません。raw production-log と causal のマッピングには型付き impl model がないため、
+abstraction も拒否します。</p>
 <p>抽象側の生成 enum が Map の binder で、実装側の Map が design enum をキーにするときは、
 binder を逆方向に変換します。例えば <code>column_key Column -&gt; DesignColumn</code> に対して
 <code>map column_exists[c: Column] = design_exists[convert(column_key, c)]</code> と書きます。</p>

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -15,11 +15,34 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-struct EnumConversion {
+struct EnumMapping {
     source: String,
     target: String,
     members: Vec<(String, String)>,
     span: Span,
+    assurance: EnumMappingAssurance,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EnumMappingAssurance {
+    Bijection,
+    SourceTotal,
+}
+
+impl EnumMappingAssurance {
+    const fn declaration_name(self) -> &'static str {
+        match self {
+            Self::Bijection => "enum conversion",
+            Self::SourceTotal => "enum abstraction",
+        }
+    }
+
+    const fn call_name(self) -> &'static str {
+        match self {
+            Self::Bijection => "convert",
+            Self::SourceTotal => "abstract",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -118,7 +141,7 @@ fn build_refinement(
     let mut abs_name = None;
     let mut maps_auto = None;
     let mut state_maps = BTreeMap::new();
-    let mut enum_conversion_items = Vec::new();
+    let mut enum_mapping_items = Vec::new();
     let mut action_correspondences = BTreeMap::new();
     let mut action_sources = Vec::new();
     let mut progress = Vec::new();
@@ -134,7 +157,28 @@ fn build_refinement(
                 target,
                 members,
                 span,
-            } => enum_conversion_items.push((name, source, target, members, span)),
+            } => enum_mapping_items.push((
+                EnumMappingAssurance::Bijection,
+                name,
+                source,
+                target,
+                members,
+                span,
+            )),
+            RefinementItem::EnumAbstraction {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => enum_mapping_items.push((
+                EnumMappingAssurance::SourceTotal,
+                name,
+                source,
+                target,
+                members,
+                span,
+            )),
             RefinementItem::Map {
                 name,
                 binder,
@@ -211,14 +255,14 @@ fn build_refinement(
             None,
         ));
     }
-    let enum_conversions = build_enum_conversions(enum_conversion_items, &type_context)?;
+    let enum_mappings = build_enum_mappings(enum_mapping_items, &type_context)?;
     for state_map in state_maps.values_mut() {
-        state_map.expr = elaborate_enum_conversions(state_map.expr.clone(), &enum_conversions)?;
+        state_map.expr = elaborate_enum_conversions(state_map.expr.clone(), &enum_mappings)?;
     }
     for source in &mut action_sources {
         if let ActionTarget::Action(_, args) = &mut source.target {
             for argument in args {
-                *argument = elaborate_enum_conversions(argument.clone(), &enum_conversions)?;
+                *argument = elaborate_enum_conversions(argument.clone(), &enum_mappings)?;
             }
         }
     }
@@ -303,16 +347,24 @@ fn build_refinement(
     })
 }
 
-type SurfaceEnumConversion = (String, String, String, Vec<(String, String, Span)>, Span);
+type SurfaceEnumMapping = (
+    EnumMappingAssurance,
+    String,
+    String,
+    String,
+    Vec<(String, String, Span)>,
+    Span,
+);
 
-fn build_enum_conversions(
-    items: Vec<SurfaceEnumConversion>,
+fn build_enum_mappings(
+    items: Vec<SurfaceEnumMapping>,
     context: &KernelModel,
-) -> Result<BTreeMap<String, EnumConversion>, RefinementError> {
-    let mut conversions = BTreeMap::new();
-    for (name, source, target, rows, span) in items {
-        let source_members = enum_type_members(context, &source, span)?;
-        let target_members = enum_type_members(context, &target, span)?;
+) -> Result<BTreeMap<String, EnumMapping>, RefinementError> {
+    let mut mappings: BTreeMap<String, EnumMapping> = BTreeMap::new();
+    for (assurance, name, source, target, rows, span) in items {
+        let declaration = assurance.declaration_name();
+        let source_members = enum_type_members(context, declaration, &source, span)?;
+        let target_members = enum_type_members(context, declaration, &target, span)?;
         let mut seen_source = BTreeSet::new();
         let mut seen_target = BTreeSet::new();
         let mut members = Vec::new();
@@ -332,12 +384,13 @@ fn build_enum_conversions(
             if !seen_source.insert(source_member.clone()) {
                 return Err(refinement_error(
                     format!(
-                        "enum conversion '{name}' maps source member '{source_member}' more than once"
+                        "{declaration} '{name}' maps source member '{source_member}' more than once"
                     ),
                     Some(row_span),
                 ));
             }
-            if !seen_target.insert(target_member.clone()) {
+            let first_target_mapping = seen_target.insert(target_member.clone());
+            if assurance == EnumMappingAssurance::Bijection && !first_target_mapping {
                 return Err(refinement_error(
                     format!(
                         "enum conversion '{name}' maps target member '{target_member}' more than once"
@@ -357,54 +410,63 @@ fn build_enum_conversions(
             .filter(|member| !seen_target.contains(*member))
             .cloned()
             .collect::<Vec<_>>();
-        if !missing_source.is_empty() || !missing_target.is_empty() {
-            return Err(refinement_error(
+        if !missing_source.is_empty()
+            || (assurance == EnumMappingAssurance::Bijection && !missing_target.is_empty())
+        {
+            let message = if assurance == EnumMappingAssurance::Bijection {
                 format!(
                     "enum conversion '{name}' must cover every source and target member exactly once; missing source: [{}]; missing target: [{}]",
                     missing_source.join(", "),
                     missing_target.join(", ")
-                ),
-                Some(span),
-            ));
+                )
+            } else {
+                format!(
+                    "enum abstraction '{name}' must cover every source member exactly once; missing source: [{}]",
+                    missing_source.join(", ")
+                )
+            };
+            return Err(refinement_error(message, Some(span)));
         }
-        if conversions
-            .insert(
-                name.clone(),
-                EnumConversion {
-                    source,
-                    target,
-                    members,
-                    span,
-                },
-            )
-            .is_some()
-        {
-            return Err(refinement_error(
-                format!("duplicate enum conversion '{name}'"),
-                Some(span),
-            ));
+        if let Some(existing) = mappings.get(&name) {
+            let message = if existing.assurance == assurance {
+                format!("duplicate {declaration} '{name}'")
+            } else {
+                format!("duplicate enum mapping '{name}'")
+            };
+            return Err(refinement_error(message, Some(span)));
         }
+        mappings.insert(
+            name,
+            EnumMapping {
+                source,
+                target,
+                members,
+                span,
+                assurance,
+            },
+        );
     }
-    Ok(conversions)
+    Ok(mappings)
 }
 
 fn enum_type_members(
     context: &KernelModel,
+    declaration: &str,
     type_name: &str,
     span: Span,
 ) -> Result<Vec<String>, RefinementError> {
     match context.types.get(type_name) {
         Some(TypeDef::Enum { members, .. }) if members.is_empty() => Err(refinement_error(
-            format!("enum conversion endpoint '{type_name}' has no members"),
+            format!("{declaration} endpoint '{type_name}' has no members"),
             Some(span),
         )),
         Some(TypeDef::Enum { members, .. }) => Ok(members.clone()),
         Some(_) => Err(refinement_error(
-            format!("enum conversion endpoint '{type_name}' is not an enum"),
+            format!("{declaration} endpoint '{type_name}' is not an enum"),
             Some(span),
         )),
         None => Err(refinement_error(
-            format!("unknown enum conversion type '{type_name}'"),
+            format!("unknown {declaration} type '{type_name}'"),
             Some(span),
         )),
     }
@@ -413,28 +475,43 @@ fn enum_type_members(
 #[allow(clippy::too_many_lines)]
 fn elaborate_enum_conversions(
     expr: Expr,
-    conversions: &BTreeMap<String, EnumConversion>,
+    conversions: &BTreeMap<String, EnumMapping>,
 ) -> Result<Expr, RefinementError> {
     Ok(match expr {
-        Expr::Call { name, args, span } if name == "convert" => {
+        Expr::Call { name, args, span } if name == "convert" || name == "abstract" => {
+            let declaration = if name == "convert" {
+                "enum conversion"
+            } else {
+                "enum abstraction"
+            };
             let [conversion_name, argument] = args.as_slice() else {
                 return Err(refinement_error(
-                    "convert expects exactly two arguments: convert(name, expression)",
+                    format!("{name} expects exactly two arguments: {name}(name, expression)"),
                     Some(span),
                 ));
             };
             let Expr::Var(conversion_name) = conversion_name else {
                 return Err(refinement_error(
-                    "convert first argument must be an enum conversion name",
+                    format!("{name} first argument must be an {declaration} name"),
                     Some(span),
                 ));
             };
             let conversion = conversions.get(conversion_name).ok_or_else(|| {
                 refinement_error(
-                    format!("unknown enum conversion '{conversion_name}'"),
+                    format!("unknown {declaration} '{conversion_name}'"),
                     Some(span),
                 )
             })?;
+            if conversion.assurance.call_name() != name {
+                return Err(refinement_error(
+                    format!(
+                        "{} '{conversion_name}' must be invoked with {}",
+                        conversion.assurance.declaration_name(),
+                        conversion.assurance.call_name()
+                    ),
+                    Some(span),
+                ));
+            }
             let argument = elaborate_enum_conversions(argument.clone(), conversions)?;
             let (_, fallback_member) = conversion
                 .members
@@ -600,7 +677,7 @@ fn elaborate_enum_conversions(
 
 fn elaborate_conversion_binder(
     binder: Binder,
-    conversions: &BTreeMap<String, EnumConversion>,
+    conversions: &BTreeMap<String, EnumMapping>,
 ) -> Result<Binder, RefinementError> {
     Ok(match binder {
         Binder::Typed {

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -199,7 +199,7 @@ pub(crate) fn infer_type(
             let owners = enum_member_owners(model, name);
             if owners.len() > 1 {
                 error(format!(
-                    "ambiguous enum member '{name}' belongs to [{}]; use a bijective enum conversion when applicable (many-to-one: issue #455)",
+                    "ambiguous enum member '{name}' belongs to [{}]; use enum conversion/convert for a bijection or enum abstraction/abstract for a many-to-one mapping",
                     owners.join(", ")
                 ))
             } else {

--- a/rust/fsl-core/tests/enum_conversion.rs
+++ b/rust/fsl-core/tests/enum_conversion.rs
@@ -34,6 +34,156 @@ const MAPPING: &str = r"refinement R {
   action load() -> load()
 }";
 
+const ABSTRACTION: &str = r"refinement R {
+  impl Impl
+  abs Abs
+  enum abstraction stage ImplStage -> AbsStage {
+    Received -> Received
+    Loaded -> Loaded
+    Conflict -> Loaded
+  }
+  map status = abstract(stage, stage)
+  action load() -> load()
+}";
+
+#[test]
+fn source_total_abstraction_allows_repeated_and_unused_targets() {
+    let (implementation, abstraction) = models();
+    let mapping = parse_refinement(ABSTRACTION, &implementation, &abstraction)
+        .expect("many-to-one abstraction is source-total");
+    let rendered = fsl_core::expr_text(&mapping.state_maps["status"].expr);
+    assert!(rendered.contains("ImplStage.Conflict"), "{rendered}");
+    assert!(rendered.contains("AbsStage.Loaded"), "{rendered}");
+    let mut context = implementation.clone();
+    context.types.extend(abstraction.types.clone());
+    let position = SourcePos {
+        offset: 0,
+        line: 1,
+        column: 1,
+    };
+    let public = public_kernel_expression(
+        &mapping.state_maps["status"].expr,
+        &context,
+        "mapping.fsl",
+        Span {
+            start: position,
+            end: position,
+        },
+        Some(&TypeRef::Named("AbsStage".to_owned())),
+    )
+    .expect("abstraction uses existing typed Public Kernel expressions")
+    .to_string();
+    assert!(public.contains(r#""name":"ImplStage""#), "{public}");
+    assert!(public.contains(r#""name":"AbsStage""#), "{public}");
+    assert!(!public.contains("enum_abstraction"), "{public}");
+    assert!(!public.contains("abstract"), "{public}");
+
+    let reversed_implementation = build(
+        "spec Impl { enum ImplStage { Received, Loaded, Conflict } state { stage: ImplStage } init { stage = Received } action load() { requires stage == Received stage = Loaded } }",
+    );
+    let reversed_abstraction = build(
+        "spec Abs { enum AbsStage { Conflict, Loaded, Received } state { status: AbsStage } init { status = Received } action load() { requires status == Received status = Loaded } }",
+    );
+    let reversed = parse_refinement(ABSTRACTION, &reversed_implementation, &reversed_abstraction)
+        .expect("declaration order does not affect nominal mapping");
+    assert_eq!(
+        fsl_core::expr_text(&mapping.state_maps["status"].expr),
+        fsl_core::expr_text(&reversed.state_maps["status"].expr)
+    );
+}
+
+#[test]
+fn source_total_abstraction_rejects_incomplete_or_wrong_nominal_sources() {
+    let (implementation, abstraction) = models();
+    for (source, expected) in [
+        (
+            ABSTRACTION.replace("    Conflict -> Loaded\n", ""),
+            "missing source: [Conflict]",
+        ),
+        (
+            ABSTRACTION.replace("Conflict -> Loaded", "Received -> Loaded"),
+            "maps source member 'Received' more than once",
+        ),
+        (
+            ABSTRACTION.replace("Conflict -> Loaded", "Missing -> Loaded"),
+            "unknown enum member 'ImplStage.Missing'",
+        ),
+        (
+            ABSTRACTION.replace("Conflict -> Loaded", "Conflict -> Missing"),
+            "unknown enum member 'AbsStage.Missing'",
+        ),
+    ] {
+        let error = parse_refinement(&source, &implementation, &abstraction)
+            .expect_err("invalid abstraction must fail statically");
+        assert!(error.message.contains(expected), "{}", error.message);
+        assert!(error.span.is_some());
+    }
+
+    let wrong_nominal = build(
+        "spec Impl { enum ImplStage { Conflict, Loaded, Received } enum OtherStage { X, Y, Z } state { stage: ImplStage } init { stage = Received } action load() { requires stage == Received stage = Loaded } }",
+    );
+    let source = r"refinement R {
+      impl Impl
+      abs Abs
+      enum abstraction other OtherStage -> AbsStage {
+        X -> Received
+        Y -> Loaded
+        Z -> Loaded
+      }
+      map status = abstract(other, stage)
+      action load() -> load()
+    }";
+    let error = parse_refinement(source, &wrong_nominal, &abstraction)
+        .expect_err("same-spelled members from another nominal enum remain incompatible");
+    assert!(
+        error.message.contains("is not assignable"),
+        "{}",
+        error.message
+    );
+    assert!(error.span.is_some());
+}
+
+#[test]
+fn abstraction_and_conversion_calls_cannot_be_interchanged() {
+    let (implementation, abstraction) = models();
+    for (source, expected) in [
+        (
+            ABSTRACTION.replace("abstract(stage, stage)", "convert(stage, stage)"),
+            "enum abstraction 'stage' must be invoked with abstract",
+        ),
+        (
+            MAPPING.replace("convert(stage, stage)", "abstract(stage, stage)"),
+            "enum conversion 'stage' must be invoked with convert",
+        ),
+        (
+            ABSTRACTION.replace("abstract(stage, stage)", "abstract(stage)"),
+            "abstract expects exactly two arguments",
+        ),
+        (
+            ABSTRACTION.replace("abstract(stage, stage)", "abstract(missing, stage)"),
+            "unknown enum abstraction 'missing'",
+        ),
+    ] {
+        let error = parse_refinement(&source, &implementation, &abstraction)
+            .expect_err("assurance-specific calls fail closed");
+        assert!(error.message.contains(expected), "{}", error.message);
+        assert!(error.span.is_some());
+    }
+
+    let duplicate = ABSTRACTION.replace(
+        "  enum abstraction stage",
+        "  enum conversion stage ImplStage -> AbsStage { Received -> Received Loaded -> Loaded Conflict -> Conflict }\n  enum abstraction stage",
+    );
+    let error = parse_refinement(&duplicate, &implementation, &abstraction)
+        .expect_err("conversion and abstraction names share one namespace");
+    assert!(
+        error.message.contains("duplicate enum mapping 'stage'"),
+        "{}",
+        error.message
+    );
+    assert!(error.span.is_some());
+}
+
 #[test]
 fn exhaustive_conversion_keeps_nominal_identity_in_checked_and_public_expressions() {
     let (implementation, abstraction) = models();
@@ -193,8 +343,8 @@ fn merged_context_rejects_a_bare_member_shared_by_distinct_nominal_enums() {
     );
     assert!(error.message.contains("AImplStage"), "{}", error.message);
     assert!(error.message.contains("ZAbsStage"), "{}", error.message);
-    assert!(error.message.contains("bijective enum conversion"));
-    assert!(error.message.contains("issue #455"));
+    assert!(error.message.contains("enum conversion/convert"));
+    assert!(error.message.contains("enum abstraction/abstract"));
     assert!(
         error.span.is_some(),
         "diagnostic must retain the map location"
@@ -273,5 +423,26 @@ fn empty_enum_conversion_fails_closed_before_call_elaboration() {
     )
     .expect_err("empty conversions must not reach an infallible elaboration branch");
     assert!(error.message.contains("EmptyImpl' has no members"));
+    assert!(error.span.is_some());
+
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction empty EmptyImpl -> EmptyAbs {} action send(s) -> send(abstract(empty, s)) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect_err("empty abstractions must not reach fallback-based elaboration");
+    assert!(error.message.contains("EmptyImpl' has no members"));
+    assert!(error.span.is_some());
+
+    let non_empty_implementation = build(
+        "spec Impl { enum NonEmptyImpl { A } state { ready: Bool } init { ready = false } action send(s: NonEmptyImpl) { ready = true } }",
+    );
+    let error = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction empty NonEmptyImpl -> EmptyAbs {} map ready = ready action send(s) -> send(abstract(empty, s)) }",
+        &non_empty_implementation,
+        &abstraction,
+    )
+    .expect_err("an empty abstraction target has no representable result");
+    assert!(error.message.contains("EmptyAbs' has no members"));
     assert!(error.span.is_some());
 }

--- a/rust/fsl-runtime/tests/action_correspondence.rs
+++ b/rust/fsl-runtime/tests/action_correspondence.rs
@@ -148,3 +148,59 @@ fn enum_conversion_agrees_across_concrete_refinement_routes_without_ordinal_coer
     .expect("inline concrete refinement check");
     assert!(inline_result.failure.is_none(), "{inline_result:?}");
 }
+
+#[test]
+fn enum_abstraction_rejects_wrong_many_to_one_state_and_action_mappings() {
+    let implementation = build(
+        "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } action hold() { requires stage == A stage = B } action advance() { requires stage == B stage = C } }",
+    );
+    let abstraction = build(
+        "spec Abs { enum AbsStage { Y, X, Unused } state { status: AbsStage } init { status = X } action hold() { requires status == X status = X } action advance() { requires status == X status = Y } }",
+    );
+    let correct = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> Y } map status = abstract(stage, stage) action hold() -> hold() action advance() -> advance() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("source-total mapping");
+    let result = check_refinement(&implementation, &abstraction, &correct, 3)
+        .expect("concrete many-to-one refinement check");
+    assert!(result.failure.is_none(), "{result:?}");
+
+    let wrong = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> X } map status = abstract(stage, stage) action hold() -> hold() action advance() -> advance() }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("wrong mapping remains source-total and well typed");
+    let wrong = check_refinement(&implementation, &abstraction, &wrong, 3)
+        .expect("wrong mapping negative control executes");
+    assert!(
+        wrong.failure.is_some(),
+        "wrong many-to-one state mapping must not refine"
+    );
+
+    let argument_implementation = build(
+        "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } action send(s: ImplStage) { stage = s } }",
+    );
+    let argument_abstraction = build(
+        "spec Abs { enum AbsStage { Y, X, Unused } state { status: AbsStage } init { status = X } action send(s: AbsStage) { status = s } }",
+    );
+    let wrong_argument = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction state_stage ImplStage -> AbsStage { A -> X B -> X C -> Y } enum abstraction argument_stage ImplStage -> AbsStage { A -> X B -> Y C -> Y } map status = abstract(state_stage, stage) action send(s) -> send(abstract(argument_stage, s)) }",
+        &argument_implementation,
+        &argument_abstraction,
+    )
+    .expect("wrong action mapping remains source-total and well typed");
+    let wrong_argument = check_refinement(
+        &argument_implementation,
+        &argument_abstraction,
+        &wrong_argument,
+        1,
+    )
+    .expect("wrong argument negative control executes");
+    assert!(
+        wrong_argument.failure.is_some(),
+        "wrong many-to-one action argument must not refine"
+    );
+}

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1252,9 +1252,14 @@ impl<'a> Parser<'a> {
             || self.peek_symbol("{")
     }
 
-    fn enum_conversion_item(&mut self) -> Result<RefinementItem, ParseError> {
+    fn enum_mapping_item(&mut self) -> Result<RefinementItem, ParseError> {
         let span = self.bump().span;
-        self.expect_ident_value("conversion")?;
+        let is_conversion = if self.eat_ident("conversion") {
+            true
+        } else {
+            self.expect_ident_value("abstraction")?;
+            false
+        };
         let name = self.expect_ident()?;
         let source = self.expect_ident()?;
         self.expect_symbol("->")?;
@@ -1269,13 +1274,23 @@ impl<'a> Parser<'a> {
             members.push((source_member, target_member, member_span));
             self.eat_symbol(",");
         }
-        Ok(RefinementItem::EnumConversion {
-            name,
-            source,
-            target,
-            members,
-            span,
-        })
+        if is_conversion {
+            Ok(RefinementItem::EnumConversion {
+                name,
+                source,
+                target,
+                members,
+                span,
+            })
+        } else {
+            Ok(RefinementItem::EnumAbstraction {
+                name,
+                source,
+                target,
+                members,
+                span,
+            })
+        }
     }
 
     fn refinement_item(
@@ -1294,7 +1309,7 @@ impl<'a> Parser<'a> {
             return Ok(RefinementItem::MapsAuto(span));
         }
         if self.peek_ident("enum") {
-            return self.enum_conversion_item();
+            return self.enum_mapping_item();
         }
         if self.peek_ident("map") {
             let span = self.bump().span;

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -259,6 +259,13 @@ pub enum RefinementItem {
         members: Vec<(String, String, Span)>,
         span: Span,
     },
+    EnumAbstraction {
+        name: String,
+        source: String,
+        target: String,
+        members: Vec<(String, String, Span)>,
+        span: Span,
+    },
     Map {
         name: String,
         binder: Option<Binder>,
@@ -1060,6 +1067,23 @@ impl RefinementItem {
                 span,
             } => json!([
                 "enum_conversion",
+                name,
+                source,
+                target,
+                members
+                    .iter()
+                    .map(|(source, target, span)| { json!([source, target, span.python_loc()]) })
+                    .collect::<Vec<_>>(),
+                span.python_loc()
+            ]),
+            Self::EnumAbstraction {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => json!([
+                "enum_abstraction",
                 name,
                 source,
                 target,

--- a/rust/fsl-tools/src/refinement_analysis.rs
+++ b/rust/fsl-tools/src/refinement_analysis.rs
@@ -123,6 +123,31 @@ pub fn analyze_refinement(refinement: &SurfaceRefinement) -> Value {
                 insert_node(&mut nodes, value);
                 insert_edge(&mut edges, edge(&ref_id, "declares", &id));
             }
+            RefinementItem::EnumAbstraction {
+                name,
+                source,
+                target,
+                members,
+                span,
+            } => {
+                let id = format!("enum_abstraction:{name}");
+                let mut value = located_node(id.clone(), "enum_abstraction", name, *span);
+                if let Value::Object(object) = &mut value {
+                    object.insert("source_type".to_owned(), json!(source));
+                    object.insert("target_type".to_owned(), json!(target));
+                    object.insert(
+                        "members".to_owned(),
+                        json!(
+                            members
+                                .iter()
+                                .map(|(source, target, _)| json!({"source":source,"target":target}))
+                                .collect::<Vec<_>>()
+                        ),
+                    );
+                }
+                insert_node(&mut nodes, value);
+                insert_edge(&mut edges, edge(&ref_id, "declares", &id));
+            }
             RefinementItem::Map {
                 name,
                 binder,

--- a/rust/fsl-tools/tests/refinement_correspondence.rs
+++ b/rust/fsl-tools/tests/refinement_correspondence.rs
@@ -6,7 +6,7 @@ use fsl_tools::analyze_refinement;
 #[test]
 fn refinement_graph_exposes_correspondence_origin_and_shared_progress_identity() {
     let document = parse_surface_document(
-        "refinement R { impl Impl abs Abs enum conversion status ImplStatus -> AbsStatus { Open -> Ready Closed -> Done } action step(v: N) -> run(v) preserve progress { respond Eventually by step } }",
+        "refinement R { impl Impl abs Abs enum conversion status ImplStatus -> AbsStatus { Open -> Ready Closed -> Done } enum abstraction collapse ImplPhase -> AbsPhase { Queued -> Pending Running -> Pending Finished -> Done } action step(v: N) -> run(v) preserve progress { respond Eventually by step } }",
     )
     .expect("parse refinement");
     let SurfaceDocument::Refinement(refinement) = document else {
@@ -33,6 +33,22 @@ fn refinement_graph_exposes_correspondence_origin_and_shared_progress_identity()
         serde_json::json!([
             {"source": "Open", "target": "Ready"},
             {"source": "Closed", "target": "Done"}
+        ])
+    );
+    let abstraction = graph["nodes"]
+        .as_array()
+        .expect("nodes")
+        .iter()
+        .find(|node| node["id"] == "enum_abstraction:collapse")
+        .expect("enum abstraction node");
+    assert_eq!(abstraction["source_type"], "ImplPhase");
+    assert_eq!(abstraction["target_type"], "AbsPhase");
+    assert_eq!(
+        abstraction["members"],
+        serde_json::json!([
+            {"source": "Queued", "target": "Pending"},
+            {"source": "Running", "target": "Pending"},
+            {"source": "Finished", "target": "Done"}
         ])
     );
     assert!(

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use fsl_core::{FsResolver, build_model, parse_kernel_source, parse_refinement};
+use fsl_core::{FsResolver, FslValue as Value, build_model, parse_kernel_source, parse_refinement};
 
 fn block_on<F: Future>(future: F) -> F::Output {
     let mut future = pin!(future);
@@ -153,6 +153,87 @@ fn elaborated_enum_conversion_agrees_concretely_symbolically_and_in_preserved_pr
         &mapping,
         &mut solver,
         2,
+    ))
+    .expect("preserved progress check");
+    assert!(progress.violation.is_none(), "{progress:?}");
+}
+
+#[test]
+fn enum_abstraction_agrees_symbolically_and_rejects_a_wrong_target() {
+    let resolver = FsResolver::new(".");
+    let implementation = build_model(
+        parse_kernel_source(
+            "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } action hold() { requires stage == A stage = B } fair action advance() { requires stage == B stage = C } }",
+            &resolver,
+        )
+        .expect("parse implementation"),
+    )
+    .expect("build implementation");
+    let abstraction = build_model(
+        parse_kernel_source(
+            "spec Abs { enum AbsStage { Y, X, Unused } state { status: AbsStage } init { status = X } action hold() { requires status == X status = X } fair action advance() { requires status == X status = Y } leadsTo Advances { status == X ~> status == Y } }",
+            &resolver,
+        )
+        .expect("parse abstraction"),
+    )
+    .expect("build abstraction");
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> Y } map status = abstract(stage, stage) action hold() -> hold() action advance() -> advance() preserve progress { respond Advances by advance } }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("build many-to-one mapping");
+
+    let expression = &mapping.state_maps["status"].expr;
+    let mut merged = implementation.clone();
+    merged.types.extend(abstraction.types.clone());
+    merged.enum_members.extend(abstraction.enum_members.clone());
+    let state = BTreeMap::from([(
+        "stage".to_owned(),
+        Value::Enum {
+            type_name: "ImplStage".to_owned(),
+            member: "C".to_owned(),
+        },
+    )]);
+    let correct = Value::Enum {
+        type_name: "AbsStage".to_owned(),
+        member: "Y".to_owned(),
+    };
+    let wrong = Value::Enum {
+        type_name: "AbsStage".to_owned(),
+        member: "X".to_owned(),
+    };
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("solver");
+    assert!(
+        block_on(fsl_verifier::expression_matches_value(
+            &merged,
+            &mut solver,
+            expression,
+            &state,
+            &correct,
+        ))
+        .expect("prove correct many-to-one target")
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("solver");
+    assert!(
+        !block_on(fsl_verifier::expression_matches_value(
+            &merged,
+            &mut solver,
+            expression,
+            &state,
+            &wrong,
+        ))
+        .expect("reject wrong many-to-one target"),
+        "symbolic anchor must reject the deliberately wrong mapped target"
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("solver");
+    let progress = block_on(fsl_verifier::check_refinement_progress(
+        &implementation,
+        &abstraction,
+        &mapping,
+        &mut solver,
+        3,
     ))
     .expect("preserved progress check");
     assert!(progress.violation.is_none(), "{progress:?}");

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -616,6 +616,59 @@ mod tests {
     }
 
     #[test]
+    fn check_preserves_enum_abstraction_verdicts_and_locations() {
+        let source = r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> Y }
+    map status = abstract(stage, stage)
+    action hold() -> hold()
+    action advance() -> advance()
+  }
+  enum ImplStage { C, B, A }
+  state { stage: ImplStage }
+  init { stage = A }
+  action hold() { requires stage == A stage = B }
+  action advance() { requires stage == B stage = C }
+}
+"#;
+        let request = |source: String| {
+            Request {
+            cmd: "check".to_owned(),
+            source,
+            source_file: "impl.fsl".to_owned(),
+            files: BTreeMap::from([(
+                "abs.fsl".to_owned(),
+                "spec Abs { enum AbsStage { Y, X, Unused } state { status: AbsStage } init { status = X } action hold() { requires status == X status = X } action advance() { requires status == X status = Y } }".to_owned(),
+            )]),
+            options: Options::default(),
+        }
+        };
+
+        let success = block_on(check(&request(source.to_owned()), TEST_SOLVER_VERSION));
+        assert_eq!(success["result"], "ok", "{success}");
+        assert_eq!(success["implements"]["result"], "refines", "{success}");
+
+        let wrong = block_on(check(
+            &request(source.replace("C -> Y", "C -> X")),
+            TEST_SOLVER_VERSION,
+        ));
+        assert_eq!(wrong["result"], "ok", "{wrong}");
+        assert_eq!(
+            wrong["implements"]["result"], "refinement_failed",
+            "{wrong}"
+        );
+
+        let incomplete = block_on(check(
+            &request(source.replace(" C -> Y", "")),
+            TEST_SOLVER_VERSION,
+        ));
+        assert_eq!(incomplete["result"], "error", "{incomplete}");
+        assert_eq!(incomplete["kind"], "type", "{incomplete}");
+        assert_eq!(incomplete["loc"], json!({"line": 3, "column": 5}));
+        assert!(incomplete["span"].is_object(), "{incomplete}");
+    }
+
+    #[test]
     fn verified_result_contains_shared_warnings() {
         let model = model_from(
             "spec Warnings { state { x: Bool } init { x = false } \

--- a/rust/fslc/src/causal.rs
+++ b/rust/fslc/src/causal.rs
@@ -672,11 +672,11 @@ fn run_causal_observe_expectations(
         Ok(_) => return (error_output("type", "expected refinement mapping file"), 2),
         Err(error) => return (error_output("parse", &error.to_string()), 2),
     };
-    if let Some(span) = crate::untyped_replay_enum_conversion_span(&mapping) {
+    if let Some(span) = crate::untyped_replay_enum_mapping_span(&mapping) {
         return (
             crate::located_error_output(
                 "type",
-                "enum conversion requires a typed impl model and is not supported by causal --from-log mappings",
+                "enum conversion or abstraction requires a typed impl model and is not supported by causal --from-log mappings",
                 span,
             ),
             2,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -4389,14 +4389,19 @@ fn read_jsonl_records(path: &Path) -> Result<Vec<(usize, Value)>, String> {
         .collect()
 }
 
-pub(crate) fn untyped_replay_enum_conversion_span(
+pub(crate) fn untyped_replay_enum_mapping_span(
     mapping: &fsl_syntax::SurfaceRefinement,
 ) -> Option<fsl_syntax::Span> {
     for item in &mapping.items {
         match item {
-            fsl_syntax::RefinementItem::EnumConversion { span, .. } => return Some(*span),
-            fsl_syntax::RefinementItem::Map { expr, .. } => {
-                if let Some(span) = fsl_core::expression_call_span(expr, "convert") {
+            fsl_syntax::RefinementItem::EnumConversion { span, .. }
+            | fsl_syntax::RefinementItem::EnumAbstraction { span, .. } => return Some(*span),
+            fsl_syntax::RefinementItem::Map { binder, expr, .. } => {
+                if let Some(span) = binder
+                    .as_ref()
+                    .and_then(untyped_replay_binder_enum_mapping_span)
+                    .or_else(|| untyped_replay_expr_enum_mapping_span(expr))
+                {
                     return Some(span);
                 }
             }
@@ -4404,10 +4409,7 @@ pub(crate) fn untyped_replay_enum_conversion_span(
                 target: fsl_syntax::ActionTarget::Action(_, args),
                 ..
             } => {
-                if let Some(span) = args
-                    .iter()
-                    .find_map(|expr| fsl_core::expression_call_span(expr, "convert"))
-                {
+                if let Some(span) = args.iter().find_map(untyped_replay_expr_enum_mapping_span) {
                     return Some(span);
                 }
             }
@@ -4415,6 +4417,40 @@ pub(crate) fn untyped_replay_enum_conversion_span(
         }
     }
     None
+}
+
+fn untyped_replay_expr_enum_mapping_span(expr: &fsl_syntax::Expr) -> Option<fsl_syntax::Span> {
+    ["convert", "abstract"]
+        .into_iter()
+        .find_map(|name| fsl_core::expression_call_span(expr, name))
+}
+
+fn untyped_replay_binder_enum_mapping_span(
+    binder: &fsl_syntax::Binder,
+) -> Option<fsl_syntax::Span> {
+    match binder {
+        fsl_syntax::Binder::Typed { where_expr, .. } => where_expr
+            .as_deref()
+            .and_then(untyped_replay_expr_enum_mapping_span),
+        fsl_syntax::Binder::Range {
+            lo, hi, where_expr, ..
+        } => untyped_replay_expr_enum_mapping_span(lo)
+            .or_else(|| untyped_replay_expr_enum_mapping_span(hi))
+            .or_else(|| {
+                where_expr
+                    .as_deref()
+                    .and_then(untyped_replay_expr_enum_mapping_span)
+            }),
+        fsl_syntax::Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => untyped_replay_expr_enum_mapping_span(collection).or_else(|| {
+            where_expr
+                .as_deref()
+                .and_then(untyped_replay_expr_enum_mapping_span)
+        }),
+    }
 }
 
 pub(crate) fn located_error_output(kind: &str, message: &str, span: fsl_syntax::Span) -> Value {
@@ -4442,11 +4478,11 @@ fn run_log_replay(path: &Path, log_path: &Path, mapping_path: &Path) -> (Value, 
         Ok(_) => return (error_output("type", "expected refinement mapping file"), 2),
         Err(error) => return (error_output("parse", &error.to_string()), 2),
     };
-    if let Some(span) = untyped_replay_enum_conversion_span(&mapping) {
+    if let Some(span) = untyped_replay_enum_mapping_span(&mapping) {
         return (
             located_error_output(
                 "type",
-                "enum conversion requires a typed impl model and is not supported by --from-log mappings",
+                "enum conversion or abstraction requires a typed impl model and is not supported by --from-log mappings",
                 span,
             ),
             2,

--- a/rust/fslc/tests/causal_cli.rs
+++ b/rust/fslc/tests/causal_cli.rs
@@ -958,6 +958,50 @@ fn observe_expectations_rejects_enum_conversion_without_typed_impl_model() {
 }
 
 #[test]
+fn observe_expectations_rejects_enum_abstraction_in_a_binder_without_typed_impl_model() {
+    let scratch = tempfile_dir();
+    let mapping = scratch.join("enum-abstraction-mapping.fsl");
+    std::fs::write(
+        &mapping,
+        r"refinement ExternalRefinesIncident {
+  impl External
+  abs IncidentResponse
+
+  map status[k: ExternalStatus where abstract(missing, k) == k] = k
+}
+",
+    )
+    .expect("write mapping");
+
+    let (output, status) = run_cli(&[
+        "causal",
+        "observe-expectations",
+        INCIDENT,
+        "--from-log",
+        OBS_LOG,
+        "--mapping",
+        mapping.to_str().expect("utf-8 mapping path"),
+        "--scope",
+        OBS_SCOPE,
+        "--period-start",
+        "2026-01-01",
+        "--period-end",
+        "2026-03-31",
+    ]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "type");
+    assert_eq!(output["loc"]["line"], 5, "{output}");
+    assert!(output["loc"]["column"].is_number(), "{output}");
+    assert!(
+        output["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("typed impl model")
+    );
+}
+
+#[test]
 fn observe_expectations_fails_without_period() {
     let (output, status) = run_cli(&[
         "causal",

--- a/rust/fslc/tests/issue_455_enum_abstraction.rs
+++ b/rust/fslc/tests/issue_455_enum_abstraction.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn write(path: &Path, source: &str) {
+    std::fs::write(path, source).expect("write fixture");
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn cli_accepts_source_total_abstraction_and_rejects_wrong_or_incomplete_mappings() {
+    let scratch = std::env::temp_dir().join(format!("fslc-issue-455-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    let implementation = scratch.join("impl.fsl");
+    let abstraction = scratch.join("abs.fsl");
+    let correct = scratch.join("correct.fsl");
+    let wrong = scratch.join("wrong.fsl");
+    let incomplete = scratch.join("incomplete.fsl");
+    write(
+        &implementation,
+        "spec Impl { enum ImplStage { C, B, A } state { stage: ImplStage } init { stage = A } action hold() { requires stage == A stage = B } action advance() { requires stage == B stage = C } }",
+    );
+    write(
+        &abstraction,
+        "spec Abs { enum AbsStage { Y, X, Unused } state { status: AbsStage } init { status = X } action hold() { requires status == X status = X } action advance() { requires status == X status = Y } }",
+    );
+    let mapping = "refinement R { impl Impl abs Abs enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> Y } map status = abstract(stage, stage) action hold() -> hold() action advance() -> advance() }";
+    write(&correct, mapping);
+    write(&wrong, &mapping.replace("C -> Y", "C -> X"));
+    write(&incomplete, &mapping.replace("C -> Y", ""));
+
+    let base = [
+        "refine".to_owned(),
+        implementation.display().to_string(),
+        abstraction.display().to_string(),
+    ];
+    let (success, status) = run(&[
+        base[0].clone(),
+        base[1].clone(),
+        base[2].clone(),
+        correct.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{success}");
+    assert_eq!(success["result"], "refines");
+
+    let (failure, status) = run(&[
+        base[0].clone(),
+        base[1].clone(),
+        base[2].clone(),
+        wrong.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 1, "{failure}");
+    assert_ne!(failure["result"], "refines");
+    assert!(failure["impl_trace"].is_array(), "{failure}");
+
+    let (type_error, status) = run(&[
+        base[0].clone(),
+        base[1].clone(),
+        base[2].clone(),
+        incomplete.display().to_string(),
+    ]);
+    assert_eq!(status, 2, "{type_error}");
+    assert_eq!(type_error["kind"], "type");
+    assert!(type_error["loc"].is_object(), "{type_error}");
+    assert!(type_error["span"].is_object(), "{type_error}");
+    assert!(
+        type_error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("missing source: [C]"))
+    );
+
+    let (replay, status) = run(&[
+        "replay".to_owned(),
+        abstraction.display().to_string(),
+        "--from-log".to_owned(),
+        scratch.join("not-read.jsonl").display().to_string(),
+        "--mapping".to_owned(),
+        correct.display().to_string(),
+    ]);
+    assert_eq!(status, 2, "{replay}");
+    assert_eq!(replay["kind"], "type");
+    assert!(replay["loc"].is_object(), "{replay}");
+    assert!(
+        replay["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("typed impl model"))
+    );
+
+    let binder_call = scratch.join("binder-call.fsl");
+    write(
+        &binder_call,
+        "refinement R { impl External abs Abs map status[k: AbsStage where abstract(missing, k) == k] = X }",
+    );
+    let (binder_replay, status) = run(&[
+        "replay".to_owned(),
+        abstraction.display().to_string(),
+        "--from-log".to_owned(),
+        scratch.join("not-read.jsonl").display().to_string(),
+        "--mapping".to_owned(),
+        binder_call.display().to_string(),
+    ]);
+    assert_eq!(status, 2, "{binder_replay}");
+    assert_eq!(binder_replay["kind"], "type");
+    assert!(binder_replay["loc"].is_object(), "{binder_replay}");
+    assert!(
+        binder_replay["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("typed impl model"))
+    );
+
+    let (diff, status) = run(&[
+        "diff".to_owned(),
+        abstraction.display().to_string(),
+        implementation.display().to_string(),
+        "--mapping".to_owned(),
+        correct.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{diff}");
+    assert_eq!(diff["directions"]["new_to_old"]["result"], "refines");
+    assert_eq!(diff["directions"]["old_to_new"]["result"], "unknown");
+
+    let (wrong_diff, status) = run(&[
+        "diff".to_owned(),
+        abstraction.display().to_string(),
+        implementation.display().to_string(),
+        "--mapping".to_owned(),
+        wrong.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{wrong_diff}");
+    assert_eq!(
+        wrong_diff["directions"]["new_to_old"]["result"],
+        "refinement_failed"
+    );
+    assert!(
+        wrong_diff["findings"]
+            .as_array()
+            .is_some_and(|findings| findings.iter().any(|item| {
+                item["kind"] == "behavior_added" && item["direction"] == "new_to_old"
+            })),
+        "{wrong_diff}"
+    );
+}
+
+#[test]
+fn inline_implements_supports_abstraction_and_keeps_errors_located() {
+    let scratch =
+        std::env::temp_dir().join(format!("fslc-issue-455-inline-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    write(
+        &scratch.join("abs.fsl"),
+        "spec Abs { enum AbsStage { X, Y, Unused } state { status: AbsStage } init { status = X } action step() { status = Y } }",
+    );
+    let implementation = scratch.join("impl.fsl");
+    let source = r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum abstraction stage ImplStage -> AbsStage { A -> X B -> X C -> Y }
+    map status = abstract(stage, stage)
+    action step() -> step()
+  }
+  enum ImplStage { C, B, A }
+  state { stage: ImplStage }
+  init { stage = A }
+  action step() { stage = C }
+}"#;
+    write(&implementation, source);
+    let (success, status) = run(&["check".to_owned(), implementation.display().to_string()]);
+    assert_eq!(status, 0, "{success}");
+
+    write(&implementation, &source.replace(" C -> Y", ""));
+    let (failure, status) = run(&["check".to_owned(), implementation.display().to_string()]);
+    assert_eq!(status, 2, "{failure}");
+    assert_eq!(failure["kind"], "type");
+    assert_eq!(failure["loc"], serde_json::json!({"line": 3, "column": 5}));
+    assert!(failure["span"].is_object(), "{failure}");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -608,9 +608,13 @@ refinement <Name> {
   enum conversion <name> <ImplEnum> -> <AbsEnum> {
     <ImplMember> -> <AbsMember>                  // exhaustive bijection; every member exactly once
   }
+  enum abstraction <name> <ImplEnum> -> <AbsEnum> {
+    <ImplMember> -> <AbsMember>                  // source-total; repeated/unused targets are allowed
+  }
   map <abs_var> = <expr over impl state>          // scalar abstract variable
   map <abs_var>[<x>: <KeyType>] = <expr>          // per-element mapping of a Map
   // use convert(<name>, <expr>) in a map or action argument
+  // use abstract(<name>, <expr>) for an enum abstraction
   // map and action arguments otherwise use the same expressions as specs, including if <c> then <a> else <b>
   action <impl_act>(<formal params>...) -> <abs_act>(<expr>...) | stutter
   // formal params may be bare names or name: Type annotations matching the impl action
@@ -636,14 +640,21 @@ abs member sits at the same ordinal index). Same-named domain types
 (`lo..hi`) with different bounds are fine — an out-of-range value there is
 still caught as `map_out_of_bounds`/`abs_state_mismatch`.
 
-Distinct nominal enums stay incompatible unless an `enum conversion` is
-declared and invoked with `convert(name, expr)`. Both endpoints must be enums;
+Distinct nominal enums stay incompatible without an explicit named enum
+mapping. Use `enum conversion` plus `convert(name, expr)` for a bijection. Both
+endpoints must be enums;
 unknown, duplicate, or missing source/target members fail as a located type
 error. Conversion is member-wise and never inferred from ordinal position.
 For a requirements `process` stage target, use the checked Kernel enum name
 reported by `fslc kernel` (for example `CommandStage`). Raw production-log and
 causal replay mappings have no typed impl model and therefore reject enum
 conversion declarations/calls; use a typed refinement mapping instead.
+Use `enum abstraction` plus `abstract(name, expr)` for a source-total
+many-to-one boundary. Both endpoint enums are non-empty and every source
+appears exactly once; repeated targets and
+targets unused by all rows are intentional and accepted. It shares the local
+name namespace with conversions, but its call form cannot be interchanged with
+`convert`. Raw replay rejects abstractions for the same missing-type reason.
 For a generated abstract Map key such as DB `Column`, the conversion direction
 is abstract-to-implementation: convert the abstract binder before indexing the
 implementation Map (for example `Column -> DesignColumn`).


### PR DESCRIPTION
## Problem

Bijective enum conversion cannot express a nominal many-to-one abstraction without weakening its target-total and unique-target assurance.

## Contract

- Add distinct enum abstraction declarations invoked with abstract(name, expr).
- Require non-empty enum endpoints and exactly one row for every source member.
- Allow repeated targets and targets intentionally unused by all rows.
- Keep enum conversion source/target totality and target uniqueness unchanged.
- Preserve declaration-order independence and fail closed without a typed implementation model.

## Implementation

- Parse and project the new surface item while preserving the existing enum_conversion compatibility projection.
- Share typed EnumMember/conditional lowering across bijective and source-total assurances.
- Cover state maps, action arguments, inline implements, progress, semantic diff, analysis graphs, CLI, Worker, Public Kernel expressions, and production/causal raw replay.
- Update the accepted design, English/Japanese language references, generated site pages, skill reference, diagnostics, and changelog.

## Verification

- Focused core, runtime, verifier, tools, CLI, WASM, causal, and semantic-diff controls pass.
- Deliberately wrong state/action mappings are rejected concretely and a wrong target is rejected symbolically.
- implementation-local-optima-audit completed; one redundant target-set update was removed and no material local optimum remains.
- Independent review completed; raw binder replay fail-open, stale migration guidance, and empty-endpoint policy gaps were fixed; final review has no actionable findings.
- ./tools/check-native-integration.sh passes, including Clippy, the full Rust workspace, native/browser Z3 probes, and 351 Worker/native parity cases.

Closes #455