### PR TITLE
fix(tests): restore the injected-corpus negative-control matrix on the native surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   other testgen target already emitted, restoring byte-identity with the
   frozen Python reference and giving the generated conformance harness a real
   negative control against a guard-weakened implementation (#471).
+- The `examples/gallery/injected/` negative-control detector matrix and its
+  primary/blind calibration are now measured on the authoritative native CLI,
+  not only the frozen Python reference: 17 injected specs and the
+  `agentic_rag` `backported_constraints_slice.fsl` mutation slice carried a
+  `requirement` annotation text conflict between their outer block and an
+  inner legacy tag (checked-model error since #237) that the corpus never
+  followed; the redundant inner tag is removed and the outer block's already-
+  correct requirement text is the sole source of truth. Adds
+  `rust/fslc/tests/injection_detector_matrix.rs` (the native primary/blind
+  matrix, run by `tools/check-native-integration.sh`) and
+  `rust/fslc/tests/corpus_check_sweep.rs` (an exhaustive `specs/`+`examples/`
+  `check` sweep closing the gap left by `rust/fsl-lsp/tests/corpus.rs`, which
+  never builds a checked model) (#485).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   exactly instead of silently running the forall as a last-write-wins loop
   and returning `result:"proved"` / exit 0 for a spec with no valid initial
   state (#480).
+- `fslc testgen`'s `pytest` target now emits the `forbidden`-scenario rejection
+  assertion (`result = adapter.step(...)` / `_assert_rejected(...)`) that every
+  other testgen target already emitted, restoring byte-identity with the
+  frozen Python reference and giving the generated conformance harness a real
+  negative control against a guard-weakened implementation (#471).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -66,6 +66,18 @@ mutation is meaningful as a delta from an accepted baseline, and
 acceptance/forbidden traces provide the independent channel for boundary or guard
 drift. No single green detector establishes intent fidelity.
 
+This calibration is measured on the authoritative native surface, not only the
+frozen Python reference (issue #485): `rust/fslc/tests/injection_detector_matrix.rs`
+runs the same primary/blind matrix against the native `fslc` binary and is part
+of the Rust CI-equivalent gate (`tools/check-native-integration.sh`, which does
+not execute Python — AGENTS.md). `tests/test_injection_bench.py` measures the
+same native binary by default too (`FSLC_BENCH_CLI=python` switches back to the
+frozen reference); it regenerates the committed `examples/gallery/injected/MATRIX.json`
+evidence artifact. A detector gap that is native-only and already filed (the
+`unreachable-antecedent` lane's `vacuity` primary detector against a
+`forall`-quantified implication, issue #486) is an explicit, documented
+exclusion in both — never a silent pass.
+
 ## Pipeline stages and failure semantics — `tests/test_dialect_conformance.py`
 
 One parametrized test per class; every obligation is an `assert`, never a skip.
@@ -113,10 +125,26 @@ with pinning and the covered files the whole harness projects to ≈ 3 min
 single-threaded. Bounds are explicit constants (`depth` per dialect,
 `EXPR_STATES`) — raising coverage is a registry diff, not a hidden loop change.
 
-This harness belongs to the frozen Python reference implementation and is no
-longer run by `.github/workflows/ci.yml`. It remains available for manual
-historical/reference checks; active CI coverage is provided by the Rust
-workspace tests and WASM browser validation.
+This harness — the full dual-evaluator pipeline (Monitor load, BFS/expression
+agreement, verdict agreement) — belongs to the frozen Python reference
+implementation and is no longer run by `.github/workflows/ci.yml`. It remains
+available for manual historical/reference checks; active CI coverage is
+provided by the Rust workspace tests and WASM browser validation.
+
+Its narrower structural obligation — every `.fsl` under `specs/`/`examples/`
+either `check`s cleanly or is a declared/excluded error, so nothing rots
+silently the way issue #485's 18 files did — has a native equivalent that
+*is* active CI: `rust/fslc/tests/corpus_check_sweep.rs`. Unlike
+`rust/fsl-lsp/tests/corpus.rs` (parse + index only, never builds a checked
+model), this sweep runs `fslc check` on every file and requires each one to
+either succeed, declare `// expected-result: error` for a `check`-targeted
+invocation, be a `refinement`-dialect file (structurally out of scope: a
+mapping file has no `state` block, so `fslc check` always reports "spec has
+no state block" regardless of whether the mapping is sound — whether it is
+actually exercised by `fslc refine` is a separate claim tracked by #483, not
+asserted here), or the injected detector corpus (its own matrix, above), or
+carry a reasoned exclusion naming the test or issue that actually owns its
+expected behavior.
 
 The external-compiler conformance surface introduced by issue #208 is separate
 from this historical corpus gate. Native `fslc conformance` emits versioned,

--- a/examples/agentic_rag/mutation_slices/README.md
+++ b/examples/agentic_rag/mutation_slices/README.md
@@ -47,14 +47,20 @@ fslc mutate examples/agentic_rag/mutation_slices/backported_constraints_slice.fs
 
 ## Observed Results
 
-2026-06-20時点の手元確認結果。
+2026-07-25時点、権威実装（native `fslc`、`rust/target/debug/fslc`）での実測値
+（issue #485。それ以前の版は frozen Python `python -m fslc` の実測値で、
+`backported_constraints_slice.fsl`はnativeでは`check`が
+requirement注釈のtext衝突でexit 2になり、この表自体が再現不能だった。同不具合は
+`REQ-3`/`REQ-4`/`REQ-5`ブロック内の重複legacy注釈テキストを削除して修正済み）。
+mutation engineの列挙順・演算子集合がPython参照実装とnativeで異なるため、
+killed/survivedの絶対数はPython実測値と一致しない。
 
 | Slice | Verify | Mutate summary |
 |---|---|---|
-| `answer_safety_slice.fsl` | `verified` at depth 6 | `80 total / 58 killed / 22 survived` |
-| `tool_approval_slice.fsl` | `verified` at depth 7 | `100 total / 63 killed / 37 survived` |
-| `retry_liveness_slice.fsl` | `verified` at depth 8 | `88 total / 67 killed / 21 survived` |
-| `backported_constraints_slice.fsl` | `verified` at depth 7 | `180 total / 160 killed / 20 survived` |
+| `answer_safety_slice.fsl` | `verified` at depth 6 | `80 total / 64 killed / 16 survived` |
+| `tool_approval_slice.fsl` | `verified` at depth 7 | `100 total / 67 killed / 33 survived` |
+| `retry_liveness_slice.fsl` | `verified` at depth 8 | `95 total / 73 killed / 22 survived` |
+| `backported_constraints_slice.fsl` | `verified` at depth 7 | `180 total / 161 killed / 19 survived` |
 
 `backported_constraints_slice.fsl`では、以下の本体へ戻した制約が直接killしている。
 
@@ -64,9 +70,9 @@ fslc mutate examples/agentic_rag/mutation_slices/backported_constraints_slice.fs
 | `DraftedHasEvidenceAndCitation` | 8 |
 | `EvidenceBadMeansNoCitation` | 6 |
 | `GuardFailedMeansFailedGuard` | 6 |
-| `ToolApprovalMeansRequested` | 6 |
-| `ToolApprovedMeansApproved` | 6 |
-| `ExecutionComesFromApprovedStage` | 5 |
+| `ToolApprovalMeansRequested` | 5 |
+| `ToolApprovedMeansApproved` | 5 |
+| `ExecutionComesFromApprovedStage` | 4 |
 | `RetryConsumesOneBudget` | 4 |
 
 ## Reading Notes

--- a/examples/agentic_rag/mutation_slices/SURVIVOR_REVIEW.md
+++ b/examples/agentic_rag/mutation_slices/SURVIVOR_REVIEW.md
@@ -1,6 +1,7 @@
 # Agentic RAG mutation survivor review
 
-2026-06-20時点の`mutation_slices/`に対するsurvivor分類。
+2026-06-20時点の`mutation_slices/`に対するsurvivor分類（分類自体は実測値の
+CLI に依存しないため据え置き。実測値の再取得は「反映後の確認」を参照）。
 
 このメモは、`fslc mutate`のsurvivorをそのまま「失敗」と扱わず、本体requirementsへ戻すべき制約だけを選ぶためのレビュー台帳である。
 
@@ -63,14 +64,24 @@ denial reasonを区別したくなったら、`reason` enumを追加する別設
 
 ## 反映後の確認
 
+2026-07-25時点、権威実装（native `fslc`、issue #485）での再実測。以前の版は
+frozen Python実測値で、`backported_constraints_slice.fsl`の3行はnativeでは
+`check`がrequirement注釈のtext衝突でexit 2になり再現不能だった
+（`README.md`参照、修正済み）。
+
 - `fslc check examples/agentic_rag/agentic_rag_requirements.fsl`: `ok`
 - `fslc verify examples/agentic_rag/agentic_rag_requirements.fsl --depth 8 --deadlock ignore --exclude-property RequestEventuallyHandled`: `verified`
 - `fslc verify examples/agentic_rag/agentic_rag_requirements.fsl --depth 8 --deadlock ignore --property RequestEventuallyHandled`: `verified`
-- `fslc refine examples/agentic_rag/agentic_rag_requirements.fsl examples/agentic_rag/agentic_rag_business.fsl examples/agentic_rag/agentic_rag_requirements_refines_business.fsl --depth 7`: `refines`
-- `fslc refine examples/agentic_rag/agentic_rag_design.fsl examples/agentic_rag/agentic_rag_requirements.fsl examples/agentic_rag/agentic_rag_design_refines_requirements.fsl --depth 6`: `refines`
+- `fslc refine examples/agentic_rag/agentic_rag_requirements.fsl examples/agentic_rag/agentic_rag_business.fsl examples/agentic_rag/agentic_rag_requirements_refines_business.fsl --depth 7`: **native では `error`**
+  (`kind:"semantics"`, `"indexed progress map for 'req_stage' is not implemented"`) —
+  既知・別issue #483（indexed map と preserve progress の併用が native未実装）。
+  #485の範囲外、ここでは未着手。
+- `fslc refine examples/agentic_rag/agentic_rag_design.fsl examples/agentic_rag/agentic_rag_requirements.fsl examples/agentic_rag/agentic_rag_design_refines_requirements.fsl --depth 6`: **native では `error`**
+  (`kind:"semantics"`, `"indexed progress map for 'req' is not implemented"`) — 同じく issue #483。
 - `fslc check examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl`: `ok`
 - `fslc verify examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl --depth 7 --deadlock ignore`: `verified`
-- `fslc mutate examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl --depth 7 --by-requirement --max-mutants 180`: `180 total / 160 killed / 20 survived`
+- `fslc mutate examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl --depth 7 --by-requirement --max-mutants 180`: `180 total / 161 killed / 19 survived`
+  (mutation engineの列挙順・演算子集合がPython参照実装と異なるため、絶対数はPython実測値と一致しない)
 
 `backported_constraints_slice.fsl`で直接killした本体反映済み制約:
 
@@ -80,9 +91,9 @@ denial reasonを区別したくなったら、`reason` enumを追加する別設
 | `DraftedHasEvidenceAndCitation` | 8 |
 | `EvidenceBadMeansNoCitation` | 6 |
 | `GuardFailedMeansFailedGuard` | 6 |
-| `ToolApprovalMeansRequested` | 6 |
-| `ToolApprovedMeansApproved` | 6 |
-| `ExecutionComesFromApprovedStage` | 5 |
+| `ToolApprovalMeansRequested` | 5 |
+| `ToolApprovedMeansApproved` | 5 |
+| `ExecutionComesFromApprovedStage` | 4 |
 | `RetryConsumesOneBudget` | 4 |
 
 ## 次に見る候補

--- a/examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl
+++ b/examples/agentic_rag/mutation_slices/backported_constraints_slice.fsl
@@ -115,7 +115,7 @@ requirements AgenticRagBackportedConstraintsSlice {
       req[r].st = HumanReview
     }
 
-    invariant EvidenceReadyHasEvidenceAndCitation "REQ-3: EvidenceReadyは十分な証拠と許可済み引用を表す" {
+    invariant EvidenceReadyHasEvidenceAndCitation {
       forall r: Req {
         req[r].st == EvidenceReady => (
           req[r].evidence == Adequate and req[r].citation_ok
@@ -123,7 +123,7 @@ requirements AgenticRagBackportedConstraintsSlice {
       }
     }
 
-    invariant DraftedHasEvidenceAndCitation "REQ-3: Draftedは回答可能な証拠と引用を保持している" {
+    invariant DraftedHasEvidenceAndCitation {
       forall r: Req {
         req[r].st == Drafted => (
           req[r].evidence == Adequate and req[r].citation_ok
@@ -131,7 +131,7 @@ requirements AgenticRagBackportedConstraintsSlice {
       }
     }
 
-    invariant EvidenceBadMeansNoCitation "REQ-3: EvidenceBadは不十分な証拠と引用不可を表す" {
+    invariant EvidenceBadMeansNoCitation {
       forall r: Req {
         req[r].st == EvidenceBad => (
           req[r].evidence == Inadequate and not req[r].citation_ok
@@ -139,7 +139,7 @@ requirements AgenticRagBackportedConstraintsSlice {
       }
     }
 
-    trans RetryConsumesOneBudget "REQ-3: retry時はbudgetを1だけ消費する" {
+    trans RetryConsumesOneBudget {
       forall r: Req {
         (old(req[r].st) == EvidenceBad and req[r].st == Retrieving) => (
           req[r].retry == old(req[r].retry) - 1
@@ -164,7 +164,7 @@ requirements AgenticRagBackportedConstraintsSlice {
       req[r].guard = Failed
     }
 
-    invariant GuardFailedMeansFailedGuard "REQ-4: GuardFailedは出力ガードレール失敗を表す" {
+    invariant GuardFailedMeansFailedGuard {
       forall r: Req {
         req[r].st == GuardFailed => req[r].guard == Failed
       }
@@ -196,19 +196,19 @@ requirements AgenticRagBackportedConstraintsSlice {
       req[r].st = ActionExecuted
     }
 
-    invariant ToolApprovalMeansRequested "REQ-5: ToolApprovalはRequested承認状態を表す" {
+    invariant ToolApprovalMeansRequested {
       forall r: Req {
         req[r].st == ToolApproval => req[r].approval == Requested
       }
     }
 
-    invariant ToolApprovedMeansApproved "REQ-5: ToolApprovedはApproved承認状態を表す" {
+    invariant ToolApprovedMeansApproved {
       forall r: Req {
         req[r].st == ToolApproved => req[r].approval == Approved
       }
     }
 
-    trans ExecutionComesFromApprovedStage "REQ-5: ActionExecutedはToolApprovedからだけ入る" {
+    trans ExecutionComesFromApprovedStage {
       forall r: Req {
         req[r].st == ActionExecuted => (
           old(req[r].st) == ToolApproved or old(req[r].st) == ActionExecuted

--- a/examples/gallery/injected/MATRIX.json
+++ b/examples/gallery/injected/MATRIX.json
@@ -478,8 +478,8 @@
           "status": "not-caught"
         },
         "vacuity": {
-          "signal": "vacuous_implication:ImpossibleDraftShipment",
-          "status": "caught"
+          "signal": "verified",
+          "status": "not-caught"
         },
         "verify": {
           "signal": "verified",
@@ -724,8 +724,8 @@
           "status": "not-caught"
         },
         "vacuity": {
-          "signal": "vacuous_implication:ImpossibleNewPaid",
-          "status": "caught"
+          "signal": "verified",
+          "status": "not-caught"
         },
         "verify": {
           "signal": "verified",
@@ -882,12 +882,26 @@
         "not-caught": 3
       },
       "vacuity": {
-        "caught": 3
+        "caught": 1,
+        "not-caught": 2
       },
       "verify": {
         "not-caught": 3
       }
     }
   },
-  "surprises": []
+  "surprises": [
+    {
+      "actual": "not-caught",
+      "detector": "vacuity",
+      "file": "examples/gallery/injected/order_workflow__unreachable_antecedent.fsl",
+      "kind": "missing-primary"
+    },
+    {
+      "actual": "not-caught",
+      "detector": "vacuity",
+      "file": "examples/gallery/injected/return_system__unreachable_antecedent.fsl",
+      "kind": "missing-primary"
+    }
+  ]
 }

--- a/examples/gallery/injected/bank__boundary_flip.fsl
+++ b/examples/gallery/injected/bank__boundary_flip.fsl
@@ -15,7 +15,7 @@ requirements BankBoundaryFlipInjected {
     }
   }
   requirement BANK-WITHDRAW "withdrawals may use the full available balance" {
-    action withdraw(a: Amount) "BANK-WITHDRAW: withdrawing the exact balance is allowed" {
+    action withdraw(a: Amount) {
       requires a > 0
       requires balance > a
       balance = balance - a

--- a/examples/gallery/injected/bank__guard_weakening.fsl
+++ b/examples/gallery/injected/bank__guard_weakening.fsl
@@ -15,7 +15,7 @@ requirements BankGuardWeakeningInjected {
     }
   }
   requirement BANK-WITHDRAW "withdrawals require available balance" {
-    action withdraw(a: Amount) "BANK-WITHDRAW: overdraft guard is weakened" {
+    action withdraw(a: Amount) {
       requires a > 0
       requires balance >= a - 1
       balance = balance - a

--- a/examples/gallery/injected/bank__over_strengthened_guard.fsl
+++ b/examples/gallery/injected/bank__over_strengthened_guard.fsl
@@ -9,7 +9,7 @@ requirements BankOverStrengthenedGuardInjected {
   init { balance = 0 }
 
   requirement BANK-DEPOSIT "positive deposits increase balance" {
-    action deposit(a: Amount) "BANK-DEPOSIT: impossible over-strengthened guard" {
+    action deposit(a: Amount) {
       requires a > 3
       balance = balance + a
     }

--- a/examples/gallery/injected/order_workflow__boundary_flip.fsl
+++ b/examples/gallery/injected/order_workflow__boundary_flip.fsl
@@ -12,7 +12,7 @@ requirements OrderBoundaryFlipInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed with quantity at the minimum boundary" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: boundary flipped from q >= 1 to q > 1" {
+    action place(o: OrderId, q: Qty) {
       requires orders[o].status == Draft
       requires q > 1
       orders[o].status = Placed

--- a/examples/gallery/injected/order_workflow__fabricated_constraint.fsl
+++ b/examples/gallery/injected/order_workflow__fabricated_constraint.fsl
@@ -12,7 +12,7 @@ requirements OrderFabricatedConstraintInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
+    action place(o: OrderId, q: Qty) { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
   }
   requirement OR-PAY "placed orders can be paid" {
     action pay(o: OrderId) "OR-PAY: placed orders can be paid" { requires orders[o].status == Placed orders[o].status = Paid revenue = revenue + orders[o].qty }

--- a/examples/gallery/injected/order_workflow__guard_weakening.fsl
+++ b/examples/gallery/injected/order_workflow__guard_weakening.fsl
@@ -12,7 +12,7 @@ requirements OrderGuardWeakeningInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
+    action place(o: OrderId, q: Qty) { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
   }
   requirement OR-PAY "placed orders can be paid" {
     action pay(o: OrderId) "OR-PAY: placed orders can be paid" { requires orders[o].status == Placed orders[o].status = Paid revenue = revenue + orders[o].qty }
@@ -21,7 +21,7 @@ requirements OrderGuardWeakeningInjected {
     action ship(o: OrderId) "OR-SHIP: paid orders can be shipped" { requires orders[o].status == Paid orders[o].status = Shipped shipped = shipped.add(o) }
   }
   requirement OR-CANCEL "only placed or paid orders can be cancelled" {
-    action cancel(o: OrderId) "OR-CANCEL: weakened to allow shipped cancellation" {
+    action cancel(o: OrderId) {
       requires orders[o].status == Placed or orders[o].status == Paid or orders[o].status == Shipped
       if orders[o].status == Paid { revenue = revenue - orders[o].qty }
       orders[o].status = Cancelled

--- a/examples/gallery/injected/order_workflow__invariant_weakening.fsl
+++ b/examples/gallery/injected/order_workflow__invariant_weakening.fsl
@@ -12,7 +12,7 @@ requirements OrderInvariantWeakeningInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
+    action place(o: OrderId, q: Qty) { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
   }
   requirement OR-PAY "placed orders can be paid" {
     action pay(o: OrderId) "OR-PAY: placed orders can be paid" { requires orders[o].status == Placed orders[o].status = Paid revenue = revenue + orders[o].qty }

--- a/examples/gallery/injected/order_workflow__omission.fsl
+++ b/examples/gallery/injected/order_workflow__omission.fsl
@@ -16,7 +16,7 @@ requirements OrderOmissionInjected {
   }
 
   requirement OR-PLACE "orders can be placed with a positive quantity" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" {
+    action place(o: OrderId, q: Qty) {
       requires orders[o].status == Draft
       requires q >= 1
       orders[o].status = Placed

--- a/examples/gallery/injected/order_workflow__over_strengthened_guard.fsl
+++ b/examples/gallery/injected/order_workflow__over_strengthened_guard.fsl
@@ -12,10 +12,10 @@ requirements OrderOverStrengthenedGuardInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
+    action place(o: OrderId, q: Qty) { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
   }
   requirement OR-PAY "placed orders can be paid" {
-    action pay(o: OrderId) "OR-PAY: impossible over-strengthened guard" {
+    action pay(o: OrderId) {
       requires orders[o].status == Shipped
       orders[o].status = Paid
       revenue = revenue + orders[o].qty

--- a/examples/gallery/injected/order_workflow__unreachable_antecedent.fsl
+++ b/examples/gallery/injected/order_workflow__unreachable_antecedent.fsl
@@ -12,7 +12,7 @@ requirements OrderUnreachableAntecedentInjected {
   init { forall o: OrderId { orders[o] = Order { status: Draft, qty: 0 } } shipped = Set {} revenue = 0 }
 
   requirement OR-PLACE "orders can be placed" {
-    action place(o: OrderId, q: Qty) "OR-PLACE: place positive quantity" { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
+    action place(o: OrderId, q: Qty) { requires orders[o].status == Draft requires q >= 1 orders[o].status = Placed orders[o].qty = q }
   }
   requirement OR-PAY "placed orders can be paid" {
     action pay(o: OrderId) "OR-PAY: placed orders can be paid" { requires orders[o].status == Placed orders[o].status = Paid revenue = revenue + orders[o].qty }

--- a/examples/gallery/injected/return_system__boundary_flip.fsl
+++ b/examples/gallery/injected/return_system__boundary_flip.fsl
@@ -13,7 +13,7 @@ requirements ReturnBoundaryFlipInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: boundary flipped from a <= limit to a < limit" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a < AUTO_LIMIT {
@@ -24,7 +24,7 @@ requirements ReturnBoundaryFlipInjected {
     }
   }
   requirement RET-PAY "approved returns can be paid" {
-    action pay(c: CaseId) "RET-PAY: pay approved return" {
+    action pay(c: CaseId) {
       requires sys[c].st == AutoApproved or sys[c].st == MgrApproved
       sys[c].st = Paid
       paid_count = paid_count + 1

--- a/examples/gallery/injected/return_system__fabricated_constraint.fsl
+++ b/examples/gallery/injected/return_system__fabricated_constraint.fsl
@@ -13,7 +13,7 @@ requirements ReturnFabricatedConstraintInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT { sys[c] = RCase { st: AutoApproved, amount: a } } else { sys[c] = RCase { st: MgrQueue, amount: a } }

--- a/examples/gallery/injected/return_system__guard_weakening.fsl
+++ b/examples/gallery/injected/return_system__guard_weakening.fsl
@@ -13,14 +13,14 @@ requirements ReturnGuardWeakeningInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT { sys[c] = RCase { st: AutoApproved, amount: a } } else { sys[c] = RCase { st: MgrQueue, amount: a } }
     }
   }
   requirement RET-PAY "approved returns can be paid" {
-    action pay(c: CaseId) "RET-PAY: weakened to pay manager-queue returns" {
+    action pay(c: CaseId) {
       requires sys[c].st == AutoApproved or sys[c].st == MgrApproved or sys[c].st == MgrQueue
       sys[c].st = Paid
       paid_count = paid_count + 1

--- a/examples/gallery/injected/return_system__invariant_weakening.fsl
+++ b/examples/gallery/injected/return_system__invariant_weakening.fsl
@@ -13,18 +13,18 @@ requirements ReturnInvariantWeakeningInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT { sys[c] = RCase { st: AutoApproved, amount: a } } else { sys[c] = RCase { st: MgrQueue, amount: a } }
     }
   }
   requirement RET-MGR "manager decides returns above the threshold" {
-    action mgr_approve(c: CaseId) "RET-MGR: approve large return" { requires sys[c].st == MgrQueue sys[c].st = MgrApproved }
-    action mgr_reject(c: CaseId) "RET-MGR: reject large return" { requires sys[c].st == MgrQueue sys[c].st = MgrRejected }
+    action mgr_approve(c: CaseId) { requires sys[c].st == MgrQueue sys[c].st = MgrApproved }
+    action mgr_reject(c: CaseId) { requires sys[c].st == MgrQueue sys[c].st = MgrRejected }
   }
   requirement RET-PAY "approved returns can be paid" {
-    action pay(c: CaseId) "RET-PAY: pay approved return" {
+    action pay(c: CaseId) {
       requires sys[c].st == AutoApproved or sys[c].st == MgrApproved
       sys[c].st = Paid
       paid_count = paid_count + 1

--- a/examples/gallery/injected/return_system__omission.fsl
+++ b/examples/gallery/injected/return_system__omission.fsl
@@ -13,7 +13,7 @@ requirements ReturnOmissionInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT {
@@ -24,7 +24,7 @@ requirements ReturnOmissionInjected {
     }
   }
   requirement RET-MGR "manager decides returns above the threshold" {
-    action mgr_approve(c: CaseId) "RET-MGR: approve large return" { requires sys[c].st == MgrQueue sys[c].st = MgrApproved }
-    action mgr_reject(c: CaseId) "RET-MGR: reject large return" { requires sys[c].st == MgrQueue sys[c].st = MgrRejected }
+    action mgr_approve(c: CaseId) { requires sys[c].st == MgrQueue sys[c].st = MgrApproved }
+    action mgr_reject(c: CaseId) { requires sys[c].st == MgrQueue sys[c].st = MgrRejected }
   }
 }

--- a/examples/gallery/injected/return_system__over_strengthened_guard.fsl
+++ b/examples/gallery/injected/return_system__over_strengthened_guard.fsl
@@ -13,14 +13,14 @@ requirements ReturnOverStrengthenedGuardInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT { sys[c] = RCase { st: AutoApproved, amount: a } } else { sys[c] = RCase { st: MgrQueue, amount: a } }
     }
   }
   requirement RET-PAY "approved returns can be paid" {
-    action pay(c: CaseId) "RET-PAY: impossible over-strengthened guard" {
+    action pay(c: CaseId) {
       requires sys[c].st == Paid
       sys[c].st = Paid
       paid_count = paid_count + 1

--- a/examples/gallery/injected/return_system__unreachable_antecedent.fsl
+++ b/examples/gallery/injected/return_system__unreachable_antecedent.fsl
@@ -13,14 +13,14 @@ requirements ReturnUnreachableAntecedentInjected {
   init { forall c: CaseId { sys[c] = RCase { st: New, amount: 0 } } paid_count = 0 }
 
   requirement RET-SUBMIT "threshold-or-below returns are auto-approved" {
-    action submit(c: CaseId, a: Amount) "RET-SUBMIT: submit return" {
+    action submit(c: CaseId, a: Amount) {
       requires sys[c].st == New
       requires a > 0
       if a <= AUTO_LIMIT { sys[c] = RCase { st: AutoApproved, amount: a } } else { sys[c] = RCase { st: MgrQueue, amount: a } }
     }
   }
   requirement RET-PAY "approved returns can be paid" {
-    action pay(c: CaseId) "RET-PAY: pay approved return" {
+    action pay(c: CaseId) {
       requires sys[c].st == AutoApproved or sys[c].st == MgrApproved
       sys[c].st = Paid
       paid_count = paid_count + 1

--- a/rust/fsl-tools/src/testgen.rs
+++ b/rust/fsl-tools/src/testgen.rs
@@ -741,6 +741,27 @@ def _assert_rejected(result, expected_kind):
                 python_literal(&expected, &state_order)
             );
         }
+        if scenario["kind"].as_str() == Some("forbidden") && scenario["forbidden_step"].is_object()
+        {
+            let step = &scenario["forbidden_step"];
+            let action = step["action"].as_str().unwrap_or_default();
+            let param_order = input
+                .actions
+                .iter()
+                .find(|item| item.name == action)
+                .map_or(&[][..], |item| item.params.as_slice());
+            let _ = writeln!(
+                text,
+                "    result = adapter.step({}, {})",
+                python_string(action),
+                python_literal(&step["params"], param_order)
+            );
+            let _ = writeln!(
+                text,
+                "    _assert_rejected(result, {})",
+                python_literal(&scenario["rejected_by"], &[])
+            );
+        }
     }
     text.push_str(
         r#"

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Exhaustive native `check` sweep over `specs/` + `examples/` (issue #485
+//! item 5). `rust/fsl-lsp/tests/corpus.rs` only parses and indexes every
+//! file; it never builds a checked model, so a file that fails `fslc check`
+//! can rot silently forever — this is exactly how the 18 files issue #485
+//! repaired (a `requirement` annotation text conflict) went undetected on
+//! `main`. This test closes that hole: every `.fsl` file must either
+//! succeed under `fslc check`, declare `// expected-result: error` for a
+//! header-less (or explicitly `check`-targeted) invocation — the
+//! `examples/gallery/{errors,adversarial}` convention — or be on the
+//! explicit, reasoned exclusion below. `refinement`-dialect files are
+//! excluded structurally, not because coverage is known to exist elsewhere:
+//! a mapping file has no `state` block to build a checked model from, so
+//! `fslc check` always reports `semantics`/"spec has no state block" for one
+//! regardless of whether the mapping itself is sound. Whether a given
+//! mapping is actually exercised by `fslc refine` is a separate, narrower
+//! claim this sweep does not make (of the 28 such files, issue #483 found
+//! only the gallery fixtures and `examples/refinement_liveness/*` are
+//! refined by any test; the `agentic_rag`/`multi_agent_system` mappings are
+//! refined by nothing — see #483, not re-asserted as closed here).
+//! `examples/gallery/injected/` (its own primary/blind detector matrix in
+//! `injection_detector_matrix.rs`) is a genuine verified-elsewhere category,
+//! not a silent skip.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+/// Repo-relative path (forward slashes) -> reason a bare
+/// check-must-pass-or-declare-error rule does not apply. Each reason names
+/// the test or issue that actually owns this file's expected behavior, so a
+/// stale entry is reviewable (and, for issue #475, this test additionally
+/// pins the current defect so a fix forces the entry's removal instead of
+/// silently going unnoticed).
+const GOVERNANCE_FIXTURE_EXCLUSIONS: &[(&str, &str)] = &[
+    (
+        "examples/gallery/errors/governance_malformed_business.fsl",
+        "malformed `business` fixture consumed by governance_malformed_dependency.fsl's \
+         `delegates ... from`; its own parse failure is the fixture's purpose, validated \
+         indirectly by cli_regression.rs::native_check_locates_a_malformed_dependency_at_the_governance_reference",
+    ),
+    (
+        "examples/gallery/errors/governance_malformed_dependency.fsl",
+        "validated by cli_regression.rs::native_check_locates_a_malformed_dependency_at_the_governance_reference",
+    ),
+    (
+        "examples/gallery/errors/governance_missing_before.fsl",
+        "validated by cli_regression.rs::native_check_rejects_an_incomplete_governance_contract",
+    ),
+    (
+        "examples/gallery/adversarial/governance_semantic_after.fsl",
+        "fixture referenced by governance_semantic_dependency.fsl's `after ... from`; its own \
+         undefined-type failure is the fixture's purpose, validated indirectly by \
+         cli_regression.rs::native_check_locates_a_semantic_dependency_error_at_the_preservation",
+    ),
+    (
+        "examples/gallery/adversarial/governance_semantic_dependency.fsl",
+        "validated by cli_regression.rs::native_check_locates_a_semantic_dependency_error_at_the_preservation",
+    ),
+];
+
+/// Known, currently-broken files pending a fix tracked by a filed issue, not
+/// this test's scope. Pins the exact current failure so the entry must be
+/// removed (loudly, via a failing assertion) once the fix lands, instead of
+/// this sweep silently going green either way.
+const KNOWN_DB_DOUBLE_ASSIGNMENT_GAP: &[&str] = &[
+    "examples/db/safe_rename_preservation.fsl",
+    "examples/db/unsafe_lossy_merge_preservation.fsl",
+    "examples/db/unsafe_lossy_split_preservation.fsl",
+    "examples/db/unsafe_split_without_annotation.fsl",
+];
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn collect_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read corpus directory") {
+        let path = entry.expect("read corpus entry").path();
+        if path.is_dir() {
+            collect_fsl_files(&path, out);
+        } else if path.extension().is_some_and(|extension| extension == "fsl") {
+            out.push(path);
+        }
+    }
+}
+
+fn repo_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .expect("path under workspace root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// The file's top-level dialect keyword (`spec`, `requirements`,
+/// `refinement`, `governance`, ...): the first token on the first
+/// non-blank, non-`//`-comment line.
+fn top_level_keyword(source: &str) -> Option<&str> {
+    source
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with("//"))
+        .and_then(|line| line.split_whitespace().next())
+}
+
+/// Parse the `// key: value` header comments in the first 10 lines, the
+/// `expected-command`/`expected-result` convention
+/// `examples/gallery/{valid,errors,adversarial}` use.
+fn headers(source: &str) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    for line in source.lines().take(10) {
+        let Some(body) = line.trim().strip_prefix("//") else {
+            continue;
+        };
+        if let Some((key, value)) = body.trim().split_once(':') {
+            out.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
+    }
+    out
+}
+
+fn run_check(path: &Path) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["check", path.to_str().expect("utf8 path")])
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc check {}`: {error}; stderr={}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn every_corpus_spec_checks_ok_or_declares_its_error() {
+    let root = root();
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 150,
+        "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let governance_exclusions = GOVERNANCE_FIXTURE_EXCLUSIONS
+        .iter()
+        .map(|&(path, _)| path)
+        .collect::<BTreeSet<_>>();
+    let db_gap = KNOWN_DB_DOUBLE_ASSIGNMENT_GAP
+        .iter()
+        .copied()
+        .collect::<BTreeSet<&str>>();
+
+    let mut failures = Vec::new();
+    let mut db_gap_regressions = Vec::new();
+    let mut seen_db_gap = BTreeSet::new();
+
+    for path in &files {
+        let rel = repo_relative(&root, path);
+
+        if rel.starts_with("examples/gallery/injected/") {
+            continue; // own primary/blind matrix: injection_detector_matrix.rs
+        }
+
+        let source = std::fs::read_to_string(path).expect("read corpus source");
+        if top_level_keyword(&source) == Some("refinement") {
+            continue; // no `state` block to `check`; `fslc refine` coverage tracked by #483, not asserted here
+        }
+
+        if governance_exclusions.contains(rel.as_str()) {
+            continue;
+        }
+
+        let result = run_check(path);
+
+        if db_gap.contains(rel.as_str()) {
+            seen_db_gap.insert(rel.clone());
+            let is_expected_double_assignment = result["result"] == "error"
+                && result["kind"] == "semantics"
+                && result["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("assign the same state location more than once"));
+            if !is_expected_double_assignment {
+                db_gap_regressions.push(format!(
+                    "{rel}: no longer the known double-assignment error (remove from \
+                     KNOWN_DB_DOUBLE_ASSIGNMENT_GAP and close issue #475): {result}"
+                ));
+            }
+            continue;
+        }
+
+        let file_headers = headers(&source);
+        // `expected-command`/`expected-result` may target a *stricter* verb
+        // than `check` (`verify`, `refine`): a declared error there does not
+        // guarantee `check` itself fails (e.g. vacuity only surfaces under
+        // `verify --vacuity error`), so it only pins the "must fail" edge
+        // when the header targets `check` specifically. Any declared error
+        // (for any command) also makes a `check`-time failure unsurprising
+        // — a semantics-class defect (e.g. double assignment) often
+        // surfaces at both. Only a *completely undeclared* `check` failure
+        // is the structural hole this test exists to catch.
+        let declares_error = file_headers
+            .get("expected-result")
+            .is_some_and(|r| r == "error");
+        let targets_check = file_headers
+            .get("expected-command")
+            .is_none_or(|command| command == "check" || command.starts_with("check "));
+
+        let is_error = result["result"] == "error";
+        if targets_check && declares_error && !is_error {
+            failures.push(format!(
+                "{rel}: declares `expected-result: error` for `check` but got {result}"
+            ));
+        } else if !declares_error && is_error {
+            failures.push(format!(
+                "{rel}: `fslc check` unexpectedly failed and the file does not declare \
+                 `expected-result: error` anywhere (add the header, register a reasoned \
+                 exclusion, or fix the regression): {result}"
+            ));
+        }
+    }
+
+    let seen_db_gap = seen_db_gap
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<&str>>();
+    let missing_db_gap = db_gap.difference(&seen_db_gap).copied().collect::<Vec<_>>();
+    assert!(
+        missing_db_gap.is_empty(),
+        "KNOWN_DB_DOUBLE_ASSIGNMENT_GAP entries no longer found in the corpus scan: {missing_db_gap:?}"
+    );
+    assert!(
+        db_gap_regressions.is_empty(),
+        "{}",
+        db_gap_regressions.join("\n")
+    );
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/rust/fslc/tests/injection_detector_matrix.rs
+++ b/rust/fslc/tests/injection_detector_matrix.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native primary/blind negative-control detector matrix for
+//! `examples/gallery/injected/`. See issue #485 and
+//! `docs/DESIGN-conformance-harness.md`: the injected corpus is only a valid
+//! detector calibration if it is measured against the authoritative native
+//! CLI, not only the frozen Python reference (`tests/test_injection_bench.py`,
+//! which now defaults to measuring this same native binary too).
+//!
+//! For every injected spec, the detector named by its `expect-detector`
+//! header (the *primary* detector) must catch the injected defect, and the
+//! detector this defect type is designed to be invisible to (the *blind*
+//! detector) must not. A green positive path alone is not evidence a
+//! detector works (AGENTS.md); this test is the negative control.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const DEPTH: &str = "4";
+const DIFF_MUTATE_DEPTH: &str = "3";
+const DIFF_MUTATE_MAX: &str = "30";
+
+/// Files where the primary detector is a known, filed, native-only gap.
+/// Native `vacuous_implication` (`rust/fsl-runtime/src/lib.rs`) only matches
+/// an invariant whose *top-level* expression is `Binary{op: "=>"}`; it does
+/// not unwrap a `forall`-quantified implication, which is the shape
+/// `docs/DESIGN-vacuity.md:22-24` documents as the primary case. See issue
+/// #486 (filed while repairing issue #485; distinct from issue #465, which
+/// covers the four vacuity kinds that are entirely unimplemented).
+/// `bank__unreachable_antecedent.fsl` is unaffected: its implication is not
+/// wrapped in `forall`. This pins the *current* gap exactly, so the assertion
+/// fails loudly (forcing an update) once #486 is fixed rather than silently
+/// staying green.
+const KNOWN_NATIVE_VACUITY_FORALL_GAP: &[&str] = &[
+    "order_workflow__unreachable_antecedent.fsl",
+    "return_system__unreachable_antecedent.fsl",
+];
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn injected_dir() -> PathBuf {
+    root().join("examples/gallery/injected")
+}
+
+fn run_cli(args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {}`: {error}; stderr={}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn primary_detector(inject: &str) -> &'static str {
+    match inject {
+        "omission" => "strict_tags_requirements",
+        "boundary-flip" | "guard-weakening" => "forbidden_acceptance",
+        "invariant-weakening" => "mutate",
+        "unreachable-antecedent" => "vacuity",
+        "fabricated-constraint" => "strict_tags",
+        "over-strengthened-guard" => "verify",
+        other => panic!("unknown injection type: {other}"),
+    }
+}
+
+fn blind_detector(inject: &str) -> &'static str {
+    match inject {
+        "omission"
+        | "boundary-flip"
+        | "guard-weakening"
+        | "unreachable-antecedent"
+        | "over-strengthened-guard" => "strict_tags",
+        "invariant-weakening" => "verify",
+        "fabricated-constraint" => "vacuity",
+        other => panic!("unknown injection type: {other}"),
+    }
+}
+
+fn baseline_for(base: &str) -> PathBuf {
+    match base {
+        "specs/bank.fsl" => root().join("specs/bank.fsl"),
+        "specs/order_workflow.fsl" => root().join("specs/order_workflow.fsl"),
+        "examples/layers/return_system.fsl" => root().join("examples/layers/return_system.fsl"),
+        other => panic!("unknown base spec: {other}"),
+    }
+}
+
+/// Parse the `// key: value` header comments in the first 8 lines, the same
+/// convention `tests/test_injection_bench.py::_headers` reads.
+fn headers(path: &Path) -> BTreeMap<String, String> {
+    let source = std::fs::read_to_string(path).expect("read injected spec");
+    let mut out = BTreeMap::new();
+    for line in source.lines().take(8) {
+        let trimmed = line.trim();
+        let Some(body) = trimmed.strip_prefix("//") else {
+            continue;
+        };
+        let body = body.trim();
+        if let Some((key, value)) = body.split_once(':') {
+            out.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
+    }
+    out
+}
+
+fn warning_names(value: &Value, kind: &str) -> Vec<String> {
+    value["warnings"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|warning| warning["kind"] == kind)
+        .map(|warning| warning["name"].as_str().unwrap_or_default().to_owned())
+        .collect()
+}
+
+struct Cell {
+    caught: bool,
+    signal: String,
+}
+
+fn cell(caught: bool, signal: impl Into<String>) -> Cell {
+    Cell {
+        caught,
+        signal: signal.into(),
+    }
+}
+
+/// Write a per-domain requirement-id registry derived from `ids.txt`, the
+/// same derivation `tests/test_injection_bench.py::_registry_for` uses for
+/// `strict_tags_requirements`.
+fn registry_for(expect_signal: &str, scratch: &Path) -> PathBuf {
+    let expected = expect_signal.rsplit(':').next().unwrap_or(expect_signal);
+    let prefix = format!("{}-", expected.split('-').next().unwrap_or(expected));
+    let ids = std::fs::read_to_string(injected_dir().join("ids.txt")).expect("read ids.txt");
+    let matching = ids
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with(&prefix))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let path = scratch.join(format!(
+        "{}_ids.txt",
+        prefix.to_lowercase().trim_matches('-')
+    ));
+    std::fs::write(&path, format!("{matching}\n")).expect("write registry");
+    path
+}
+
+fn scratch_dir() -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "fslc-injection-detector-matrix-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&directory).expect("create scratch dir");
+    directory
+}
+
+fn forbidden_acceptance_cell(path_str: &str) -> Cell {
+    let check = run_cli(&["check", path_str]);
+    if check["result"] == "error"
+        && matches!(check["kind"].as_str(), Some("acceptance" | "forbidden"))
+    {
+        cell(
+            true,
+            format!("{}:{}", check["kind"].as_str().unwrap_or(""), check["id"]),
+        )
+    } else {
+        cell(false, check["result"].to_string())
+    }
+}
+
+fn verify_cell(path_str: &str) -> Cell {
+    let verify = run_cli(&["verify", path_str, "--depth", DEPTH, "--deadlock", "ignore"]);
+    if verify["result"] == "reachable_failed" {
+        let names = verify["unreached"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .map(|item| item["name"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join(",");
+        cell(true, format!("reachable_failed:{names}"))
+    } else if verify["result"] == "violated" {
+        cell(true, format!("violated:{}", verify["violation_kind"]))
+    } else {
+        cell(false, verify["result"].to_string())
+    }
+}
+
+fn vacuity_cell(path_str: &str) -> Cell {
+    let vacuity = run_cli(&[
+        "verify",
+        path_str,
+        "--depth",
+        DEPTH,
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+    ]);
+    let vacuity_kind = vacuity["kind"].as_str().unwrap_or_default();
+    if vacuity["result"] == "error" && vacuity_kind.starts_with("vacuous_") {
+        let names = vacuity["findings"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .map(|f| f["name"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join(",");
+        cell(true, format!("{vacuity_kind}:{names}"))
+    } else {
+        cell(false, vacuity_kind.to_owned())
+    }
+}
+
+fn strict_tags_cell(path_str: &str) -> Cell {
+    let strict = run_cli(&["check", path_str, "--strict-tags"]);
+    let untagged = warning_names(&strict, "untagged");
+    if untagged.is_empty() {
+        cell(false, strict["result"].to_string())
+    } else {
+        cell(true, format!("untagged:{}", untagged.join(",")))
+    }
+}
+
+fn strict_tags_requirements_cell(path_str: &str, expect_signal: &str, scratch: &Path) -> Cell {
+    let registry = registry_for(expect_signal, scratch);
+    let registry_str = registry.to_str().expect("utf8 registry path");
+    let strict_req = run_cli(&[
+        "check",
+        path_str,
+        "--strict-tags",
+        "--requirements",
+        registry_str,
+    ]);
+    let unreferenced = warning_names(&strict_req, "unreferenced_requirement");
+    if unreferenced.is_empty() {
+        cell(false, strict_req["result"].to_string())
+    } else {
+        cell(
+            true,
+            format!("unreferenced_requirement:{}", unreferenced.join(",")),
+        )
+    }
+}
+
+/// Only meaningful for `invariant-weakening`: a single-spec `mutate` run
+/// only ever shows survivors, so detection requires a baseline differential
+/// against the unmodified base spec (`tests/test_injection_bench.py`'s
+/// `_measure_case` docstring-equivalent comment).
+fn mutate_differential_cell(path_str: &str, base: &str) -> Cell {
+    let baseline = run_cli(&[
+        "mutate",
+        baseline_for(base).to_str().expect("utf8"),
+        "--depth",
+        DIFF_MUTATE_DEPTH,
+        "--max-mutants",
+        DIFF_MUTATE_MAX,
+    ]);
+    let injected = run_cli(&[
+        "mutate",
+        path_str,
+        "--depth",
+        DIFF_MUTATE_DEPTH,
+        "--max-mutants",
+        DIFF_MUTATE_MAX,
+    ]);
+    let base_survived = baseline["summary"]["survived"].as_i64().unwrap_or(0);
+    let injected_survived = injected["summary"]["survived"].as_i64().unwrap_or(0);
+    cell(
+        injected_survived > base_survived,
+        format!("survivors {base_survived}->{injected_survived}"),
+    )
+}
+
+fn measure(
+    path: &Path,
+    headers: &BTreeMap<String, String>,
+    scratch: &Path,
+) -> BTreeMap<&'static str, Cell> {
+    let path_str = path.to_str().expect("utf8 path");
+    let mut cells = BTreeMap::new();
+    cells.insert("forbidden_acceptance", forbidden_acceptance_cell(path_str));
+    cells.insert("verify", verify_cell(path_str));
+    cells.insert("vacuity", vacuity_cell(path_str));
+    cells.insert("strict_tags", strict_tags_cell(path_str));
+    cells.insert(
+        "strict_tags_requirements",
+        strict_tags_requirements_cell(path_str, &headers["expect-signal"], scratch),
+    );
+    cells.insert(
+        "mutate",
+        if headers["inject"] == "invariant-weakening" {
+            mutate_differential_cell(path_str, &headers["base"])
+        } else {
+            cell(false, "not-differential")
+        },
+    );
+    cells
+}
+
+#[test]
+fn native_injected_corpus_primary_blind_matrix() {
+    let mut paths = std::fs::read_dir(injected_dir())
+        .expect("read injected dir")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "fsl"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    assert_eq!(paths.len(), 21, "expected 21 injected specs");
+
+    let scratch = scratch_dir();
+    let mut failures = Vec::new();
+    let mut known_gap_regressions = Vec::new();
+
+    for path in &paths {
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let case_headers = headers(path);
+        let inject = case_headers["inject"].as_str();
+        let cells = measure(path, &case_headers, &scratch);
+
+        let primary = primary_detector(inject);
+        let primary_caught = cells[primary].caught;
+        if KNOWN_NATIVE_VACUITY_FORALL_GAP.contains(&file_name) {
+            // Pin the current, filed-as-#486 gap exactly: this must stay
+            // "not caught" until #486 lands. If it starts catching, this
+            // assertion fails and forces the exclusion to be removed instead
+            // of silently going green.
+            if primary_caught {
+                known_gap_regressions.push(format!(
+                    "{file_name}: primary {primary} now catches (remove from \
+                     KNOWN_NATIVE_VACUITY_FORALL_GAP and close issue #486): {}",
+                    cells[primary].signal
+                ));
+            }
+        } else if !primary_caught {
+            failures.push(format!(
+                "{file_name}: primary {primary} did not catch {inject}: {}",
+                cells[primary].signal
+            ));
+        }
+
+        let blind = blind_detector(inject);
+        if cells[blind].caught {
+            failures.push(format!(
+                "{file_name}: blind detector {blind} unexpectedly caught {inject}: {}",
+                cells[blind].signal
+            ));
+        }
+    }
+
+    assert!(
+        known_gap_regressions.is_empty(),
+        "{}",
+        known_gap_regressions.join("\n")
+    );
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/rust/fslc/tests/testgen_contract.rs
+++ b/rust/fslc/tests/testgen_contract.rs
@@ -13,7 +13,7 @@ fn root() -> PathBuf {
         .to_owned()
 }
 
-fn generated_digest(spec: &str, depth: &str, target: &str, stem: &str) -> String {
+fn generated_content(spec: &str, depth: &str, target: &str, stem: &str) -> String {
     let root = root();
     let directory = root.join("rust/target/testgen-contract");
     std::fs::create_dir_all(&directory).expect("create testgen output directory");
@@ -29,9 +29,13 @@ fn generated_digest(spec: &str, depth: &str, target: &str, stem: &str) -> String
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
+    std::fs::read_to_string(output_path).expect("read generated scaffold")
+}
+
+fn generated_digest(spec: &str, depth: &str, target: &str, stem: &str) -> String {
     format!(
         "{:x}",
-        Sha256::digest(std::fs::read(output_path).expect("read generated scaffold"))
+        Sha256::digest(generated_content(spec, depth, target, stem).as_bytes())
     )
 }
 
@@ -90,6 +94,41 @@ fn compose_bridge_preserves_pytest_and_baked_target_goldens() {
             "compose {target} output changed"
         );
     }
+}
+
+/// Issue #471: the native `emit_pytest` scenario loop dropped the
+/// `forbidden`-scenario rejection assertion (`_assert_rejected`), so a
+/// generated pytest harness that named itself `test_scenario_forbidden_FB_1`
+/// asserted nothing about the forbidden transition and passed against a
+/// guard-weakened implementation. `specs/cart_v1.fsl` (the golden above) has
+/// no `forbidden` declaration, so that golden alone cannot catch this class
+/// of regression. This is the coupled regression case: a golden digest for a
+/// spec that *does* declare `forbidden`, plus the byte-identical-to-Python
+/// content this golden guards being non-trivial (both lines the emitter had
+/// been silently dropping, mirroring `tests/test_verified_bugs.py`'s
+/// `test_forbidden_testgen_rejection_assertion`, which only exercises the
+/// frozen Python `fslc.cli.run_testgen`).
+#[test]
+fn pytest_target_emits_the_forbidden_rejection_assertion() {
+    let content = generated_content(
+        "examples/gallery/valid/small_forbidden_guarded_cancel.fsl",
+        "3",
+        "pytest",
+        "fbcancel",
+    );
+    assert!(
+        content.contains("result = adapter.step('cancel', {'o': 0})"),
+        "forbidden step call missing from generated pytest:\n{content}"
+    );
+    assert!(
+        content.contains("_assert_rejected(result, 'requires_failed')"),
+        "forbidden rejection assertion missing from generated pytest:\n{content}"
+    );
+    assert_eq!(
+        format!("{:x}", Sha256::digest(content.as_bytes())),
+        "da26cf763e96508472a0fcda8c2b4d7c69652d478794c772bd2053389e1b2e51",
+        "small_forbidden_guarded_cancel.fsl pytest output changed"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/test_injection_bench.py
+++ b/tests/test_injection_bench.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from collections import Counter, defaultdict
@@ -12,6 +13,13 @@ ROOT = Path(__file__).resolve().parents[1]
 INJECTED = ROOT / "examples" / "gallery" / "injected"
 MATRIX_PATH = INJECTED / "MATRIX.json"
 PY = sys.executable
+RUST_CLI = ROOT / "rust" / "target" / "debug" / "fslc"
+
+# The measured CLI is the authoritative native binary by default
+# (docs/DESIGN-conformance-harness.md: detector calibration is measured on
+# the authoritative native surface, not only the frozen Python reference).
+# Set FSLC_BENCH_CLI=python to measure the frozen reference instead.
+CLI = [str(RUST_CLI)] if os.environ.get("FSLC_BENCH_CLI", "native") != "python" else [PY, "-m", "fslc"]
 
 DEPTH = "4"
 MUTATE_DEPTH = "2"
@@ -45,6 +53,18 @@ PRIMARY_DETECTOR = {
     "over-strengthened-guard": "verify",
 }
 
+# Native-only, filed gap: `vacuous_implication` (rust/fsl-runtime/src/lib.rs)
+# only matches an invariant whose top-level expression is a direct `=>`; it
+# does not unwrap a `forall`-quantified implication, the shape
+# docs/DESIGN-vacuity.md:22-24 documents as the primary case. See issue #486
+# (distinct from #465, which covers the four vacuity kinds with no native
+# implementation at all). Only applies when CLI == native; against the
+# frozen Python reference these two files' primary detector already catches.
+KNOWN_NATIVE_VACUITY_FORALL_GAP = {
+    "order_workflow__unreachable_antecedent.fsl",
+    "return_system__unreachable_antecedent.fsl",
+}
+
 BLIND_DETECTOR = {
     "omission": "strict_tags",
     "boundary-flip": "strict_tags",
@@ -58,7 +78,7 @@ BLIND_DETECTOR = {
 
 def _run(args: list[str]) -> dict[str, Any]:
     proc = subprocess.run(
-        [str(PY), "-m", "fslc", *args],
+        [*CLI, *args],
         cwd=ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -294,7 +314,19 @@ def test_error_injection_benchmark_matrix(tmp_path):
             cases.append(measured)
 
             primary = PRIMARY_DETECTOR[headers["inject"]]
-            if measured["detectors"][primary]["status"] != "caught":
+            primary_caught = measured["detectors"][primary]["status"] == "caught"
+            known_gap = CLI == [str(RUST_CLI)] and path.name in KNOWN_NATIVE_VACUITY_FORALL_GAP
+            if known_gap:
+                # Pin the current gap exactly: fail loudly (forcing this
+                # exclusion to be removed) once issue #486 is fixed, instead
+                # of silently staying green either way.
+                if primary_caught:
+                    failures.append(
+                        f"{path.name}: primary {primary} now catches (remove from "
+                        f"KNOWN_NATIVE_VACUITY_FORALL_GAP and close issue #486): "
+                        f"{measured['detectors'][primary]}"
+                    )
+            elif not primary_caught:
                 failures.append(
                     f"{path.name}: primary {primary} did not catch "
                     f"{headers['inject']}: {measured['detectors'][primary]}"

--- a/tools/check_rust_phase3_commands.py
+++ b/tools/check_rust_phase3_commands.py
@@ -165,7 +165,7 @@ def run(binary: Path = RUST) -> dict[str, Any]:
             elif py_out.read_bytes() != rs_out.read_bytes():
                 failures.append({"case": f"testgen:{target}:content", "python": "different bytes", "rust": "different bytes"})
         forbidden_spec = "examples/gallery/valid/small_forbidden_guarded_cancel.fsl"
-        for target in ("vitest", "swift", "kotlin", "dart", "phpunit"):
+        for target in ("pytest", "vitest", "swift", "kotlin", "dart", "phpunit"):
             py_out = Path(directory) / f"py-testgen-forbidden-{target}"
             rs_out = Path(directory) / f"rs-testgen-forbidden-{target}"
             arguments = ["testgen", forbidden_spec, "--depth", "3", "--target", target, "-o"]


### PR DESCRIPTION
## Problem

The repository's detector-calibration assets did not work against the authoritative native implementation, so they could not detect drift in it.

- **#485** — `examples/gallery/injected/` is the only negative-control calibration for this repository's detector suite (`docs/DESIGN-conformance-harness.md:62-67`). Its committed evidence (`MATRIX.json`, declaring `"surprises": []` and 21/21 primary caught) and its only executable check (`tests/test_injection_bench.py`) measured **exclusively the frozen Python reference**. Against the native CLI, **17 of 21 injected specs plus the `agentic_rag` mutation slice failed `fslc check` outright** — exit 2, `kind:"semantics"`, `requirement annotation '<ID>' has conflicting text`. So if the native acceptance/forbidden verdicts, reachable coverage, vacuity diagnostics, strict-tags, or mutate diffs regressed, this matrix could say nothing about it. `AGENTS.md:77-79` names exactly this state: a green positive path that cannot establish drift detection.
- **#471** — the generated **pytest** conformance harness emitted no assertion at all for `forbidden` scenarios, so a harness named `test_scenario_forbidden_FB_1` passed against a guard-weakened implementation. Every other testgen target (vitest/swift/kotlin/dart/phpunit) already emitted it.

## Contract change

No language or CLI contract changes. The corpus is brought into compliance with an existing contract, and calibration moves to the authoritative surface.

- The 18 corpus files violated `docs/LANGUAGE.md:1749` ("identical `(id, text)` pairs deduplicate; conflicting text for one requirement ID is a checked-model error", enforced since #237). The native rule was correct; the corpus predates it and was never repaired. **The repair removes only the redundant inner legacy `"ID: text"` tag** — the enclosing `requirement` block already supplies the id/text by fan-out. Every injected defect line and every header comment (`base` / `inject` / `expect-detector` / `expect-signal` / `note`) is byte-unchanged.
- `examples/gallery/injected/MATRIX.json` is regenerated from the **native** measurement, not hand-edited. It now records 2 honest `missing-primary` surprises instead of the previous false `"surprises": []`.
- `docs/DESIGN-conformance-harness.md` no longer implies that refinement mapping files are covered elsewhere.

## Test evidence

**Detector calibration, native primary catch rate: 4/21 → 19/21** (blind cross-catches 0, unchanged).

The remaining 2 (`order_workflow__unreachable_antecedent.fsl`, `return_system__unreachable_antecedent.fsl` — the `vacuity` lane against a `forall`-quantified implication) are a genuine native gap **found during this work and filed as #486**. They are registered as explicit pinned exclusions that fail loudly if they silently start passing — not hidden.

New native tests, wired into `cargo test --workspace` and therefore into `tools/check-native-integration.sh` (which must not execute Python, per `AGENTS.md`):

- `rust/fslc/tests/injection_detector_matrix.rs` — the full 6-detector primary/blind matrix (`forbidden_acceptance` / `verify` / `vacuity` / `strict_tags` / `strict_tags_requirements` / `mutate`) run against the built native `fslc`.
- `rust/fslc/tests/corpus_check_sweep.rs` — exhaustive native `check` sweep. **207 total `.fsl` under `specs/`+`examples/`; 149 asserted directly** (9 declaring `expected-result: error`, 140 required to check ok); **58 excluded, none silently**: 21 injected corpus (covered by the matrix test above), 28 refinement-dialect (structural — a mapping file has no `state` block, so `fslc check` always reports `semantics`/"spec has no state block"; whether these are actually exercised by `fslc refine` is tracked by #483 and explicitly *not* claimed here), 5 governance fixtures (each naming its owning `cli_regression.rs` test), 4 db double-assignment (pinned to #475). Verified to catch a real regression by deliberately corrupting `specs/cart_v1.fsl`.
- `rust/fslc/tests/testgen_contract.rs::pytest_target_emits_the_forbidden_rejection_assertion` — golden SHA-256 digest plus explicit content assertions. **Confirmed to fail when the #471 fix is reverted.**

The #471 fix is exactly two emitted lines; the generated harness diff for `examples/gallery/valid/small_forbidden_guarded_cancel.fsl` is:

```
+    result = adapter.step('cancel', {'o': 0})
+    _assert_rejected(result, 'requires_failed')
```

Gate results from the worktree:

```
cargo fmt --check                                        clean
cargo clippy --workspace --all-targets --locked -D warnings   clean
cargo test --workspace --locked                          0 failures
cargo build --workspace --locked                         clean
./tools/check-native-integration.sh rust                 exit 0
```

The wasm leg was not run — untouched surface.

## Documentation and skills

- `docs/DESIGN-conformance-harness.md` — calibration is measured on the authoritative native surface; refinement exclusions justified structurally rather than by an unverified coverage claim.
- `examples/agentic_rag/mutation_slices/README.md`, `SURVIVOR_REVIEW.md` — re-measured against native. Absolute counts differ from the old Python numbers because mutation enumeration differs between implementations; this is stated explicitly rather than papered over.
- `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #485, fixes #471.

Found and filed during this work, **not** fixed here:
- **#486** — native `vacuous_implication` never unwraps a `forall`-quantified invariant, so it misses the shape `docs/DESIGN-vacuity.md:22-24` documents as the primary case. Distinct from #465 (whose four kinds are entirely unimplemented).
- **#483** (pre-existing) — `SURVIVOR_REVIEW.md`'s own `fslc refine` steps fail natively with `indexed progress map ... is not implemented`. Now visible in that document instead of silently claiming `refines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
