### PR TITLE
fix(verify,runtime): totalize property-context zero division and implement indexed refinement progress maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `rust/fslc/tests/corpus_check_sweep.rs` (an exhaustive `specs/`+`examples/`
   `check` sweep closing the gap left by `rust/fsl-lsp/tests/corpus.rs`, which
   never builds a checked model) (#485).
+- `preserve progress` now works with an indexed (per-element) refinement state
+  map (`map a[i: K] = expr`), not only scalar maps. `fsl-core::substitute_expr_indexed`
+  substitutes each pulled-back read `a[e]` with the map's own expression, its
+  binder replaced by `e` (DESIGN-refinement.md's "substituted on the read"
+  rule), matching capture-avoidance already applied to scalar substitution.
+  `rust/fsl-verifier/src/refinement.rs`'s `check_refinement_progress` no
+  longer rejects the mapping outright the moment *any* indexed map exists
+  (previously `VerifyError("indexed progress map for '<name>' is not
+  implemented")`, `kind:"semantics"`, exit 2) — including when the pulled
+  `leadsTo` does not even read that map. This restores the documented
+  DESIGN-refinement.md:20-40 canonical shape (indexed map + `preserve
+  progress` in the same mapping) and the `examples/agentic_rag` and
+  `examples/multi_agent_system` cross-layer `refine` commands, which
+  previously reported the verifier's own missing feature as a spec error
+  instead of `refines`/`refinement_failed` (#483).
 - Zero-division is now totally defined in property-context expressions
   (`invariant`, `trans`, `reachable`, `leadsTo`, and refinement state mapping),
   matching `DESIGN-divmod.md` §2.1/§2.3: `a / 0` and `a % 0` evaluate to `0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `rust/fslc/tests/corpus_check_sweep.rs` (an exhaustive `specs/`+`examples/`
   `check` sweep closing the gap left by `rust/fsl-lsp/tests/corpus.rs`, which
   never builds a checked model) (#485).
+- Zero-division is now totally defined in property-context expressions
+  (`invariant`, `trans`, `reachable`, `leadsTo`, and refinement state mapping),
+  matching `DESIGN-divmod.md` §2.1/§2.3: `a / 0` and `a % 0` evaluate to `0`
+  instead of raising a concrete `RuntimeError` there, in both the Z3 symbolic
+  encoding (`div`/`modulo` are now pinned with `ite(divisor == 0, 0, ...)`)
+  and the concrete Monitor/BFS evaluator. Previously an unrelated `/0`/`%0`
+  inside an invariant could mask a genuine, independent invariant violation
+  behind a misattributed `violation_kind:"partial_op"` / `_partial_<action>`
+  counterexample under the default (BMC) and `--engine induction` engines,
+  and made `--engine explicit` return a raw `result:"error"` / `kind:"semantics"`
+  instead of the real verdict — breaking the documented symbolic/concrete/BFS
+  agreement invariant. Action-context (`requires`/body/`ensures`) division by
+  a divisor that can reach zero is still reported as `partial_op` (§2.2 is
+  unchanged); Euclidean negative-number division/modulo semantics were
+  already correct and are unaffected (#477).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -527,7 +527,14 @@ invariant OnlyEligible { forall c: Claim { approved[c] => eligible(c) } }
 
 - 算術: `+ - * / %`、単項 `-`、`min(a, b)` / `max(a, b)` / `abs(a)`
   (`a//b` は `//` 以降がすべてコメントになってしまうので、除算は空白を入れて
-  `a / b` と書きます)
+  `a / b` と書きます)。`/` と `%` は `b != 0` のとき Euclidean(ユークリッド)
+  剰余系に従います(`a == b * (a / b) + (a % b)` かつ `0 <= a % b < |b|`。
+  よって `-7 / 2 == -4`、`-7 % 2 == 1`)。ゼロ除算は**全域的に定義**されており、
+  `a / 0 == 0` と `a % 0 == 0` は常に評価できます — invariant/trans/reachable/
+  leadsTo/mapping 式で `a / 0` を読んでも評価が失敗することはありません。
+  action の `requires`/本体/`ensures` 内では、ゼロになりうる除数への未ガードの
+  `/`/`%` は値自体が定義されていても `partial_op`(§6 参照)として報告されます —
+  `y != 0 => P(x / y)` や `requires y != 0` でガードしてください。
 - 比較: `== != < <= > >=`
 - 論理: `and or not =>`
 - 条件: `if condition then when_true else when_false`。条件は `Bool` で、両方の
@@ -637,7 +644,7 @@ until  Name { P until Q }    // unless safety plus a leadsTo P ~> Q progress obl
 | 検査 | 内容 | 違反時 |
 |---|---|---|
 | 型境界 | すべての有界型の状態変数(Map の値、struct のフィールド、Seq の要素を含む)が範囲内にある | `violated` / `type_bound` / `_bounds_<var>` |
-| 部分演算 | `pop()`/`head()`/`at(i)` の時点で列が非空かつインデックスが範囲内であり、`/` `%` の除数が非ゼロ | `violated` / `partial_op` / `_partial_<action>` |
+| 部分演算(action 文脈限定: `requires`/本体/`ensures` のみ、§3 参照) | `pop()`/`head()`/`at(i)` の時点で列が非空かつインデックスが範囲内であり、`/` `%` の除数が非ゼロ | `violated` / `partial_op` / `_partial_<action>` |
 | action カバレッジ | 各 action が深さ K 以内に少なくとも 1 回 enabled になる | `action_coverage` にブロックしている requires の診断 |
 | デッドロック | すべての action が disabled になる状態への到達 | 警告(`--deadlock error` で `violated`) |
 | trans | 2 状態の述語が到達可能なすべての遷移で成立するか | `violated` / `trans` / `trans` + トレース |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -542,7 +542,14 @@ variable capture instead of inventing internal binder names. See
 
 - Arithmetic: `+ - * / %`, unary `-`, `min(a, b)` / `max(a, b)` / `abs(a)`
   (since `a//b` would turn everything after `//` into a comment, write division
-  as `a / b` with whitespace)
+  as `a / b` with whitespace). `/` and `%` are Euclidean for `b != 0`
+  (`a == b * (a / b) + (a % b)` and `0 <= a % b < |b|`, so `-7 / 2 == -4` and
+  `-7 % 2 == 1`). Division by zero is **totally defined**: `a / 0 == 0` and
+  `a % 0 == 0` always evaluate, so an invariant/trans/reachable/leadsTo/mapping
+  expression that reads `a / 0` never fails to evaluate. Inside an action's
+  `requires`/body/`ensures`, an unguarded `/`/`%` whose divisor can reach zero
+  is still reported as `partial_op` (see §6) even though the value is defined —
+  guard it with `y != 0 => P(x / y)` or `requires y != 0`.
 - Comparison: `== != < <= > >=`
 - Logical: `and or not =>`
 - Conditional: `if condition then when_true else when_false`. The condition is
@@ -657,7 +664,7 @@ variable.
 | Check | Content | On violation |
 |---|---|---|
 | Type bounds | Every bounded-type state variable (including Map values, struct fields, and Seq elements) is within range | `violated` / `type_bound` / `_bounds_<var>` |
-| Partial operations | At the time of `pop()`/`head()`/`at(i)`, the sequence is non-empty and the index is in range, and the divisor of `/` `%` is non-zero | `violated` / `partial_op` / `_partial_<action>` |
+| Partial operations (action context: `requires`/body/`ensures` only, see §3) | At the time of `pop()`/`head()`/`at(i)`, the sequence is non-empty and the index is in range, and the divisor of `/` `%` is non-zero | `violated` / `partial_op` / `_partial_<action>` |
 | action coverage | Each action is enabled at least once within depth K | diagnosis of the blocking requires in `action_coverage` |
 | Deadlock | Reaching a state where all actions become disabled | warning (`violated` with `--deadlock error`) |
 | trans | Whether the two-state predicate holds across all reachable transitions | `violated` / `trans` / `trans` + trace |

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -10,7 +10,9 @@ use fsl_syntax::{
     parse_document,
 };
 
