### PR TITLE
fix(dialects): implement six missing native dialect behaviors (ai agent, ai hard rules, db findings/lowering, compose fairness, conformance registration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,11 @@ the focused `fsl-solver-z3`, `fsl-verifier`, and `fslc-rust` tests.
   regression cases, `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/reference.md`, a design
   note, and `CHANGELOG.md`. `docs/LANGUAGE.ja.md` is a second canonical source kept section-aligned
   1:1 with `docs/LANGUAGE.md` (same count/order of `## ` sections) — `tools/build_site_reference.py`
-  fails loudly on drift; see `docs/DESIGN-docs-site.md` D7.
+  fails loudly on drift; see `docs/DESIGN-docs-site.md` D7. A new dialect's top-level construct (and
+  any new `examples/`/`specs/` directory) additionally moves with `tests/dialect_registry.py`
+  (`DIALECTS`, `EVIDENCE_CONSTRUCTS`, or `MONITOR_EXCLUSIONS`), or the conformance harness
+  (`docs/DESIGN-conformance-harness.md`) fails loudly with an unregistered-construct error instead
+  of silently excluding the corpus.
 - Do not weaken or hollow out `.fsl` specs to make checks pass. Verify mutation/vacuity evidence.
 - Every formal-to-implementation conformance anchor must include a negative control that rejects a
   known contract-violating trace, transition, or mutation. A green positive path alone does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   a divisor that can reach zero is still reported as `partial_op` (§2.2 is
   unchanged); Euclidean negative-number division/modulo semantics were
   already correct and are unaffected (#477).
+- Native `fslc db check` now evaluates `rule all_active_writes_exist` the same way it already
+  evaluated `rule all_active_reads_exist`: dropping a column that is still declared as an active
+  artifact's write capability now yields a `column_removed_while_still_written` finding with
+  `witness`, `minimal_conflict_set`, `repair_candidates`, and `artifact_version` populated, and the
+  top-level JSON `result` is reconciled to `"violated"` whenever the attached `kernel` projection
+  reports a violation. Previously the write branch was silently missing (a regressive port relative
+  to the frozen Python reference), so a write-drop incompatibility returned `verified_under_assumptions`
+  with an empty `findings` array — a confidently green false negative, and one that escaped a
+  hardcoded kernel depth-8 default entirely for deep migration histories, since the findings layer
+  is depth-independent once the write branch exists (#469).
+- Native `fslc check`/`verify`/`db check` no longer reject two writes indexed by distinct enum
+  members as a possible alias (`"an action may not assign the same state location more than once"`).
+  The write-aliasing analysis now resolves enum-member indices (both the typed `Expr::EnumMember`
+  literal and a local constant bound to an enum value) to their nominal `(type_name, member)`
+  identity, matching the same-index detection already applied to `Int`/`Bool` constants. This
+  restores `fslc check`/`db check` on the four `examples/db/` `dbsystem` `rename`/`split`/`merge`
+  preservation fixtures, which previously exited 2 against a golden corpus snapshot of `"ok"` (#475).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   identity, matching the same-index detection already applied to `Int`/`Bool` constants. This
   restores `fslc check`/`db check` on the four `examples/db/` `dbsystem` `rename`/`split`/`merge`
   preservation fixtures, which previously exited 2 against a golden corpus snapshot of `"ok"` (#475).
+- Native `fslc check`/`verify` now emit the documented `fair_not_inherited` `compose` warning: when a
+  non-fair synchronized action references a `fair` component action, `warnings` includes a
+  `kind: "fair_not_inherited"` entry naming the composite action and fair constituent(s), matching the
+  frozen Python reference's message and `loc` exactly. Compose lowering previously discarded
+  constituent `fair` markers with no warning at all (`rust/fsl-core/src/compose.rs` had no warnings
+  channel), so a declared `fair` constituent silently stopped contributing fairness through
+  synchronization with no diagnostic signal — the same failure mode issue #16 fixed in the frozen
+  Python reference, regressed by the native port (#474).
 - The frozen `tests/test_dialect_conformance.py` corpus-conformance harness (`docs/DESIGN-conformance-harness.md`)
   is green again (0 failing of 212, up from 201 passed / 6 failed). Four intentional-error `governance`
   gallery fixtures gained the `// expected-result: error` front matter that reclassifies them as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   a divisor that can reach zero is still reported as `partial_op` (§2.2 is
   unchanged); Euclidean negative-number division/modulo semantics were
   already correct and are unaffected (#477).
+- The recursive `agent` dialect (`docs/LANGUAGE.md` §13.6) now has a real grammar and structural
+  analyzer in native, matching the frozen reference's `src/fslc/ai_parser.py`/`ai_agent.py` exactly
+  (confirmed by byte-identical JSON, including `agent_ir`/`graph_summary`, on
+  `examples/ai/recursive_support_agent.fsl` and every documented finding-kind fixture). Previously
+  `rust/fsl-syntax`'s `parse_agent` only balanced braces and discarded the entire body, so any token
+  soup that lexed cleanly parsed as an empty agent and `fslc ai check` on a recursive `agent` document
+  returned `"expected an ai_component document"` (native rejected the dialect entirely) while `fslc
+  check` unconditionally reported the hardcoded constant `agent_analysis_result: "agent_analyzed"`
+  with no analysis behind it — a confidently green false negative on AI agent authority-delegation
+  safety, and native's own CLI contract (`rust/fslc/cli-contract.json`) already advertised "check an
+  ai_component hard contract or recursive agent structure" as a capability it did not have. A `grant
+  authority`/`grant context` that exceeds the immediate parent's declared boundary is now a check-time
+  `kind:"semantics"` error from `ai check` and `check` alike; the six documented
+  `agent_structural_violation` finding kinds (`child_authority_exceeds_parent_authority`,
+  `child_context_exceeds_parent_context`, `irreversible_operation_without_human_approval_path`,
+  `visibility_leak_across_sibling_agents`, `low_trust_agent_path_to_high_authority_tool`,
+  `policy_review_bypass_in_orchestration`) are all computed by `fslc ai check`. `fslc verify`'s
+  rejection of agent documents and `fslc fmt`'s refusal to reformat a well-formed agent body (no
+  native pretty-printer exists yet) are both unchanged (#468).
 - Native `ai_component` lowering (`fslc check`/`verify`/`ai check`) no longer collapses to a
   one-boolean catalog sentinel with an unsatisfiable no-op action. It now generates the documented
   `Tool` enum, `human_approved`/`tool_executed`/`tool_suggested: Map<Tool, Bool>` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   a divisor that can reach zero is still reported as `partial_op` (§2.2 is
   unchanged); Euclidean negative-number division/modulo semantics were
   already correct and are unaffected (#477).
+- Native `ai_component` lowering (`fslc check`/`verify`/`ai check`) no longer collapses to a
+  one-boolean catalog sentinel with an unsatisfiable no-op action. It now generates the documented
+  `Tool` enum, `human_approved`/`tool_executed`/`tool_suggested: Map<Tool, Bool>` and
+  `fallback_required: Bool` state, `suggest_*`/`approve_*`/`execute_*`/`fallback_*` actions (no
+  `execute_*` action is ever generated for a forbidden tool; an approval-required tool's `execute_*`
+  action always carries `requires human_approved[tool]`), and the
+  `ai_forbidden_tool_not_executed__<Tool>` / `ai_approval_before_execute__<Tool>` invariants. `check
+  hard { rule <Name>; }` now rejects an unknown rule name as a check-time `kind:"semantics"` error
+  (previously silently accepted) from `ai check`, `check`, and `verify` alike. `fslc ai check` also
+  implements the four previously-unchecked hard rules (`tool_authority`, the two static findings
+  were entirely missing; `tool_schema_declared` was missing; `human_approval_required` used a
+  narrower `irreversible && may_execute && !approved` predicate than the documented
+  `irreversible && !requires_human_approval && !forbidden` rule, so a tool only in `may_suggest`
+  passed silently) and populates `repair_candidates` instead of always emitting `[]`. `fslc ai
+  replay` gains the matching `tool_authority` findings for `suggest`/`execute` calls outside
+  authority and now flags a declared precondition with no `preconditions` evidence object at all
+  (previously only an explicit `false` value was caught, so missing evidence passed silently). This
+  was AGENTS.md's "confidently green false negative" on the AI dialect's tool-authority /
+  human-approval safety claims (#470).
 - Native `fslc db check` now evaluates `rule all_active_writes_exist` the same way it already
   evaluated `rule all_active_reads_exist`: dropping a column that is still declared as an active
   artifact's write capability now yields a `column_removed_while_still_written` finding with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   identity, matching the same-index detection already applied to `Int`/`Bool` constants. This
   restores `fslc check`/`db check` on the four `examples/db/` `dbsystem` `rename`/`split`/`merge`
   preservation fixtures, which previously exited 2 against a golden corpus snapshot of `"ok"` (#475).
+- The frozen `tests/test_dialect_conformance.py` corpus-conformance harness (`docs/DESIGN-conformance-harness.md`)
+  is green again (0 failing of 212, up from 201 passed / 6 failed). Four intentional-error `governance`
+  gallery fixtures gained the `// expected-result: error` front matter that reclassifies them as
+  `DECLARED_ERROR` instead of `CONFORMANCE`; the no-action `governance_semantic_before.fsl` "before"
+  fragment and the three `examples/causal/*.fsl` files (a dialect the frozen Python reference does not
+  implement at all) are now registered exclusions (`MONITOR_EXCLUSIONS` and a new `causal` entry in
+  `EVIDENCE_CONSTRUCTS`/`is_causal_source`) instead of falling through to `UNKNOWN`. The always-red
+  harness had made a new registration gap indistinguishable from a pre-existing one (#476).
 - Refinement typechecking now rejects an unshadowed bare enum member shared by distinct
   implementation and abstraction enums, preventing checked and evaluation
   merge order from assigning different nominal identities. Existing identifier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,11 @@ inventory and explicitly optional Python surfaces.
 
 - **Language or semantics:** update Rust syntax/lowering, typed model, symbolic and concrete evaluation,
   regression cases, `docs/LANGUAGE.md`, `skills/fsl/reference.md`, an accepted design note, and
-  `CHANGELOG.md` together.
+  `CHANGELOG.md` together. A new dialect's top-level construct, and any new `examples/`/`specs/`
+  directory it lands in, must also be registered in `tests/dialect_registry.py` (`DIALECTS`,
+  `EVIDENCE_CONSTRUCTS`, or `MONITOR_EXCLUSIONS` with a reason) — the conformance harness
+  (`docs/DESIGN-conformance-harness.md`) scans every `.fsl` under `specs/`/`examples/` and fails
+  loudly on an unregistered construct instead of silently skipping it.
 - **Public Kernel contract:** update schemas, Rust exporter/consumer paths, conformance vectors,
   agreement tests, `docs/DESIGN-kernel-contract.md`, language/reference docs, and changelog.
 - **CLI/JSON contract:** preserve field meanings, ordering requirements, raw-output modes, exit codes,

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -34,8 +34,14 @@ exhaustively; the registry says what may exist there.
 - `EVIDENCE_CONSTRUCTS: dict[str, str]` — construct → reason, for whole file
   kinds that have **no kernel expansion by design**: `ai-project`
   (`is_ai_project_source`; external statistical evidence, `fslc ai
-  eval/regress/drift/compat`, `formal_result:"not_run"`) and `ai-agent`
-  (`is_ai_agent_source`; structural analysis, `agent_analyzed`, not formal proof).
+  eval/regress/drift/compat`, `formal_result:"not_run"`), `ai-agent`
+  (`is_ai_agent_source`; structural analysis, `agent_analyzed`, not formal proof),
+  and `causal` (`is_causal_source`; the causal graph never enters `KernelModel`,
+  `fsl-runtime`, or `fsl-solver` — see [`DESIGN-causal.md`](DESIGN-causal.md) §1 —
+  and native `check` reports `result:"causal_model_checked"` /
+  `formal_result:"not_run"`. The frozen Python reference has no causal
+  implementation at all, so `is_causal_source` is a keyword sniff that lives in
+  `tests/dialect_registry.py` itself rather than `src/fslc`).
 - `MONITOR_EXCLUSIONS: dict[str, str]` — repo-relative path → reason, for
   individual files the frozen Python Monitor legitimately rejects. Each entry
   names its active native or BMC-side coverage, and a stale entry fails the
@@ -45,8 +51,8 @@ exhaustively; the registry says what may exist there.
 
 `classify(path)` reads the source and returns one of:
 
-1. `EXCLUDED` — `is_ai_project_source` / `is_ai_agent_source` match, or path in
-   `MONITOR_EXCLUSIONS`.
+1. `EXCLUDED` — `is_ai_project_source` / `is_ai_agent_source` / `is_causal_source`
+   match, or path in `MONITOR_EXCLUSIONS`.
 2. `REFINEMENT` — top-level keyword `refinement` (mapping files are not state
    machines; refine semantics are covered by `test_refine*.py` and the
    refinement fixtures in `test_oracle_agreement.py`).
@@ -130,6 +136,13 @@ agreement, verdict agreement) — belongs to the frozen Python reference
 implementation and is no longer run by `.github/workflows/ci.yml`. It remains
 available for manual historical/reference checks; active CI coverage is
 provided by the Rust workspace tests and WASM browser validation.
+"Manual/reference" describes who runs it, not whether it may stay red: a
+corpus registration gap here is invisible to CI precisely because nothing
+else runs the full dual-evaluator pipeline over `specs/`/`examples/`, so a
+failing run must still be treated as a reviewable registration diff to land
+(a new dialect/example directory registered in `tests/dialect_registry.py`,
+or a stale exclusion/declared-error front matter removed), not left red
+indefinitely — see issue #476.
 
 Its narrower structural obligation — every `.fsl` under `specs/`/`examples/`
 either `check`s cleanly or is a declared/excluded error, so nothing rots

--- a/examples/gallery/adversarial/governance_semantic_after.fsl
+++ b/examples/gallery/adversarial/governance_semantic_after.fsl
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+// expected-result: error
 spec After {
   state { missing: Missing }
   init { }

--- a/examples/gallery/errors/governance_malformed_business.fsl
+++ b/examples/gallery/errors/governance_malformed_business.fsl
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
-
+// expected-result: error
 business Broken {

--- a/examples/gallery/errors/governance_malformed_dependency.fsl
+++ b/examples/gallery/errors/governance_malformed_dependency.fsl
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+// expected-result: error
 governance MalformedDependency {
   control CTRL-1 "Referenced business remains parseable"
   delegates Broken from "governance_malformed_business.fsl" {

--- a/examples/gallery/errors/governance_missing_before.fsl
+++ b/examples/gallery/errors/governance_missing_before.fsl
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+// expected-result: error
 governance Broken {
   preservation MissingBefore {
     after After from "../../self/monitor_action_boundary.fsl"

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -9,6 +9,7 @@ use fsl_syntax::{
     SpecItem, Statement, SurfaceCompose, SurfaceDocument, SurfaceSpec, SyncAction, TypeExpr,
     parse_document,
 };
+use serde_json::{Value, json};
 
 use crate::{
     CoreError, IndexedReplacements, KernelSpec, PredicateExpander, expand_spec_domains, substitute,
@@ -161,7 +162,12 @@ fn parse_component(
     Ok((expand_spec_domains(spec)?, parsed.annotations))
 }
 
-fn composed_kernel(name: String, items: Vec<SpecItem>, annotations: Annotations) -> KernelSpec {
+fn composed_kernel(
+    name: String,
+    items: Vec<SpecItem>,
+    annotations: Annotations,
+    diagnostics: Vec<Value>,
+) -> KernelSpec {
     let mut kernel = KernelSpec {
         spec: SurfaceSpec {
             name,
@@ -171,6 +177,7 @@ fn composed_kernel(name: String, items: Vec<SpecItem>, annotations: Annotations)
         origins: crate::OriginRegistry::default(),
         annotations: fsl_syntax::AnnotationRegistry::default(),
         projections: Vec::new(),
+        diagnostics,
     };
     kernel.annotations.extend(crate::SPEC_TARGET, annotations);
     kernel
@@ -225,6 +232,7 @@ pub fn lower_compose(
         })
         .collect::<HashSet<_>>();
 
+    let mut warnings = Vec::new();
     let mut static_items = Vec::new();
     let mut init = Vec::new();
     let mut init_meta = None;
@@ -279,7 +287,7 @@ pub fn lower_compose(
                 static_items.push(rewrite_compose_item(item.clone(), &components)?);
             }
             ComposeItem::SyncAction(action) => {
-                actions.push(sync_action(action, &components)?);
+                actions.push(sync_action(action, &components, &mut warnings)?);
             }
             ComposeItem::Use { .. } | ComposeItem::Internal { .. } => {}
         }
@@ -294,6 +302,7 @@ pub fn lower_compose(
         compose.name,
         static_items,
         component_annotations,
+        warnings,
     ))
 }
 
@@ -931,6 +940,7 @@ fn resolve_alias_statement(
 fn sync_action(
     action: &SyncAction,
     components: &BTreeMap<String, Component>,
+    warnings: &mut Vec<Value>,
 ) -> Result<SpecItem, CoreError> {
     let params = action
         .params
@@ -939,6 +949,7 @@ fn sync_action(
         .map(|param| resolve_alias_param(param, components))
         .collect::<Result<Vec<_>, _>>()?;
     let mut items = Vec::new();
+    let mut fair_constituents = Vec::new();
     for reference in &action.refs {
         let component = components.get(&reference.alias).ok_or_else(|| CoreError {
             message: format!("unknown alias '{}'", reference.alias),
@@ -958,6 +969,14 @@ fn sync_action(
                 column: action.span.start.column,
                 origin: None,
             })?;
+        // Fairness is not inherited through synchronization (docs/LANGUAGE.md
+        // "Compose"): capture the constituent's own `fair` marker here, before
+        // `rewrite_component_item` and the composite's single `fair: action.fair`
+        // below discard it, so a non-fair composite that references a fair
+        // constituent can be reported.
+        if matches!(&source, SpecItem::Action { fair: true, .. }) {
+            fair_constituents.push(format!("{}.{}", reference.alias, reference.action));
+        }
         let SpecItem::Action {
             params: source_params,
             items: source_items,
@@ -1002,6 +1021,17 @@ fn sync_action(
             .map(|item| resolve_alias_action_item(item, components))
             .collect::<Result<Vec<_>, _>>()?,
     );
+    if !action.fair && !fair_constituents.is_empty() {
+        let refs = fair_constituents.join(", ");
+        warnings.push(json!({
+            "kind": "fair_not_inherited",
+            "message": format!(
+                "synchronized action '{}' is not fair; fair constituent action(s) {refs} will not contribute fairness unless the composite action is declared fair",
+                action.name,
+            ),
+            "loc": action.span.python_loc(),
+        }));
+    }
     Ok(SpecItem::Action {
         name: action.name.clone(),
         params,

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -2198,55 +2198,6 @@ pub fn lower_governance(governance: SurfaceGovernance) -> Result<KernelSpec, Cor
     })
 }
 
-fn lower_catalog_sentinel(name: String, prefix: &str, id: &str) -> Result<KernelSpec, CoreError> {
-    let span = zero_span();
-    let state_name = format!("_{prefix}_ok");
-    let action_name = format!("_{prefix}_noop");
-    let invariant_name = format!("_{prefix}_catalog_ok");
-    let metadata = meta(id, format!("{prefix} catalog {name}"));
-    lower_direct_spec(SurfaceSpec {
-        name,
-        meta: None,
-        items: vec![
-            SpecItem::State(vec![StateField::generated(
-                state_name.clone(),
-                TypeExpr::Bool,
-                span,
-            )]),
-            SpecItem::Init {
-                statements: vec![Statement::Assign {
-                    target: LValue::Var(state_name.clone()),
-                    value: Expr::Bool(true),
-                    span,
-                }],
-                meta: None,
-                annotations: Annotations::default(),
-            },
-            SpecItem::Action {
-                name: action_name,
-                params: Vec::new(),
-                items: vec![ActionItem::Requires(Expr::Bool(false), span)],
-                span,
-                fair: false,
-                meta: metadata.clone(),
-                sync: false,
-                annotations: Annotations::default(),
-            },
-            SpecItem::Invariant {
-                name: invariant_name,
-                expr: Box::new(Expr::Var(state_name)),
-                span,
-                meta: metadata,
-                annotations: Annotations::default(),
-            },
-            SpecItem::Terminal {
-                expr: Box::new(Expr::Bool(true)),
-                span,
-            },
-        ],
-    })
-}
-
 /// Lower a database compatibility document to its executable catalog kernel.
 ///
 /// # Errors
@@ -2267,13 +2218,459 @@ pub fn lower_domain(domain: &fsl_syntax::DomainSpec) -> Result<KernelSpec, CoreE
     crate::lower_direct_spec_with_origins(surface, origins)
 }
 
-/// Lower an AI hard-contract document to its executable catalog kernel.
+/// The five documented `ai_component` `check hard { rule <Name>; }` rules
+/// (`docs/DESIGN-ai-hard.md` "Static Rules"). Naming any other rule is a
+/// check-time error (`docs/LANGUAGE.md` §13.6).
+const AI_HARD_RULES: [&str; 5] = [
+    "tool_authority",
+    "human_approval_required",
+    "forbidden_tool_blocked",
+    "tool_schema_declared",
+    "tool_precondition_declared",
+];
+
+/// Name of the generated `forbidden_tool_blocked` invariant for one tool.
+/// Shared with `fsl_tools::check_ai`, which must translate a kernel
+/// invariant-violation name back to the failed hard-contract rule and tool.
+#[must_use]
+pub fn ai_forbidden_invariant_name(tool_name: &str) -> String {
+    format!("ai_forbidden_tool_not_executed__{}", ai_safe(tool_name))
+}
+
+/// Name of the generated `human_approval_required` invariant for one tool.
+/// Shared with `fsl_tools::check_ai` (see [`ai_forbidden_invariant_name`]).
+#[must_use]
+pub fn ai_approval_invariant_name(tool_name: &str) -> String {
+    format!("ai_approval_before_execute__{}", ai_safe(tool_name))
+}
+
+fn ai_safe(name: &str) -> String {
+    let mut out = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if out.is_empty() {
+        out.push('x');
+    } else if out.starts_with(|ch: char| ch.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    out
+}
+
+fn ai_tool_member(name: &str) -> String {
+    format!("tool_{}", ai_safe(name))
+}
+
+fn ai_span(loc: fsl_syntax::AiLoc) -> fsl_syntax::Span {
+    let position = fsl_syntax::SourcePos {
+        offset: 0,
+        line: loc.line,
+        column: loc.column,
+    };
+    fsl_syntax::Span {
+        start: position,
+        end: position,
+    }
+}
+
+/// Validate and resolve `check hard { rule ...; }`, defaulting to all five
+/// rules when the block is omitted (`docs/LANGUAGE.md` §13.6).
 ///
 /// # Errors
 ///
-/// Returns [`CoreError`] if the generated kernel catalog is invalid.
+/// Returns [`CoreError`] when a named rule is not one of [`AI_HARD_RULES`].
+fn ai_rule_set(component: &fsl_syntax::AiComponent) -> Result<BTreeSet<String>, CoreError> {
+    let names = if component.check.rules.is_empty() {
+        AI_HARD_RULES
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect::<Vec<_>>()
+    } else {
+        component
+            .check
+            .rules
+            .iter()
+            .map(|rule| rule.name.clone())
+            .collect::<Vec<_>>()
+    };
+    for name in &names {
+        if !AI_HARD_RULES.contains(&name.as_str()) {
+            let loc = component.check.loc.unwrap_or(component.loc);
+            return Err(core_error(
+                format!("unknown ai hard-contract rule '{name}'"),
+                ai_span(loc),
+            ));
+        }
+    }
+    Ok(names.into_iter().collect())
+}
+
+/// Tool-authority sets shared by lowering (`lower_ai_component`) and the
+/// static/kernel-translated hard-contract findings (`fsl_tools::check_ai`),
+/// so both compute exactly the same executable/approval-required/forbidden
+/// membership instead of drifting apart.
+#[derive(Debug)]
+pub struct AiToolSets<'a> {
+    pub suggestible: BTreeSet<&'a str>,
+    pub executable: BTreeSet<&'a str>,
+    pub approval_required: BTreeSet<&'a str>,
+    pub forbidden: BTreeSet<&'a str>,
+}
+
+#[must_use]
+pub fn ai_tool_sets(component: &fsl_syntax::AiComponent) -> AiToolSets<'_> {
+    AiToolSets {
+        suggestible: component
+            .authority
+            .may_suggest
+            .iter()
+            .map(|rule| rule.name.as_str())
+            .collect(),
+        executable: component
+            .authority
+            .may_execute
+            .iter()
+            .chain(&component.authority.requires_human_approval)
+            .map(|rule| rule.name.as_str())
+            .collect(),
+        approval_required: component
+            .authority
+            .requires_human_approval
+            .iter()
+            .map(|rule| rule.name.as_str())
+            .chain(
+                component
+                    .tools
+                    .iter()
+                    .filter(|tool| tool.irreversible)
+                    .map(|tool| tool.name.as_str()),
+            )
+            .collect(),
+        forbidden: component
+            .authority
+            .forbidden
+            .iter()
+            .map(|rule| rule.name.as_str())
+            .collect(),
+    }
+}
+
+fn ai_action(
+    name: String,
+    statement: Statement,
+    span: fsl_syntax::Span,
+    meta_id: &str,
+    meta_text: String,
+) -> SpecItem {
+    SpecItem::Action {
+        name,
+        params: Vec::new(),
+        items: vec![ActionItem::Statement(statement)],
+        span,
+        fair: false,
+        meta: meta(meta_id, meta_text),
+        sync: false,
+        annotations: Annotations::default(),
+    }
+}
+
+fn ai_index_assign(map_name: &str, index: Expr, value: Expr, span: fsl_syntax::Span) -> Statement {
+    Statement::Assign {
+        target: LValue::Index(map_name.to_owned(), index),
+        value,
+        span,
+    }
+}
+
+/// Lower an AI hard-contract document to its executable catalog kernel.
+///
+/// Mirrors the frozen reference's `expand_ai_component`
+/// (`src/fslc/ai_expand.py`) behaviorally: a `Tool` enum over declared tools
+/// (declaration order); `human_approved` / `tool_executed` / `tool_suggested:
+/// Map<Tool, Bool>` and `fallback_required: Bool` state; generated
+/// `suggest_*` / `approve_*` / `execute_*` / `fallback_*` actions (a
+/// forbidden tool gets no `execute_*` action, an approval-required
+/// executable tool's `execute_*` action carries `requires
+/// human_approved[tool]`); and, gated by the resolved rule set, generated
+/// `ai_forbidden_tool_not_executed__<Tool>` / `ai_approval_before_execute__
+/// <Tool>` invariants.
+///
+/// # Errors
+///
+/// Returns [`CoreError`] when `check hard { rule ... }` names an unknown rule
+/// or the generated kernel catalog is invalid.
+#[allow(clippy::too_many_lines)]
 pub fn lower_ai_component(component: fsl_syntax::AiComponent) -> Result<KernelSpec, CoreError> {
-    lower_catalog_sentinel(component.name, "ai", "AI")
+    let rules = ai_rule_set(&component)?;
+    let span = zero_span();
+
+    let members = component
+        .tools
+        .iter()
+        .map(|tool| (tool.name.as_str(), ai_tool_member(&tool.name)))
+        .collect::<BTreeMap<_, _>>();
+    let tool_by_name = component
+        .tools
+        .iter()
+        .map(|tool| (tool.name.as_str(), tool))
+        .collect::<BTreeMap<_, _>>();
+    let member_expr = |tool_name: &str| Expr::Var(members[tool_name].clone());
+    let tool_span = |tool_name: &str| {
+        tool_by_name
+            .get(tool_name)
+            .and_then(|tool| tool.loc)
+            .map_or(span, ai_span)
+    };
+
+    let mut items = vec![
+        SpecItem::Enum {
+            name: "Tool".to_owned(),
+            members: component
+                .tools
+                .iter()
+                .map(|tool| members[tool.name.as_str()].clone())
+                .collect(),
+            symmetric: false,
+        },
+        SpecItem::State(vec![
+            StateField::generated(
+                "human_approved",
+                TypeExpr::Map(
+                    Box::new(TypeExpr::Name("Tool".to_owned())),
+                    Box::new(TypeExpr::Bool),
+                ),
+                span,
+            ),
+            StateField::generated(
+                "tool_executed",
+                TypeExpr::Map(
+                    Box::new(TypeExpr::Name("Tool".to_owned())),
+                    Box::new(TypeExpr::Bool),
+                ),
+                span,
+            ),
+            StateField::generated(
+                "tool_suggested",
+                TypeExpr::Map(
+                    Box::new(TypeExpr::Name("Tool".to_owned())),
+                    Box::new(TypeExpr::Bool),
+                ),
+                span,
+            ),
+            StateField::generated("fallback_required", TypeExpr::Bool, span),
+        ]),
+        SpecItem::Init {
+            statements: vec![
+                Statement::ForAll {
+                    binder: typed_binder("t", "Tool"),
+                    statements: vec![
+                        ai_index_assign(
+                            "human_approved",
+                            Expr::Var("t".to_owned()),
+                            Expr::Bool(false),
+                            span,
+                        ),
+                        ai_index_assign(
+                            "tool_executed",
+                            Expr::Var("t".to_owned()),
+                            Expr::Bool(false),
+                            span,
+                        ),
+                        ai_index_assign(
+                            "tool_suggested",
+                            Expr::Var("t".to_owned()),
+                            Expr::Bool(false),
+                            span,
+                        ),
+                    ],
+                    span,
+                },
+                Statement::Assign {
+                    target: LValue::Var("fallback_required".to_owned()),
+                    value: Expr::Bool(false),
+                    span,
+                },
+            ],
+            meta: None,
+            annotations: Annotations::default(),
+        },
+    ];
+
+    let AiToolSets {
+        suggestible,
+        executable,
+        approval_required,
+        forbidden,
+    } = ai_tool_sets(&component);
+
+    let mut generated_names = Vec::new();
+    for &tool_name in &suggestible {
+        let name = format!("suggest_{}", ai_safe(tool_name));
+        generated_names.push(name.clone());
+        items.push(ai_action(
+            name,
+            ai_index_assign(
+                "tool_suggested",
+                member_expr(tool_name),
+                Expr::Bool(true),
+                tool_span(tool_name),
+            ),
+            tool_span(tool_name),
+            "AI-AUTHORITY",
+            format!("{} may suggest {tool_name}", component.name),
+        ));
+    }
+    for &tool_name in approval_required.difference(&forbidden) {
+        let name = format!("approve_{}", ai_safe(tool_name));
+        generated_names.push(name.clone());
+        items.push(ai_action(
+            name,
+            ai_index_assign(
+                "human_approved",
+                member_expr(tool_name),
+                Expr::Bool(true),
+                tool_span(tool_name),
+            ),
+            tool_span(tool_name),
+            "AI-HUMAN-APPROVAL",
+            format!("human approval token is finite state for {tool_name}"),
+        ));
+    }
+    for &tool_name in executable.difference(&forbidden) {
+        let name = format!("execute_{}", ai_safe(tool_name));
+        generated_names.push(name.clone());
+        let mut action_items = Vec::new();
+        if approval_required.contains(tool_name) {
+            action_items.push(ActionItem::Requires(
+                Expr::Index(
+                    Box::new(Expr::Var("human_approved".to_owned())),
+                    Box::new(member_expr(tool_name)),
+                ),
+                tool_span(tool_name),
+            ));
+        }
+        action_items.push(ActionItem::Statement(ai_index_assign(
+            "tool_executed",
+            member_expr(tool_name),
+            Expr::Bool(true),
+            tool_span(tool_name),
+        )));
+        let text = if approval_required.contains(tool_name) {
+            format!(
+                "{} may execute {tool_name} after human approval",
+                component.name
+            )
+        } else {
+            format!("{} may execute {tool_name}", component.name)
+        };
+        items.push(SpecItem::Action {
+            name,
+            params: Vec::new(),
+            items: action_items,
+            span: tool_span(tool_name),
+            fair: false,
+            meta: meta("AI-TOOL-EXECUTE", text),
+            sync: false,
+            annotations: Annotations::default(),
+        });
+    }
+    if generated_names.is_empty() {
+        generated_names.push("observe_component".to_owned());
+        items.push(ai_action(
+            "observe_component".to_owned(),
+            Statement::Assign {
+                target: LValue::Var("fallback_required".to_owned()),
+                value: Expr::Var("fallback_required".to_owned()),
+                span,
+            },
+            span,
+            "AI-OBSERVE",
+            format!(
+                "{} has no executable hard-contract transition",
+                component.name
+            ),
+        ));
+    }
+
+    if rules.contains("forbidden_tool_blocked") {
+        for &tool_name in &forbidden {
+            let name = ai_forbidden_invariant_name(tool_name);
+            generated_names.push(name.clone());
+            items.push(SpecItem::Invariant {
+                name,
+                expr: Box::new(Expr::Not(Box::new(Expr::Index(
+                    Box::new(Expr::Var("tool_executed".to_owned())),
+                    Box::new(member_expr(tool_name)),
+                )))),
+                span: tool_span(tool_name),
+                meta: meta(
+                    "AI-FORBIDDEN",
+                    format!("{tool_name} is forbidden and cannot be executed"),
+                ),
+                annotations: Annotations::default(),
+            });
+        }
+    }
+    if rules.contains("human_approval_required") {
+        for &tool_name in approval_required.difference(&forbidden) {
+            let name = ai_approval_invariant_name(tool_name);
+            generated_names.push(name.clone());
+            items.push(SpecItem::Invariant {
+                name,
+                expr: Box::new(Expr::Binary {
+                    op: "=>".to_owned(),
+                    left: Box::new(Expr::Index(
+                        Box::new(Expr::Var("tool_executed".to_owned())),
+                        Box::new(member_expr(tool_name)),
+                    )),
+                    right: Box::new(Expr::Index(
+                        Box::new(Expr::Var("human_approved".to_owned())),
+                        Box::new(member_expr(tool_name)),
+                    )),
+                }),
+                span: tool_span(tool_name),
+                meta: meta(
+                    "AI-HUMAN-APPROVAL",
+                    format!("{tool_name} can execute only after human approval"),
+                ),
+                annotations: Annotations::default(),
+            });
+        }
+    }
+
+    for fallback in &component.fallback {
+        let name = format!("fallback_{}", ai_safe(&fallback.reason));
+        generated_names.push(name.clone());
+        let fallback_span = ai_span(fallback.loc);
+        items.push(ai_action(
+            name,
+            Statement::Assign {
+                target: LValue::Var("fallback_required".to_owned()),
+                value: Expr::Bool(true),
+                span: fallback_span,
+            },
+            fallback_span,
+            "AI-FALLBACK",
+            format!("{} requires {}", fallback.reason, fallback.target),
+        ));
+    }
+
+    items.push(SpecItem::Terminal {
+        expr: Box::new(Expr::Bool(false)),
+        span,
+    });
+
+    lower_direct_spec(SurfaceSpec {
+        name: component.name,
+        meta: None,
+        items,
+    })
 }
 
 /// Extract executable acceptance and must-forbid traces from requirements.

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -43,8 +43,9 @@ pub use diagnostics::{
     requirement_metadata, version_metadata,
 };
 pub use dialect::{
-    GovernanceContract, GovernanceDelegate, GovernancePreservation, RequirementsTraceCase,
-    RequirementsTraceContract, RequirementsTraceExpectation, RequirementsTraceStep,
+    AiToolSets, GovernanceContract, GovernanceDelegate, GovernancePreservation,
+    RequirementsTraceCase, RequirementsTraceContract, RequirementsTraceExpectation,
+    RequirementsTraceStep, ai_approval_invariant_name, ai_forbidden_invariant_name, ai_tool_sets,
     governance_contract, lower_ai_component, lower_business, lower_db, lower_domain,
     lower_governance, lower_requirements, requirements_trace_contract,
 };

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -152,6 +152,12 @@ pub struct KernelSpec {
     origins: OriginRegistry,
     annotations: AnnotationRegistry,
     projections: Vec<ProjectionDef>,
+    /// Warnings discovered only while lowering the surface document (e.g.
+    /// compose's `fair_not_inherited`), which the checked [`KernelModel`]
+    /// cannot reconstruct on its own because the information that produced
+    /// them (per-component `fair` markers) does not survive expansion.
+    /// `check`/`verify` merge these with [`model_warnings`].
+    diagnostics: Vec<Value>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -177,6 +183,7 @@ pub fn build_surface_model(spec: SurfaceSpec) -> Result<KernelModel, ModelError>
         origins: OriginRegistry::default(),
         annotations: AnnotationRegistry::default(),
         projections: Vec::new(),
+        diagnostics: Vec::new(),
     })
 }
 
@@ -214,6 +221,11 @@ impl KernelSpec {
     #[must_use]
     pub fn projections(&self) -> &[ProjectionDef] {
         &self.projections
+    }
+
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Value] {
+        &self.diagnostics
     }
 
     pub(crate) fn set_projections(&mut self, projections: Vec<ProjectionDef>) {
@@ -400,6 +412,7 @@ fn lower_direct_spec_with_origins(
         origins,
         annotations: AnnotationRegistry::default(),
         projections: Vec::new(),
+        diagnostics: Vec::new(),
     })
 }
 

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -1337,6 +1337,30 @@ fn write_is_injective_for_binder(target: &LValue, binder: &Binder) -> bool {
     matches!(index, Some(Expr::Var(index)) if index == name)
 }
 
+/// Resolve an index expression to a comparable static identity, if it has one.
+///
+/// This is used only for the write-aliasing check in [`lvalues_may_alias`]. It
+/// recognizes enum-member indices (both the typed `Expr::EnumMember` literal and
+/// a local constant bound to an enum value) in addition to the `Int`/`Bool`
+/// constants that [`eval_const`] already handles, so two writes indexed by
+/// distinct enum members are provably distinct. It must not be used to widen
+/// what counts as a constant expression elsewhere (`eval_const`/`ConstType` are
+/// shared with `const_int`, domain-type bounds, `Seq` capacity, and `within`
+/// deadlines).
+fn static_index_identity(expr: &Expr, constants: &BTreeMap<String, Value>) -> Option<Value> {
+    match expr {
+        Expr::EnumMember { type_name, member } => Some(Value::Enum {
+            type_name: type_name.clone(),
+            member: member.clone(),
+        }),
+        Expr::Var(name) => match constants.get(name) {
+            Some(value @ Value::Enum { .. }) => Some(value.clone()),
+            _ => eval_const(expr, constants).ok(),
+        },
+        _ => eval_const(expr, constants).ok(),
+    }
+}
+
 fn lvalues_may_alias(left: &LValue, right: &LValue, constants: &BTreeMap<String, Value>) -> bool {
     let (left_root, left_index, left_fields) = lvalue_path(left);
     let (right_root, right_index, right_fields) = lvalue_path(right);
@@ -1344,7 +1368,10 @@ fn lvalues_may_alias(left: &LValue, right: &LValue, constants: &BTreeMap<String,
         return false;
     }
     if let (Some(left), Some(right)) = (left_index, right_index)
-        && let (Ok(left), Ok(right)) = (eval_const(left, constants), eval_const(right, constants))
+        && let (Some(left), Some(right)) = (
+            static_index_identity(left, constants),
+            static_index_identity(right, constants),
+        )
         && left != right
     {
         return false;

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -483,6 +483,7 @@ impl ModelBuilder {
             origins,
             annotations,
             projections,
+            diagnostics: _,
         } = kernel;
         Self {
             spec,

--- a/rust/fsl-core/tests/duplicate_writes.rs
+++ b/rust/fsl-core/tests/duplicate_writes.rs
@@ -117,6 +117,40 @@ fn rejects_a_write_that_may_overlap_a_forall_write() {
 }
 
 #[test]
+fn permits_provably_distinct_enum_member_indexes() {
+    build(
+        "spec DistinctEnum { enum Color { Red, Green } state { flag: Map<Color, Bool> } \
+         init { flag[Red] = false flag[Green] = false } \
+         action both() { flag[Red] = true flag[Green] = true } }",
+    )
+    .expect("distinct enum-member indexes cannot alias");
+}
+
+#[test]
+fn rejects_a_repeated_enum_member_index() {
+    let error = build(
+        "spec RepeatedEnum { enum Color { Red, Green } state { flag: Map<Color, Bool> } \
+         init { flag[Red] = false flag[Green] = false } \
+         action dup() { flag[Red] = true flag[Red] = false } }",
+    )
+    .expect_err("the same enum member written twice must fail");
+
+    assert!(error.message.contains("same state location"));
+}
+
+#[test]
+fn rejects_an_enum_member_write_that_may_overlap_a_forall_write() {
+    let error = build(
+        "spec EnumBulkThenOne { enum Color { Red, Green } state { flag: Map<Color, Bool> } \
+         init { forall c: Color { flag[c] = false } } \
+         action write() { forall c: Color { flag[c] = true } flag[Red] = false } }",
+    )
+    .expect_err("post-forall write overlaps the Red binder value");
+
+    assert!(error.message.contains("same state location"));
+}
+
+#[test]
 fn permits_distinct_fields_even_when_indexes_may_alias() {
     build(
         "spec Fields { type K = 0..1 struct Pair { left: Bool, right: Bool } \

--- a/rust/fsl-syntax/src/ai.rs
+++ b/rust/fsl-syntax/src/ai.rs
@@ -4,6 +4,7 @@
 use serde_json::{Value, json};
 
 use crate::annotation_parse;
+use crate::surface::SurfaceAgent;
 use crate::{Annotations, ParseError, Span, Token, TokenKind, lex};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -135,6 +136,52 @@ impl AiAuthority {
     }
 }
 
+// --- Recursive `agent` dialect IR (issue #468) -----------------------------
+//
+// These types are structurally distinct from `ai_component`'s IR above:
+// `agent` bodies nest (via `children`), separate a bare `tools [X, Y];` list
+// (`tool_names`) from full `tool X { ... }` blocks (`tools`), and add
+// grant/orchestration/failure-policy/contract/trust/review-gate declarations
+// that `ai_component` does not have.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiAgentGrant {
+    /// `"authority"` or `"context"`.
+    pub kind: String,
+    pub names: Vec<String>,
+    pub loc: AiLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiAgentOutput {
+    pub name: String,
+    pub visibility: Vec<String>,
+    pub loc: AiLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiDelegationEdge {
+    pub source: String,
+    pub target: String,
+    pub loc: AiLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiFailurePolicy {
+    pub agent: String,
+    pub condition: String,
+    pub action: String,
+    pub target: Option<String>,
+    pub retry_limit: Option<i64>,
+    pub loc: AiLoc,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AiAgentContract {
+    pub hard_rules: Vec<String>,
+    pub loc: AiLoc,
+}
+
 impl AiFallback {
     fn python_ast(&self) -> Value {
         json!({"$type":"AiFallback","reason":self.reason,"target":self.target,"loc":self.loc.python_ast()})
@@ -177,6 +224,37 @@ pub(crate) fn parse_ai_component_tokens(
         return Err(parser.error("unexpected token after ai_component"));
     }
     Ok(component)
+}
+
+/// Parse one recursive `agent { ... }` document (issue #468) into its typed
+/// tree. This only enforces per-block grammar (including "declare at most
+/// once" duplicate checks, mirroring the frozen reference's parse-time
+/// transformer). Cross-node structural checks -- grant boundaries, unknown
+/// orchestration/`review_gate`/`failure_policy` child references, output
+/// visibility targets, and the graph-based finding kinds -- are a separate
+/// pass over the parsed tree (`fsl_tools`' agent analyzer), matching
+/// `docs/DESIGN-ai-hard.md`'s separation of parse/grammar from structural
+/// analysis.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when lexical or syntactic analysis fails.
+pub(crate) fn parse_agent_tokens(
+    source: &str,
+    tokens: Vec<Token>,
+    cursor: usize,
+) -> Result<SurfaceAgent, ParseError> {
+    let mut parser = AiParser {
+        source,
+        tokens,
+        cursor,
+        pending_annotations: Annotations::default(),
+    };
+    let agent = parser.agent()?;
+    if !matches!(parser.peek().kind, TokenKind::Eof) {
+        return Err(parser.error("unexpected token after agent"));
+    }
+    Ok(agent)
 }
 
 struct AiParser<'a> {
@@ -445,6 +523,246 @@ impl AiParser<'_> {
             annotations,
             loc: Some(loc),
         })
+    }
+
+    /// Parse one `agent { ... }` body, recursing into nested `agent`
+    /// declarations for `children`. `docs/LANGUAGE.md` §13.6: nested agents
+    /// are ordinary agents scoped by their parent, not a distinct
+    /// `sub_agent` type.
+    #[allow(clippy::too_many_lines)]
+    fn agent(&mut self) -> Result<SurfaceAgent, ParseError> {
+        let start = self.peek().span;
+        let loc: AiLoc = start.into();
+        self.expect_ident_value("agent")?;
+        let name = self.expect_ident()?;
+        self.expect_symbol("{")?;
+        let mut agent = SurfaceAgent {
+            name,
+            span: start,
+            model: None,
+            prompt: None,
+            context: Vec::new(),
+            tool_names: Vec::new(),
+            tools: Vec::new(),
+            authority: AiAuthority::default(),
+            grants: Vec::new(),
+            outputs: Vec::new(),
+            orchestration: Vec::new(),
+            failure_policy: Vec::new(),
+            contracts: Vec::new(),
+            children: Vec::new(),
+            trust: None,
+            review_gates: Vec::new(),
+            loc,
+        };
+        let (mut seen_authority, mut seen_context, mut seen_tools) = (false, false, false);
+        let (mut seen_orchestration, mut seen_failure_policy) = (false, false);
+        while !self.peek_symbol("}") {
+            self.take_leading_annotations()?;
+            if self.eat_ident("model") {
+                self.expect_no_pending_annotations()?;
+                if agent.model.is_some() {
+                    return Err(self.error("agent may declare model at most once"));
+                }
+                agent.model = Some(self.atom()?);
+                self.eat_symbol(";");
+            } else if self.eat_ident("prompt") {
+                self.expect_no_pending_annotations()?;
+                if agent.prompt.is_some() {
+                    return Err(self.error("agent may declare prompt at most once"));
+                }
+                agent.prompt = Some(self.atom()?);
+                self.eat_symbol(";");
+            } else if self.eat_ident("context") {
+                self.expect_no_pending_annotations()?;
+                if seen_context {
+                    return Err(self.error("agent may declare context at most once"));
+                }
+                agent.context = self.names()?;
+                seen_context = true;
+                self.eat_symbol(";");
+            } else if self.eat_ident("tools") {
+                self.expect_no_pending_annotations()?;
+                if seen_tools {
+                    return Err(self.error("agent may declare tools at most once"));
+                }
+                agent.tool_names = self.names()?;
+                seen_tools = true;
+                self.eat_symbol(";");
+            } else if self.peek_ident("tool") {
+                agent.tools.push(self.tool()?);
+            } else if self.eat_ident("trust") {
+                self.expect_no_pending_annotations()?;
+                if agent.trust.is_some() {
+                    return Err(self.error("agent may declare trust at most once"));
+                }
+                agent.trust = Some(self.expect_ident()?);
+                self.eat_symbol(";");
+            } else if self.eat_ident("review_gate") {
+                self.expect_no_pending_annotations()?;
+                agent.review_gates.push(self.expect_ident()?);
+                self.eat_symbol(";");
+            } else if self.peek_ident("authority") {
+                let authority = self.authority()?;
+                if seen_authority {
+                    return Err(self.error("agent may declare authority at most once"));
+                }
+                agent.authority = authority;
+                seen_authority = true;
+            } else if self.peek_ident("grant") {
+                self.expect_no_pending_annotations()?;
+                agent.grants.push(self.grant()?);
+            } else if self.peek_ident("output") {
+                agent.outputs.push(self.agent_output()?);
+            } else if self.eat_ident("orchestration") {
+                self.expect_no_pending_annotations()?;
+                if seen_orchestration {
+                    return Err(self.error("agent may declare orchestration at most once"));
+                }
+                agent.orchestration = self.orchestration()?;
+                seen_orchestration = true;
+            } else if self.eat_ident("failure_policy") {
+                self.expect_no_pending_annotations()?;
+                if seen_failure_policy {
+                    return Err(self.error("agent may declare failure_policy at most once"));
+                }
+                agent.failure_policy = self.failure_policy()?;
+                seen_failure_policy = true;
+            } else if self.eat_ident("contract") {
+                self.expect_no_pending_annotations()?;
+                agent.contracts.push(self.agent_contract()?);
+            } else if self.peek_ident("agent") {
+                agent.children.push(self.agent()?);
+            } else {
+                return Err(self.error("expected agent declaration"));
+            }
+        }
+        let end = self.peek().span;
+        self.bump();
+        agent.span = Span {
+            start: start.start,
+            end: end.end,
+        };
+        Ok(agent)
+    }
+
+    fn grant(&mut self) -> Result<AiAgentGrant, ParseError> {
+        let loc = self.loc();
+        self.bump();
+        let kind = if self.eat_ident("authority") {
+            "authority".to_owned()
+        } else if self.eat_ident("context") {
+            "context".to_owned()
+        } else {
+            return Err(self.error("expected 'authority' or 'context' after grant"));
+        };
+        let names = self.names()?;
+        self.eat_symbol(";");
+        Ok(AiAgentGrant { kind, names, loc })
+    }
+
+    fn agent_output(&mut self) -> Result<AiAgentOutput, ParseError> {
+        let loc = self.loc();
+        self.bump();
+        let name = self.expect_ident()?;
+        self.expect_ident_value("visibility")?;
+        let visibility = self.names()?;
+        self.eat_symbol(";");
+        Ok(AiAgentOutput {
+            name,
+            visibility,
+            loc,
+        })
+    }
+
+    fn orchestration(&mut self) -> Result<Vec<AiDelegationEdge>, ParseError> {
+        self.expect_symbol("{")?;
+        let mut edges = Vec::new();
+        while !self.peek_symbol("}") {
+            self.take_leading_annotations()?;
+            self.expect_no_pending_annotations()?;
+            let loc = self.loc();
+            let source = self.expect_ident()?;
+            self.expect_symbol("->")?;
+            let target = self.expect_ident()?;
+            self.eat_symbol(";");
+            edges.push(AiDelegationEdge {
+                source,
+                target,
+                loc,
+            });
+        }
+        self.bump();
+        Ok(edges)
+    }
+
+    fn failure_policy(&mut self) -> Result<Vec<AiFailurePolicy>, ParseError> {
+        self.expect_symbol("{")?;
+        let mut items = Vec::new();
+        while !self.peek_symbol("}") {
+            self.take_leading_annotations()?;
+            self.expect_no_pending_annotations()?;
+            let loc = self.loc();
+            self.expect_ident_value("when")?;
+            let agent_name = self.expect_ident()?;
+            self.expect_symbol(".")?;
+            let condition = self.expect_ident()?;
+            self.expect_symbol("->")?;
+            let (action, retry_limit, target) = if self.eat_ident("retry") {
+                self.expect_ident_value("up_to")?;
+                let limit = self.expect_int()?;
+                ("retry".to_owned(), Some(limit), None)
+            } else {
+                ("target".to_owned(), None, Some(self.expect_ident()?))
+            };
+            self.eat_symbol(";");
+            items.push(AiFailurePolicy {
+                agent: agent_name,
+                condition,
+                action,
+                target,
+                retry_limit,
+                loc,
+            });
+        }
+        self.bump();
+        Ok(items)
+    }
+
+    fn agent_contract(&mut self) -> Result<AiAgentContract, ParseError> {
+        let loc = self.loc();
+        self.expect_symbol("{")?;
+        let mut hard_rules = Vec::new();
+        while !self.peek_symbol("}") {
+            self.take_leading_annotations()?;
+            self.expect_no_pending_annotations()?;
+            if self.eat_ident("hard") {
+                self.expect_symbol("{")?;
+                while !self.peek_symbol("}") {
+                    self.take_leading_annotations()?;
+                    self.expect_no_pending_annotations()?;
+                    self.expect_ident_value("rule")?;
+                    hard_rules.push(self.expect_ident()?);
+                    self.eat_symbol(";");
+                }
+                self.bump();
+            } else if self.eat_ident("rule") {
+                hard_rules.push(self.expect_ident()?);
+                self.eat_symbol(";");
+            } else {
+                return Err(self.error("expected 'hard' or 'rule' inside contract"));
+            }
+        }
+        self.bump();
+        Ok(AiAgentContract { hard_rules, loc })
+    }
+
+    fn expect_int(&mut self) -> Result<i64, ParseError> {
+        let token = self.bump().clone();
+        match token.kind {
+            TokenKind::Int(value) => Ok(value),
+            _ => Err(ParseError::new("expected integer", token.span)),
+        }
     }
 
     fn names(&mut self) -> Result<Vec<String>, ParseError> {

--- a/rust/fsl-syntax/src/dispatch.rs
+++ b/rust/fsl-syntax/src/dispatch.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use crate::annotation_parse::leading_annotations;
 use crate::lexer::lex_declaration_prefix;
-use crate::{Annotations, ParseError, Span, SurfaceAgent, SurfaceDocument, Token, TokenKind, lex};
+use crate::{Annotations, ParseError, SurfaceDocument, Token, TokenKind, lex};
 
 /// Original source passed beside the shared token stream to a dialect frontend.
 #[derive(Clone, Copy, Debug)]
@@ -223,66 +223,11 @@ fn parse_ai(
 }
 
 fn parse_agent(
-    _source: SourceFile<'_>,
+    source: SourceFile<'_>,
     tokens: Vec<Token>,
     cursor: usize,
 ) -> Result<SurfaceDocument, ParseError> {
-    let mut tokens = tokens.into_iter().skip(cursor);
-    let start = tokens.next().expect("dispatch selected agent token").span;
-    let name = match tokens.next() {
-        Some(Token {
-            kind: TokenKind::Ident(name),
-            ..
-        }) => name,
-        Some(token) => {
-            return Err(ParseError::coded(
-                "FSL-PARSE",
-                "expected agent name",
-                token.span,
-            ));
-        }
-        None => unreachable!("lexer always appends EOF"),
-    };
-    let open = tokens.next().expect("lexer appends EOF");
-    if !matches!(&open.kind, TokenKind::Symbol(symbol) if symbol == "{") {
-        return Err(ParseError::new("expected '{' after agent name", open.span));
-    }
-    let mut depth = 1_usize;
-    let end = loop {
-        let token = tokens.next().expect("lexer appends EOF");
-        match &token.kind {
-            TokenKind::Symbol(symbol) if symbol == "{" => {
-                depth += 1;
-            }
-            TokenKind::Symbol(symbol) if symbol == "}" => {
-                depth -= 1;
-                if depth == 0 {
-                    break token.span;
-                }
-            }
-            TokenKind::Eof => {
-                return Err(ParseError::new(
-                    "agent declaration must contain balanced braces",
-                    token.span,
-                ));
-            }
-            _ => {}
-        }
-    };
-    let trailing = tokens.next().expect("lexer appends EOF");
-    if !matches!(trailing.kind, TokenKind::Eof) {
-        return Err(ParseError::new(
-            "unexpected token after agent",
-            trailing.span,
-        ));
-    }
-    Ok(SurfaceDocument::Agent(SurfaceAgent {
-        name,
-        span: Span {
-            start: start.start,
-            end: end.end,
-        },
-    }))
+    crate::ai::parse_agent_tokens(source.source(), tokens, cursor).map(SurfaceDocument::Agent)
 }
 
 #[cfg(test)]

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -24,7 +24,8 @@ mod surface;
 mod syntax_expr;
 
 pub use ai::{
-    AiAuthority, AiAuthorityRule, AiCheckRule, AiComponent, AiFallback, AiHardCheck, AiLoc, AiTool,
+    AiAgentContract, AiAgentGrant, AiAgentOutput, AiAuthority, AiAuthorityRule, AiCheckRule,
+    AiComponent, AiDelegationEdge, AiFailurePolicy, AiFallback, AiHardCheck, AiLoc, AiTool,
     parse_ai_component,
 };
 pub use annotation::{

--- a/rust/fsl-syntax/src/lossless.rs
+++ b/rust/fsl-syntax/src/lossless.rs
@@ -383,7 +383,8 @@ fn refuse_opaque_agent(tree: &LosslessDocument, dialect: &str) -> Result<(), For
         && close > open + 1
     {
         return Err(FormatError::Unsafe {
-            message: "cannot format an opaque agent body without a native semantic grammar"
+            message: "cannot format an agent body: no native pretty-printer exists for the \
+                      recursive agent grammar yet"
                 .to_owned(),
             span: Span {
                 start: tokens[open + 1].span.start,
@@ -999,8 +1000,24 @@ mod tests {
 
     #[test]
     fn nonempty_opaque_agent_body_is_refused() {
+        // Issue #468: `agent` grew a real semantic grammar (previously a
+        // brace-counting stub that accepted any token soup), so a body that
+        // is not valid agent syntax is now rejected at parse time --
+        // matching the frozen reference exactly (both report `kind:"parse"`
+        // at 1:17 for this exact source). `refuse_opaque_agent`'s
+        // `FormatError::Unsafe` heuristic is unreachable for genuinely
+        // invalid syntax; it still refuses well-formed, non-empty agent
+        // bodies, because no native pretty-printer exists for the agent
+        // grammar yet (see the next test).
         let source = "agent Planner { opaque_call() }";
-        let error = format_source(source, FormatEdition::Current).expect_err("opaque body");
+        let error = format_source(source, FormatEdition::Current).expect_err("invalid agent body");
+        assert!(matches!(error, FormatError::Parse(_)));
+    }
+
+    #[test]
+    fn nonempty_well_formed_agent_body_is_still_refused_pending_a_printer() {
+        let source = "agent Planner { model foo; }";
+        let error = format_source(source, FormatEdition::Current).expect_err("no agent printer");
         assert!(matches!(error, FormatError::Unsafe { .. }));
     }
 

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -4,7 +4,9 @@
 use serde_json::{Map, Value, json};
 
 use crate::{
-    AiComponent, Annotations, Binder, DbSystem, DomainSpec, Expr, QualifiedName, Span, SymbolPath,
+    AiAgentContract, AiAgentGrant, AiAgentOutput, AiAuthority, AiComponent, AiDelegationEdge,
+    AiFailurePolicy, AiLoc, AiTool, Annotations, Binder, DbSystem, DomainSpec, Expr, QualifiedName,
+    Span, SymbolPath,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -652,10 +654,30 @@ pub struct SurfaceCompose {
     pub items: Vec<ComposeItem>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// Recursive `agent` dialect body (issue #468). Nested agents are ordinary
+/// `SurfaceAgent` values held in `children` -- lexical nesting only, not a
+/// distinct sub-agent type (`docs/LANGUAGE.md` §13.6).
+#[derive(Clone, Debug, PartialEq)]
 pub struct SurfaceAgent {
     pub name: String,
     pub span: Span,
+    pub model: Option<String>,
+    pub prompt: Option<String>,
+    pub context: Vec<String>,
+    /// Bare names from a `tools [X, Y];` list, kept separate from `tools`
+    /// (full `tool X { ... }` blocks) -- `docs/LANGUAGE.md` §13.6.
+    pub tool_names: Vec<String>,
+    pub tools: Vec<AiTool>,
+    pub authority: AiAuthority,
+    pub grants: Vec<AiAgentGrant>,
+    pub outputs: Vec<AiAgentOutput>,
+    pub orchestration: Vec<AiDelegationEdge>,
+    pub failure_policy: Vec<AiFailurePolicy>,
+    pub contracts: Vec<AiAgentContract>,
+    pub children: Vec<SurfaceAgent>,
+    pub trust: Option<String>,
+    pub review_gates: Vec<String>,
+    pub loc: AiLoc,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/rust/fsl-tools/src/agent.rs
+++ b/rust/fsl-tools/src/agent.rs
@@ -1,0 +1,859 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural analysis for the recursive fsl-ai `agent` dialect (issue #468).
+//!
+//! Mirrors the frozen reference's `src/fslc/ai_agent.py` behaviorally: lexical
+//! nesting defines namespace/scope only (`AI-ASSUME-NESTING-NOT-DELEGATION`),
+//! a child agent receives no implicit authority/context
+//! (`AI-ASSUME-NO-IMPLICIT-INHERITANCE`) and must stay inside its immediate
+//! parent's declared boundary via explicit `grant`, and runtime collaboration
+//! is declared separately via `orchestration` edges. A `grant` that exceeds
+//! the parent boundary is a check-time `AgentError` (semantics error,
+//! `docs/LANGUAGE.md` §13.6), distinct from the six `agent_structural_violation`
+//! finding kinds below, which are reported findings, not parse/validation
+//! failures.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use fsl_syntax::{AiAuthority, AiFailurePolicy, AiLoc, AiTool, SurfaceAgent};
+use serde_json::{Value, json};
+
+const AI_AGENT_DIALECT_VERSION: &str = "fsl-ai-agent.v0";
+const AI_FINDING_SCHEMA_VERSION: &str = "fsl-ai-finding.v0";
+
+#[derive(Clone, Debug)]
+pub struct AgentError {
+    pub message: String,
+    pub loc: Option<AiLoc>,
+    pub hint: Option<String>,
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+fn agent_err<T>(message: impl Into<String>, loc: Option<AiLoc>) -> Result<T, AgentError> {
+    Err(AgentError {
+        message: message.into(),
+        loc,
+        hint: None,
+    })
+}
+
+fn agent_err_hint<T>(
+    message: impl Into<String>,
+    loc: Option<AiLoc>,
+    hint: impl Into<String>,
+) -> Result<T, AgentError> {
+    Err(AgentError {
+        message: message.into(),
+        loc,
+        hint: Some(hint.into()),
+    })
+}
+
+struct AgentInfo<'a> {
+    agent: &'a SurfaceAgent,
+    path: Vec<String>,
+    parent: Option<Vec<String>>,
+    available_authority: BTreeSet<String>,
+    available_context: BTreeSet<String>,
+}
+
+fn path_str(path: &[String]) -> String {
+    path.join(".")
+}
+
+fn all_tool_names(agent: &SurfaceAgent) -> BTreeSet<String> {
+    let mut names: BTreeSet<String> = agent.tool_names.iter().cloned().collect();
+    names.extend(agent.tools.iter().map(|tool| tool.name.clone()));
+    names
+}
+
+fn authority_names(authority: &AiAuthority) -> BTreeSet<String> {
+    authority
+        .may_suggest
+        .iter()
+        .chain(&authority.may_execute)
+        .chain(&authority.requires_human_approval)
+        .map(|rule| rule.name.clone())
+        .collect()
+}
+
+fn declared_authority_boundary(agent: &SurfaceAgent) -> BTreeSet<String> {
+    let mut set = all_tool_names(agent);
+    set.extend(authority_names(&agent.authority));
+    set
+}
+
+fn high_authority_tools(agent: &SurfaceAgent) -> Vec<String> {
+    let approval: BTreeSet<&str> = agent
+        .authority
+        .requires_human_approval
+        .iter()
+        .map(|rule| rule.name.as_str())
+        .collect();
+    let mut names: BTreeSet<String> = agent
+        .tools
+        .iter()
+        .filter(|tool| tool.irreversible || approval.contains(tool.name.as_str()))
+        .map(|tool| tool.name.clone())
+        .collect();
+    names.extend(
+        agent
+            .authority
+            .requires_human_approval
+            .iter()
+            .map(|rule| rule.name.clone()),
+    );
+    names.into_iter().collect()
+}
+
+fn granted(agent: &SurfaceAgent, kind: &str) -> BTreeSet<String> {
+    agent
+        .grants
+        .iter()
+        .filter(|grant| grant.kind == kind)
+        .flat_map(|grant| grant.names.iter().cloned())
+        .collect()
+}
+
+fn first_grant_loc(agent: &SurfaceAgent, kind: &str) -> AiLoc {
+    agent
+        .grants
+        .iter()
+        .find(|grant| grant.kind == kind)
+        .map_or(agent.loc, |grant| grant.loc)
+}
+
+fn tool_map(agent: &SurfaceAgent) -> BTreeMap<String, AiTool> {
+    let mut map: BTreeMap<String, AiTool> = agent
+        .tool_names
+        .iter()
+        .map(|name| {
+            (
+                name.clone(),
+                AiTool {
+                    name: name.clone(),
+                    schema: None,
+                    irreversible: false,
+                    preconditions: Vec::new(),
+                    effect: None,
+                    annotations: fsl_syntax::Annotations::default(),
+                    loc: None,
+                },
+            )
+        })
+        .collect();
+    for tool in &agent.tools {
+        map.insert(tool.name.clone(), tool.clone());
+    }
+    map
+}
+
+fn dedupe(values: &[String], label: &str, path: &str, loc: AiLoc) -> Result<(), AgentError> {
+    let mut seen = BTreeSet::new();
+    for value in values {
+        if !seen.insert(value.as_str()) {
+            return agent_err(
+                format!("agent '{path}' declares duplicate {label} '{value}'"),
+                Some(loc),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_local_duplicates(node: &SurfaceAgent, path: &[String]) -> Result<(), AgentError> {
+    let component = path_str(path);
+    dedupe(
+        &node
+            .children
+            .iter()
+            .map(|child| child.name.clone())
+            .collect::<Vec<_>>(),
+        "child agent",
+        &component,
+        node.loc,
+    )?;
+    dedupe(
+        &node
+            .tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>(),
+        "tool",
+        &component,
+        node.loc,
+    )?;
+    dedupe(&node.tool_names, "tool", &component, node.loc)?;
+    let tool_set: BTreeSet<&str> = node.tools.iter().map(|tool| tool.name.as_str()).collect();
+    let name_set: BTreeSet<&str> = node.tool_names.iter().map(String::as_str).collect();
+    let overlap = tool_set
+        .intersection(&name_set)
+        .copied()
+        .collect::<Vec<_>>();
+    if !overlap.is_empty() {
+        return agent_err(
+            format!(
+                "agent '{component}' declares duplicate tool {}",
+                overlap.join(", ")
+            ),
+            Some(node.loc),
+        );
+    }
+    dedupe(
+        &node
+            .outputs
+            .iter()
+            .map(|output| output.name.clone())
+            .collect::<Vec<_>>(),
+        "output",
+        &component,
+        node.loc,
+    )?;
+    Ok(())
+}
+
+fn validate_output_visibility(
+    node: &SurfaceAgent,
+    parent_info: Option<&AgentInfo<'_>>,
+    path: &[String],
+) -> Result<(), AgentError> {
+    let parent_children: BTreeSet<String> = parent_info.map_or_else(BTreeSet::new, |parent| {
+        parent
+            .agent
+            .children
+            .iter()
+            .map(|child| child.name.clone())
+            .collect()
+    });
+    let own_children: BTreeSet<String> = node
+        .children
+        .iter()
+        .map(|child| child.name.clone())
+        .collect();
+    let mut allowed: BTreeSet<String> = std::iter::once("self".to_owned())
+        .chain(own_children)
+        .collect();
+    if parent_info.is_some() {
+        allowed.insert("parent".to_owned());
+        for name in &parent_children {
+            if name != &node.name {
+                allowed.insert(name.clone());
+            }
+        }
+    }
+    for output in &node.outputs {
+        let unknown = output
+            .visibility
+            .iter()
+            .filter(|target| !allowed.contains(target.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !unknown.is_empty() {
+            return agent_err_hint(
+                format!(
+                    "agent '{}' output '{}' has unknown visibility target: {}",
+                    path_str(path),
+                    output.name,
+                    unknown.join(", ")
+                ),
+                Some(output.loc),
+                "visibility targets must be parent, self, child agents, or sibling agents in the parent scope",
+            );
+        }
+    }
+    Ok(())
+}
+
+fn require_child(
+    name: &str,
+    child_names: &BTreeSet<&str>,
+    node: &SurfaceAgent,
+    loc: AiLoc,
+    label: &str,
+) -> Result<(), AgentError> {
+    if !child_names.contains(name) {
+        return agent_err_hint(
+            format!("{label} '{name}' is not a child agent of '{}'", node.name),
+            Some(loc),
+            "orchestration and failure_policy edges are separate from lexical nesting and reference immediate children",
+        );
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+fn walk<'a>(
+    node: &'a SurfaceAgent,
+    parent_info: Option<&AgentInfo<'a>>,
+) -> Result<Vec<AgentInfo<'a>>, AgentError> {
+    let path = match parent_info {
+        None => vec![node.name.clone()],
+        Some(parent) => {
+            let mut path = parent.path.clone();
+            path.push(node.name.clone());
+            path
+        }
+    };
+
+    let (available_authority, available_context) = if let Some(parent) = parent_info {
+        let grant_authority = granted(node, "authority");
+        let grant_context = granted(node, "context");
+        let extra_authority = grant_authority
+            .difference(&parent.available_authority)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if !extra_authority.is_empty() {
+            return agent_err_hint(
+                format!(
+                    "agent '{}' grant authority exceeds parent boundary: {}",
+                    path_str(&path),
+                    extra_authority.into_iter().collect::<Vec<_>>().join(", ")
+                ),
+                Some(first_grant_loc(node, "authority")),
+                "grant only tools/capabilities declared in the immediate parent boundary",
+            );
+        }
+        let extra_context = grant_context
+            .difference(&parent.available_context)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if !extra_context.is_empty() {
+            return agent_err_hint(
+                format!(
+                    "agent '{}' grant context exceeds parent boundary: {}",
+                    path_str(&path),
+                    extra_context.into_iter().collect::<Vec<_>>().join(", ")
+                ),
+                Some(first_grant_loc(node, "context")),
+                "grant only context symbols declared in the immediate parent boundary",
+            );
+        }
+        (grant_authority, grant_context)
+    } else {
+        if let Some(grant) = node.grants.first() {
+            return agent_err_hint(
+                format!(
+                    "top-level agent '{}' cannot declare grant {}",
+                    node.name, grant.kind
+                ),
+                Some(grant.loc),
+                "declare root authority/context directly, and grant only inside nested agents",
+            );
+        }
+        (
+            declared_authority_boundary(node),
+            node.context.iter().cloned().collect(),
+        )
+    };
+
+    validate_local_duplicates(node, &path)?;
+    let child_names: BTreeSet<&str> = node
+        .children
+        .iter()
+        .map(|child| child.name.as_str())
+        .collect();
+    for edge in &node.orchestration {
+        require_child(
+            &edge.source,
+            &child_names,
+            node,
+            edge.loc,
+            "orchestration source",
+        )?;
+        require_child(
+            &edge.target,
+            &child_names,
+            node,
+            edge.loc,
+            "orchestration target",
+        )?;
+    }
+    for gate in &node.review_gates {
+        require_child(gate, &child_names, node, node.loc, "review_gate")?;
+    }
+    for policy in &node.failure_policy {
+        require_child(
+            &policy.agent,
+            &child_names,
+            node,
+            policy.loc,
+            "failure_policy source",
+        )?;
+    }
+
+    let info = AgentInfo {
+        agent: node,
+        path: path.clone(),
+        parent: parent_info.map(|parent| parent.path.clone()),
+        available_authority,
+        available_context,
+    };
+    if !node.outputs.is_empty() {
+        validate_output_visibility(node, parent_info, &path)?;
+    }
+
+    let mut all = vec![info];
+    for child in &node.children {
+        let child_infos = walk(child, Some(&all[0]))?;
+        all.extend(child_infos);
+    }
+    Ok(all)
+}
+
+fn agent_assumptions() -> Vec<Value> {
+    vec![
+        json!({"id":"AI-ASSUME-AGENT-DECLARATIONS","text":"agent authority, context, tool, visibility, and orchestration declarations are complete"}),
+        json!({"id":"AI-ASSUME-NESTING-NOT-DELEGATION","text":"lexical nesting defines namespace and scope only; runtime collaboration comes from orchestration edges"}),
+        json!({"id":"AI-ASSUME-NO-IMPLICIT-INHERITANCE","text":"nested agents do not inherit parent authority or context without explicit grant declarations"}),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finding(
+    component: &str,
+    tool: Option<&str>,
+    failed_rule: &str,
+    violation: &str,
+    severity: &str,
+    witness: &Value,
+    minimal_conflict_set: &Value,
+    repair_candidates: &Value,
+    assumptions: &[Value],
+) -> Value {
+    json!({
+        "schema_version": AI_FINDING_SCHEMA_VERSION, "fsl": AI_AGENT_DIALECT_VERSION, "result": "violated",
+        "kind": "agent_structural_violation", "severity": severity, "component": component, "contract": "agent_structure",
+        "tool": tool, "failed_rule": failed_rule, "violation": violation, "guarantee_kind": "agent_structural",
+        "evidence": {"kind": "static_agent_graph", "formal_proof": false},
+        "witness": witness, "minimal_conflict_set": minimal_conflict_set, "repair_candidates": repair_candidates,
+        "assumptions": assumptions, "redaction": {"policy": "agent, tool, context, and graph labels only; prompts and tool args are not emitted"},
+    })
+}
+
+fn reachability(
+    edges: &[fsl_syntax::AiDelegationEdge],
+    nodes: impl Iterator<Item = String>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut graph: BTreeMap<String, BTreeSet<String>> =
+        nodes.map(|node| (node, BTreeSet::new())).collect();
+    for edge in edges {
+        graph
+            .entry(edge.source.clone())
+            .or_default()
+            .insert(edge.target.clone());
+        graph.entry(edge.target.clone()).or_default();
+    }
+    let mut closure = graph;
+    loop {
+        let snapshot = closure.clone();
+        let mut changed = false;
+        for (node, targets) in &mut closure {
+            let mut expanded = targets.clone();
+            for target in targets.iter() {
+                if let Some(more) = snapshot.get(target) {
+                    expanded.extend(more.iter().cloned());
+                }
+            }
+            if &expanded != targets {
+                *targets = expanded;
+                changed = true;
+            }
+            let _ = node;
+        }
+        if !changed {
+            break;
+        }
+    }
+    closure
+}
+
+/// Compute the six documented `agent_structural_violation` finding kinds
+/// (`docs/DESIGN-ai-hard.md` "Rules enforced as stable semantics") over an
+/// already-validated agent tree.
+#[allow(clippy::too_many_lines)]
+fn agent_findings(
+    infos: &BTreeMap<Vec<String>, AgentInfo<'_>>,
+    assumptions: &[Value],
+) -> Vec<Value> {
+    let mut findings = Vec::new();
+    let by_path: BTreeMap<String, &AgentInfo<'_>> = infos
+        .values()
+        .map(|info| (path_str(&info.path), info))
+        .collect();
+
+    for info in infos.values() {
+        let node = info.agent;
+        let component = path_str(&info.path);
+        if info.parent.is_some() {
+            let used_authority = declared_authority_boundary(node);
+            let exceeded = used_authority
+                .difference(&info.available_authority)
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            if !exceeded.is_empty() {
+                findings.push(finding(
+                    &component,
+                    exceeded.iter().next().map(String::as_str),
+                    "authority_grant_subset",
+                    "child_authority_exceeds_parent_authority",
+                    "error",
+                    &json!({"agent": component, "used_authority": used_authority, "granted_authority": info.available_authority, "exceeded": exceeded}),
+                    &json!({"agent": component, "exceeded_authority": exceeded}),
+                    &json!([{"kind":"grant_change","weakens_spec":false,"description":"grant only authority inside the parent boundary or remove the child use"}]),
+                    assumptions,
+                ));
+            }
+            let mut used_context = node.context.clone();
+            used_context.sort();
+            let context_set: BTreeSet<String> = node.context.iter().cloned().collect();
+            let context_exceeded = context_set
+                .difference(&info.available_context)
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            if !context_exceeded.is_empty() {
+                findings.push(finding(
+                    &component,
+                    None,
+                    "context_grant_subset",
+                    "child_context_exceeds_parent_context",
+                    "error",
+                    &json!({"agent": component, "used_context": used_context, "granted_context": info.available_context, "exceeded": context_exceeded}),
+                    &json!({"agent": component, "exceeded_context": context_exceeded}),
+                    &json!([{"kind":"grant_change","weakens_spec":false,"description":"grant only context inside the parent boundary or remove the child read"}]),
+                    assumptions,
+                ));
+            }
+        }
+
+        for tool in &node.tools {
+            let approval_declared = node
+                .authority
+                .requires_human_approval
+                .iter()
+                .any(|rule| rule.name == tool.name);
+            if tool.irreversible && !approval_declared {
+                findings.push(finding(
+                    &component,
+                    Some(&tool.name),
+                    "human_approval_path",
+                    "irreversible_operation_without_human_approval_path",
+                    "error",
+                    &json!({"agent": component, "tool": tool.name, "irreversible": true, "requires_human_approval": false}),
+                    &json!({"agent": component, "tool": tool.name}),
+                    &json!([{"kind":"authority_change","weakens_spec":false,"description":format!("add {} to requires_human_approval or route it to a human review state", tool.name)}]),
+                    assumptions,
+                ));
+            }
+        }
+    }
+
+    for info in infos.values() {
+        let parent = info.agent;
+        if parent.children.is_empty() {
+            continue;
+        }
+        let child_paths: BTreeMap<String, Vec<String>> = parent
+            .children
+            .iter()
+            .map(|child| {
+                let mut path = info.path.clone();
+                path.push(child.name.clone());
+                (child.name.clone(), path)
+            })
+            .collect();
+        let reachability = reachability(&parent.orchestration, child_paths.keys().cloned());
+
+        for child in &parent.children {
+            let source_path = &child_paths[&child.name];
+            for output in &child.outputs {
+                for target in &output.visibility {
+                    if target == "parent" || target == "self" || !child_paths.contains_key(target) {
+                        continue;
+                    }
+                    let reachable_from_child =
+                        reachability.get(&child.name).cloned().unwrap_or_default();
+                    if !reachable_from_child.contains(target) {
+                        findings.push(finding(
+                            &path_str(source_path),
+                            None,
+                            "visibility_requires_delegation",
+                            "visibility_leak_across_sibling_agents",
+                            "error",
+                            &json!({"output": output.name, "source_agent": path_str(source_path), "target_agent": path_str(&child_paths[target]), "delegation_path_exists": false}),
+                            &json!({"source_agent": path_str(source_path), "target_agent": path_str(&child_paths[target]), "output": output.name}),
+                            &json!([{"kind":"orchestration_change","weakens_spec":false,"description":"add an orchestration path for the declared sibling visibility or remove the visibility target"}]),
+                            assumptions,
+                        ));
+                    }
+                }
+            }
+        }
+
+        for (source_name, reachable) in &reachability {
+            let Some(source_info) = by_path.get(&path_str(&child_paths[source_name])) else {
+                continue;
+            };
+            if source_info.agent.trust.as_deref() != Some("low") {
+                continue;
+            }
+            for target_name in reachable {
+                let target_path = &child_paths[target_name];
+                let target_info = &infos[target_path];
+                let high_tools = high_authority_tools(target_info.agent);
+                if !high_tools.is_empty() {
+                    findings.push(finding(
+                        &path_str(&child_paths[source_name]),
+                        Some(high_tools[0].as_str()),
+                        "tool_reachability_graph",
+                        "low_trust_agent_path_to_high_authority_tool",
+                        "error",
+                        &json!({"source_agent": path_str(&child_paths[source_name]), "source_trust": "low", "target_agent": path_str(target_path), "high_authority_tools": high_tools}),
+                        &json!({"source_agent": path_str(&child_paths[source_name]), "target_agent": path_str(target_path)}),
+                        &json!([{"kind":"orchestration_change","weakens_spec":false,"description":"route low-trust output through a review gate before it can influence high-authority tools"}]),
+                        assumptions,
+                    ));
+                }
+            }
+        }
+
+        if !parent.review_gates.is_empty() {
+            let gates: BTreeSet<String> = parent.review_gates.iter().cloned().collect();
+            for (source_name, reachable) in &reachability {
+                if gates.contains(source_name) {
+                    continue;
+                }
+                for target_name in reachable {
+                    if gates.contains(target_name) {
+                        continue;
+                    }
+                    let target_path = &child_paths[target_name];
+                    let target_info = &infos[target_path];
+                    let high_tools = high_authority_tools(target_info.agent);
+                    if high_tools.is_empty() {
+                        continue;
+                    }
+                    let has_review_path = gates.iter().any(|gate| {
+                        reachable.contains(gate)
+                            && reachability
+                                .get(gate)
+                                .is_some_and(|reach| reach.contains(target_name))
+                    });
+                    if !has_review_path {
+                        findings.push(finding(
+                            &path_str(&info.path),
+                            Some(high_tools[0].as_str()),
+                            "policy_review_gate",
+                            "policy_review_bypass_in_orchestration",
+                            "error",
+                            &json!({"parent_agent": path_str(&info.path), "source_agent": path_str(&child_paths[source_name]), "target_agent": path_str(target_path), "review_gates": gates}),
+                            &json!({"parent_agent": path_str(&info.path), "source_agent": path_str(&child_paths[source_name]), "target_agent": path_str(target_path)}),
+                            &json!([{"kind":"orchestration_change","weakens_spec":false,"description":"insert the declared review gate on paths to high-authority agents"}]),
+                            assumptions,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    findings
+}
+
+fn tool_ir(tool: &AiTool) -> Value {
+    json!({"name": tool.name, "schema": tool.schema, "irreversible": tool.irreversible, "preconditions": tool.preconditions, "effect": tool.effect})
+}
+
+fn authority_ir(authority: &AiAuthority) -> Value {
+    json!({
+        "may_suggest": authority.may_suggest.iter().map(|rule| rule.name.clone()).collect::<Vec<_>>(),
+        "may_execute": authority.may_execute.iter().map(|rule| rule.name.clone()).collect::<Vec<_>>(),
+        "requires_human_approval": authority.requires_human_approval.iter().map(|rule| rule.name.clone()).collect::<Vec<_>>(),
+        "forbidden": authority.forbidden.iter().map(|rule| rule.name.clone()).collect::<Vec<_>>(),
+    })
+}
+
+fn failure_ir(policy: &AiFailurePolicy, path: &[String]) -> Value {
+    let mut source_path = path.to_vec();
+    source_path.push(policy.agent.clone());
+    json!({"source": path_str(&source_path), "condition": policy.condition, "action": policy.action, "target": policy.target, "retry_limit": policy.retry_limit})
+}
+
+fn agent_ir(agent: &SurfaceAgent, prefix: &[String]) -> Value {
+    let mut path = prefix.to_vec();
+    path.push(agent.name.clone());
+    json!({
+        "path": path_str(&path),
+        "name": agent.name,
+        "model": agent.model,
+        "prompt": agent.prompt,
+        "trust": agent.trust,
+        "context": agent.context,
+        "tools": agent.tools.iter().map(tool_ir).collect::<Vec<_>>(),
+        "tool_names": agent.tool_names,
+        "authority": authority_ir(&agent.authority),
+        "grants": agent.grants.iter().map(|grant| json!({"kind": grant.kind, "names": grant.names})).collect::<Vec<_>>(),
+        "outputs": agent.outputs.iter().map(|output| json!({"name": output.name, "visibility": output.visibility})).collect::<Vec<_>>(),
+        "review_gates": agent.review_gates,
+        "orchestration": agent.orchestration.iter().map(|edge| {
+            let mut source_path = path.clone();
+            source_path.push(edge.source.clone());
+            let mut target_path = path.clone();
+            target_path.push(edge.target.clone());
+            json!({"source": edge.source, "target": edge.target, "source_path": path_str(&source_path), "target_path": path_str(&target_path)})
+        }).collect::<Vec<_>>(),
+        "failure_policy": agent.failure_policy.iter().map(|policy| failure_ir(policy, &path)).collect::<Vec<_>>(),
+        "contracts": agent.contracts.iter().map(|contract| json!({"hard_rules": contract.hard_rules})).collect::<Vec<_>>(),
+        "children": agent.children.iter().map(|child| agent_ir(child, &path)).collect::<Vec<_>>(),
+    })
+}
+
+fn visibility_target_path(
+    path: &[String],
+    parent: Option<&[String]>,
+    target: &str,
+) -> Option<String> {
+    if target == "self" {
+        return Some(path_str(path));
+    }
+    if target == "parent" {
+        return parent.map(path_str);
+    }
+    if let Some(parent) = parent {
+        let mut extended = parent.to_vec();
+        extended.push(target.to_owned());
+        Some(path_str(&extended))
+    } else {
+        let mut extended = path.to_vec();
+        extended.push(target.to_owned());
+        Some(path_str(&extended))
+    }
+}
+
+fn graph_summary(infos: &BTreeMap<Vec<String>, AgentInfo<'_>>) -> Value {
+    let mut scope_tree = Vec::new();
+    let mut authority_graph = Vec::new();
+    let mut information_flow_graph = Vec::new();
+    let mut delegation_graph = Vec::new();
+    let mut tool_reachability_graph = Vec::new();
+    let mut failure_policies = Vec::new();
+
+    for info in infos.values() {
+        let node = info.agent;
+        let path = &info.path;
+        let child_paths: BTreeMap<String, Vec<String>> = node
+            .children
+            .iter()
+            .map(|child| {
+                let mut p = path.clone();
+                p.push(child.name.clone());
+                (child.name.clone(), p)
+            })
+            .collect();
+        scope_tree.push(json!({
+            "path": path_str(path),
+            "parent": info.parent.as_ref().map(|parent| path_str(parent)),
+            "children": node.children.iter().map(|child| path_str(&child_paths[&child.name])).collect::<Vec<_>>(),
+        }));
+        if let Some(parent) = &info.parent {
+            authority_graph.push(json!({
+                "agent": path_str(path),
+                "parent": path_str(parent),
+                "granted_authority": info.available_authority,
+                "granted_context": info.available_context,
+            }));
+        }
+        for edge in &node.orchestration {
+            let mut source_path = path.clone();
+            source_path.push(edge.source.clone());
+            let mut target_path = path.clone();
+            target_path.push(edge.target.clone());
+            delegation_graph.push(json!({
+                "parent": path_str(path),
+                "source": path_str(&source_path),
+                "target": path_str(&target_path),
+            }));
+        }
+        for output in &node.outputs {
+            for target in &output.visibility {
+                information_flow_graph.push(json!({
+                    "source": format!("{}.output.{}", path_str(path), output.name),
+                    "target": visibility_target_path(path, info.parent.as_deref(), target),
+                }));
+            }
+        }
+        for (tool_name, tool) in tool_map(node) {
+            tool_reachability_graph.push(json!({
+                "agent": path_str(path),
+                "tool": tool_name,
+                "irreversible": tool.irreversible,
+                "requires_human_approval": node.authority.requires_human_approval.iter().any(|rule| rule.name == tool_name),
+                "may_execute": node.authority.may_execute.iter().any(|rule| rule.name == tool_name),
+                "may_suggest": node.authority.may_suggest.iter().any(|rule| rule.name == tool_name),
+            }));
+        }
+        for policy in &node.failure_policy {
+            failure_policies.push(failure_ir(policy, path));
+        }
+    }
+
+    json!({
+        "scope_tree": scope_tree,
+        "delegation_graph": delegation_graph,
+        "authority_graph": authority_graph,
+        "information_flow_graph": information_flow_graph,
+        "tool_reachability_graph": tool_reachability_graph,
+        "failure_policy": failure_policies,
+    })
+}
+
+/// Analyze a recursive `agent` document: validate the lexical tree (grant
+/// boundaries, unknown orchestration/`review_gate`/`failure_policy` child
+/// references, output visibility targets -- all check-time errors) and
+/// compute the six structural finding kinds.
+///
+/// # Errors
+///
+/// Returns [`AgentError`] for a tree-validation failure (see above); this is
+/// a `kind:"semantics"` check-time error at the CLI layer, not a finding.
+pub fn analyze_ai_agent(agent: &SurfaceAgent) -> Result<Value, AgentError> {
+    let infos_vec = walk(agent, None)?;
+    let infos: BTreeMap<Vec<String>, AgentInfo<'_>> = infos_vec
+        .into_iter()
+        .map(|info| (info.path.clone(), info))
+        .collect();
+    let assumptions = agent_assumptions();
+    let findings = agent_findings(&infos, &assumptions);
+    let result = if findings.is_empty() {
+        "agent_analyzed"
+    } else {
+        "violated"
+    };
+    Ok(json!({
+        "result": result,
+        "dialect": AI_AGENT_DIALECT_VERSION,
+        "finding_schema_version": AI_FINDING_SCHEMA_VERSION,
+        "ai_agent": agent.name,
+        "formal_result": "not_run",
+        "evidence": {"kind": "static_agent_graph", "formal_proof": false},
+        "guarantee_boundary": {
+            "proved": "not claimed for recursive agent composition",
+            "agent_structural": "lexical scope, grant subset, delegation, visibility, failure policy, and tool-reachability structure",
+            "runtime_replay": "not run for agent composition",
+            "evaluator_supported": "outside this structural analysis",
+            "statistically_supported": "outside this structural analysis",
+        },
+        "assumptions": assumptions,
+        "agent_ir": agent_ir(agent, &[]),
+        "graph_summary": graph_summary(&infos),
+        "findings": findings,
+        "note": "recursive agent analysis is structural only; it does not prove LLM semantic correctness or statistical/evaluator-backed quality claims",
+    }))
+}

--- a/rust/fsl-tools/src/ai.rs
+++ b/rust/fsl-tools/src/ai.rs
@@ -38,12 +38,103 @@ fn finding(
     })
 }
 
-/// Check the structural hard-contract portion of an AI component.
-#[must_use]
-pub fn check_ai(component: &AiComponent, kernel: Value) -> Value {
-    let assumptions = assumptions(false);
+#[allow(clippy::too_many_arguments)]
+fn hard_finding(
+    component: &AiComponent,
+    tool: Option<&str>,
+    violation: &str,
+    rule: &str,
+    kind: &str,
+    guarantee: &str,
+    evidence_kind: &str,
+    witness: &Value,
+    minimal_conflict_set: &Value,
+    repair_candidates: &Value,
+    assumptions: &[Value],
+) -> Value {
+    json!({
+        "schema_version":"fsl-ai-finding.v0","fsl":"fsl-ai-hard.v0","result":"violated",
+        "kind":kind,"severity":"error","component":component.name,"contract":"hard","tool":tool,
+        "failed_rule":rule,"violation":violation,"guarantee_kind":guarantee,
+        "evidence":{"kind":evidence_kind,"formal_proof":matches!(evidence_kind,"bmc"|"induction")},
+        "witness":witness,"minimal_conflict_set":minimal_conflict_set,"repair_candidates":repair_candidates,
+        "assumptions":assumptions,"redaction":{"policy":"tool names, schema names, and redacted event metadata only; prompts and tool args are not emitted by default"}
+    })
+}
+
+fn authority_repairs(tool_name: &str) -> Value {
+    json!([
+        {"kind":"authority_change","weakens_spec":false,"description":format!("remove {tool_name} from executable authority or from forbidden, after policy review")},
+        {"kind":"runtime_guard","weakens_spec":false,"description":format!("block {tool_name} before side effects when forbidden authority applies")},
+    ])
+}
+
+fn approval_repairs(tool_name: &str) -> Value {
+    json!([
+        {"kind":"authority_change","weakens_spec":false,"description":format!("add {tool_name} to requires_human_approval")},
+        {"kind":"workflow_change","weakens_spec":false,"description":format!("insert a human approval token before executing {tool_name}")},
+        {"kind":"tool_change","weakens_spec":true,"description":format!("mark {tool_name} reversible only if the external side effect is actually reversible")},
+    ])
+}
+
+fn schema_repairs(tool_name: &str) -> Value {
+    json!([
+        {"kind":"schema_declaration","weakens_spec":false,"description":format!("declare the input schema expected for {tool_name}")},
+    ])
+}
+
+fn repairs_for_kernel_violation(violation: &str, tool_name: &str) -> Value {
+    match violation {
+        "human_approval_required_before_irreversible_tool" => json!([
+            {"kind":"workflow_change","weakens_spec":false,"description":format!("insert a human_approval event before executing {tool_name}")},
+            {"kind":"runtime_guard","weakens_spec":false,"description":format!("block {tool_name} until a valid approval token exists")},
+        ]),
+        "forbidden_tool_call" => json!([
+            {"kind":"runtime_guard","weakens_spec":false,"description":format!("block {tool_name} before external side effects")},
+            {"kind":"authority_change","weakens_spec":true,"description":format!("remove {tool_name} from forbidden only if policy explicitly permits it")},
+        ]),
+        _ => json!([]),
+    }
+}
+
+/// Structural (pre-kernel) hard-contract findings: `tool_authority` (a
+/// forbidden tool also declared executable), `human_approval_required` (an
+/// irreversible tool with no explicit `requires_human_approval`, mirroring
+/// `docs/DESIGN-ai-hard.md`'s rule text rather than the narrower "and it is
+/// in `may_execute`" precondition), and `tool_schema_declared` (an
+/// executable tool with no declared schema).
+fn static_ai_findings(component: &AiComponent, assumptions: &[Value]) -> Vec<Value> {
+    let sets = fsl_core::ai_tool_sets(component);
     let mut findings = Vec::new();
-    let approvals = component
+    for &tool_name in sets.forbidden.intersection(&sets.executable) {
+        let authority_kind = if component
+            .authority
+            .may_execute
+            .iter()
+            .any(|rule| rule.name == tool_name)
+        {
+            "may_execute"
+        } else {
+            "requires_human_approval"
+        };
+        findings.push(hard_finding(
+            component,
+            Some(tool_name),
+            "forbidden_tool_declared_executable",
+            "tool_authority",
+            "ai_hard_contract_violation",
+            "syntactic_hard",
+            "static_check",
+            &json!({"tool":tool_name,"authority":["forbidden", authority_kind]}),
+            &json!({"component":component.name,"tool":tool_name}),
+            &authority_repairs(tool_name),
+            assumptions,
+        ));
+    }
+    // Explicit-only: distinct from `sets.approval_required`, which already
+    // folds irreversible tools in -- this must catch the tool that has not
+    // (yet) been explicitly listed.
+    let explicit_approval = component
         .authority
         .requires_human_approval
         .iter()
@@ -51,32 +142,179 @@ pub fn check_ai(component: &AiComponent, kernel: Value) -> Value {
         .collect::<BTreeSet<_>>();
     for tool in &component.tools {
         if tool.irreversible
-            && component
-                .authority
-                .may_execute
-                .iter()
-                .any(|rule| rule.name == tool.name)
-            && !approvals.contains(tool.name.as_str())
+            && !explicit_approval.contains(tool.name.as_str())
+            && !sets.forbidden.contains(tool.name.as_str())
         {
-            findings.push(finding(
+            findings.push(hard_finding(
                 component,
                 Some(&tool.name),
                 "irreversible_tool_without_human_approval_guard",
                 "human_approval_required",
                 "ai_hard_contract_violation",
                 "syntactic_hard",
-                &json!({"tool":tool.name,"irreversible":true}),
-                &assumptions,
+                "static_check",
+                &json!({"tool":tool.name,"irreversible":true,"requires_human_approval":false}),
+                &json!({"component":component.name,"tool":tool.name}),
+                &approval_repairs(&tool.name),
+                assumptions,
             ));
         }
     }
-    let violated = !findings.is_empty();
+    for tool in &component.tools {
+        if sets.executable.contains(tool.name.as_str()) && tool.schema.is_none() {
+            findings.push(hard_finding(
+                component,
+                Some(&tool.name),
+                "executable_tool_without_schema",
+                "tool_schema_declared",
+                "ai_hard_contract_violation",
+                "syntactic_hard",
+                "static_check",
+                &json!({"tool":tool.name,"schema":Value::Null}),
+                &json!({"component":component.name,"tool":tool.name}),
+                &schema_repairs(&tool.name),
+                assumptions,
+            ));
+        }
+    }
+    findings
+}
+
+fn kernel_projection(kernel: &Value) -> Value {
+    let Value::Object(kernel) = kernel else {
+        return kernel.clone();
+    };
+    Value::Object(
+        [
+            "result",
+            "spec",
+            "depth",
+            "checked_to_depth",
+            "completeness",
+            "invariant",
+            "violation_kind",
+        ]
+        .into_iter()
+        .filter_map(|key| {
+            kernel
+                .get(key)
+                .cloned()
+                .map(|value| (key.to_owned(), value))
+        })
+        .collect(),
+    )
+}
+
+/// Translate a violated generated invariant (`forbidden_tool_blocked` /
+/// `human_approval_required`) back into an `ai_hard_contract_violation`
+/// finding. Both invariants are structural tautologies given the generated
+/// guards (no `execute_*` action exists for a forbidden tool; an
+/// approval-required tool's `execute_*` action always `requires
+/// human_approved[tool]`), so this is depth-independent defense-in-depth
+/// mirroring the frozen reference's `_translate_kernel_result`, not the
+/// primary detection path.
+fn translate_kernel_violation(
+    component: &AiComponent,
+    kernel: &Value,
+    assumptions: &[Value],
+) -> Vec<Value> {
+    if kernel.get("result").and_then(Value::as_str) != Some("violated")
+        || kernel.get("violation_kind").and_then(Value::as_str) != Some("invariant")
+    {
+        return Vec::new();
+    }
+    let Some(inv_name) = kernel.get("invariant").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    let sets = fsl_core::ai_tool_sets(component);
+    let translated = sets
+        .forbidden
+        .iter()
+        .find(|&&tool_name| fsl_core::ai_forbidden_invariant_name(tool_name) == inv_name)
+        .map(|&tool_name| {
+            (
+                "ai_hard_contract_violation",
+                "forbidden_tool_call",
+                "forbidden_tool_blocked",
+                tool_name,
+            )
+        })
+        .or_else(|| {
+            sets.approval_required
+                .difference(&sets.forbidden)
+                .find(|&&tool_name| fsl_core::ai_approval_invariant_name(tool_name) == inv_name)
+                .map(|&tool_name| {
+                    (
+                        "ai_hard_contract_violation",
+                        "human_approval_required_before_irreversible_tool",
+                        "human_approval_required",
+                        tool_name,
+                    )
+                })
+        });
+    let Some((kind, violation, rule, tool_name)) = translated else {
+        return Vec::new();
+    };
+    let evidence_kind = if kernel.get("completeness").and_then(Value::as_str) == Some("induction") {
+        "induction"
+    } else {
+        "bmc"
+    };
+    vec![hard_finding(
+        component,
+        Some(tool_name),
+        violation,
+        rule,
+        kind,
+        "syntactic_hard",
+        evidence_kind,
+        &json!({"invariant":inv_name,"trace":kernel.get("trace").cloned().unwrap_or_else(|| json!([]))}),
+        &json!({"component":component.name,"tool":tool_name,"invariant":inv_name}),
+        &repairs_for_kernel_violation(violation, tool_name),
+        assumptions,
+    )]
+}
+
+/// Check the structural hard-contract portion of an AI component.
+///
+/// `kernel` is the *unprojected* result of verifying the generated kernel
+/// spec (`fslc verify`'s full JSON envelope for the lowered `ai_component`),
+/// so witness construction can use fields like `trace` that the published
+/// `kernel` projection below deliberately omits.
+#[must_use]
+pub fn check_ai(component: &AiComponent, kernel: &Value) -> Value {
+    let assumptions = assumptions(false);
+    let static_findings = static_ai_findings(component, &assumptions);
+    let guarantee_boundary = json!({"proved":"kernel safety facts over the finite hard-contract expansion","evaluator_supported":"external evaluator evidence and never reported as formal proof","statistically_supported":"external statistical evidence and never reported as formal proof","runtime_replay":"observed evidence, not proof"});
+    if !static_findings.is_empty() {
+        return json!({
+            "result":"violated","dialect":"fsl-ai-hard.v0","finding_schema_version":"fsl-ai-finding.v0",
+            "ai_component":component.name,"guarantee_boundary":guarantee_boundary,
+            "assumptions":assumptions,"findings":static_findings,"formal_result":"not_run","kernel":Value::Null,
+        });
+    }
+    let translated = translate_kernel_violation(component, kernel, &assumptions);
+    let kernel_result = kernel
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or("error")
+        .to_owned();
+    let (result, findings, formal_result) = if !translated.is_empty() {
+        ("violated".to_owned(), translated, kernel_result)
+    } else if matches!(kernel_result.as_str(), "verified" | "proved") {
+        (
+            "verified_under_assumptions".to_owned(),
+            Vec::new(),
+            kernel_result,
+        )
+    } else {
+        (kernel_result.clone(), Vec::new(), kernel_result)
+    };
     json!({
-        "result":if violated{"violated"}else{"verified_under_assumptions"},"dialect":"fsl-ai-hard.v0",
-        "finding_schema_version":"fsl-ai-finding.v0","ai_component":component.name,
-        "guarantee_boundary":{"proved":"kernel safety facts over the finite hard-contract expansion","evaluator_supported":"external evaluator evidence and never reported as formal proof","statistically_supported":"external statistical evidence and never reported as formal proof","runtime_replay":"observed evidence, not proof"},
-        "assumptions":assumptions,"findings":findings,"formal_result":if violated{"not_run"}else{"verified"},
-        "kernel":if violated{Value::Null}else{kernel}
+        "result":result,"dialect":"fsl-ai-hard.v0","finding_schema_version":"fsl-ai-finding.v0",
+        "ai_component":component.name,"guarantee_boundary":guarantee_boundary,
+        "assumptions":assumptions,"findings":findings,"formal_result":formal_result,
+        "kernel":kernel_projection(kernel),
     })
 }
 
@@ -92,6 +330,7 @@ pub fn replay_ai(component: &AiComponent, events: &[Value]) -> Value {
         .iter()
         .map(|tool| (tool.name.as_str(), tool))
         .collect::<std::collections::BTreeMap<_, _>>();
+    let sets = fsl_core::ai_tool_sets(component);
     for (index, event) in events.iter().enumerate() {
         let event_type = event
             .get("event")
@@ -129,6 +368,15 @@ pub fn replay_ai(component: &AiComponent, events: &[Value]) -> Value {
                 findings.push(finding(component,Some(tool_name),"undeclared_tool_observed","runtime_observation","observed_contract_violation","runtime_observed",&json!({"event_index":index,"reason":"observed tool call is not declared by the AI component"}),&assumptions));
                 continue;
             };
+            if mode == "suggest"
+                && !sets.suggestible.contains(tool_name)
+                && !sets.executable.contains(tool_name)
+            {
+                findings.push(finding(component,Some(tool_name),"suggestion_without_authority","tool_authority","ai_hard_contract_violation","syntactic_hard",&json!({"event_index":index,"reason":"tool suggestion is outside may_suggest/may_execute authority"}),&assumptions));
+            }
+            if mode == "execute" && !sets.executable.contains(tool_name) {
+                findings.push(finding(component,Some(tool_name),"execution_without_authority","tool_authority","ai_hard_contract_violation","syntactic_hard",&json!({"event_index":index,"reason":"tool execution is outside may_execute/requires_human_approval authority"}),&assumptions));
+            }
             if mode == "execute"
                 && component
                     .authority
@@ -176,21 +424,40 @@ pub fn replay_ai(component: &AiComponent, events: &[Value]) -> Value {
                     &assumptions,
                 ));
             }
-            if call
-                .get("preconditions")
-                .and_then(Value::as_object)
-                .is_some_and(|values| values.values().any(|value| value == &Value::Bool(false)))
-            {
-                findings.push(finding(
-                    component,
-                    Some(tool_name),
-                    "business_precondition_mismatch",
-                    "tool_precondition_declared",
-                    "ai_hard_contract_violation",
-                    "syntactic_hard",
-                    &json!({"event_index":index}),
-                    &assumptions,
-                ));
+            if !tool.preconditions.is_empty() {
+                match call.get("preconditions").and_then(Value::as_object) {
+                    None => {
+                        // A declared precondition with no evidence object at
+                        // all previously passed silently -- only an explicit
+                        // `false` value was ever caught.
+                        findings.push(finding(
+                            component,
+                            Some(tool_name),
+                            "business_precondition_mismatch",
+                            "tool_precondition_declared",
+                            "ai_hard_contract_violation",
+                            "syntactic_hard",
+                            &json!({"event_index":index,"missing_preconditions":tool.preconditions}),
+                            &assumptions,
+                        ));
+                    }
+                    Some(observed) => {
+                        for name in &tool.preconditions {
+                            if observed.get(name) != Some(&Value::Bool(true)) {
+                                findings.push(finding(
+                                    component,
+                                    Some(tool_name),
+                                    "business_precondition_mismatch",
+                                    "tool_precondition_declared",
+                                    "ai_hard_contract_violation",
+                                    "syntactic_hard",
+                                    &json!({"event_index":index,"precondition":name,"observed":observed.get(name)}),
+                                    &assumptions,
+                                ));
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/rust/fsl-tools/src/db.rs
+++ b/rust/fsl-tools/src/db.rs
@@ -197,6 +197,26 @@ fn capability<'a>(artifact: &'a DbArtifact, name: &str) -> &'a [DbColumnRef] {
     artifact.capabilities.get(name).map_or(&[], Vec::as_slice)
 }
 
+fn compat_repairs(capability_name: &str, artifact: &str, column: &str, environment: &str) -> Value {
+    json!([
+        {
+            "kind": "compat_shim",
+            "weakens_spec": false,
+            "description": format!("keep or restore {column} until {artifact} is outside {environment}"),
+        },
+        {
+            "kind": "rollout_window_change",
+            "weakens_spec": false,
+            "description": format!("narrow the {artifact} environment window before dropping {column}"),
+        },
+        {
+            "kind": "declaration_change",
+            "weakens_spec": true,
+            "description": format!("remove the declared {capability_name} capability only if {artifact} truly no longer uses {column}"),
+        }
+    ])
+}
+
 fn window(entry: &DbEnvironmentArtifact, environment: &DbEnvironment) -> (i64, i64) {
     entry.schema_window.unwrap_or(environment.schema_window)
 }
@@ -328,23 +348,43 @@ fn findings(system: &DbSystem, assumptions: &[Value]) -> Vec<Value> {
                             continue;
                         };
                         let range = window(entry, environment);
-                        if range.1 < migration.to_schema
-                            || !capability(artifact, "reads").contains(&operation.column)
-                        {
+                        if range.1 < migration.to_schema {
                             continue;
                         }
-                        let mut finding = common_finding(
-                            "column_removed_while_still_read",
-                            "all_active_reads_exist",
-                            assumptions,
-                        );
-                        finding.insert("environment".to_owned(), json!(environment.name));
-                        finding.insert("migration".to_owned(), json!(migration.name));
-                        finding.insert("schema_element".to_owned(), json!(element));
-                        finding.insert("artifact".to_owned(), json!(artifact.name));
-                        finding.insert("witness".to_owned(), json!({"environment_role": entry.role, "schema_version": migration.to_schema}));
-                        finding.insert("minimal_conflict_set".to_owned(), json!({"environment": environment.name, "artifact": artifact.name, "migration": migration.name, "schema_element": element}));
-                        findings.push(Value::Object(finding));
+                        for (capability_name, kind, rule) in [
+                            (
+                                "reads",
+                                "column_removed_while_still_read",
+                                "all_active_reads_exist",
+                            ),
+                            (
+                                "writes",
+                                "column_removed_while_still_written",
+                                "all_active_writes_exist",
+                            ),
+                        ] {
+                            if !capability(artifact, capability_name).contains(&operation.column) {
+                                continue;
+                            }
+                            let mut finding = common_finding(kind, rule, assumptions);
+                            finding.insert("environment".to_owned(), json!(environment.name));
+                            finding.insert("migration".to_owned(), json!(migration.name));
+                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert("artifact".to_owned(), json!(artifact.name));
+                            finding.insert("artifact_version".to_owned(), json!(artifact.name));
+                            finding.insert("witness".to_owned(), json!({"environment_role": entry.role, "schema_version": migration.to_schema, "declared_capability": capability_name}));
+                            finding.insert("minimal_conflict_set".to_owned(), json!({"environment": environment.name, "artifact": artifact.name, "migration": migration.name, "schema_element": element}));
+                            finding.insert(
+                                "repair_candidates".to_owned(),
+                                compat_repairs(
+                                    capability_name,
+                                    &artifact.name,
+                                    &element,
+                                    &environment.name,
+                                ),
+                            );
+                            findings.push(Value::Object(finding));
+                        }
                     }
                 }
             }

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Native report generators and specialized FSL dialect engines.
 
+mod agent;
 mod ai;
 mod analysis;
 mod analysis_export;
@@ -38,6 +39,7 @@ mod testgen;
 mod typestate;
 mod undecided;
 
+pub use agent::{AgentError, analyze_ai_agent};
 pub use ai::{check_ai, replay_ai};
 pub use analysis::{
     analyze_model, analyze_tsg, build_tsg, conservation_review_findings, review_finding,

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -108,19 +108,25 @@ fn implements_error(
     output
 }
 
-fn build(request: &Request, solver_version: &str) -> Result<KernelModel, Value> {
+fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Value>), Value> {
     let resolver = MemoryResolver {
         files: request.files.clone(),
     };
     let kernel =
         fsl_core::parse_kernel_source_with_file(&request.source, &resolver, &request.source_file)
             .map_err(|failure| error(solver_version, "parse", failure.to_string()))?;
-    fsl_core::build_model(kernel).map_err(|failure| {
+    // Compose-lowering warnings (e.g. `fair_not_inherited`) are computed while
+    // lowering, before `build_model` drops the per-component information that
+    // produced them, so they must be captured here rather than derived from
+    // the checked KernelModel below.
+    let diagnostics = kernel.diagnostics().to_vec();
+    let model = fsl_core::build_model(kernel).map_err(|failure| {
         fslc_rust::verification_output::render_semantic_error(
             envelope(solver_version),
             &failure.to_string(),
         )
-    })
+    })?;
+    Ok((model, diagnostics))
 }
 
 async fn check(request: &Request, solver_version: &str) -> Value {
@@ -137,8 +143,8 @@ async fn check(request: &Request, solver_version: &str) -> Value {
             &failure,
         );
     }
-    let model = match build(request, solver_version) {
-        Ok(model) => model,
+    let (model, compose_warnings) = match build(request, solver_version) {
+        Ok(built) => built,
         Err(error) => return error,
     };
     let has_trace_contract = match fslc_rust::verification_output::validate_requirement_trace_source(
@@ -153,7 +159,11 @@ async fn check(request: &Request, solver_version: &str) -> Value {
     let mut output = envelope(solver_version);
     output.insert("result".to_owned(), json!("ok"));
     output.insert("spec".to_owned(), json!(model.name));
-    output.insert("warnings".to_owned(), Value::Array(model_warnings(&model)));
+    let warnings = compose_warnings
+        .into_iter()
+        .chain(model_warnings(&model))
+        .collect::<Vec<_>>();
+    output.insert("warnings".to_owned(), Value::Array(warnings));
     let mut output = add_frontend_metadata(
         request,
         solver_version,
@@ -330,8 +340,8 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
     if let Err(failure) = fsl_syntax::parse_surface_document(&request.source) {
         return error(solver_version, "parse", failure.to_string());
     }
-    let model = match build(request, solver_version) {
-        Ok(model) => model,
+    let (model, compose_warnings) = match build(request, solver_version) {
+        Ok(built) => built,
         Err(error) => return error,
     };
     let has_trace_contract = match fslc_rust::verification_output::validate_requirement_trace_source(
@@ -391,7 +401,7 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
         return error(solver_version, "internal", failure);
     }
     let statistics = fsl_solver::SmtSolver::statistics(&solver);
-    let (output, _) = fslc_rust::verification_output::render_bmc_output(
+    let (mut output, _) = fslc_rust::verification_output::render_bmc_output(
         envelope(solver_version),
         &model,
         &result,
@@ -403,6 +413,16 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             statistics: &statistics,
         },
     );
+    if !compose_warnings.is_empty()
+        && let Some(object) = output.as_object_mut()
+        && object.get("result").and_then(Value::as_str) != Some("error")
+        && let Some(Value::Array(warnings)) = object.get_mut("warnings")
+    {
+        // See the matching comment in native `run_verify` (rust/fslc/src/main.rs):
+        // compose-lowering warnings must be captured before `build_model` drops
+        // per-component fairness information, so they cannot come from `model`.
+        warnings.splice(0..0, compose_warnings);
+    }
     add_frontend_metadata(
         request,
         solver_version,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5198,8 +5198,8 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
     }
-    match load_model(path) {
-        Ok(model) => {
+    match load_kernel_model(path) {
+        Ok((_, kernel, model)) => {
             let has_trace_contract = match validate_requirement_traces(path, &model) {
                 Ok((Some(failure), _)) => return (failure, 2),
                 Ok((None, has_contract)) => has_contract,
@@ -5212,7 +5212,7 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
                 Ok(implements) => implements,
                 Err(error) => return (implements_error_output(&error), 2),
             };
-            let warnings = if implements.is_some() || has_trace_contract {
+            let model_level_warnings = if implements.is_some() || has_trace_contract {
                 model_warnings(&model)
                     .into_iter()
                     .filter(|warning| {
@@ -5223,6 +5223,12 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
             } else {
                 model_warnings(&model)
             };
+            let warnings = kernel
+                .diagnostics()
+                .iter()
+                .cloned()
+                .chain(model_level_warnings)
+                .collect::<Vec<_>>();
             output.insert("warnings".to_owned(), Value::Array(warnings));
             if let Some(implements) = implements {
                 output.insert("implements".to_owned(), implements);
@@ -13841,7 +13847,8 @@ fn run_verify(
     }
     let mut has_trace_contract = false;
     let mut implements = None;
-    if let Ok(model) = load_model(path) {
+    let mut compose_warnings = Vec::new();
+    if let Ok((_, kernel, model)) = load_kernel_model(path) {
         match validate_requirement_traces(path, &model) {
             Ok((Some(failure), _)) => return (failure, 2),
             Ok((None, has_contract)) => has_trace_contract = has_contract,
@@ -13851,6 +13858,7 @@ fn run_verify(
             Ok(implements) => implements,
             Err(error) => return (implements_error_output(&error), 2),
         };
+        compose_warnings = kernel.diagnostics().to_vec();
     }
     let deadlock = match DeadlockMode::parse(deadlock_mode) {
         Ok(mode) => mode,
@@ -13891,6 +13899,17 @@ fn run_verify(
         }),
         Err(error) => return (error_output("usage", &error), 2),
     };
+    if let Value::Object(envelope) = &mut output
+        && envelope.get("result").and_then(Value::as_str) != Some("error")
+        && !compose_warnings.is_empty()
+        && let Some(Value::Array(warnings)) = envelope.get_mut("warnings")
+    {
+        // Compose-lowering warnings (e.g. `fair_not_inherited`) are computed
+        // while lowering, before the checked KernelModel drops the per-
+        // component information that produced them, so they cannot be
+        // recovered from `model`/`fsl_runtime::verification_warnings` alone.
+        warnings.splice(0..0, compose_warnings);
+    }
     if let Value::Object(envelope) = &mut output
         && envelope.get("result").and_then(Value::as_str) != Some("error")
         && let Some(implements) = implements

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5826,10 +5826,11 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     if status == 2 {
         return (kernel, status);
     }
-    wrap_specialized(fsl_tools::check_ai(
-        &component,
-        stable_kernel_projection(kernel),
-    ))
+    // `check_ai` needs the unprojected verify envelope (fields like `trace`
+    // that `stable_kernel_projection` omits) to translate a kernel invariant
+    // violation into a finding; it applies its own published-kernel
+    // projection to the `kernel` field of its own output.
+    wrap_specialized(fsl_tools::check_ai(&component, &kernel))
 }
 
 fn read_json_events(path: &Path) -> Result<Vec<Value>, String> {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5171,13 +5171,27 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
                 surface: fsl_syntax::SurfaceDocument::Agent(agent),
                 ..
             }) => {
+                // `check` on an agent document is deliberately lenient: the
+                // top-level `result` stays "ok" even when the structural
+                // analysis finds a violation (matching the frozen
+                // reference); `fslc ai check` is the actual gate (exit 1 on
+                // `agent_analysis_result: "violated"`). A grant-boundary or
+                // other tree-validation failure is still a hard error here.
+                let analysis = match fsl_tools::analyze_ai_agent(&agent) {
+                    Ok(analysis) => analysis,
+                    Err(error) => return (agent_error_output(&error), 2),
+                };
+                let analysis_result = analysis
+                    .get("result")
+                    .cloned()
+                    .unwrap_or_else(|| json!("agent_analyzed"));
                 let mut output = envelope();
                 output.insert("result".to_owned(), json!("ok"));
                 output.insert("spec".to_owned(), json!(agent.name));
                 output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
                 output.insert("warnings".to_owned(), json!([]));
-                output.insert("ai_analysis_result".to_owned(), json!("agent_analyzed"));
-                output.insert("agent_analysis_result".to_owned(), json!("agent_analyzed"));
+                output.insert("ai_analysis_result".to_owned(), analysis_result.clone());
+                output.insert("agent_analysis_result".to_owned(), analysis_result);
                 return (Value::Object(output), 0);
             }
             Ok(_) => {}
@@ -5812,25 +5826,49 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     if fslc_rust::frontend_output::is_ai_project(&source) {
         return run_ai_project_check(&source);
     }
-    let component = match parse_surface_document(path) {
-        Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => component,
-        Ok(_) => {
-            return (
-                semantic_error_output("expected an ai_component document"),
-                2,
-            );
+    match parse_surface_document(path) {
+        Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => {
+            let (kernel, status) =
+                run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
+            if status == 2 {
+                return (kernel, status);
+            }
+            // `check_ai` needs the unprojected verify envelope (fields like
+            // `trace` that `stable_kernel_projection` omits) to translate a
+            // kernel invariant violation into a finding; it applies its own
+            // published-kernel projection to the `kernel` field of its own
+            // output.
+            wrap_specialized(fsl_tools::check_ai(&component, &kernel))
         }
-        Err(error) => return (semantic_error_output(&error), 2),
-    };
-    let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
-    if status == 2 {
-        return (kernel, status);
+        Ok(fsl_syntax::SurfaceDocument::Agent(agent)) => {
+            match fsl_tools::analyze_ai_agent(&agent) {
+                Ok(analysis) => wrap_specialized(analysis),
+                Err(error) => (agent_error_output(&error), 2),
+            }
+        }
+        Ok(_) => (
+            semantic_error_output("expected an ai_component or agent document"),
+            2,
+        ),
+        Err(error) => (semantic_error_output(&error), 2),
     }
-    // `check_ai` needs the unprojected verify envelope (fields like `trace`
-    // that `stable_kernel_projection` omits) to translate a kernel invariant
-    // violation into a finding; it applies its own published-kernel
-    // projection to the `kernel` field of its own output.
-    wrap_specialized(fsl_tools::check_ai(&component, &kernel))
+}
+
+fn agent_error_output(error: &fsl_tools::AgentError) -> Value {
+    let mut output = envelope();
+    output.insert("result".to_owned(), json!("error"));
+    output.insert("kind".to_owned(), json!("semantics"));
+    output.insert("message".to_owned(), json!(error.message));
+    if let Some(loc) = error.loc {
+        output.insert(
+            "loc".to_owned(),
+            json!({"line": loc.line, "column": loc.column}),
+        );
+    }
+    if let Some(hint) = &error.hint {
+        output.insert("hint".to_owned(), json!(hint));
+    }
+    Value::Object(output)
 }
 
 fn read_json_events(path: &Path) -> Result<Vec<Value>, String> {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5641,6 +5641,9 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
             return (kernel, kernel_status);
         }
         if let Value::Object(kernel) = kernel {
+            if kernel.get("result").and_then(Value::as_str) == Some("violated") {
+                result.insert("result".to_owned(), json!("violated"));
+            }
             let projection = [
                 "result",
                 "spec",

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -10,8 +10,8 @@ use sha2::{Digest, Sha256};
 use super::{
     CliVerifyOptions, ScopeBounds, add_strict_tag_warnings, apply_vacuity_mode, block_on_native,
     display, envelope, error_output, implements_error_output, implements_result, invariant_names,
-    load_model, load_model_scoped, load_snapshot_value_object, load_state_snapshot,
-    select_properties, selected_implicit_bounds, semantic_error_output,
+    load_kernel_model, load_model, load_model_scoped, load_snapshot_value_object,
+    load_state_snapshot, select_properties, selected_implicit_bounds, semantic_error_output,
     validate_requirement_traces, validate_specialized_document,
 };
 
@@ -1536,6 +1536,11 @@ struct PreparedCliVerification {
     model: Result<KernelModel, String>,
     initial_state: Option<std::collections::BTreeMap<String, FslValue>>,
     has_trace_contract: bool,
+    /// Compose-lowering warnings (e.g. `fair_not_inherited`), computed while
+    /// lowering the surface document, before `build_model` drops the per-
+    /// component information (like constituent `fair` markers) that produced
+    /// them. `model`/`fsl_runtime::verification_warnings` cannot recover them.
+    compose_warnings: Vec<Value>,
 }
 
 pub(super) fn run_verify_cli(
@@ -1640,6 +1645,17 @@ fn prepare_cli_verification(
             Err(error) => return Err((semantic_error_output(&error), 2)),
         }
     }
+    // `--instances`/`--values` scope overrides go through
+    // `parse_kernel_source_with_bounds` (`load_model_scoped`), a separate
+    // lowering entrypoint that does not apply to compose documents, so
+    // compose-lowering warnings are only collected in the unscoped case.
+    let compose_warnings = if has_scope {
+        Vec::new()
+    } else {
+        load_kernel_model(path)
+            .map(|(_, kernel, _)| kernel.diagnostics().to_vec())
+            .unwrap_or_default()
+    };
     validate_cli_property_selection(path, options, has_scope, snapshot_model.as_ref().ok())?;
     Ok(PreparedCliVerification {
         has_scope,
@@ -1647,6 +1663,7 @@ fn prepare_cli_verification(
         model: snapshot_model,
         initial_state,
         has_trace_contract,
+        compose_warnings,
     })
 }
 
@@ -1957,7 +1974,12 @@ fn execute_cli_verification(
         Err(error) => return (error_output("usage", &error), 2),
     };
     if !filtered {
-        decorate_default_cli_verification(&mut output, implements, prepared.has_trace_contract);
+        decorate_default_cli_verification(
+            &mut output,
+            implements,
+            prepared.has_trace_contract,
+            &prepared.compose_warnings,
+        );
     }
     (output, status)
 }
@@ -1966,6 +1988,7 @@ fn decorate_default_cli_verification(
     output: &mut Value,
     implements: Option<Value>,
     has_trace_contract: bool,
+    compose_warnings: &[Value],
 ) {
     let Value::Object(envelope) = output else {
         return;
@@ -1982,6 +2005,16 @@ fn decorate_default_cli_verification(
             warning.get("message").and_then(Value::as_str)
                 != Some("spec declares no user invariants (only implicit type bounds are checked)")
         });
+    }
+    if !compose_warnings.is_empty()
+        && envelope.get("result").and_then(Value::as_str) != Some("error")
+        && let Some(Value::Array(warnings)) = envelope.get_mut("warnings")
+    {
+        // Compose-lowering warnings (e.g. `fair_not_inherited`) are computed
+        // while lowering, before the checked KernelModel drops the per-
+        // component information that produced them, so they cannot be
+        // recovered from `model`/`fsl_runtime::verification_warnings` alone.
+        warnings.splice(0..0, compose_warnings.iter().cloned());
     }
 }
 

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -96,6 +96,14 @@ pub fn render_semantic_error(mut output: Map<String, Value>, message: &str) -> V
             json!("struct fields must be scalar (domain type, enum, Bool, Int) or Option<scalar>; use a separate Map for Set/Map/Seq/struct fields"),
         );
     }
+    if message.starts_with("unknown ai hard-contract rule '") {
+        output.insert(
+            "hint".to_owned(),
+            json!(
+                "supported rules: forbidden_tool_blocked, human_approval_required, tool_authority, tool_precondition_declared, tool_schema_declared"
+            ),
+        );
+    }
     Value::Object(output)
 }
 

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -32,9 +32,7 @@ use serde_json::Value;
 /// Repo-relative path (forward slashes) -> reason a bare
 /// check-must-pass-or-declare-error rule does not apply. Each reason names
 /// the test or issue that actually owns this file's expected behavior, so a
-/// stale entry is reviewable (and, for issue #475, this test additionally
-/// pins the current defect so a fix forces the entry's removal instead of
-/// silently going unnoticed).
+/// stale entry is reviewable.
 const GOVERNANCE_FIXTURE_EXCLUSIONS: &[(&str, &str)] = &[
     (
         "examples/gallery/errors/governance_malformed_business.fsl",
@@ -60,17 +58,6 @@ const GOVERNANCE_FIXTURE_EXCLUSIONS: &[(&str, &str)] = &[
         "examples/gallery/adversarial/governance_semantic_dependency.fsl",
         "validated by cli_regression.rs::native_check_locates_a_semantic_dependency_error_at_the_preservation",
     ),
-];
-
-/// Known, currently-broken files pending a fix tracked by a filed issue, not
-/// this test's scope. Pins the exact current failure so the entry must be
-/// removed (loudly, via a failing assertion) once the fix lands, instead of
-/// this sweep silently going green either way.
-const KNOWN_DB_DOUBLE_ASSIGNMENT_GAP: &[&str] = &[
-    "examples/db/safe_rename_preservation.fsl",
-    "examples/db/unsafe_lossy_merge_preservation.fsl",
-    "examples/db/unsafe_lossy_split_preservation.fsl",
-    "examples/db/unsafe_split_without_annotation.fsl",
 ];
 
 fn root() -> PathBuf {
@@ -159,14 +146,7 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
         .iter()
         .map(|&(path, _)| path)
         .collect::<BTreeSet<_>>();
-    let db_gap = KNOWN_DB_DOUBLE_ASSIGNMENT_GAP
-        .iter()
-        .copied()
-        .collect::<BTreeSet<&str>>();
-
     let mut failures = Vec::new();
-    let mut db_gap_regressions = Vec::new();
-    let mut seen_db_gap = BTreeSet::new();
 
     for path in &files {
         let rel = repo_relative(&root, path);
@@ -185,22 +165,6 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
         }
 
         let result = run_check(path);
-
-        if db_gap.contains(rel.as_str()) {
-            seen_db_gap.insert(rel.clone());
-            let is_expected_double_assignment = result["result"] == "error"
-                && result["kind"] == "semantics"
-                && result["message"]
-                    .as_str()
-                    .is_some_and(|m| m.contains("assign the same state location more than once"));
-            if !is_expected_double_assignment {
-                db_gap_regressions.push(format!(
-                    "{rel}: no longer the known double-assignment error (remove from \
-                     KNOWN_DB_DOUBLE_ASSIGNMENT_GAP and close issue #475): {result}"
-                ));
-            }
-            continue;
-        }
 
         let file_headers = headers(&source);
         // `expected-command`/`expected-result` may target a *stricter* verb
@@ -233,19 +197,5 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
         }
     }
 
-    let seen_db_gap = seen_db_gap
-        .iter()
-        .map(String::as_str)
-        .collect::<BTreeSet<&str>>();
-    let missing_db_gap = db_gap.difference(&seen_db_gap).copied().collect::<Vec<_>>();
-    assert!(
-        missing_db_gap.is_empty(),
-        "KNOWN_DB_DOUBLE_ASSIGNMENT_GAP entries no longer found in the corpus scan: {missing_db_gap:?}"
-    );
-    assert!(
-        db_gap_regressions.is_empty(),
-        "{}",
-        db_gap_regressions.join("\n")
-    );
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/rust/fslc/tests/db_direct_lowering.rs
+++ b/rust/fslc/tests/db_direct_lowering.rs
@@ -130,6 +130,23 @@ fn direct_lowering_preserves_catalog_shape_and_source_order() {
     assert!(secondary_names.contains("all_active_reads_exist"));
     assert!(secondary_names.contains("removed_only_after_unused"));
 
+    // #469's coupled kernel-side anchor: `all_active_writes_exist` must be lowered
+    // exactly like `all_active_reads_exist`, so the write branch shares the same
+    // regression coverage as the read branch instead of only the findings layer.
+    let write_origin = kernel
+        .origins()
+        .targets()
+        .find(|(target, _)| target.starts_with("property:invariant:db_writeQqDbSepqQ"))
+        .and_then(|(_, origins)| origins.first())
+        .expect("write compatibility origin");
+    let write_secondary_names = write_origin
+        .secondary
+        .iter()
+        .filter_map(|site| site.declaration_path.last().map(String::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(write_secondary_names.contains("all_active_writes_exist"));
+    assert!(write_secondary_names.contains("removed_only_after_unused"));
+
     let terminal = syntax.items.last().expect("terminal item");
     assert!(matches!(terminal, SpecItem::Terminal { .. }));
     build_model(kernel).expect("directly lowered catalog builds a checked model");
@@ -212,6 +229,13 @@ fn direct_lowering_preserves_structural_transform_shapes() {
             expected,
             "{path}"
         );
+        // Negative control for #475: this used to be silently skipped, so a
+        // regression in the enum-member alias analysis (spurious duplicate-write
+        // rejection on rename/split/merge's simultaneous field assignments) shipped
+        // undetected. `fslc check` on these exact files must also build cleanly.
+        build_model(kernel).unwrap_or_else(|error| {
+            panic!("directly lowered {expected_name} must build a checked model: {error}")
+        });
     }
 }
 

--- a/rust/fslc/tests/fixtures/issue_468_authority_exceeds_grant.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_authority_exceeds_grant.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Parent {
+  context [Ticket];
+  tools [SearchDocs, RefundPayment];
+  authority { may_execute [SearchDocs, RefundPayment]; }
+
+  agent Child {
+    grant authority [SearchDocs];
+    grant context [Ticket];
+    tools [RefundPayment];
+    authority { may_execute [RefundPayment]; }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_468_bad_grant.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_bad_grant.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Parent {
+  context [Ticket];
+  tools [SearchDocs];
+
+  agent Child {
+    grant authority [RefundPayment];
+    grant context [Ticket];
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_468_junk_body.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_junk_body.fsl
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Junk { this is not valid fsl at all 12345; grant nonsense stuff; }

--- a/rust/fslc/tests/fixtures/issue_468_policy_bypass.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_policy_bypass.fsl
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Parent {
+  context [Ticket];
+  tools [Draft, CheckPolicy, RefundPayment];
+  authority {
+    may_execute [Draft, CheckPolicy];
+    requires_human_approval [RefundPayment];
+  }
+
+  agent Draft {
+    grant authority [Draft];
+    grant context [Ticket];
+    tools [Draft];
+    authority { may_execute [Draft]; }
+  }
+
+  agent Policy {
+    grant authority [CheckPolicy];
+    grant context [Ticket];
+    tools [CheckPolicy];
+    authority { may_execute [CheckPolicy]; }
+  }
+
+  agent Payment {
+    grant authority [RefundPayment];
+    grant context [Ticket];
+    tool RefundPayment irreversible {
+      schema RefundPaymentV1;
+    }
+    authority { requires_human_approval [RefundPayment]; }
+  }
+
+  review_gate Policy;
+  orchestration {
+    Draft -> Payment;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_468_unsafe_graph.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_unsafe_graph.fsl
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Parent {
+  context [Ticket];
+  tools [Draft, RefundPayment];
+  authority {
+    may_execute [Draft];
+    requires_human_approval [RefundPayment];
+  }
+
+  agent Untrusted {
+    trust low;
+    grant authority [Draft];
+    grant context [Ticket];
+    tools [Draft];
+    authority { may_execute [Draft]; }
+    output DraftOut visibility Payment;
+  }
+
+  agent Payment {
+    grant authority [RefundPayment];
+    grant context [Ticket];
+    tool RefundPayment irreversible {
+      schema RefundPaymentV1;
+    }
+    authority { may_execute [RefundPayment]; }
+  }
+
+  orchestration {
+    Untrusted -> Payment;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_468_visibility_leak.fsl
+++ b/rust/fslc/tests/fixtures/issue_468_visibility_leak.fsl
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+agent Parent {
+  context [Ticket];
+  tools [Draft, CheckPolicy];
+  authority { may_execute [Draft, CheckPolicy]; }
+
+  agent Draft {
+    grant authority [Draft];
+    grant context [Ticket];
+    tools [Draft];
+    authority { may_execute [Draft]; }
+    output DraftOut visibility Policy;
+  }
+
+  agent Policy {
+    grant authority [CheckPolicy];
+    grant context [Ticket];
+    tools [CheckPolicy];
+    authority { may_execute [CheckPolicy]; }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_469_unsafe_drop_column_with_writer.fsl
+++ b/rust/fslc/tests/fixtures/issue_469_unsafe_drop_column_with_writer.fsl
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+dbsystem UnsafeDropColumnWithWriter {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+    }
+  }
+
+  migration drop_legacy_name from 0 to 1 {
+    drop users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id;
+  }
+
+  artifact worker_v1 {
+    writes users.legacy_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v2 when schema 1..1;
+    may_exist worker_v1 when schema 0..1;
+  }
+
+  check compatibility {
+    rule all_active_writes_exist;
+    rule removed_only_after_unused;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_469_unsafe_drop_column_with_writer_deep_history.fsl
+++ b/rust/fslc/tests/fixtures/issue_469_unsafe_drop_column_with_writer_deep_history.fsl
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+dbsystem UnsafeDropColumnWithWriterDeepHistory {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column legacy_name: Text present backfilled nullable;
+      column pad0: Text absent nullable;
+      column pad1: Text absent nullable;
+      column pad2: Text absent nullable;
+      column pad3: Text absent nullable;
+      column pad4: Text absent nullable;
+      column pad5: Text absent nullable;
+      column pad6: Text absent nullable;
+      column pad7: Text absent nullable;
+      column pad8: Text absent nullable;
+      column pad9: Text absent nullable;
+      column pad10: Text absent nullable;
+      column pad11: Text absent nullable;
+    }
+  }
+
+  migration add_pad0 from 0 to 1 {
+    add users.pad0 nullable;
+  }
+
+  migration add_pad1 from 1 to 2 {
+    add users.pad1 nullable;
+  }
+
+  migration add_pad2 from 2 to 3 {
+    add users.pad2 nullable;
+  }
+
+  migration add_pad3 from 3 to 4 {
+    add users.pad3 nullable;
+  }
+
+  migration add_pad4 from 4 to 5 {
+    add users.pad4 nullable;
+  }
+
+  migration add_pad5 from 5 to 6 {
+    add users.pad5 nullable;
+  }
+
+  migration add_pad6 from 6 to 7 {
+    add users.pad6 nullable;
+  }
+
+  migration add_pad7 from 7 to 8 {
+    add users.pad7 nullable;
+  }
+
+  migration add_pad8 from 8 to 9 {
+    add users.pad8 nullable;
+  }
+
+  migration add_pad9 from 9 to 10 {
+    add users.pad9 nullable;
+  }
+
+  migration add_pad10 from 10 to 11 {
+    add users.pad10 nullable;
+  }
+
+  migration add_pad11 from 11 to 12 {
+    add users.pad11 nullable;
+  }
+
+  migration drop_legacy_name from 12 to 13 {
+    drop users.legacy_name;
+  }
+
+  artifact server_v2 {
+    reads users.id;
+  }
+
+  artifact worker_v1 {
+    writes users.legacy_name;
+  }
+
+  environment prod {
+    schema 0..13;
+    active server_v2 when schema 13..13;
+    may_exist worker_v1 when schema 0..13;
+  }
+
+  check compatibility {
+    rule all_active_writes_exist;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_470_human_approval_narrow.fsl
+++ b/rust/fslc/tests/fixtures/issue_470_human_approval_narrow.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_component HumanApprovalNarrow {
+  model m1;
+  prompt p1;
+  input InV1;
+  output OutV1;
+  tool RefundPayment irreversible {
+    schema RefundPaymentV1;
+  }
+  authority {
+    may_suggest RefundPayment;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_470_replay_component.fsl
+++ b/rust/fslc/tests/fixtures/issue_470_replay_component.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_component ReplayComponent {
+  model m1;
+  prompt p1;
+  input InV1;
+  output OutV1;
+  tool AuditTool {
+    schema AuditToolV1;
+    precondition case_open;
+  }
+  tool UnauthorizedTool {
+    schema UnauthorizedToolV1;
+  }
+  authority {
+    may_execute AuditTool;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_470_replay_events.jsonl
+++ b/rust/fslc/tests/fixtures/issue_470_replay_events.jsonl
@@ -1,0 +1,2 @@
+{"component":"ReplayComponent","event":"tool_call","tool":"UnauthorizedTool","mode":"suggest"}
+{"component":"ReplayComponent","event":"tool_call","tool":"AuditTool","mode":"execute"}

--- a/rust/fslc/tests/fixtures/issue_470_tool_authority_violation.fsl
+++ b/rust/fslc/tests/fixtures/issue_470_tool_authority_violation.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_component ToolAuthorityViolation {
+  model m1;
+  prompt p1;
+  input InV1;
+  output OutV1;
+  tool SearchOrder {
+    schema SearchOrderV1;
+  }
+  authority {
+    may_execute SearchOrder;
+    forbidden SearchOrder;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_470_tool_schema_violation.fsl
+++ b/rust/fslc/tests/fixtures/issue_470_tool_schema_violation.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_component ToolSchemaViolation {
+  model m1;
+  prompt p1;
+  input InV1;
+  output OutV1;
+  tool SearchOrder {
+    precondition order_exists;
+  }
+  authority {
+    may_execute SearchOrder;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_470_unknown_rule.fsl
+++ b/rust/fslc/tests/fixtures/issue_470_unknown_rule.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_component UnknownRule {
+  model m1;
+  prompt p1;
+  input InV1;
+  output OutV1;
+  tool SearchOrder {
+    schema SearchOrderV1;
+    precondition order_exists;
+  }
+  authority {
+    may_execute SearchOrder;
+  }
+  check hard {
+    rule totally_bogus_rule_name;
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_474_fair_core.fsl
+++ b/rust/fslc/tests/fixtures/issue_474_fair_core.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec FairWarningCore {
+  type Id = 0..0
+  state { done: Bool }
+  init { done = false }
+  fair action decay_fresh(i: Id) { done = true }
+  action plain_decay(i: Id) { done = done }
+  invariant CoreOk { true }
+}

--- a/rust/fslc/tests/fixtures/issue_474_fair_kept.fsl
+++ b/rust/fslc/tests/fixtures/issue_474_fair_kept.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose FairKept {
+  use FairWarningCore as core from "issue_474_fair_core.fsl"
+  use FairWarningNote as ntf from "issue_474_fair_note.fsl"
+  fair action decay_fresh(i: core.Id) = core.decay_fresh(i) || ntf.raise(i) { }
+}

--- a/rust/fslc/tests/fixtures/issue_474_fair_loss.fsl
+++ b/rust/fslc/tests/fixtures/issue_474_fair_loss.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose FairLoss {
+  use FairWarningCore as core from "issue_474_fair_core.fsl"
+  use FairWarningNote as ntf from "issue_474_fair_note.fsl"
+  action decay_fresh(i: core.Id) = core.decay_fresh(i) || ntf.raise(i) { }
+}

--- a/rust/fslc/tests/fixtures/issue_474_fair_note.fsl
+++ b/rust/fslc/tests/fixtures/issue_474_fair_note.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec FairWarningNote {
+  type Id = 0..0
+  state { raised: Bool }
+  init { raised = false }
+  action raise(i: Id) { raised = true }
+  invariant NoteOk { true }
+}

--- a/rust/fslc/tests/fixtures/issue_474_no_fair_loss.fsl
+++ b/rust/fslc/tests/fixtures/issue_474_no_fair_loss.fsl
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose NoFairLoss {
+  use FairWarningCore as core from "issue_474_fair_core.fsl"
+  use FairWarningNote as ntf from "issue_474_fair_note.fsl"
+  action plain_and_note(i: core.Id) = core.plain_decay(i) || ntf.raise(i) { }
+}

--- a/rust/fslc/tests/issue_468_recursive_agent.rs
+++ b/rust/fslc/tests/issue_468_recursive_agent.rs
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #468: the recursive `agent` dialect's
+//! grammar was a brace-counting stub (`rust/fsl-syntax/src/dispatch.rs`'s
+//! former `parse_agent`) that discarded the entire body -- any token soup
+//! that lexed cleanly parsed as an empty `SurfaceAgent { name, span }`, so
+//! `fslc ai check` on the documented example returned
+//! `"expected an ai_component document"` (native's `ai check` rejected
+//! `agent` entirely) and `fslc check` hardcoded
+//! `agent_analysis_result: "agent_analyzed"` with no analysis behind it --
+//! AGENTS.md's "confidently green false negative" on AI agent
+//! authority-delegation safety.
+//!
+//! Native now has a real recursive-descent grammar
+//! (`rust/fsl-syntax/src/ai.rs`'s `AiParser::agent`) and a structural
+//! analyzer (`rust/fsl-tools/src/agent.rs`) that is behaviorally identical
+//! to the frozen reference's `src/fslc/ai_agent.py` -- confirmed by exact
+//! JSON diff against `.venv/bin/python3 -m fslc ai check` on every fixture
+//! below, including the full `agent_ir`/`graph_summary` output for the
+//! documented multi-agent example.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn violations(value: &Value) -> std::collections::BTreeSet<String> {
+    value["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .map(|finding| {
+            finding["violation"]
+                .as_str()
+                .expect("violation string")
+                .to_owned()
+        })
+        .collect()
+}
+
+// --- the documented positive example: exact JSON parity with the frozen
+// reference, including the full agent_ir/graph_summary -----------------
+
+#[test]
+fn ai_check_matches_the_frozen_reference_exactly_on_the_documented_example() {
+    let path = "examples/ai/recursive_support_agent.fsl";
+    let (native, status) = run(&["ai", "check", path]);
+    assert_eq!(status, 0, "{native}");
+    assert_eq!(native["result"], "agent_analyzed");
+    assert_eq!(native["formal_result"], "not_run");
+    assert_eq!(native["findings"].as_array().map(Vec::len), Some(0));
+
+    let ir = &native["agent_ir"];
+    assert_eq!(ir["path"], "SupportOrchestrator");
+    let child_paths = ir["children"]
+        .as_array()
+        .expect("children array")
+        .iter()
+        .map(|child| child["path"].as_str().expect("path").to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        child_paths,
+        vec![
+            "SupportOrchestrator.RetrievalAgent".to_owned(),
+            "SupportOrchestrator.PolicyCheckAgent".to_owned(),
+            "SupportOrchestrator.DraftAnswerAgent".to_owned(),
+            "SupportOrchestrator.SendAgent".to_owned(),
+        ]
+    );
+    assert_eq!(
+        native["graph_summary"]["delegation_graph"][0],
+        serde_json::json!({
+            "parent": "SupportOrchestrator",
+            "source": "SupportOrchestrator.RetrievalAgent",
+            "target": "SupportOrchestrator.PolicyCheckAgent",
+        })
+    );
+    assert_eq!(
+        native["graph_summary"]["failure_policy"][0],
+        serde_json::json!({
+            "source": "SupportOrchestrator.RetrievalAgent",
+            "condition": "failed",
+            "action": "retry",
+            "target": null,
+            "retry_limit": 2,
+        })
+    );
+}
+
+#[test]
+fn check_is_parseable_for_corpus_sweeps_and_stays_lenient_on_the_top_level_result() {
+    let (value, status) = run(&["check", "examples/ai/recursive_support_agent.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok");
+    assert_eq!(value["spec"], "SupportOrchestrator");
+    assert_eq!(value["dialect"], "fsl-ai-agent.v0");
+    assert_eq!(value["agent_analysis_result"], "agent_analyzed");
+}
+
+// --- grammar: garbage bodies are now real parse errors, not silently
+// accepted ---------------------------------------------------------------
+
+#[test]
+fn check_rejects_a_syntactically_invalid_agent_body() {
+    // Before #468, only lexing mattered (braces just had to balance); this
+    // body must now fail to parse, matching the frozen reference exactly
+    // (both report `kind:"parse"` at the same 3:14 position for this file).
+    let path = fixture("issue_468_junk_body.fsl").display().to_string();
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "parse");
+    assert_eq!(value["loc"], serde_json::json!({"line": 3, "column": 14}));
+}
+
+// --- grant-boundary exceedance: a check-time semantics error, not a
+// finding (docs/LANGUAGE.md §13.6) ---------------------------------------
+
+#[test]
+fn ai_check_rejects_a_grant_that_exceeds_the_parent_boundary() {
+    let path = fixture("issue_468_bad_grant.fsl").display().to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(
+                "agent 'Parent.Child' grant authority exceeds parent boundary: RefundPayment"
+            )),
+        "{value}"
+    );
+    assert_eq!(value["loc"], serde_json::json!({"line": 8, "column": 5}));
+}
+
+#[test]
+fn check_also_rejects_the_same_grant_boundary_error() {
+    // The grant-boundary check-time error must be reachable from `check`
+    // too, not only `ai check` -- both entrypoints run the same structural
+    // analyzer.
+    let path = fixture("issue_468_bad_grant.fsl").display().to_string();
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "semantics");
+}
+
+// --- the six documented agent_structural_violation finding kinds --------
+
+#[test]
+fn ai_check_reports_visibility_leak_across_sibling_agents() {
+    let path = fixture("issue_468_visibility_leak.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    assert_eq!(
+        violations(&value),
+        ["visibility_leak_across_sibling_agents".to_owned()].into()
+    );
+    let finding = &value["findings"][0];
+    assert_eq!(finding["guarantee_kind"], "agent_structural");
+    assert_eq!(
+        finding["evidence"],
+        serde_json::json!({"kind": "static_agent_graph", "formal_proof": false})
+    );
+}
+
+#[test]
+fn ai_check_reports_child_authority_exceeds_parent_authority() {
+    let path = fixture("issue_468_authority_exceeds_grant.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    assert_eq!(
+        violations(&value),
+        ["child_authority_exceeds_parent_authority".to_owned()].into()
+    );
+    assert_eq!(
+        value["findings"][0]["minimal_conflict_set"]["exceeded_authority"],
+        serde_json::json!(["RefundPayment"])
+    );
+}
+
+#[test]
+fn ai_check_reports_irreversible_and_low_trust_reachability_findings_together() {
+    let path = fixture("issue_468_unsafe_graph.fsl").display().to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    assert_eq!(
+        violations(&value),
+        [
+            "irreversible_operation_without_human_approval_path".to_owned(),
+            "low_trust_agent_path_to_high_authority_tool".to_owned(),
+        ]
+        .into()
+    );
+}
+
+#[test]
+fn ai_check_reports_policy_review_bypass_in_orchestration() {
+    let path = fixture("issue_468_policy_bypass.fsl").display().to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    assert_eq!(
+        violations(&value),
+        ["policy_review_bypass_in_orchestration".to_owned()].into()
+    );
+}
+
+// --- negative control: a document that satisfies every rule finds
+// nothing, and the once-hardcoded sentinel is gone -----------------------
+
+#[test]
+fn ai_check_finds_nothing_when_every_rule_is_satisfied() {
+    // `examples/ai/recursive_support_agent.fsl` (checked above) already
+    // proves the zero-finding path end to end; this asserts the same
+    // invariant holds for `check`'s leniently-reported `agent_analysis_result`.
+    let (value, _status) = run(&["check", "examples/ai/recursive_support_agent.fsl"]);
+    assert_eq!(value["agent_analysis_result"], "agent_analyzed");
+    assert_ne!(value["agent_analysis_result"], "violated");
+}
+
+#[test]
+fn verify_still_rejects_agent_documents_as_kernel_specs() {
+    // `agent` never lowers to the kernel (docs/LANGUAGE.md §13.6); this
+    // boundary must be unchanged by the new grammar/analyzer.
+    let (value, status) = run(&[
+        "verify",
+        "examples/ai/recursive_support_agent.fsl",
+        "--depth",
+        "4",
+    ]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "parse");
+    assert_eq!(
+        value["message"],
+        "agent documents cannot be verified as Kernel specs"
+    );
+}
+
+#[test]
+fn fmt_still_refuses_a_well_formed_agent_body() {
+    // No native pretty-printer exists for the agent grammar; fmt must keep
+    // refusing well-formed, non-empty agent bodies (unchanged by #468).
+    let (value, status) = run(&["fmt", "examples/ai/recursive_support_agent.fsl"]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["code"], "FSL-FMT-UNSAFE");
+}

--- a/rust/fslc/tests/issue_469_db_finding_kind_census.rs
+++ b/rust/fslc/tests/issue_469_db_finding_kind_census.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Detection-gate coupled change for issue #469: the missing
+//! `column_removed_while_still_written` branch shipped undetected because no
+//! fixture anywhere exercised it and no gate compared the finding `kind`s
+//! native `fslc db check` can actually emit against the documented,
+//! schema-enumerated set. This census mechanically enumerates every `kind`
+//! reachable from `fslc db check` over the full `examples/db/` corpus plus
+//! the write-drop regression fixtures under `tests/fixtures/` (kept out of
+//! `examples/db/` so they do not appear in the frozen Python reference's
+//! `tests/snapshots/corpus_snapshot.json` corpus-membership set) and diffs
+//! it against the check-time subset of
+//! `schemas/fslc/db/finding.v0.schema.json`'s `kind` enum, so a future
+//! documented-but-unreachable check-time kind fails this test instead of
+//! shipping silently green.
+//!
+//! Scope note: three schema kinds (`declared_unused_but_observed`,
+//! `unsupported_artifact_observed`, `legacy_api_still_called`) are `fslc db
+//! observe` runtime-evidence findings, never emitted by `db check`, and are
+//! excluded from this static-check census on purpose.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn run(args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for {args:?}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn collect_kinds(value: &Value, kinds: &mut BTreeSet<String>) {
+    if let Some(findings) = value.get("findings").and_then(Value::as_array) {
+        for finding in findings {
+            if let Some(kind) = finding.get("kind").and_then(Value::as_str) {
+                kinds.insert(kind.to_owned());
+            }
+        }
+    }
+}
+
+const OBSERVE_ONLY_KINDS: [&str; 3] = [
+    "declared_unused_but_observed",
+    "unsupported_artifact_observed",
+    "legacy_api_still_called",
+];
+
+#[test]
+fn db_check_reaches_every_schema_documented_check_time_finding_kind() {
+    let schema_source =
+        std::fs::read_to_string(workspace_root().join("schemas/fslc/db/finding.v0.schema.json"))
+            .expect("read fsl-db-finding schema");
+    let schema: Value = serde_json::from_str(&schema_source).expect("parse finding schema");
+    let documented_kinds = schema["properties"]["kind"]["enum"]
+        .as_array()
+        .expect("kind enum")
+        .iter()
+        .map(|kind| kind.as_str().expect("kind is a string").to_owned())
+        .filter(|kind| !OBSERVE_ONLY_KINDS.contains(&kind.as_str()))
+        .collect::<BTreeSet<_>>();
+    assert!(
+        documented_kinds.len() >= 8,
+        "sanity: expected a substantial documented check-time kind enum, got {documented_kinds:?}"
+    );
+
+    let mut reached_kinds = BTreeSet::new();
+    let db_examples_dir = workspace_root().join("examples/db");
+    let mut fsl_files = std::fs::read_dir(&db_examples_dir)
+        .expect("read examples/db")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(std::ffi::OsStr::to_str) == Some("fsl"))
+        .collect::<Vec<_>>();
+    fsl_files.sort();
+    assert!(
+        !fsl_files.is_empty(),
+        "expected .fsl fixtures under examples/db"
+    );
+
+    for path in &fsl_files {
+        let relative = path
+            .strip_prefix(workspace_root())
+            .expect("path under workspace root")
+            .to_str()
+            .expect("utf8 path");
+        let value = run(&["db", "check", relative]);
+        collect_kinds(&value, &mut reached_kinds);
+    }
+
+    // `column_removed_while_still_written` (issue #469) is exercised only by
+    // these regression fixtures, deliberately kept out of `examples/db/` so
+    // they do not enter the frozen Python reference's snapshot corpus.
+    for name in [
+        "issue_469_unsafe_drop_column_with_writer.fsl",
+        "issue_469_unsafe_drop_column_with_writer_deep_history.fsl",
+    ] {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures")
+            .join(name);
+        let value = run(&["db", "check", path.to_str().expect("utf8 path")]);
+        collect_kinds(&value, &mut reached_kinds);
+    }
+
+    let missing = documented_kinds
+        .difference(&reached_kinds)
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "finding kind(s) documented in schemas/fslc/db/finding.v0.schema.json are unreachable \
+         from native `fslc db check` over the examples/db corpus: {missing:?}"
+    );
+}

--- a/rust/fslc/tests/issue_469_db_write_drop_finding.rs
+++ b/rust/fslc/tests/issue_469_db_write_drop_finding.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #469: `fslc db check` reported a success
+//! verdict with an empty `findings` array on a write-drop compatibility
+//! violation because `rust/fsl-tools/src/db.rs` only ever probed the `reads`
+//! capability when a migration drops a column, and `run_db_check` never
+//! reconciled the top-level JSON `result` with a subsequently violated
+//! `kernel` projection. Both the (bounded-depth) shallow case and a
+//! deep-migration-history case that used to escape the kernel's hardcoded
+//! depth-8 default must now report `result: "violated"` with a
+//! `column_removed_while_still_written` finding, exactly as the frozen
+//! Python reference does.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const READER_CONTROL: &str = "examples/db/unsafe_drop_column_with_worker.fsl";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn db_check_reports_a_write_drop_violation_with_a_populated_finding() {
+    let writer = fixture("issue_469_unsafe_drop_column_with_writer.fsl");
+    let (value, status) = run(&["db", "check", writer.to_str().expect("utf8 path")]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated", "{value}");
+
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    let finding = &findings[0];
+    assert_eq!(finding["kind"], "column_removed_while_still_written");
+    assert_eq!(finding["failed_rule"], "all_active_writes_exist");
+    assert_eq!(finding["environment"], "prod");
+    assert_eq!(finding["artifact"], "worker_v1");
+    assert_eq!(finding["artifact_version"], "worker_v1");
+    assert_eq!(finding["witness"]["declared_capability"], "writes");
+    assert!(
+        finding["repair_candidates"]
+            .as_array()
+            .is_some_and(|candidates| !candidates.is_empty()),
+        "{value}"
+    );
+}
+
+#[test]
+fn db_check_does_not_let_a_depth_bounded_kernel_pass_hide_a_write_drop_violation() {
+    // Before the fix, this deep-migration-history variant escaped detection at
+    // the hardcoded default kernel depth (8): the findings layer had no `writes`
+    // branch, so `findings` stayed empty and the top-level `result` reported
+    // `verified_under_assumptions` with exit 0 -- a confidently green false
+    // negative. The findings layer is depth-independent, so this must be
+    // caught unconditionally, without needing `--depth` at all.
+    let writer_deep_history = fixture("issue_469_unsafe_drop_column_with_writer_deep_history.fsl");
+    let (value, status) = run(&[
+        "db",
+        "check",
+        writer_deep_history.to_str().expect("utf8 path"),
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated", "{value}");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["kind"] == "column_removed_while_still_written"),
+        "{value}"
+    );
+}
+
+#[test]
+fn db_check_reads_control_is_unaffected_by_the_writes_branch() {
+    // Negative control: the pre-existing `reads` branch must still be exactly
+    // what it was before the fix, distinguished from `writes` findings by the
+    // dedup key's `kind` field.
+    let (value, status) = run(&["db", "check", READER_CONTROL]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated", "{value}");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    assert_eq!(findings[0]["kind"], "column_removed_while_still_read");
+    assert_eq!(findings[0]["failed_rule"], "all_active_reads_exist");
+}

--- a/rust/fslc/tests/issue_470_ai_hard_rules.rs
+++ b/rust/fslc/tests/issue_470_ai_hard_rules.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #470: native `ai_component` lowering
+//! (`rust/fsl-core/src/dialect.rs::lower_ai_component`) used to be a
+//! one-boolean catalog sentinel (`lower_catalog_sentinel`) that could never
+//! be violated -- `fslc ai check` reported `verified_under_assumptions`
+//! with `findings: []` and `formal_result: "verified"` on specs that
+//! violate the documented hard contract, and `check hard { rule <bogus> }`
+//! silently parsed as a no-op instead of a check-time error. This is
+//! AGENTS.md's "confidently green false negative", on the highest-
+//! consequence claim in the dialect (AI tool authority / human-approval
+//! safety).
+//!
+//! Native now lowers the documented `Tool` enum / `human_approved` /
+//! `tool_executed` / `tool_suggested` / `fallback_required` state and
+//! generated actions/invariants (`docs/LANGUAGE.md` §13.6,
+//! `docs/DESIGN-ai-hard.md`), validates `check hard { rule ... }` against
+//! the five documented rule names, and `fsl_tools::check_ai`/`replay_ai`
+//! implement all five hard rules instead of only a narrowed
+//! `human_approval_required`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn run_str(args: &[&str]) -> (Value, i32) {
+    run(&args.iter().map(|arg| (*arg).to_owned()).collect::<Vec<_>>())
+}
+
+// --- unknown rule name: check-time error from all three entrypoints -----
+
+#[test]
+fn ai_check_rejects_an_unknown_hard_rule_name() {
+    let path = fixture("issue_470_unknown_rule.fsl").display().to_string();
+    let (value, status) = run_str(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message
+                .contains("unknown ai hard-contract rule 'totally_bogus_rule_name'")),
+        "{value}"
+    );
+}
+
+#[test]
+fn check_rejects_an_unknown_hard_rule_name() {
+    let path = fixture("issue_470_unknown_rule.fsl").display().to_string();
+    let (value, status) = run_str(&["check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+}
+
+#[test]
+fn verify_rejects_an_unknown_hard_rule_name() {
+    let path = fixture("issue_470_unknown_rule.fsl").display().to_string();
+    let (value, status) = run_str(&["verify", &path, "--depth", "4"]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+}
+
+// --- the four documented static violations -------------------------------
+
+#[test]
+fn ai_check_rejects_a_forbidden_tool_also_declared_executable() {
+    let path = fixture("issue_470_tool_authority_violation.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run_str(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    assert_eq!(findings[0]["failed_rule"], "tool_authority");
+    assert_eq!(
+        findings[0]["violation"],
+        "forbidden_tool_declared_executable"
+    );
+    assert_eq!(findings[0]["tool"], "SearchOrder");
+    assert!(
+        findings[0]["repair_candidates"]
+            .as_array()
+            .is_some_and(|candidates| !candidates.is_empty()),
+        "{value}"
+    );
+}
+
+#[test]
+fn ai_check_rejects_an_executable_tool_without_a_schema() {
+    let path = fixture("issue_470_tool_schema_violation.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run_str(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    assert_eq!(findings[0]["failed_rule"], "tool_schema_declared");
+    assert_eq!(findings[0]["violation"], "executable_tool_without_schema");
+}
+
+#[test]
+fn ai_check_rejects_an_irreversible_tool_without_explicit_human_approval() {
+    // Negative control for the narrowed predicate: this tool is only
+    // `may_suggest`, never `may_execute`, so the old
+    // `irreversible && may_execute.contains && !approvals.contains`
+    // predicate would have missed it entirely.
+    let path = fixture("issue_470_human_approval_narrow.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run_str(&["ai", "check", &path]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "violated");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    assert_eq!(findings[0]["failed_rule"], "human_approval_required");
+    assert_eq!(
+        findings[0]["violation"],
+        "irreversible_tool_without_human_approval_guard"
+    );
+}
+
+// --- positive control: the documented example stays clean ---------------
+
+#[test]
+fn ai_check_reports_no_findings_for_the_documented_positive_example() {
+    let (value, status) = run_str(&["ai", "check", "examples/ai/refund_agent_tool_safety.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "verified_under_assumptions");
+    assert_eq!(value["findings"].as_array().map(Vec::len), Some(0));
+    assert_eq!(value["formal_result"], "verified");
+}
+
+// --- kernel expansion is real, not the one-boolean sentinel --------------
+
+#[test]
+fn verify_checks_the_documented_generated_invariants_not_a_sentinel() {
+    let (value, status) = run_str(&[
+        "verify",
+        "examples/ai/refund_agent_tool_safety.fsl",
+        "--depth",
+        "8",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "verified");
+    let mut invariants = value["invariants_checked"]
+        .as_array()
+        .expect("invariants_checked array")
+        .iter()
+        .map(|name| name.as_str().expect("invariant name").to_owned())
+        .collect::<Vec<_>>();
+    invariants.sort();
+    assert_eq!(
+        invariants,
+        vec![
+            "ai_approval_before_execute.RefundPayment".to_owned(),
+            "ai_forbidden_tool_not_executed.DeleteCustomerData".to_owned(),
+        ]
+    );
+    // The pre-fix sentinel lowering emitted exactly these two names instead.
+    assert!(
+        !invariants
+            .iter()
+            .any(|name| name.contains("_ai_ok") || name.contains("_ai_catalog_ok"))
+    );
+}
+
+#[test]
+fn kernel_emits_the_documented_tool_enum_and_actions_not_the_noop_sentinel() {
+    let (value, status) = run_str(&["kernel", "examples/ai/refund_agent_tool_safety.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    let actions = value["actions"]
+        .as_array()
+        .expect("actions array")
+        .iter()
+        .map(|action| action["name"].as_str().expect("action name").to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(actions.contains("execute_RefundPayment"), "{actions:?}");
+    assert!(actions.contains("execute_SearchOrder"), "{actions:?}");
+    assert!(actions.contains("approve_RefundPayment"), "{actions:?}");
+    // No forbidden tool ever gets an execute action generated for it.
+    assert!(
+        !actions.contains("execute_DeleteCustomerData"),
+        "{actions:?}"
+    );
+    // The pre-fix sentinel lowering emitted exactly one action: `_ai_noop`.
+    assert!(!actions.contains("_ai_noop"), "{actions:?}");
+    assert!(actions.len() > 1, "{actions:?}");
+}
+
+// --- replay: tool_authority and missing-precondition-evidence -----------
+
+#[test]
+fn replay_reports_tool_authority_and_missing_precondition_evidence() {
+    let path = fixture("issue_470_replay_component.fsl")
+        .display()
+        .to_string();
+    let logs = fixture("issue_470_replay_events.jsonl")
+        .display()
+        .to_string();
+    let (value, status) = run_str(&["ai", "replay", &path, "--logs", &logs]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "replay_nonconformant");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 2, "{value}");
+
+    let authority = findings
+        .iter()
+        .find(|finding| finding["tool"] == "UnauthorizedTool")
+        .expect("tool_authority finding");
+    assert_eq!(authority["failed_rule"], "tool_authority");
+    assert_eq!(authority["violation"], "suggestion_without_authority");
+
+    let precondition = findings
+        .iter()
+        .find(|finding| finding["tool"] == "AuditTool")
+        .expect("precondition finding");
+    assert_eq!(precondition["failed_rule"], "tool_precondition_declared");
+    assert_eq!(precondition["violation"], "business_precondition_mismatch");
+    assert_eq!(
+        precondition["witness"]["missing_preconditions"],
+        serde_json::json!(["case_open"])
+    );
+}
+
+#[test]
+fn replay_is_conformant_when_authority_and_preconditions_are_satisfied() {
+    let path = fixture("issue_470_replay_component.fsl")
+        .display()
+        .to_string();
+    let scratch = std::env::temp_dir().join("issue_470_replay_conformant.jsonl");
+    std::fs::write(
+        &scratch,
+        concat!(
+            r#"{"component":"ReplayComponent","event":"tool_call","tool":"AuditTool","mode":"execute","preconditions":{"case_open":true}}"#,
+            "\n"
+        ),
+    )
+    .expect("write scratch events");
+    let (value, status) = run_str(&[
+        "ai",
+        "replay",
+        &path,
+        "--logs",
+        scratch.to_str().expect("utf8 path"),
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "replay_conformant");
+    assert_eq!(value["findings"].as_array().map(Vec::len), Some(0));
+}

--- a/rust/fslc/tests/issue_474_compose_fair_not_inherited.rs
+++ b/rust/fslc/tests/issue_474_compose_fair_not_inherited.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #474: native `fslc check`/`verify` never
+//! emitted the documented `fair_not_inherited` compose warning
+//! (`docs/LANGUAGE.md`, `docs/DESIGN-compose.md`) because
+//! `rust/fsl-core/src/compose.rs` had no warnings channel at all -- a
+//! synchronized action's constituent `fair` markers were silently discarded
+//! during lowering (`sync_action`, formerly `resolve_alias_action`) with
+//! nothing recording that the composite failed to inherit them, and the
+//! checked `KernelModel` cannot reconstruct this after the fact (only the
+//! composite's own single `fair` marker survives expansion).
+//!
+//! Three-lane matrix (matches the frozen Python reference's
+//! `src/fslc/compose.py` behavior exactly, including the warning message and
+//! `loc`):
+//! - `fair_loss`: a non-fair synchronized action references a fair
+//!   constituent -> exactly one `fair_not_inherited` warning.
+//! - `fair_kept`: the same synchronized action is declared `fair` itself ->
+//!   no warning (fairness is intentionally not inherited; the author opted
+//!   in explicitly).
+//! - `no_fair_loss`: the synchronized action references only non-fair
+//!   constituents -> no warning (there is nothing lost).
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+        .display()
+        .to_string()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn fair_not_inherited_warnings(value: &Value) -> Vec<&Value> {
+    value["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .filter(|warning| warning["kind"] == "fair_not_inherited")
+        .collect()
+}
+
+#[test]
+fn check_reports_fair_not_inherited_for_a_non_fair_synchronized_action() {
+    let path = fixture("issue_474_fair_loss.fsl");
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok");
+
+    let warnings = fair_not_inherited_warnings(&value);
+    assert_eq!(warnings.len(), 1, "{value}");
+    assert_eq!(
+        warnings[0]["message"],
+        "synchronized action 'decay_fresh' is not fair; fair constituent action(s) \
+         core.decay_fresh will not contribute fairness unless the composite action \
+         is declared fair"
+    );
+    assert_eq!(
+        warnings[0]["loc"],
+        serde_json::json!({"line": 6, "column": 3})
+    );
+}
+
+#[test]
+fn check_is_silent_when_the_synchronized_action_is_itself_declared_fair() {
+    // Negative control: fairness is intentionally not inherited (the composite
+    // keeps only its own `fair` marker), so declaring the sync action fair
+    // itself must suppress the warning -- it is not a blanket "any fair
+    // constituent" trigger.
+    let path = fixture("issue_474_fair_kept.fsl");
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok");
+    assert!(fair_not_inherited_warnings(&value).is_empty(), "{value}");
+}
+
+#[test]
+fn check_is_silent_when_no_referenced_constituent_is_fair() {
+    // Negative control: no fair constituent is referenced at all, so there is
+    // nothing to warn about.
+    let path = fixture("issue_474_no_fair_loss.fsl");
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok");
+    assert!(fair_not_inherited_warnings(&value).is_empty(), "{value}");
+}
+
+#[test]
+fn verify_reports_the_same_warning_as_check_and_still_verifies() {
+    let path = fixture("issue_474_fair_loss.fsl");
+    let (value, status) = run(&["verify", &path, "--depth", "3"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "verified", "{value}");
+
+    let warnings = fair_not_inherited_warnings(&value);
+    assert_eq!(warnings.len(), 1, "{value}");
+    assert_eq!(
+        warnings[0]["message"],
+        "synchronized action 'decay_fresh' is not fair; fair constituent action(s) \
+         core.decay_fresh will not contribute fairness unless the composite action \
+         is declared fair"
+    );
+}
+
+#[test]
+fn verify_is_silent_on_the_fair_kept_and_no_fair_loss_controls() {
+    for name in ["issue_474_fair_kept.fsl", "issue_474_no_fair_loss.fsl"] {
+        let path = fixture(name);
+        let (value, status) = run(&["verify", &path, "--depth", "3"]);
+        assert_eq!(status, 0, "{name}: {value}");
+        assert_eq!(value["result"], "verified", "{name}: {value}");
+        assert!(
+            fair_not_inherited_warnings(&value).is_empty(),
+            "{name}: {value}"
+        );
+    }
+}
+
+#[test]
+fn existing_compose_corpus_is_unaffected() {
+    // No fair constituents are referenced by any non-fair synchronized action
+    // in the shipped corpus, so this must stay a no-op change for it.
+    for path in ["specs/order_system.fsl", "specs/bank_system.fsl"] {
+        let (value, status) = run(&["check", path]);
+        assert_eq!(status, 0, "{path}: {value}");
+        assert_eq!(value["result"], "ok", "{path}: {value}");
+        assert!(
+            fair_not_inherited_warnings(&value).is_empty(),
+            "{path}: {value}"
+        );
+    }
+}

--- a/tests/dialect_registry.py
+++ b/tests/dialect_registry.py
@@ -17,6 +17,27 @@ from dataclasses import dataclass
 SCAN_ROOTS = ("specs", "examples")
 
 
+def is_causal_source(source: str) -> bool:
+    """Sniff the top-level ``causal`` keyword.
+
+    Native intentionally excludes "causal" from its dialect-dispatch
+    ``frontends!`` list (``docs/DESIGN-causal.md`` §1: the causal graph never
+    enters ``KernelModel``, ``fsl-runtime``, or ``fsl-solver``), and the frozen
+    Python reference has no causal implementation at all, so
+    ``src/fslc/dialect_registry.py``'s ``DIALECT_KEYWORDS`` deliberately
+    excludes it too. This predicate therefore lives in test infrastructure,
+    not ``src/fslc`` — adding it there would misrepresent the frozen
+    reference as understanding a dialect it does not implement.
+    """
+    for line in source.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        tokens = stripped.split()
+        return bool(tokens) and tokens[0] == "causal"
+    return False
+
+
 @dataclass(frozen=True)
 class Dialect:
     construct: str  # the file's top-level keyword
@@ -49,6 +70,13 @@ EVIDENCE_CONSTRUCTS: dict[str, str] = {
         "fsl-ai recursive agent file (is_ai_agent_source): structural analysis "
         "only (agent_analyzed), formal_result not_run, never expands to a "
         "kernel spec"
+    ),
+    "causal": (
+        "causal profile file (is_causal_source, docs/DESIGN-causal.md §1): the "
+        "causal graph never enters KernelModel/fsl-runtime/fsl-solver, and "
+        "check reports result=causal_model_checked / formal_result=not_run. "
+        "Native coverage lives in rust/fslc/tests/causal_cli.rs; the frozen "
+        "Python reference has no causal implementation at all"
     ),
 }
 
@@ -89,5 +117,13 @@ MONITOR_EXCLUSIONS: dict[str, str] = {
         "Python reference intentionally retains the pre-Rust compatibility "
         "surface. Native Monitor, symbolic, CLI, origin, and parser coverage "
         "lives in the Rust workspace tests"
+    ),
+    "examples/gallery/adversarial/governance_semantic_before.fsl": (
+        "governance preservation 'before' fragment with no actions. Monitor "
+        "requires >=1 action (same shape as examples/self/no_actions.fsl "
+        "above), but native `fslc check` accepts it (ok, warnings only) -- it "
+        "is not a DECLARED_ERROR fixture. Native coverage lives in "
+        "rust/fslc/tests/cli_regression.rs::"
+        "native_check_locates_a_semantic_dependency_error_at_the_preservation"
     ),
 }

--- a/tests/test_dialect_conformance.py
+++ b/tests/test_dialect_conformance.py
@@ -32,7 +32,13 @@ from fslc.parser import parse_src
 from fslc.runtime import Monitor
 
 from agreement import assert_expr_agreement
-from dialect_registry import DIALECTS, EVIDENCE_CONSTRUCTS, MONITOR_EXCLUSIONS, SCAN_ROOTS
+from dialect_registry import (
+    DIALECTS,
+    EVIDENCE_CONSTRUCTS,
+    MONITOR_EXCLUSIONS,
+    SCAN_ROOTS,
+    is_causal_source,
+)
 from oracle import ROOT, VerifyCase, assert_verdict_agrees, bfs_oracle, can_monitor
 
 EXPR_STATES = 40
@@ -83,6 +89,8 @@ def classify(path: Path) -> Classified:
         return Classified(path, EXCLUDED, reason="ai-project")
     if is_ai_agent_source(src):
         return Classified(path, EXCLUDED, reason="ai-agent")
+    if is_causal_source(src):
+        return Classified(path, EXCLUDED, reason="causal")
 
     construct = dialect_keyword(src)
     if construct == "refinement":
@@ -193,6 +201,9 @@ def test_exclusion_still_holds(case: Classified):
     if case.reason == "ai-agent":
         assert is_ai_agent_source(src), (case.id, "no longer an ai-agent source — remove the exclusion")
         return
+    if case.reason == "causal":
+        assert is_causal_source(src), (case.id, "no longer a causal source — remove the exclusion")
+        return
     ok, _reason = can_monitor(case.path)
     assert not ok, (
         f"{case.id}: Monitor can now load this file — the exclusion in "
@@ -227,10 +238,11 @@ def test_registry_floors():
 
 
 def test_registry_covers_ai_evidence_constructs():
-    # EVIDENCE_CONSTRUCTS is documentation of *why* ai-project/ai-agent files
-    # are excluded; make sure the corpus still actually contains at least one
-    # of each so the exclusion reasons stay exercised, not just declared.
-    assert set(EVIDENCE_CONSTRUCTS) == {"ai-project", "ai-agent"}
+    # EVIDENCE_CONSTRUCTS is documentation of *why* ai-project/ai-agent/causal
+    # files are excluded; make sure the corpus still actually contains at
+    # least one of each so the exclusion reasons stay exercised, not just
+    # declared.
+    assert set(EVIDENCE_CONSTRUCTS) == {"ai-project", "ai-agent", "causal"}
     reasons = {c.reason for c in EXCLUDED_CASES}
     for construct in EVIDENCE_CONSTRUCTS:
         assert construct in reasons, f"no corpus file currently exercises the '{construct}' exclusion"


### PR DESCRIPTION
## Problem

Six dialect-layer behaviors that `docs/` or the frozen Python reference promise were absent, wrong, or reported without any analysis behind them. Four of the six returned **exit 0 on input that is genuinely broken**.

| Issue | Before |
|---|---|
| **#468** | `fslc check` reported the hardcoded constant `agent_analysis_result: "agent_analyzed"` **with no analysis behind it**, while `fslc ai check` rejected the documented recursive-agent example outright. `rust/fsl-syntax`'s `parse_agent` was a brace-counting stub: any token soup that lexed cleanly parsed as an empty `SurfaceAgent`. The claim being faked is AI agent authority-delegation safety — low-trust→high-authority paths, review-gate bypass, grant-boundary escalation. |
| **#470** | `ai check` implemented 1 of the 5 documented hard rules and silently accepted unknown rule names. |
| **#469** | `db check` returned `verified_under_assumptions` with an empty `findings` array on a write-drop compatibility violation. |
| **#475** | The `dbsystem` `rename`/`split`/`merge` preservation transforms lower to simultaneous field assignments indexed by distinct enum members, which the write-aliasing analysis could not prove distinct — so `check`/`verify`/`db check` rejected four `examples/db/` fixtures with exit 2 against a golden snapshot of `"ok"`. |
| **#474** | The `fair_not_inherited` warning promised by `docs/LANGUAGE.md`, `docs/DESIGN-compose.md` and `skills/fsl/reference.md` was absent: native lowering never grew a warnings channel, so a fair-losing compose always returned zero warnings. |
| **#476** | The only harness that scans `specs/`+`examples/` exhaustively for Monitor/BFS/verify agreement was silently red (201 passed / 6 failed) with no CI gate re-asserting it. |

## Contract change

- **#468** — `SurfaceAgent` now carries the full recursive body (model / prompt / context / tools / authority / grants / outputs / orchestration / failure_policy / contracts / children / trust / review_gates). `AiParser` gains an `agent()` method reusing its existing `tool()` / `authority()` / `names()` / `atom()` primitives, and a real structural analyzer replaces the constant.
- **#470** — all five documented hard rules implemented; an unknown rule name is now rejected rather than silently accepted.
- **#469** — `db.rs::findings()` mirrors the `reads`/`writes` capabilities symmetrically, populating `column_removed_while_still_written`, `witness.declared_capability`, `repair_candidates`, and `artifact_version`. `run_db_check` also reconciles the top-level `result` to `"violated"` when the attached `kernel` projection reports a violation, closing a JSON-envelope self-contradiction.
- **#475** — `lvalues_may_alias` resolves `Expr::EnumMember` and enum-valued local constants to their nominal `(type_name, member)` identity via a dedicated `static_index_identity` helper, **without** widening `eval_const`/`ConstType` (which is shared by `const_int`, domain-type bounds, `Seq` capacity, and `within` deadlines).
- **#474** — `KernelSpec` gains an internal `diagnostics: Vec<Value>` for warnings discovered during lowering, before `build_model` erases the per-component `fair` markers that produce them. `run_check`, `run_verify`'s native CLI path, and the browser Worker all splice them in. **The Public Kernel projection is unchanged** — verified byte-identical, with `diagnostics` not leaking into `fslc kernel` output.
- **#476** — native is not diverging here; all six red cases were Python-side registration gaps. Four intentional-error `governance` fixtures gained `// expected-result: error` front matter (**replacing each file's existing blank line 2 rather than inserting one**, so the `loc:{line,column}` values already asserted in `cli_regression.rs` do not shift); `governance_semantic_before.fsl` became a registered `MONITOR_EXCLUSIONS` entry; `examples/causal/*.fsl` became a registered `EXCLUDED` class. `AGENTS.md` and `CONTRIBUTING.md`'s coupled-change rules now name `tests/dialect_registry.py` explicitly, and `docs/DESIGN-conformance-harness.md` clarifies that "manual/reference" CI status does not license leaving the harness red.

## Test evidence

Verified independently against a `main` binary, not taken on report:

- **#470** — all four cases were **exit 0 on main**: unknown rule name → now exit 2 `"unknown ai hard-contract rule '…'"`; tool-authority, tool-schema, and human-approval-narrowing violations → now exit 1 `violated`.
- **#469** — `db check` on the write-drop fixture: `verified_under_assumptions` / `findings: []` → `violated` / one `column_removed_while_still_written`.
- **#475** — the four `examples/db/` fixtures go exit 2 → exit 0. **A corpus-wide `check` sweep over all 209 `.fsl` files under `specs/`+`examples/` found exactly those four differences and nothing else**, so the aliasing-precision increase did not silently start accepting anything else. `examples/gallery/errors/semantics_duplicate_assignment.fsl` still exits 2 on both binaries; `cargo test -p fsl-core --test duplicate_writes` is 12/12 including `rejects_a_repeated_enum_member_index`, `rejects_an_enum_member_write_that_may_overlap_a_forall_write`, `rejects_a_constant_index_repeated_by_forall`, and `rejects_parameter_indexes_that_may_alias`.
- **#474** — `fair_not_inherited` emitted where main emitted nothing; **no** warning when fairness is kept or when no constituent is fair (guards against over-triggering); `fslc kernel` output byte-identical on both an unrelated spec and the fair-loss fixture.
- **#476** — I re-checked the central claim rather than trusting it. All four governance fixtures genuinely error natively for real reasons (`"governance preservation missing before at 4:3"`, `"expected business declaration at 4:1"`, `"invalid governance dependency"`, `"unknown type 'Missing'"`), `governance_semantic_before.fsl` genuinely checks `ok` natively, and all six `examples/causal/*.fsl` genuinely check `ok` natively. The front matter is truthful and the exclusions are correct — **not an allowlist concealing a native defect**. `tests/test_dialect_conformance.py`: 212 passed / 0 failed (was 201 / 6). `cli_regression.rs` (22 tests) and `causal_cli.rs` (41 tests) unchanged at 0 failed, confirming the edited fixtures' `loc` assertions were not disturbed.

The two `#469` regression fixtures live under `rust/fslc/tests/fixtures/`, **not** `examples/db/`: `tests/test_corpus_snapshot.py::test_snapshot_has_no_missing_or_extra_specs` asserts the live `specs/`+`examples/` set matches a golden snapshot exactly, and since `src/fslc/` is scheduled for deletion, a native Rust fixture is the right home rather than a corpus addition requiring a Python snapshot regeneration.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (1:1 section-aligned), `docs/DESIGN-conformance-harness.md`, `docs/DESIGN-compose.md`, `skills/fsl/reference.md`, `AGENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #468, fixes #469, fixes #470, fixes #474, fixes #475, fixes #476.

(Note: the db commit's own trailer reads `Fixes #469, #475`. GitHub requires the keyword before *each* number, so #475 is closed by this PR body rather than by that trailer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
