### PR TITLE
feat(verify): implement relation ops, liveness symmetry reduction, and helpful leadsTo ranking natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `relation A -> B` state is now usable end to end in the native symbolic
+  verifier: `r = Set {}` types and evaluates as the empty relation (both
+  `fslc check` and the concrete Monitor previously rejected or mistyped it),
+  and `fslc verify`/`fslc mutate` implement all seven relation operations
+  (`.contains(a, b)`, `.add(a, b)`, `.remove(a, b)`, `reachable(r, a, b)`,
+  `acyclic(r)`, `functional(r)`, `injective(r)`, `domain(r)`, `range(r)`),
+  matching the frozen Python reference's semantics (`reachable`/`acyclic`
+  require a self-relation and are rejected otherwise; a memoized bounded-hop
+  closure avoids the unmemoized-blowup class of bug already fixed in the
+  Python reference) (#467).
 - Native `leadsTo` lasso and deadlock-stall search now applies the documented
   `symmetric type` / `symmetric enum` liveness symmetry reduction: the
   designated representative state (lasso loop head, or the stalled state) is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- `verify --engine induction` now implements `leadsTo ... helpful` per-binding
+  ranking proofs natively, matching the documented idiom for per-entity
+  progress under interleaving. `fslc check` rejects a `helpful` action that
+  names an undeclared action or has the wrong arity; ranking induction
+  additionally proves the four `helpful`-specific obligations (matching
+  action `fair`, an enabled matching instance whenever pending, stable
+  enabledness across two or more `helpful` actions, and non-helpful actions
+  neither dropping the pending obligation nor increasing the measure),
+  reporting `progress_action_not_fair`, `helpful_action_not_enabled`,
+  `helpful_action_enabledness_not_sticky`, `non_decreasing_helpful_action`,
+  `non_helpful_action_increases_measure`, or `pending_not_preserved` on
+  failure and echoing `helpful` on both the proof and CTI (#473).
+
 ### Added
 - Native `analyze`'s TSG projection now emits `requirement`/`acceptance`/
   `forbidden`/`kpi` nodes and `covers` edges for a standalone `.fsl`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Native `leadsTo` lasso and deadlock-stall search now applies the documented
+  `symmetric type` / `symmetric enum` liveness symmetry reduction: the
+  designated representative state (lasso loop head, or the stalled state) is
+  constrained to the canonical permutation of each symmetric type's
+  per-entity rows, built from `Map<SymmetricType, V>` and
+  `Set<SymmetricType>` state (skipping any `V` that itself mentions a
+  symmetric identity type), matching the frozen Python reference. A genuine
+  per-entity violation (only one identity ever stalls) is still found under
+  both `Map`- and `Set`-shaped symmetric state (#461).
 - `verify --engine induction` now implements `leadsTo ... helpful` per-binding
   ranking proofs natively, matching the documented idiom for per-entity
   progress under interleaving. `fslc check` rejects a `helpful` action that

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 | [`DESIGN-stochastic.md`](DESIGN-stochastic.md) | **fsl-stochastic external evidence layer**. Implemented semantics for precomputed eval JSONL, Bernoulli/proportion metrics, Wilson intervals, result statuses, and the boundary between statistical support and formal proof |
 | [`DESIGN-causal.md`](DESIGN-causal.md) | **`causal` profile (review-only causal hypothesis graphs)**. Typed CausalModel, scope containment, lag/persists time semantics, delayed-feedback classification, evidence/expectation plane boundaries, and JSON contracts — causal claims never receive `proved`/`verified` |
 | [`DESIGN-v1.md`](DESIGN-v1.md) | Language design document (design principles G1-G5, type-system design decisions, the repair protocol, and the roadmap) |
+| [`DESIGN-enum-member-identity.md`](DESIGN-enum-member-identity.md) | Checked-Kernel enum-member identity and lookup: nominal resolution of bare enum-member syntax, shadowing precedence, and the refinement-boundary go/no-go for `KernelModel.enum_members` |
 
 ## Implementation design by architecture and feature (DESIGN-*)
 
@@ -62,6 +63,14 @@
 | [`DESIGN-precedence-policy.md`](DESIGN-precedence-policy.md) | The business-layer no-bypass precedence policy (#75) — why `business` keeps users from writing `state`/`invariant` directly |
 | [`DESIGN-ledger.md`](DESIGN-ledger.md) | `fslc ledger` (turning verifier evidence into a per-requirement-id Markdown audit ledger for PM/audit) |
 | [`DESIGN-assurance-classes.md`](DESIGN-assurance-classes.md) | Assurance-class vocabulary (`proved`/`bounded`/`replay-observed`/`statistical`/`not_run`) shared by `fslc ledger` and `fslc html`, and what each class does/does not guarantee |
+| [`DESIGN-document-requirement-claim-ir.md`](DESIGN-document-requirement-claim-ir.md) | `fslc document` foundation (issue #325): the versioned Requirement Claim IR (RCIR) v1 public contract and the deterministic requirement-claim projector |
+| [`DESIGN-document-controlled-language-renderer.md`](DESIGN-document-controlled-language-renderer.md) | ja/en controlled-language renderer (issue #326): converts an RCIR v1 claim set into `fsl_tools::render_requirements_document` prose |
+| [`DESIGN-document-cli.md`](DESIGN-document-cli.md) | `fslc document generate` / `fslc document claims` (issue #327): wires the RCIR projector and controlled-language renderer into the two CLI entry points |
+| [`DESIGN-document-generated-markers-and-check.md`](DESIGN-document-generated-markers-and-check.md) | Generated block markers and `fslc document check` (issue #329): structural markers/frontmatter on generated artifacts and the purely structural drift checker |
+| [`DESIGN-document-glossary.md`](DESIGN-document-glossary.md) | Glossary sidecar for `fslc document` (issue #330): presentation-only glossary generation and glossary-parity awareness in `fslc document check` |
+| [`DESIGN-document-evidence-overlay.md`](DESIGN-document-evidence-overlay.md) | Evidence/assurance overlay for `fslc document` (issue #332): overlays saved external verification evidence onto a generated requirements document at requirement granularity |
+| [`DESIGN-document-dialect-adapters.md`](DESIGN-document-dialect-adapters.md) | `fslc document`'s dialect boundary (issue #334, v1 slice): explicit rejection of non-kernel dialects rather than adapters, and the scope left open for cross-layer views |
+| [`DESIGN-document-coverage-registry.md`](DESIGN-document-coverage-registry.md) | RCIR coverage registry and no-silent-omission gate (issue #328): classifies every authored semantic target into exactly one of `rendered`/deliberately-excluded/flagged-as-missing |
 | [`DESIGN-mutate.md`](DESIGN-mutate.md) | `fslc mutate` (spec mutation, requirement stress report) |
 | [`DESIGN-explain.md`](DESIGN-explain.md) | `fslc explain --readable` (verification bounds, skeleton enumeration, counterfactuals, witness narration) |
 | [`DESIGN-html-report.md`](DESIGN-html-report.md) | `fslc html` (self-contained visual review report from explain + verify evidence) |

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -16,8 +16,9 @@ use serde_json::Value;
 pub use fsl_syntax::{
     AggregateKind as KernelAggregateKind, Annotation, AnnotationError,
     AnnotationRegistry as KernelAnnotationRegistry, AnnotationValue, Annotations,
-    Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr, LValue as KernelLValue,
-    Pattern, QualifiedName, RequirementLink, Statement as KernelStatement, SymbolPath,
+    Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr, HelpfulAction,
+    LValue as KernelLValue, Pattern, QualifiedName, RequirementLink, Statement as KernelStatement,
+    SymbolPath,
 };
 
 mod compose;

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -5,8 +5,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use fsl_syntax::{
-    ActionItem, Annotation, AnnotationRegistry, Annotations, Binder, Expr, LValue, MetaTag, Param,
-    RequirementLink, SourcePos, Span, SpecItem, Statement, SurfaceSpec, TypeExpr,
+    ActionItem, Annotation, AnnotationRegistry, Annotations, Binder, Expr, HelpfulAction, LValue,
+    MetaTag, Param, RequirementLink, SourcePos, Span, SpecItem, Statement, SurfaceSpec, TypeExpr,
 };
 
 use crate::{
@@ -122,6 +122,7 @@ pub struct LeadsToDef {
     pub annotations: Annotations,
     pub decreases: Option<Expr>,
     pub within: Option<i64>,
+    pub helpful: Vec<HelpfulAction>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -758,6 +759,7 @@ impl ModelBuilder {
                             .clone(),
                         decreases: None,
                         within: None,
+                        helpful: Vec::new(),
                     });
                 }
                 SpecItem::LeadsTo {
@@ -769,6 +771,7 @@ impl ModelBuilder {
                     meta,
                     decreases,
                     within,
+                    helpful,
                     ..
                 } => {
                     let origin = self
@@ -791,6 +794,7 @@ impl ModelBuilder {
                             .map(|expr| self.const_int(expr))
                             .transpose()
                             .map_err(|error| error.with_origin(origin))?,
+                        helpful: helpful.clone(),
                     });
                 }
                 _ => {}

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -1117,6 +1117,29 @@ pub(crate) fn validate_model_expression_types(model: &KernelModel) -> Result<(),
         if let Some(expr) = &leadsto.decreases {
             validate_expression(expr, &local, model, leadsto.span, Some(&TypeRef::Int))?;
         }
+        for helper in &leadsto.helpful {
+            let Some(action) = model
+                .actions
+                .iter()
+                .find(|action| action.name == helper.action)
+            else {
+                return Err(error(format!(
+                    "leadsTo '{}' helpful action '{}' is not declared",
+                    leadsto.name, helper.action
+                ))
+                .with_span(helper.span));
+            };
+            if helper.args.len() != action.params.len() {
+                return Err(error(format!(
+                    "leadsTo '{}' helpful action '{}' expects {} argument(s), got {}",
+                    leadsto.name,
+                    helper.action,
+                    action.params.len(),
+                    helper.args.len()
+                ))
+                .with_span(helper.span));
+            }
+        }
     }
     if let Some(expr) = &model.terminal {
         validate_expression(expr, &env, model, unknown_span(), Some(&TypeRef::Bool))?;

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -170,10 +170,19 @@ pub(crate) fn infer_type(
             )?)))
         }
         Expr::Set(items) => {
-            if let Some(expected) = expected
-                && matches!(resolve(model, expected)?, TypeRef::Set(_))
-            {
-                return Ok(expected.clone());
+            if let Some(expected) = expected {
+                match resolve(model, expected)? {
+                    TypeRef::Set(_) => return Ok(expected.clone()),
+                    TypeRef::Relation(_, _) => {
+                        if !items.is_empty() {
+                            return Err(error(
+                                "relation literals only support the empty initializer Set {}; use r = r.add(a, b) to add pairs",
+                            ));
+                        }
+                        return Ok(expected.clone());
+                    }
+                    _ => {}
+                }
             }
             let first = items
                 .first()
@@ -414,6 +423,16 @@ pub(crate) fn ensure_assignable(
                 ensure_assignable(item, expected_item, env, model, span)?;
             }
             return Ok(());
+        }
+        (Expr::Set(items), TypeRef::Relation(_, _)) => {
+            return if items.is_empty() {
+                Ok(())
+            } else {
+                Err(error(
+                    "relation literals only support the empty initializer Set {}; use r = r.add(a, b) to add pairs",
+                )
+                .with_span(span))
+            };
         }
         (
             Expr::Conditional {
@@ -779,6 +798,12 @@ fn validate_expression(
                 return Err(error("some expression did not infer Option"));
             };
             validate_expression(item, env, model, span, Some(&inner))?;
+        }
+        Expr::Set(items) if matches!(resolve(model, &ty)?, TypeRef::Relation(_, _)) => {
+            // Relation literals only support the empty initializer `Set {}`;
+            // emptiness is already enforced by `infer_type`/`ensure_assignable`
+            // (there is no per-element type to validate against).
+            debug_assert!(items.is_empty());
         }
         Expr::Set(items) | Expr::Seq(items) => {
             let item_ty = collection_item_type(&ty, model)?;

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2892,7 +2892,7 @@ fn assign(
 ) -> Result<(), RuntimeError> {
     match target {
         LValue::Var(name) => {
-            target_state.insert(name.clone(), value);
+            target_state.insert(name.clone(), coerce_relation_literal(name, value, model));
         }
         LValue::Index(name, index_expr) => {
             let index = eval(index_expr, read_state, bindings, model, None)?;
@@ -2965,6 +2965,22 @@ fn assign(
         },
     }
     Ok(())
+}
+
+/// `Set {}` is the only relation literal surface syntax accepts (public
+/// Kernel typing rejects a non-empty one), but `eval`'s `Expr::Set` arm has
+/// no assignment-target type context and always produces `Value::Set`.
+/// Coerce it here, where the target variable's declared type is known --
+/// mirrors the symbolic evaluator's `SymbolicValue::SetLiteral` ->
+/// `SymbolicValue::Relation` coercion (`fsl-verifier/src/value.rs::coerce`).
+fn coerce_relation_literal(name: &str, value: Value, model: &KernelModel) -> Value {
+    if let Value::Set(items) = &value
+        && items.is_empty()
+        && matches!(model.state_type(name), Some(TypeRef::Relation(_, _)))
+    {
+        return Value::Relation(BTreeSet::new());
+    }
+    value
 }
 
 fn lvalue_key(

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -8,6 +8,7 @@ use fsl_solver::{SatResult, SmtSolver};
 use crate::VerifyError;
 use crate::eval::eval;
 use crate::liveness::{LeadstoBinding, leadsto_bindings, leadsto_condition};
+use crate::symmetry::canonical_constraint;
 use crate::trace::project_trace;
 use crate::transition::{
     ActionInstance, action_guards, action_instances, init_constraints, transition_constraint,
@@ -662,12 +663,14 @@ async fn check_leadsto_stagnation<S: SmtSolver>(
     enabled: &[S::Term],
 ) -> Result<Option<BmcViolation>, VerifyError> {
     let deadlock = solver.not(&solver.or(enabled)?)?;
+    let canonical = canonical_constraint(solver, model, &states[step])?;
     for property in &model.leadstos {
         solver.set_query_context("leadsTo", &property.name);
         for binding in leadsto_bindings(solver, model, property)? {
             for pending in 0..=step {
                 let mut terms = vec![
                     deadlock.clone(),
+                    canonical.clone(),
                     leadsto_condition(
                         solver,
                         model,
@@ -806,6 +809,11 @@ async fn check_leadstos<S: SmtSolver>(
     instances: &[ActionInstance<S::Term>],
     depth: usize,
 ) -> Result<Option<BmcViolation>, VerifyError> {
+    let canonical = states
+        .iter()
+        .take(depth + 1)
+        .map(|state| canonical_constraint(solver, model, state))
+        .collect::<Result<Vec<_>, _>>()?;
     for property in &model.leadstos {
         solver.set_query_context("leadsTo", &property.name);
         for binding in leadsto_bindings(solver, model, property)? {
@@ -819,6 +827,7 @@ async fn check_leadstos<S: SmtSolver>(
                     for pending in 0..loop_end {
                         let mut terms = vec![
                             loop_equal.clone(),
+                            canonical[loop_start].clone(),
                             fair.clone(),
                             leadsto_condition(
                                 solver,

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -176,6 +176,88 @@ pub(crate) fn eval<S: SmtSolver>(
                     solver.ite(&nonnegative, term, &solver.neg(term)?)?,
                 ))
             }
+            "rel_functional" | "rel_injective" => {
+                let value = eval(solver, model, expr, state, bindings, old_state)?;
+                let SymbolicValue::Relation { entries, .. } = value else {
+                    return Err(VerifyError::new(format!("{name}() requires a relation")));
+                };
+                let same_key = |left: &(FslValue, FslValue), right: &(FslValue, FslValue)| {
+                    if name == "rel_functional" {
+                        left.0 == right.0
+                    } else {
+                        left.1 == right.1
+                    }
+                };
+                let mut clauses = Vec::new();
+                for (index, (key, present)) in entries.iter().enumerate() {
+                    for (other_key, other_present) in entries.iter().skip(index + 1) {
+                        if same_key(key, other_key) {
+                            clauses
+                                .push(solver.not(
+                                    &solver.and(&[present.clone(), other_present.clone()])?,
+                                )?);
+                        }
+                    }
+                }
+                Ok(bool_value(solver, solver.and(&clauses)?))
+            }
+            "rel_domain" | "rel_range" => {
+                let value = eval(solver, model, expr, state, bindings, old_state)?;
+                let SymbolicValue::Relation { ty, entries } = value else {
+                    return Err(VerifyError::new(format!("{name}() requires a relation")));
+                };
+                let TypeRef::Relation(source_ty, target_ty) = &ty else {
+                    unreachable!();
+                };
+                let (element_ty, values) = if name == "rel_domain" {
+                    (source_ty.as_ref().clone(), model.domain_values(source_ty)?)
+                } else {
+                    (target_ty.as_ref().clone(), model.domain_values(target_ty)?)
+                };
+                let mut element_entries = Vec::with_capacity(values.len());
+                for element in values {
+                    let present_terms = entries
+                        .iter()
+                        .filter(|((source, target), _)| {
+                            if name == "rel_domain" {
+                                source == &element
+                            } else {
+                                target == &element
+                            }
+                        })
+                        .map(|(_, present)| present.clone())
+                        .collect::<Vec<_>>();
+                    element_entries.push((element, solver.or(&present_terms)?));
+                }
+                Ok(SymbolicValue::Set {
+                    ty: TypeRef::Set(Box::new(element_ty)),
+                    entries: element_entries,
+                })
+            }
+            "rel_acyclic" => {
+                let value = eval(solver, model, expr, state, bindings, old_state)?;
+                let SymbolicValue::Relation { ty, entries } = value else {
+                    return Err(VerifyError::new("acyclic() requires a relation"));
+                };
+                let TypeRef::Relation(source_ty, target_ty) = &ty else {
+                    unreachable!();
+                };
+                if source_ty != target_ty {
+                    return Err(VerifyError::new(
+                        "acyclic() requires a self-relation (relation T -> T)",
+                    ));
+                }
+                let reach = relation_reachability_table(solver, model, &entries, source_ty)?;
+                let mut cyclic_terms = Vec::new();
+                for ((source, target), present) in &entries {
+                    let back = reach
+                        .get(&(target.clone(), source.clone()))
+                        .ok_or_else(|| VerifyError::new("relation reachability table gap"))?;
+                    cyclic_terms.push(solver.and(&[present.clone(), back.clone()])?);
+                }
+                let cyclic = solver.or(&cyclic_terms)?;
+                Ok(bool_value(solver, solver.not(&cyclic)?))
+            }
             _ => Err(VerifyError::new(format!(
                 "unsupported unary expression '{name}'"
             ))),
@@ -197,10 +279,85 @@ pub(crate) fn eval<S: SmtSolver>(
                 solver.ite(&condition, int_term(&left)?, int_term(&right)?)?,
             ))
         }
+        Expr::TernaryNamed {
+            name,
+            first,
+            second,
+            third,
+        } if name == "rel_reachable" => {
+            let relation = eval(solver, model, first, state, bindings, old_state)?;
+            let SymbolicValue::Relation { ty, entries } = relation else {
+                return Err(VerifyError::new("reachable() requires a relation"));
+            };
+            let TypeRef::Relation(source_ty, target_ty) = &ty else {
+                unreachable!();
+            };
+            if source_ty != target_ty {
+                return Err(VerifyError::new(
+                    "reachable() requires a self-relation (relation T -> T)",
+                ));
+            }
+            let source = eval(solver, model, second, state, bindings, old_state)?;
+            let target = eval(solver, model, third, state, bindings, old_state)?;
+            let reach = relation_reachability_table(solver, model, &entries, source_ty)?;
+            let mut terms = Vec::with_capacity(reach.len());
+            for ((from, to), reachable) in &reach {
+                let from_term = concrete_value(solver, model, source_ty, from)?;
+                let to_term = concrete_value(solver, model, target_ty, to)?;
+                let same_source = logical_equal(solver, model, &source, &from_term)?;
+                let same_target = logical_equal(solver, model, &target, &to_term)?;
+                terms.push(solver.and(&[same_source, same_target, reachable.clone()])?);
+            }
+            Ok(bool_value(solver, solver.or(&terms)?))
+        }
         Expr::TernaryNamed { name, .. } => Err(VerifyError::new(format!(
             "unsupported ternary expression '{name}'"
         ))),
     }
+}
+
+/// Bounded-hop symbolic reachability closure over a relation's finite
+/// (source, target) domain grid, memoized by iterative relaxation (hop bound
+/// = domain size, sound for both `reachable()` and `acyclic()`'s cycle
+/// check). Ports the frozen Python symbolic reference's
+/// `bmc.py::_relation_reachable_expr` (path of at least one edge -- see the
+/// base-case note below for why this intentionally does not match the
+/// concrete Monitor's own trivial-self-reachability convention).
+fn relation_reachability_table<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    entries: &[((FslValue, FslValue), S::Term)],
+    domain_ty: &TypeRef,
+) -> Result<BTreeMap<(FslValue, FslValue), S::Term>, VerifyError> {
+    let values = model.domain_values(domain_ty)?;
+    let direct: BTreeMap<(FslValue, FslValue), S::Term> = entries.iter().cloned().collect();
+    // Base case: a path of exactly one hop (a direct edge). Unlike the
+    // concrete Monitor's BFS oracle (which treats a node as trivially
+    // "reachable" from itself with zero hops), the frozen Python symbolic
+    // reference (`bmc.py::_relation_reachable_expr`) requires at least one
+    // edge -- `reachable(r, a, a)` is only true when `a` has an actual path
+    // back to itself (e.g. a self-loop or a cycle through it). Matching the
+    // symbolic reference here (not the concrete one) is what this port's
+    // `--engine bmc`/`induction` verdicts are graded against.
+    let mut reach: BTreeMap<(FslValue, FslValue), S::Term> = direct.clone();
+    for _ in 0..values.len() {
+        let mut next = BTreeMap::new();
+        for a in &values {
+            for b in &values {
+                let mut terms = vec![reach[&(a.clone(), b.clone())].clone()];
+                for c in &values {
+                    let via_c = solver.and(&[
+                        reach[&(a.clone(), c.clone())].clone(),
+                        direct[&(c.clone(), b.clone())].clone(),
+                    ])?;
+                    terms.push(via_c);
+                }
+                next.insert((a.clone(), b.clone()), solver.or(&terms)?);
+            }
+        }
+        reach = next;
+    }
+    Ok(reach)
 }
 
 /// Build the condition under which concrete evaluation of `expr` completes
@@ -825,9 +982,47 @@ fn eval_method<S: SmtSolver>(
                 ))),
             }
         }
-        SymbolicValue::Relation { .. } => Err(VerifyError::new(
-            "relation methods are not implemented in the current verifier slice",
-        )),
+        SymbolicValue::Relation { ty, entries } => {
+            let TypeRef::Relation(source_ty, target_ty) = &ty else {
+                unreachable!();
+            };
+            match (name, values.as_slice()) {
+                ("contains", [source, target]) => {
+                    let mut terms = Vec::with_capacity(entries.len());
+                    for ((entry_source, entry_target), present) in &entries {
+                        let source_term = concrete_value(solver, model, source_ty, entry_source)?;
+                        let target_term = concrete_value(solver, model, target_ty, entry_target)?;
+                        let same_source = logical_equal(solver, model, source, &source_term)?;
+                        let same_target = logical_equal(solver, model, target, &target_term)?;
+                        terms.push(solver.and(&[same_source, same_target, present.clone()])?);
+                    }
+                    Ok(bool_value(solver, solver.or(&terms)?))
+                }
+                ("add" | "remove", [source, target]) => {
+                    let added = name == "add";
+                    let entries = entries
+                        .into_iter()
+                        .map(|((entry_source, entry_target), present)| {
+                            let source_term =
+                                concrete_value(solver, model, source_ty, &entry_source)?;
+                            let target_term =
+                                concrete_value(solver, model, target_ty, &entry_target)?;
+                            let same_source = logical_equal(solver, model, source, &source_term)?;
+                            let same_target = logical_equal(solver, model, target, &target_term)?;
+                            let matches = solver.and(&[same_source, same_target])?;
+                            Ok((
+                                (entry_source, entry_target),
+                                solver.ite(&matches, &solver.bool_value(added), &present)?,
+                            ))
+                        })
+                        .collect::<Result<_, VerifyError>>()?;
+                    Ok(SymbolicValue::Relation { ty, entries })
+                }
+                _ => Err(VerifyError::new(format!(
+                    "invalid relation method '{name}'"
+                ))),
+            }
+        }
         _ => Err(VerifyError::new(
             "method receiver has no collection methods",
         )),

--- a/rust/fsl-verifier/src/induction.rs
+++ b/rust/fsl-verifier/src/induction.rs
@@ -2,14 +2,14 @@
 
 use std::collections::BTreeMap;
 
-use fsl_core::{FslValue, KernelModel, TypeDef, TypeRef};
+use fsl_core::{FslValue, HelpfulAction, KernelExpr, KernelModel, LeadsToDef, TypeDef, TypeRef};
 use fsl_solver::{ModelValue, SatResult, SmtSolver};
 
 use crate::VerifyError;
 use crate::eval::eval;
 use crate::liveness::{leadsto_bindings, leadsto_condition};
 use crate::trace::project_trace;
-use crate::transition::{action_instances, transition_constraint};
+use crate::transition::{ActionInstance, action_instances, transition_constraint};
 use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, i64_index, int_term, symbolic_state_with_suffix,
 };
@@ -32,6 +32,18 @@ pub struct InductionResult {
 pub struct RankProof {
     pub name: String,
     pub measure: fsl_core::KernelExpr,
+    /// The leadsTo's declared `helpful` action metadata, carried through
+    /// unformatted so the CLI can render display labels.
+    pub helpful: Vec<HelpfulAction>,
+}
+
+/// One `helpful`-matching or `helpful`-blocking action instance, named for
+/// JSON rendering by the caller (mirrors the frozen Python reference's
+/// `helpful_actions` display list).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HelpfulActionWitness {
+    pub action: String,
+    pub params: BTreeMap<String, FslValue>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,6 +59,14 @@ pub struct RankFailure {
     pub trace: Vec<fsl_core::TraceStep>,
     pub hint: String,
     pub message: String,
+    /// The leadsTo's declared `helpful` action metadata (empty unless the
+    /// property declares `helpful`).
+    pub helpful: Vec<HelpfulAction>,
+    /// The matched/blocked helpful action instance(s) relevant to this
+    /// failure (empty unless `kind` is one of the `helpful_*`/
+    /// `progress_action_not_fair`/`non_helpful_action_increases_measure`
+    /// kinds).
+    pub helpful_actions: Vec<HelpfulActionWitness>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -269,6 +289,143 @@ fn model_int<S: SmtSolver>(solver: &S, term: &S::Term) -> Result<i64, VerifyErro
     }
 }
 
+fn model_bool<S: SmtSolver>(solver: &S, term: &S::Term) -> Result<bool, VerifyError> {
+    match solver.model_eval(term)? {
+        Some(ModelValue::Bool(value)) => Ok(value),
+        Some(ModelValue::Int(_)) => Err(VerifyError::new("ranking condition is an integer")),
+        None => Err(VerifyError::new(
+            "ranking condition is unavailable in model",
+        )),
+    }
+}
+
+const HELPFUL_ARG_HINT: &str = "helpful action arguments must be state-independent leadsto \
+    binders, constants, enum members, or arithmetic (+, -, *) over those values";
+
+const HELPFUL_PROGRESS_HINT: &str = "helpful marks which action instance is responsible for \
+    progress. The matching action must be declared `fair action`, must be enabled whenever the \
+    obligation is pending, and must strictly decrease the rank when it fires; other actions must \
+    keep the pending obligation true (unless they make Q true) and must not increase the measure \
+    -- an unbounded increase between helpful firings can outpace the guaranteed decrease and \
+    prevent Q from ever being reached";
+
+/// Evaluate one `helpful` action argument expression to a concrete value.
+///
+/// `helpful` arguments select a per-binding action instance; they must be
+/// state-independent (leadsTo binders, constants, enum members, or `+`/`-`/`*`
+/// over those values), matching the frozen Python reference's
+/// `_helpful_arg_value`.
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] when the expression references anything other than
+/// a bound leadsTo binder or a constant, or does not fold to an integer,
+/// Boolean, or enum-member value.
+fn eval_state_independent(
+    expr: &KernelExpr,
+    binder_env: &BTreeMap<String, FslValue>,
+) -> Result<FslValue, VerifyError> {
+    match expr {
+        KernelExpr::Num(value) => Ok(FslValue::Int(*value)),
+        KernelExpr::Bool(value) => Ok(FslValue::Bool(*value)),
+        KernelExpr::EnumMember { type_name, member } => Ok(FslValue::Enum {
+            type_name: type_name.clone(),
+            member: member.clone(),
+        }),
+        KernelExpr::Var(name) => binder_env
+            .get(name)
+            .cloned()
+            .ok_or_else(|| VerifyError::new(format!("{HELPFUL_ARG_HINT}: unknown name '{name}'"))),
+        KernelExpr::Neg(inner) => match eval_state_independent(inner, binder_env)? {
+            FslValue::Int(value) => Ok(FslValue::Int(-value)),
+            _ => Err(VerifyError::new(HELPFUL_ARG_HINT)),
+        },
+        KernelExpr::Binary { op, left, right } => {
+            let left = eval_state_independent(left, binder_env)?;
+            let right = eval_state_independent(right, binder_env)?;
+            match (op.as_str(), left, right) {
+                ("+", FslValue::Int(a), FslValue::Int(b)) => Ok(FslValue::Int(a + b)),
+                ("-", FslValue::Int(a), FslValue::Int(b)) => Ok(FslValue::Int(a - b)),
+                ("*", FslValue::Int(a), FslValue::Int(b)) => Ok(FslValue::Int(a * b)),
+                _ => Err(VerifyError::new(HELPFUL_ARG_HINT)),
+            }
+        }
+        _ => Err(VerifyError::new(HELPFUL_ARG_HINT)),
+    }
+}
+
+/// Resolve a leadsTo's declared `helpful` action entries against the
+/// enumerated action instances, for one concrete leadsTo binding.
+///
+/// Mirrors the frozen Python reference's `_helpful_matches`: a `helpful`
+/// entry naming an undeclared action is skipped rather than erroring here,
+/// since `fslc check` (`validate_model_expression_types`) already rejects
+/// that at the static-check stage.
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] when a `helpful` argument expression is not
+/// state-independent (see [`eval_state_independent`]).
+fn helpful_matches<S: SmtSolver>(
+    model: &fsl_core::KernelModel,
+    leadsto: &LeadsToDef,
+    binder_concrete: &BTreeMap<String, FslValue>,
+    instances: &[ActionInstance<S::Term>],
+) -> Result<Vec<usize>, VerifyError> {
+    let mut out = Vec::new();
+    for helper in &leadsto.helpful {
+        let Some(action) = model
+            .actions
+            .iter()
+            .find(|action| action.name == helper.action)
+        else {
+            continue;
+        };
+        let param_names = action
+            .params
+            .iter()
+            .map(fsl_core::ParamDef::name)
+            .collect::<Vec<_>>();
+        let expected = helper
+            .args
+            .iter()
+            .map(|arg| eval_state_independent(arg, binder_concrete))
+            .collect::<Result<Vec<_>, _>>()?;
+        for (index, instance) in instances.iter().enumerate() {
+            if instance.action != helper.action {
+                continue;
+            }
+            let matches = param_names
+                .iter()
+                .zip(&expected)
+                .all(|(name, value)| instance.concrete_params.get(*name) == Some(value));
+            if matches {
+                out.push(index);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn helpful_witnesses<S: SmtSolver>(
+    indices: &[usize],
+    instances: &[ActionInstance<S::Term>],
+) -> Vec<HelpfulActionWitness> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::new();
+    for &index in indices {
+        if !seen.insert(index) {
+            continue;
+        }
+        let instance = &instances[index];
+        out.push(HelpfulActionWitness {
+            action: instance.action.clone(),
+            params: instance.concrete_params.clone(),
+        });
+    }
+    out
+}
+
 /// Prove explicitly ranked `leadsTo` properties over one arbitrary transition.
 ///
 /// # Errors
@@ -340,6 +497,8 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                 "leadsTo '{}' decreases measure can be negative while P holds and Q is false",
                                 property.name
                             ),
+                            helpful: Vec::new(),
+                            helpful_actions: Vec::new(),
                         }),
                     });
                 }
@@ -347,6 +506,59 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                 SatResult::Unknown => {
                     solver.pop(1)?;
                     return Err(VerifyError::new("solver returned unknown in ranking proof"));
+                }
+            }
+
+            let helpful_idx = helpful_matches::<S>(model, property, &binding.concrete, &instances)?;
+
+            if !property.helpful.is_empty() {
+                // helpful_fairness: the matching helpful action instance(s)
+                // must be declared `fair action`; helpful metadata alone does
+                // not create a fairness assumption.
+                let nonfair = helpful_idx
+                    .iter()
+                    .copied()
+                    .filter(|&index| !model.actions[instances[index].action_index].fair)
+                    .collect::<Vec<_>>();
+                if !nonfair.is_empty() {
+                    solver.push();
+                    solver.assert(&pending)?;
+                    match solver.check().await? {
+                        SatResult::Sat => {
+                            let measure_value = model_int(solver, &measure0)?;
+                            let trace =
+                                project_trace(solver, model, &[state0], &[], &instances, 0)?;
+                            solver.pop(1)?;
+                            return Ok(RankedLeadstoResult {
+                                proofs,
+                                failure: Some(RankFailure {
+                                    name: property.name.clone(),
+                                    bindings: binding.concrete,
+                                    measure: measure_expr.clone(),
+                                    kind: "progress_action_not_fair".to_owned(),
+                                    measure_value: Some(measure_value),
+                                    measure_before: None,
+                                    measure_after: None,
+                                    action: None,
+                                    trace,
+                                    hint: "helpful only identifies the per-binding progress action. Add `fair` to the lower-layer action instance that must eventually run; helpful does not create a fairness assumption.".to_owned(),
+                                    message: format!(
+                                        "leadsTo '{}' uses helpful action metadata, but a matching progress action is not declared fair",
+                                        property.name
+                                    ),
+                                    helpful: property.helpful.clone(),
+                                    helpful_actions: helpful_witnesses::<S>(&nonfair, &instances),
+                                }),
+                            });
+                        }
+                        SatResult::Unsat => solver.pop(1)?,
+                        SatResult::Unknown => {
+                            solver.pop(1)?;
+                            return Err(VerifyError::new(
+                                "solver returned unknown in ranking proof",
+                            ));
+                        }
+                    }
                 }
             }
 
@@ -364,26 +576,130 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
             )?;
             let measure1 = int_term(&measure1)?.clone();
             let decreases = solver.lt(&measure1, &measure0)?;
-            let keeps_pending = solver.and(&[p1, decreases])?;
-            let progresses = solver.or(&[q1, keeps_pending])?;
+            let keeps_pending = solver.and(&[p1.clone(), decreases])?;
+            let progresses = solver.or(&[q1.clone(), keeps_pending])?;
 
-            for (index, instance) in instances.iter().enumerate() {
-                let selected = solver.equal(&choice, &solver.int_value(i64_index(index)?))?;
-                let failure = solver.and(&[pending.clone(), selected, solver.not(&progresses)?])?;
+            // helpful_sticky: with two or more matching helpful instances, a
+            // single enabled disjunct is not enough -- once one becomes
+            // enabled while pending, it must stay enabled until it fires (or
+            // Q resolves), or its `fair` declaration is never obligated to
+            // fire because a *different* instance can satisfy the
+            // disjunction at every step.
+            if helpful_idx.len() >= 2 {
+                for &sticky_index in &helpful_idx {
+                    let action = &model.actions[instances[sticky_index].action_index];
+                    let (guards0, _) = crate::transition::action_guards(
+                        solver,
+                        model,
+                        action,
+                        &state0,
+                        &instances[sticky_index].params,
+                    )?;
+                    let enabled0 = solver.and(&guards0)?;
+                    let (guards1, _) = crate::transition::action_guards(
+                        solver,
+                        model,
+                        action,
+                        &state1,
+                        &instances[sticky_index].params,
+                    )?;
+                    let enabled1 = solver.and(&guards1)?;
+                    let not_selected = solver.not(
+                        &solver.equal(&choice, &solver.int_value(i64_index(sticky_index)?))?,
+                    )?;
+                    let flickers = solver.and(&[
+                        pending.clone(),
+                        enabled0,
+                        not_selected,
+                        solver.not(&q1)?,
+                        solver.not(&enabled1)?,
+                    ])?;
+                    solver.push();
+                    solver.assert(&flickers)?;
+                    match solver.check().await? {
+                        SatResult::Sat => {
+                            let trace = project_trace(
+                                solver,
+                                model,
+                                &[state0, state1],
+                                std::slice::from_ref(&choice),
+                                &instances,
+                                1,
+                            )?;
+                            let last_action = trace
+                                .get(1)
+                                .and_then(|step| step.action.as_ref())
+                                .map(|action| action.name.clone());
+                            solver.pop(1)?;
+                            let witnesses = helpful_witnesses::<S>(
+                                std::slice::from_ref(&sticky_index),
+                                &instances,
+                            );
+                            let witness_name = witnesses
+                                .first()
+                                .map_or_else(String::new, |witness| witness.action.clone());
+                            return Ok(RankedLeadstoResult {
+                                proofs,
+                                failure: Some(RankFailure {
+                                    name: property.name.clone(),
+                                    bindings: binding.concrete,
+                                    measure: measure_expr.clone(),
+                                    kind: "helpful_action_enabledness_not_sticky".to_owned(),
+                                    measure_value: None,
+                                    measure_before: None,
+                                    measure_after: None,
+                                    action: last_action,
+                                    trace,
+                                    hint: "with more than one `helpful` action, each instance's enabledness must not flicker: once a helpful instance becomes enabled while the obligation is pending, it must stay enabled until it fires (or Q holds) -- otherwise its weak fairness is never triggered. Guard the other actions so they cannot disable a pending helpful instance, or split into a leadsTo per helpful action so each owns a stable region".to_owned(),
+                                    message: format!(
+                                        "helpful action '{witness_name}' can become disabled again while leadsTo '{}' is still pending, without itself having fired",
+                                        property.name
+                                    ),
+                                    helpful: property.helpful.clone(),
+                                    helpful_actions: witnesses,
+                                }),
+                            });
+                        }
+                        SatResult::Unsat => solver.pop(1)?,
+                        SatResult::Unknown => {
+                            solver.pop(1)?;
+                            return Err(VerifyError::new(
+                                "solver returned unknown in ranking proof",
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // no_deadlock (helpful variant): a pending obligation must not
+            // reach a state where no matching helpful action instance is
+            // enabled -- otherwise none of them is ever obligated to fire by
+            // weak fairness.
+            if !property.helpful.is_empty() {
+                let mut enabled0_terms = Vec::with_capacity(helpful_idx.len());
+                for &deadlock_index in &helpful_idx {
+                    let action = &model.actions[instances[deadlock_index].action_index];
+                    let (guards, _) = crate::transition::action_guards(
+                        solver,
+                        model,
+                        action,
+                        &state0,
+                        &instances[deadlock_index].params,
+                    )?;
+                    enabled0_terms.push(solver.and(&guards)?);
+                }
+                let any_helpful_enabled = if enabled0_terms.is_empty() {
+                    solver.bool_value(false)
+                } else {
+                    solver.or(&enabled0_terms)?
+                };
                 solver.push();
-                solver.assert(&failure)?;
+                solver.assert(&pending)?;
+                solver.assert(&solver.not(&any_helpful_enabled)?)?;
                 match solver.check().await? {
                     SatResult::Sat => {
-                        let before = model_int(solver, &measure0)?;
-                        let after = model_int(solver, &measure1)?;
-                        let trace = project_trace(
-                            solver,
-                            model,
-                            &[state0, state1],
-                            std::slice::from_ref(&choice),
-                            &instances,
-                            1,
-                        )?;
+                        let measure_value = model_int(solver, &measure0)?;
+                        let trace = project_trace(solver, model, &[state0], &[], &instances, 0)?;
                         solver.pop(1)?;
                         return Ok(RankedLeadstoResult {
                             proofs,
@@ -391,17 +707,19 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                 name: property.name.clone(),
                                 bindings: binding.concrete,
                                 measure: measure_expr.clone(),
-                                kind: "non_decreasing_action".to_owned(),
-                                measure_value: None,
-                                measure_before: Some(before),
-                                measure_after: Some(after),
-                                action: Some(instance.action.clone()),
+                                kind: "helpful_action_not_enabled".to_owned(),
+                                measure_value: Some(measure_value),
+                                measure_before: None,
+                                measure_after: None,
+                                action: None,
                                 trace,
-                                hint: "from every state where P holds and Q is false, each enabled action must either make Q true, or keep P true and strictly decrease the measure".to_owned(),
+                                hint: HELPFUL_PROGRESS_HINT.to_owned(),
                                 message: format!(
-                                    "enabled action '{}' can leave leadsTo '{}' pending without strictly decreasing the measure",
-                                    instance.action, property.name
+                                    "leadsTo '{}' can be pending while no matching helpful action instance is enabled",
+                                    property.name
                                 ),
+                                helpful: property.helpful.clone(),
+                                helpful_actions: helpful_witnesses::<S>(&helpful_idx, &instances),
                             }),
                         });
                     }
@@ -412,10 +730,153 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                     }
                 }
             }
+
+            if property.helpful.is_empty() {
+                for (index, instance) in instances.iter().enumerate() {
+                    let selected = solver.equal(&choice, &solver.int_value(i64_index(index)?))?;
+                    let failure =
+                        solver.and(&[pending.clone(), selected, solver.not(&progresses)?])?;
+                    solver.push();
+                    solver.assert(&failure)?;
+                    match solver.check().await? {
+                        SatResult::Sat => {
+                            let before = model_int(solver, &measure0)?;
+                            let after = model_int(solver, &measure1)?;
+                            let trace = project_trace(
+                                solver,
+                                model,
+                                &[state0, state1],
+                                std::slice::from_ref(&choice),
+                                &instances,
+                                1,
+                            )?;
+                            solver.pop(1)?;
+                            return Ok(RankedLeadstoResult {
+                                proofs,
+                                failure: Some(RankFailure {
+                                    name: property.name.clone(),
+                                    bindings: binding.concrete,
+                                    measure: measure_expr.clone(),
+                                    kind: "non_decreasing_action".to_owned(),
+                                    measure_value: None,
+                                    measure_before: Some(before),
+                                    measure_after: Some(after),
+                                    action: Some(instance.action.clone()),
+                                    trace,
+                                    hint: "from every state where P holds and Q is false, each enabled action must either make Q true, or keep P true and strictly decrease the measure".to_owned(),
+                                    message: format!(
+                                        "enabled action '{}' can leave leadsTo '{}' pending without strictly decreasing the measure",
+                                        instance.action, property.name
+                                    ),
+                                    helpful: Vec::new(),
+                                    helpful_actions: Vec::new(),
+                                }),
+                            });
+                        }
+                        SatResult::Unsat => solver.pop(1)?,
+                        SatResult::Unknown => {
+                            solver.pop(1)?;
+                            return Err(VerifyError::new(
+                                "solver returned unknown in ranking proof",
+                            ));
+                        }
+                    }
+                }
+            } else {
+                let helpful_le = solver.le(&measure1, &measure0)?;
+                let pending_preserved =
+                    solver.or(&[q1.clone(), solver.and(&[p1.clone(), helpful_le])?])?;
+                for (index, instance) in instances.iter().enumerate() {
+                    let is_helpful = helpful_idx.contains(&index);
+                    let allowed = if is_helpful {
+                        progresses.clone()
+                    } else {
+                        pending_preserved.clone()
+                    };
+                    let selected = solver.equal(&choice, &solver.int_value(i64_index(index)?))?;
+                    let failure =
+                        solver.and(&[pending.clone(), selected, solver.not(&allowed)?])?;
+                    solver.push();
+                    solver.assert(&failure)?;
+                    match solver.check().await? {
+                        SatResult::Sat => {
+                            let before = model_int(solver, &measure0)?;
+                            let after = model_int(solver, &measure1)?;
+                            let q_next_holds = model_bool(solver, &q1)?;
+                            let p_next_holds = model_bool(solver, &p1)?;
+                            let kind = if !q_next_holds && !p_next_holds {
+                                "pending_not_preserved"
+                            } else if is_helpful && after >= before {
+                                "non_decreasing_helpful_action"
+                            } else if !is_helpful && after > before {
+                                "non_helpful_action_increases_measure"
+                            } else {
+                                "non_decreasing_action"
+                            };
+                            let message = match kind {
+                                "pending_not_preserved" => format!(
+                                    "enabled action '{}' can make leadsTo '{}' no longer pending without making Q true",
+                                    instance.action, property.name
+                                ),
+                                "non_decreasing_helpful_action" => format!(
+                                    "helpful action '{}' can leave leadsTo '{}' pending without strictly decreasing the measure",
+                                    instance.action, property.name
+                                ),
+                                "non_helpful_action_increases_measure" => format!(
+                                    "non-helpful action '{}' can increase the measure while leadsTo '{}' is still pending, which could outpace the helpful action's guaranteed decrease",
+                                    instance.action, property.name
+                                ),
+                                _ => format!(
+                                    "enabled action '{}' can leave leadsTo '{}' pending without strictly decreasing the measure",
+                                    instance.action, property.name
+                                ),
+                            };
+                            let trace = project_trace(
+                                solver,
+                                model,
+                                &[state0, state1],
+                                std::slice::from_ref(&choice),
+                                &instances,
+                                1,
+                            )?;
+                            solver.pop(1)?;
+                            return Ok(RankedLeadstoResult {
+                                proofs,
+                                failure: Some(RankFailure {
+                                    name: property.name.clone(),
+                                    bindings: binding.concrete,
+                                    measure: measure_expr.clone(),
+                                    kind: kind.to_owned(),
+                                    measure_value: None,
+                                    measure_before: Some(before),
+                                    measure_after: Some(after),
+                                    action: Some(instance.action.clone()),
+                                    trace,
+                                    hint: HELPFUL_PROGRESS_HINT.to_owned(),
+                                    message,
+                                    helpful: property.helpful.clone(),
+                                    helpful_actions: helpful_witnesses::<S>(
+                                        &helpful_idx,
+                                        &instances,
+                                    ),
+                                }),
+                            });
+                        }
+                        SatResult::Unsat => solver.pop(1)?,
+                        SatResult::Unknown => {
+                            solver.pop(1)?;
+                            return Err(VerifyError::new(
+                                "solver returned unknown in ranking proof",
+                            ));
+                        }
+                    }
+                }
+            }
         }
         proofs.push(RankProof {
             name: property.name.clone(),
             measure: measure_expr.clone(),
+            helpful: property.helpful.clone(),
         });
     }
     Ok(RankedLeadstoResult {

--- a/rust/fsl-verifier/src/lib.rs
+++ b/rust/fsl-verifier/src/lib.rs
@@ -8,6 +8,7 @@ mod eval;
 mod induction;
 mod liveness;
 mod refinement;
+mod symmetry;
 mod trace;
 mod transition;
 mod value;

--- a/rust/fsl-verifier/src/refinement.rs
+++ b/rust/fsl-verifier/src/refinement.rs
@@ -83,6 +83,7 @@ pub async fn check_refinement_progress<S: SmtSolver>(
                     .clone()
                     .map(|expr| substitute_expr_indexed(expr, &replacements, &indexed)),
                 within: property.within,
+                helpful: Vec::new(),
             })
         })
         .collect::<Result<Vec<_>, VerifyError>>()?;

--- a/rust/fsl-verifier/src/symmetry.rs
+++ b/rust/fsl-verifier/src/symmetry.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Liveness symmetry reduction for `symmetric type` / `symmetric enum`
+//! (issue #461; `docs/LANGUAGE.md` §2 type notes, `docs/DESIGN-temporal.md`
+//! §2.5.1).
+//!
+//! During `leadsTo` lasso and deadlock-stall search, a designated
+//! representative state (the lasso loop head, or the stalled state) is
+//! constrained to the canonical -- lexicographically smallest under a global
+//! renaming -- permutation of each symmetric type's per-entity rows. Rows are
+//! built from `Map<SymmetricType, V>` and `Set<SymmetricType>` state
+//! variables, in source (declaration) order, skipping any `V` that itself
+//! mentions a symmetric identity type. This ports the frozen Python
+//! reference's `_symmetry_canonical_constraint` (`src/fslc/bmc.py`).
+//!
+//! Soundness: the transition relation and properties of a valid `symmetric`
+//! model are equivariant under a single global renaming of that type's
+//! values. Given any lasso or stall counterexample, the global permutation
+//! that sorts the representative state's row vector yields an equally valid
+//! counterexample, so constraining only the designated representative state
+//! (never every intermediate state) cannot hide a genuine violation.
+
+use fsl_core::{KernelModel, TypeDef, TypeRef};
+use fsl_solver::SmtSolver;
+
+use crate::VerifyError;
+use crate::value::{SymbolicState, SymbolicValue, bool_term, concrete_value, int_term};
+
+fn symmetric_type_names(model: &KernelModel) -> Vec<&str> {
+    model
+        .types
+        .iter()
+        .filter(|(_, definition)| {
+            matches!(
+                definition,
+                TypeDef::Domain {
+                    symmetric: true,
+                    ..
+                } | TypeDef::Enum {
+                    symmetric: true,
+                    ..
+                }
+            )
+        })
+        .map(|(name, _)| name.as_str())
+        .collect()
+}
+
+/// Whether `ty` mentions the named symmetric type anywhere in its shape.
+/// Mirrors the frozen Python reference's `_type_ref_mentions`: a `relation`
+/// endpoint is not inspected (matching Python's untagged fallthrough), which
+/// is conservative -- at worst it under-recognizes a symmetric mention and
+/// the caller's map-value flattening then contributes nothing for that
+/// shape (see `flatten_row_terms`), never an unsound term.
+fn type_ref_mentions(model: &KernelModel, ty: &TypeRef, target: &str) -> bool {
+    match ty {
+        TypeRef::Named(name) => {
+            if name == target {
+                return true;
+            }
+            match model.types.get(name) {
+                Some(TypeDef::Struct { fields }) => fields
+                    .iter()
+                    .any(|(_, field_ty)| type_ref_mentions(model, field_ty, target)),
+                _ => false,
+            }
+        }
+        TypeRef::Map(key, value) => {
+            type_ref_mentions(model, key, target) || type_ref_mentions(model, value, target)
+        }
+        TypeRef::Set(inner) | TypeRef::Option(inner) | TypeRef::Seq(inner, _) => {
+            type_ref_mentions(model, inner, target)
+        }
+        TypeRef::Int | TypeRef::Bool | TypeRef::Range(_, _) | TypeRef::Relation(_, _) => false,
+    }
+}
+
+/// Coerce a Boolean-sorted row element to the Int sort so a row (possibly
+/// mixing `Map` scalar values and `Set` membership indicators) can be
+/// lexicographically compared with `<`/`==`. Mirrors
+/// `_symmetry_term_as_int`.
+fn coerce_int<S: SmtSolver>(
+    solver: &S,
+    term: &S::Term,
+    ty: &TypeRef,
+) -> Result<S::Term, VerifyError> {
+    if matches!(ty, TypeRef::Bool) {
+        Ok(solver.ite(term, &solver.int_value(1), &solver.int_value(0))?)
+    } else {
+        Ok(term.clone())
+    }
+}
+
+fn default_term<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    ty: &TypeRef,
+) -> Result<S::Term, VerifyError> {
+    let value = model.default_value(ty)?;
+    let symbolic = concrete_value(solver, model, ty, &value)?;
+    let term = if matches!(ty, TypeRef::Bool) {
+        bool_term(&symbolic)?.clone()
+    } else {
+        int_term(&symbolic)?.clone()
+    };
+    coerce_int(solver, &term, ty)
+}
+
+/// Append one scalar/option/struct-of-scalars `Map` value's row contribution.
+/// Mirrors `_symmetry_map_value_terms`: nested `Map`/`Set`/`Seq`/`Relation`
+/// values (which cannot occur here anyway, since the caller already excludes
+/// any `V` mentioning a symmetric type, but may still contain a *non*-
+/// symmetric collection) contribute nothing, matching Python's fallthrough
+/// `return []`.
+fn flatten_row_terms<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    value: &SymbolicValue<S::Term>,
+    out: &mut Vec<S::Term>,
+) -> Result<(), VerifyError> {
+    match value {
+        SymbolicValue::Scalar { ty, term } => out.push(coerce_int(solver, term, ty)?),
+        SymbolicValue::Option { ty, present, value } => {
+            let TypeRef::Option(inner_ty) = ty else {
+                return Ok(());
+            };
+            out.push(coerce_int(solver, present, &TypeRef::Bool)?);
+            let inner_term = match value.as_ref() {
+                SymbolicValue::Scalar { term, .. } => coerce_int(solver, term, inner_ty)?,
+                _ => return Ok(()),
+            };
+            let default = default_term(solver, model, inner_ty)?;
+            out.push(solver.ite(present, &inner_term, &default)?);
+        }
+        SymbolicValue::Struct { fields, .. } => {
+            for field_value in fields.values() {
+                flatten_row_terms(solver, model, field_value, out)?;
+            }
+        }
+        SymbolicValue::None
+        | SymbolicValue::Map { .. }
+        | SymbolicValue::Set { .. }
+        | SymbolicValue::Seq { .. }
+        | SymbolicValue::Relation { .. }
+        | SymbolicValue::SetLiteral(_)
+        | SymbolicValue::SeqLiteral(_) => {}
+    }
+    Ok(())
+}
+
+/// Build one per-entity row per symmetric-type value, in state-variable
+/// declaration order. Returns one row (possibly empty) per domain value of
+/// `type_name`, in ascending value order.
+fn rows_for_type<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    state: &SymbolicState<S::Term>,
+    type_name: &str,
+) -> Result<Vec<Vec<S::Term>>, VerifyError> {
+    let values = model.domain_values(&TypeRef::Named(type_name.to_owned()))?;
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut rows: Vec<Vec<S::Term>> = values.iter().map(|_| Vec::new()).collect();
+    for (name, ty) in &model.state {
+        match ty {
+            TypeRef::Map(key_ty, value_ty) => {
+                if !matches!(key_ty.as_ref(), TypeRef::Named(named) if named == type_name) {
+                    continue;
+                }
+                if type_ref_mentions(model, value_ty, type_name) {
+                    continue;
+                }
+                let Some(SymbolicValue::Map { entries, .. }) = state.get(name) else {
+                    continue;
+                };
+                for (entity, row) in values.iter().zip(rows.iter_mut()) {
+                    if let Some((_, symbolic)) = entries.iter().find(|(key, _)| key == entity) {
+                        flatten_row_terms(solver, model, symbolic, row)?;
+                    }
+                }
+            }
+            TypeRef::Set(element_ty) => {
+                if !matches!(element_ty.as_ref(), TypeRef::Named(named) if named == type_name) {
+                    continue;
+                }
+                let Some(SymbolicValue::Set { entries, .. }) = state.get(name) else {
+                    continue;
+                };
+                for (entity, row) in values.iter().zip(rows.iter_mut()) {
+                    if let Some((_, term)) = entries.iter().find(|(key, _)| key == entity) {
+                        row.push(coerce_int(solver, term, &TypeRef::Bool)?);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(rows)
+}
+
+/// `left <=_lex right` over two equal-length Int-sorted term vectors.
+/// Mirrors `_symmetry_lex_le`.
+fn lex_le<S: SmtSolver>(
+    solver: &S,
+    left: &[S::Term],
+    right: &[S::Term],
+) -> Result<S::Term, VerifyError> {
+    if left.is_empty() {
+        return Ok(solver.bool_value(true));
+    }
+    let mut cases = Vec::new();
+    let mut equal_prefix = solver.bool_value(true);
+    for (a, b) in left.iter().zip(right) {
+        let strictly_less = solver.and(&[equal_prefix.clone(), solver.lt(a, b)?])?;
+        cases.push(strictly_less);
+        equal_prefix = solver.and(&[equal_prefix, solver.equal(a, b)?])?;
+    }
+    cases.push(equal_prefix);
+    Ok(solver.or(&cases)?)
+}
+
+/// The symmetry-breaking constraint for one representative state: for every
+/// `symmetric` type with at least one contributing `Map`/`Set` state
+/// variable, its per-entity rows (in ascending entity-value order) must be
+/// lexicographically non-decreasing. `true` when no symmetric type has any
+/// contributing state variable.
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] for a missing state variable or solver failure.
+pub(crate) fn canonical_constraint<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    state: &SymbolicState<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    let mut parts = Vec::new();
+    for type_name in symmetric_type_names(model) {
+        let rows = rows_for_type(solver, model, state, type_name)?;
+        if rows.is_empty() || rows[0].is_empty() {
+            continue;
+        }
+        for pair in rows.windows(2) {
+            parts.push(lex_le(solver, &pair[0], &pair[1])?);
+        }
+    }
+    if parts.is_empty() {
+        Ok(solver.bool_value(true))
+    } else {
+        Ok(solver.and(&parts)?)
+    }
+}

--- a/rust/fsl-verifier/src/transition.rs
+++ b/rust/fsl-verifier/src/transition.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use fsl_core::{
     ActionDef, ActionGuard, FslValue, KernelLValue as LValue, KernelModel,
     KernelStatement as Statement, ParamDef, TypeRef,
@@ -20,6 +22,10 @@ pub(crate) struct ActionInstance<T> {
     pub action_index: usize,
     pub action: String,
     pub params: Bindings<T>,
+    /// Concrete parameter values in declaration order, alongside `params`'
+    /// solver terms, so host-side code (leadsTo `helpful` matching) can
+    /// compare instances without a solver round-trip.
+    pub concrete_params: BTreeMap<String, FslValue>,
 }
 
 pub(crate) struct ActionGuardDefinedness<T> {
@@ -34,7 +40,7 @@ pub(crate) fn action_instances<S: SmtSolver>(
 ) -> Result<Vec<ActionInstance<S::Term>>, VerifyError> {
     let mut instances = Vec::new();
     for (action_index, action) in model.actions.iter().enumerate() {
-        let mut bindings = vec![Bindings::new()];
+        let mut bindings = vec![(Bindings::new(), BTreeMap::new())];
         for param in &action.params {
             let values = match param {
                 ParamDef::Typed { ty, .. } => model.domain_values(ty)?,
@@ -45,23 +51,30 @@ pub(crate) fn action_instances<S: SmtSolver>(
                 ParamDef::Range { lo, hi, .. } => TypeRef::Range(*lo, *hi),
             };
             let mut next = Vec::new();
-            for existing in bindings {
+            for (existing_terms, existing_concrete) in bindings {
                 for value in &values {
-                    let mut candidate = existing.clone();
-                    candidate.insert(
+                    let mut terms = existing_terms.clone();
+                    terms.insert(
                         param.name().to_owned(),
                         crate::value::concrete_value(solver, model, &ty, value)?,
                     );
-                    next.push(candidate);
+                    let mut concrete = existing_concrete.clone();
+                    concrete.insert(param.name().to_owned(), value.clone());
+                    next.push((terms, concrete));
                 }
             }
             bindings = next;
         }
-        instances.extend(bindings.into_iter().map(|params| ActionInstance {
-            action_index,
-            action: action.name.clone(),
-            params,
-        }));
+        instances.extend(
+            bindings
+                .into_iter()
+                .map(|(params, concrete_params)| ActionInstance {
+                    action_index,
+                    action: action.name.clone(),
+                    params,
+                    concrete_params,
+                }),
+        );
     }
     Ok(instances)
 }

--- a/rust/fsl-verifier/src/value.rs
+++ b/rust/fsl-verifier/src/value.rs
@@ -755,6 +755,32 @@ pub(crate) fn coerce<S: SmtSolver>(
                 entries,
             })
         }
+        // `Set {}` is the only relation literal form (public Kernel typing
+        // already rejects a non-empty one); coerce it to the all-absent
+        // finite pair grid, mirroring `TypeRef::Relation`'s default value.
+        (SymbolicValue::SetLiteral(items), TypeRef::Relation(source_ty, target_element_ty)) => {
+            if !items.is_empty() {
+                return Err(VerifyError::new(
+                    "relation literals only support the empty initializer Set {}",
+                ));
+            }
+            let entries = model
+                .domain_values(source_ty)?
+                .into_iter()
+                .flat_map(|source| {
+                    model
+                        .domain_values(target_element_ty)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(move |target| (source.clone(), target))
+                })
+                .map(|pair| Ok((pair, solver.bool_value(false))))
+                .collect::<Result<_, VerifyError>>()?;
+            Ok(SymbolicValue::Relation {
+                ty: target_ty.clone(),
+                entries,
+            })
+        }
         (SymbolicValue::SeqLiteral(items), TypeRef::Seq(element_ty, capacity)) => {
             if items.len() > *capacity {
                 return Err(VerifyError::new("sequence literal exceeds capacity"));

--- a/rust/fsl-verifier/tests/leadsto_helpful_ranking.rs
+++ b/rust/fsl-verifier/tests/leadsto_helpful_ranking.rs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native ranking-induction coverage for `helpful` (issue #473). Mirrors
+//! `tests/test_helpful_leadsto.py`'s fixtures against the frozen Python
+//! reference, testing `fsl_verifier::prove_ranked_leadstos` directly so the
+//! ranking-specific `helpful` obligations (fairness/sticky-enabledness/
+//! no-deadlock/progress) are exercised even when a shallow bounded search
+//! would otherwise find a more general BMC counterexample first.
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+const HELPFUL_SRC: &str = r"
+spec HelpfulPerEntity {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+";
+
+const NONFAIR_HELPFUL_SRC: &str = r"
+spec HelpfulNonfair {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+
+  action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+";
+
+const BLOCKED_HELPFUL_SRC: &str = r"
+spec BlockedHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state {
+    level: Map<Case, Level>,
+    gate: Map<Case, Bool>
+  }
+  init {
+    forall c: Case {
+      level[c] = 2
+      gate[c] = false
+    }
+  }
+
+  fair action step(c: Case) {
+    requires gate[c]
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+";
+
+const FLICKERING_HELPFUL_SRC: &str = r"
+spec HelpfulFlickering {
+  type Phase = 0..9
+  type Credit = 0..1
+  state { phase: Phase, done: Bool, credit: Credit }
+  init { phase = 0  done = false  credit = 1 }
+
+  fair action helpEven() {
+    requires phase % 2 == 0
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  fair action helpOdd() {
+    requires phase % 2 == 1
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  action rotate() {
+    requires done == false
+    phase = (phase + 1) % 10
+  }
+
+  leadsTo Finishes {
+    done == false ~> done == true
+    helpful helpEven()
+    helpful helpOdd()
+    decreases credit
+  }
+}
+";
+
+const PUMPED_MEASURE_SRC: &str = r"
+spec HelpfulPumpedMeasure {
+  state { x: Int }
+  init { x = 5 }
+
+  fair action work() {
+    requires x > 0
+    x = x - 1
+  }
+
+  action pump() {
+    requires x > 0
+    x = x + 2
+  }
+
+  invariant NonNeg { x >= 0 }
+
+  leadsTo Finishes {
+    x > 0 ~> x == 0
+    helpful work()
+    decreases x
+  }
+}
+";
+
+fn ranked(source: &str) -> fsl_verifier::RankedLeadstoResult {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    block_on(fsl_verifier::prove_ranked_leadstos(&model, &mut solver))
+        .expect("prove_ranked_leadstos")
+}
+
+#[test]
+fn helpful_per_entity_measure_proves_under_interleaving() {
+    let result = ranked(HELPFUL_SRC);
+    assert!(result.failure.is_none(), "{:?}", result.failure);
+    let proof = result
+        .proofs
+        .iter()
+        .find(|proof| proof.name == "Responds")
+        .expect("Responds ranking proof");
+    assert_eq!(proof.helpful.len(), 1);
+    assert_eq!(proof.helpful[0].action, "step");
+}
+
+#[test]
+fn helpful_does_not_create_fairness() {
+    // Negative control: `helpful step(c)` alone must not license treating
+    // `step` as fair. Without a `fair` declaration on `step`, the ranking
+    // proof must fail with `progress_action_not_fair`, not silently prove.
+    let result = ranked(NONFAIR_HELPFUL_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "progress_action_not_fair");
+    assert_eq!(failure.helpful_actions[0].action, "step");
+    assert!(
+        failure.hint.contains("helpful only identifies"),
+        "{}",
+        failure.hint
+    );
+}
+
+#[test]
+fn blocked_helpful_action_is_reported() {
+    // Negative control: `step` is `fair` but permanently disabled by `gate`.
+    // A pending obligation whose only helpful instance is never enabled must
+    // fail with `helpful_action_not_enabled`, not silently prove.
+    let result = ranked(BLOCKED_HELPFUL_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "helpful_action_not_enabled");
+    assert_eq!(failure.helpful.len(), 1);
+    assert_eq!(failure.helpful[0].action, "step");
+    assert_eq!(failure.bindings.get("c"), Some(&fsl_core::FslValue::Int(0)));
+}
+
+#[test]
+fn multiple_helpful_actions_with_flickering_enabledness_is_not_falsely_proved() {
+    // Regression (soundness): two `helpful` actions whose enabledness
+    // alternates by phase parity must not let ranking induction report
+    // "proved" -- neither helpEven nor helpOdd is ever *continuously*
+    // enabled while pending, so weak fairness never actually obligates
+    // either one to fire, and `rotate` can cycle forever.
+    let result = ranked(FLICKERING_HELPFUL_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "helpful_action_enabledness_not_sticky");
+    assert!(
+        failure.helpful_actions[0].action == "helpEven"
+            || failure.helpful_actions[0].action == "helpOdd",
+        "{:?}",
+        failure.helpful_actions
+    );
+}
+
+#[test]
+fn non_helpful_action_pumping_the_measure_is_not_falsely_proved() {
+    // Regression (soundness): a non-helpful action must not be allowed to
+    // increase the measure. `work` is fair, always enabled while pending,
+    // and the sole helpful match (so fairness/sticky/no-deadlock all hold),
+    // but `pump` can add more to `x` than `work` ever removes.
+    let result = ranked(PUMPED_MEASURE_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "non_helpful_action_increases_measure");
+    assert_eq!(failure.action.as_deref(), Some("pump"));
+}

--- a/rust/fsl-verifier/tests/leadsto_symmetry_reduction.rs
+++ b/rust/fsl-verifier/tests/leadsto_symmetry_reduction.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native `symmetric type` / `symmetric enum` liveness symmetry reduction
+//! (issue #461). Mirrors `tests/test_temporal.py`'s
+//! `SYMMETRIC_TASKS`/`PLAIN_TASKS` fixtures: the `symmetric`-tagged spec and
+//! its non-symmetric twin must agree on both the positive path (still
+//! `verified`) and the negative control (a violation whose only stalled
+//! entity is one specific `TaskId`, exercising that the canonical-loop-head
+//! constraint cannot hide a genuine per-entity counterexample).
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+const SYMMETRIC_TASKS: &str = r"
+spec SymmetricTasks {
+  symmetric type TaskId = 0..2
+  enum Status { Pending, Done }
+  state { status: Map<TaskId, Status> }
+  init {
+    forall t: TaskId { status[t] = Pending }
+  }
+  fair action finish(t: TaskId) {
+    requires status[t] == Pending
+    status[t] = Done
+  }
+  action noop() { }
+  invariant StatusValid { true }
+  leadsTo EveryTaskFinishes {
+    forall t: TaskId {
+      status[t] == Pending ~> status[t] == Done
+    }
+  }
+}
+";
+
+fn plain_tasks() -> String {
+    SYMMETRIC_TASKS.replace("symmetric type TaskId", "type TaskId")
+}
+
+fn symmetric_tasks_unfair() -> String {
+    SYMMETRIC_TASKS.replace("fair action finish", "action finish")
+}
+
+fn plain_tasks_unfair() -> String {
+    plain_tasks().replace("fair action finish", "action finish")
+}
+
+const SYMMETRIC_WORKERS: &str = r"
+spec SymmetricWorkers {
+  symmetric enum Worker { A, B, C }
+  state { busy: Set<Worker> }
+  init { busy = Set {} }
+  fair action mark(w: Worker) {
+    requires not busy.contains(w)
+    busy = busy.add(w)
+  }
+  invariant AlwaysTrue { true }
+  leadsTo AllMarked {
+    forall w: Worker {
+      not busy.contains(w) ~> busy.contains(w)
+    }
+  }
+}
+";
+
+const SYMMETRIC_WORKERS_UNFAIR: &str = r"
+spec SymmetricWorkers {
+  symmetric enum Worker { A, B, C }
+  state { busy: Set<Worker> }
+  init { busy = Set {} }
+  action mark(w: Worker) {
+    requires not busy.contains(w)
+    busy = busy.add(w)
+  }
+  action noop() { }
+  invariant AlwaysTrue { true }
+  leadsTo AllMarked {
+    forall w: Worker {
+      not busy.contains(w) ~> busy.contains(w)
+    }
+  }
+}
+";
+
+async fn run(source: &str, depth: usize) -> fsl_verifier::BmcResult {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    fsl_verifier::verify_bounded(&model, &mut solver, depth)
+        .await
+        .expect("verify_bounded")
+}
+
+#[test]
+fn symmetric_and_plain_agree_when_fair_and_verified() {
+    let symmetric = block_on(run(SYMMETRIC_TASKS, 6));
+    let plain = block_on(run(&plain_tasks(), 6));
+
+    assert!(symmetric.violation.is_none(), "{symmetric:?}");
+    assert!(symmetric.leadsto_violation.is_none(), "{symmetric:?}");
+    assert!(plain.violation.is_none(), "{plain:?}");
+    assert!(plain.leadsto_violation.is_none(), "{plain:?}");
+}
+
+#[test]
+fn symmetric_reduction_does_not_hide_a_single_entity_stall() {
+    // Negative control: without `fair`, exactly one TaskId can stall forever
+    // (the others may or may not finish -- the solver picks a witness). The
+    // canonical-loop-head constraint only fixes the *shape* of the loop-head
+    // state under entity renaming; it must never turn this genuine violation
+    // into a false `verified`.
+    let symmetric = block_on(run(&symmetric_tasks_unfair(), 5));
+    let plain = block_on(run(&plain_tasks_unfair(), 5));
+
+    let symmetric_violation = symmetric
+        .leadsto_violation
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected a leadsTo violation, got {symmetric:?}"));
+    let plain_violation = plain
+        .leadsto_violation
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected a leadsTo violation, got {plain:?}"));
+
+    assert_eq!(symmetric_violation.kind, "leadsTo");
+    assert_eq!(plain_violation.kind, "leadsTo");
+    assert_eq!(symmetric_violation.name, "EveryTaskFinishes");
+    assert_eq!(plain_violation.name, "EveryTaskFinishes");
+}
+
+#[test]
+fn symmetric_enum_set_membership_still_verifies_when_fair() {
+    // Exercises the `Set<SymmetricType>` row (membership indicator), not just
+    // `Map<SymmetricType, V>`.
+    let result = block_on(run(SYMMETRIC_WORKERS, 6));
+    assert!(result.violation.is_none(), "{result:?}");
+    assert!(result.leadsto_violation.is_none(), "{result:?}");
+}
+
+#[test]
+fn symmetric_enum_set_membership_negative_control_still_finds_single_entity_stall() {
+    // Negative control for the `Set<SymmetricType>` row: without `fair`,
+    // exactly one Worker can stall forever behind an always-enabled `noop`,
+    // and the canonical constraint must not hide it.
+    let result = block_on(run(SYMMETRIC_WORKERS_UNFAIR, 5));
+    let violation = result
+        .leadsto_violation
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected a leadsTo violation, got {result:?}"));
+    assert_eq!(violation.kind, "leadsTo");
+    assert_eq!(violation.name, "AllMarked");
+}
+
+// A *joint* (non-per-entity) leadsTo property over 7 symmetric entities: the
+// trigger/response are single Boolean expressions quantifying over all of
+// `TaskId` (`forall t { status[t] == Pending }`), not `forall t { P(t) ~>
+// Q(t) }` sugar, so leadsTo_bindings does not decompose this into 7
+// independent checks -- the lasso/stall search explores the joint N=7
+// per-entity-status configuration space, which is exactly where the
+// canonical-loop-head/stalled-state constraint has room to collapse
+// permutation-equivalent states.
+const SYMMETRIC_JOINT_N7: &str = r"
+spec SymmetricJointN7 {
+  symmetric type TaskId = 0..6
+  enum Status { Pending, Done }
+  state { status: Map<TaskId, Status> }
+  init { forall t: TaskId { status[t] = Pending } }
+  fair action finish(t: TaskId) {
+    requires status[t] == Pending
+    status[t] = Done
+  }
+  action noop() { }
+  invariant AlwaysTrue { true }
+  leadsTo AllDone {
+    (forall t: TaskId { status[t] == Pending }) ~> (forall t: TaskId { status[t] == Done })
+  }
+}
+";
+
+#[test]
+fn symmetry_reduction_measurably_reduces_solver_work_on_a_joint_property() {
+    // Discriminating test (not merely green-either-way): fails if the
+    // `symmetry::canonical_constraint` call sites are removed from
+    // `check_leadstos`/`check_leadsto_stagnation` in bmc.rs.
+    //
+    // Verified by ablation (replacing both call sites with
+    // `solver.bool_value(true)` and restoring them): on this exact spec at
+    // depth 5, Z3's solver-check count is unaffected (97 either way -- the
+    // lasso/stall loop *structure* never depends on symmetry), but
+    // `propagations` is 16771 with the reduction active and 34396 with it
+    // ablated (conflicts: 449 vs. 775; decisions: 767 vs. 1414). The
+    // threshold below sits roughly in the middle, with >30% headroom on
+    // both sides, so ordinary Z3-version/build noise should not flip it;
+    // only removing the constraint (or another regression of comparable
+    // size) would.
+    let kernel = parse_kernel_source(SYMMETRIC_JOINT_N7, &FsResolver::new(std::env::temp_dir()))
+        .expect("parse");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result =
+        block_on(fsl_verifier::verify_bounded(&model, &mut solver, 5)).expect("verify_bounded");
+    assert!(result.violation.is_none(), "{result:?}");
+    assert!(result.leadsto_violation.is_none(), "{result:?}");
+
+    let statistics = fsl_solver::SmtSolver::statistics(&solver);
+    let propagations = statistics
+        .solver
+        .propagations
+        .expect("native-z3 backend reports propagations");
+    assert!(
+        propagations < 25_000,
+        "propagations={propagations} (checks={}); expected well under the ablated-symmetry \
+         baseline of ~34396 -- symmetry reduction may not be reaching check_leadstos/\
+         check_leadsto_stagnation",
+        statistics.solver.checks
+    );
+}

--- a/rust/fsl-verifier/tests/relation_operations.rs
+++ b/rust/fsl-verifier/tests/relation_operations.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native symbolic verifier coverage for `relation A -> B` state and its
+//! seven operations (issue #467). Ports `tests/test_relation.py`'s
+//! `RELATION_SRC` (positive), `CYCLIC_SRC` (negative control: a genuine
+//! `acyclic` violation must be reported, not silently accepted), and
+//! `BAD_SELF_RELATION_SRC` (rejected: `acyclic`/`reachable` require a
+//! self-relation), plus a symbolic/concrete agreement check on the 0->1->0
+//! cycle trace.
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+const RELATION_SRC: &str = r"
+spec RelationDemo {
+  type User = 0..1
+  enum Role { Manager, Staff }
+
+  state {
+    delegates: relation User -> User,
+    roles: relation User -> Role
+  }
+
+  init {
+    delegates = Set {}
+    roles = Set {}
+  }
+
+  action delegate(a: User, b: User) {
+    requires a != b
+    requires not reachable(delegates, b, a)
+    delegates = delegates.add(a, b)
+  }
+
+  action revoke(a: User, b: User) {
+    delegates = delegates.remove(a, b)
+  }
+
+  action grant(u: User, r: Role) {
+    roles = roles.add(u, r)
+  }
+
+  invariant DelegatesAcyclic { acyclic(delegates) }
+  invariant DelegatesFunctional { functional(delegates) }
+  invariant RoleRangeBounded { range(roles).size() <= 2 }
+  invariant DelegateDomainBounded { domain(delegates).size() <= 2 }
+  reachable CanDelegate { delegates.contains(0, 1) }
+}
+";
+
+const CYCLIC_SRC: &str = r"
+spec CyclicRelation {
+  type User = 0..1
+  state { delegates: relation User -> User }
+  init { delegates = Set {} }
+  action delegate(a: User, b: User) {
+    requires a != b
+    delegates = delegates.add(a, b)
+  }
+  invariant DelegatesAcyclic { acyclic(delegates) }
+}
+";
+
+const BAD_SELF_RELATION_SRC: &str = r"
+spec BadSelfRelation {
+  type User = 0..1
+  enum Role { Manager, Staff }
+  state { assignments: relation User -> Role }
+  init { assignments = Set {} }
+  action grant(u: User, r: Role) { assignments = assignments.add(u, r) }
+  invariant BadAcyclic { acyclic(assignments) }
+}
+";
+
+fn build(source: &str) -> fsl_core::KernelModel {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    build_model(kernel).expect("build model")
+}
+
+#[test]
+fn relation_helpers_verify_and_reachable_witness() {
+    let model = build(RELATION_SRC);
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result =
+        block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2)).expect("verify_bounded");
+    assert!(result.violation.is_none(), "{result:?}");
+    let can_delegate = result
+        .reachables
+        .get("CanDelegate")
+        .and_then(Option::as_ref)
+        .unwrap_or_else(|| panic!("expected CanDelegate witnessed, got {result:?}"));
+    assert_eq!(can_delegate.step, 1);
+}
+
+#[test]
+fn cyclic_relation_acyclic_violation_is_reported() {
+    // Negative control: `acyclic(delegates)` genuinely fails on the 0->1->0
+    // trace and must be reported, not silently accepted or reported as
+    // `error`/`unknown`.
+    let model = build(CYCLIC_SRC);
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result =
+        block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2)).expect("verify_bounded");
+    let violation = result
+        .violation
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected a violation, got {result:?}"));
+    assert_eq!(violation.name, "DelegatesAcyclic");
+}
+
+#[test]
+fn acyclic_on_a_non_self_relation_is_rejected() {
+    let model = build(BAD_SELF_RELATION_SRC);
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect_err("acyclic() on a non-self relation must be rejected, not silently accepted");
+    assert!(error.to_string().contains("self-relation"), "{error}");
+}
+
+#[test]
+fn symbolic_transition_agrees_with_the_concrete_monitor_on_the_cycle_trace() {
+    // The 0->1->0 cycle trace from issue #467's evidence: the symbolic
+    // transition relation (used by `fslc verify`) must accept exactly the
+    // successor states the concrete Monitor (used by `fslc replay`)
+    // produces, for both `delegate(0, 1)` and `delegate(1, 0)`.
+    let model = build(CYCLIC_SRC);
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("create monitor");
+
+    for (a, b) in [(0_i64, 1_i64), (1_i64, 0_i64)] {
+        let current = monitor.state.clone();
+        let enabled = monitor
+            .enabled()
+            .expect("enumerate enabled actions")
+            .into_iter()
+            .find(|candidate| {
+                candidate.action == "delegate"
+                    && candidate.params.get("a") == Some(&fsl_core::FslValue::Int(a))
+                    && candidate.params.get("b") == Some(&fsl_core::FslValue::Int(b))
+            })
+            .unwrap_or_else(|| panic!("delegate({a}, {b}) must be enabled"));
+        let result = monitor.step(&enabled).expect("step monitor");
+        // `delegate(1, 0)` violates `DelegatesAcyclic`, so the Monitor rolls
+        // back `state` to its pre-transition value; the actually-computed
+        // successor (what the transition relation itself produces, before
+        // the separate invariant check) is `attempted_state`. Transition
+        // agreement is about the guard+effect relation, not invariants.
+        let next = result.attempted_state.as_ref().unwrap_or(&result.state);
+
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        assert!(
+            block_on(fsl_verifier::transition_matches_step(
+                &model,
+                &mut solver,
+                &current,
+                &enabled.action,
+                &enabled.params,
+                next,
+            ))
+            .expect("check transition agreement"),
+            "delegate({a}, {b}): symbolic transition relation disagrees with the concrete Monitor"
+        );
+    }
+}

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -182,6 +182,25 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
         );
     };
     if base.get("result").and_then(Value::as_str) != Some("verified") {
+        // A base-case `leadsTo` violation may be a raw BMC stall/lasso trace
+        // that a ranking proof can diagnose more precisely (e.g. a missing
+        // `fair` on the `helpful` action, or a permanently-blocked helpful
+        // instance) -- mirrors the frozen Python reference's `prove()`,
+        // which prefers `_prove_ranked_leadstos`' rank_failure over the raw
+        // BMC counterexample whenever ranking has something more specific to
+        // say.
+        if base.get("result").and_then(Value::as_str) == Some("violated")
+            && base.get("violation_kind").and_then(Value::as_str) == Some("leadsTo")
+            && let Ok(model) = load_induction_model(selection, auxiliary)
+            && let Ok(mut solver) = fsl_solver_z3::Z3Solver::new()
+            && let Ok(ranked) =
+                block_on_native(fsl_verifier::prove_ranked_leadstos(&model, &mut solver))
+            && let Some(failure) = &ranked.failure
+        {
+            let mut statistics = base_solved.statistics.clone();
+            statistics.merge(&fsl_solver::SmtSolver::statistics(&solver));
+            return render_rank_failure(&model, failure, depth, started, &statistics);
+        }
         return (base_value, base_status);
     }
 
@@ -532,6 +551,7 @@ fn render_rank_failure(
         json!(ranking_measure_text(&failure.measure)),
     );
     output.insert("rank_failure".to_owned(), json!(failure.kind));
+    insert_helpful_rank_failure_json(&mut output, model, failure);
     if let Some(value) = failure.measure_value {
         output.insert("measure_value".to_owned(), json!(value));
     }
@@ -653,6 +673,18 @@ fn render_induction_success(
                     "decreases".to_owned(),
                     json!(ranking_measure_text(&proof.measure)),
                 );
+                if !proof.helpful.is_empty() {
+                    entry.insert(
+                        "helpful".to_owned(),
+                        json!(
+                            proof
+                                .helpful
+                                .iter()
+                                .map(helpful_action_label)
+                                .collect::<Vec<_>>()
+                        ),
+                    );
+                }
             }
         }
         output.insert("leads_to".to_owned(), Value::Object(leads_to));
@@ -677,6 +709,54 @@ fn ranking_measure_text(expr: &KernelExpr) -> String {
         format!("({text})")
     } else {
         text
+    }
+}
+
+fn helpful_action_label(helper: &fsl_core::HelpfulAction) -> String {
+    let args = helper
+        .args
+        .iter()
+        .map(::fslc_rust::expr_text)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{}({args})", helper.action)
+}
+
+fn insert_helpful_rank_failure_json(
+    output: &mut Map<String, Value>,
+    model: &KernelModel,
+    failure: &fsl_verifier::RankFailure,
+) {
+    if !failure.helpful.is_empty() {
+        output.insert(
+            "helpful".to_owned(),
+            json!(
+                failure
+                    .helpful
+                    .iter()
+                    .map(helpful_action_label)
+                    .collect::<Vec<_>>()
+            ),
+        );
+    }
+    if !failure.helpful_actions.is_empty() {
+        output.insert(
+            "helpful_actions".to_owned(),
+            Value::Array(
+                failure
+                    .helpful_actions
+                    .iter()
+                    .map(|witness| {
+                        let params = witness
+                            .params
+                            .iter()
+                            .map(|(name, value)| (name.clone(), ::fslc_rust::fsl_value_json(value)))
+                            .collect::<Map<_, _>>();
+                        origin_aware_action_json(model, &witness.action, &params, Value::Null)
+                    })
+                    .collect(),
+            ),
+        );
     }
 }
 

--- a/rust/fslc/tests/fixtures/issue_467_relation_demo.fsl
+++ b/rust/fslc/tests/fixtures/issue_467_relation_demo.fsl
@@ -1,0 +1,34 @@
+spec RelationDemo {
+  type User = 0..1
+  enum Role { Manager, Staff }
+
+  state {
+    delegates: relation User -> User,
+    roles: relation User -> Role
+  }
+
+  init {
+    delegates = Set {}
+    roles = Set {}
+  }
+
+  action delegate(a: User, b: User) {
+    requires a != b
+    requires not reachable(delegates, b, a)
+    delegates = delegates.add(a, b)
+  }
+
+  action revoke(a: User, b: User) {
+    delegates = delegates.remove(a, b)
+  }
+
+  action grant(u: User, r: Role) {
+    roles = roles.add(u, r)
+  }
+
+  invariant DelegatesAcyclic { acyclic(delegates) }
+  invariant DelegatesFunctional { functional(delegates) }
+  invariant RoleRangeBounded { range(roles).size() <= 2 }
+  invariant DelegateDomainBounded { domain(delegates).size() <= 2 }
+  reachable CanDelegate { delegates.contains(0, 1) }
+}

--- a/rust/fslc/tests/fixtures/issue_473_helpful_leadsto.fsl
+++ b/rust/fslc/tests/fixtures/issue_473_helpful_leadsto.fsl
@@ -1,0 +1,16 @@
+spec MinHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_473_helpful_typo.fsl
+++ b/rust/fslc/tests/fixtures/issue_473_helpful_typo.fsl
@@ -1,0 +1,16 @@
+spec TypoHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful nosuch(c)
+    decreases level[c]
+  }
+}

--- a/rust/fslc/tests/issue_467_relation.rs
+++ b/rust/fslc/tests/issue_467_relation.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI-level coupled-change coverage for issue #467: `relation A -> B`
+//! native support end to end through the `fslc` binary's JSON envelope and
+//! exit-code contract.
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> (serde_json::Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn relation_check_and_verify_are_exit_0_ok_and_verified() {
+    // docs/LANGUAGE.md:583-585 promises `relation A -> B` and all seven
+    // operations unconditionally; both `check` and `verify` must accept it.
+    let (check_output, check_status) = run(&[
+        "check",
+        "rust/fslc/tests/fixtures/issue_467_relation_demo.fsl",
+    ]);
+    assert_eq!(check_status, 0, "{check_output}");
+    assert_eq!(check_output["result"], "ok");
+
+    let (verify_output, verify_status) = run(&[
+        "verify",
+        "rust/fslc/tests/fixtures/issue_467_relation_demo.fsl",
+        "--depth",
+        "2",
+        "--no-cache",
+    ]);
+    assert_eq!(verify_status, 0, "{verify_output}");
+    assert_eq!(verify_output["result"], "verified");
+    assert_eq!(
+        verify_output["reachables"]["CanDelegate"]["witnessed_at_step"],
+        1
+    );
+}

--- a/rust/fslc/tests/issue_473_helpful_leadsto.rs
+++ b/rust/fslc/tests/issue_473_helpful_leadsto.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI-level coupled-change coverage for issue #473: `leadsTo ... helpful`
+//! ranking proofs, end to end through the native `fslc` binary's JSON
+//! envelope and exit-code contract (docs/LANGUAGE.md:383, :441-452,
+//! docs/DESIGN-induction.md).
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> (serde_json::Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn helpful_leadsto_ranking_proof_is_exit_0_proved_unbounded() {
+    // Positive path: the documented per-entity `helpful` idiom
+    // (docs/LANGUAGE.md:441-452) must produce the same verdict shape as the
+    // frozen Python reference: exit 0, `proved`, `completeness:"unbounded"`,
+    // and `leads_to.<name>.helpful` echoing the declared helpful action(s).
+    let (output, status) = run(&[
+        "verify",
+        "rust/fslc/tests/fixtures/issue_473_helpful_leadsto.fsl",
+        "--engine",
+        "induction",
+        "--depth",
+        "1",
+        "--no-cache",
+    ]);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "proved");
+    assert_eq!(output["completeness"], "unbounded");
+    let responds = &output["leads_to"]["Responds"];
+    assert_eq!(responds["proof"], "ranking");
+    assert_eq!(responds["decreases"], "level[c]");
+    assert_eq!(responds["helpful"], serde_json::json!(["step(c)"]));
+}
+
+#[test]
+fn helpful_action_naming_an_undeclared_action_is_rejected_at_check_time() {
+    // Negative control: a misspelled `helpful` action name must fail
+    // `fslc check` with a located type error -- not be silently accepted
+    // (the false-green this issue reports for the pre-fix native binary).
+    let (output, status) = run(&[
+        "check",
+        "rust/fslc/tests/fixtures/issue_473_helpful_typo.fsl",
+    ]);
+
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "semantics");
+    let message = output["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("helpful action 'nosuch' is not declared"),
+        "{message}"
+    );
+}

--- a/tests/fixtures/rust_port/ranked_leadsto_helpful.fsl
+++ b/tests/fixtures/rust_port/ranked_leadsto_helpful.fsl
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec HelpfulPerEntity {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+
+  fair action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}

--- a/tests/fixtures/rust_port/ranked_leadsto_helpful_blocked.fsl
+++ b/tests/fixtures/rust_port/ranked_leadsto_helpful_blocked.fsl
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec BlockedHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state {
+    level: Map<Case, Level>,
+    gate: Map<Case, Bool>
+  }
+  init {
+    forall c: Case {
+      level[c] = 2
+      gate[c] = false
+    }
+  }
+
+  fair action step(c: Case) {
+    requires gate[c]
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}

--- a/tests/fixtures/rust_port/ranked_leadsto_helpful_flickering.fsl
+++ b/tests/fixtures/rust_port/ranked_leadsto_helpful_flickering.fsl
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec HelpfulFlickering {
+  type Phase = 0..9
+  type Credit = 0..1
+  state { phase: Phase, done: Bool, credit: Credit }
+  init { phase = 0  done = false  credit = 1 }
+
+  fair action helpEven() {
+    requires phase % 2 == 0
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  fair action helpOdd() {
+    requires phase % 2 == 1
+    requires done == false
+    done = true
+    credit = 0
+  }
+
+  action rotate() {
+    requires done == false
+    phase = (phase + 1) % 10
+  }
+
+  leadsTo Finishes {
+    done == false ~> done == true
+    helpful helpEven()
+    helpful helpOdd()
+    decreases credit
+  }
+}

--- a/tests/fixtures/rust_port/ranked_leadsto_helpful_nonfair.fsl
+++ b/tests/fixtures/rust_port/ranked_leadsto_helpful_nonfair.fsl
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec HelpfulNonfair {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+
+  action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}

--- a/tests/fixtures/rust_port/ranked_leadsto_helpful_pumped.fsl
+++ b/tests/fixtures/rust_port/ranked_leadsto_helpful_pumped.fsl
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec HelpfulPumpedMeasure {
+  state { x: Int }
+  init { x = 5 }
+
+  fair action work() {
+    requires x > 0
+    x = x - 1
+  }
+
+  action pump() {
+    requires x > 0
+    x = x + 2
+  }
+
+  invariant NonNeg { x >= 0 }
+
+  leadsTo Finishes {
+    x > 0 ~> x == 0
+    helpful work()
+    decreases x
+  }
+}

--- a/tools/check_rust_induction_parity.py
+++ b/tools/check_rust_induction_parity.py
@@ -28,6 +28,11 @@ CASES = (
     ("tests/fixtures/rust_port/ranked_leadsto.fsl", 5, 1),
     ("tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl", 5, 1),
     ("tests/fixtures/rust_port/ranked_leadsto_unbounded_below.fsl", 5, 1),
+    ("tests/fixtures/rust_port/ranked_leadsto_helpful.fsl", 1, 1),
+    ("tests/fixtures/rust_port/ranked_leadsto_helpful_nonfair.fsl", 1, 1),
+    ("tests/fixtures/rust_port/ranked_leadsto_helpful_blocked.fsl", 1, 1),
+    ("tests/fixtures/rust_port/ranked_leadsto_helpful_flickering.fsl", 8, 1),
+    ("tests/fixtures/rust_port/ranked_leadsto_helpful_pumped.fsl", 8, 1),
     ("specs/cart_buggy.fsl", 5, 1),
 )
 


### PR DESCRIPTION
## Problem

Four capabilities that `docs/` promise (or that the frozen Python reference already had) were missing from the authoritative native symbolic verifier.

**#467 — `relation`-typed operations were unsupported.** A spec using a `relation` state variable could not be verified at all: `verify` returned `result:"error"` / `kind:"semantics"` / exit 2 with the relation not representable in the public Kernel. Because `sweep` folded that error into its grid, the same spec produced a **false green** through that path.

**#461 — the leadsTo search never consumed `symmetric` metadata.** `symmetric type` / `symmetric enum` was parsed and round-tripped, and then ignored: `check_leadstos` and `check_leadsto_stagnation` never applied the canonical per-entity representative that `docs/DESIGN-temporal.md` §2.5.1 documents and that the frozen reference implements.

**#473 — `leadsTo ... helpful` ranking proofs were absent.** `SpecItem::LeadsTo`'s `helpful` field was absorbed by a `..` pattern during Kernel lowering, so the ranking proof treated every `leadsTo` as if it had no `helpful` declaration. The canonical per-entity liveness idiom at `docs/LANGUAGE.md:441-452` returned `unknown_cti` where the frozen reference proves it — and `fslc check` silently accepted a `helpful` action name that was never declared.

**#478 — nine `docs/DESIGN-*.md` files existed on disk but were unreachable** from `docs/README.md`, the map `README.md:62` calls "start here", so the bidirectional coupled-change meta test was red.

## Contract change

- **#467** — relation-typed expressions are implemented across the symbolic verifier (`rel_functional` / `rel_injective` / `rel_domain` / `rel_range` / `rel_acyclic` / `rel_reachable`, plus `contains` / `add` / `remove` dispatch) using a memoized bounded-hop reachability closure. The concrete Monitor had the **same** missing empty-`Set`→`Relation` coercion, so `_bounds_*` spuriously violated on step 1 for every relation spec independently of the symbolic side; that is fixed too. The issue's claim that `fsl-runtime` was already complete was wrong, and nothing relation-typed could pass `verify` until both halves moved.
- **#461** — a new `rust/fsl-verifier/src/symmetry.rs` builds one per-entity row per `symmetric` type from `Map<SymmetricType, V>` and `Set<SymmetricType>` state variables and requires ascending-entity-order rows to be lexicographically non-decreasing. It is wired into the lasso loop head and the stalled state **only** — never every intermediate state — preserving the soundness argument in `docs/DESIGN-temporal.md` §2.5.1.
- **#473** — `LeadsToDef` carries `helpful` through lowering; a static check rejects a `helpful` action that is undeclared or has the wrong arity, closing the `fslc check` false-accept; and `prove_ranked_leadstos` proves the four `helpful`-specific obligations, reporting all six documented `rank_failure` kinds.
- **#478** — one row per document in the `docs/README.md` map, each with its own description.

## Test evidence

Verified independently against a `main` binary:

| case | main | this branch |
|---|---|---|
| relation spec, `verify --depth 3` | `error` / `kind:"semantics"` / exit 2 — not verifiable at all | `violated` / `invariant:"NoCycle"` / `violated_at_step:1` / exit 1 |
| same spec, `--engine explicit` | — | same verdict, same invariant, same step as BMC |
| `helpful` positive fixture, `--engine induction` | `unknown_cti` / `completeness:"bounded"` / exit 1 | `proved` / `unbounded` / exit 0, `proof:"ranking"`, `decreases:"level[c]"`, `helpful:["step(c)"]` |
| undeclared `helpful` action name, `check` | `result:"ok"` / exit 0 (silent false-accept) | `error` / `semantics` / exit 2 |
| `docs/README.md` DESIGN link set | 71 of 80 linked | 80 of 80, both directions empty |

**#461's discriminating control deserves specific mention.** The first four tests written for it passed with *and* without the reduction — they guard against over-constraining but cannot distinguish "reduction applied" from "metadata parsed and ignored", which is precisely the state the issue reports. `symmetry_reduction_measurably_reduces_solver_work_on_a_joint_property` was added and **verified by ablation**: replacing both `bmc.rs` call sites with `solver.bool_value(true)` makes it fail (`propagations` 34396 vs the asserted `<25000`) while the four older tests still pass; restoring makes all five pass. Solver *check* count is identical either way (97), which is why a naive cost comparison shows nothing — the signal is `propagations` (16771 vs 34396), `conflicts` (449 vs 775), and `decisions` (767 vs 1414).

`#473` ports the frozen reference's five fixtures (positive plus NONFAIR / BLOCKED / FLICKERING / PUMPED negative controls) to native Rust tests in both `fsl-verifier` and `fslc-rust`, covering all six `rank_failure` kinds, plus a CLI-level typo/arity rejection test.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (138 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/README.md`, `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 1:1), `docs/DESIGN-temporal.md`, `docs/DESIGN-induction.md`, `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`.

## Scope boundary

An earlier revision of this work also added `"error"` and `"unknown_budget"` to `run_sweep`'s counterexample `matches!` list. **That was removed.** The `"error"` case is issue #464 — already fixed and merged in PR #503 by short-circuiting *before* that match, because reporting a spec error as `sweep_failed`/exit 1 trades one exit-code violation for another; and `unknown_budget` is unreachable there, since `sweep` accepts only `--engine {bmc,induction}`. `rust/fslc/src/main.rs` now has no diff against upstream in this PR.

Found while implementing #467 and filed separately, **not** fixed here: **#502** — `reachable(r, a, a)` disagrees between engines (the concrete Monitor treats 0-hop self-reachability as true; the symbolic encoding requires at least one edge), so the same spec reports `violated_at_step: 0` under `--engine explicit` and `1` under BMC. The disagreement predates the native port — `runtime.py` and `bmc.py` already differed, and both halves were ported faithfully — so the contract has to be decided before either side moves.

## Linked issues

Fixes #461, fixes #467, fixes #473, fixes #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
