### PR TITLE
fix(chain,ledger): fail closed on manifest and replay errors instead of silent verified/exit 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   non-default initial branch is no longer missed either. A state variable
   assigned on only some init paths (not any) is unaffected and keeps the
   prior single-valuation behavior (#493).
+- `fslc chain`'s project-manifest reader now fails closed instead of silently
+  discarding malformed input: an unrecognized top-level section (including a
+  plain typo), zero recognized `[business]`/`[requirements]`/`[design]`/
+  `[impl]` sections (including an empty manifest), or a present-but-unparseable
+  `depth`/`refine_depth` value (for example one followed by a TOML inline
+  comment) is now a `kind: "parse"` error at exit 2 instead of a silently
+  dropped layer, a vacuous `verified` over zero executed layers, or a silently
+  substituted default depth that understates a declared depth (#489).
+- `fslc chain`'s documented default and bare-filename invocations (e.g.
+  `fslc chain` or `fslc chain fsl-project.toml` from the manifest's own
+  directory) no longer fail the `[impl]` layer with an io error: an empty
+  manifest parent directory now normalizes to `.` before resolving files and
+  launching the implementation command (#500).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   whole `ledger` command through the standard error envelope and exit code,
   the same as `--evidence`, instead of silently rendering a ledger with the
   implementation-log conformance row missing (#499).
+- `fslc ledger --evidence` now surfaces a failing external evidence source
+  (a definitive nonconformant/mismatch/unsupported verdict) as a 🔴 要確認
+  finding for every requirement it attaches to — recursively, via its root
+  `requirements`/`requirement.id` or a `requirement.id` nested inside a
+  `findings`/`checks` array item — or as a spec-level finding when it fails
+  with no requirement attribution at all. Previously a failing source only
+  ever affected the assurance-class column, so a requirement explicitly
+  attached to failing evidence still rendered green with no finding; the
+  assurance-class computation itself is unchanged (class and verdict stay
+  orthogonal, so a failing source still never lowers an independently
+  proven requirement's class) (#508).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   directory) no longer fail the `[impl]` layer with an io error: an empty
   manifest parent directory now normalizes to `.` before resolving files and
   launching the implementation command (#500).
+- `fslc ledger --impl-log` no longer discards a replay error (missing file,
+  malformed JSON, wrong-spec trace, schema-invalid trace): it now fails the
+  whole `ledger` command through the standard error envelope and exit code,
+  the same as `--evidence`, instead of silently rendering a ledger with the
+  implementation-log conformance row missing (#499).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/docs/DESIGN-layers.md
+++ b/docs/DESIGN-layers.md
@@ -311,9 +311,24 @@ existing `verify` path at that depth; omitting `depth` runs the existing `check`
 path. `refine_against` names another manifest layer and requires an explicit
 `mapping` file because `fslc refine` needs the state/action correspondence. The
 implementation command runs with the manifest directory as its working
-directory. By default the chain short-circuits on the first failed layer and
-marks the remaining planned layers as `skipped`; `--keep-going` records the
-failure and continues through the rest of the manifest.
+directory (a bare filename such as the documented default `fsl-project.toml`
+resolves to `.`, not to an empty `current_dir`). By default the chain
+short-circuits on the first failed layer and marks the remaining planned
+layers as `skipped`; `--keep-going` records the failure and continues through
+the rest of the manifest.
+
+The manifest reader is fail-closed (issue #489): a top-level section name
+other than `[business]`, `[requirements]`, `[design]`, or `[impl]` — including
+a plain typo — is a `kind: "parse"` error at exit 2 rather than a silently
+dropped layer, and a manifest with zero recognized sections (including an
+empty file) is the same error rather than a vacuous `verified` with
+`layers: []`. A `depth` or `refine_depth` value that is present but not a
+plain non-negative integer (for example, one followed by a TOML inline
+comment) is also a `kind: "parse"` error for that layer at exit 2; only an
+*absent* key defaults (to `check` for `depth`, or to 8 for `refine_depth`'s
+cascade through `depth` and the target layer's `depth`). A malformed value is
+never silently substituted with a default, since that would understate a
+depth the manifest author explicitly declared.
 
 ## 8. Phased plan
 

--- a/docs/DESIGN-ledger.md
+++ b/docs/DESIGN-ledger.md
@@ -31,6 +31,18 @@ reads as "guarantees nothing".
   `--evidence` already fails closed on an unreadable evidence file.
 - The built `spec` — the requirement registry (every `requirement` id + text) and
   `control` governance (owner / severity) when present.
+- `--evidence <result.json>`... (repeatable) — external producer envelopes fold
+  into the assurance-class column (`docs/DESIGN-assurance-classes.md`), but a
+  **failing** source (a definitive `nonconformant`/`replay_nonconformant`/
+  `observed_mismatch`/`evidence_failed`/`statistically_unsupported` verdict,
+  not a verdict-less gate failure like `dataset_invalid`) also adds a 🔴 要確認
+  finding: one per requirement id it attaches to, recursively — its own root
+  `requirements`/`requirement.id`, or a `requirement.id` nested inside a
+  `findings`/`checks` array item — or a spec-level（仕様全体）finding when it
+  fails with no requirement attribution at all (issue #508). A failing source
+  never lowers or removes an independently proven requirement's assurance
+  class; class (method strength) and verdict (pass/fail) stay orthogonal, so
+  the finding is additive only.
 
 ## CLI contract
 

--- a/docs/DESIGN-ledger.md
+++ b/docs/DESIGN-ledger.md
@@ -23,7 +23,12 @@ reads as "guarantees nothing".
 - `run_scenarios(file, depth, deadlock)` — passing acceptance / forbidden /
   reachable confirmations per requirement.
 - `--impl-log <trace.json>` (optional) → `run_replay` — implementation-log
-  conformance (`conformant` / `nonconformant`).
+  conformance (`conformant` / `nonconformant`). A replay **error** (missing
+  file, malformed JSON, wrong-spec trace, schema-invalid trace) is not
+  evidence and must not be rendered as an empty/missing implementation-log
+  row: it fails the whole `ledger` command through the same standard error
+  envelope and exit code as any other input error (issue #499), the same way
+  `--evidence` already fails closed on an unreadable evidence file.
 - The built `spec` — the requirement registry (every `requirement` id + text) and
   `control` governance (owner / severity) when present.
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -889,7 +889,10 @@ imported / imported_with_warnings、
 refinement_failed / sweep_failed / observed_mismatch、
 `2` = spec エラー(parse / type / semantics / io / vacuous / acceptance / forbidden /
 `--vacuity error`)、`3` = 内部エラー。`observed_*` は `fslc db observe` の結果、
-`imported`/`imported_with_warnings` は `fslc db import` の結果です。
+`imported`/`imported_with_warnings` は `fslc db import` の結果です。同じ `2` の
+対応付けは `chain` のプロジェクトマニフェストリーダー(未知のセクション、認識できる
+セクションが0個、パース不能な `depth`/`refine_depth` — `docs/DESIGN-layers.md` §7)
+でもフェイルクローズドに適用されます。
 
 ### 結果の種類
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -892,7 +892,9 @@ refinement_failed / sweep_failed / observed_mismatch、
 `imported`/`imported_with_warnings` は `fslc db import` の結果です。同じ `2` の
 対応付けは `chain` のプロジェクトマニフェストリーダー(未知のセクション、認識できる
 セクションが0個、パース不能な `depth`/`refine_depth` — `docs/DESIGN-layers.md` §7)
-でもフェイルクローズドに適用されます。
+と、`ledger --impl-log` の replay 入力(replay エラーは実装ログの証跡ではなく、
+空の台帳行として描画してはならない — `docs/DESIGN-ledger.md`)でもフェイルクローズド
+に適用されます。
 
 ### 結果の種類
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -914,7 +914,10 @@ imported / imported_with_warnings,
 refinement_failed / sweep_failed / observed_mismatch,
 `2` = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 `--vacuity error`), `3` = internal error. `observed_*` is `fslc db observe`'s
-result; `imported`/`imported_with_warnings` is `fslc db import`'s.
+result; `imported`/`imported_with_warnings` is `fslc db import`'s. The same
+`2` mapping is fail-closed for `chain`'s project-manifest reader (unrecognized
+section, zero recognized sections, or an unparseable `depth`/`refine_depth` —
+`docs/DESIGN-layers.md` §7).
 
 ### Kinds of result
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -917,7 +917,9 @@ refinement_failed / sweep_failed / observed_mismatch,
 result; `imported`/`imported_with_warnings` is `fslc db import`'s. The same
 `2` mapping is fail-closed for `chain`'s project-manifest reader (unrecognized
 section, zero recognized sections, or an unparseable `depth`/`refine_depth` —
-`docs/DESIGN-layers.md` §7).
+`docs/DESIGN-layers.md` §7) and for `ledger --impl-log`'s replay input (a
+replay error is not implementation-log evidence and must not be rendered as
+an empty ledger row — `docs/DESIGN-ledger.md`).
 
 ### Kinds of result
 

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -408,6 +408,10 @@ fn translate(finding: &Finding) -> String {
         ),
         "refinement" => "詳細仕様が上位契約から逸脱している。対応付け（mapping）かガードを修正する。".to_owned(),
         "conformance" => "実装ログが仕様に非適合。実装か仕様のどちらが正かを確定する。".to_owned(),
+        "external_evidence" => format!(
+            "外部証跡『{}』が非適合/失敗を報告している。証跡（実装ログ・統計評価等）と仕様のどちらが正かを責任者が確認する。",
+            finding.name
+        ),
         "coverage" => format!(
             "アクション『{}』が一度も実行可能にならない（死アクション）。ガードを緩めるか前提アクションを追加する。",
             finding.name
@@ -433,6 +437,7 @@ fn next_action(finding: &Finding) -> String {
             "sla" => "urgent 前提 or 期限値を見直し",
             "refinement" => "mapping / ガードを修正",
             "conformance" => "実装 or 仕様を一致させる",
+            "external_evidence" => "外部証跡の結果を確認し、要件 or 実装のどちらを直すか判断",
             "coverage" => "ガードを緩める / 前提アクションを追加",
             "vacuity" => "fslc mutate で実効性を確認",
             _ => "責任者が対応方針を決定",
@@ -462,6 +467,114 @@ pub(crate) fn evidence_requirement_ids(item: &Value) -> Vec<&str> {
         ids.push(id);
     }
     ids
+}
+
+/// Every requirement ID an evidence envelope attaches to, recursively:
+/// [`evidence_requirement_ids`] at the root, plus the same lookup applied to
+/// each item of a top-level `findings`/`checks` array (issue #508 — a
+/// producer such as `fsl-ai check` attributes per-finding rather than only
+/// at the envelope root).
+fn evidence_attached_requirement_ids(item: &Value) -> Vec<String> {
+    let mut ids = evidence_requirement_ids(item)
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    for key in ["findings", "checks"] {
+        for nested in item
+            .get(key)
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            ids.extend(
+                evidence_requirement_ids(nested)
+                    .into_iter()
+                    .map(str::to_owned),
+            );
+        }
+    }
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Whether an evidence envelope's own result token is a definitive `pass`,
+/// a definitive `fail`, or carries no verdict at all (gate failures like
+/// `dataset_invalid`, or structural-only output like `compared`) — issue
+/// #508 / `docs/DESIGN-assurance-classes.md` `classify_source`. This is
+/// deliberately independent of [`assurance_token`]: class (method strength)
+/// and verdict (outcome) are orthogonal, so a failing source must never
+/// change the assurance label, only add a finding.
+fn evidence_verdict(value: &Value) -> Option<bool> {
+    let result = value.get("result").and_then(Value::as_str).unwrap_or("");
+    if matches!(
+        result,
+        "conformant"
+            | "replay_conformant"
+            | "observed_conformant"
+            | "conformance_checked"
+            | "observed_supported"
+            | "evidence_supported"
+    ) {
+        return Some(true);
+    }
+    if matches!(
+        result,
+        "nonconformant" | "replay_nonconformant" | "observed_mismatch" | "evidence_failed"
+    ) {
+        return Some(false);
+    }
+    match value.get("status").and_then(Value::as_str) {
+        Some("statistically_supported") => Some(true),
+        Some("statistically_unsupported") => Some(false),
+        _ => None,
+    }
+}
+
+/// Turn every failing `--evidence` envelope into ledger [`Finding`]s (issue
+/// #508): a failing source must surface as a 🔴 要確認 row for every
+/// requirement it attaches to (root `requirements`/`requirement.id`, or
+/// nested inside `findings`/`checks`), and as a spec-level finding when it
+/// fails without attaching to any requirement at all. A passing or
+/// verdict-less envelope (gate failure, structural analysis) contributes no
+/// finding — it only ever affects [`assurance_cell`]'s class.
+fn collect_evidence_findings(evidence: &[(String, Value)]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for (source, item) in evidence {
+        if evidence_verdict(item) != Some(false) {
+            continue;
+        }
+        let result = item
+            .get("result")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let summary = format!("外部証跡『{source}』が非適合/失敗を報告(result: {result})");
+        let ids = evidence_attached_requirement_ids(item);
+        if ids.is_empty() {
+            findings.push(Finding {
+                requirement_id: None,
+                requirement_text: None,
+                trace_type: "external_evidence".to_owned(),
+                name: source.clone(),
+                summary,
+                next_action: None,
+                raw: item.clone(),
+            });
+            continue;
+        }
+        for id in ids {
+            findings.push(Finding {
+                requirement_id: Some(id),
+                requirement_text: None,
+                trace_type: "external_evidence".to_owned(),
+                name: source.clone(),
+                summary: summary.clone(),
+                next_action: None,
+                raw: item.clone(),
+            });
+        }
+    }
+    findings
 }
 
 /// Classify one JSON envelope (an evidence file's parsed contents, or a
@@ -593,7 +706,10 @@ fn assurance_cell(
         }
     }
     for (_, item) in evidence {
-        if evidence_requirement_ids(item).contains(&requirement_id) {
+        if evidence_attached_requirement_ids(item)
+            .iter()
+            .any(|id| id == requirement_id)
+        {
             sources.push(assurance_token(item));
         }
     }
@@ -693,9 +809,10 @@ pub fn render_ledger_with_approvals(
     let (mut requirement_order, registry) = requirement_registry(model);
     let undecided = undecided_declarations(model);
     let findings = collect_findings(model, verification);
+    let evidence_findings = collect_evidence_findings(evidence);
     let mut by_requirement: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
     let mut spec_level = Vec::new();
-    for finding in &findings {
+    for finding in findings.iter().chain(evidence_findings.iter()) {
         if let Some(requirement_id) = &finding.requirement_id {
             by_requirement
                 .entry(requirement_id.clone())
@@ -1031,10 +1148,7 @@ pub fn render_ledger_with_approvals(
             "## 外部エビデンス\n\n| ファイル | producer結果 | 保証クラス | 対象要件ID |\n|---|---|---|---|\n",
         );
         for (source, item) in evidence {
-            let ids = evidence_requirement_ids(item)
-                .into_iter()
-                .map(str::to_owned)
-                .collect::<Vec<_>>();
+            let ids = evidence_attached_requirement_ids(item);
             let ids = if ids.is_empty() {
                 "（仕様全体）".to_owned()
             } else {
@@ -1054,7 +1168,13 @@ pub fn render_ledger_with_approvals(
     output.push_str(
         "## 付録: 生 JSON 反例（証跡）\n\n<details><summary>raw findings</summary>\n\n```json\n",
     );
-    let raw = Value::Array(findings.into_iter().map(|finding| finding.raw).collect());
+    let raw = Value::Array(
+        findings
+            .into_iter()
+            .chain(evidence_findings)
+            .map(|finding| finding.raw)
+            .collect(),
+    );
     output.push_str(&serde_json::to_string_pretty(&raw).unwrap_or_else(|_| "[]".to_owned()));
     output.push_str("\n```\n\n</details>\n");
     output

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3528,6 +3528,17 @@ fn skipped_chain_entry(
     })
 }
 
+/// Parses a manifest depth value read from `key` in `[layer]`. The manifest
+/// reader treats a present-but-unparseable value as a fail-closed error
+/// rather than silently substituting a default; only an absent key may
+/// default (the caller decides that). Returns the message for a chain-layer
+/// parse-error entry on failure.
+fn parse_manifest_depth(layer: &str, key: &str, raw: &str) -> Result<usize, String> {
+    raw.trim()
+        .parse::<usize>()
+        .map_err(|_| format!("[{layer}] invalid {key} value: {raw:?}"))
+}
+
 #[allow(
     clippy::bool_to_int_with_if,
     clippy::manual_let_else,
@@ -3556,6 +3567,26 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
             return (output, 2);
         }
     };
+    let known_sections = ["business", "requirements", "design", "impl"];
+    let mut unknown_sections = sections
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !known_sections.contains(name))
+        .collect::<Vec<_>>();
+    unknown_sections.sort_unstable();
+    if !unknown_sections.is_empty() {
+        let mut output = error_output(
+            "parse",
+            &format!(
+                "unrecognized manifest section(s): [{}] (expected [business], [requirements], [design], and/or [impl])",
+                unknown_sections.join("], [")
+            ),
+        );
+        if let Value::Object(output) = &mut output {
+            output.insert("manifest".to_owned(), json!(path.display().to_string()));
+        }
+        return (output, 2);
+    }
     let mut steps = Vec::<(String, String)>::new();
     for layer in ["business", "requirements", "design"] {
         if let Some(section) = sections.get(layer) {
@@ -3568,7 +3599,20 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
     if sections.contains_key("impl") {
         steps.push(("impl".to_owned(), "impl".to_owned()));
     }
-    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    if steps.is_empty() {
+        let mut output = error_output(
+            "parse",
+            "project manifest declares no [business], [requirements], [design], or [impl] section",
+        );
+        if let Value::Object(output) = &mut output {
+            output.insert("manifest".to_owned(), json!(path.display().to_string()));
+        }
+        return (output, 2);
+    }
+    let base = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
     let mut layers = Vec::new();
     for (index, (kind, layer)) in steps.iter().enumerate() {
         let section = &sections[layer];
@@ -3576,20 +3620,29 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
             if let Some(file) = section.values.get("file") {
                 let file_path = base.join(file);
                 let (detail, status, check_kind, depth) =
-                    if let Some(depth) = section.values.get("depth") {
-                        let depth = depth.parse::<usize>().unwrap_or(8);
-                        let (detail, status) = run_verify(
-                            &file_path,
-                            depth,
-                            section
-                                .values
-                                .get("deadlock")
-                                .map_or("warn", String::as_str),
-                            "bmc",
-                            DEFAULT_EXPLICIT_BUDGET,
-                            1,
-                        );
-                        (detail, status, "verify", Some(depth))
+                    if let Some(raw_depth) = section.values.get("depth") {
+                        match parse_manifest_depth(layer, "depth", raw_depth) {
+                            Ok(depth) => {
+                                let (detail, status) = run_verify(
+                                    &file_path,
+                                    depth,
+                                    section
+                                        .values
+                                        .get("deadlock")
+                                        .map_or("warn", String::as_str),
+                                    "bmc",
+                                    DEFAULT_EXPLICIT_BUDGET,
+                                    1,
+                                );
+                                (detail, status, "verify", Some(depth))
+                            }
+                            Err(message) => (
+                                json!({"result": "error", "kind": "parse", "message": message}),
+                                2,
+                                "verify",
+                                None,
+                            ),
+                        }
                     } else {
                         let (detail, status) = run_check(&file_path, &file_path);
                         (detail, status, "check", None)
@@ -3663,31 +3716,58 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
                 let file_path = base.join(&section.values["file"]);
                 let target_path = base.join(&target_section.expect("checked").values["file"]);
                 let mapping_path = base.join(mapping.expect("checked"));
-                let depth = section
-                    .values
-                    .get("refine_depth")
-                    .or_else(|| section.values.get("depth"))
-                    .or_else(|| target_section.and_then(|target| target.values.get("depth")))
-                    .and_then(|depth| depth.parse().ok())
-                    .unwrap_or(8);
-                let (detail, status) = run_refine(&file_path, &target_path, &mapping_path, depth);
-                let passed = chain_layer_passes(&detail, status);
-                (
-                    json!({
-                        "layer": format!("{layer}->{target}"),
-                        "kind": "refine",
-                        "file": file_path.display().to_string(),
-                        "against": target,
-                        "abs_file": target_path.display().to_string(),
-                        "mapping": mapping_path.display().to_string(),
-                        "depth": depth,
-                        "status": if passed { "passed" } else { "failed" },
-                        "result": detail.get("result").cloned().unwrap_or(Value::Null),
-                        "exit_code": if passed { 0 } else { status.max(1) },
-                        "detail": detail,
-                    }),
-                    !passed,
-                )
+                // Precedence: an explicit `refine_depth` or `depth` on this layer wins
+                // outright, even if malformed (a present-but-invalid key must error, not
+                // silently fall through to the next candidate or the default).
+                let depth_result = if let Some(raw) = section.values.get("refine_depth") {
+                    parse_manifest_depth(layer, "refine_depth", raw)
+                } else if let Some(raw) = section.values.get("depth") {
+                    parse_manifest_depth(layer, "depth", raw)
+                } else if let Some(raw) =
+                    target_section.and_then(|target| target.values.get("depth"))
+                {
+                    parse_manifest_depth(target, "depth", raw)
+                } else {
+                    Ok(8)
+                };
+                match depth_result {
+                    Ok(depth) => {
+                        let (detail, status) =
+                            run_refine(&file_path, &target_path, &mapping_path, depth);
+                        let passed = chain_layer_passes(&detail, status);
+                        (
+                            json!({
+                                "layer": format!("{layer}->{target}"),
+                                "kind": "refine",
+                                "file": file_path.display().to_string(),
+                                "against": target,
+                                "abs_file": target_path.display().to_string(),
+                                "mapping": mapping_path.display().to_string(),
+                                "depth": depth,
+                                "status": if passed { "passed" } else { "failed" },
+                                "result": detail.get("result").cloned().unwrap_or(Value::Null),
+                                "exit_code": if passed { 0 } else { status.max(1) },
+                                "detail": detail,
+                            }),
+                            !passed,
+                        )
+                    }
+                    Err(message) => {
+                        let detail =
+                            json!({"result": "error", "kind": "parse", "message": message});
+                        (
+                            json!({
+                                "layer": format!("{layer}->{target}"),
+                                "kind": "refine",
+                                "status": "failed",
+                                "result": "error",
+                                "exit_code": 2,
+                                "detail": detail,
+                            }),
+                            true,
+                        )
+                    }
+                }
             }
         } else {
             let command = section.values.get("command").cloned().unwrap_or_default();

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -10369,9 +10369,19 @@ fn prepare_ledger_report(request: &LedgerReportRequest<'_>) -> Result<PreparedLe
         DEFAULT_EXPLICIT_BUDGET,
         1,
     );
-    let replay = request
-        .impl_log
-        .map(|trace| run_replay(request.path, trace).0);
+    let replay = match request.impl_log {
+        Some(trace) => {
+            let (detail, status) = run_replay(request.path, trace);
+            // Only `conformant` (0) and `nonconformant` (1) are replay
+            // evidence; io/parse/internal errors (>=2) must fail the ledger
+            // command instead of silently omitting the implementation-log row.
+            if status >= 2 {
+                return Err(detail);
+            }
+            Some(detail)
+        }
+        None => None,
+    };
     let evidence = request
         .evidence_paths
         .iter()

--- a/rust/fslc/tests/chain_cli.rs
+++ b/rust/fslc/tests/chain_cli.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for `fslc chain` (issues #489, #500): a manifest reader
+//! that silently discards an unparseable `depth`, silently treats zero
+//! recognized layer sections as success, or fails the `[impl]` layer for the
+//! documented bare-filename invocation is a confidently-green false negative
+//! (AGENTS.md). Every test here fails if the corresponding fix is reverted.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::Value;
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root")
+}
+
+fn chain_fixture_dir() -> PathBuf {
+    repo_root().join("tests/fixtures/chain")
+}
+
+/// A fresh scratch directory per test under `rust/target/`, so parallel test
+/// binaries never collide and no cleanup step is required (gitignored).
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = repo_root().join(format!(
+        "rust/target/chain-cli-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// The committed fixture manifests' `[impl] command` invokes `python -c
+/// "print('impl ok')"`. `python` is not reliably on PATH on Windows CI
+/// runners, and the nested `\"..\"` quoting is interpreted differently
+/// under `cmd /C` than under `sh -c` (the exact class of shell-portability
+/// gap issue #500 is itself about). Rewriting the committed fixture would
+/// ripple into the frozen Python compatibility suite that also reads it, so
+/// only the scratch-dir *copy* is patched, to this same test binary's own
+/// executable: no interpreter dependency, and a single unquoted absolute
+/// path plus plain arguments behaves identically under both shells (no
+/// nested quoting is introduced). `business.fsl` is always present in the
+/// copy and independently verified by the `[business]` layer that already
+/// runs earlier in the same chain, so it is a reliable, deterministic
+/// success.
+const PYTHON_IMPL_COMMAND: &str = "command = \"python -c \\\"print('impl ok')\\\"\"";
+
+fn portable_impl_command_line() -> String {
+    // TOML/JSON string escaping for the path itself (Windows paths carry
+    // `\`), not shell quoting — the shell command has no embedded quotes.
+    let escaped_path = env!("CARGO_BIN_EXE_fslc").replace('\\', "\\\\");
+    format!("command = \"{escaped_path} check business.fsl\"")
+}
+
+/// `git checkout` on Windows CI (`core.autocrlf=true`) rewrites this
+/// repository's LF fixture text to CRLF; `fs::read_to_string` (unlike C
+/// stdio text mode) never translates line endings back, so the checked-out
+/// bytes carry a literal `\r` before every `\n`. Every subsequent
+/// line-literal match in this file (this function's own
+/// [`PYTHON_IMPL_COMMAND`] replace, and each test's own `"depth = 2\n"` /
+/// `"refine_against = \"requirements\"\n"` replace against the manifest
+/// this function writes into the scratch dir) assumes bare `\n`, so
+/// `copy_chain_fixture` normalizes once here — the one place every scratch
+/// copy passes through — rather than requiring every downstream read to
+/// repeat the normalization.
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+fn copy_chain_fixture(dir: &Path) {
+    for entry in fs::read_dir(chain_fixture_dir()).expect("read chain fixture dir") {
+        let entry = entry.expect("fixture entry");
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let dest = dir.join(path.file_name().expect("file name"));
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "toml")
+        {
+            let manifest = fs::read_to_string(&path).expect("read manifest fixture");
+            let manifest = normalize_line_endings(&manifest);
+            assert!(
+                manifest.contains(PYTHON_IMPL_COMMAND),
+                "fixture {} no longer has the expected [impl] command line to rewrite",
+                path.display()
+            );
+            let manifest = manifest.replace(PYTHON_IMPL_COMMAND, &portable_impl_command_line());
+            fs::write(&dest, manifest).expect("write portable manifest copy");
+        } else {
+            fs::copy(&path, &dest).expect("copy fixture file");
+        }
+    }
+}
+
+fn run(cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run native fslc")
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("JSON stdout")
+}
+
+fn layer<'a>(value: &'a Value, name: &str) -> &'a Value {
+    value["layers"]
+        .as_array()
+        .expect("layers array")
+        .iter()
+        .find(|entry| entry["layer"] == name)
+        .unwrap_or_else(|| panic!("layer '{name}' present in {value}"))
+}
+
+#[test]
+fn chain_clean_manifest_runs_five_layers_and_verifies() {
+    let dir = scratch_dir("clean");
+    copy_chain_fixture(&dir);
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(
+        output.status.success(),
+        "clean manifest chain failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value = json(&output);
+    assert_eq!(value["result"], "verified");
+    assert_eq!(value["layers"].as_array().expect("layers").len(), 5);
+}
+
+#[test]
+fn chain_default_and_bare_filename_invocations_run_impl_layer() {
+    // Regression for #500: `Path::parent()` on a bare filename (no directory
+    // component) returns `Some("")`, and `Command::current_dir("")` used to
+    // fail with an io error, so the documented default invocation never
+    // reached the [impl] layer.
+    let dir = scratch_dir("bare-filename");
+    copy_chain_fixture(&dir);
+
+    for args in [vec!["chain", "fsl-project.toml"], vec!["chain"]] {
+        let output = run(&dir, &args);
+        assert!(
+            output.status.success(),
+            "chain {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value = json(&output);
+        assert_eq!(value["result"], "verified", "chain {args:?}: {value}");
+        let impl_layer = layer(&value, "impl");
+        assert_eq!(impl_layer["status"], "passed");
+        assert_eq!(impl_layer["exit_code"], 0);
+    }
+}
+
+#[test]
+fn chain_rejects_manifest_with_inline_comment_depth() {
+    // Regression for #489 (path 1): a TOML inline comment after `depth`
+    // failed the bare `usize` parse and used to fall back silently to the
+    // hardcoded default of 8 via `unwrap_or(8)`, understating a declared
+    // depth without any diagnostic.
+    let dir = scratch_dir("inline-comment-depth");
+    copy_chain_fixture(&dir);
+    let manifest = fs::read_to_string(dir.join("fsl-project.toml")).expect("read manifest");
+    let manifest = manifest.replace("depth = 2\n", "depth = 2  # keep it deep\n");
+    assert!(
+        manifest.contains("# keep it deep"),
+        "fixture no longer has a `depth = 2` line to rewrite"
+    );
+    fs::write(dir.join("fsl-project.toml"), manifest).expect("write manifest");
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    let design_layer = layer(&value, "design");
+    assert_eq!(design_layer["status"], "failed");
+    assert_eq!(design_layer["exit_code"], 2);
+    let message = design_layer["detail"]["message"]
+        .as_str()
+        .expect("error message");
+    assert!(message.contains("invalid depth value"), "{message}");
+}
+
+#[test]
+fn chain_omitted_depth_still_defaults() {
+    // Distinguishes an absent `depth` key (falls back to the `check` path)
+    // from a present-but-unparseable one (previous test): only omission may
+    // default silently.
+    let dir = scratch_dir("omitted-depth");
+    copy_chain_fixture(&dir);
+    let manifest = fs::read_to_string(dir.join("fsl-project.toml")).expect("read manifest");
+    let manifest = manifest.replace("depth = 2\n", "");
+    fs::write(dir.join("fsl-project.toml"), manifest).expect("write manifest");
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value = json(&output);
+    assert_eq!(value["result"], "verified");
+    assert_eq!(layer(&value, "design")["kind"], "check");
+}
+
+#[test]
+fn chain_rejects_malformed_refine_depth() {
+    // A present-but-invalid `refine_depth` must not silently fall through to
+    // `depth` or the target layer's `depth` (or the hardcoded default).
+    let dir = scratch_dir("malformed-refine-depth");
+    copy_chain_fixture(&dir);
+    let manifest = fs::read_to_string(dir.join("fsl-project.toml")).expect("read manifest");
+    let manifest = manifest.replace(
+        "refine_against = \"requirements\"\n",
+        "refine_against = \"requirements\"\nrefine_depth = notanumber\n",
+    );
+    fs::write(dir.join("fsl-project.toml"), manifest).expect("write manifest");
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    let refine_layer = layer(&value, "design->requirements");
+    assert_eq!(refine_layer["status"], "failed");
+    assert_eq!(refine_layer["exit_code"], 2);
+    let message = refine_layer["detail"]["message"]
+        .as_str()
+        .expect("error message");
+    assert!(message.contains("invalid refine_depth value"), "{message}");
+}
+
+#[test]
+fn chain_rejects_empty_manifest() {
+    // Regression for #489 (path 2): zero recognized layer sections used to
+    // report `result: "verified"` with `layers: []` at exit 0.
+    let dir = scratch_dir("empty-manifest");
+    fs::write(dir.join("fsl-project.toml"), "").expect("write empty manifest");
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert!(value.get("layers").is_none(), "{value}");
+}
+
+#[test]
+fn chain_rejects_unknown_section_name() {
+    // A misspelled layer section name (e.g. `[businesss]`) used to be
+    // ignored rather than diagnosed, silently dropping that layer from the
+    // chain even when it sits alongside otherwise-valid sections.
+    let dir = scratch_dir("unknown-section");
+    fs::write(
+        dir.join("fsl-project.toml"),
+        "[businesss]\nfile = \"business.fsl\"\n\n[requirements]\nfile = \"requirements.fsl\"\n",
+    )
+    .expect("write manifest");
+
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert!(value.get("layers").is_none(), "{value}");
+    let message = value["message"].as_str().expect("error message");
+    assert!(message.contains("businesss"), "{message}");
+}
+
+const DEPTH_GATE_SPEC: &str = r"spec DepthGate {
+  type Counter = 0..12
+
+  state {
+    counter: Counter
+  }
+
+  init {
+    counter = 0
+  }
+
+  action tick() {
+    requires counter < 12
+    counter = counter + 1
+  }
+
+  invariant BelowNine { counter < 9 }
+}
+";
+
+#[test]
+fn chain_honors_declared_depth_beyond_the_silent_fallback_of_eight() {
+    // `DepthGate`'s invariant only breaks at step 9: depth 8 (the old
+    // silent-fallback value) reports `verified`, depth 9 reports `violated`.
+    // A manifest that declares depth = 9 must actually search 9 steps
+    // (proving #489's fix does not just error out but also uses the
+    // declared value correctly), while the same depth written with a
+    // trailing inline comment must fail closed instead of quietly reusing 8
+    // and missing the counterexample.
+    let dir = scratch_dir("depth-gate");
+    fs::write(dir.join("depth_gate.fsl"), DEPTH_GATE_SPEC).expect("write spec");
+
+    fs::write(
+        dir.join("fsl-project.toml"),
+        "[business]\nfile = \"depth_gate.fsl\"\ndepth = 9\n",
+    )
+    .expect("write manifest");
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(json(&output)["result"], "violated");
+
+    fs::write(
+        dir.join("fsl-project.toml"),
+        "[business]\nfile = \"depth_gate.fsl\"\ndepth = 9  # keep it deep\n",
+    )
+    .expect("write manifest with inline comment");
+    let output = run(&dir, &["chain", "fsl-project.toml"]);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(json(&output)["result"], "error");
+}

--- a/rust/fslc/tests/ledger_evidence_findings_cli.rs
+++ b/rust/fslc/tests/ledger_evidence_findings_cli.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for issue #508: `fslc ledger --evidence` used to use
+//! external evidence only to label assurance class, never as a finding — a
+//! requirement explicitly attached to failing evidence (root `requirements`
+//! list, or a nested `findings[]`/`checks[]` item's `requirement.id`) still
+//! rendered green with no 🔴 row, and evidence with no requirement
+//! attribution at all was silently dropped rather than becoming a
+//! spec-level finding. `docs/DESIGN-assurance-classes.md`: "a failing
+//! source never lowers the class of an independently proven requirement —
+//! it adds a 要確認 finding." Every `*_is_a_red_finding`/`*_finding` test
+//! here fails if the fix is reverted; the `*_stays_green` tests guard that
+//! a passing or verdict-less (gate-failure) source is not turned into a
+//! false positive.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root")
+}
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = repo_root().join(format!(
+        "rust/target/ledger-evidence-findings-cli-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+const SPEC: &str = r#"spec LedgerProbe {
+  state { x: Bool = false }
+  action stay() { x = x }
+  @requirement("REQ-AUDIT-001", "x remains false")
+  invariant Safe { not x }
+}
+"#;
+
+fn run(cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run native fslc")
+}
+
+/// Writes the probe spec and the given evidence JSON into a fresh scratch
+/// dir, runs `ledger --evidence`, and returns the rendered Markdown.
+fn render(name: &str, evidence_json: &str) -> String {
+    let dir = scratch_dir(name);
+    fs::write(dir.join("ledger_probe.fsl"), SPEC).expect("write spec");
+    fs::write(dir.join("evidence.json"), evidence_json).expect("write evidence");
+    let output = run(
+        &dir,
+        &[
+            "ledger",
+            "ledger_probe.fsl",
+            "--evidence",
+            "evidence.json",
+            "-o",
+            "ledger.md",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "ledger --evidence failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::read_to_string(dir.join("ledger.md")).expect("ledger written")
+}
+
+fn requirement_row(markdown: &str) -> &str {
+    markdown
+        .lines()
+        .find(|line| line.starts_with("| REQ-AUDIT-001 |"))
+        .unwrap_or_else(|| panic!("REQ-AUDIT-001 row present in {markdown}"))
+}
+
+#[test]
+fn ledger_evidence_root_attached_failure_is_a_red_finding() {
+    let markdown = render(
+        "root-attached",
+        r#"{"result":"replay_nonconformant","formal_result":"not_run","evidence":{"kind":"runtime_replay"},"requirements":["REQ-AUDIT-001"],"findings":[{"kind":"human_approval_required_before_irreversible_tool","requirement":{"id":"REQ-AUDIT-001"}}]}"#,
+    );
+    let row = requirement_row(&markdown);
+    assert!(row.contains("🔴 要確認"), "{row}");
+    assert!(row.contains("external_evidence"), "{row}");
+    assert!(
+        markdown.contains("外部証跡『evidence.json』が非適合/失敗を報告"),
+        "{markdown}"
+    );
+}
+
+#[test]
+fn ledger_evidence_nested_attached_failure_is_a_red_finding() {
+    // No root `requirements` list — attribution comes solely from the
+    // nested `findings[0].requirement.id`.
+    let markdown = render(
+        "nested-attached",
+        r#"{"result":"replay_nonconformant","formal_result":"not_run","evidence":{"kind":"runtime_replay"},"findings":[{"kind":"human_approval_required_before_irreversible_tool","requirement":{"id":"REQ-AUDIT-001"}}]}"#,
+    );
+    let row = requirement_row(&markdown);
+    assert!(row.contains("🔴 要確認"), "{row}");
+    // The assurance-class column must also recognize the nested
+    // attribution (not just the finding), so the external evidence's class
+    // is folded into the same row rather than silently dropped.
+    assert!(row.contains("replay-observed"), "{row}");
+}
+
+#[test]
+fn ledger_evidence_unattached_failure_is_a_spec_level_finding() {
+    // No requirement attribution anywhere: this must not be silently
+    // dropped, but it also cannot upgrade any specific requirement row —
+    // it becomes a （仕様全体） spec-level finding.
+    let markdown = render(
+        "unattached",
+        r#"{"result":"replay_nonconformant","formal_result":"not_run","evidence":{"kind":"runtime_replay"}}"#,
+    );
+    let row = requirement_row(&markdown);
+    assert!(row.contains("🟢"), "{row}");
+    assert!(
+        markdown.contains("（仕様全体） | 要件ID未付与の検出 | 🔴 要確認"),
+        "{markdown}"
+    );
+}
+
+#[test]
+fn ledger_evidence_passing_result_stays_green() {
+    let markdown = render(
+        "passing",
+        r#"{"result":"conformant","formal_result":"not_run","evidence":{"kind":"runtime_replay"},"requirements":["REQ-AUDIT-001"]}"#,
+    );
+    let row = requirement_row(&markdown);
+    assert!(row.contains('🟢'), "{row}");
+    assert!(!row.contains("external_evidence"), "{row}");
+}
+
+#[test]
+fn ledger_evidence_gate_failure_without_verdict_stays_green() {
+    // A gate failure (no Wilson interval computed) carries no
+    // pass/fail verdict at all — `not_run` class, but not a finding.
+    let markdown = render(
+        "gate-failure",
+        r#"{"result":"dataset_invalid","formal_result":"not_run","requirements":["REQ-AUDIT-001"]}"#,
+    );
+    let row = requirement_row(&markdown);
+    assert!(row.contains('🟢'), "{row}");
+    assert!(!row.contains("external_evidence"), "{row}");
+}

--- a/rust/fslc/tests/ledger_impl_log_cli.rs
+++ b/rust/fslc/tests/ledger_impl_log_cli.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for issue #499: `fslc ledger --impl-log` used to discard
+//! every replay error (missing file, malformed JSON, wrong-spec trace,
+//! schema-invalid trace) and still return `result: "generated"` at exit 0
+//! with the implementation-log row silently missing. The ledger is an audit
+//! artifact, so a silently-empty evidence chain is worse here than a crash
+//! (AGENTS.md: "a confidently green false negative is more dangerous than a
+//! crash"). Every `*_errors` test here fails if the fix is reverted; the
+//! `*_still_generates` tests guard that legitimate replay evidence
+//! (conformant and nonconformant, as opposed to a replay error) is not
+//! collaterally broken by making the command fail-closed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::Value;
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = repo_root().join(format!(
+        "rust/target/ledger-impl-log-cli-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native fslc")
+}
+
+fn json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("JSON stdout")
+}
+
+const SPEC: &str = "replay_trace.fsl";
+
+fn ledger_with_impl_log(impl_log: &Path, output_md: &Path) -> Output {
+    run(&[
+        "ledger",
+        fixture(SPEC).to_str().expect("spec path"),
+        "--impl-log",
+        impl_log.to_str().expect("impl-log path"),
+        "-o",
+        output_md.to_str().expect("output path"),
+    ])
+}
+
+#[test]
+fn ledger_impl_log_missing_file_errors() {
+    let dir = scratch_dir("missing-file");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(Path::new("/no/such/impl-log.json"), &out);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "io");
+    assert!(
+        !out.exists(),
+        "ledger must not be written on a replay error"
+    );
+}
+
+#[test]
+fn ledger_impl_log_malformed_json_errors() {
+    let dir = scratch_dir("malformed-json");
+    let log = dir.join("log.json");
+    fs::write(&log, "not json").expect("write malformed log");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(&log, &out);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert!(
+        !out.exists(),
+        "ledger must not be written on a replay error"
+    );
+}
+
+#[test]
+fn ledger_impl_log_wrong_spec_errors() {
+    let dir = scratch_dir("wrong-spec");
+    let mut trace: Value = serde_json::from_str(
+        &fs::read_to_string(fixture("replay_trace.valid.v1.json")).expect("read fixture"),
+    )
+    .expect("parse fixture JSON");
+    trace["spec"] = Value::String("SomeOtherSpec".to_owned());
+    let log = dir.join("log.json");
+    fs::write(&log, trace.to_string()).expect("write wrong-spec log");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(&log, &out);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert!(
+        value["message"]
+            .as_str()
+            .expect("error message")
+            .contains("does not match checked spec"),
+        "{value}"
+    );
+    assert!(
+        !out.exists(),
+        "ledger must not be written on a replay error"
+    );
+}
+
+#[test]
+fn ledger_impl_log_schema_invalid_trace_errors() {
+    // `replay_trace.bad-tick.v1.json` declares tick 2 for its first event,
+    // which the versioned replay-trace schema rejects (ticks must start at
+    // 1 and increase by exactly one).
+    let dir = scratch_dir("schema-invalid");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(&fixture("replay_trace.bad-tick.v1.json"), &out);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let value = json(&output);
+    assert_eq!(value["result"], "error");
+    assert!(
+        !out.exists(),
+        "ledger must not be written on a replay error"
+    );
+}
+
+#[test]
+fn ledger_impl_log_conformant_trace_still_generates() {
+    let dir = scratch_dir("conformant");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(&fixture("replay_trace.valid.v1.json"), &out);
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(&out).expect("ledger written");
+    assert!(content.contains("実装ログ適合: 適合"), "{content}");
+}
+
+#[test]
+fn ledger_impl_log_nonconformant_trace_still_generates() {
+    // Nonconformance is legitimate replay evidence (the implementation log
+    // disagrees with the spec), not a replay error, and must keep surfacing
+    // in the ledger exactly as before this fix.
+    let dir = scratch_dir("nonconformant");
+    let out = dir.join("ledger.md");
+    let output = ledger_with_impl_log(&fixture("replay_trace.state-mismatch.v1.json"), &out);
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(&out).expect("ledger written");
+    assert!(content.contains("実装ログ適合"), "{content}");
+    assert!(content.contains("非適合"), "{content}");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1179,7 +1179,12 @@ runs `verify`, while omitting `depth` runs `check`. A layer with
 `refine_against = "requirements"` must also set `mapping = "..."`. `[impl]`
 runs its shell `command` from the manifest directory. JSON is stdout; the
 consolidated table is stderr. Without `--keep-going`, execution stops after the
-first failed layer and later layers are marked `skipped`.
+first failed layer and later layers are marked `skipped`. The manifest reader
+is fail-closed: an unrecognized top-level section name, zero recognized
+sections (including an empty file), or a present-but-unparseable `depth` /
+`refine_depth` value (e.g. one followed by an inline comment) is a `kind:
+"parse"` error at exit 2 rather than a silently dropped layer or a silently
+substituted default — only an *absent* `depth`/`refine_depth` key defaults.
 
 - `mutate` applies a deterministic single mutation to the kernel AST (requires
   deletion/negation, assignment deletion, enum swap, integer/type-bound ±1,

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1145,7 +1145,12 @@ reader can decide approve/reject/risk-accept from. It is a presentation layer
 (no new verification): the `trace_type` discriminator drives a per-finding
 business translation, governance columns (risk/decider) come from `control`
 metadata when present (fill-in otherwise), and the guarantee limit is stated in
-positive form. Raw JSON is demoted to a collapsed appendix. See
+positive form. Raw JSON is demoted to a collapsed appendix. `--impl-log
+<trace.json>` folds a `run_replay` conformance row into the ledger, but a
+replay **error** (missing file, malformed JSON, wrong-spec trace,
+schema-invalid trace) fails the whole `ledger` command through the standard
+error envelope and exit code, the same as `--evidence`, rather than rendering
+a ledger with the implementation-log row silently missing. See
 `docs/DESIGN-ledger.md`.
 
 Digest-bound approvals (issue #190) are separate from assurance class and from

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1150,8 +1150,15 @@ positive form. Raw JSON is demoted to a collapsed appendix. `--impl-log
 replay **error** (missing file, malformed JSON, wrong-spec trace,
 schema-invalid trace) fails the whole `ledger` command through the standard
 error envelope and exit code, the same as `--evidence`, rather than rendering
-a ledger with the implementation-log row silently missing. See
-`docs/DESIGN-ledger.md`.
+a ledger with the implementation-log row silently missing. A **failing**
+`--evidence` source (a definitive nonconformant/mismatch/unsupported verdict,
+not a verdict-less gate failure) adds a 🔴 要確認 finding for every
+requirement it attaches to — its own root `requirements`/`requirement.id`, or
+a `requirement.id` nested inside a `findings`/`checks` array item — or a
+spec-level（仕様全体）finding when it fails with no attribution at all; it
+never silently renders green while failing evidence sits unread in the
+appendix, and never changes assurance class (that stays orthogonal to
+verdict). See `docs/DESIGN-ledger.md`.
 
 Digest-bound approvals (issue #190) are separate from assurance class and from
 the ledger's empty human-decision checkbox. `approval create` must be run from a


### PR DESCRIPTION
## Problem

Two commands returned a success verdict and exit 0 while silently discarding the very errors they exist to surface, and the documented happy path of `fslc chain` did not run at all.

**#489 — `fslc chain` silently drops layers it cannot parse.** With a manifest containing a misspelled section next to a valid one:

```toml
[businesss]
file = "business.fsl"

[requirements]
file = "requirements.fsl"
```

`fslc chain` reported `result:"verified"` / exit 0, having verified **only the `requirements` layer**. The user believes a two-layer chain was checked; one layer never ran. The same shape applied to a present-but-unparseable `depth` / `refine_depth` value (for example one carrying an inline comment), which fell through to a silent `unwrap_or(8)` — so a manifest declaring `depth = 12` could be verified at depth 8 while still reporting success.

**#499 — `fslc ledger --impl-log` discards every replay error.** `run_replay`'s exit status was thrown away (`.map(|trace| run_replay(...).0)`), so a missing, malformed, wrong-spec, or schema-invalid trace still produced a rendered markdown ledger and exit 0. The ledger is an audit artifact; a silently-empty evidence chain is the worst version of this bug class.

**#500 — the documented invocation does not work.** `fslc chain fsl-project.toml` run from the manifest's own directory always failed its `[impl]` layer with an io error, because an empty manifest-parent was never normalized to `.` before resolving files.

**#508 — failing external evidence was not surfaced as requirement findings.**

## Contract change

All four fail closed instead of failing silent. No language contract changes.

- **#489 / #500** — an unrecognized top-level section, or zero recognized sections, now returns `kind:"parse"` / exit 2 instead of a vacuous `verified` with `layers: []`. A present-but-unparseable `depth`/`refine_depth` errors for that layer; **only an absent key still defaults**, which is the distinction that makes the fix safe. An empty manifest parent normalizes to `"."` before resolving files and launching `[impl]`.
- **#499** — `run_replay`'s status is no longer discarded. Status 0 (`conformant`) and 1 (`nonconformant`) still render as before; status ≥ 2 (io / parse / internal) returns through the same `Result<PreparedLedgerReport, Value>` path `--evidence` already used, producing the standard `(error, 2)` envelope. **No ledger file is written.**
- **#508** — failing external evidence is reported as requirement findings rather than omitted. Kept as a separate commit from #499: replay-transport errors and failing evidence *content* are different root causes on the same surface.

## Test evidence

Verified independently against a `main` binary:

| case | before | after |
|---|---|---|
| `chain typo.toml` (`[businesss]` + valid `[requirements]`) | `result:"verified"` / exit 0, typo'd layer silently dropped | `result:"error"` / `kind:"parse"` / exit 2 / `"unrecognized manifest section(s): [businesss] (expected [business], [requirements], [design], and/or [impl])"` |
| `ledger specs/cart_v1.fsl --impl-log /no/such/file.jsonl` | markdown ledger written, no impl-log row, exit 0 | `result:"error"` / `kind:"io"` / exit 2, no file written |

Every negative control was confirmed by **reverting the fix, observing the failure, and restoring**:

- `chain_cli.rs` — reverting `main.rs` produced **8 failed / 0 passed**; restored, 8/8 pass. Controls: `chain_rejects_empty_manifest`, `chain_rejects_unknown_section_name`, `chain_rejects_manifest_with_inline_comment_depth`, `chain_rejects_malformed_refine_depth`.
- `ledger_impl_log_cli.rs` — reverting produced **4 failed / 2 passed** (`..._missing_file_errors`, `..._malformed_json_errors`, `..._wrong_spec_errors`, `..._schema_invalid_trace_errors`); restored, 6/6 pass. Each also asserts **no ledger file was written**.

Two controls deserve specific mention because they pin things a weaker test would miss:

- **`chain_honors_declared_depth_beyond_the_silent_fallback_of_eight`** uses a spec whose invariant only breaks at step 9 and asserts that `depth = 9` actually yields `violated` / exit 1. This proves the declared depth is *honestly consumed* rather than silently downgraded to the `unwrap_or(8)` fallback — a test that only checked "malformed depth errors" would still pass against a build that quietly downgraded every valid depth.
- **`chain_omitted_depth_still_defaults`** is the counterpart regression control, keeping the legitimate default path distinguishable from the malformed one.

Positive controls confirm no regression: `chain_default_and_bare_filename_invocations_run_impl_layer`, `chain_clean_manifest_runs_five_layers_and_verifies`, `ledger_impl_log_conformant_trace_still_generates`, `ledger_impl_log_nonconformant_trace_still_generates`.

Gate on the rebased base (`main` @ 15ae1e0): `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (118 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/DESIGN-layers.md` §7, `docs/DESIGN-ledger.md`, `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (1:1 section-aligned, exit-code paragraph), `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #489, fixes #500, fixes #499, fixes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
