### PR TITLE
test(workflow): complete design-family Phase 0 spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- Added an evidence-gated `fsl-design-family.v0` sidecar prototype with three
+  maintained three-variant dogfood families, native check/verify/refine/diff
+  orchestration tests, raw producer and deterministic digest controls, and an
+  accepted agent/workflow-only decision without new language or CLI semantics
+  (#427).
 - Refinement mappings can declare a source-total `enum abstraction` and invoke
   it with `abstract(name, expr)` for nominal many-to-one mappings. Repeated and
   unused targets are allowed, while missing, duplicate, unknown, or

--- a/docs/DESIGN-design-family.md
+++ b/docs/DESIGN-design-family.md
@@ -1,0 +1,267 @@
+# FSL design-family Phase 0 decision
+
+Status: Accepted evidence-gated spike decision for issue #427. This document does
+not commit a language construct, Public Kernel node, or product CLI command.
+
+## Decision
+
+Keep a design family as a versioned sidecar workflow over existing native
+`fslc` producers. Do not add `design_family` grammar, union variant state spaces,
+or add `fslc family` in Phase 0.
+
+Gate A (catalog and formal eligibility) and Gate B (directed pair comparison)
+are **go as an agent/workflow convention**. They are **no-go as a native language
+or CLI feature without new usage evidence**. The durable Phase 0 evidence is:
+
+- the closed `fsl-design-family.v0` manifest schema;
+- three maintained family fixtures with three independent variants each;
+- a native integration-test harness that invokes the existing `fslc` process
+  contract and retains raw JSON, stderr, argv, and real exit codes;
+- positive paths and rejecting controls for refinement, dependency drift,
+  comparison orientation, bounded completeness, and nested `implements`;
+- this accepted decision and its explicit gaps.
+
+The harness is intentionally test-owned. It establishes that orchestration is
+possible without widening the product surface. A later independent command or
+thin product CLI requires a separate issue with observed repeated use, an exact
+transitive-input contract, and a semantic-digest API that covers every admitted
+variant dialect.
+
+Gate C (AI implementation experiments and leading indicators) and Gate D (causal
+bridge) remain outside this decision. Issue #446 owns the quantitative/decision
+boundary. A family report never contains ranking, recommendation, selection,
+causal support, or an AI-run scheduler.
+
+## Boundary
+
+```text
+common contract
+  -> independent checked variants
+  -> variant -> contract refinement
+  -> directed OLD/NEW semantic diff
+  -> stable summary + unmodified producer evidence
+```
+
+A family is orchestration metadata. It has no state, action, transition, or
+property and is never lowered to the Kernel. Every contract and variant remains
+an independent checked model. The harness never generates a correspondence from
+names or reverses a declared mapping.
+
+The Phase 0 prototype lives at:
+
+- schema: `schemas/fslc/design-family/design-family.v0.schema.json`
+- fixtures: `rust/fslc/tests/fixtures/design_family/`
+- harness: `rust/fslc/tests/issue_427_design_family.rs`
+
+The fixtures are artificial verification models, not asserted production-domain
+rules. Their `MODEL-*` comments keep that boundary visible.
+
+## Manifest v0
+
+The closed JSON manifest has these required fields:
+
+- `schema_version`: exactly `fsl-design-family.v0`;
+- `family_id`: stable family identity;
+- `contract`: source, checked symbol, and exact declared inputs;
+- `verification`: Phase 0 fixes the engine to `bmc` plus an inclusive depth;
+- `variants`: stable ID, independent source/symbol, refinement mapping, and
+  exact declared inputs;
+- `comparisons`: stable ID, ordered OLD/NEW IDs, NEW-owned scope, depth, exact
+  mapping, and `new_to_old` mapping direction;
+- `bundle_control`: a checked compose entry, imported dependency, and exact
+  input list used for the dependency-drift negative control.
+
+Unknown fields fail schema validation. Variant and comparison IDs must be
+unique; comparison endpoints must resolve to listed variants. The schema permits
+only repository-relative paths. Runtime ownership of the manifest is external
+to `fslc`; this v0 schema is a spike artifact, not a product compatibility
+promise.
+
+## Orchestration protocol
+
+For each family the prototype performs the following operations and does not
+omit failed rows:
+
+1. Validate the closed manifest and all ID references.
+2. Run `fslc document claims` for the contract and every variant. Check the
+   declared symbol and retain `fsl-kernel-ast-v1+sha256` semantic identity.
+3. Run native `check` and configured `verify` for the contract and every variant.
+4. Treat `implements.result != refines` as failure even when the top-level
+   process exits zero.
+5. Run every declared `fslc refine VARIANT CONTRACT MAPPING --depth K`; check
+   that the producer names the same abstract contract and retain
+   `checked_to_depth`.
+6. Require at least two distinct variant semantic digests. A duplicate digest
+   is reported as a deterministic warning naming the digest and variant IDs,
+   but does not count as another semantic candidate.
+7. Probe each comparison mapping as `NEW -> OLD`, require its checked impl/abs
+   symbols to match the declared endpoints, then run directed
+   `fslc diff OLD NEW --depth K --mapping M` only after the
+   prerequisite forbidden-replay completeness fix (#460). Retain OLD, NEW,
+   scope owner, mapping direction, depth, bounded completeness, summary, and
+   findings.
+8. Check the compose import probe and hash the manifest-declared source bundle.
+9. Emit a stable summary projection and keep every raw producer row separately.
+
+Semantic diff findings remain informative unless an explicit gate is configured
+by a future contract. `no_semantic_change` is never rendered as equivalence;
+every comparison retains `completeness: bounded` and depth.
+
+## Report and exit contract sketch
+
+The stable report projection is `fsl-design-family-report.v0` and contains:
+
+- family result plus independent Gate A catalog/eligibility and Gate B pair
+  comparison statuses;
+- contract and variant IDs, symbols, sources, semantic digests, check results,
+  and per-model verification verdict/assurance/completeness, requested engine,
+  producer-reported engine when present, and depth;
+- per-variant refinement result and depth;
+- ordered comparison identity, scope owner, mapping identity/direction, depth,
+  producer result/summary, and bounded completeness;
+- source-bundle and exact mapping digests;
+- producer component versions;
+- a canonical report digest over this stable projection.
+
+Raw evidence is a separate array of rows containing phase, subject, argv, actual
+process exit code, exact stdout bytes, parsed stdout JSON, and exact stderr bytes.
+The stable report digest deliberately excludes raw solver cost, cache metadata,
+and wall-clock-sensitive evidence. Raw evidence is not normalized or rewritten.
+This separation is necessary: byte-deterministic summary identity and unmodified
+producer output cannot be the same payload.
+
+Aggregation preserves this precedence:
+
+| Class | Family exit |
+|---|---:|
+| Internal producer failure | 3 |
+| Manifest, I/O, parse, type, reference, or producer-contract failure | 2 |
+| Verification, refinement, or explicitly gated comparison failure | 1 |
+| Eligible family or informative diff finding | 0 |
+
+The prototype exercises the precedence function directly and runs independent
+rows even after a sibling fails. A deliberately invalid variant refinement
+produces a family exit 1 while all three variant and refinement rows, all raw
+producer exits, and Gate B remain present. A future command that adds dependency-
+ordered short-circuiting must use explicit `blocked`, `skipped`, and `not_run`
+rows instead of deleting work that could not run.
+
+Manifest read, parse, schema, and reference failures return a deterministic
+exit-2 failed report rather than aborting the harness. Producer rows are checked
+for a JSON envelope before verdict classification; non-JSON output and process
+statuses outside 0 through 3 fail closed as internal exit 3. Negative controls
+exercise both boundaries. Phase-specific required fields and the process
+exit/verdict pair are also checked, so a typed but contradictory producer row is
+a producer-contract exit 2 rather than evidence of eligibility.
+
+## Digest and provenance result
+
+| Identity | Phase 0 source | Result / gap |
+|---|---|---|
+| Semantic digest | `fslc document claims` → `fsl-kernel-ast-v1+sha256` | Reused without inventing another digest. Public only for the document-supported `spec`/`requirements` surface; not a general all-dialect family API. |
+| Source bundle digest | SHA-256 over path/length-framed manifest-declared exact bytes | Deterministic and dependency-drift-sensitive. The repository has no public exact transitive-input enumerator, so completeness depends on the closed manifest list. |
+| Mapping digest | SHA-256 over exact mapping bytes | Sufficient for exact mapping identity; comments and formatting intentionally change it. |
+| Producer | Native check/verify/refine/diff raw JSON + real exit and versions | Complete for executed commands; no family producer exists. |
+| Report digest | Canonical JSON of the stable projection | Stable by construction and separate from raw evidence noise. |
+
+The source-bundle limitation is material. A maintained user-facing command must
+either obtain the exact resolver dependency closure or fail closed on a clean,
+exact Git tree identity. It must not silently call a directory-wide verifier
+cache key a source-bundle digest.
+
+## Existing `chain` reuse decision
+
+`fslc chain` supplies useful behavior knowledge but is not a suitable internal
+implementation dependency for the spike.
+
+| Concern | Reuse decision |
+|---|---|
+| Native check/verify/refine JSON and process contract | Reuse through child processes. |
+| Nested `implements.result` failure rule | Reuse the rule and negative control. |
+| Result/assurance vocabulary | Reuse without collapsing verdict and method. |
+| Chain manifest parser | Do not reuse: it is private, fixed to business/requirements/design/impl, and not a typed variant catalog. |
+| Chain runner | Do not reuse: it fixes BMC in one path, does not represent directed pairs, and normalizes internal exit 3 to 2. |
+| Chain summary | Do not reuse: it cannot preserve family identities, digests, comparison scope, or raw producer provenance. |
+
+This preserves the product boundary and avoids extracting a generic framework
+from one fixed layer pipeline before another production owner exists.
+
+## Dogfood evidence and rejecting controls
+
+The maintained families are:
+
+1. order processing: synchronous, event-driven, and saga;
+2. concurrent work ownership: shared lock, actor mailbox, and partitioned queue;
+3. persistence: CRUD, event log, and snapshot plus log.
+
+Each contract and variant checks and verifies at the declared bound; every
+variant refines the same contract. Each family also has a deliberately invalid
+mapping that must return `refinement_failed`. The shared controls establish:
+
+- changing only a checked imported dependency changes the source-bundle digest;
+- depth-1 comparison remains explicitly bounded and is never called equivalent;
+- reversing OLD/NEW changes the directed result while retaining both identities;
+- a top-level successful `check` with nested `implements.result:
+  refinement_failed` maps to a gated exit 1 rather than family success;
+- a failed variant refinement yields a failed Gate A/family report without
+  omitting other variants, comparison results, or raw evidence;
+- an unknown manifest field and an unknown comparison endpoint fail closed;
+- raw stdout and real exit codes exist for every executed producer;
+- the stable report digest recomputes exactly.
+
+## Leading-indicator handoff gap
+
+The family report may hand the following identities to a separate experiment
+protocol:
+
+- family and variant IDs;
+- exact declared source-bundle, semantic, and mapping digests;
+- contract and formal eligibility results;
+- comparison orientation, scope, depth, and bounded/unknown evidence;
+- producer versions and raw evidence.
+
+It deliberately does not contain the following experiment facts:
+
+- implementation repository/tree and build artifacts;
+- model, prompt, tools, budget, execution order, random seed, or scheduler;
+- task corpus, repetitions, exclusion rules, or source-lineage independence;
+- test harness/conformance artifact identity;
+- leading-indicator definitions, units, windows, thresholds, uncertainty, or
+  pre-registration;
+- lagging KPI observations, causal support, utility/loss, or human decision.
+
+Those belong to the versioned protocol/decision boundary in #446. Their absence
+must yield `not_run` or `inconclusive`, never a ranking inferred from formal
+eligibility.
+
+## Option comparison
+
+| Option | Evidence quality | Product cost | Decision |
+|---|---|---|---|
+| Folder/agent convention only | Weak identity and omission gates | Low | Reject as the sole mechanism. |
+| Closed sidecar + test-owned native harness | Deterministic, rejecting, no product contract | Low | Accept for Phase 0 and agent/workflow use. |
+| Maintained independent command | Usable outside tests, but creates distribution and compatibility obligations | Medium | Defer until repeated use and dependency-closure gaps are resolved. |
+| Thin `fslc family` command | Best discoverability, permanent CLI/schema obligations | High | No-go in Phase 0. |
+| `design_family` language/Kernel feature | Would incorrectly pull orchestration into model semantics | Highest | No-go. |
+
+The existing `fsl-design-review` procedure already requires a variant matrix
+against a frozen abstract contract. No new agent-skill clause is accepted by
+this spike: there is no measured residual/ablation evidence showing that another
+skill instruction improves over that procedure. The closed schema, executable
+negative controls, and this design are the durable output specification.
+
+## Reevaluation triggers
+
+Open a separate implementation issue only when at least one trigger has concrete
+evidence:
+
+- two or more maintained consumers need the same report outside tests;
+- agents repeatedly omit invalid variants or lose raw exits despite the closed
+  schema and existing review procedure;
+- a public resolver API can return an exact transitive source closure;
+- semantic identity is required for dialects not supported by `document claims`;
+- users require a stable stored report rather than PR/CI evidence.
+
+Any future proposal must retain all negative controls here and compare an
+independent command against a thin CLI. It must not use successful dogfood alone
+as evidence for a language feature.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
 | [`DESIGN-temporal.md`](DESIGN-temporal.md) | leadsTo, weak fairness (lasso counterexamples), and respond scenarios |
 | [`DESIGN-refinement.md`](DESIGN-refinement.md) | Refinement checking (mapping files, conditional expressions, preserve progress) |
 | [`DESIGN-semantic-diff.md`](DESIGN-semantic-diff.md) | `fslc diff` bounded semantic comparison (bidirectional refinement, invariant implication, forbidden replay, scope and gate contract) |
+| [`DESIGN-design-family.md`](DESIGN-design-family.md) | Accepted Phase 0 design-family decision: closed sidecar catalog, independent variant eligibility, directed bounded comparison, provenance/digest gaps, dogfood controls, and no native language/CLI commitment (#427) |
 | [`DESIGN-diff-git.md`](DESIGN-diff-git.md) | Git/CI adapter for revision-consistent full-tree materialization and changed-spec batch semantic diff |
 | [`DESIGN-approval.md`](DESIGN-approval.md) | Digest-bound human approval records, rendering drift checks, and approved-baseline semantic diff |
 | [`DESIGN-compose.md`](DESIGN-compose.md) | Spec composition (namespaces, synchronized actions, internal) |

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-OWNER-003: A mailbox enqueue is separate from actor-owned mutation.
+spec ActorOwnership {
+  type Worker = 0..1
+  state { owner: Option<Worker>, mailbox: Option<Worker> }
+  init { owner = none  mailbox = none }
+
+  action enqueue(w: Worker) { requires mailbox == none  mailbox = some(w) }
+  action claim(w: Worker) { requires owner == none  requires mailbox == some(w)  owner = some(w)  mailbox = none }
+  action release(w: Worker) { requires owner == some(w)  owner = none }
+
+  reachable CanOwn { owner != none }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor_refines_contract.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement ActorRefinesOwnershipContract {
+  impl ActorOwnership
+  abs OwnershipContract
+  map owner = owner
+  action enqueue(w) -> stutter
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor_to_shared_lock.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/actor_to_shared_lock.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement ActorToSharedLock {
+  impl ActorOwnership
+  abs SharedLockOwnership
+  map owner = owner
+  map locked = owner != none
+  action enqueue(w) -> stutter
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/bundle_dependency.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/bundle_dependency.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+spec OwnershipBundleDependency {
+  state { observed: Bool }
+  init { observed = false }
+  action observe() { observed = true }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/bundle_probe.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/bundle_probe.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+compose OwnershipBundleProbe {
+  use OwnershipBundleDependency as dependency from "bundle_dependency.fsl"
+  action observe() = dependency.observe() { }
+  internal dependency.observe
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/contract.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-OWNER-001: Artificial single-item ownership contract.
+spec OwnershipContract {
+  type Worker = 0..1
+  state { owner: Option<Worker> }
+  init { owner = none }
+
+  action claim(w: Worker) { requires owner == none  owner = some(w) }
+  action release(w: Worker) { requires owner == some(w)  owner = none }
+
+  reachable CanOwn { owner != none }
+  reachable CanRelease { owner == none }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/manifest.json
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/manifest.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "fsl-design-family.v0",
+  "family_id": "concurrent_ownership",
+  "contract": {
+    "source": "contract.fsl",
+    "symbol": "OwnershipContract",
+    "inputs": ["contract.fsl"]
+  },
+  "verification": { "engine": "bmc", "depth": 4 },
+  "variants": [
+    {
+      "id": "shared_lock",
+      "source": "shared_lock.fsl",
+      "symbol": "SharedLockOwnership",
+      "refinement": "shared_lock_refines_contract.fsl",
+      "inputs": ["shared_lock.fsl", "shared_lock_refines_contract.fsl"]
+    },
+    {
+      "id": "actor",
+      "source": "actor.fsl",
+      "symbol": "ActorOwnership",
+      "refinement": "actor_refines_contract.fsl",
+      "inputs": ["actor.fsl", "actor_refines_contract.fsl"]
+    },
+    {
+      "id": "partitioned_queue",
+      "source": "partitioned_queue.fsl",
+      "symbol": "PartitionedQueueOwnership",
+      "refinement": "partitioned_queue_refines_contract.fsl",
+      "inputs": ["partitioned_queue.fsl", "partitioned_queue_refines_contract.fsl"]
+    }
+  ],
+  "comparisons": [
+    {
+      "id": "shared_lock__to__actor",
+      "old": "shared_lock",
+      "new": "actor",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "actor_to_shared_lock.fsl",
+      "mapping_direction": "new_to_old"
+    },
+    {
+      "id": "shared_lock__to__partitioned_queue",
+      "old": "shared_lock",
+      "new": "partitioned_queue",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "partitioned_queue_to_shared_lock.fsl",
+      "mapping_direction": "new_to_old"
+    }
+  ],
+  "bundle_control": {
+    "entry": "bundle_probe.fsl",
+    "dependency": "bundle_dependency.fsl",
+    "inputs": ["bundle_probe.fsl", "bundle_dependency.fsl"]
+  }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/negative_refinement.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/negative_refinement.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement InvalidSharedLockMapping {
+  impl SharedLockOwnership
+  abs OwnershipContract
+  map owner = none
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-OWNER-004: Routing pins the worker before the queue grants ownership.
+spec PartitionedQueueOwnership {
+  type Worker = 0..1
+  state { owner: Option<Worker>, routed: Option<Worker> }
+  init { owner = none  routed = none }
+
+  action route(w: Worker) { requires routed == none  routed = some(w) }
+  action claim(w: Worker) { requires owner == none  requires routed == some(w)  owner = some(w)  routed = none }
+  action release(w: Worker) { requires owner == some(w)  owner = none }
+
+  reachable CanOwn { owner != none }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue_refines_contract.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement PartitionedQueueRefinesOwnershipContract {
+  impl PartitionedQueueOwnership
+  abs OwnershipContract
+  map owner = owner
+  action route(w) -> stutter
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue_to_shared_lock.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/partitioned_queue_to_shared_lock.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement PartitionedQueueToSharedLock {
+  impl PartitionedQueueOwnership
+  abs SharedLockOwnership
+  map owner = owner
+  map locked = owner != none
+  action route(w) -> stutter
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/shared_lock.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/shared_lock.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-OWNER-002: The owner and lock bit change atomically.
+spec SharedLockOwnership {
+  type Worker = 0..1
+  state { owner: Option<Worker>, locked: Bool }
+  init { owner = none  locked = false }
+
+  action claim(w: Worker) { requires owner == none  requires not locked  owner = some(w)  locked = true }
+  action release(w: Worker) { requires owner == some(w)  requires locked  owner = none  locked = false }
+
+  invariant LockMatchesOwner { locked == (owner != none) }
+  reachable CanOwn { owner != none }
+}

--- a/rust/fslc/tests/fixtures/design_family/concurrent_ownership/shared_lock_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/concurrent_ownership/shared_lock_refines_contract.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SharedLockRefinesOwnershipContract {
+  impl SharedLockOwnership
+  abs OwnershipContract
+  map owner = owner
+  action claim(w) -> claim(w)
+  action release(w) -> release(w)
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/bundle_dependency.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/bundle_dependency.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+spec OrderBundleDependency {
+  state { observed: Bool }
+  init { observed = false }
+  action observe() { observed = true }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/bundle_probe.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/bundle_probe.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+compose OrderBundleProbe {
+  use OrderBundleDependency as dependency from "bundle_dependency.fsl"
+  action observe() = dependency.observe() { }
+  internal dependency.observe
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/contract.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-ORDER-001: Artificial Phase 0 contract; not a production order policy.
+spec OrderContract {
+  type Phase = 0..2
+  state { phase: Phase }
+  init { phase = 0 }
+
+  action finish() { requires phase == 0  phase = 1 }
+  action cancel() { requires phase == 0  phase = 2 }
+
+  reachable CanFinish { phase == 1 }
+  reachable CanCancel { phase == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/event_driven.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/event_driven.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-ORDER-003: Queueing is an independent step before event handling.
+spec EventDrivenOrder {
+  type Phase = 0..2
+  state { phase: Phase, queued: Bool }
+  init { phase = 0  queued = false }
+
+  action enqueue() { requires phase == 0  requires not queued  queued = true }
+  action finish() { requires phase == 0  requires queued  phase = 1  queued = false }
+  action cancel() { requires phase == 0  phase = 2  queued = false }
+
+  invariant QueueOnlyWhilePending { queued => phase == 0 }
+  reachable CanFinish { phase == 1 }
+  reachable CanCancel { phase == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/event_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/event_refines_contract.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement EventRefinesOrderContract {
+  impl EventDrivenOrder
+  abs OrderContract
+  map phase = phase
+  action enqueue() -> stutter
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/event_to_synchronous.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/event_to_synchronous.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement EventToSynchronous {
+  impl EventDrivenOrder
+  abs SynchronousOrder
+  map phase = phase
+  map committed = phase == 1
+  action enqueue() -> stutter
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/manifest.json
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/manifest.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "fsl-design-family.v0",
+  "family_id": "order_processing",
+  "contract": {
+    "source": "contract.fsl",
+    "symbol": "OrderContract",
+    "inputs": ["contract.fsl"]
+  },
+  "verification": { "engine": "bmc", "depth": 4 },
+  "variants": [
+    {
+      "id": "synchronous",
+      "source": "synchronous.fsl",
+      "symbol": "SynchronousOrder",
+      "refinement": "synchronous_refines_contract.fsl",
+      "inputs": ["synchronous.fsl", "synchronous_refines_contract.fsl"]
+    },
+    {
+      "id": "event_driven",
+      "source": "event_driven.fsl",
+      "symbol": "EventDrivenOrder",
+      "refinement": "event_refines_contract.fsl",
+      "inputs": ["event_driven.fsl", "event_refines_contract.fsl"]
+    },
+    {
+      "id": "saga",
+      "source": "saga.fsl",
+      "symbol": "SagaOrder",
+      "refinement": "saga_refines_contract.fsl",
+      "inputs": ["saga.fsl", "saga_refines_contract.fsl"]
+    }
+  ],
+  "comparisons": [
+    {
+      "id": "synchronous__to__event_driven",
+      "old": "synchronous",
+      "new": "event_driven",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "event_to_synchronous.fsl",
+      "mapping_direction": "new_to_old"
+    },
+    {
+      "id": "synchronous__to__saga",
+      "old": "synchronous",
+      "new": "saga",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "saga_to_synchronous.fsl",
+      "mapping_direction": "new_to_old"
+    }
+  ],
+  "bundle_control": {
+    "entry": "bundle_probe.fsl",
+    "dependency": "bundle_dependency.fsl",
+    "inputs": ["bundle_probe.fsl", "bundle_dependency.fsl"]
+  }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/negative_manifest.json
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/negative_manifest.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "fsl-design-family.v0",
+  "family_id": "order_processing_negative_control",
+  "contract": {
+    "source": "contract.fsl",
+    "symbol": "OrderContract",
+    "inputs": ["contract.fsl"]
+  },
+  "verification": { "engine": "bmc", "depth": 4 },
+  "variants": [
+    {
+      "id": "synchronous",
+      "source": "synchronous.fsl",
+      "symbol": "SynchronousOrder",
+      "refinement": "negative_refinement.fsl",
+      "inputs": ["synchronous.fsl", "negative_refinement.fsl"]
+    },
+    {
+      "id": "event_driven",
+      "source": "event_driven.fsl",
+      "symbol": "EventDrivenOrder",
+      "refinement": "event_refines_contract.fsl",
+      "inputs": ["event_driven.fsl", "event_refines_contract.fsl"]
+    },
+    {
+      "id": "saga",
+      "source": "saga.fsl",
+      "symbol": "SagaOrder",
+      "refinement": "saga_refines_contract.fsl",
+      "inputs": ["saga.fsl", "saga_refines_contract.fsl"]
+    }
+  ],
+  "comparisons": [
+    {
+      "id": "synchronous__to__event_driven",
+      "old": "synchronous",
+      "new": "event_driven",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "event_to_synchronous.fsl",
+      "mapping_direction": "new_to_old"
+    }
+  ],
+  "bundle_control": {
+    "entry": "bundle_probe.fsl",
+    "dependency": "bundle_dependency.fsl",
+    "inputs": ["bundle_probe.fsl", "bundle_dependency.fsl"]
+  }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/negative_refinement.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/negative_refinement.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement InvalidSynchronousOrderMapping {
+  impl SynchronousOrder
+  abs OrderContract
+  map phase = 0
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/saga.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/saga.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-ORDER-004: Reservation and charging are explicit saga coordination steps.
+spec SagaOrder {
+  type Phase = 0..2
+  state { phase: Phase, reserved: Bool, charged: Bool }
+  init { phase = 0  reserved = false  charged = false }
+
+  action reserve() { requires phase == 0  requires not reserved  reserved = true }
+  action charge() { requires phase == 0  requires reserved  charged = true }
+  action finish() { requires phase == 0  requires charged  phase = 1 }
+  action cancel() { requires phase == 0  phase = 2  reserved = false  charged = false }
+
+  invariant ChargeNeedsReservation { charged => reserved }
+  reachable CanFinish { phase == 1 }
+  reachable CanCancel { phase == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/saga_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/saga_refines_contract.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SagaRefinesOrderContract {
+  impl SagaOrder
+  abs OrderContract
+  map phase = phase
+  action reserve() -> stutter
+  action charge() -> stutter
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/saga_to_synchronous.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/saga_to_synchronous.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SagaToSynchronous {
+  impl SagaOrder
+  abs SynchronousOrder
+  map phase = phase
+  map committed = phase == 1
+  action reserve() -> stutter
+  action charge() -> stutter
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/synchronous.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/synchronous.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-ORDER-002: A synchronous commit is represented as one atomic finish step.
+spec SynchronousOrder {
+  type Phase = 0..2
+  state { phase: Phase, committed: Bool }
+  init { phase = 0  committed = false }
+
+  action finish() { requires phase == 0  phase = 1  committed = true }
+  action cancel() { requires phase == 0  phase = 2 }
+
+  invariant CommitMatchesFinish { committed => phase == 1 }
+  reachable CanFinish { phase == 1 }
+  reachable CanCancel { phase == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/order_processing/synchronous_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/order_processing/synchronous_refines_contract.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SynchronousRefinesOrderContract {
+  impl SynchronousOrder
+  abs OrderContract
+  map phase = phase
+  action finish() -> finish()
+  action cancel() -> cancel()
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/bundle_dependency.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/bundle_dependency.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+spec PersistenceBundleDependency {
+  state { observed: Bool }
+  init { observed = false }
+  action observe() { observed = true }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/bundle_probe.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/bundle_probe.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+compose PersistenceBundleProbe {
+  use PersistenceBundleDependency as dependency from "bundle_dependency.fsl"
+  action observe() = dependency.observe() { }
+  internal dependency.observe
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/contract.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-PERSIST-001: Artificial logical-value contract, not a durability claim.
+spec PersistenceContract {
+  type Value = 0..2
+  state { value: Value }
+  init { value = 0 }
+  action write(v: Value) { value = v }
+  reachable CanChange { value == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/crud.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/crud.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-PERSIST-002: CRUD stores only the latest value and a bounded write count.
+spec CrudPersistence {
+  type Value = 0..2
+  type Count = 0..4
+  state { value: Value, writes: Count }
+  init { value = 0  writes = 0 }
+  action write(v: Value) { requires writes < 4  value = v  writes = writes + 1 }
+  reachable CanChange { value == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/crud_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/crud_refines_contract.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement CrudRefinesPersistenceContract {
+  impl CrudPersistence
+  abs PersistenceContract
+  map value = value
+  action write(v) -> write(v)
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/event_log.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/event_log.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-PERSIST-003: Every accepted write appends the logical value to a finite log.
+spec EventLogPersistence {
+  const CAP = 4
+  type Value = 0..2
+  state { value: Value, log: Seq<Value, CAP> }
+  init { value = 0  log = Seq {} }
+  action write(v: Value) { requires log.size() < CAP  value = v  log = log.push(v) }
+  invariant LatestEventMatchesValue {
+    log.size() > 0 => value == log.at(log.size() - 1)
+  }
+  reachable CanChange { value == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/event_log_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/event_log_refines_contract.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement EventLogRefinesPersistenceContract {
+  impl EventLogPersistence
+  abs PersistenceContract
+  map value = value
+  action write(v) -> write(v)
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/event_log_to_crud.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/event_log_to_crud.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement EventLogToCrud {
+  impl EventLogPersistence
+  abs CrudPersistence
+  map value = value
+  map writes = log.size()
+  action write(v) -> write(v)
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/manifest.json
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/manifest.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "fsl-design-family.v0",
+  "family_id": "persistence_model",
+  "contract": {
+    "source": "contract.fsl",
+    "symbol": "PersistenceContract",
+    "inputs": ["contract.fsl"]
+  },
+  "verification": { "engine": "bmc", "depth": 4 },
+  "variants": [
+    {
+      "id": "crud",
+      "source": "crud.fsl",
+      "symbol": "CrudPersistence",
+      "refinement": "crud_refines_contract.fsl",
+      "inputs": ["crud.fsl", "crud_refines_contract.fsl"]
+    },
+    {
+      "id": "event_log",
+      "source": "event_log.fsl",
+      "symbol": "EventLogPersistence",
+      "refinement": "event_log_refines_contract.fsl",
+      "inputs": ["event_log.fsl", "event_log_refines_contract.fsl"]
+    },
+    {
+      "id": "snapshot_log",
+      "source": "snapshot_log.fsl",
+      "symbol": "SnapshotLogPersistence",
+      "refinement": "snapshot_log_refines_contract.fsl",
+      "inputs": ["snapshot_log.fsl", "snapshot_log_refines_contract.fsl"]
+    }
+  ],
+  "comparisons": [
+    {
+      "id": "crud__to__event_log",
+      "old": "crud",
+      "new": "event_log",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "event_log_to_crud.fsl",
+      "mapping_direction": "new_to_old"
+    },
+    {
+      "id": "crud__to__snapshot_log",
+      "old": "crud",
+      "new": "snapshot_log",
+      "scope_owner": "new",
+      "depth": 4,
+      "mapping": "snapshot_log_to_crud.fsl",
+      "mapping_direction": "new_to_old"
+    }
+  ],
+  "bundle_control": {
+    "entry": "bundle_probe.fsl",
+    "dependency": "bundle_dependency.fsl",
+    "inputs": ["bundle_probe.fsl", "bundle_dependency.fsl"]
+  }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/negative_refinement.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/negative_refinement.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement InvalidCrudMapping {
+  impl CrudPersistence
+  abs PersistenceContract
+  map value = 0
+  action write(v) -> write(v)
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log.fsl
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// MODEL-PERSIST-004: Snapshotting is an explicit stutter at the logical contract.
+spec SnapshotLogPersistence {
+  const CAP = 4
+  type Value = 0..2
+  state { value: Value, snapshot: Value, pending: Seq<Value, CAP>, dirty: Bool }
+  init { value = 0  snapshot = 0  pending = Seq {}  dirty = false }
+  action write(v: Value) {
+    requires pending.size() < CAP
+    value = v
+    pending = pending.push(v)
+    dirty = true
+  }
+  action take_snapshot() {
+    requires dirty
+    snapshot = value
+    pending = Seq {}
+    dirty = false
+  }
+  invariant CleanSnapshotMatches { not dirty => snapshot == value }
+  reachable CanChange { value == 2 }
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log_refines_contract.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log_refines_contract.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SnapshotLogRefinesPersistenceContract {
+  impl SnapshotLogPersistence
+  abs PersistenceContract
+  map value = value
+  action write(v) -> write(v)
+  action take_snapshot() -> stutter
+}

--- a/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log_to_crud.fsl
+++ b/rust/fslc/tests/fixtures/design_family/persistence_model/snapshot_log_to_crud.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+refinement SnapshotLogToCrud {
+  impl SnapshotLogPersistence
+  abs CrudPersistence
+  map value = value
+  map writes = pending.size()
+  action write(v) -> write(v)
+  action take_snapshot() -> stutter
+}

--- a/rust/fslc/tests/issue_427_design_family.rs
+++ b/rust/fslc/tests/issue_427_design_family.rs
@@ -1,0 +1,1043 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Evidence-gated Phase 0 prototype for issue #427.
+//!
+//! This is deliberately a test-owned sidecar harness, not an `fslc family`
+//! product command. It composes the existing native process contracts without
+//! adding grammar, Kernel, runtime, solver, or verifier semantics.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+const SCHEMA: &str = "schemas/fslc/design-family/design-family.v0.schema.json";
+const FAMILIES: [&str; 3] = [
+    "order_processing",
+    "concurrent_ownership",
+    "persistence_model",
+];
+
+struct PrototypeReport {
+    stable: Value,
+    evidence: Vec<Value>,
+    exit_code: i32,
+}
+
+fn repository_file(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn fixture(family: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/design_family")
+        .join(family)
+}
+
+fn read_json(path: &Path) -> Value {
+    read_json_result(path).unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn read_json_result(path: &Path) -> Result<Value, String> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {}: {error}", path.display()))?;
+    serde_json::from_str(&source).map_err(|error| format!("parse JSON {}: {error}", path.display()))
+}
+
+fn compiled_schema() -> jsonschema::Validator {
+    jsonschema::validator_for(&read_json(&repository_file(SCHEMA))).expect("schema compiles")
+}
+
+fn assert_schema_valid(value: &Value) {
+    schema_result(value).unwrap_or_else(|error| panic!("{error}"));
+}
+
+fn schema_result(value: &Value) -> Result<(), String> {
+    let errors = compiled_schema()
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("schema validation errors: {errors:?}"))
+    }
+}
+
+fn run(cwd: &Path, arguments: &[String]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run native fslc")
+}
+
+fn json_stdout(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not JSON: {error}\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    })
+}
+
+fn command_evidence(cwd: &Path, phase: &str, subject: &str, arguments: Vec<String>) -> Value {
+    let output = run(cwd, &arguments);
+    let exit_code = output.status.code().unwrap_or(3);
+    let stdout_raw = String::from_utf8(output.stdout).expect("fslc stdout is UTF-8");
+    let stdout_json: Value = serde_json::from_str(&stdout_raw).unwrap_or(Value::Null);
+    let json_parsed = !stdout_json.is_null();
+    let argv = arguments.into_iter().map(Value::String).collect::<Vec<_>>();
+    json!({
+        "phase": phase,
+        "subject": subject,
+        "argv": argv,
+        "exit_code": exit_code,
+        "stdout_raw": stdout_raw,
+        "stdout_json": stdout_json,
+        "json_parsed": json_parsed,
+        "stderr_raw": String::from_utf8(output.stderr).expect("fslc stderr is UTF-8"),
+    })
+}
+
+fn nested_implements_gate(result: &Value) -> i32 {
+    let Some(implements) = result.get("implements") else {
+        return 0;
+    };
+    let Some(nested) = implements
+        .as_object()
+        .and_then(|object| object.get("result"))
+        .and_then(Value::as_str)
+    else {
+        return 2;
+    };
+    match nested {
+        "refines" => 0,
+        "refinement_failed" => 1,
+        _ => 2,
+    }
+}
+
+fn canonical(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let sorted = object
+                .iter()
+                .map(|(key, value)| (key.clone(), canonical(value)))
+                .collect::<BTreeMap<_, _>>();
+            Value::Object(sorted.into_iter().collect::<Map<_, _>>())
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonical).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn stable_digest(value: &Value) -> String {
+    let bytes = serde_json::to_vec(&canonical(value)).expect("canonical JSON serializes");
+    sha256_bytes(&bytes)
+}
+
+fn framed_input_digest(
+    cwd: &Path,
+    manifest_name: &str,
+    inputs: &[String],
+    override_input: Option<(&str, &[u8])>,
+) -> Result<String, String> {
+    let mut paths = inputs.to_vec();
+    paths.push(manifest_name.to_owned());
+    paths.sort();
+    paths.dedup();
+    let mut framed = b"fsl-design-family-source-bundle-v0\0".to_vec();
+    for relative in paths {
+        let bytes = match override_input {
+            Some((path, bytes)) if path == relative => bytes.to_vec(),
+            _ => std::fs::read(cwd.join(&relative))
+                .map_err(|error| format!("read bundle input {relative}: {error}"))?,
+        };
+        framed.extend((relative.len() as u64).to_be_bytes());
+        framed.extend(relative.as_bytes());
+        framed.extend((bytes.len() as u64).to_be_bytes());
+        framed.extend(bytes);
+    }
+    Ok(sha256_bytes(&framed))
+}
+
+fn strings(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|item| item.as_str().expect("string").to_owned())
+        .collect()
+}
+
+fn semantic_digest_summary<'a>(models: impl IntoIterator<Item = &'a Value>) -> (usize, Vec<Value>) {
+    let mut groups = BTreeMap::<String, Vec<String>>::new();
+    for model in models {
+        let (Some(id), Some(digest)) = (model["id"].as_str(), model["semantic_digest"].as_str())
+        else {
+            continue;
+        };
+        groups
+            .entry(digest.to_owned())
+            .or_default()
+            .push(id.to_owned());
+    }
+    let distinct = groups.len();
+    let warnings = groups
+        .into_iter()
+        .filter_map(|(digest, mut variants)| {
+            if variants.len() < 2 {
+                return None;
+            }
+            variants.sort();
+            Some(json!({
+                "kind": "duplicate_semantic_digest",
+                "semantic_digest": digest,
+                "variants": variants,
+            }))
+        })
+        .collect();
+    (distinct, warnings)
+}
+
+fn manifest_consistency(manifest: &Value) -> Result<(), String> {
+    let contract = &manifest["contract"];
+    require_declared_input(contract, "source", "contract")?;
+    let variants = manifest["variants"].as_array().expect("schema validated");
+    let mut ids = BTreeSet::new();
+    for variant in variants {
+        let id = variant["id"].as_str().expect("schema validated");
+        if !ids.insert(id) {
+            return Err(format!("duplicate variant id '{id}'"));
+        }
+        require_declared_input(variant, "source", id)?;
+        require_declared_input(variant, "refinement", id)?;
+    }
+    let mut comparison_ids = BTreeSet::new();
+    for comparison in manifest["comparisons"]
+        .as_array()
+        .expect("schema validated")
+    {
+        let id = comparison["id"].as_str().expect("schema validated");
+        if !comparison_ids.insert(id) {
+            return Err(format!("duplicate comparison id '{id}'"));
+        }
+        for endpoint in ["old", "new"] {
+            let variant = comparison[endpoint].as_str().expect("schema validated");
+            if !ids.contains(variant) {
+                return Err(format!(
+                    "comparison '{id}' references unknown {endpoint} '{variant}'"
+                ));
+            }
+        }
+        if comparison["old"] == comparison["new"] {
+            return Err(format!("comparison '{id}' must name two distinct variants"));
+        }
+    }
+    let bundle = &manifest["bundle_control"];
+    require_declared_input(bundle, "entry", "bundle_control")?;
+    require_declared_input(bundle, "dependency", "bundle_control")?;
+    Ok(())
+}
+
+fn require_declared_input(owner: &Value, field: &str, context: &str) -> Result<(), String> {
+    let required = owner[field].as_str().expect("schema validated");
+    if strings(&owner["inputs"])
+        .iter()
+        .any(|input| input == required)
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "{context} {field} '{required}' is absent from its exact inputs"
+        ))
+    }
+}
+
+fn assurance_projection(result: &Value, requested_engine: &str) -> Value {
+    let completeness = result
+        .get("completeness")
+        .and_then(Value::as_str)
+        .unwrap_or("not_run");
+    json!({
+        "result": result.get("result").cloned().unwrap_or(Value::Null),
+        "assurance": match completeness {
+            "bounded" => "bounded",
+            "unbounded" => "proved",
+            _ => "not_run",
+        },
+        "completeness": result.get("completeness").cloned().unwrap_or(Value::Null),
+        "requested_engine": requested_engine,
+        "producer_engine": result.get("engine").cloned().unwrap_or(Value::Null),
+        "checked_to_depth": result.get("checked_to_depth").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn variant_by_id<'a>(manifest: &'a Value, id: &str) -> &'a Value {
+    manifest["variants"]
+        .as_array()
+        .expect("variants")
+        .iter()
+        .find(|variant| variant["id"] == id)
+        .unwrap_or_else(|| panic!("unknown variant {id}"))
+}
+
+fn aggregate_exit(codes: impl IntoIterator<Item = i32>) -> i32 {
+    let mut result = 0;
+    for code in codes {
+        result = result.max(match code {
+            2 => 2,
+            1 => 1,
+            0 => 0,
+            _ => 3,
+        });
+    }
+    result
+}
+
+fn evidence_exit(row: &Value) -> i32 {
+    i32::try_from(row["exit_code"].as_i64().unwrap_or(3)).unwrap_or(3)
+}
+
+fn producer_gate(row: &Value, accepted_results: &[&str]) -> i32 {
+    if !row["json_parsed"].as_bool().unwrap_or(false) {
+        return 3;
+    }
+    match evidence_exit(row) {
+        2 => 2,
+        0 | 1 if !producer_envelope_valid(row) => 2,
+        0 | 1 if !producer_result_exit_valid(row, accepted_results) => 2,
+        1 => 1,
+        0 => nested_implements_gate(&row["stdout_json"]),
+        _ => 3,
+    }
+}
+
+fn producer_result_exit_valid(row: &Value, accepted_results: &[&str]) -> bool {
+    let exit = evidence_exit(row);
+    let Some(result) = row["stdout_json"]["result"].as_str() else {
+        return false;
+    };
+    match exit {
+        0 => accepted_results.contains(&result),
+        1 => match row["phase"].as_str() {
+            Some("verify") => matches!(result, "violated" | "reachable_failed"),
+            Some("refine" | "comparison_mapping") => result == "refinement_failed",
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn producer_envelope_valid(row: &Value) -> bool {
+    let output = &row["stdout_json"];
+    if !output["result"].is_string() {
+        return false;
+    }
+    if output.get("implements").is_some() && nested_implements_gate(output) == 2 {
+        return false;
+    }
+    match row["phase"].as_str() {
+        Some("semantic_digest") => {
+            output["spec"]["name"].is_string()
+                && output["spec"]["spec_digest"].is_string()
+                && output["spec"]["spec_digest_algorithm"].is_string()
+        }
+        Some("check" | "bundle_control_check") => output["versions"].is_object(),
+        Some("verify") => match output["result"].as_str() {
+            Some("verified") => {
+                output["completeness"] == "bounded"
+                    && output["checked_to_depth"].is_u64()
+                    && output["versions"].is_object()
+            }
+            Some("violated") => {
+                output["completeness"] == "bounded"
+                    && output["checked_to_depth"].is_u64()
+                    && output["versions"].is_object()
+                    && output["violated_at_step"].is_u64()
+                    && output["trace"].is_array()
+            }
+            Some("reachable_failed") => {
+                output["completeness"] == "bounded"
+                    && output["checked_to_depth"].is_u64()
+                    && output["versions"].is_object()
+                    && output["unreached"].is_array()
+            }
+            _ => false,
+        },
+        Some("refine" | "comparison_mapping") => {
+            output["impl"].is_string()
+                && output["abs"].is_string()
+                && match output["result"].as_str() {
+                    Some("refines") => output["checked_to_depth"].is_u64(),
+                    Some("refinement_failed") => {
+                        output["kind"].is_string() && output["violated_at_step"].is_u64()
+                    }
+                    _ => false,
+                }
+        }
+        Some("diff") => {
+            output["old"]["spec"].is_string()
+                && output["new"]["spec"].is_string()
+                && output["scope"]["comparison"].is_string()
+                && output["bounded"]["completeness"].is_string()
+                && output["summary"].is_array()
+        }
+        _ => false,
+    }
+}
+
+fn failed_manifest_report(family: &str, manifest_name: &str, message: &str) -> PrototypeReport {
+    let mut stable = json!({
+        "schema_version": "fsl-design-family-report.v0",
+        "family_id": family,
+        "result": "failed",
+        "gates": {
+            "catalog_eligibility": "failed",
+            "pair_comparison": "not_run",
+            "distinct_semantic_candidates": 0,
+        },
+        "error": {
+            "kind": "manifest_contract",
+            "manifest": manifest_name,
+            "message": message,
+        },
+    });
+    let report_digest = stable_digest(&stable);
+    stable
+        .as_object_mut()
+        .expect("report object")
+        .insert("report_digest".to_owned(), json!(report_digest));
+    PrototypeReport {
+        stable,
+        evidence: Vec::new(),
+        exit_code: 2,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_family(family: &str) -> PrototypeReport {
+    run_family_manifest(family, "manifest.json")
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_family_manifest(family: &str, manifest_name: &str) -> PrototypeReport {
+    let cwd = fixture(family);
+    let manifest = match read_json_result(&cwd.join(manifest_name)) {
+        Ok(manifest) => manifest,
+        Err(error) => return failed_manifest_report(family, manifest_name, &error),
+    };
+    run_family_value(family, manifest_name, &manifest)
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_family_value(family: &str, manifest_name: &str, manifest: &Value) -> PrototypeReport {
+    if let Err(error) = schema_result(manifest).and_then(|()| manifest_consistency(manifest)) {
+        return failed_manifest_report(family, manifest_name, &error);
+    }
+    let cwd = fixture(family);
+    let depth = manifest["verification"]["depth"]
+        .as_u64()
+        .expect("depth")
+        .to_string();
+    let engine = manifest["verification"]["engine"]
+        .as_str()
+        .expect("engine")
+        .to_owned();
+    let mut evidence = Vec::new();
+    let mut catalog_codes = Vec::new();
+    let mut comparison_codes = Vec::new();
+    let mut stable_models = Vec::new();
+    let contract = &manifest["contract"];
+    let mut models = vec![("contract".to_owned(), contract.clone())];
+    models.extend(
+        manifest["variants"]
+            .as_array()
+            .expect("variants")
+            .iter()
+            .map(|variant| {
+                (
+                    variant["id"].as_str().expect("id").to_owned(),
+                    variant.clone(),
+                )
+            }),
+    );
+
+    for (id, model) in &models {
+        let source = model["source"].as_str().expect("source").to_owned();
+        let claims = command_evidence(
+            &cwd,
+            "semantic_digest",
+            id,
+            vec!["document".into(), "claims".into(), source.clone()],
+        );
+        let check = command_evidence(&cwd, "check", id, vec!["check".into(), source.clone()]);
+        let verify = command_evidence(
+            &cwd,
+            "verify",
+            id,
+            vec![
+                "verify".into(),
+                source,
+                "--engine".into(),
+                engine.clone(),
+                "--depth".into(),
+                depth.clone(),
+            ],
+        );
+        let claims_gate = producer_gate(&claims, &["requirement_claims"]);
+        let check_gate = producer_gate(&check, &["ok"]);
+        let verify_gate = producer_gate(&verify, &["verified"]);
+        let symbol_gate = i32::from(claims["stdout_json"]["spec"]["name"] != model["symbol"]) * 2;
+        let model_exit = aggregate_exit([claims_gate, check_gate, verify_gate, symbol_gate]);
+        catalog_codes.push(model_exit);
+        stable_models.push(json!({
+            "id": id,
+            "symbol": model["symbol"],
+            "source": model["source"],
+            "status": if model_exit == 0 { "eligible" } else { "failed" },
+            "semantic_digest": claims["stdout_json"]["spec"]["spec_digest"],
+            "semantic_digest_algorithm": claims["stdout_json"]["spec"]["spec_digest_algorithm"],
+            "verification": assurance_projection(&verify["stdout_json"], &engine),
+            "check_result": check["stdout_json"]["result"],
+        }));
+        evidence.extend([claims, check, verify]);
+    }
+
+    let (distinct_candidates, warnings) = semantic_digest_summary(stable_models.iter().skip(1));
+    if distinct_candidates < 2 {
+        catalog_codes.push(2);
+    }
+
+    let contract_source = contract["source"].as_str().expect("contract source");
+    let mut stable_refinements = Vec::new();
+    let mut mapping_digests = BTreeMap::new();
+    for variant in manifest["variants"].as_array().expect("variants") {
+        let id = variant["id"].as_str().expect("id");
+        let mapping = variant["refinement"].as_str().expect("refinement");
+        let row = command_evidence(
+            &cwd,
+            "refine",
+            id,
+            vec![
+                "refine".into(),
+                variant["source"].as_str().expect("source").into(),
+                contract_source.into(),
+                mapping.into(),
+                "--depth".into(),
+                depth.clone(),
+            ],
+        );
+        let mut row_gate = producer_gate(&row, &["refines"]);
+        if row["stdout_json"]["abs"] != contract["symbol"] {
+            row_gate = row_gate.max(2);
+        }
+        if let Ok(bytes) = std::fs::read(cwd.join(mapping)) {
+            mapping_digests.insert(mapping.to_owned(), json!(sha256_bytes(&bytes)));
+        } else {
+            row_gate = row_gate.max(2);
+            mapping_digests.insert(mapping.to_owned(), Value::Null);
+        }
+        catalog_codes.push(row_gate);
+        stable_refinements.push(json!({
+            "variant": id,
+            "status": if row_gate == 0 { "passed" } else { "failed" },
+            "result": row["stdout_json"]["result"],
+            "checked_to_depth": row["stdout_json"]["checked_to_depth"],
+        }));
+        evidence.push(row);
+    }
+
+    let mut stable_comparisons = Vec::new();
+    for comparison in manifest["comparisons"].as_array().expect("comparisons") {
+        let id = comparison["id"].as_str().expect("comparison id");
+        let old = variant_by_id(manifest, comparison["old"].as_str().expect("old"));
+        let new = variant_by_id(manifest, comparison["new"].as_str().expect("new"));
+        let mapping = comparison["mapping"].as_str().expect("mapping");
+        let mapping_probe = command_evidence(
+            &cwd,
+            "comparison_mapping",
+            id,
+            vec![
+                "refine".into(),
+                new["source"].as_str().expect("new source").into(),
+                old["source"].as_str().expect("old source").into(),
+                mapping.into(),
+                "--depth".into(),
+                comparison["depth"].as_u64().expect("depth").to_string(),
+            ],
+        );
+        let mut mapping_gate = match producer_gate(&mapping_probe, &["refines"]) {
+            1 => 0,
+            code => code,
+        };
+        if mapping_probe["stdout_json"]["impl"] != new["symbol"]
+            || mapping_probe["stdout_json"]["abs"] != old["symbol"]
+        {
+            mapping_gate = mapping_gate.max(2);
+        }
+        let row = command_evidence(
+            &cwd,
+            "diff",
+            id,
+            vec![
+                "diff".into(),
+                old["source"].as_str().expect("old source").into(),
+                new["source"].as_str().expect("new source").into(),
+                "--depth".into(),
+                comparison["depth"].as_u64().expect("depth").to_string(),
+                "--mapping".into(),
+                mapping.into(),
+            ],
+        );
+        let mut diff_gate = producer_gate(&row, &["semantic_diff", "no_semantic_change"]);
+        if row["stdout_json"]["old"]["spec"] != old["symbol"]
+            || row["stdout_json"]["new"]["spec"] != new["symbol"]
+            || row["stdout_json"]["scope"]["comparison"] != comparison["scope_owner"]
+            || row["stdout_json"]["bounded"]["completeness"] != "bounded"
+        {
+            diff_gate = diff_gate.max(2);
+        }
+        if let Ok(bytes) = std::fs::read(cwd.join(mapping)) {
+            mapping_digests.insert(mapping.to_owned(), json!(sha256_bytes(&bytes)));
+        } else {
+            mapping_gate = mapping_gate.max(2);
+            mapping_digests.insert(mapping.to_owned(), Value::Null);
+        }
+        let comparison_gate = aggregate_exit([mapping_gate, diff_gate]);
+        comparison_codes.push(comparison_gate);
+        stable_comparisons.push(json!({
+            "id": id,
+            "status": if comparison_gate == 0 { "reported" } else { "failed" },
+            "old": comparison["old"],
+            "new": comparison["new"],
+            "scope_owner": comparison["scope_owner"],
+            "mapping": mapping,
+            "mapping_direction": comparison["mapping_direction"],
+            "depth": comparison["depth"],
+            "result": row["stdout_json"]["result"],
+            "summary": row["stdout_json"]["summary"],
+            "completeness": row["stdout_json"]["bounded"]["completeness"],
+            "mapping_probe_result": mapping_probe["stdout_json"]["result"],
+        }));
+        evidence.extend([mapping_probe, row]);
+    }
+
+    let bundle = &manifest["bundle_control"];
+    let bundle_check = command_evidence(
+        &cwd,
+        "bundle_control_check",
+        "import_probe",
+        vec![
+            "check".into(),
+            bundle["entry"].as_str().expect("entry").into(),
+        ],
+    );
+    catalog_codes.push(producer_gate(&bundle_check, &["ok"]));
+    evidence.push(bundle_check);
+
+    let all_inputs = models
+        .iter()
+        .flat_map(|(_, model)| strings(&model["inputs"]))
+        .chain(strings(&bundle["inputs"]))
+        .chain(mapping_digests.keys().cloned())
+        .collect::<Vec<_>>();
+    let source_bundle_digest =
+        if let Ok(digest) = framed_input_digest(&cwd, manifest_name, &all_inputs, None) {
+            json!(digest)
+        } else {
+            catalog_codes.push(2);
+            Value::Null
+        };
+    let catalog_exit = aggregate_exit(catalog_codes);
+    let comparison_exit = aggregate_exit(comparison_codes);
+    let exit_code = aggregate_exit([catalog_exit, comparison_exit]);
+    let producer = evidence
+        .iter()
+        .find(|row| row["phase"] == "check")
+        .map_or(Value::Null, |row| row["stdout_json"]["versions"].clone());
+    let mut stable = json!({
+        "schema_version": "fsl-design-family-report.v0",
+        "family_id": manifest["family_id"],
+        "result": if exit_code == 0 { "eligible" } else { "failed" },
+        "gates": {
+            "catalog_eligibility": if catalog_exit == 0 { "passed" } else { "failed" },
+            "pair_comparison": if comparison_exit == 0 { "passed" } else { "failed" },
+            "distinct_semantic_candidates": distinct_candidates,
+        },
+        "contract": stable_models.remove(0),
+        "variants": stable_models,
+        "refinements": stable_refinements,
+        "comparisons": stable_comparisons,
+        "warnings": warnings,
+        "digests": {
+            "source_bundle": source_bundle_digest,
+            "source_bundle_algorithm": "fsl-design-family-source-bundle-v0+sha256",
+            "mappings": mapping_digests,
+        },
+        "producer": producer,
+    });
+    let report_digest = stable_digest(&stable);
+    stable
+        .as_object_mut()
+        .expect("report object")
+        .insert("report_digest".to_owned(), json!(report_digest));
+    PrototypeReport {
+        stable,
+        evidence,
+        exit_code,
+    }
+}
+
+#[test]
+fn prototype_schema_is_closed_and_rejects_malformed_manifests() {
+    let mut family_ids = BTreeSet::new();
+    for family in FAMILIES {
+        let manifest = read_json(&fixture(family).join("manifest.json"));
+        assert_schema_valid(&manifest);
+        manifest_consistency(&manifest).expect("valid manifest");
+        assert!(
+            family_ids.insert(
+                manifest["family_id"]
+                    .as_str()
+                    .expect("family id")
+                    .to_owned()
+            )
+        );
+    }
+    let mut malformed = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    malformed
+        .as_object_mut()
+        .expect("object")
+        .insert("ranking".to_owned(), json!("best"));
+    assert!(!compiled_schema().is_valid(&malformed));
+    let malformed_report = run_family_value("order_processing", "inline.json", &malformed);
+    assert_eq!(malformed_report.exit_code, 2);
+    assert_eq!(
+        malformed_report.stable["error"]["kind"],
+        "manifest_contract"
+    );
+    assert!(malformed_report.evidence.is_empty());
+
+    let mut bad_reference = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    bad_reference["comparisons"][0]["old"] = json!("missing");
+    assert!(manifest_consistency(&bad_reference).is_err());
+    let bad_reference_report = run_family_value("order_processing", "inline.json", &bad_reference);
+    assert_eq!(bad_reference_report.exit_code, 2);
+
+    let mut incomplete_inputs = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    incomplete_inputs["variants"][0]["inputs"] = json!(["synchronous_refines_contract.fsl"]);
+    assert!(manifest_consistency(&incomplete_inputs).is_err());
+    let incomplete_report = run_family_value("order_processing", "inline.json", &incomplete_inputs);
+    assert_eq!(incomplete_report.exit_code, 2);
+
+    let mut self_comparison = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    self_comparison["comparisons"][0]["new"] = self_comparison["comparisons"][0]["old"].clone();
+    assert!(manifest_consistency(&self_comparison).is_err());
+
+    let mut no_comparisons = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    no_comparisons["comparisons"] = json!([]);
+    assert!(!compiled_schema().is_valid(&no_comparisons));
+
+    let mut unsupported_engine = read_json(&fixture(FAMILIES[0]).join("manifest.json"));
+    unsupported_engine["verification"]["engine"] = json!("induction");
+    assert!(!compiled_schema().is_valid(&unsupported_engine));
+}
+
+#[test]
+fn prototype_runs_three_families_with_deterministic_provenance() {
+    let mut report_digests = BTreeSet::new();
+    for family in FAMILIES {
+        let report = run_family(family);
+        assert_eq!(report.exit_code, 0);
+        assert_eq!(report.stable["result"], "eligible");
+        assert_eq!(report.stable["gates"]["catalog_eligibility"], "passed");
+        assert_eq!(report.stable["gates"]["pair_comparison"], "passed");
+        assert_eq!(report.stable["warnings"], json!([]));
+        assert_eq!(report.stable["variants"].as_array().map(Vec::len), Some(3));
+        for model in std::iter::once(&report.stable["contract"]).chain(
+            report.stable["variants"]
+                .as_array()
+                .expect("variants")
+                .iter(),
+        ) {
+            assert_eq!(model["verification"]["assurance"], "bounded");
+            assert_eq!(model["verification"]["completeness"], "bounded");
+            assert_eq!(model["verification"]["requested_engine"], "bmc");
+        }
+        assert!(
+            report.stable["comparisons"]
+                .as_array()
+                .expect("comparisons")
+                .iter()
+                .all(|comparison| comparison["scope_owner"] == "new"
+                    && comparison["mapping_direction"] == "new_to_old")
+        );
+        assert!(report.evidence.iter().all(|row| {
+            row.get("stdout_raw").and_then(Value::as_str).is_some()
+                && row.get("exit_code").and_then(Value::as_i64).is_some()
+        }));
+        let mut without_digest = report.stable.clone();
+        let declared = without_digest
+            .as_object_mut()
+            .expect("object")
+            .remove("report_digest")
+            .expect("digest");
+        assert_eq!(declared, stable_digest(&without_digest));
+        report_digests.insert(declared.as_str().expect("digest").to_owned());
+    }
+    assert_eq!(report_digests.len(), FAMILIES.len());
+}
+
+#[test]
+fn duplicate_semantic_candidates_warn_without_failing_eligibility() {
+    let candidates = json!([
+        {"id": "a", "semantic_digest": "sha256:same"},
+        {"id": "b", "semantic_digest": "sha256:same"},
+        {"id": "c", "semantic_digest": "sha256:other"}
+    ]);
+    let (distinct, warnings) =
+        semantic_digest_summary(candidates.as_array().expect("candidate array"));
+    assert_eq!(distinct, 2);
+    assert!(distinct >= 2, "A/A/B remains eligible");
+    assert_eq!(
+        warnings,
+        vec![json!({
+            "kind": "duplicate_semantic_digest",
+            "semantic_digest": "sha256:same",
+            "variants": ["a", "b"]
+        })]
+    );
+}
+
+#[test]
+fn negative_controls_reject_false_family_success() {
+    let cases = [
+        ("order_processing", "synchronous.fsl"),
+        ("concurrent_ownership", "shared_lock.fsl"),
+        ("persistence_model", "crud.fsl"),
+    ];
+    for (family, variant) in cases {
+        let output = run(
+            &fixture(family),
+            &[
+                "refine".into(),
+                variant.into(),
+                "contract.fsl".into(),
+                "negative_refinement.fsl".into(),
+                "--depth".into(),
+                "4".into(),
+            ],
+        );
+        assert_eq!(output.status.code(), Some(1));
+        let result = json_stdout(&output);
+        assert_eq!(result["result"], "refinement_failed");
+    }
+
+    let failed_report = run_family_manifest("order_processing", "negative_manifest.json");
+    assert_eq!(failed_report.exit_code, 1);
+    assert_eq!(failed_report.stable["result"], "failed");
+    assert_eq!(
+        failed_report.stable["gates"]["catalog_eligibility"],
+        "failed"
+    );
+    assert_eq!(failed_report.stable["gates"]["pair_comparison"], "passed");
+    assert_eq!(
+        failed_report.stable["variants"].as_array().map(Vec::len),
+        Some(3)
+    );
+    assert_eq!(
+        failed_report.stable["refinements"].as_array().map(Vec::len),
+        Some(3)
+    );
+    assert_eq!(failed_report.stable["refinements"][0]["status"], "failed");
+    assert!(failed_report.evidence.iter().any(|row| {
+        row["phase"] == "refine" && row["subject"] == "synchronous" && row["exit_code"] == 1
+    }));
+
+    let inline = run(
+        &repository_file("tests/fixtures/chain"),
+        &["check".into(), "requirements_broken_implements.fsl".into()],
+    );
+    assert_eq!(inline.status.code(), Some(0));
+    let inline_json = json_stdout(&inline);
+    assert_eq!(inline_json["implements"]["result"], "refinement_failed");
+    assert_eq!(nested_implements_gate(&inline_json), 1);
+    let nested_row = json!({
+        "phase": "check",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": inline_json,
+    });
+    assert_eq!(producer_gate(&nested_row, &["ok"]), 1);
+
+    assert_producer_contract_negative_controls();
+
+    assert_eq!(aggregate_exit([0, 1]), 1);
+    assert_eq!(aggregate_exit([1, 2]), 2);
+    assert_eq!(aggregate_exit([2, 3]), 3);
+    assert_eq!(aggregate_exit([0, 4]), 3);
+}
+
+fn assert_producer_contract_negative_controls() {
+    let non_json_failure = json!({
+        "exit_code": 1,
+        "json_parsed": false,
+        "stdout_json": null,
+    });
+    assert_eq!(producer_gate(&non_json_failure, &["ok"]), 3);
+    let unexpected_exit = json!({
+        "phase": "check",
+        "exit_code": 4,
+        "json_parsed": true,
+        "stdout_json": {"result": "ok", "versions": {}},
+    });
+    assert_eq!(producer_gate(&unexpected_exit, &["ok"]), 3);
+
+    let malformed_implements = json!({
+        "phase": "check",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "ok", "versions": {}, "implements": {}},
+    });
+    assert_eq!(producer_gate(&malformed_implements, &["ok"]), 2);
+    let unknown_implements = json!({
+        "phase": "check",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "ok", "versions": {}, "implements": {"result": "maybe"}},
+    });
+    assert_eq!(producer_gate(&unknown_implements, &["ok"]), 2);
+    let incomplete_verify = json!({
+        "phase": "verify",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "verified", "checked_to_depth": 4, "versions": {}},
+    });
+    assert_eq!(producer_gate(&incomplete_verify, &["verified"]), 2);
+    let reachable_failure = json!({
+        "phase": "verify",
+        "exit_code": 1,
+        "json_parsed": true,
+        "stdout_json": {
+            "result": "reachable_failed",
+            "completeness": "bounded",
+            "checked_to_depth": 4,
+            "versions": {},
+            "unreached": ["CanFinish"]
+        },
+    });
+    assert_eq!(producer_gate(&reachable_failure, &["verified"]), 1);
+    let incomplete_refine = json!({
+        "phase": "refine",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "refines", "impl": "I", "abs": "A"},
+    });
+    assert_eq!(producer_gate(&incomplete_refine, &["refines"]), 2);
+    let success_with_failure_exit = json!({
+        "phase": "comparison_mapping",
+        "exit_code": 1,
+        "json_parsed": true,
+        "stdout_json": {"result": "refines", "impl": "I", "abs": "A", "checked_to_depth": 4},
+    });
+    assert_eq!(producer_gate(&success_with_failure_exit, &["refines"]), 2);
+    let failure_with_success_exit = json!({
+        "phase": "comparison_mapping",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {
+            "result": "refinement_failed",
+            "impl": "I",
+            "abs": "A",
+            "kind": "stutter_changed_abs",
+            "violated_at_step": 1
+        },
+    });
+    assert_eq!(producer_gate(&failure_with_success_exit, &["refines"]), 2);
+    let incomplete_claims = json!({
+        "phase": "semantic_digest",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "requirement_claims", "spec": {"name": "S"}},
+    });
+    assert_eq!(
+        producer_gate(&incomplete_claims, &["requirement_claims"]),
+        2
+    );
+    let incomplete_diff = json!({
+        "phase": "diff",
+        "exit_code": 0,
+        "json_parsed": true,
+        "stdout_json": {"result": "semantic_diff", "old": {"spec": "O"}, "new": {"spec": "N"}},
+    });
+    assert_eq!(producer_gate(&incomplete_diff, &["semantic_diff"]), 2);
+}
+
+#[test]
+fn dependency_drift_and_comparison_orientation_remain_explicit() {
+    for family in FAMILIES {
+        let cwd = fixture(family);
+        let manifest = read_json(&cwd.join("manifest.json"));
+        let bundle = &manifest["bundle_control"];
+        let inputs = strings(&bundle["inputs"]);
+        let baseline =
+            framed_input_digest(&cwd, "manifest.json", &inputs, None).expect("baseline digest");
+        let dependency = bundle["dependency"].as_str().expect("dependency");
+        let mut changed = std::fs::read(cwd.join(dependency)).expect("dependency bytes");
+        changed.extend(b"\n// dependency-only drift control\n");
+        let drifted =
+            framed_input_digest(&cwd, "manifest.json", &inputs, Some((dependency, &changed)))
+                .expect("drift digest");
+        assert_ne!(baseline, drifted);
+    }
+
+    let cwd = fixture("order_processing");
+    let forward = run(
+        &cwd,
+        &[
+            "diff".into(),
+            "synchronous.fsl".into(),
+            "event_driven.fsl".into(),
+            "--depth".into(),
+            "1".into(),
+            "--mapping".into(),
+            "event_to_synchronous.fsl".into(),
+        ],
+    );
+    let reversed = run(
+        &cwd,
+        &[
+            "diff".into(),
+            "event_driven.fsl".into(),
+            "synchronous.fsl".into(),
+            "--depth".into(),
+            "1".into(),
+            "--mapping".into(),
+            "event_to_synchronous.fsl".into(),
+        ],
+    );
+    assert!(forward.status.success() && reversed.status.success());
+    let forward = json_stdout(&forward);
+    let reversed = json_stdout(&reversed);
+    assert_eq!(forward["bounded"]["completeness"], "bounded");
+    assert_eq!(reversed["bounded"]["completeness"], "bounded");
+    assert_eq!(forward["old"]["spec"], "SynchronousOrder");
+    assert_eq!(forward["new"]["spec"], "EventDrivenOrder");
+    assert_eq!(reversed["old"]["spec"], "EventDrivenOrder");
+    assert_eq!(reversed["new"]["spec"], "SynchronousOrder");
+    assert_ne!(forward["directions"], reversed["directions"]);
+}

--- a/rust/fslc/tests/native_integration.rs
+++ b/rust/fslc/tests/native_integration.rs
@@ -346,7 +346,7 @@ fn published_schema_inventory_is_complete_and_parseable() {
     let mut schemas = Vec::new();
     collect_schemas(&root().join("schemas/fslc"), &mut schemas);
     schemas.sort();
-    assert_eq!(schemas.len(), 41, "published schema inventory changed");
+    assert_eq!(schemas.len(), 42, "published schema inventory changed");
     let mut ids = BTreeSet::new();
     for path in schemas {
         let schema: Value =

--- a/schemas/fslc/design-family/design-family.v0.schema.json
+++ b/schemas/fslc/design-family/design-family.v0.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fsl.dev/schemas/fslc/design-family/design-family.v0.schema.json",
+  "title": "FSL design family Phase 0 manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "family_id", "contract", "verification", "variants", "comparisons", "bundle_control"],
+  "properties": {
+    "schema_version": { "const": "fsl-design-family.v0" },
+    "family_id": { "$ref": "#/$defs/id" },
+    "contract": { "$ref": "#/$defs/model" },
+    "verification": { "$ref": "#/$defs/verification" },
+    "variants": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/variant" }
+    },
+    "comparisons": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/comparison" }
+    },
+    "bundle_control": { "$ref": "#/$defs/bundle_control" }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_][A-Za-z0-9_./-]*$",
+      "not": { "pattern": "(^|/)\\.\\.(/|$)" }
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/path" }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "symbol", "inputs"],
+      "properties": {
+        "source": { "$ref": "#/$defs/path" },
+        "symbol": { "type": "string", "minLength": 1 },
+        "inputs": { "$ref": "#/$defs/inputs" }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["engine", "depth"],
+      "properties": {
+        "engine": { "const": "bmc" },
+        "depth": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "symbol", "refinement", "inputs"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "source": { "$ref": "#/$defs/path" },
+        "symbol": { "type": "string", "minLength": 1 },
+        "refinement": { "$ref": "#/$defs/path" },
+        "inputs": { "$ref": "#/$defs/inputs" }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "old", "new", "scope_owner", "depth", "mapping", "mapping_direction"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "old": { "$ref": "#/$defs/id" },
+        "new": { "$ref": "#/$defs/id" },
+        "scope_owner": { "const": "new" },
+        "depth": { "type": "integer", "minimum": 1 },
+        "mapping": { "$ref": "#/$defs/path" },
+        "mapping_direction": { "const": "new_to_old" }
+      }
+    },
+    "bundle_control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entry", "dependency", "inputs"],
+      "properties": {
+        "entry": { "$ref": "#/$defs/path" },
+        "dependency": { "$ref": "#/$defs/path" },
+        "inputs": { "$ref": "#/$defs/inputs" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Complete the evidence-gated Phase 0 spike for comparing multiple design variants against one contract.
- Accept an agent/workflow-only sidecar approach while explicitly declining new FSL grammar, Public Kernel, runtime, solver, verifier, or product CLI semantics.
- Closes #427.

## Changes
- Publish the closed BMC-only fsl-design-family.v0 manifest schema and update the schema inventory anchor.
- Add three maintained families with three variants each, contract refinements, directed comparison mappings, bundle-dependency probes, and negative controls.
- Add a test-owned native orchestrator for check, verify, refine, and diff with raw producer evidence, stable report digests, source/mapping provenance, duplicate-digest warnings, and fail-closed exit/envelope checks.
- Record the Gate A/Gate B decision, option comparison, provenance gaps, reevaluation triggers, and leading-indicator handoff gap in the accepted design note and changelog.

## Verification
- cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test issue_427_design_family --locked: 5 passed
- cargo clippy --manifest-path rust/Cargo.toml -p fslc-rust --test issue_427_design_family --locked -- -D warnings: passed
- cargo fmt --manifest-path rust/Cargo.toml --all -- --check: passed
- ./tools/check-native-integration.sh: passed, including native/browser Z3 and 351 Worker/native parity cases
- Independent review: no actionable findings after fixes
- implementation-local-optima-audit: completed; digest ownership and manifest/input consistency were consolidated, while the exact transitive-input limitation remains explicit

## Risk / Review Notes
- This PR adds no product command or language semantics; the orchestration remains test-owned Phase 0 evidence.
- Source-bundle completeness is limited to the closed manifest because no exact public transitive-input enumerator exists.
- This PR is stacked on #463 because the forbidden-replay completeness fix from #460 is a prerequisite.

## Follow-Up / Post-Merge Checks
- Merge #463 first, then retarget this PR to main before merging.
- Reevaluate a thin CLI only after repeated real-family use provides leading-indicator evidence and closes the transitive-input API gap.