### PR TITLE
fix: stop five false-green verdicts (explicit init, sweep, refine, testgen, vacuity selection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ venv/
 .mypy_cache/
 .ruff_cache/
 
+# Z3 solver trace file, written by native-z3 test/CLI runs into whichever
+# directory the process's cwd happens to be (rust/, rust/fsl-solver-z3/,
+# rust/fsl-verifier/, rust/fslc/, repo root, ...) — not a repo deliverable
+.z3-trace
+
 # VSCode extension build artifacts
 node_modules/
 editors/vscode/out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false
   `no_semantic_change` result (#460, prerequisite for #427).
+- `fslc testgen` (and `domain testgen`) no longer converts a genuine
+  `violated`/`reachable_failed` counterexample from the underlying scenarios
+  machinery into an unrelated exit-2 `kind:"semantics"` spec error. The
+  guard that only short-circuited on `status == 2` let a real `violated`
+  invariant/`leadsTo`, or a `--strict` `reachable_failed`, fall through to
+  `fsl_tools::validate_scenarios`, which found no `scenarios` array in what
+  was actually a `verify`-shaped envelope and reported a generic error —
+  changing the exit code from 1 to 2, replacing `result` with `"error"`,
+  and destroying the trace/blame evidence a repair loop depends on. Both
+  guards (`run_testgen`, `run_domain_testgen`) now propagate any non-zero
+  status verbatim; the success path (`result:"generated"`, exit 0) is
+  unaffected (#472).
 - `fslc refine` now verifies the impl spec's own internal consistency (type
   bounds, invariants, `trans`, `ensures`) before checking any correspondence
   against the abstraction. An impl that violates itself within `--depth` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false
   `no_semantic_change` result (#460, prerequisite for #427).
+- `sweep` no longer folds a spec `error` (parse / type / semantics / io /
+  vacuous / a mistyped `--instances`/`--values` name / a missing file) into
+  the positive `sweep_passed`/exit-0 verdict. Any scope in the grid that
+  errors now short-circuits the sweep with that error's envelope and exit
+  code (2, or 3 for `kind:"internal"`) returned verbatim, instead of being
+  discarded as an unrecognized grid-cell result while the top-level verdict
+  fell back to "no counterexample found" — previously a one-character typo
+  in `--instances` could turn a sweep over a genuinely violating spec from
+  exit 1 `sweep_failed` into exit 0 `sweep_passed` (#464).
 - `verify --engine explicit` now agrees with symbolic BMC on a contradictory
   `init`: a `forall` binder that writes different concrete values to the same
   non-indexed location across binder values (e.g. `forall k: K { x = k }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false
   `no_semantic_change` result (#460, prerequisite for #427).
+- `fslc refine` now verifies the impl spec's own internal consistency (type
+  bounds, invariants, `trans`, `ensures`) before checking any correspondence
+  against the abstraction. An impl that violates itself within `--depth` —
+  e.g. a dropped `requires` that lets a state variable step outside its
+  declared type bound — is reported `result:"violated"` with a `note`
+  explaining this is a property of the refinement input, never `refines`
+  and never folded into `refinement_failed`. Previously `check_refinement`'s
+  BFS silently discarded (`continue`d past) any violation the impl produced
+  while stepping, so a guard weakening that broke the impl's own bounds
+  could pass as `refines`/exit 0 with no counterexample at all. `fslc diff`
+  gains the same detection as a new `impl_violated` finding kind that fails
+  its gate unconditionally (unlike other finding kinds, not subject to
+  `--forbid`), since a self-violating side makes the comparison untrustworthy;
+  the `implements`-clause mutation oracle and the `implements:` verify
+  metadata (`requirements_implements_output`) are also corrected to stop
+  reporting the impl-violation case as a clean/`"refines"` refinement (#466).
 - `--vacuity {error,ignore}` now selects over the complete documented 5-kind
   vacuity lane set (`fsl_core::VACUITY_KINDS`) instead of only the two kinds
   spelled `vacuous_*`. `always_true_requires`, `tautology_over_frozen`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,30 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   wrong-nominal sources fail closed; concrete, symbolic, progress, CLI, Worker,
   Public Kernel projection, and raw-replay guards share the checked semantics
   without weakening bijective `enum conversion` (#455).
+- Native `verify` now reports the `vacuous_leadsto` vacuity lane: a `leadsTo`
+  whose trigger never becomes reachable within `--depth` is a hollow
+  property, the same class BMC already reports for an implication invariant's
+  unreachable antecedent (`vacuous_implication`). Detected via the same
+  solver-free existential-reachability BFS `fsl-runtime::verification_warnings`
+  already uses, so `fsl-runtime` gains no new solver dependency (#465, partial;
+  `always_true_requires`, `tautology_over_frozen`, and `urgency_freeze` remain
+  unimplemented on native — see `docs/DESIGN-rust-port.md` "Shared semantic
+  diagnostics").
 
 ### Fixed
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false
   `no_semantic_change` result (#460, prerequisite for #427).
+- `--vacuity {error,ignore}` now selects over the complete documented 5-kind
+  vacuity lane set (`fsl_core::VACUITY_KINDS`) instead of only the two kinds
+  spelled `vacuous_*`. `always_true_requires`, `tautology_over_frozen`, and
+  `urgency_freeze` previously could not be promoted to `--vacuity error` or
+  suppressed by `--vacuity ignore` because none of the three names start
+  with `vacuous_`; native `apply_vacuity_mode` matched by name prefix rather
+  than the closed kind set (#465, the CLI half; the lanes for these three
+  kinds are still unimplemented on native, see above — this fix prevents a
+  *second*, independent bug from compounding the first once they land).
 - `sweep` no longer folds a spec `error` (parse / type / semantics / io /
   vacuous / a mistyped `--instances`/`--values` name / a missing file) into
   the positive `sweep_passed`/exit-0 verdict. Any scope in the grid that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false
   `no_semantic_change` result (#460, prerequisite for #427).
+- `verify --engine explicit` now agrees with symbolic BMC on a contradictory
+  `init`: a `forall` binder that writes different concrete values to the same
+  non-indexed location across binder values (e.g. `forall k: K { x = k }`
+  with `|K| > 1`) is detected by the concrete Monitor without a solver and
+  reported as `result:"error"`, `kind:"vacuous"`,
+  `message:"init constraints are unsatisfiable"`, exit 2 — matching BMC
+  exactly instead of silently running the forall as a last-write-wins loop
+  and returning `result:"proved"` / exit 0 for a spec with no valid initial
+  state (#480).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -201,7 +201,13 @@ pseudorandom walk and `pathlib` for resolving the SPEC path):
    If some `reachable` targets are not witnessed at the requested depth, testgen
    still embeds the witnessed scenarios and returns warning JSON naming each
    missing target with a depth hint. `--strict` restores all-or-nothing
-   `reachable_failed`.
+   `reachable_failed`. A genuine `violated`/`reachable_failed` verdict from the
+   underlying scenarios machinery — the spec itself has a bug, not a testgen
+   input problem — is returned verbatim (`result`, exit code, and trace
+   unchanged), the same envelope `fslc verify`/`fslc scenarios` return for the
+   identical spec; it is never re-wrapped as a generic exit-2 spec error (a
+   native-only regression fixed in issue #472, see `rust/fslc/src/main.rs`
+   `run_testgen`/`run_domain_testgen`).
 3. **Random-walk conformance test**: with the concrete Monitor as the oracle, choose actions
    from `mon.enabled()` by pseudorandom (fixed seed, `random.Random(0)`) for
    N=100 steps, and on every step assert `adapter.step(...)` → `observe() == mon.state`.

--- a/docs/DESIGN-explicit-engine.md
+++ b/docs/DESIGN-explicit-engine.md
@@ -81,6 +81,23 @@ Key points:
   so the explicit engine must never silently explore only the default-seeded
   state: any spec it accepts has exactly one initial state, and everything
   else is an explicit error. The Rust port must enforce the same gate.
+- **Unsatisfiable init (fail closed, kind `vacuous`).** Definite assignment
+  alone does not guarantee a consistent initial state: `init forall` executes
+  once per binder value, and when two binder values write different concrete
+  values to the same non-binder-indexed location (e.g. `forall k: K { x = k }`
+  with `|K| > 1`), the assignment cannot hold simultaneously for every binder
+  value. Symbolic BMC encodes each `init forall` iteration as a constraint
+  conjunct and reports the resulting UNSAT as `result:"error"`,
+  `kind:"vacuous"`, `message:"init constraints are unsatisfiable"` (exit 2,
+  §3 of `docs/DESIGN-vacuity.md`). The Rust `fsl-runtime` Monitor (used by
+  every concrete-initial-state caller, not only this engine) detects the same
+  contradiction without a solver: it tracks the concrete value written to
+  each resolved lvalue location across the whole `init` block and fails with
+  the identical message the instant a later write disagrees with an earlier
+  one at the same location. A later write that repeats the *same* value is
+  not a conflict and is accepted, so the ordinary "assign this literal for
+  every binder value" idiom (`forall k: K { m[k] = 0 }`, and even a
+  non-indexed `forall k: K { ready = true }`) is unaffected.
 
 ## 3. Verdict and JSON contract
 
@@ -95,6 +112,7 @@ unchanged:
 | Closure reached, no violation | `proved` | 0 | Unbounded claim; `closure: true` |
 | State budget exceeded | `unknown_budget` | 1 | Explicit truncation; never reported as verified |
 | Unsupported spec feature | `error` (kind `semantics`) | 2 | Fail closed, see §5 |
+| Init unsatisfiable | `error` (kind `vacuous`) | 2 | Same verdict, kind, message, and exit code as BMC, see §2 |
 
 Every result carries exploration stats alongside the standard `cost` object:
 states explored, maximum frontier width, and whether closure was reached.

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -165,6 +165,17 @@ Two consequences fall out of reusing the same merge, not from new logic:
 
 α(s) := the mapping that defines the impl state → abs state mapping.
 
+0. **impl self-consistency (precondition, issue #466)**: before any of the
+   following steps run, the impl spec's own reachable states up to depth K —
+   including its initial state — are checked concretely for a type-bound,
+   invariant, `trans`, or `ensures` violation, independent of the mapping and
+   the abstraction entirely. This is a property of the refinement *input*
+   (the impl spec is broken on its own), not a refinement fidelity verdict:
+   `result:"violated"` with the impl's own `violation_kind`/trace and an
+   explanatory `note`, never `result:"refines"` and never folded into
+   `refinement_failed` (whose `kind`s below describe a mismatch *between*
+   impl and abs, not a defect in the impl alone). If this precondition finds
+   a violation, steps 1-4 do not run.
 1. **init correspondence**: for the impl's initial state s₀, α(s₀) satisfies the
    abs init constraints. Counterexample: `refinement_failed` / `at: "init"`.
 2. **transition correspondence**: for a reachable impl transition
@@ -493,7 +504,17 @@ change abs's stock) → `impl_checkout` consumes the reserved stock) +
    out-of-range impl value there is already caught downstream as
    `abs_state_mismatch`, so merging is safe. The fix: give impl and abs
    layers distinct type names.
-8. No regression of existing features (refine is a completely independent CLI
+9. **impl self-violation (precondition, issue #466)**: an impl whose own
+   guard/type-bound weakening lets it violate itself within depth K (e.g. a
+   dropped `requires` that lets a state variable step outside its declared
+   type bound) → `result:"violated"` with the impl's own `violation_kind`,
+   never `refines`. `docs/DESIGN-refinement.md` §2 step 0. Rust coverage:
+   `rust/fsl-runtime/tests/refinement.rs` (the `check_refinement` contract
+   directly, plus a regression control distinguishing this from a pure
+   guard-weakening `abs_requires_failed`) and
+   `rust/fslc/tests/issue_466_refine_impl_self_violation.rs` (the `fslc
+   refine` and `fslc diff` CLI contract).
+10. No regression of existing features (refine is a completely independent CLI
    path).
 
 ## 6. Documentation Reflection

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -251,9 +251,16 @@ solver-independent crates used by both delivery surfaces:
   the same semantic gate.
 - `fsl-core` owns model-only warnings, requirement metadata projection, and
   deterministic state summaries.
-- `fsl-runtime::verification_warnings` owns vacuous-implication reachability,
-  deadlock warnings, and action-coverage warnings. It consumes only the checked
-  model and backend-neutral result facts.
+- `fsl-runtime::verification_warnings` owns vacuous-implication and
+  vacuous-leadsto reachability, deadlock warnings, and action-coverage
+  warnings. It consumes only the checked model and backend-neutral result
+  facts. The remaining three `docs/DESIGN-vacuity.md` §2 lanes
+  (`always_true_requires`, `tautology_over_frozen`, `urgency_freeze`) are
+  solver-dependent and are not yet implemented on the Rust side (#465);
+  `--vacuity` selects over the closed 5-kind set in
+  `fsl-core::VACUITY_KINDS`, not a `"vacuous_"` name-prefix check, so the
+  three unimplemented lanes fail closed by absence rather than by a
+  misclassified warning once they are added.
 - Shared warnings use typed `kind` values for downstream selection. In
   particular, induction removes bounded `kind:"deadlock"` warnings through
   `fsl-runtime::induction_warnings`; frontends never classify a warning by

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -821,7 +821,11 @@ Public Kernel v2 はオプトインで、
 したスコープを `sweep.minimal_counterexample` として返します。`--values` に
 ついては、sweep は下限を固定して上限を拡大します(`lo..lo`, `lo..lo+1`, ...,
 `lo..hi`)。sweep の合格は「このグリッドに反例がない」ことを意味し、非有界の証明
-ではありません。
+ではありません。グリッド中のいずれかのスコープが spec `error`(parse / type /
+semantics / io / vacuous / …)を返した場合、それは反例ではありません。`sweep` は
+その基盤のエラー envelope をそのまま返します(`result`、`kind`、`message`、
+`loc`、exit code は変更しません)。`sweep_passed`/`sweep_failed` に畳み込むこと
+はありません。
 
 `diff` は、ソーステキストではなく状態機械の意味を比較します。有界の refinement を
 両方向に実行します: NEW→OLD の失敗は `behavior_added`、OLD→NEW の失敗は

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1293,6 +1293,18 @@ fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth
 `abs_after_*` を伴います。静的なエラー(マップの欠落、未知の action など)は
 `kind: "type"`(exit 2)です。
 
+`refine` はどの対応関係も検査する前に、まず impl spec が `--depth` の範囲内で
+それ自身の型境界や不変条件を破っていないか(内部的に一貫しているか)を検証しま
+す。壊れた impl を refinement mapping で意味のあるものにすることはできないため、
+これは abstraction や mapping とは独立に検査されます: `result: "violated"`
+(exit 1)に `violation_kind` と、これが fidelity の失敗ではなく refinement
+*入力*自体の性質であることを説明する `note` を伴います。`refines` として報告さ
+れることはなく、`refinement_failed`(上記の `kind` 群は impl と abs の**間**の
+不一致を表すものであり、impl 単独の欠陥ではありません)に畳み込まれることもあり
+ません。`fslc diff` は同じ条件を `impl_violated` の finding として表面化させ、
+gate を無条件に(`--forbid` の対象ではなく)失敗させます。自己矛盾した側がある
+比較そのものが信頼できないためです。
+
 状態変数のペアが 1:1 でマップされる場合でも、impl と abs には**別々の enum/struct
 型名**を与えてください。型メタデータは refinement 検査のために名前でマージされ
 ます。両側で異なるメンバーリスト(またはフィールド集合)を持って宣言された同名の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1325,6 +1325,19 @@ with `kind` (`abs_requires_failed` / `abs_state_mismatch` / `stutter_changed_abs
 `abs_after_*`. A static error (a missing map, an unknown action, etc.) is
 `kind: "type"` (exit 2).
 
+Before any correspondence is checked, `refine` first verifies that the impl
+spec is internally consistent on its own — does not violate its own type
+bounds or invariants — within `--depth`. A refinement mapping cannot make a
+broken impl meaningful, so this is checked independently of the abstraction
+and the mapping: `result: "violated"` (exit 1) with `violation_kind` and a
+`note` explaining this is a property of the refinement *input*, not a
+fidelity failure. It is never reported `refines`, and never folded into
+`refinement_failed` (whose `kind`s above describe a mismatch *between* impl
+and abs, not a defect in the impl alone). `fslc diff` surfaces the same
+condition as an `impl_violated` finding and fails its gate unconditionally
+(not subject to `--forbid`), since a self-violating side makes the
+comparison itself untrustworthy.
+
 Give impl and abs **distinct enum/struct type names**, even when a state
 variable pair is mapped 1:1. Type metadata is merged by name for refinement
 checking; a same-named enum (or struct) declared with a different member

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -844,6 +844,10 @@ verification result under `sweep.results`, and returns the first failing scope
 under `sweep.minimal_counterexample`. For `--values`, the sweep fixes the lower
 bound and expands the upper bound (`lo..lo`, `lo..lo+1`, ..., `lo..hi`). A
 passing sweep means "no counterexample in this grid", not an unbounded proof.
+A spec `error` (parse / type / semantics / io / vacuous / …) from any scope in
+the grid is not a counterexample: `sweep` returns that underlying error
+envelope verbatim (`result`, `kind`, `message`, `loc`, exit code unchanged)
+instead of folding it into `sweep_passed`/`sweep_failed`.
 
 `diff` compares state-machine meaning instead of source text. It runs bounded
 refinement in both directions: NEW→OLD failure is `behavior_added`, while

--- a/rust/fsl-core/src/diagnostics.rs
+++ b/rust/fsl-core/src/diagnostics.rs
@@ -89,3 +89,25 @@ pub fn insert_requirement_metadata(
         output.insert("requirements".to_owned(), Value::Array(requirements));
     }
 }
+
+/// The complete, closed set of warning `kind` values `--vacuity` selects
+/// over (`warn`/`error`/`ignore`). Mirrors the frozen Python reference's
+/// `diagnostics._VACUITY_KINDS`. Kept as an explicit enumeration rather than
+/// a `"vacuous_"` name-prefix check: `always_true_requires`,
+/// `tautology_over_frozen`, and `urgency_freeze` are vacuity findings but do
+/// not share that prefix, so a prefix check silently exempts them from both
+/// `--vacuity ignore` (they would stay in `warnings`) and `--vacuity error`
+/// (a hollow spec carrying only one of these three would never fail closed).
+pub const VACUITY_KINDS: [&str; 5] = [
+    "vacuous_implication",
+    "vacuous_leadsto",
+    "tautology_over_frozen",
+    "urgency_freeze",
+    "always_true_requires",
+];
+
+/// Whether `kind` is one of the closed [`VACUITY_KINDS`] `--vacuity` selects over.
+#[must_use]
+pub fn is_vacuity_kind(kind: &str) -> bool {
+    VACUITY_KINDS.contains(&kind)
+}

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -39,7 +39,8 @@ pub use compose::{
     FileResolver, FsResolver, lower_compose, parse_kernel_source, parse_kernel_source_with_file,
 };
 pub use diagnostics::{
-    insert_requirement_metadata, model_warnings, requirement_metadata, version_metadata,
+    VACUITY_KINDS, insert_requirement_metadata, is_vacuity_kind, model_warnings,
+    requirement_metadata, version_metadata,
 };
 pub use dialect::{
     GovernanceContract, GovernanceDelegate, GovernancePreservation, RequirementsTraceCase,

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1236,6 +1236,13 @@ pub struct RefinementCheck {
     pub action_map: BTreeMap<String, String>,
     pub abs_has_ensures: bool,
     pub failure: Option<RefinementFailure>,
+    /// Set instead of `failure` when the implementation violates its own
+    /// semantics (a type bound, invariant, `trans`, `ensures`, or
+    /// `partial_op`) within `depth`, independent of the refinement mapping.
+    /// This is a property of the refinement *input* (the impl spec is
+    /// broken on its own), not a refinement fidelity verdict, so it must
+    /// never be reported as `refines` or folded into `refinement_failed`.
+    pub impl_violation: Option<(Violation, Vec<TraceStep>)>,
 }
 
 fn merged_refinement_model(
@@ -1432,6 +1439,24 @@ pub fn check_refinement(
     mapping: &Refinement,
     depth: usize,
 ) -> Result<RefinementCheck, RuntimeError> {
+    // The impl spec must be internally consistent before its transitions are
+    // compared against the abstraction at all: refinement fidelity is
+    // meaningless to evaluate for a spec that already breaks its own type
+    // bounds or invariants. Checking this first — and returning immediately
+    // — means the correspondence walk below never needs to decide what a
+    // mid-walk self-violation means; by construction it cannot encounter
+    // one within the same `depth`.
+    if let Some((violation, trace)) = first_self_violation(implementation.clone(), depth)? {
+        return Ok(RefinementCheck {
+            implementation: implementation.name.clone(),
+            abstraction: abstraction.name.clone(),
+            depth,
+            action_map: BTreeMap::new(),
+            abs_has_ensures: false,
+            failure: None,
+            impl_violation: Some((violation, trace)),
+        });
+    }
     let eval_model = merged_refinement_model(implementation, abstraction)?;
     let impl_initial = Monitor::new(implementation.clone())?;
     let abs_initial = Monitor::new(abstraction.clone())?;
@@ -1463,6 +1488,7 @@ pub fn check_refinement(
             .iter()
             .any(|action| !action.ensures.is_empty()),
         failure: None,
+        impl_violation: None,
     };
     let initial_trace = vec![TraceStep {
         step: 0,
@@ -1551,6 +1577,12 @@ pub fn check_refinement(
             let mut child = monitor.clone();
             let stepped = child.step(&enabled)?;
             if stepped.violation.is_some() {
+                // Unreachable in practice: `first_self_violation` above
+                // already proved the impl has no self-violation within
+                // `depth`, and this walk never explores past `depth`. Kept
+                // as a defensive skip (never a silent `refines`) rather than
+                // an `unreachable!()`, since only silence here — not a
+                // panic — would resurrect the false-green #466 fixes.
                 continue;
             }
             let mut child_trace = trace.clone();
@@ -1770,6 +1802,62 @@ pub fn find_boundary_violation(
                     return Ok(Some((violation, child_trace)));
                 }
                 continue;
+            }
+            if visited.insert(child.state.clone()) {
+                queue.push_back((child, child_trace, step + 1));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Find the first violation of ANY kind (type bound, user invariant, `trans`,
+/// `ensures`, or `partial_op`) the model has against its own semantics,
+/// concretely, within `depth` — i.e. whether the model is internally
+/// consistent at all, independent of any refinement mapping.
+///
+/// Unlike [`find_boundary_violation`], which is scoped to
+/// `partial_op`/`type_bound` for its own narrower callers, this checks every
+/// violation kind `Monitor::current_violation`/`Monitor::step` can report,
+/// including a violation already present in the initial state (init can
+/// itself violate an invariant or type bound before any action runs).
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] when concrete evaluation or execution fails.
+fn first_self_violation(
+    model: KernelModel,
+    depth: usize,
+) -> Result<Option<(Violation, Vec<TraceStep>)>, RuntimeError> {
+    let initial = Monitor::new(model)?;
+    let initial_trace = vec![TraceStep {
+        step: 0,
+        state: initial.state.clone(),
+        action: None,
+        changes: BTreeMap::new(),
+    }];
+    if let Some(violation) = initial.current_violation()? {
+        return Ok(Some((violation, initial_trace)));
+    }
+    let mut queue = VecDeque::from([(initial.clone(), initial_trace, 0_usize)]);
+    let mut visited = BTreeSet::from([initial.state.clone()]);
+    while let Some((monitor, trace, step)) = queue.pop_front() {
+        if step >= depth {
+            continue;
+        }
+        for instance in monitor.enabled()? {
+            let mut child = monitor.clone();
+            let before = child.state.clone();
+            let stepped = child.step(&instance)?;
+            let mut child_trace = trace.clone();
+            child_trace.push(trace_step_from_result(
+                step + 1,
+                &before,
+                &instance,
+                &stepped,
+            ));
+            if let Some(violation) = stepped.violation {
+                return Ok(Some((violation, child_trace)));
             }
             if visited.insert(child.state.clone()) {
                 queue.push_back((child, child_trace, step + 1));

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1817,6 +1817,21 @@ pub fn expression_reachable(
     Ok(false)
 }
 
+/// Wrap `expr` in a nested `exists` quantifier over `binders`, outermost
+/// binder first — the same existential closure the frozen Python reference
+/// (`bmc._exists_wrap`) uses to check reachability of a leadsTo trigger or
+/// implication antecedent independent of any particular binding.
+fn exists_wrap(binders: &[Binder], expr: Expr) -> Expr {
+    binders
+        .iter()
+        .rev()
+        .fold(expr, |body, binder| Expr::Quantified {
+            quantifier: "exists".to_owned(),
+            binder: binder.clone(),
+            body: Box::new(body),
+        })
+}
+
 /// Build solver-independent verification warnings shared by native and browser frontends.
 #[must_use]
 pub fn verification_warnings(
@@ -1841,6 +1856,29 @@ pub fn verification_warnings(
                 "name": display_name(&property.name),
                 "message": format!("invariant '{}' has an implication antecedent that is unreachable within depth {depth}", display_name(&property.name)),
                 "hint": "the antecedent is not reachable within this depth; check whether an action that should establish it is missing, or whether the antecedent expression is wrong",
+                "loc": property.span.python_loc(),
+                "classification": "insufficient_depth",
+                "blocking": [],
+                "faithfulness_class": "intent_unexercised",
+                "recommended_action": "add a single-shot reachable for the action / raise --depth",
+            });
+            if let JsonValue::Object(warning) = &mut warning {
+                insert_requirement_metadata(warning, &property.annotations, property.meta.as_ref());
+            }
+            warnings.push(warning);
+        }
+    }
+    for property in &model.leadstos {
+        let trigger = exists_wrap(&property.binders, property.before.clone());
+        if matches!(
+            expression_reachable(model.clone(), &trigger, depth),
+            Ok(false)
+        ) {
+            let mut warning = json!({
+                "kind": "vacuous_leadsto",
+                "name": display_name(&property.name),
+                "message": format!("leadsTo '{}' has a trigger that is unreachable within depth {depth}", display_name(&property.name)),
+                "hint": "the trigger is not reachable within this depth; check whether an action that should establish it is missing, or whether the trigger expression is wrong",
                 "loc": property.span.python_loc(),
                 "classification": "insufficient_depth",
                 "blocking": [],

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -786,8 +786,9 @@ impl Monitor {
             .map(|(name, ty)| Ok((name.clone(), model.default_value(ty)?)))
             .collect::<Result<State, RuntimeError>>()?;
         let mut bindings = Bindings::new();
+        let mut written = BTreeMap::new();
         for statement in &model.init {
-            execute_init_statement(statement, &mut state, &mut bindings, &model)?;
+            execute_init_statement(statement, &mut state, &mut bindings, &model, &mut written)?;
         }
         Ok(Self {
             model,
@@ -2394,16 +2395,40 @@ fn evaluate_action_guards(
     Ok(Some(bindings))
 }
 
+/// Execute one `init` statement, threading `written` — the concrete value
+/// already assigned to each resolved lvalue location during this `init`
+/// execution — through every branch and `forall` iteration.
+///
+/// `forall` bulk-initializes by executing its body once per binder value.
+/// When distinct binder values resolve to the *same* concrete location
+/// (typically a target that does not index by the binder), imperative
+/// last-write-wins would silently discard every assignment but the last —
+/// masking exactly the case the symbolic engine reports as unsatisfiable
+/// init (`forall k: K { x = k }` demands `x` equal every member of `K`
+/// simultaneously). Detecting a location written to two different concrete
+/// values keeps the concrete and symbolic engines in agreement without
+/// requiring a solver: unsatisfiability is witnessed directly by the
+/// conflicting concrete values, no search needed.
 fn execute_init_statement(
     statement: &Statement,
     state: &mut State,
     bindings: &mut Bindings,
     model: &KernelModel,
+    written: &mut BTreeMap<String, Value>,
 ) -> Result<(), RuntimeError> {
     match statement {
         Statement::Assign { target, value, .. } => {
             let value = eval(value, state, bindings, model, None)?;
             let read_state = state.clone();
+            let key = lvalue_key(target, &read_state, bindings, model)?;
+            match written.get(&key) {
+                Some(previous) if *previous != value => {
+                    return Err(runtime_error("init constraints are unsatisfiable"));
+                }
+                _ => {
+                    written.insert(key, value.clone());
+                }
+            }
             assign(target, value, &read_state, state, bindings, model)?;
         }
         Statement::If {
@@ -2418,7 +2443,7 @@ fn execute_init_statement(
                 else_statements
             };
             for statement in branch {
-                execute_init_statement(statement, state, bindings, model)?;
+                execute_init_statement(statement, state, bindings, model, written)?;
             }
         }
         Statement::ForAll {
@@ -2431,7 +2456,7 @@ fn execute_init_statement(
                     continue;
                 }
                 for statement in statements {
-                    execute_init_statement(statement, state, &mut local, model)?;
+                    execute_init_statement(statement, state, &mut local, model, written)?;
                 }
             }
         }

--- a/rust/fsl-runtime/tests/diagnostics.rs
+++ b/rust/fsl-runtime/tests/diagnostics.rs
@@ -1,7 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
+use std::collections::BTreeMap;
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
 use serde_json::json;
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    build_model(parse_kernel_source(source, &FsResolver::new(".")).expect("parse kernel"))
+        .expect("build model")
+}
+
+/// Negative control for #465: native `verification_warnings` emitted only
+/// `vacuous_implication`, never `vacuous_leadsto`, so a `leadsTo` whose
+/// trigger never becomes true within depth K was reported `verified` with no
+/// warning at all (`--vacuity error` could not fail closed on it, because it
+/// had nothing to select). If this regresses, the trigger-unreachable case
+/// stops appearing in `warnings`.
+#[test]
+fn vacuous_leadsto_is_reported_when_the_trigger_is_unreachable() {
+    let unreachable = model(
+        "spec VacuousLeadsto { state { pending: Bool, done: Bool } \
+         init { pending = false done = false } \
+         action finish() { requires pending pending = false done = true } \
+         leadsTo Served { pending ~> done } }",
+    );
+    let warnings =
+        fsl_runtime::verification_warnings(&unreachable, 3, false, None, None, &BTreeMap::new());
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.get("kind").and_then(|k| k.as_str()) == Some("vacuous_leadsto")),
+        "expected a vacuous_leadsto warning: {warnings:#?}"
+    );
+
+    // Regression control: a leadsTo whose trigger *is* reachable must not be
+    // flagged, so the lane does not over-trigger on ordinary leadsTo use.
+    let reachable = model(
+        "spec ReachableLeadsto { state { pending: Bool, done: Bool } \
+         init { pending = false done = false } \
+         action request() { requires not pending pending = true } \
+         action finish() { requires pending pending = false done = true } \
+         leadsTo Served { pending ~> done } }",
+    );
+    let warnings =
+        fsl_runtime::verification_warnings(&reachable, 3, false, None, None, &BTreeMap::new());
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning.get("kind").and_then(|k| k.as_str()) == Some("vacuous_leadsto")),
+        "reachable trigger must not be flagged: {warnings:#?}"
+    );
+}
 
 #[test]
 fn induction_drops_only_typed_deadlock_warnings() {

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -173,6 +173,36 @@ fn deterministic_init_tracks_branches_foralls_and_duplicate_locations() {
     assert_eq!(error.message, "nested forall in init is not supported");
 }
 
+/// Negative control for #480: a `forall` binder over more than one value
+/// that writes to a target *not* indexed by the binder demands the same
+/// location equal every binder value simultaneously. When those values
+/// differ, no initial state can satisfy every iteration at once — the same
+/// contradiction the symbolic engine already reports as unsatisfiable init.
+/// Before the fix, `Monitor::new` executed the forall as an imperative
+/// last-write-wins loop and silently produced a (bogus) initial state.
+#[test]
+fn forall_init_writing_conflicting_values_to_the_same_location_is_unsatisfiable() {
+    let contradictory = model(
+        "spec Contradictory { type K = 0..1 state { x: Int } \
+         init { forall k: K { x = k } } action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(contradictory, 4, 100)
+        .expect_err("contradictory forall init rejected");
+    assert_eq!(error.message, "init constraints are unsatisfiable");
+
+    // Regression control: repeating the *same* value on every iteration is
+    // satisfiable and must not be flagged.
+    let consistent = model(
+        "spec Consistent { type K = 0..2 state { ready: Bool } \
+         init { forall k: K { ready = true } } \
+         action noop() { } invariant AlwaysReady { ready } }",
+    );
+    let result =
+        fsl_runtime::verify_explicit(consistent, 4, 100).expect("consistent forall init accepted");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+}
+
 #[test]
 fn explicit_violation_trace_replays_through_the_monitor() {
     let model = model(

--- a/rust/fsl-runtime/tests/refinement.rs
+++ b/rust/fsl-runtime/tests/refinement.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source, parse_refinement};
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    build_model(parse_kernel_source(source, &FsResolver::new(".")).expect("parse kernel"))
+        .expect("build model")
+}
+
+const ABS: &str = "spec MinAbs { type AQty = 0..1 state { n: AQty } init { n = 1 } \
+     action dec() { requires n > 0 n = n - 1 } }";
+
+/// Negative control for #466: an impl whose own guardless `dec()` walks its
+/// state past its declared type bound must be reported as violating itself
+/// — never `refines`. Before the fix, `check_refinement`'s BFS silently
+/// `continue`d past any `stepped.violation`, discarding the impl's own
+/// type-bound violation and reporting `refines` because the correspondence
+/// check was never reached for that step.
+#[test]
+fn check_refinement_reports_an_impl_self_violation_instead_of_refines() {
+    let implementation = model(
+        "spec MinImplBounded { type IQty = 0..1 state { n: IQty } init { n = 1 } \
+         action dec() { n = n - 1 } }",
+    );
+    let abstraction = model(ABS);
+    let mapping = parse_refinement(
+        "refinement M { impl MinImplBounded abs MinAbs maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 4)
+        .expect("check_refinement runs");
+
+    let (violation, trace) = checked
+        .impl_violation
+        .expect("impl's own type-bound violation must be reported");
+    assert_eq!(violation.kind, "type_bound");
+    assert_eq!(violation.name, "_bounds_n");
+    assert!(!trace.is_empty());
+    assert!(
+        checked.failure.is_none(),
+        "impl_violation and failure must be mutually exclusive: {:?}",
+        checked.failure
+    );
+}
+
+/// Regression control: an impl that never breaks its own bounds and
+/// genuinely refines the abstraction must still report `impl_violation:
+/// None` and `failure: None` (i.e. `refines`).
+#[test]
+fn check_refinement_still_refines_when_the_impl_is_internally_consistent() {
+    let implementation = model(
+        "spec MinImplRefines { type IQty = 0..1 state { n: IQty } init { n = 1 } \
+         action dec() { requires n > 0 n = n - 1 } }",
+    );
+    let abstraction = model(ABS);
+    let mapping = parse_refinement(
+        "refinement M { impl MinImplRefines abs MinAbs maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 4)
+        .expect("check_refinement runs");
+
+    assert!(checked.impl_violation.is_none());
+    assert!(checked.failure.is_none());
+}
+
+/// Regression control: a genuine refinement fidelity failure (impl weakens
+/// a guard the abstraction relies on, without ever breaking its own type
+/// bounds) must still be reported as `refinement_failed` via `failure`, not
+/// swallowed into `impl_violation`.
+#[test]
+fn check_refinement_still_reports_abs_requires_failed_for_a_pure_guard_weakening() {
+    let implementation = model(
+        "spec MinImplWide { type IQty = -1..1 state { n: IQty } init { n = 1 } \
+         action dec() { n = n - 1 } }",
+    );
+    let abstraction = model(ABS);
+    let mapping = parse_refinement(
+        "refinement M { impl MinImplWide abs MinAbs maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    // Depth 2 is enough to hit the guard-weakening mismatch (impl steps
+    // n: 1 -> 0 -> -1, both within IQty's -1..1 bound) before the impl's own
+    // bound would break at n = -2 (depth 3+, see #480/#466 commit history).
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 2)
+        .expect("check_refinement runs");
+
+    assert!(
+        checked.impl_violation.is_none(),
+        "impl_violation: {:?}",
+        checked.impl_violation
+    );
+    let failure = checked.failure.expect("guard weakening must be detected");
+    assert_eq!(failure.kind, "abs_requires_failed");
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -10,7 +10,8 @@ use std::time::Instant;
 
 use fsl_core::{
     Annotations, FslValue, KernelExpr, KernelLValue, KernelModel, KernelSpec, KernelStatement,
-    ParamDef, TypeDef, TypeRef, insert_requirement_metadata, model_warnings, requirement_metadata,
+    ParamDef, TraceStep, TypeDef, TypeRef, insert_requirement_metadata, model_warnings,
+    requirement_metadata,
 };
 use serde_json::{Map, Value, json};
 
@@ -8559,7 +8560,28 @@ fn apply_implements_mutation_oracle(
     let checked =
         fsl_runtime::check_refinement(model, &contract.abstraction, &contract.refinement, depth)
             .map_err(|error| error.to_string())?;
-    if let Some(failure) = checked.failure {
+    if let Some((_, trace)) = &checked.impl_violation {
+        // The mutant violates its own type bounds/invariants — a property of
+        // the mutated impl spec, not a refinement fidelity failure, but a
+        // real, detectable difference (#466): it must not be reported clean.
+        let killer_requirements = trace
+            .last()
+            .and_then(|step| step.action.as_ref())
+            .and_then(|action| {
+                model
+                    .actions
+                    .iter()
+                    .find(|candidate| candidate.name == action.name)
+            })
+            .map_or_else(Vec::new, |action| {
+                annotation_requirement_ids(&action.annotations)
+            });
+        *outcome = MutationOracle {
+            clean: false,
+            killed_by: Some("refinement".to_owned()),
+            killer_requirements,
+        };
+    } else if let Some(failure) = checked.failure {
         let killer_requirements = failure
             .impl_action
             .as_ref()
@@ -12086,7 +12108,7 @@ fn finish_analysis(
     (Value::Object(output), 0)
 }
 
-const DIFF_FINDING_KINDS: [&str; 7] = [
+const DIFF_FINDING_KINDS: [&str; 8] = [
     "behavior_added",
     "behavior_removed",
     "invariant_weakened",
@@ -12094,6 +12116,7 @@ const DIFF_FINDING_KINDS: [&str; 7] = [
     "forbidden_relaxed",
     "scope_changed",
     "unknown",
+    "impl_violated",
 ];
 
 fn diff_shape_mismatch(implementation: &KernelModel, abstraction: &KernelModel) -> Option<Value> {
@@ -12187,6 +12210,24 @@ fn semantic_diff_direction(
         }
         Err(error) => return Err(error.to_string()),
     };
+    if let Some((violation, trace)) = checked.impl_violation {
+        // The implementation side of this direction violates its own type
+        // bounds/invariants (#466) — not a behavior difference to review,
+        // but a broken input. `refines`/`no_semantic_change` would hide a
+        // real regression from a diff gate entirely, so this is surfaced as
+        // its own finding kind and made an unconditional gate failure below
+        // (unlike ordinary findings, never opt-in via `--forbid`).
+        let public = json!({
+            "result":"impl_violated","checked_to_depth":depth,
+            "violation_kind":violation.kind,"invariant":display(&violation.name),
+            "violated_at_step":violation.step,
+        });
+        let raw = json!({
+            "kind":violation.kind,"violated_at_step":violation.step,
+            "impl_trace":fslc_rust::trace_json(implementation,&trace),
+        });
+        return Ok((public, Some(raw)));
+    }
     if let Some(failure) = checked.failure {
         let impl_action = failure.impl_action.as_ref().map(|action| {
             let definition = implementation
@@ -12640,6 +12681,12 @@ fn run_diff(
                 "detail":public.get("mismatch").or_else(||public.get("detail"))
                     .or_else(||public.get("message")).cloned().unwrap_or(Value::Null),
             })),
+            Some("impl_violated") => findings.push(json!({
+                "kind":"impl_violated","direction":direction,
+                "witness":diff_counterexample(raw),
+                "violation_kind":public.get("violation_kind").cloned().unwrap_or(Value::Null),
+                "invariant":public.get("invariant").cloned().unwrap_or(Value::Null),
+            })),
             _ => {}
         }
     }
@@ -12683,11 +12730,21 @@ fn run_diff(
     let mut forbidden = forbid.to_vec();
     forbidden.sort();
     forbidden.dedup();
-    let violations = forbidden
+    let mut violations = forbidden
         .iter()
         .filter(|kind| present.contains(kind.as_str()))
         .cloned()
         .collect::<Vec<_>>();
+    // `impl_violated` is not an ordinary opt-in finding: it means one side
+    // of this diff violates its own type bounds/invariants, so the
+    // comparison itself is not trustworthy. Unlike `--forbid`-gated kinds
+    // (a reviewer's judgment call on whether a *behavior* difference is
+    // acceptable), this always fails the gate, matching how a plain
+    // parse/type error in either input already exits non-zero before
+    // reaching this comparison at all.
+    if present.contains("impl_violated") && !violations.iter().any(|kind| kind == "impl_violated") {
+        violations.push("impl_violated".to_owned());
+    }
     let mut output = envelope();
     output.insert("result".to_owned(), json!("semantic_diff"));
     output.insert(
@@ -13200,6 +13257,44 @@ fn mismatch_paths(
     paths
 }
 
+/// Render `RefinementCheck::impl_violation`: the implementation itself
+/// violates a type bound, invariant, `trans`, or `ensures` within `depth`,
+/// discovered before any refinement correspondence was even attempted. Not
+/// `refines` and not `refinement_failed` (#466) — this is a property of the
+/// refinement *input*, so it is reported with the same shape `fslc verify`
+/// uses for a `violated` result plus an explanatory `note`, matching the
+/// frozen Python reference's `refine()` (`src/fslc/refine.py`, accepted as
+/// [1.2.9] in CHANGELOG.md).
+fn impl_self_violation_output(
+    implementation: &KernelModel,
+    violation: &fsl_runtime::Violation,
+    trace: &[TraceStep],
+    depth: usize,
+) -> Map<String, Value> {
+    let mut output = envelope();
+    output.insert("impl".to_owned(), json!(implementation.name));
+    output.insert("result".to_owned(), json!("violated"));
+    output.insert("violation_kind".to_owned(), json!(violation.kind));
+    if violation.kind == "trans" {
+        output.insert("trans".to_owned(), json!(display(&violation.name)));
+    }
+    output.insert("invariant".to_owned(), json!(display(&violation.name)));
+    output.insert("violated_at_step".to_owned(), json!(violation.step));
+    output.insert("checked_to_depth".to_owned(), json!(depth));
+    output.insert(
+        "impl_trace".to_owned(),
+        fslc_rust::trace_json(implementation, trace),
+    );
+    output.insert(
+        "note".to_owned(),
+        json!(
+            "this result is a property of the impl spec itself (a refinement input), not a refinement failure; verify the impl spec independently before checking refinement"
+        ),
+    );
+    output.insert("trace_type".to_owned(), json!("refinement"));
+    output
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_refine(
     implementation_path: &Path,
@@ -13236,6 +13331,17 @@ fn run_refine(
             Ok(checked) => checked,
             Err(error) => return (error_output("type", &error.to_string()), 2),
         };
+    if let Some((violation, trace)) = checked.impl_violation {
+        return (
+            Value::Object(impl_self_violation_output(
+                &implementation,
+                &violation,
+                &trace,
+                checked.depth,
+            )),
+            1,
+        );
+    }
     let progress = if checked.failure.is_none() && !mapping.progress.is_empty() {
         let mut solver = match fsl_solver_z3::Z3Solver::new() {
             Ok(solver) => solver,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6488,7 +6488,10 @@ fn run_domain_testgen(
         Err(error) => return (semantic_error_output(&error), 2),
     };
     let (generic, generic_status) = run_testgen(path, depth, target, deadlock_mode, strict, None);
-    if generic_status == 2 {
+    if generic_status != 0 {
+        // Same reasoning as run_testgen above: `domain testgen` must not
+        // re-wrap a genuine violated/reachable_failed/internal result from
+        // the generic testgen path as a domain-specific error.
         return (generic, generic_status);
     }
     let mut content = generic
@@ -9500,7 +9503,16 @@ fn run_testgen(
         Err(error) => return (semantic_error_output(&error), 2),
     };
     let (scenarios, status) = run_scenarios_mode(path, depth, deadlock_mode, !strict);
-    if status == 2 {
+    if status != 0 {
+        // A genuine `violated`/`reachable_failed` counterexample (status 1)
+        // is not a spec error: propagate it verbatim (verdict, exit code,
+        // and trace) instead of falling through to
+        // `fsl_tools::validate_scenarios`, which only understands a real
+        // `scenarios` envelope and turns the missing `scenarios` array into
+        // an unrelated exit-2 `kind:"semantics"` error — silently
+        // reclassifying "your spec has a bug" as "fix your input" and
+        // destroying the trace. Status 3 (internal) is propagated the same
+        // way for the same reason.
         return (scenarios, status);
     }
     let walk = match fslc_rust::testgen_trace_vectors(&model) {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -13756,7 +13756,7 @@ fn apply_vacuity_mode(output: &mut Value, mode: &str) -> Option<i32> {
                     warning
                         .get("kind")
                         .and_then(Value::as_str)
-                        .is_some_and(|kind| kind.starts_with("vacuous_"))
+                        .is_some_and(fsl_core::is_vacuity_kind)
                 })
                 .cloned()
                 .collect::<Vec<_>>()
@@ -13768,7 +13768,7 @@ fn apply_vacuity_mode(output: &mut Value, mode: &str) -> Option<i32> {
                 !warning
                     .get("kind")
                     .and_then(Value::as_str)
-                    .is_some_and(|kind| kind.starts_with("vacuous_"))
+                    .is_some_and(fsl_core::is_vacuity_kind)
             });
         }
         return None;
@@ -14433,6 +14433,40 @@ fn block_on_native<F: Future>(future: F) -> F::Output {
 #[cfg(test)]
 mod exit_status_tests {
     use super::*;
+
+    /// Negative control for #465: before the fix, `apply_vacuity_mode`
+    /// selected findings with `kind.starts_with("vacuous_")`, which matches
+    /// only 2 of the 5 documented vacuity kinds
+    /// (`docs/LANGUAGE.md` §15, `fsl_core::VACUITY_KINDS`).
+    /// `always_true_requires`, `tautology_over_frozen`, and `urgency_freeze`
+    /// do not share that prefix, so `--vacuity error` silently let a hollow
+    /// spec carrying only one of those three pass, and `--vacuity ignore`
+    /// silently left it in `warnings`. If this regresses to a prefix check,
+    /// these assertions fail.
+    #[test]
+    fn apply_vacuity_mode_covers_every_vacuity_kind_not_only_the_vacuous_prefix() {
+        for kind in fsl_core::VACUITY_KINDS {
+            let mut error_output = json!({
+                "result": "verified",
+                "warnings": [{"kind": kind, "message": "hollow"}],
+            });
+            let status = apply_vacuity_mode(&mut error_output, "error");
+            assert_eq!(status, Some(2), "kind={kind}: {error_output:#}");
+            assert_eq!(error_output["result"], "error");
+            assert_eq!(error_output["kind"], kind);
+
+            let mut ignore_output = json!({
+                "result": "verified",
+                "warnings": [{"kind": kind, "message": "hollow"}],
+            });
+            assert_eq!(apply_vacuity_mode(&mut ignore_output, "ignore"), None);
+            assert_eq!(
+                ignore_output["warnings"].as_array().map(Vec::len),
+                Some(0),
+                "kind={kind} was not ignored: {ignore_output:#}"
+            );
+        }
+    }
 
     #[test]
     fn internal_error_envelopes_always_exit_three() {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3317,7 +3317,18 @@ fn run_sweep(
                     from_state: None,
                     edition: "current".to_owned(),
                 };
-                let (mut verification, _) = run_verify_cli(path, path, &options);
+                let (mut verification, status) = run_verify_cli(path, path, &options);
+                if verification.get("result").and_then(Value::as_str) == Some("error") {
+                    // A spec error (parse/type/semantics/io/vacuous/…) is not a
+                    // counterexample: folding it into the sweep grid let a single
+                    // mistyped `--instances` name, missing file, or unparseable
+                    // spec collapse into `sweep_passed`/exit 0 even when the same
+                    // spec has a real counterexample under the correct scope.
+                    // Return the underlying error verbatim (kind, message, loc,
+                    // and exit code — 2, or 3 for `kind:"internal"` — preserved)
+                    // instead of absorbing it as a passing grid cell.
+                    return (verification, status);
+                }
                 if let Value::Object(envelope) = &mut verification {
                     let trace_type = envelope.remove("trace_type");
                     envelope.insert(

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -184,7 +184,16 @@ pub fn requirements_implements_output(
                 message: error.to_string(),
                 span: None,
             })?;
-    Ok(Some(if let Some(failure) = checked.failure {
+    Ok(Some(if let Some((violation, _)) = checked.impl_violation {
+        // The impl itself violates its own type bounds/invariants (#466):
+        // a property of the refinement input, not a refinement fidelity
+        // verdict, so it must not be reported `refines`.
+        json!({
+            "abs": contract.abstraction.name,
+            "result": "impl_violated",
+            "violation": {"result": "violated", "kind": violation.kind},
+        })
+    } else if let Some(failure) = checked.failure {
         json!({
             "abs": contract.abstraction.name,
             "result": "refinement_failed",

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -228,6 +228,49 @@ fn explicit_init_forall_domains_match_bmc_semantics_errors() {
     assert_eq!(bmc["result"], "verified");
 }
 
+/// Negative control for #480: `forall k: K { x = k }` over a multi-valued
+/// `K` demands `x` equal every member of `K` simultaneously, which BMC
+/// already reports as unsatisfiable init (`kind:"vacuous"`, exit 2). Before
+/// the fix, the explicit engine silently ran the forall as a last-write-wins
+/// imperative loop and returned `result:"proved"` / exit 0 — a confidently
+/// green false negative over a spec with no valid initial state. If this
+/// regresses, `explicit` will diverge from `bmc` again on this fixture.
+#[test]
+fn explicit_rejects_contradictory_forall_init_and_agrees_with_bmc() {
+    let path = fixture_path("explicit_init_contradictory.fsl");
+
+    let (explicit, explicit_status) = verify(&path, "explicit", 4, &[]);
+    assert_eq!(explicit_status, 2, "explicit accepted a contradictory init");
+    assert_eq!(explicit["result"], "error");
+    assert_eq!(explicit["kind"], "vacuous");
+    assert_eq!(explicit["message"], "init constraints are unsatisfiable");
+
+    let (bmc, bmc_status) = verify(&path, "bmc", 4, &[]);
+    assert_eq!(bmc_status, explicit_status, "exit code must match BMC");
+    assert_eq!(bmc["result"], explicit["result"]);
+    assert_eq!(bmc["kind"], explicit["kind"]);
+    assert_eq!(bmc["message"], explicit["message"]);
+}
+
+/// Regression control: a `forall` that writes the *same* concrete value to a
+/// non-indexed target on every iteration is satisfiable (the simultaneous
+/// constraints agree) and must keep verifying. This guards the #480 fix
+/// against over-triggering on the ordinary "repeat this literal for every
+/// binder value" idiom.
+#[test]
+fn explicit_accepts_forall_init_writing_the_same_value_every_iteration() {
+    let path = fixture_path("explicit_init_forall_same_value.fsl");
+
+    let (explicit, explicit_status) = verify(&path, "explicit", 4, &[]);
+    assert_eq!(explicit_status, 0, "explicit: {explicit:#}");
+    assert_eq!(explicit["result"], "proved");
+    assert_eq!(explicit["closure"], true);
+
+    let (bmc, bmc_status) = verify(&path, "bmc", 4, &[]);
+    assert_eq!(bmc_status, 0, "bmc: {bmc:#}");
+    assert_eq!(bmc["result"], "verified");
+}
+
 #[test]
 fn explicit_closure_proves_true_noninductive_invariant() {
     let fixture =

--- a/rust/fslc/tests/fixtures/explicit_init_contradictory.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_contradictory.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec ExplicitInitContradictory {
+  type K = 0..1
+  state { x: Int }
+  init {
+    forall k: K { x = k }
+  }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/explicit_init_forall_same_value.fsl
+++ b/rust/fslc/tests/fixtures/explicit_init_forall_same_value.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Every binder value writes the *same* concrete value to a non-indexed
+// target. Unlike explicit_init_contradictory.fsl this is satisfiable (all
+// the simultaneous constraints agree), so it must still verify — a fix for
+// the contradictory-init case must not flag consistent repeated writes.
+spec ExplicitInitForallSameValue {
+  type K = 0..2
+  state { ready: Bool }
+  init {
+    forall k: K { ready = true }
+  }
+  action noop() { }
+  invariant AlwaysReady { ready }
+}

--- a/rust/fslc/tests/fixtures/sweep_clean.fsl
+++ b/rust/fslc/tests/fixtures/sweep_clean.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec SweepClean {
+  type Amount = 0..3
+  state { balance: Int }
+  init { balance = 0 }
+  action deposit(a: Amount) {
+    requires a > 0 and balance + a <= 3
+    balance = balance + a
+  }
+  invariant WithinBounds { balance <= 3 }
+}

--- a/rust/fslc/tests/fixtures/sweep_violating.fsl
+++ b/rust/fslc/tests/fixtures/sweep_violating.fsl
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec SweepViolating {
+  type Amount = 0..3
+  state { balance: Int }
+  init { balance = 0 }
+  action deposit(a: Amount) {
+    requires a > 0
+    balance = balance + a
+  }
+  invariant TooSmall { balance <= 1 }
+}

--- a/rust/fslc/tests/fixtures/testgen_leadsto_violation.fsl
+++ b/rust/fslc/tests/fixtures/testgen_leadsto_violation.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `pending` is only ever set true and never observed together with `done`
+// becoming true afterward within a small depth: the leadsTo genuinely
+// violates, matching #472's leadsTo repro.
+spec TestgenLeadstoViolation {
+  state { pending: Bool, done: Bool }
+  init { pending = false done = false }
+
+  action request() {
+    requires not pending
+    pending = true
+  }
+
+  leadsTo Served { pending ~> done }
+}

--- a/rust/fslc/tests/fixtures/testgen_strict_unreached.fsl
+++ b/rust/fslc/tests/fixtures/testgen_strict_unreached.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `Two` is not reachable within depth 1: at depth 1, `--strict` must abort
+// as `reachable_failed` instead of the default partial-generation mode.
+spec TestgenStrictUnreached {
+  type Small = 0..2
+  state { x: Small }
+  init { x = 0 }
+
+  action inc() {
+    requires x < 2
+    x = x + 1
+  }
+
+  reachable One { x == 1 }
+  reachable Two { x == 2 }
+}

--- a/rust/fslc/tests/fixtures/vacuous_leadsto.fsl
+++ b/rust/fslc/tests/fixtures/vacuous_leadsto.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The trigger `pending` is never reachable within a small depth because no
+// action ever sets it — `finish`'s own guard requires it, so `finish` is
+// itself never enabled. The leadsTo is hollow: it checks nothing.
+spec VacuousLeadstoFixture {
+  state { pending: Bool, done: Bool }
+  init { pending = false  done = false }
+
+  action finish() {
+    requires pending
+    pending = false
+    done = true
+  }
+
+  leadsTo Served { pending ~> done }
+}

--- a/rust/fslc/tests/issue_466_refine_impl_self_violation.rs
+++ b/rust/fslc/tests/issue_466_refine_impl_self_violation.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #466: `fslc refine`, `fslc diff`, and the
+//! `implements`-clause mutation oracle must never report `refines` (or fold
+//! into `no_semantic_change`/`gate.passed:true`) when the implementation
+//! spec violates its own type bounds within `--depth`. That is a property
+//! of the refinement *input*, not a refinement fidelity verdict.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn write(path: &Path, source: &str) {
+    std::fs::write(path, source).expect("write fixture");
+}
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("fslc-issue-466-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create scratch directory");
+    dir
+}
+
+const ABS: &str = "spec MinAbs { type AQty = 0..1 state { n: AQty } init { n = 1 } \
+     action dec() { requires n > 0 n = n - 1 } }";
+const IMPL_SELF_VIOLATING: &str =
+    "spec MinImpl { type IQty = 0..1 state { n: IQty } init { n = 1 } action dec() { n = n - 1 } }";
+const MAPPING_AUTO: &str = "refinement M { impl MinImpl abs MinAbs maps auto }";
+
+/// `fslc refine` on an impl that breaks its own type bound within `--depth`
+/// must report `result:"violated"`/exit 1 with a `note` explaining this is
+/// a property of the refinement input — never `refines`/exit 0.
+#[test]
+fn refine_reports_violated_not_refines_when_impl_breaks_its_own_bound() {
+    let dir = scratch("refine");
+    let implementation = dir.join("impl.fsl");
+    let abstraction = dir.join("abs.fsl");
+    let mapping = dir.join("map.fsl");
+    write(&implementation, IMPL_SELF_VIOLATING);
+    write(&abstraction, ABS);
+    write(&mapping, MAPPING_AUTO);
+
+    let (output, status) = run(&[
+        "refine".to_owned(),
+        implementation.display().to_string(),
+        abstraction.display().to_string(),
+        mapping.display().to_string(),
+        "--depth".to_owned(),
+        "4".to_owned(),
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated");
+    assert_eq!(output["violation_kind"], "type_bound");
+    assert_ne!(output["result"], "refines");
+    assert!(
+        output["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("property of the impl spec itself")),
+        "{output:#}"
+    );
+}
+
+/// `fslc diff` must not fold an introduced self-violation into
+/// `no_semantic_change`/`gate.passed:true`: it must appear as an
+/// `impl_violated` finding and fail the gate unconditionally (not gated by
+/// `--forbid`).
+#[test]
+fn diff_reports_impl_violated_and_fails_the_gate_unconditionally() {
+    let dir = scratch("diff");
+    let clean = dir.join("clean.fsl");
+    let broken = dir.join("broken.fsl");
+    // Same spec name and shape on both sides (diff's automatic identity
+    // mapping requires matching state/action names); only the guard on
+    // `dec()` differs, so `broken` violates its own type bound `n >= 0`
+    // where `clean` does not.
+    write(
+        &clean,
+        "spec DiffTarget { type Qty = 0..1 state { n: Qty } init { n = 1 } \
+         action dec() { requires n > 0 n = n - 1 } }",
+    );
+    write(
+        &broken,
+        "spec DiffTarget { type Qty = 0..1 state { n: Qty } init { n = 1 } \
+         action dec() { n = n - 1 } }",
+    );
+
+    let (output, status) = run(&[
+        "diff".to_owned(),
+        clean.display().to_string(),
+        broken.display().to_string(),
+        "--depth".to_owned(),
+        "4".to_owned(),
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["gate"]["passed"], false);
+    assert!(
+        output["gate"]["violations"]
+            .as_array()
+            .is_some_and(|violations| violations.iter().any(|v| v == "impl_violated")),
+        "{output:#}"
+    );
+    assert!(
+        output["summary"]
+            .as_array()
+            .is_some_and(|summary| summary.iter().any(|s| s == "impl_violated")),
+        "{output:#}"
+    );
+    assert_ne!(output["summary"], serde_json::json!(["no_semantic_change"]));
+    assert!(
+        output["findings"]
+            .as_array()
+            .is_some_and(|findings| findings
+                .iter()
+                .any(|finding| finding["kind"] == "impl_violated")),
+        "{output:#}"
+    );
+}
+
+/// Regression control: an ordinary clean `fslc diff` (neither side
+/// self-violating) must keep returning `gate.passed:true`/exit 0, so the
+/// `impl_violated` gate addition does not over-trigger.
+#[test]
+fn diff_still_passes_when_neither_side_self_violates() {
+    let dir = scratch("diff-clean");
+    let left = dir.join("left.fsl");
+    let right = dir.join("right.fsl");
+    let source = "spec DiffCleanTarget { type Qty = 0..1 state { n: Qty } init { n = 1 } \
+         action dec() { requires n > 0 n = n - 1 } }";
+    write(&left, source);
+    write(&right, source);
+
+    let (output, status) = run(&[
+        "diff".to_owned(),
+        left.display().to_string(),
+        right.display().to_string(),
+        "--depth".to_owned(),
+        "4".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["gate"]["passed"], true);
+    assert_eq!(output["summary"], serde_json::json!(["no_semantic_change"]));
+}

--- a/rust/fslc/tests/issue_472_testgen_violated_propagation.rs
+++ b/rust/fslc/tests/issue_472_testgen_violated_propagation.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #472: `testgen` (and `domain testgen`) must
+//! propagate a genuine `violated`/`reachable_failed` counterexample from
+//! the underlying `scenarios` machinery verbatim — verdict, exit code, and
+//! trace — instead of re-wrapping it as an unrelated exit-2
+//! `kind:"semantics"` generic error when `fsl_tools::validate_scenarios`
+//! finds no `scenarios` array in what is actually a `verify`-shaped
+//! envelope.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn scratch_output(name: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("fslc-issue-472-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create scratch directory");
+    dir.join(name).display().to_string()
+}
+
+/// A committed corpus spec (`specs/cart_buggy.fsl`) with a genuine
+/// `invariant` violation must produce `result:"violated"`/exit 1 with a
+/// full trace from `testgen`, matching `verify`/`scenarios` on the same
+/// spec — not exit 2 `kind:"semantics"` with the trace destroyed.
+#[test]
+fn testgen_propagates_a_violated_invariant_instead_of_a_generic_error() {
+    let output_path = scratch_output("cart_buggy.py");
+    let (testgen, status) = run(&[
+        "testgen",
+        "specs/cart_buggy.fsl",
+        "--depth",
+        "6",
+        "-o",
+        &output_path,
+    ]);
+    assert_eq!(status, 1, "{testgen:#}");
+    assert_eq!(testgen["result"], "violated");
+    assert_eq!(testgen["violation_kind"], "invariant");
+    assert!(
+        testgen["trace"]
+            .as_array()
+            .is_some_and(|trace| !trace.is_empty()),
+        "trace must survive: {testgen:#}"
+    );
+
+    let (verify, verify_status) = run(["verify", "specs/cart_buggy.fsl", "--depth", "6"].as_ref());
+    assert_eq!(verify_status, status);
+    assert_eq!(verify["invariant"], testgen["invariant"]);
+    assert_eq!(verify["violated_at_step"], testgen["violated_at_step"]);
+}
+
+/// A `leadsTo` violation must also propagate as `result:"violated"`/exit 1
+/// with `violation_kind:"leadsTo"`, not a generic exit-2 error.
+#[test]
+fn testgen_propagates_a_leadsto_violation_instead_of_a_generic_error() {
+    let path = "rust/fslc/tests/fixtures/testgen_leadsto_violation.fsl";
+    let output_path = scratch_output("leadsto.py");
+    let (testgen, status) = run(&["testgen", path, "--depth", "6", "-o", &output_path]);
+    assert_eq!(status, 1, "{testgen:#}");
+    assert_eq!(testgen["result"], "violated");
+    assert_eq!(testgen["violation_kind"], "leadsTo");
+}
+
+/// `--strict` must abort as `reachable_failed`/exit 1 with
+/// `unreached[].classification`, not a generic exit-2 error — and the
+/// non-strict default (partial generation) on the same fixture must stay
+/// exit 0, so this fix does not over-trigger on the lenient path.
+#[test]
+fn testgen_strict_propagates_reachable_failed_and_non_strict_stays_lenient() {
+    let path = "rust/fslc/tests/fixtures/testgen_strict_unreached.fsl";
+
+    let strict_output = scratch_output("strict.py");
+    let (strict, strict_status) = run(&[
+        "testgen",
+        path,
+        "--depth",
+        "1",
+        "--strict",
+        "-o",
+        &strict_output,
+    ]);
+    assert_eq!(strict_status, 1, "{strict:#}");
+    assert_eq!(strict["result"], "reachable_failed");
+    assert!(
+        strict["unreached"]
+            .as_array()
+            .is_some_and(|unreached| !unreached.is_empty()),
+        "{strict:#}"
+    );
+
+    let lenient_output = scratch_output("lenient.py");
+    let (lenient, lenient_status) = run(&["testgen", path, "--depth", "1", "-o", &lenient_output]);
+    assert_eq!(lenient_status, 0, "{lenient:#}");
+    assert_ne!(lenient["result"], "reachable_failed");
+}
+
+/// `domain testgen` must inherit the same propagation from the generic
+/// testgen path it wraps.
+#[test]
+fn domain_testgen_propagates_a_violated_result_from_the_generic_path() {
+    let path = "rust/fslc/tests/fixtures/domain_origin_violation.fsl";
+    let output_path = scratch_output("domain_violated.py");
+    let (output, status) = run(&[
+        "domain",
+        "testgen",
+        path,
+        "--depth",
+        "6",
+        "-o",
+        &output_path,
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated");
+    assert_ne!(output["kind"], "semantics");
+}
+
+/// Regression control: an ordinary passing spec must keep returning
+/// `result:"generated"`/exit 0 with real generated content, so the fix
+/// does not over-trigger on the success path.
+#[test]
+fn testgen_still_generates_for_a_clean_spec() {
+    let output_path = scratch_output("clean.py");
+    let (output, status) = run(&[
+        "testgen",
+        "specs/cart_v1.fsl",
+        "--depth",
+        "4",
+        "-o",
+        &output_path,
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "generated");
+}

--- a/rust/fslc/tests/sweep_contract.rs
+++ b/rust/fslc/tests/sweep_contract.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #464: `sweep` must never fold a spec error into the
+//! `sweep_passed`/exit-0 verdict. A one-character typo in `--instances`, a
+//! parse error, or a missing file are not "no counterexample in this grid" —
+//! they are documented exit-2 spec errors (`docs/LANGUAGE.md` exit-code
+//! table) that a caller gating on exit code or `result` must be able to
+//! distinguish from a genuinely clean sweep.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (serde_json::Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn fixture(name: &str) -> String {
+    format!("rust/fslc/tests/fixtures/{name}")
+}
+
+/// The masking case: a spec with a genuine counterexample, swept under a
+/// mistyped `--instances` name. Before the fix this returned
+/// `sweep_passed`/exit 0 (a one-character typo silently turned a red gate
+/// green); the spec declares no entity/number bounds at all, so any
+/// `--instances` name is a documented exit-2 error
+/// (`docs/LANGUAGE.md` §"NAME with no matching entity/number declaration").
+#[test]
+fn sweep_does_not_mask_a_typo_d_instances_name_as_sweep_passed() {
+    let path = fixture("sweep_violating.fsl");
+
+    let (baseline, baseline_status) = run_cli(&["sweep", &path, "--depth", "0..3"]);
+    assert_eq!(baseline_status, 1, "baseline: {baseline:#}");
+    assert_eq!(baseline["result"], "sweep_failed");
+    assert!(!baseline["sweep"]["minimal_counterexample"].is_null());
+
+    let (typo, typo_status) = run_cli(&[
+        "sweep",
+        &path,
+        "--instances",
+        "Amountt=1..2",
+        "--depth",
+        "0..3",
+    ]);
+    assert_eq!(typo_status, 2, "typo'd --instances must not pass: {typo:#}");
+    assert_eq!(typo["result"], "error");
+    assert_eq!(typo["kind"], "semantics");
+    assert!(
+        typo["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("--instances/--values only apply")),
+        "unexpected message: {typo:#}"
+    );
+    // The masking case is specifically that this must not become sweep_passed.
+    assert_ne!(typo["result"], "sweep_passed");
+}
+
+/// A parse error must surface as-is (`kind`, `message`, `loc`,
+/// `diagnostic_code` preserved) instead of being absorbed as a passing grid
+/// cell. Reuses the committed gallery corpus fixture so the expected
+/// diagnostic is pinned by an existing `expected-kind: parse` contract.
+#[test]
+fn sweep_propagates_a_parse_error_verbatim() {
+    let path = "examples/gallery/errors/parse_missing_expression.fsl";
+    let (check, _) = run_cli(&["check", path]);
+    assert_eq!(check["kind"], "parse", "fixture drifted: {check:#}");
+
+    let (swept, status) = run_cli(&["sweep", path, "--depth", "0..2"]);
+    assert_eq!(status, 2, "swept: {swept:#}");
+    assert_eq!(swept["result"], "error");
+    assert_eq!(swept["kind"], check["kind"]);
+    assert_eq!(swept["message"], check["message"]);
+}
+
+/// A missing spec file must surface as an exit-2 spec error, not
+/// `sweep_passed`.
+#[test]
+fn sweep_propagates_a_missing_file_error_instead_of_sweep_passed() {
+    let (swept, status) = run_cli(&["sweep", "specs/nope_does_not_exist.fsl", "--depth", "0..1"]);
+    assert_eq!(status, 2, "swept: {swept:#}");
+    assert_eq!(swept["result"], "error");
+    assert_ne!(swept["result"], "sweep_passed");
+}
+
+/// Regression control: an ordinary clean sweep (no counterexample, no
+/// argument error) must keep returning `sweep_passed`/exit 0, and a sweep
+/// over a genuinely violating spec with correct arguments must keep
+/// returning `sweep_failed`/exit 1 with `minimal_counterexample` populated.
+/// This guards against over-triggering the #464 fix on non-error grid cells.
+#[test]
+fn sweep_still_passes_clean_specs_and_fails_genuine_counterexamples() {
+    let clean = fixture("sweep_clean.fsl");
+    let (passed, passed_status) = run_cli(&["sweep", &clean, "--depth", "0..3"]);
+    assert_eq!(passed_status, 0, "clean: {passed:#}");
+    assert_eq!(passed["result"], "sweep_passed");
+    assert!(passed["sweep"]["minimal_counterexample"].is_null());
+
+    let violating = fixture("sweep_violating.fsl");
+    let (failed, failed_status) = run_cli(&["sweep", &violating, "--depth", "0..3"]);
+    assert_eq!(failed_status, 1, "violating: {failed:#}");
+    assert_eq!(failed["result"], "sweep_failed");
+    assert!(!failed["sweep"]["minimal_counterexample"].is_null());
+}

--- a/rust/fslc/tests/vacuity_contract.rs
+++ b/rust/fslc/tests/vacuity_contract.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #465: native `--vacuity` must select over the full
+//! documented 5-kind lane set (`docs/LANGUAGE.md` §15,
+//! `fsl_core::VACUITY_KINDS`), not just the two kinds spelled `vacuous_*`.
+//! This file exercises the `vacuous_leadsto` lane end to end through the CLI
+//! (`warn`/`error`/`ignore`) — the lane that was entirely missing from
+//! native `verification_warnings` before the fix.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (serde_json::Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+const FIXTURE: &str = "rust/fslc/tests/fixtures/vacuous_leadsto.fsl";
+
+#[test]
+fn vacuous_leadsto_warns_by_default() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    let warnings = output["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_leadsto"),
+        "expected a vacuous_leadsto warning: {output:#}"
+    );
+}
+
+/// Before #465, `vacuous_leadsto` was entirely unimplemented in native
+/// `verification_warnings`, so `--vacuity error` had nothing to select and
+/// this hollow leadsTo passed with `result:"verified"`/exit 0. If this
+/// regresses, the assertions below fail.
+#[test]
+fn vacuous_leadsto_fails_closed_under_vacuity_error() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "vacuous_leadsto");
+    assert_eq!(output["trace_type"], "vacuity");
+}
+
+#[test]
+fn vacuous_leadsto_is_suppressed_under_vacuity_ignore() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    let warnings = output["warnings"].as_array().expect("warnings array");
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_leadsto"),
+        "vacuous_leadsto must be suppressed: {output:#}"
+    );
+}
+
+/// Regression control: a leadsTo whose trigger is genuinely reachable must
+/// not be flagged, so `--vacuity error` still passes an ordinary spec.
+#[test]
+fn a_reachable_leadsto_trigger_is_not_flagged() {
+    let (output, status) = run_cli(&[
+        "verify",
+        "specs/mutex_queue.fsl",
+        "--depth",
+        "6",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_ne!(output["result"], "error");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1456,7 +1456,11 @@ emit the same scenarios:
 If a `reachable` target is not witnessed at the requested depth, `testgen` still
 generates tests for the scenarios it did witness and returns `warnings[]` with a
 message such as `reachable SoldOut not witnessed at depth 3; try --depth >= 4`.
-Use `--strict` to restore all-or-nothing `reachable_failed`.
+Use `--strict` to restore all-or-nothing `reachable_failed`. A genuine
+`violated`/`reachable_failed` result — the spec itself has a bug, not a
+testgen input problem — is returned verbatim (verdict, exit code, and trace
+unchanged), the same envelope `verify`/`scenarios` return for the identical
+spec; it is never re-wrapped as a generic exit-2 spec error.
 
 ## 10. Three-layer dialects (consulting / requirements / design)
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -990,8 +990,13 @@ schema as BMC. Results carry `states_explored`, `max_frontier_width`, and
 properties, nondeterministic `init` (every state variable must be definitely
 assigned), and `init forall` binder domains that reference state variables
 (range bounds and collections must be compile-time constants) — use
-`--engine bmc` for those specs. `--from-state`, `--lemma`, and `--k` do not
-apply to this engine.
+`--engine bmc` for those specs. A definitely-assigned but contradictory
+`init` (an `init forall` that writes different concrete values to the same
+non-indexed location across binder values, e.g. `forall k: K { x = k }` with
+`|K| > 1`) is also rejected, matching BMC exactly: `result:"error"`,
+`kind:"vacuous"`, `message:"init constraints are unsatisfiable"`, exit 2 —
+never `proved`. `--from-state`, `--lemma`, and `--k` do not apply to this
+engine.
 
 `--engine auto` tries explicit first and falls back to bmc transparently
 when explicit can't decide the spec (a fail-closed rejection above, or

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1321,6 +1321,14 @@ first failed layer and later layers are marked `skipped`.
   `kind:"progress_lost"`, `violation_kind:"leadsTo"`, `impl_trace`,
   `progress_failure:"lasso_blocks_progress"|"deadlock_or_stall_blocks_progress"`,
   `progress:{leadsTo, actions}`, and `faithfulness_class:"liveness_not_refined"`.
+- **impl self-violation** (checked before any correspondence, `refine`'s own
+  input precondition): if the impl spec violates its own type bounds or
+  invariants within `--depth` — independent of the abstraction and mapping —
+  `refine` reports `result:"violated"` with the impl's own `violation_kind`
+  and a `note` that this is a property of the refinement input, not a
+  fidelity failure. Never `refines`, never folded into `refinement_failed`.
+  `fslc diff` surfaces the same condition as an `impl_violated` finding and
+  fails its gate unconditionally (not `--forbid`-gated).
 - leadsTo ranking failure: `unknown_cti` / `violation_kind:"leadsTo_rank"` with
   `rank_failure` (`unbounded_below`, `deadlock`, `non_decreasing_action`, or
   `pending_not_preserved`; with `helpful`, also `progress_action_not_fair`,

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1222,7 +1222,10 @@ first failed layer and later layers are marked `skipped`.
   `result:"sweep_passed"` or `"sweep_failed"`, with every run under
   `sweep.results` and the first failing scope under
   `sweep.minimal_counterexample`. For `--values NAME=LO..HI`, it fixes `LO` and
-  expands `LO..LO`, `LO..LO+1`, ..., `LO..HI`.
+  expands `LO..LO`, `LO..LO+1`, ..., `LO..HI`. A spec `error` from any scope
+  (parse/type/semantics/io/vacuous, a mistyped `--instances`/`--values` name,
+  a missing file) is returned verbatim — exit code and `kind` unchanged —
+  instead of being folded into `sweep_passed`/`sweep_failed`.
 - `explain` is deterministic formatting with no LLM. JSON mode enumerates
   state/action/requires/writes/properties/implicit checks by source loc and
   structural traversal, and attaches to each user invariant the shortest


### PR DESCRIPTION
## Problem

Five commands returned a **green verdict where the contract requires a loud failure**. `AGENTS.md:67-68` calls this class more dangerous than a crash, and four of the five here produced `exit 0` on input that is genuinely broken.

| Issue | Before |
|---|---|
| **#480** | `verify --engine explicit` on a spec whose `init` is unsatisfiable → `result:"proved"`, `completeness:"unbounded"`, `exit 0`, and `action_coverage` marking an action that can never fire. BMC on the same file → `error`/`vacuous`/exit 2. |
| **#464** | `sweep` over a spec with a real counterexample, plus a one-character typo in `--instances` → `sweep_passed`/exit 0. Without the typo: `sweep_failed`/exit 1. |
| **#466** | `refine` discarded the impl's own type-bound violation and returned `refines`/exit 0. `diff` inherited it: `no_semantic_change`, `gate.passed:true`, exit 0. |
| **#472** | `testgen` converted a genuine `violated` counterexample into an exit-2 `kind:"semantics"` error with no spec name, no `loc`, and the trace destroyed. |
| **#465** | `--vacuity error` could not promote or suppress 3 of the 5 documented vacuity kinds, because selection used `kind.starts_with("vacuous_")` — which only 2 of the 5 names match. |

Plus **#487**: a 0-byte `.z3-trace` was tracked in git and the pattern was absent from `.gitignore`, so every Z3-using test run dirtied the working tree in whichever directory it ran from.

## Contract change

No language contract changes. Each fix restores an already-documented contract.

- **#480** — the concrete Monitor now detects an `init` that writes two different concrete values to the same resolved lvalue (what `forall k: K { x = k }` does when `|K| > 1`) and fails with the exact message BMC already uses, so the existing `semantic_error_kind` classifier maps it to `kind:"vacuous"` with no CLI change. Fixed at `Monitor::new`, the single shared init-construction path, so `refine` / `replay` / `testgen` / `mutate` inherit the guarantee.
- **#464** — `run_sweep` captures the real status from `run_verify_cli` and returns the underlying error envelope verbatim (`kind`, `message`, `loc`, exit code) the instant a grid cell errors. Deliberately **not** by adding `"error"` to the counterexample `matches!` list, which would trade one exit-code violation for another — an error is not a counterexample.
- **#466** — `check_refinement` now checks the impl's own reachable states for a type-bound / invariant / `trans` / `ensures` violation *before* touching the mapping, matching the frozen reference's accepted `[1.2.9]` behavior. New mutually-exclusive `RefinementCheck::impl_violation`; all four call sites updated. In `diff` it becomes an `impl_violated` finding that fails the gate **unconditionally** — a self-violating side makes the comparison untrustworthy, so this is not a reviewer `--forbid` judgment call. `docs/DESIGN-refinement.md` gains an explicit §2 step 0 and §5 test-plan item recording the ordering decision.
- **#472** — both `run_testgen` and `run_domain_testgen` guards change from `status == 2` to `status != 0`, propagating the verdict and exit code verbatim. Status 3 (internal) stops being silently downgraded to 2.
- **#465** — selection moves to a closed 5-element `fsl_core::VACUITY_KINDS`, collapsing **two** separately-broken copies of the prefix check onto one source of truth, and the `vacuous_leadsto` lane is added using the existing solver-free `expression_reachable` BFS (no new solver dependency; `fsl-runtime` stays independent of `fsl-solver`).

## Test evidence

Every fix carries a negative control in `rust/*/tests/` plus a regression control against over-triggering. Verified independently against a `main` binary:

- **#480** — corpus `check` over all `.fsl` under `specs/`+`examples/`: **0 differences**. Corpus `verify --engine explicit` over the same set: **exactly 1 difference, and it is the target file** (`examples/gallery/errors/vacuous_contradictory_init.fsl`, exit 0 → exit 2). Zero false positives corpus-wide. Both engines now return exit 2 / `kind:"vacuous"` / the same message. Regression control pins the ordinary bulk-init idiom (`forall k: K { m[k] = 0 }`).
- **#464** — masking case → `error`/`semantics`/exit 2; correct sweep still `sweep_failed`/exit 1; missing file → exit 2; clean spec still `sweep_passed`/exit 0.
- **#466** — `refine specs/cart_v1_buggy.fsl specs/cart_v1.fsl` → `violated`/`type_bound`/`_bounds_stock`/exit 1. `diff specs/cart_v1.fsl specs/cart_v1_buggy.fsl` → `impl_violated`/`gate.passed:false`/exit 1. **Regression control confirmed by construction**: a pure guard weakening whose impl stays inside its own bounds still reports `refinement_failed`/`abs_requires_failed` on both binaries, so step 0 does not swallow correspondence diagnoses.
- **#472** — `testgen specs/cart_buggy.fsl --depth 6` → `violated`/`invariant`/`NoNegativeStock`/`violated_at_step:4`/exit 1, matching `verify` on the same spec field for field. Clean spec still `generated`/exit 0.
- **#465** — the new `vacuous_leadsto` fixture under `--vacuity error` → exit 2 / `kind:"vacuous_leadsto"`. Corpus sweep of all 18 `leadsTo`-bearing specs at depth 6: zero new false positives.
- **#487** — `git check-ignore -v rust/fslc/.z3-trace` resolves to `.gitignore:24:.z3-trace`, confirming the pattern matches at any depth; the tracked file is untracked.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked`, `cargo build --workspace --locked`, and `./tools/check-native-integration.sh rust` (including the `fsl-runtime`/`fsl-wasm` solver-independence assertions, which confirm the `fsl-runtime` changes in #480 and #466 pulled in no Z3 dependency) all exit 0.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 1:1), `docs/DESIGN-refinement.md`, `docs/DESIGN-explicit-engine.md`, `docs/DESIGN-bridge.md`, `docs/DESIGN-rust-port.md`, `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #480, fixes #464, fixes #466, fixes #472, fixes #487.

**#465 is deliberately NOT closed** — `Refs #465`, not `Fixes`. This PR closes the CLI kind-selection bug and adds 1 of the 4 missing lanes. Three lanes remain unimplemented (`always_true_requires`, `tautology_over_frozen`, `urgency_freeze`), all genuinely Z3-dependent and belonging in `fsl-verifier` rather than `fsl-runtime`. The headline defect still reproduces: the issue's `FrozenGhostTautology` spec under `--vacuity error` returns `verified`/exit 0 where the contract requires exit 2 / `kind:"tautology_over_frozen"`. Leaving them absent fails closed — the kind-selection fix means they can never be silently mis-promoted once added — whereas a rushed Z3 encoding could itself become a new false green or false red.

Found while working, filed separately, not fixed here: **#486** — the existing `vacuous_implication` lane only matches a bare top-level `Expr::Binary{op:"=>"}`, so an invariant written as `forall k: K { P(k) => Q(k) }` is never peeled and a genuinely vacuous forall-wrapped implication is never flagged even under `--vacuity error`. Independently discovered by two agents in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
