### PR TITLE
fix(diff): report unrelatable forbidden scenarios as unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   without weakening bijective `enum conversion` (#455).
 
 ### Fixed
+- Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
+  model and reports missing actions, incompatible arity, or incompatible NEW
+  argument domains as explicit `unknown` findings instead of a false
+  `no_semantic_change` result (#460, prerequisite for #427).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/docs/DESIGN-semantic-diff.md
+++ b/docs/DESIGN-semantic-diff.md
@@ -62,6 +62,14 @@ Each OLD `forbidden` scenario is replayed against NEW. If NEW accepts the step
 OLD required to be rejected, the result contains `forbidden_relaxed` and the
 accepted trace. A scenario that cannot be related because its action or
 arguments no longer exist becomes `unknown`, not a false relaxation finding.
+Scenario arguments are evaluated against the OLD typed model and OLD replay
+state before their values are matched to the NEW action parameter domains; NEW
+must not reinterpret a same-spelled nominal enum member as its own type.
+The finding carries `subject:"forbidden"`, the OLD case `id`, a stable
+`reason` (`forbidden_step_unrelatable` or `forbidden_replay_failed`), and the
+zero-based failing `step` plus `action` when available. A matching action that
+is disabled by its guard is a related rejection and therefore preserves the
+forbidden scenario; it is not reported as `unknown`.
 
 ## Scope changes
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -12271,57 +12271,164 @@ fn compare_diff_invariants(old: &KernelModel, new: &KernelModel) -> Vec<Value> {
     }
 }
 
-fn forbidden_diff_findings(old_path: &Path, new: &KernelModel) -> Vec<Value> {
-    let Ok(source) = std::fs::read_to_string(old_path) else {
-        return Vec::new();
-    };
-    let Ok(Some(contract)) = fsl_core::requirements_trace_contract(&source) else {
-        return Vec::new();
-    };
-    let mut findings = Vec::new();
-    for case in contract.forbidden {
-        let Ok(mut monitor) = fsl_runtime::Monitor::new(new.clone()) else {
-            continue;
+fn old_forbidden_arguments(
+    monitor: &mut fsl_runtime::Monitor,
+    step: &fsl_core::RequirementsTraceStep,
+    is_final: bool,
+) -> Result<Vec<FslValue>, String> {
+    let (arguments, instance) = requirement_step_match(monitor, step)?;
+    let Some(instance) = instance else {
+        return if is_final {
+            Ok(arguments)
+        } else {
+            Err("OLD forbidden setup was not enabled".to_owned())
         };
-        let mut accepted_trace = vec![json!({
-            "step":0,"state":fslc_rust::state_json(&monitor.state),
-        })];
-        let mut accepted_final = false;
-        for (index, step) in case.steps.iter().enumerate() {
-            let Ok((arguments, instance)) = requirement_step_match(&monitor, step) else {
-                break;
-            };
-            let Some(instance) = instance else {
-                break;
-            };
-            let Ok(stepped) = monitor.step(&instance) else {
-                break;
-            };
-            if stepped.violation.is_some() {
-                break;
-            }
-            accepted_trace.push(json!({
-                "step":index+1,"state":fslc_rust::state_json(&monitor.state),
-                "action":{"name":display(&instance.action),
-                    "params":instance.params.iter().map(|(name,value)|(
-                        name.clone(),fslc_rust::fsl_value_json(value)
-                    )).collect::<Map<_,_>>()},
-            }));
-            accepted_final = index + 1 == case.steps.len();
-            let _ = arguments;
+    };
+    let stepped = monitor.step(&instance).map_err(|error| error.to_string())?;
+    match (is_final, stepped.violation.is_some()) {
+        (false, false) | (true, true) => Ok(arguments),
+        (false, true) => Err("OLD forbidden setup was rejected".to_owned()),
+        (true, false) => Err("OLD forbidden final step was accepted".to_owned()),
+    }
+}
+
+fn forbidden_unknown(
+    id: &str,
+    reason: &str,
+    step: Option<(usize, &fsl_core::RequirementsTraceStep)>,
+    detail: &str,
+) -> Value {
+    let mut finding = json!({
+        "kind":"unknown","subject":"forbidden","id":id,
+        "reason":reason,"detail":detail,
+    });
+    if let Some((index, step)) = step {
+        finding["step"] = json!(index);
+        finding["action"] = json!(step.name);
+    }
+    finding
+}
+
+fn forbidden_case_finding(
+    case: &fsl_core::RequirementsTraceCase,
+    old: &KernelModel,
+    new: &KernelModel,
+) -> Option<Value> {
+    let mut old_monitor = match fsl_runtime::Monitor::new(old.clone()) {
+        Ok(monitor) => monitor,
+        Err(error) => {
+            return Some(forbidden_unknown(
+                &case.id,
+                "forbidden_replay_failed",
+                None,
+                &error.to_string(),
+            ));
         }
-        if accepted_final {
-            findings.push(json!({
-                "kind":"forbidden_relaxed","id":case.id,
-                "witness":{
-                    "trace_type":"counterexample","trace":accepted_trace,
-                    "accepted_step":case.steps.last().map(|step|step.name.clone()),
-                    "state":fslc_rust::state_json(&monitor.state),
-                },
-            }));
+    };
+    let mut monitor = match fsl_runtime::Monitor::new(new.clone()) {
+        Ok(monitor) => monitor,
+        Err(error) => {
+            return Some(forbidden_unknown(
+                &case.id,
+                "forbidden_replay_failed",
+                None,
+                &error.to_string(),
+            ));
+        }
+    };
+    let mut accepted_trace = vec![json!({
+        "step":0,"state":fslc_rust::state_json(&monitor.state),
+    })];
+    for (index, step) in case.steps.iter().enumerate() {
+        let is_final = index + 1 == case.steps.len();
+        let arguments = match old_forbidden_arguments(&mut old_monitor, step, is_final) {
+            Ok(arguments) => arguments,
+            Err(error) => {
+                return Some(forbidden_unknown(
+                    &case.id,
+                    "forbidden_replay_failed",
+                    Some((index, step)),
+                    &error,
+                ));
+            }
+        };
+        let instance = match fslc_rust::verification_output::requirement_step_match_values(
+            &monitor, step, &arguments,
+        ) {
+            Ok(instance) => instance,
+            Err(error) => {
+                let reason = match &error {
+                    fslc_rust::verification_output::RequirementStepRelationError::Unrelatable(
+                        _,
+                    ) => "forbidden_step_unrelatable",
+                    fslc_rust::verification_output::RequirementStepRelationError::Replay(_) => {
+                        "forbidden_replay_failed"
+                    }
+                };
+                return Some(forbidden_unknown(
+                    &case.id,
+                    reason,
+                    Some((index, step)),
+                    &error.to_string(),
+                ));
+            }
+        };
+        let instance = instance?;
+        let stepped = match monitor.step(&instance) {
+            Ok(stepped) => stepped,
+            Err(error) => {
+                return Some(forbidden_unknown(
+                    &case.id,
+                    "forbidden_replay_failed",
+                    Some((index, step)),
+                    &error.to_string(),
+                ));
+            }
+        };
+        if stepped.violation.is_some() {
+            return None;
+        }
+        accepted_trace.push(json!({
+            "step":index+1,"state":fslc_rust::state_json(&monitor.state),
+            "action":{"name":display(&instance.action),
+                "params":instance.params.iter().map(|(name,value)|(
+                    name.clone(),fslc_rust::fsl_value_json(value)
+                )).collect::<Map<_,_>>()},
+        }));
+    }
+    Some(json!({
+        "kind":"forbidden_relaxed","id":case.id,
+        "witness":{
+            "trace_type":"counterexample","trace":accepted_trace,
+            "accepted_step":case.steps.last().map(|step|step.name.clone()),
+            "state":fslc_rust::state_json(&monitor.state),
+        },
+    }))
+}
+
+fn forbidden_diff_findings(
+    old_source: &str,
+    old: &KernelModel,
+    new: &KernelModel,
+) -> Result<Vec<Value>, String> {
+    let Some(contract) =
+        fsl_core::requirements_trace_contract(old_source).map_err(|error| error.to_string())?
+    else {
+        return Ok(Vec::new());
+    };
+    for case in &contract.forbidden {
+        if case.steps.is_empty() {
+            return Err(format!(
+                "forbidden '{}' must have at least one step",
+                case.id
+            ));
         }
     }
-    findings
+    Ok(contract
+        .forbidden
+        .iter()
+        .filter_map(|case| forbidden_case_finding(case, old, new))
+        .collect())
 }
 
 fn add_verify_items(scope: &mut ScopeBounds, items: &[fsl_syntax::VerifyItem]) {
@@ -12526,7 +12633,10 @@ fn run_diff(
         }
     }
     findings.extend(compare_diff_invariants(&old_model, &new_model));
-    findings.extend(forbidden_diff_findings(old, &new_model));
+    match forbidden_diff_findings(&old_source, &old_model, &new_model) {
+        Ok(forbidden_findings) => findings.extend(forbidden_findings),
+        Err(error) => return (error_output("type", &error), 2),
+    }
     if scope_changed {
         findings.push(json!({
             "kind":"scope_changed","old":public_scope(&old_scope),

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -7,8 +7,9 @@ use std::fmt;
 use std::future::Future;
 
 use fsl_core::{
-    FslValue, KernelExpr, KernelModel, TypeDef, TypeRef, display_name, fsl_value_json,
-    insert_requirement_metadata, internal_origin_json, origin_display_name, state_json, trace_json,
+    ActionDef, FslValue, KernelExpr, KernelModel, ParamDef, TypeDef, TypeRef, display_name,
+    fsl_value_json, insert_requirement_metadata, internal_origin_json, origin_display_name,
+    state_json, trace_json,
 };
 use fsl_solver::VerificationStatistics;
 use fsl_verifier::{BmcResult, BmcViolation};
@@ -36,6 +37,25 @@ impl fmt::Display for RequirementsImplementsError {
 }
 
 impl std::error::Error for RequirementsImplementsError {}
+
+/// Why a requirements step could not be replayed across semantic-diff models.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequirementStepRelationError {
+    /// The target action, arity, or argument domain cannot represent the OLD step.
+    Unrelatable(String),
+    /// The target model matched structurally but failed during concrete evaluation.
+    Replay(String),
+}
+
+impl fmt::Display for RequirementStepRelationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unrelatable(message) | Self::Replay(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for RequirementStepRelationError {}
 
 impl DeadlockMode {
     /// Parse the public CLI/Worker spelling.
@@ -308,17 +328,10 @@ pub fn requirement_step_match(
         );
     }
     let enabled = monitor.enabled().map_err(|error| error.to_string())?;
-    let branch_prefix = format!("{}__b", step.name);
-    for action in &monitor.model.actions {
-        if action.name != step.name
-            && !action.name.starts_with(&branch_prefix)
-            && display_name(&action.name) != step.name
-        {
-            continue;
-        }
-        if action.params.len() != arguments.len() {
-            continue;
-        }
+    for action in requirement_actions_by_name(monitor, step)
+        .into_iter()
+        .filter(|action| action.params.len() == arguments.len())
+    {
         let params = action
             .params
             .iter()
@@ -333,6 +346,107 @@ pub fn requirement_step_match(
         }
     }
     Ok((arguments, None))
+}
+
+fn requirement_actions_by_name<'a>(
+    monitor: &'a fsl_runtime::Monitor,
+    step: &fsl_core::RequirementsTraceStep,
+) -> Vec<&'a ActionDef> {
+    let branch_prefix = format!("{}__b", step.name);
+    monitor
+        .model
+        .actions
+        .iter()
+        .filter(|action| {
+            action.name == step.name
+                || action.name.starts_with(&branch_prefix)
+                || display_name(&action.name) == step.name
+        })
+        .collect()
+}
+
+/// Resolve a requirements trace step using arguments evaluated in its source model.
+///
+/// # Errors
+///
+/// Returns a diagnostic when the action, arity, argument domains, or enabled
+/// actions cannot be related to the target Monitor.
+pub fn requirement_step_match_values(
+    monitor: &fsl_runtime::Monitor,
+    step: &fsl_core::RequirementsTraceStep,
+    arguments: &[FslValue],
+) -> Result<Option<fsl_runtime::EnabledAction>, RequirementStepRelationError> {
+    let named_actions = requirement_actions_by_name(monitor, step);
+    if named_actions.is_empty() {
+        return Err(RequirementStepRelationError::Unrelatable(format!(
+            "unknown requirement action '{}'",
+            step.name
+        )));
+    }
+    let matching_actions = named_actions
+        .into_iter()
+        .filter(|action| action.params.len() == arguments.len())
+        .collect::<Vec<_>>();
+    if matching_actions.is_empty() {
+        return Err(RequirementStepRelationError::Unrelatable(format!(
+            "requirement action '{}' has no variant with {} argument(s)",
+            step.name,
+            arguments.len()
+        )));
+    }
+    let matching_actions = matching_actions
+        .into_iter()
+        .filter_map(|action| {
+            let belongs = action.params.iter().zip(arguments.iter()).try_fold(
+                true,
+                |belongs, (parameter, value)| {
+                    let in_domain = match parameter {
+                        ParamDef::Typed { ty, .. } => monitor
+                            .model
+                            .domain_values(ty)
+                            .map_err(|error| {
+                                RequirementStepRelationError::Replay(error.to_string())
+                            })?
+                            .contains(value),
+                        ParamDef::Range { lo, hi, .. } => matches!(
+                            value,
+                            FslValue::Int(value) if lo <= value && value <= hi
+                        ),
+                    };
+                    Ok::<_, RequirementStepRelationError>(belongs && in_domain)
+                },
+            );
+            match belongs {
+                Ok(true) => Some(Ok(action)),
+                Ok(false) => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if matching_actions.is_empty() {
+        return Err(RequirementStepRelationError::Unrelatable(format!(
+            "arguments for requirement action '{}' do not belong to the NEW action domain",
+            step.name
+        )));
+    }
+    let enabled = monitor
+        .enabled()
+        .map_err(|error| RequirementStepRelationError::Replay(error.to_string()))?;
+    for action in matching_actions {
+        let params = action
+            .params
+            .iter()
+            .zip(arguments.iter())
+            .map(|(param, value)| (param.name().to_owned(), value.clone()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        if let Some(instance) = enabled
+            .iter()
+            .find(|instance| instance.action == action.name && instance.params == params)
+        {
+            return Ok(Some(instance.clone()));
+        }
+    }
+    Ok(None)
 }
 
 fn requirement_step_json(step: &fsl_core::RequirementsTraceStep, arguments: &[FslValue]) -> Value {

--- a/rust/fslc/tests/issue_460_semantic_diff_forbidden.rs
+++ b/rust/fslc/tests/issue_460_semantic_diff_forbidden.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn write(path: &Path, source: &str) {
+    std::fs::write(path, source).expect("write fixture");
+}
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn old_requirements() -> &'static str {
+    r#"requirements Old {
+  state { ready: Bool }
+  init { ready = false }
+  requirement REQ-1 "prepare then reject" {
+    action prepare() { ready = true }
+    action reject() { requires ready == false ready = ready }
+  }
+  forbidden FB-1 "reject after prepare" {
+    prepare() reject()
+    expect rejected
+  }
+}"#
+}
+
+fn related_new(final_requires: &str) -> String {
+    format!(
+        r"spec New {{
+  state {{ ready: Bool }}
+  init {{ ready = false }}
+  action prepare() {{ ready = true }}
+  action reject() {{ requires {final_requires} ready = ready }}
+}}"
+    )
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn unrelatable_forbidden_is_unknown_and_can_fail_the_gate() {
+    let scratch = std::env::temp_dir().join(format!("fslc-issue-460-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    let old = scratch.join("old.fsl");
+    let old_domain = scratch.join("old-domain.fsl");
+    let missing = scratch.join("missing.fsl");
+    let wrong_arity = scratch.join("wrong-arity.fsl");
+    let wrong_domain = scratch.join("wrong-domain.fsl");
+    let replay_failure = scratch.join("replay-failure.fsl");
+    write(&old, old_requirements());
+    write(
+        &old_domain,
+        r#"requirements Old {
+  enum OldKind { A }
+  state { ready: Bool }
+  init { ready = false }
+  requirement REQ-1 "prepare then reject" {
+    action prepare() { ready = true }
+    action reject(value: OldKind) { requires ready == false ready = ready }
+  }
+  forbidden FB-1 "reject after prepare" {
+    prepare() reject(A)
+    expect rejected
+  }
+}"#,
+    );
+    write(
+        &missing,
+        r"spec New {
+  state { ready: Bool }
+  init { ready = false }
+  action prepare() { ready = true }
+  action other() { ready = ready }
+}",
+    );
+    write(
+        &wrong_arity,
+        r"spec New {
+  state { ready: Bool }
+  init { ready = false }
+  action prepare() { ready = true }
+  action reject(value: Bool) { requires value ready = ready }
+}",
+    );
+    write(
+        &wrong_domain,
+        r"spec New {
+  enum NewKind { A }
+  state { ready: Bool }
+  init { ready = false }
+  action prepare() { ready = true }
+  action reject(value: NewKind) { requires value == A ready = ready }
+}",
+    );
+    write(
+        &replay_failure,
+        r"spec New {
+  state { ready: Bool, zero: Int }
+  init { ready = false zero = 0 }
+  action prepare() { ready = true }
+  action reject() { requires 1 / zero == 0 ready = ready }
+}",
+    );
+
+    for (old, new, reason, step, action, detail) in [
+        (
+            &old,
+            &missing,
+            "forbidden_step_unrelatable",
+            1,
+            "reject",
+            "unknown requirement action 'reject'",
+        ),
+        (
+            &old,
+            &wrong_arity,
+            "forbidden_step_unrelatable",
+            1,
+            "reject",
+            "no variant with 0 argument(s)",
+        ),
+        (
+            &old_domain,
+            &wrong_domain,
+            "forbidden_step_unrelatable",
+            1,
+            "reject",
+            "do not belong to the NEW action domain",
+        ),
+        (
+            &old,
+            &replay_failure,
+            "forbidden_replay_failed",
+            0,
+            "prepare",
+            "division by zero",
+        ),
+    ] {
+        let (result, status) = run(&[
+            "diff".to_owned(),
+            old.display().to_string(),
+            new.display().to_string(),
+            "--depth".to_owned(),
+            "2".to_owned(),
+            "--forbid".to_owned(),
+            "unknown".to_owned(),
+        ]);
+        assert_eq!(status, 1, "{result}");
+        assert!(
+            result["summary"]
+                .as_array()
+                .is_some_and(|summary| summary.iter().any(|kind| kind == "unknown"))
+        );
+        let finding = result["findings"]
+            .as_array()
+            .and_then(|findings| {
+                findings.iter().find(|finding| {
+                    finding["kind"] == "unknown"
+                        && finding["subject"] == "forbidden"
+                        && finding["id"] == "FB-1"
+                })
+            })
+            .unwrap_or_else(|| panic!("missing forbidden unknown: {result}"));
+        assert_eq!(finding["reason"], reason);
+        assert_eq!(finding["step"], step);
+        assert_eq!(finding["action"], action);
+        assert!(
+            finding["detail"]
+                .as_str()
+                .is_some_and(|message| message.contains(detail))
+        );
+        assert_eq!(result["gate"]["passed"], false);
+        assert_eq!(result["gate"]["violations"], serde_json::json!(["unknown"]));
+    }
+
+    std::fs::remove_dir_all(scratch).expect("remove scratch directory");
+}
+
+#[test]
+fn strict_diff_relation_does_not_replace_structured_check_failures() {
+    let scratch = std::env::temp_dir().join(format!(
+        "fslc-issue-460-check-sibling-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    let source = scratch.join("broken-setup.fsl");
+    write(
+        &source,
+        r#"requirements BrokenSetup {
+  state { ready: Bool }
+  init { ready = false }
+  action reject() { requires ready ready = ready }
+  forbidden FB-1 "missing setup stays structured" {
+    missing() reject()
+    expect rejected
+  }
+}"#,
+    );
+
+    let (result, status) = run(&["check".to_owned(), source.display().to_string()]);
+    assert_eq!(status, 2, "{result}");
+    assert_eq!(result["result"], "error");
+    assert_eq!(result["kind"], "forbidden_setup");
+    assert_eq!(result["id"], "FB-1");
+    assert_eq!(result["failed_step"], 0);
+    assert_eq!(result["step"]["action"], "missing");
+    assert!(result["loc"].is_object());
+    assert_eq!(result["trace_type"], "forbidden");
+
+    std::fs::remove_dir_all(scratch).expect("remove scratch directory");
+}
+
+#[test]
+fn related_guard_rejection_is_preserved_but_acceptance_is_relaxed() {
+    let scratch = std::env::temp_dir().join(format!(
+        "fslc-issue-460-negative-control-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).expect("create scratch directory");
+    let old = scratch.join("old.fsl");
+    let preserved = scratch.join("preserved.fsl");
+    let relaxed = scratch.join("relaxed.fsl");
+    write(&old, old_requirements());
+    write(&preserved, &related_new("ready == false"));
+    write(&relaxed, &related_new("ready == true"));
+
+    let (preserved_result, status) = run(&[
+        "diff".to_owned(),
+        old.display().to_string(),
+        preserved.display().to_string(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{preserved_result}");
+    assert_eq!(
+        preserved_result["summary"],
+        serde_json::json!(["no_semantic_change"])
+    );
+    assert!(
+        preserved_result["findings"]
+            .as_array()
+            .is_some_and(Vec::is_empty)
+    );
+
+    let (relaxed_result, status) = run(&[
+        "diff".to_owned(),
+        old.display().to_string(),
+        relaxed.display().to_string(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{relaxed_result}");
+    assert!(
+        relaxed_result["findings"]
+            .as_array()
+            .is_some_and(|findings| findings.iter().any(|finding| {
+                finding["kind"] == "forbidden_relaxed" && finding["id"] == "FB-1"
+            }))
+    );
+
+    std::fs::remove_dir_all(scratch).expect("remove scratch directory");
+}


### PR DESCRIPTION
## Summary
- Fix the false-green recorded in #427: OLD forbidden scenarios that cannot be related to NEW now emit `unknown` instead of disappearing into `no_semantic_change`.
- Close #460 as the dedicated prerequisite; #427 remains the evidence-gated design-family spike.

## Changes
- Evaluate forbidden-step arguments in the OLD typed model and replay state, then match the resulting nominal values against NEW action names, arity, and parameter domains.
- Classify missing/incompatible actions as `forbidden_step_unrelatable` and concrete evaluation failures as `forbidden_replay_failed`, retaining case ID and failing step evidence.
- Preserve ordinary requirements check/scenarios structured diagnostics and preserve guard-disabled forbidden cases; fully accepted traces remain `forbidden_relaxed`.
- Document the accepted JSON behavior and add the changelog entry. The frozen Python implementation is unchanged.

## Verification
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test issue_460_semantic_diff_forbidden --locked`
- `cargo clippy --manifest-path rust/Cargo.toml -p fslc-rust --all-targets --locked -- -D warnings`
- `./tools/check-native-integration.sh` (Rust workspace, native/browser Z3 probes, 351 Worker/native parity cases)
- Implementation local-optima audit completed; independent re-review found no actionable findings.

## Risk / Review Notes
- Public semantic-diff output gains precise `unknown` finding details for a case previously omitted. Default analysis still exits 0; `--forbid unknown` intentionally exits 1.
- No migration, persisted-data, dependency, CLI flag, or Python compatibility change.

## Follow-Up / Post-Merge Checks
- #427 can treat directed forbidden comparison as complete only after this prerequisite is merged.

Closes #460
Related to #427