-use crate::{CoreError, KernelSpec, PredicateExpander, expand_spec_domains, substitute};
+use crate::{
+    CoreError, IndexedReplacements, KernelSpec, PredicateExpander, expand_spec_domains, substitute,
+};
 
 pub trait FileResolver {
     /// Read one source-relative FSL dependency.
@@ -1242,15 +1244,16 @@ fn resolve_alias_action_item(
 }
 
 fn substitute_action_item(item: ActionItem, replacements: &HashMap<String, Expr>) -> ActionItem {
+    let indexed = IndexedReplacements::new();
     match item {
         ActionItem::Requires(expr, span) => {
-            ActionItem::Requires(substitute(expr, replacements), span)
+            ActionItem::Requires(substitute(expr, replacements, &indexed), span)
         }
         ActionItem::Ensures(expr, span) => {
-            ActionItem::Ensures(substitute(expr, replacements), span)
+            ActionItem::Ensures(substitute(expr, replacements, &indexed), span)
         }
         ActionItem::Let(name, expr, span) => {
-            ActionItem::Let(name, substitute(expr, replacements), span)
+            ActionItem::Let(name, substitute(expr, replacements, &indexed), span)
         }
         ActionItem::Statement(statement) => {
             ActionItem::Statement(substitute_statement(statement, replacements))
@@ -1259,6 +1262,7 @@ fn substitute_action_item(item: ActionItem, replacements: &HashMap<String, Expr>
 }
 
 fn substitute_statement(statement: Statement, replacements: &HashMap<String, Expr>) -> Statement {
+    let indexed = IndexedReplacements::new();
     match statement {
         Statement::Assign {
             target,
@@ -1266,7 +1270,7 @@ fn substitute_statement(statement: Statement, replacements: &HashMap<String, Exp
             span,
         } => Statement::Assign {
             target: substitute_lvalue(target, replacements),
-            value: substitute(value, replacements),
+            value: substitute(value, replacements, &indexed),
             span,
         },
         Statement::If {
@@ -1275,7 +1279,7 @@ fn substitute_statement(statement: Statement, replacements: &HashMap<String, Exp
             else_statements,
             span,
         } => Statement::If {
-            condition: substitute(condition, replacements),
+            condition: substitute(condition, replacements, &indexed),
             then_statements: then_statements
                 .into_iter()
                 .map(|statement| substitute_statement(statement, replacements))
@@ -1303,7 +1307,10 @@ fn substitute_statement(statement: Statement, replacements: &HashMap<String, Exp
 
 fn substitute_lvalue(lvalue: LValue, replacements: &HashMap<String, Expr>) -> LValue {
     match lvalue {
-        LValue::Index(name, expr) => LValue::Index(name, substitute(expr, replacements)),
+        LValue::Index(name, expr) => LValue::Index(
+            name,
+            substitute(expr, replacements, &IndexedReplacements::new()),
+        ),
         LValue::Field(base, field) => {
             LValue::Field(Box::new(substitute_lvalue(*base, replacements)), field)
         }

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -1040,7 +1040,7 @@ impl PredicateExpander {
                 .cloned()
                 .zip(args)
                 .collect::<HashMap<_, _>>();
-            return Ok(substitute(body, &replacements));
+            return Ok(substitute(body, &replacements, &IndexedReplacements::new()));
         }
         Ok(match expr {
             Expr::Some(expr) => Expr::Some(Box::new(self.expand_expr(*expr, stack)?)),
@@ -1377,10 +1377,18 @@ fn binder_name(binder: &Binder) -> &str {
     }
 }
 
+/// Indexed (per-element) replacement: a state variable name maps to its own
+/// binder and mapping expression, e.g. `map a[i: Id] = b[i]` becomes
+/// `("a", (i-binder, b[i]))`. Each read `a[e]` is replaced by the mapping
+/// expression with its binder substituted by `e` (DESIGN-refinement.md's
+/// "substituted on the read" rule).
+pub type IndexedReplacements = HashMap<String, (Binder, Expr)>;
+
 #[allow(clippy::too_many_lines)]
 pub(crate) fn substitute<S: std::hash::BuildHasher>(
     expr: Expr,
     replacements: &HashMap<String, Expr, S>,
+    indexed: &IndexedReplacements,
 ) -> Expr {
     if let Expr::Var(name) = &expr
         && let Some(replacement) = replacements.get(name)
@@ -1388,58 +1396,70 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
         return replacement.clone();
     }
     match expr {
-        Expr::Some(expr) => Expr::Some(Box::new(substitute(*expr, replacements))),
+        Expr::Some(expr) => Expr::Some(Box::new(substitute(*expr, replacements, indexed))),
         Expr::Set(items) => Expr::Set(
             items
                 .into_iter()
-                .map(|item| substitute(item, replacements))
+                .map(|item| substitute(item, replacements, indexed))
                 .collect(),
         ),
         Expr::Seq(items) => Expr::Seq(
             items
                 .into_iter()
-                .map(|item| substitute(item, replacements))
+                .map(|item| substitute(item, replacements, indexed))
                 .collect(),
         ),
         Expr::Struct { name, fields } => Expr::Struct {
             name,
             fields: fields
                 .into_iter()
-                .map(|(name, expr)| (name, substitute(expr, replacements)))
+                .map(|(name, expr)| (name, substitute(expr, replacements, indexed)))
                 .collect(),
         },
         Expr::Call { name, args, span } => Expr::Call {
             name,
             args: args
                 .into_iter()
-                .map(|arg| substitute(arg, replacements))
+                .map(|arg| substitute(arg, replacements, indexed))
                 .collect(),
             span,
         },
-        Expr::Index(base, index) => Expr::Index(
-            Box::new(substitute(*base, replacements)),
-            Box::new(substitute(*index, replacements)),
-        ),
-        Expr::Field(base, name) => Expr::Field(Box::new(substitute(*base, replacements)), name),
+        Expr::Index(base, index) => {
+            let substituted_index = Box::new(substitute(*index, replacements, indexed));
+            if let Expr::Var(name) = base.as_ref()
+                && let Some((binder, state_expr)) = indexed.get(name)
+            {
+                let single = HashMap::from([(binder_name(binder).to_owned(), *substituted_index)]);
+                substitute(state_expr.clone(), &single, indexed)
+            } else {
+                Expr::Index(
+                    Box::new(substitute(*base, replacements, indexed)),
+                    substituted_index,
+                )
+            }
+        }
+        Expr::Field(base, name) => {
+            Expr::Field(Box::new(substitute(*base, replacements, indexed)), name)
+        }
         Expr::Method {
             receiver,
             name,
             args,
         } => Expr::Method {
-            receiver: Box::new(substitute(*receiver, replacements)),
+            receiver: Box::new(substitute(*receiver, replacements, indexed)),
             name,
             args: args
                 .into_iter()
-                .map(|arg| substitute(arg, replacements))
+                .map(|arg| substitute(arg, replacements, indexed))
                 .collect(),
         },
         Expr::Binary { op, left, right } => Expr::Binary {
             op,
-            left: Box::new(substitute(*left, replacements)),
-            right: Box::new(substitute(*right, replacements)),
+            left: Box::new(substitute(*left, replacements, indexed)),
+            right: Box::new(substitute(*right, replacements, indexed)),
         },
-        Expr::Neg(expr) => Expr::Neg(Box::new(substitute(*expr, replacements))),
-        Expr::Not(expr) => Expr::Not(Box::new(substitute(*expr, replacements))),
+        Expr::Neg(expr) => Expr::Neg(Box::new(substitute(*expr, replacements, indexed))),
+        Expr::Not(expr) => Expr::Not(Box::new(substitute(*expr, replacements, indexed))),
         Expr::Conditional {
             condition,
             then_expr,
@@ -1447,12 +1467,12 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             spans,
         } => Expr::Conditional {
             spans,
-            condition: Box::new(substitute(*condition, replacements)),
-            then_expr: Box::new(substitute(*then_expr, replacements)),
-            else_expr: Box::new(substitute(*else_expr, replacements)),
+            condition: Box::new(substitute(*condition, replacements, indexed)),
+            then_expr: Box::new(substitute(*then_expr, replacements, indexed)),
+            else_expr: Box::new(substitute(*else_expr, replacements, indexed)),
         },
         Expr::Is { expr, pattern } => Expr::Is {
-            expr: Box::new(substitute(*expr, replacements)),
+            expr: Box::new(substitute(*expr, replacements, indexed)),
             pattern,
         },
         Expr::Quantified {
@@ -1460,12 +1480,12 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             binder,
             body,
         } => {
-            let (binder, mut contents, scoped) =
-                capture_avoiding_binding(binder, vec![*body], replacements);
+            let (binder, mut contents, scoped, scoped_indexed) =
+                capture_avoiding_binding(binder, vec![*body], replacements, indexed);
             Expr::Quantified {
                 quantifier,
-                binder: substitute_binder(binder, replacements),
-                body: Box::new(substitute(contents.remove(0), &scoped)),
+                binder: substitute_binder(binder, replacements, indexed),
+                body: Box::new(substitute(contents.remove(0), &scoped, &scoped_indexed)),
             }
         }
         Expr::Aggregate {
@@ -1474,25 +1494,25 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             value,
         } => {
             let contents = value.map_or_else(Vec::new, |expr| vec![*expr]);
-            let (binder, mut contents, scoped) =
-                capture_avoiding_binding(binder, contents, replacements);
+            let (binder, mut contents, scoped, scoped_indexed) =
+                capture_avoiding_binding(binder, contents, replacements, indexed);
             Expr::Aggregate {
                 kind,
-                binder: substitute_binder(binder, replacements),
+                binder: substitute_binder(binder, replacements, indexed),
                 value: contents
                     .pop()
-                    .map(|expr| Box::new(substitute(expr, &scoped))),
+                    .map(|expr| Box::new(substitute(expr, &scoped, &scoped_indexed))),
             }
         }
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
             name,
-            expr: Box::new(substitute(*expr, replacements)),
+            expr: Box::new(substitute(*expr, replacements, indexed)),
             span,
         },
         Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
             name,
-            left: Box::new(substitute(*left, replacements)),
-            right: Box::new(substitute(*right, replacements)),
+            left: Box::new(substitute(*left, replacements, indexed)),
+            right: Box::new(substitute(*right, replacements, indexed)),
         },
         Expr::TernaryNamed {
             name,
@@ -1501,15 +1521,15 @@ pub(crate) fn substitute<S: std::hash::BuildHasher>(
             third,
         } => Expr::TernaryNamed {
             name,
-            first: Box::new(substitute(*first, replacements)),
-            second: Box::new(substitute(*second, replacements)),
-            third: Box::new(substitute(*third, replacements)),
+            first: Box::new(substitute(*first, replacements, indexed)),
+            second: Box::new(substitute(*second, replacements, indexed)),
+            third: Box::new(substitute(*third, replacements, indexed)),
         },
         other => other,
     }
 }
 
-/// Substitute free variable references in an expression.
+/// Substitute free scalar variable references in an expression.
 ///
 /// Refinement uses this to pull abstract properties back through scalar state
 /// maps before bounded progress checking.
@@ -1518,7 +1538,21 @@ pub fn substitute_expr<S: std::hash::BuildHasher>(
     expr: Expr,
     replacements: &HashMap<String, Expr, S>,
 ) -> Expr {
-    substitute(expr, replacements)
+    substitute(expr, replacements, &IndexedReplacements::new())
+}
+
+/// Substitute both free scalar variable references and indexed map reads
+/// (`m[e]`, see [`IndexedReplacements`]) in an expression.
+///
+/// Refinement uses this to pull abstract properties back through both scalar
+/// and per-element (indexed) state maps before bounded progress checking.
+#[must_use]
+pub fn substitute_expr_indexed<S: std::hash::BuildHasher>(
+    expr: Expr,
+    replacements: &HashMap<String, Expr, S>,
+    indexed: &IndexedReplacements,
+) -> Expr {
+    substitute(expr, replacements, indexed)
 }
 
 fn without_replacement<S: std::hash::BuildHasher>(
@@ -1532,24 +1566,48 @@ fn without_replacement<S: std::hash::BuildHasher>(
         .collect()
 }
 
+fn without_indexed_replacement(
+    indexed: &IndexedReplacements,
+    binding: &str,
+) -> IndexedReplacements {
+    indexed
+        .iter()
+        .filter(|(name, _)| name.as_str() != binding)
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
+}
+
 fn capture_avoiding_binding<S: std::hash::BuildHasher>(
     binder: Binder,
     contents: Vec<Expr>,
     replacements: &HashMap<String, Expr, S>,
-) -> (Binder, Vec<Expr>, HashMap<String, Expr>) {
+    indexed: &IndexedReplacements,
+) -> (
+    Binder,
+    Vec<Expr>,
+    HashMap<String, Expr>,
+    IndexedReplacements,
+) {
     let binding = binder_name(&binder).to_owned();
     let scoped = without_replacement(replacements, &binding);
-    if !scoped
+    let scoped_indexed = without_indexed_replacement(indexed, &binding);
+    let captures = scoped
         .values()
         .any(|replacement| free_vars(replacement).contains(&binding))
-    {
-        return (binder, contents, scoped);
+        || scoped_indexed
+            .values()
+            .any(|(_, state_expr)| free_vars(state_expr).contains(&binding));
+    if !captures {
+        return (binder, contents, scoped, scoped_indexed);
     }
 
     let mut names = HashSet::from([binding.clone()]);
     names.extend(scoped.keys().cloned());
     for replacement in scoped.values() {
         collect_names(replacement, &mut names);
+    }
+    for (_, state_expr) in scoped_indexed.values() {
+        collect_names(state_expr, &mut names);
     }
     collect_binder_names(&binder, &mut names);
     for content in &contents {
@@ -1569,9 +1627,9 @@ fn capture_avoiding_binding<S: std::hash::BuildHasher>(
     let binder = rename_binder_binding(binder, fresh, &rename);
     let contents = contents
         .into_iter()
-        .map(|content| substitute(content, &rename))
+        .map(|content| substitute(content, &rename, &IndexedReplacements::new()))
         .collect();
-    (binder, contents, scoped)
+    (binder, contents, scoped, scoped_indexed)
 }
 
 fn rename_binder_binding(binder: Binder, fresh: String, rename: &HashMap<String, Expr>) -> Binder {
@@ -1583,7 +1641,8 @@ fn rename_binder_binding(binder: Binder, fresh: String, rename: &HashMap<String,
         } => Binder::Typed {
             name: fresh,
             type_name,
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, rename, &IndexedReplacements::new()))),
         },
         Binder::Range {
             lo, hi, where_expr, ..
@@ -1591,7 +1650,8 @@ fn rename_binder_binding(binder: Binder, fresh: String, rename: &HashMap<String,
             name: fresh,
             lo,
             hi,
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, rename, &IndexedReplacements::new()))),
         },
         Binder::Collection {
             collection,
@@ -1600,7 +1660,8 @@ fn rename_binder_binding(binder: Binder, fresh: String, rename: &HashMap<String,
         } => Binder::Collection {
             name: fresh,
             collection,
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, rename))),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, rename, &IndexedReplacements::new()))),
         },
     }
 }
@@ -1651,8 +1712,10 @@ fn collect_names(expr: &Expr, names: &mut HashSet<String>) {
 fn substitute_binder<S: std::hash::BuildHasher>(
     binder: Binder,
     replacements: &HashMap<String, Expr, S>,
+    indexed: &IndexedReplacements,
 ) -> Binder {
     let scoped = without_replacement(replacements, binder_name(&binder));
+    let scoped_indexed = without_indexed_replacement(indexed, binder_name(&binder));
     match binder {
         Binder::Typed {
             name,
@@ -1661,7 +1724,8 @@ fn substitute_binder<S: std::hash::BuildHasher>(
         } => Binder::Typed {
             name,
             type_name,
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, &scoped, &scoped_indexed))),
         },
         Binder::Range {
             name,
@@ -1670,9 +1734,10 @@ fn substitute_binder<S: std::hash::BuildHasher>(
             where_expr,
         } => Binder::Range {
             name,
-            lo: Box::new(substitute(*lo, replacements)),
-            hi: Box::new(substitute(*hi, replacements)),
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
+            lo: Box::new(substitute(*lo, replacements, indexed)),
+            hi: Box::new(substitute(*hi, replacements, indexed)),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, &scoped, &scoped_indexed))),
         },
         Binder::Collection {
             name,
@@ -1680,8 +1745,9 @@ fn substitute_binder<S: std::hash::BuildHasher>(
             where_expr,
         } => Binder::Collection {
             name,
-            collection: Box::new(substitute(*collection, replacements)),
-            where_expr: where_expr.map(|expr| Box::new(substitute(*expr, &scoped))),
+            collection: Box::new(substitute(*collection, replacements, indexed)),
+            where_expr: where_expr
+                .map(|expr| Box::new(substitute(*expr, &scoped, &scoped_indexed))),
         },
     }
 }

--- a/rust/fsl-core/tests/binder_aggregates.rs
+++ b/rust/fsl-core/tests/binder_aggregates.rs
@@ -276,6 +276,67 @@ fn substitution_respects_nested_binder_shadowing() {
     assert_ne!(name, "queue");
 }
 
+/// Indexed (per-element) substitution (`substitute_expr_indexed`, issue #483)
+/// must be as capture-avoiding as the existing scalar case above: a `forall`
+/// binder that happens to share a name with a free variable of the indexed
+/// map's own mapping expression must be renamed before the read is expanded,
+/// not left to accidentally capture that variable.
+#[test]
+fn indexed_substitution_avoids_capturing_the_mapping_expressions_free_variable() {
+    // map a[i] = queue[i] — the indexed map's own binder is `i`, and its
+    // mapping expression `queue[i]` has `queue` free.
+    let state_expr = KernelExpr::Index(
+        Box::new(KernelExpr::Var("queue".to_owned())),
+        Box::new(KernelExpr::Var("i".to_owned())),
+    );
+    let state_binder = KernelBinder::Range {
+        name: "i".to_owned(),
+        lo: Box::new(KernelExpr::Num(0)),
+        hi: Box::new(KernelExpr::Num(2)),
+        where_expr: None,
+    };
+    let indexed = HashMap::from([("a".to_owned(), (state_binder, state_expr))]);
+
+    // forall queue: T { a[queue] } — the *outer* binder is also named
+    // `queue`, colliding with the mapping expression's free variable.
+    let target = KernelExpr::Quantified {
+        quantifier: "forall".to_owned(),
+        binder: KernelBinder::Range {
+            name: "queue".to_owned(),
+            lo: Box::new(KernelExpr::Num(0)),
+            hi: Box::new(KernelExpr::Num(2)),
+            where_expr: None,
+        },
+        body: Box::new(KernelExpr::Index(
+            Box::new(KernelExpr::Var("a".to_owned())),
+            Box::new(KernelExpr::Var("queue".to_owned())),
+        )),
+    };
+
+    let substituted =
+        fsl_core::substitute_expr_indexed(target, &HashMap::<String, KernelExpr>::new(), &indexed);
+    let KernelExpr::Quantified {
+        binder: KernelBinder::Range { name: fresh, .. },
+        body,
+        ..
+    } = substituted
+    else {
+        panic!("expected forall");
+    };
+    assert_ne!(
+        fresh, "queue",
+        "the outer binder must be renamed to avoid capture"
+    );
+    // The result must be `queue[<fresh>]`, i.e. the mapping expression's own
+    // `queue` still refers to the free implementation variable, not to the
+    // (renamed) outer binder.
+    let KernelExpr::Index(base, index) = *body else {
+        panic!("expected an index expression after indexed substitution");
+    };
+    assert_eq!(*base, KernelExpr::Var("queue".to_owned()));
+    assert_eq!(*index, KernelExpr::Var(fresh));
+}
+
 #[test]
 fn public_partial_operations_expand_aggregate_binders_without_free_variables() {
     let source = r"

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -11,7 +11,9 @@ use fsl_core::{
     TypeRef,
 };
 
-use super::{Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error};
+use super::{
+    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, with_total_division,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExplicitViolation {
@@ -254,31 +256,33 @@ fn record_reachables(
     parents: &BTreeMap<State, ParentLink>,
     result: &mut ExplicitResult,
 ) -> Result<(), RuntimeError> {
-    for property in &monitor.model.reachables {
-        if result.reachables[&property.name].is_some() {
-            continue;
-        }
-        match eval(
-            &property.expr,
-            &monitor.state,
-            &mut Bindings::new(),
-            &monitor.model,
-            None,
-        )? {
-            Value::Bool(true) => {
-                result.reachables.insert(
-                    property.name.clone(),
-                    Some(ExplicitReachableWitness {
-                        step: level,
-                        trace: reconstruct_trace(initial_state, &monitor.state, parents),
-                    }),
-                );
+    with_total_division(|| {
+        for property in &monitor.model.reachables {
+            if result.reachables[&property.name].is_some() {
+                continue;
             }
-            Value::Bool(false) => {}
-            _ => return Err(runtime_error("reachable expression must be Boolean")),
+            match eval(
+                &property.expr,
+                &monitor.state,
+                &mut Bindings::new(),
+                &monitor.model,
+                None,
+            )? {
+                Value::Bool(true) => {
+                    result.reachables.insert(
+                        property.name.clone(),
+                        Some(ExplicitReachableWitness {
+                            step: level,
+                            trace: reconstruct_trace(initial_state, &monitor.state, parents),
+                        }),
+                    );
+                }
+                Value::Bool(false) => {}
+                _ => return Err(runtime_error("reachable expression must be Boolean")),
+            }
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 fn reconstruct_trace(

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -25,6 +25,36 @@ pub use explicit::{
 pub type State = BTreeMap<String, Value>;
 pub type Bindings = BTreeMap<String, Value>;
 
+std::thread_local! {
+    /// DESIGN-divmod.md §2.1/§2.3: while set, `/` and `%` by a zero divisor
+    /// evaluate to the totally-defined value `0` instead of raising the
+    /// §2.2 action-context unguarded-operation error. Property-context
+    /// evaluation entry points (invariant, trans, reachable, leadsTo, and
+    /// refinement state mapping) scope this with [`with_total_division`];
+    /// action guard/statement/ensures evaluation leaves it unset so an
+    /// unguarded `/`/`%` there is still classified `partial_op`.
+    static TOTAL_DIVISION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+struct TotalDivisionScope {
+    previous: bool,
+}
+
+impl Drop for TotalDivisionScope {
+    fn drop(&mut self) {
+        TOTAL_DIVISION.with(|flag| flag.set(self.previous));
+    }
+}
+
+/// Evaluate property-context expressions with `/` and `%` by zero totally
+/// defined as `0` (DESIGN-divmod.md §2.1, §2.3) for the duration of `body`.
+fn with_total_division<T>(body: impl FnOnce() -> T) -> T {
+    let _scope = TotalDivisionScope {
+        previous: TOTAL_DIVISION.with(|flag| flag.replace(true)),
+    };
+    body()
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeError {
     pub message: String,
@@ -349,7 +379,7 @@ pub fn violating_bindings(
         }
     }
 
-    search(expr, state, &Bindings::new(), model)
+    with_total_division(|| search(expr, state, &Bindings::new(), model))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -467,7 +497,11 @@ fn eval_binary(
             let left = as_int(left)?;
             let right = as_int(right)?;
             if right == 0 {
-                Err(runtime_error("division by zero"))
+                if TOTAL_DIVISION.with(std::cell::Cell::get) {
+                    Ok(Value::Int(0))
+                } else {
+                    Err(runtime_error("division by zero"))
+                }
             } else {
                 Ok(Value::Int(left.div_euclid(right)))
             }
@@ -476,7 +510,11 @@ fn eval_binary(
             let left = as_int(left)?;
             let right = as_int(right)?;
             if right == 0 {
-                Err(runtime_error("remainder by zero"))
+                if TOTAL_DIVISION.with(std::cell::Cell::get) {
+                    Ok(Value::Int(0))
+                } else {
+                    Err(runtime_error("remainder by zero"))
+                }
             } else {
                 Ok(Value::Int(left.rem_euclid(right)))
             }
@@ -1094,6 +1132,14 @@ impl BoundedLivenessMonitor {
         state: &State,
         step: usize,
     ) -> Result<Option<BoundedLivenessViolation>, RuntimeError> {
+        with_total_division(|| self.observe_inner(state, step))
+    }
+
+    fn observe_inner(
+        &mut self,
+        state: &State,
+        step: usize,
+    ) -> Result<Option<BoundedLivenessViolation>, RuntimeError> {
         if step != self.next_step {
             return Err(runtime_error(format!(
                 "bounded liveness expected step {}, got {step}",
@@ -1272,6 +1318,24 @@ fn merged_refinement_model(
 }
 
 fn alpha_state(
+    implementation_state: &State,
+    implementation: &KernelModel,
+    abstraction: &KernelModel,
+    mapping: &Refinement,
+    eval_model: &KernelModel,
+) -> Result<State, RuntimeError> {
+    with_total_division(|| {
+        alpha_state_inner(
+            implementation_state,
+            implementation,
+            abstraction,
+            mapping,
+            eval_model,
+        )
+    })
+}
+
+fn alpha_state_inner(
     implementation_state: &State,
     implementation: &KernelModel,
     abstraction: &KernelModel,
@@ -1882,13 +1946,15 @@ pub fn expression_reachable(
     let mut queue = VecDeque::from([(initial.clone(), 0_usize)]);
     let mut visited = BTreeSet::from([initial.state.clone()]);
     while let Some((monitor, step)) = queue.pop_front() {
-        if as_bool(eval(
-            expression,
-            &monitor.state,
-            &mut Bindings::new(),
-            &monitor.model,
-            None,
-        )?)? {
+        if as_bool(with_total_division(|| {
+            eval(
+                expression,
+                &monitor.state,
+                &mut Bindings::new(),
+                &monitor.model,
+                None,
+            )
+        })?)? {
             return Ok(true);
         }
         if step >= depth {
@@ -2245,6 +2311,14 @@ fn leadsto_bindings(
     state: &State,
     model: &KernelModel,
 ) -> Result<Vec<Bindings>, RuntimeError> {
+    with_total_division(|| leadsto_bindings_inner(property, state, model))
+}
+
+fn leadsto_bindings_inner(
+    property: &fsl_core::LeadsToDef,
+    state: &State,
+    model: &KernelModel,
+) -> Result<Vec<Bindings>, RuntimeError> {
     let mut candidates = vec![Bindings::new()];
     for binder in &property.binders {
         let mut next = Vec::new();
@@ -2262,6 +2336,15 @@ fn leadsto_bindings(
 }
 
 fn response_pending_at(
+    property: &fsl_core::LeadsToDef,
+    binding: &Bindings,
+    trace: &[TraceStep],
+    model: &KernelModel,
+) -> Result<Option<usize>, RuntimeError> {
+    with_total_division(|| response_pending_at_inner(property, binding, trace, model))
+}
+
+fn response_pending_at_inner(
     property: &fsl_core::LeadsToDef,
     binding: &Bindings,
     trace: &[TraceStep],
@@ -2350,24 +2433,26 @@ fn record_reachables(
     step: usize,
     result: &mut BfsResult,
 ) -> Result<(), RuntimeError> {
-    for property in &monitor.model.reachables {
-        if result.reachables[&property.name].is_some() {
-            continue;
+    with_total_division(|| {
+        for property in &monitor.model.reachables {
+            if result.reachables[&property.name].is_some() {
+                continue;
+            }
+            let mut bindings = Bindings::new();
+            if as_bool(eval(
+                &property.expr,
+                &monitor.state,
+                &mut bindings,
+                &monitor.model,
+                None,
+            )?)? {
+                result
+                    .reachables
+                    .insert(property.name.clone(), Some(ReachableWitness { step }));
+            }
         }
-        let mut bindings = Bindings::new();
-        if as_bool(eval(
-            &property.expr,
-            &monitor.state,
-            &mut bindings,
-            &monitor.model,
-            None,
-        )?)? {
-            result
-                .reachables
-                .insert(property.name.clone(), Some(ReachableWitness { step }));
-        }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 fn check_state(
@@ -2380,6 +2465,18 @@ fn check_state(
 }
 
 fn check_state_selected(
+    state: &State,
+    old_state: Option<&State>,
+    model: &KernelModel,
+    step: usize,
+    checked_bounds: Option<&BTreeSet<String>>,
+) -> Result<Option<Violation>, RuntimeError> {
+    with_total_division(|| {
+        check_state_selected_inner(state, old_state, model, step, checked_bounds)
+    })
+}
+
+fn check_state_selected_inner(
     state: &State,
     old_state: Option<&State>,
     model: &KernelModel,

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -24,6 +24,28 @@ fn explicit_bfs_proves_at_state_space_closure() {
     assert_eq!(result.deadlock_step, None);
 }
 
+/// DESIGN-divmod.md §2.1/§2.3: an invariant's own `5 / 0` must not turn
+/// `--engine explicit` verification into a raw `RuntimeError` ("division by
+/// zero"). Reverting the concrete evaluator's zero-divisor totality (or its
+/// `TOTAL_DIVISION` property-context scoping) makes this `Err` instead of
+/// reporting the real `GenuineViolation` (issue #477, symptom 2).
+#[test]
+fn explicit_engine_totalizes_property_context_zero_division() {
+    let model = model(
+        "spec MaskTest { type Qty = 0..3 state { n: Qty } init { n = 0 } \
+         action bump() { requires n < 3 n = n + 1 } \
+         invariant GenuineViolation { n <= 1 } \
+         invariant ZeroDivTotal { 5 / 0 == 0 } }",
+    );
+    let result =
+        fsl_runtime::verify_explicit(model, 4, 100).expect("explicit verification must not error");
+    let violation = result
+        .violation
+        .expect("depth 4 reaches n=2, which violates GenuineViolation");
+    assert_eq!(violation.violation.kind, "invariant");
+    assert_eq!(violation.violation.name, "GenuineViolation");
+}
+
 #[test]
 fn explicit_bfs_fails_closed_at_the_state_budget() {
     let model = model(

--- a/rust/fsl-runtime/tests/monitor_regression.rs
+++ b/rust/fsl-runtime/tests/monitor_regression.rs
@@ -42,6 +42,61 @@ fn concrete_arithmetic_uses_smt_euclidean_division() {
     assert_eq!(value, FslValue::Bool(true));
 }
 
+/// DESIGN-divmod.md §2.1/§2.3: an invariant's own `/0`/`%0` is totally defined
+/// as `0`, so it must never mask a genuine, independent invariant violation
+/// behind a misattributed `partial_op` on the last-executed action. Reverting
+/// the `TOTAL_DIVISION` scoping in `check_state_selected` makes both bumps
+/// below report `partial_op`/`_partial_bump` (from `ZeroDivTotal`'s `5 / 0`)
+/// instead of ever reaching the real `GenuineViolation` (issue #477).
+#[test]
+fn property_context_zero_division_does_not_mask_a_genuine_invariant_violation() {
+    let model = model(
+        "spec MaskTest { type Qty = 0..3 state { n: Qty } init { n = 0 } ".to_owned()
+            + "action bump() { requires n < 3 n = n + 1 } "
+            + "invariant GenuineViolation { n <= 1 } "
+            + "invariant ZeroDivTotal { 5 / 0 == 0 } }",
+    );
+    let mut monitor = fsl_runtime::Monitor::new(model).expect("initialize monitor");
+    let first = monitor.enabled().expect("enabled actions")[0].clone();
+    let stepped = monitor
+        .step(&first)
+        .expect("first bump must not error on /0");
+    assert!(
+        stepped.violation.is_none(),
+        "ZeroDivTotal must not be checked/violated at n=1, got {:?}",
+        stepped.violation
+    );
+    let second = monitor.enabled().expect("enabled actions")[0].clone();
+    let stepped = monitor
+        .step(&second)
+        .expect("second bump must not error on /0");
+    let violation = stepped.violation.expect("n=2 violates GenuineViolation");
+    assert_eq!(violation.kind, "invariant");
+    assert_eq!(violation.name, "GenuineViolation");
+}
+
+/// DESIGN-divmod.md §2.2: totality of `/0`/`%0` in property contexts must not
+/// weaken the unrelated, pre-existing action-context `partial_op` check. An
+/// action that unconditionally divides by a variable that can be zero is
+/// still `partial_op`, attributed to the action that actually performs it.
+#[test]
+fn action_context_zero_division_is_still_partial_op() {
+    let model = model(
+        "spec ActionDiv0 { state { x: 0..10, d: 0..3 } init { x = 10 d = 0 } ".to_owned()
+            + "action divide() { x = x / d } }",
+    );
+    let mut monitor = fsl_runtime::Monitor::new(model).expect("initialize monitor");
+    let action = monitor.enabled().expect("enabled actions")[0].clone();
+    let stepped = monitor
+        .step(&action)
+        .expect("partial operations are outcomes, not errors");
+    let violation = stepped
+        .violation
+        .expect("unguarded x / d must be partial_op");
+    assert_eq!(violation.kind, "partial_op");
+    assert_eq!(violation.name, "_partial_divide");
+}
+
 #[test]
 fn replay_rejects_a_trace_that_is_not_enabled() {
     let model = model(

--- a/rust/fsl-solver-z3/src/lib.rs
+++ b/rust/fsl-solver-z3/src/lib.rs
@@ -324,11 +324,15 @@ impl SmtSolver for Z3Solver {
     }
 
     fn div(&self, left: &Self::Term, right: &Self::Term) -> SolverResult<Self::Term> {
-        Ok(Z3Term::Int(expect_int(left)?.div(expect_int(right)?)))
+        let (left, right) = (expect_int(left)?, expect_int(right)?);
+        let zero = Int::from_i64(0);
+        Ok(Z3Term::Int(right.eq(&zero).ite(&zero, &left.div(right))))
     }
 
     fn modulo(&self, left: &Self::Term, right: &Self::Term) -> SolverResult<Self::Term> {
-        Ok(Z3Term::Int(expect_int(left)?.modulo(expect_int(right)?)))
+        let (left, right) = (expect_int(left)?, expect_int(right)?);
+        let zero = Int::from_i64(0);
+        Ok(Z3Term::Int(right.eq(&zero).ite(&zero, &left.modulo(right))))
     }
 
     fn lt(&self, left: &Self::Term, right: &Self::Term) -> SolverResult<Self::Term> {
@@ -541,6 +545,28 @@ mod tests {
             return Err(SolverError::new("integer model value was not available"));
         };
         assert!((4..7).contains(&value));
+        Ok(())
+    }
+
+    /// DESIGN-divmod.md §2.1: `a / 0 = 0` and `a % 0 = 0` must hold for every
+    /// integer `a`, not merely by chance for the specific queries a caller
+    /// happens to issue. Reverting the `ite(right == 0, 0, ...)` pin in
+    /// `div`/`modulo` back to a bare `Int::div`/`Int::modulo` call leaves
+    /// zero-divisor results uninterpreted, so the negation below becomes
+    /// satisfiable and this assertion fails (issue #477).
+    #[test]
+    fn div_and_modulo_totalize_the_zero_divisor_for_every_integer() -> SolverResult<()> {
+        let mut solver = Z3Solver::new()?;
+        let a = solver.constant("a", &Sort::Int)?;
+        let zero = solver.int_value(0);
+        let quotient = solver.div(&a, &zero)?;
+        let remainder = solver.modulo(&a, &zero)?;
+        let totalized = solver.and(&[
+            solver.equal(&quotient, &zero)?,
+            solver.equal(&remainder, &zero)?,
+        ])?;
+        solver.assert(&solver.not(&totalized)?)?;
+        assert_eq!(block_on_ready(solver.check())?, SatResult::Unsat);
         Ok(())
     }
 

--- a/rust/fsl-verifier/src/refinement.rs
+++ b/rust/fsl-verifier/src/refinement.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use fsl_core::{KernelModel, LeadsToDef, Refinement, substitute_expr};
+use fsl_core::{IndexedReplacements, KernelModel, LeadsToDef, Refinement, substitute_expr_indexed};
 use fsl_solver::SmtSolver;
 
 use crate::{BmcViolation, VerifyError, verify_bounded};
@@ -13,13 +13,19 @@ pub struct ProgressCheck {
     pub checked: BTreeMap<String, Vec<String>>,
 }
 
-/// Pull abstract `leadsTo` properties through scalar refinement maps and check
-/// them over the implementation transition system.
+/// Pull abstract `leadsTo` properties through scalar and indexed refinement
+/// maps and check them over the implementation transition system.
+///
+/// A scalar map (`map a = expr`) substitutes bare reads of `a`. An indexed
+/// map (`map a[i: K] = expr`) substitutes each read `a[e]` with `expr`'s
+/// binder `i` replaced by `e` (DESIGN-refinement.md's "substituted on the
+/// read" rule), regardless of whether the pulled `leadsTo` also reads other,
+/// unrelated indexed maps.
 ///
 /// # Errors
 ///
-/// Returns [`VerifyError`] for indexed progress maps in the current slice,
-/// missing properties, or bounded-verifier failures.
+/// Returns [`VerifyError`] for missing properties or bounded-verifier
+/// failures.
 pub async fn check_refinement_progress<S: SmtSolver>(
     implementation: &KernelModel,
     abstraction: &KernelModel,
@@ -33,18 +39,15 @@ pub async fn check_refinement_progress<S: SmtSolver>(
             checked: BTreeMap::new(),
         });
     }
-    let replacements = mapping
-        .state_maps
-        .iter()
-        .map(|(name, state_map)| {
-            if state_map.binder.is_some() {
-                return Err(VerifyError::new(format!(
-                    "indexed progress map for '{name}' is not implemented"
-                )));
-            }
-            Ok((name.clone(), state_map.expr.clone()))
-        })
-        .collect::<Result<HashMap<_, _>, VerifyError>>()?;
+    let mut replacements = HashMap::new();
+    let mut indexed = IndexedReplacements::new();
+    for (name, state_map) in &mapping.state_maps {
+        if let Some(binder) = &state_map.binder {
+            indexed.insert(name.clone(), (binder.clone(), state_map.expr.clone()));
+        } else {
+            replacements.insert(name.clone(), state_map.expr.clone());
+        }
+    }
     let mut pulled = implementation.clone();
     for (name, definition) in &abstraction.types {
         pulled.types.insert(name.clone(), definition.clone());
@@ -71,14 +74,14 @@ pub async fn check_refinement_progress<S: SmtSolver>(
                 name: property.name.clone(),
                 span: property.span,
                 binders: property.binders.clone(),
-                before: substitute_expr(property.before.clone(), &replacements),
-                after: substitute_expr(property.after.clone(), &replacements),
+                before: substitute_expr_indexed(property.before.clone(), &replacements, &indexed),
+                after: substitute_expr_indexed(property.after.clone(), &replacements, &indexed),
                 meta: property.meta.clone(),
                 annotations: property.annotations.clone(),
                 decreases: property
                     .decreases
                     .clone()
-                    .map(|expr| substitute_expr(expr, &replacements)),
+                    .map(|expr| substitute_expr_indexed(expr, &replacements, &indexed)),
                 within: property.within,
             })
         })

--- a/rust/fsl-verifier/tests/expression_agreement.rs
+++ b/rust/fsl-verifier/tests/expression_agreement.rs
@@ -325,6 +325,37 @@ spec EmptyActionInitialViolation {
     assert_eq!(violation.step, 0);
 }
 
+/// DESIGN-divmod.md §2.1: the Z3 encoding must pin `/0`/`%0` to the total
+/// value `0`, independent of the CLI's concrete `find_boundary_violation`
+/// pre-check. This calls `verify_bounded` directly so a regression in the
+/// solver-level `div`/`modulo` pin (reverting the `ite(right == 0, 0, ...)`
+/// wrapping in `fsl-solver-z3`) is caught even if the concrete fast path
+/// were ever removed or bypassed. Without the pin, `ZeroDivTotal` masks the
+/// real `GenuineViolation` behind `partial_op`/`_partial_bump` (issue #477).
+#[test]
+fn symbolic_bmc_totalizes_property_context_zero_division() {
+    let source = r"
+spec MaskTest {
+  type Qty = 0..3
+  state { n: Qty }
+  init { n = 0 }
+  action bump() { requires n < 3  n = n + 1 }
+  invariant GenuineViolation { n <= 1 }
+  invariant ZeroDivTotal { 5 / 0 == 0 }
+}
+";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse model");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 4))
+        .expect("bounded verification must not error on /0 in ZeroDivTotal");
+
+    let violation = result.violation.expect("n=2 violates GenuineViolation");
+    assert_eq!(violation.kind, "invariant");
+    assert_eq!(violation.name, "GenuineViolation");
+    assert_eq!(violation.step, 2);
+}
+
 #[test]
 fn binder_aggregates_agree_for_ranges_sets_and_duplicate_sequences() {
     let source = r"

--- a/rust/fsl-verifier/tests/refinement_progress.rs
+++ b/rust/fsl-verifier/tests/refinement_progress.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source, parse_refinement};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    build_model(parse_kernel_source(source, &FsResolver::new(".")).expect("parse model"))
+        .expect("build model")
+}
+
+/// The canonical indexed-map shape from DESIGN-refinement.md:20-40 (`map
+/// stock[i: ItemId] = impl_stock[i] - reserved[i]` alongside `preserve
+/// progress`): an indexed per-element map used by the pulled `leadsTo`.
+///
+/// DESIGN-divmod.md is unrelated; this exercises issue #483's
+/// `rust/fsl-verifier/src/refinement.rs` early return, which used to reject
+/// *any* mapping with an indexed `state_map.binder` before even checking
+/// whether the pulled `leadsTo` reads it. Reverting the indexed-substitution
+/// fix (`fsl_core::substitute_expr_indexed` / the `IndexedReplacements` plumbing
+/// in `refinement.rs`) makes `check_refinement_progress` return
+/// `Err("indexed progress map for 'a' is not implemented")` instead of a
+/// verdict, so this test fails closed.
+#[test]
+fn indexed_progress_map_is_pulled_through_preserve_progress() {
+    let implementation = model(
+        "spec Impl { type Id = 0..2 type Lv = 0..1 state { b: Map<Id, Lv> } \
+         init { forall i: Id { b[i] = 0 } } \
+         fair action bstep(i: Id) { b[i] = 1 - b[i] } }",
+    );
+    let abstraction = model(
+        "spec Abs { type Id = 0..2 type Lv = 0..1 state { a: Map<Id, Lv> } \
+         init { forall i: Id { a[i] = 0 } } \
+         fair action step(i: Id) { a[i] = 1 - a[i] } \
+         leadsTo Done { forall i: Id { a[i] == 1 ~> a[i] == 0 } } }",
+    );
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs map a[i: Id] = b[i] action bstep(i) -> step(i) \
+         preserve progress { respond Done by bstep } }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("build indexed mapping");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let progress = block_on(fsl_verifier::check_refinement_progress(
+        &implementation,
+        &abstraction,
+        &mapping,
+        &mut solver,
+        3,
+    ))
+    .expect("indexed progress map must be checked, not rejected as unimplemented");
+    assert!(progress.violation.is_none(), "{progress:?}");
+    assert_eq!(progress.checked["Done"], vec!["bstep".to_owned()]);
+}
+
+/// Same indexed-map shape as above, but the implementation never resets
+/// `b[i]` back to `0`, so the pulled-back `Done` genuinely stalls. This is
+/// the negative half of the indexed-map fix: it proves the pulled-back check
+/// still *detects* a real progress failure, not merely that it stopped
+/// erroring. Reverting the fix makes this `Err("indexed progress map for 'a'
+/// is not implemented")` too (masking the real defect); a correct but
+/// over-permissive fix would wrongly report `violation.is_none()` here.
+#[test]
+fn indexed_progress_map_detects_a_genuine_stall() {
+    let implementation = model(
+        "spec Impl { type Id = 0..2 type Lv = 0..1 state { b: Map<Id, Lv> } \
+         init { forall i: Id { b[i] = 0 } } \
+         fair action bstep(i: Id) { requires b[i] == 0 b[i] = 1 } }",
+    );
+    let abstraction = model(
+        "spec Abs { type Id = 0..2 type Lv = 0..1 state { a: Map<Id, Lv> } \
+         init { forall i: Id { a[i] = 0 } } \
+         fair action step(i: Id) { a[i] = 1 - a[i] } \
+         leadsTo Done { forall i: Id { a[i] == 1 ~> a[i] == 0 } } }",
+    );
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs map a[i: Id] = b[i] action bstep(i) -> step(i) \
+         preserve progress { respond Done by bstep } }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("build indexed mapping");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let progress = block_on(fsl_verifier::check_refinement_progress(
+        &implementation,
+        &abstraction,
+        &mapping,
+        &mut solver,
+        4,
+    ))
+    .expect("indexed progress map must be checked, not rejected as unimplemented");
+    let violation = progress
+        .violation
+        .expect("b[i] never resets to 0, so Done must stall");
+    assert_eq!(violation.name, "Done");
+}
+
+/// CONTROL C from issue #483: an indexed state map (`map a[i: Id] = b[i]`)
+/// coexists with a `preserve progress` that only reads an unrelated scalar
+/// map (`map g = h`). The pre-fix code aborted on the mere *presence* of any
+/// indexed `state_map.binder` in `mapping.state_maps`, regardless of whether
+/// the pulled `leadsTo` referenced it — so this must not regress back to
+/// that early return.
+#[test]
+fn indexed_state_map_unread_by_pulled_leadsto_does_not_block_progress() {
+    let implementation = model(
+        "spec Impl { type Id = 0..2 type Lv = 0..1 state { b: Map<Id, Lv>, h: Lv } \
+         init { forall i: Id { b[i] = 0 } h = 0 } \
+         fair action bstep(i: Id) { b[i] = 1 - b[i] } \
+         fair action hstep() { h = 1 - h } }",
+    );
+    let abstraction = model(
+        "spec Abs { type Id = 0..2 type Lv = 0..1 state { a: Map<Id, Lv>, g: Lv } \
+         init { forall i: Id { a[i] = 0 } g = 0 } \
+         fair action step(i: Id) { a[i] = 1 - a[i] } \
+         fair action gstep() { g = 1 - g } \
+         leadsTo Done { g == 1 ~> g == 0 } }",
+    );
+    let mapping = parse_refinement(
+        "refinement R { impl Impl abs Abs map a[i: Id] = b[i] map g = h \
+         action bstep(i) -> step(i) action hstep() -> gstep() \
+         preserve progress { respond Done by hstep } }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("build mixed scalar/indexed mapping");
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let progress = block_on(fsl_verifier::check_refinement_progress(
+        &implementation,
+        &abstraction,
+        &mapping,
+        &mut solver,
+        3,
+    ))
+    .expect("an unrelated indexed map must not block a scalar-only pulled leadsTo");
+    assert!(progress.violation.is_none(), "{progress:?}");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -765,9 +765,14 @@ cannot be assigned both inline and in `init`.
    ```
 4. enabled when all requires hold. ensures is checked after the transition.
 5. For Seq `pop/head/at` and a nonzero divisor of `/` `%`, **well-definedness is
-   checked automatically** in action context (partial_op). A requires guard or an if
-   guard both work (path conditions are considered). An out-of-range at() inside an
-   invariant/reachable is an undefined value — always guard with `i < q.size() =>`.
+   checked automatically** in action context (`requires`/body/`ensures`; partial_op).
+   A requires guard or an if guard both work (path conditions are considered). An
+   out-of-range at() inside an invariant/reachable is an undefined value — always
+   guard with `i < q.size() =>`. `/`/`%` are the one exception: division by zero is
+   *totally defined* as `0` (Euclidean for `b != 0`: `-7 / 2 == -4`, `-7 % 2 == 1`),
+   so `a / 0` inside an invariant/trans/reachable/leadsTo/mapping expression always
+   evaluates to `0` rather than being undefined — only the unguarded-in-action-context
+   check is skipped there.
 6. `fair` = weak fairness: an infinite execution in which a fair instance that is
    enabled throughout the loop is never executed is excluded from leadsTo
    counterexamples. Fairness applies to whole action instances; model conditional


### PR DESCRIPTION
## Problem

Two defects where the verifier's own gap or evaluation rule was reported through the wrong envelope, sending a machine consumer to the wrong conclusion.

**#477 — zero-division totality, and `partial_op` misapplied to property contexts.** `docs/DESIGN-divmod.md` §2.1 requires `a / 0 == 0` and `a % 0 == 0` to be totally defined, and §2.3 requires no check at all in property contexts (invariant / reachable / leadsTo / mapping expressions). Native violated both, with three symptoms from one root cause:

```fsl
spec MaskTest {
  type Qty = 0..3
  state { n: Qty }
  init { n = 0 }
  action bump() { requires n < 3  n = n + 1 }
  invariant GenuineViolation { n <= 1 }
  invariant ZeroDivTotal { 5 / 0 == 0 }
}
```

| engine | before |
|---|---|
| default (BMC) / induction | `violated` / `violation_kind:"partial_op"` / `invariant:"_partial_bump"` — **points at a division problem inside an action that contains no division, hiding the genuine `GenuineViolation`** |
| `--engine explicit` | `result:"error"` / `kind:"semantics"` / `"division by zero"` / exit 2 |
| frozen reference | `verified` |

Three evaluators, three answers — a direct break of the `AGENTS.md` invariant that symbolic verification, the concrete Monitor, and solver-free BFS must agree. The most damaging part is not the disagreement but the misdirection: a repair loop or agent is sent to fix a defect that does not exist while the real one stays invisible.

**#483 — indexed state map with `preserve progress` unimplemented.** `docs/DESIGN-refinement.md:20-40`'s own canonical mapping example combines an indexed per-element state map with `preserve progress`. Native rejected that exact shape: the moment `mapping.state_maps` contained *any* indexed map, `check_refinement_progress` returned an error — without even checking whether the pulled `leadsTo` read that map. Surfaced as `kind:"semantics"` / exit 2, i.e. **the verifier's own missing capability reported as a user spec error**, on specs whose `check` is `ok`. This made `preserve progress` unusable with any multi-layer design that keeps per-entity state.

## Contract change

No language contract changes; both restore documented behavior.

- **#477** — needed **two** fixes, not one. `fsl-runtime`'s concrete evaluator now totalizes `/0` and `%0` under a scoped flag applied at property-context entry points only (`check_state_selected`, `record_reachables` including `explicit.rs`, `expression_reachable`, `BoundedLivenessMonitor::observe`, `leadsto_bindings` / `response_pending_at`, `alpha_state`, `violating_bindings`). Action-context evaluation is untouched, so an unguarded division in a guard/statement/ensures is still `partial_op` per §2.2. Separately, `fsl-solver-z3`'s `div`/`modulo` now pin the zero-divisor result with `ite(right == 0, 0, …)`. The Z3 pin is not redundant: BMC's `find_boundary_violation` CLI fast path uses the concrete evaluator and short-circuits before Z3 runs, so a concrete-only fix *looks* sufficient from the CLI while `verify_bounded` called directly still misclassifies — confirmed by reverting the pin alone.
- **#483** — implemented, not worked around. `fsl-core` gains `substitute_expr_indexed` / `IndexedReplacements`: an indexed map `name → (binder, expr)` substitutes each read `a[e]` with the map's expression, its own binder replaced by `e` — the "substituted on the read" rule already documented at `DESIGN-refinement.md:451`. Capture-avoidance, previously applied only to scalar replacements, now also renames a quantifier binder that would otherwise capture a free variable of an indexed map's expression. `check_refinement_progress` no longer special-cases indexed maps at all.

## Test evidence

Every control below was verified by **reverting the fix, confirming the test fails, and restoring** — reported per test, not asserted in the abstract.

**#477**, verified independently against a `main` binary — all three engines now agree:

| engine | before | after |
|---|---|---|
| BMC | `violated` / `partial_op` / `_partial_bump` | `violated` / `invariant` / **`GenuineViolation`** |
| `--engine explicit` | `error` / `semantics` / exit 2 | `violated` / `invariant` / **`GenuineViolation`** / exit 1 |

Controls: `property_context_zero_division_does_not_mask_a_genuine_invariant_violation`, `explicit_engine_totalizes_property_context_zero_division`, `symbolic_bmc_totalizes_property_context_zero_division` (bypasses the concrete fast path, so it catches a reverted Z3 pin specifically), `div_and_modulo_totalize_the_zero_divisor_for_every_integer` (unconstrained integer, not just literals), plus `action_context_zero_division_is_still_partial_op` as a preservation guard. Euclidean negative-number semantics (`-7 / 2 == -4`, `7 % -2 == 1`, `0 <= a % b < |b|`) were already correct and are unchanged — confirmed on all three engines.

**#483** — the documented corpus commands now reproduce their documented results natively for the first time:

| command | before | after |
|---|---|---|
| `refine` requirements→business (`--depth 7`) | `error` / `semantics` / `"indexed progress map for 'req_stage' is not implemented"` / exit 2 | `refines` / exit 0 / `progress: {BP1, BP2, BP3, BP4}` |
| `examples/agentic_rag/negative` liveness probe (`--depth 4`) | `error` / exit 2 | `refinement_failed` / `kind:"progress_lost"` / `progress_failure:"lasso_blocks_progress"` / `violation_kind:"leadsTo"` / `invariant:"RequestEventuallyHandled"` / exit 1 |

That negative probe matters more than the positive paths: it is an intentional negative-control asset that had silently drifted, and it now matches `examples/agentic_rag/negative/README.md:12` exactly. All five documented cross-layer commands across `examples/agentic_rag` and `examples/multi_agent_system` reproduce their READMEs.

Controls: `indexed_progress_map_is_pulled_through_preserve_progress` (canonical shape, positive), `indexed_progress_map_detects_a_genuine_stall` (**proves detection, not mere permissiveness**), `indexed_state_map_unread_by_pulled_leadsto_does_not_block_progress` (the issue's CONTROL C), and `indexed_substitution_avoids_capturing_the_mapping_expressions_free_variable` — reverting just the capture-avoidance extension reproduces a real variable-capture bug (`queue[queue]`).

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh rust` all exit 0 on the rebased base.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 1:1), `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`. `docs/DESIGN-refinement.md` needed no change for #483: it never documented an indexed-map limitation, and the feature is now implemented rather than left unsupported with a documented caveat.

## Linked issues

Fixes #477, fixes #483.

Found while working, filed separately, **not** fixed here: **#512** — a refinement mapping's action-correspondence argument (`action bump(v) -> bump(v / d)`) still hard-errors on a zero divisor with `result:"error"` / `kind:"type"`. That is a *third* behavior: neither §2.1/§2.3 totalization nor §2.2 `partial_op`, and classifying a runtime zero-division as `kind:"type"` is wrong under either reading. `docs/DESIGN-divmod.md` does not currently say whether §2.3's "mapping expressions" covers action-correspondence arguments, so the contract has to be decided before the implementation moves — which is why it is a separate issue rather than a silent scope extension here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
