### PR TITLE
fix(db): close compatibility detection gaps, stop false firings, and validate runtime observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,51 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   diagnostics").
 
 ### Fixed
+- `fslc db check` no longer reports a confidently green `verified_under_assumptions`
+  over a genuine compatibility violation. `validate_db` now rejects a `check
+  compatibility` rule name outside the closed vocabulary and an `environment
+  schema lo..hi` the declared migration plan never reaches (exit 2 instead of
+  silently checking nothing). `findings()` is rewritten around a materialized
+  per-migration column-state simulation (mirroring the frozen Python
+  reference's `_static_findings`) instead of syntactic pattern matching, which
+  fixes: `set_not_null` without a prior `backfill` (previously made the
+  violating kernel transition unreachable instead of reported);
+  `rollback_not_equivalent` never firing for a lossy rollbackable
+  split/merge (only `drop` was checked); `data_preservation_loss` never
+  firing for dropping an existing column (only split/merge were checked);
+  reads/writes checked against "a drop op exists somewhere in the source"
+  instead of actual per-snapshot column state (missed an initially absent
+  column with a live reader, and false-fired on a column dropped then
+  re-added); and an offline payload's TTL window never extending its
+  acceptance obligation past the emitting schema snapshot. An `active`
+  artifact's own `calls`/`expects`/`emits_offline`/`requires` declarations
+  are now checked too — previously only artifacts other than `active` were
+  treated as consumers (#490).
+- `fslc db check` no longer false-fires against already-annotated migrations
+  and supported providers. A `supported` (not just `active`) artifact's
+  `accepts`/`responds`/`provides` now counts toward compatibility (`may_exist`
+  still does not); `drop ... destructive` is accepted alongside
+  `irreversible`, and dropping an already-absent column no longer fires
+  `destructive_migration_unannotated`; `split`/`merge ... irreversible` is
+  accepted as a preservation classification alongside `lossless`/`lossy`; and
+  every finding kind is now gated by its documented rule (`rule_enabled`,
+  centralized instead of scattered per-finding conditionals), so an opt-in
+  `data_preserved`/`rollback_equivalent` rule no longer fires when it was not
+  selected (#491).
+- `api_response_field_missing`'s `failed_rule` is now the documented
+  `api_responses_expected` instead of the undocumented
+  `api_response_fields_available` (#492).
+- `fslc db observe` validates its observation envelope and every event
+  against `schemas/fslc/db/observation.v0.schema.json` before evaluating them
+  — a declared `schema_version` must equal `fsl-db-observation.v0`, and each
+  event must be an object with typed required fields and a `capability` from
+  the closed vocabulary — and fails with a located exit-2 error instead of
+  defaulting a missing/mistyped field into a fabricated `unsupported_artifact_observed`
+  witness (#505).
+- `fslc db observe` now matches an event's `flags` snapshot against artifact
+  window conditions the same way `fslc db check` does; an artifact observed
+  under the wrong feature-flag variant is `unsupported_artifact_observed`
+  instead of silently `observed_conformant` (#506).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   window conditions the same way `fslc db check` does; an artifact observed
   under the wrong feature-flag variant is `unsupported_artifact_observed`
   instead of silently `observed_conformant` (#506).
+- `fslc db import`'s SQL importer now lowers `ALTER TABLE ... DROP COLUMN`
+  into a `drop ... irreversible` migration op as documented (previously
+  unimplemented — the construct fell through to `unsupported_sql`), and a
+  malformed `CREATE TABLE` (unbalanced/missing parentheses) now produces an
+  `unsupported_sql` warning instead of being silently skipped with no warning
+  and no table (#507).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/docs/DESIGN-db.md
+++ b/docs/DESIGN-db.md
@@ -70,7 +70,11 @@ restrict itself with `when schema lo..hi`.
 `environment schema lo..hi` means exactly the set of schema versions in that
 environment that are reachable in the declared migration order. It does not mean
 every Cartesian product of arbitrary schema and artifact versions; artifact
-coexistence is explicit in the artifact windows.
+coexistence is explicit in the artifact windows. Validation rejects an
+environment schema version that the declared, strictly sequential migration
+plan never reaches, and rejects a `check compatibility` rule name outside the
+closed vocabulary below; both fail `fslc check` / `fslc db check` with exit 2
+instead of silently checking nothing.
 
 Rules checked in snapshot mode:
 
@@ -241,6 +245,19 @@ observation log to a `dbsystem` and emits `observed_mismatch` findings such as:
 Absence from logs is not proof of unused behavior. Observation results include
 `DB-ASSUME-OBSERVABILITY-COVERAGE` and `formal_result: "not_run"` to keep them
 separate from formal compatibility verification.
+
+The observation envelope is validated against
+`schemas/fslc/db/observation.v0.schema.json` before evaluation: a declared
+`schema_version` must equal `fsl-db-observation.v0`, and every event must be an
+object with typed `environment`/`artifact`/`target` strings, an integer
+`schema_version`, a `capability` from the closed vocabulary
+(`reads`/`writes`/`calls`/`requires`/`provides`), and, when present, a `flags`
+object of string values. A malformed envelope or event fails `fslc db observe`
+with exit 2 instead of defaulting missing/mistyped fields into a fabricated
+finding. An event's `flags` snapshot is matched against each artifact entry's
+`when flag ...` conditions the same way `fslc db check` matches them, so an
+artifact observed under the wrong flag variant is `unsupported_artifact_observed`
+rather than silently conformant.
 
 ### 7. Importer Boundary
 

--- a/docs/DESIGN-db.md
+++ b/docs/DESIGN-db.md
@@ -271,7 +271,8 @@ typed IR boundary. It supports:
 - `UPDATE ... SET ...` as a backfill signal
 
 Unsupported constructs are reported as `unsupported_sql` warnings and are not
-silently ignored.
+silently ignored; a malformed statement (for example an unbalanced `CREATE
+TABLE`) is reported the same way rather than being dropped without a warning.
 
 The first ORM-specific importer is `prisma-schema-minimal.v0`. It imports
 Prisma `model` scalar fields into the same typed IR and reports relation/list or

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2175,7 +2175,9 @@ dbsystem <Name> {
 ライフサイクル、destructive のアノテーション、preservation-transform の
 アノテーション、API/オフラインの互換性をカバーします。`data_preserved` と
 `rollback_equivalent` はオプトインの有界検査で、`DB-ASSUME-BOUNDED-ROW-MODEL` を
-報告します。
+報告します。上記の閉じた語彙にない `rule` 名や、宣言された厳密に順序付けられた
+マイグレーション計画では到達しない `environment schema lo..hi` は、何も検査せず
+に静かに通るのではなく、検証で exit 2 になります。
 
 フィーチャーフラグは有限の環境次元です。`fslc db check` は、宣言されたバリアント
 を schema のスナップショットとともに列挙し、
@@ -2216,6 +2218,12 @@ migration/schema の要素、最小の競合集合、修復候補を含む `find
 ログからの不在は、未使用の振る舞いの証明ではありません。
 生成されたカーネルの反例を直接調べたいときは、通常の `fslc verify` を使って
 ください。
+
+`fslc db observe` は、観測イベントを評価する前に、観測エンベロープ/イベントを
+`schemas/fslc/db/observation.v0.schema.json` に対して検証します(型付きの必須
+フィールド、閉じた `capability` 語彙、不正なレコードでは exit 2)。各イベントの
+任意の `flags` スナップショットは、`fslc db check` と同じ方法でアーティファクト
+のウィンドウと照合されます。
 
 汎用の `requires` / `provides` ケイパビリティにより、AI モデル/プロンプト/
 リトリーバー/ツールスキーマと出力スキーマのプロファイルが、DB/API/モバイル/

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2226,7 +2226,10 @@ dbsystem <Name> {
 If `check compatibility` is omitted, default rules cover read/write lifecycle,
 destructive annotations, preservation-transform annotations, and API/offline
 compatibility. `data_preserved` and `rollback_equivalent` are opt-in bounded
-checks and report `DB-ASSUME-BOUNDED-ROW-MODEL`.
+checks and report `DB-ASSUME-BOUNDED-ROW-MODEL`. A `rule` name outside the
+closed vocabulary above, or an `environment schema lo..hi` that the declared,
+strictly sequential migration plan never reaches, fails validation with exit 2
+instead of silently checking nothing.
 
 Feature flags are finite environment dimensions. `fslc db check` enumerates the
 declared variants with schema snapshots and reports
@@ -2266,6 +2269,12 @@ candidates. Runtime observation returns `observed_mismatch` with
 `formal_result: "not_run"`; absence from logs is not proof of unused behavior.
 Use ordinary `fslc verify` when you want to inspect the generated kernel
 counterexample directly.
+
+`fslc db observe` validates the observation envelope/events against
+`schemas/fslc/db/observation.v0.schema.json` (typed required fields, a closed
+`capability` vocabulary, exit 2 on a malformed record) before evaluating them,
+and matches each event's optional `flags` snapshot against artifact windows the
+same way `fslc db check` does.
 
 Generic `requires` / `provides` capabilities let AI model/prompt/retriever/tool
 schema and output schema profiles share the same compatibility check as

--- a/rust/fsl-tools/src/db.rs
+++ b/rust/fsl-tools/src/db.rs
@@ -3,11 +3,36 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
-use fsl_syntax::{DbArtifact, DbColumnRef, DbEnvironment, DbEnvironmentArtifact, DbSystem, Span};
+use fsl_syntax::{
+    DbArtifact, DbColumnRef, DbEnvironment, DbEnvironmentArtifact, DbMigration, DbMigrationOp,
+    DbSystem, Span,
+};
 use serde_json::{Map, Value, json};
 
 const DIALECT: &str = "fsl-db-mvp.v0";
 const FINDING_SCHEMA: &str = "fsl-db-finding.v0";
+const OBSERVATION_SCHEMA_VERSION: &str = "fsl-db-observation.v0";
+const OBSERVATION_CAPABILITIES: &[&str] = &["reads", "writes", "calls", "requires", "provides"];
+
+/// The default `check compatibility` rule set applied when a `dbsystem` omits
+/// the block entirely (`docs/DESIGN-db.md` "Syntax"). `data_preserved` and
+/// `rollback_equivalent` are deliberately excluded: they remain opt-in.
+const DEFAULT_RULES: &[&str] = &[
+    "all_active_reads_exist",
+    "all_active_writes_exist",
+    "removed_only_after_unused",
+    "not_null_after_backfill",
+    "destructive_operations_annotated",
+    "preservation_transforms_annotated",
+    "api_calls_accepted",
+    "api_responses_expected",
+    "offline_payloads_accepted",
+    "artifact_capabilities_provided",
+];
+
+/// Rules that exist in the closed vocabulary but are never enabled by
+/// default; a `dbsystem` must select them explicitly.
+const OPT_IN_RULES: &[&str] = &["data_preserved", "rollback_equivalent"];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DbToolError {
@@ -23,6 +48,10 @@ impl fmt::Display for DbToolError {
 
 impl std::error::Error for DbToolError {}
 
+fn tool_error(message: String, span: Option<Span>) -> DbToolError {
+    DbToolError { message, span }
+}
+
 fn reference(reference: &DbColumnRef) -> String {
     format!("{}.{}", reference.0, reference.1)
 }
@@ -32,7 +61,11 @@ fn reference(reference: &DbColumnRef) -> String {
 /// # Errors
 ///
 /// Returns [`DbToolError`] when a migration or environment references an
-/// undeclared schema element, artifact, flag, or flag variant.
+/// undeclared schema element, artifact, flag, or flag variant; when
+/// `check compatibility` selects a rule outside the closed vocabulary; or
+/// when a migration or environment schema window is not reachable in the
+/// declared, strictly sequential migration plan.
+#[allow(clippy::too_many_lines)]
 pub fn validate_db(system: &DbSystem) -> Result<(), DbToolError> {
     let columns = system
         .database
@@ -45,10 +78,10 @@ pub fn validate_db(system: &DbSystem) -> Result<(), DbToolError> {
         for operation in &migration.ops {
             for column in std::iter::once(&operation.column).chain(operation.columns.iter()) {
                 if !columns.contains(column) {
-                    return Err(DbToolError {
-                        message: format!("unknown column '{}'", reference(column)),
-                        span: Some(operation.span),
-                    });
+                    return Err(tool_error(
+                        format!("unknown column '{}'", reference(column)),
+                        Some(operation.span),
+                    ));
                 }
             }
         }
@@ -71,30 +104,87 @@ pub fn validate_db(system: &DbSystem) -> Result<(), DbToolError> {
             .collect::<BTreeMap<_, _>>();
         for artifact in &environment.artifacts {
             if !artifacts.contains(artifact.artifact.as_str()) {
-                return Err(DbToolError {
-                    message: format!("unknown artifact '{}'", artifact.artifact),
-                    span: Some(artifact.span),
-                });
+                return Err(tool_error(
+                    format!("unknown artifact '{}'", artifact.artifact),
+                    Some(artifact.span),
+                ));
             }
             for condition in &artifact.flag_conditions {
                 let Some(variants) = flags.get(condition.flag.as_str()) else {
-                    return Err(DbToolError {
-                        message: format!("unknown flag '{}'", condition.flag),
-                        span: Some(condition.span),
-                    });
+                    return Err(tool_error(
+                        format!("unknown flag '{}'", condition.flag),
+                        Some(condition.span),
+                    ));
                 };
                 if !variants.contains(&condition.variant) {
-                    return Err(DbToolError {
-                        message: format!(
+                    return Err(tool_error(
+                        format!(
                             "unknown variant '{}' for flag '{}'",
                             condition.variant, condition.flag
                         ),
-                        span: Some(condition.span),
-                    });
+                        Some(condition.span),
+                    ));
                 }
             }
         }
     }
+
+    // DB-01 (#490): `check compatibility` accepted any rule name, so a typo
+    // silently selected nothing instead of raising an error. The closed
+    // vocabulary is `DEFAULT_RULES` plus `OPT_IN_RULES`.
+    for rule in &system.check.rules {
+        if !DEFAULT_RULES.contains(&rule.name.as_str())
+            && !OPT_IN_RULES.contains(&rule.name.as_str())
+        {
+            let mut allowed = DEFAULT_RULES.to_vec();
+            allowed.extend_from_slice(OPT_IN_RULES);
+            allowed.sort_unstable();
+            return Err(tool_error(
+                format!(
+                    "unknown db compatibility rule '{}'; supported rules: {}",
+                    rule.name,
+                    allowed.join(", ")
+                ),
+                Some(rule.span),
+            ));
+        }
+    }
+
+    // DB-04 (#490): an `environment schema lo..hi` must denote schema
+    // versions actually reachable in the declared migration plan
+    // (`docs/DESIGN-db.md` "Compatibility Snapshot"). Migrations are a
+    // single, strictly sequential rollout plan, so this also rejects a
+    // migration whose `from` does not chain from the previous schema.
+    let mut current_schema = system.database.initial_schema;
+    let mut reached = BTreeSet::new();
+    reached.insert(current_schema);
+    for migration in &system.migrations {
+        if migration.from_schema != current_schema {
+            return Err(tool_error(
+                format!(
+                    "migration '{}' starts at schema {}, but the declared rollout plan is currently at {current_schema}",
+                    migration.name, migration.from_schema
+                ),
+                Some(migration.span),
+            ));
+        }
+        current_schema = migration.to_schema;
+        reached.insert(current_schema);
+    }
+    for environment in &system.environments {
+        for version in environment.schema_window.0..=environment.schema_window.1 {
+            if !reached.contains(&version) {
+                return Err(tool_error(
+                    format!(
+                        "environment '{}' includes schema {version}, which is not reachable in the declared migration plan",
+                        environment.name
+                    ),
+                    Some(environment.span),
+                ));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -217,6 +307,51 @@ fn compat_repairs(capability_name: &str, artifact: &str, column: &str, environme
     ])
 }
 
+fn destructive_repairs(column: &str) -> Value {
+    json!([
+        {
+            "kind": "annotation_change",
+            "weakens_spec": false,
+            "description": format!("mark the operation as irreversible/destructive if {column} loss is intended"),
+        },
+        {
+            "kind": "compat_shim",
+            "weakens_spec": false,
+            "description": format!("keep {column} or replace it with a compatibility shim before dropping it"),
+        }
+    ])
+}
+
+fn preservation_repairs(element: &str) -> Value {
+    json!([
+        {
+            "kind": "preservation_mapping",
+            "weakens_spec": false,
+            "description": format!("provide a lossless preservation transform for {element}"),
+        },
+        {
+            "kind": "annotation_change",
+            "weakens_spec": false,
+            "description": format!("mark {element} as lossy/irreversible when information loss is intended"),
+        }
+    ])
+}
+
+fn rollback_repairs(element: &str) -> Value {
+    json!([
+        {
+            "kind": "rollback_contract_change",
+            "weakens_spec": false,
+            "description": format!("remove rollbackable from the migration unless {element} has an inverse"),
+        },
+        {
+            "kind": "preservation_mapping",
+            "weakens_spec": false,
+            "description": format!("add a lossless inverse transform for {element}"),
+        }
+    ])
+}
+
 fn window(entry: &DbEnvironmentArtifact, environment: &DbEnvironment) -> (i64, i64) {
     entry.schema_window.unwrap_or(environment.schema_window)
 }
@@ -253,135 +388,557 @@ fn artifact_by_name<'a>(system: &'a DbSystem, name: &str) -> Option<&'a DbArtifa
         .find(|artifact| artifact.name == name)
 }
 
+/// Whether `rule` is active. An empty `check compatibility` block (or its
+/// absence) falls back to `DEFAULT_RULES`; `data_preserved` and
+/// `rollback_equivalent` stay off unless selected explicitly (DB-10 / #491).
 fn rule_enabled(system: &DbSystem, rule: &str) -> bool {
-    system.check.rules.is_empty() || system.check.rules.iter().any(|item| item.name == rule)
+    if system.check.rules.is_empty() {
+        DEFAULT_RULES.contains(&rule)
+    } else {
+        system.check.rules.iter().any(|item| item.name == rule)
+    }
+}
+
+/// Column lifecycle state used to statically simulate a migration plan
+/// (mirrors the frozen Python reference's `_apply_op`/`_static_findings`).
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+struct ColumnState {
+    exists: bool,
+    backfilled: bool,
+    not_null: bool,
+}
+
+type ColumnStates = BTreeMap<DbColumnRef, ColumnState>;
+
+fn initial_column_states(system: &DbSystem) -> ColumnStates {
+    system
+        .database
+        .tables
+        .iter()
+        .flat_map(|table| table.columns.iter())
+        .map(|column| {
+            (
+                (column.table.clone(), column.name.clone()),
+                ColumnState {
+                    exists: column.present,
+                    backfilled: column.backfilled,
+                    not_null: column.not_null,
+                },
+            )
+        })
+        .collect()
+}
+
+fn apply_migration_op(state: &mut ColumnStates, operation: &DbMigrationOp) {
+    match operation.op.as_str() {
+        "add" => {
+            state.insert(
+                operation.column.clone(),
+                ColumnState {
+                    exists: true,
+                    backfilled: false,
+                    not_null: operation.nullability.as_deref() == Some("not_null"),
+                },
+            );
+        }
+        "backfill" => {
+            if let Some(cell) = state.get_mut(&operation.column)
+                && cell.exists
+            {
+                cell.backfilled = true;
+            }
+        }
+        "set_not_null" => {
+            if let Some(cell) = state.get_mut(&operation.column)
+                && cell.exists
+            {
+                cell.not_null = true;
+            }
+        }
+        "drop" => {
+            state.insert(operation.column.clone(), ColumnState::default());
+        }
+        "rename" => {
+            if let Some(target) = operation.columns.first() {
+                let source = state.get(&operation.column).copied().unwrap_or_default();
+                state.insert(
+                    target.clone(),
+                    ColumnState {
+                        exists: true,
+                        backfilled: source.backfilled,
+                        not_null: source.not_null,
+                    },
+                );
+                state.insert(operation.column.clone(), ColumnState::default());
+            }
+        }
+        "split" => {
+            state.insert(operation.column.clone(), ColumnState::default());
+            for target in &operation.columns {
+                state.insert(
+                    target.clone(),
+                    ColumnState {
+                        exists: true,
+                        backfilled: true,
+                        not_null: false,
+                    },
+                );
+            }
+        }
+        "merge" => {
+            for source in &operation.columns {
+                state.insert(source.clone(), ColumnState::default());
+            }
+            state.insert(
+                operation.column.clone(),
+                ColumnState {
+                    exists: true,
+                    backfilled: true,
+                    not_null: false,
+                },
+            );
+        }
+        _ => {}
+    }
+}
+
+fn operation_annotations<'a>(
+    migration: &'a DbMigration,
+    operation: &'a DbMigrationOp,
+) -> BTreeSet<&'a str> {
+    migration
+        .annotations
+        .iter()
+        .chain(operation.annotations.iter())
+        .map(String::as_str)
+        .collect()
+}
+
+/// Whether `operation` loses information in the bounded row model: an
+/// existing column dropped, or a split/merge not marked `lossless`
+/// (`docs/DESIGN-db.md` "Preservation and Rollback").
+fn breaks_preservation(
+    operation: &DbMigrationOp,
+    annotations: &BTreeSet<&str>,
+    before_exists: bool,
+) -> bool {
+    match operation.op.as_str() {
+        "drop" => before_exists,
+        "split" | "merge" => !annotations.contains("lossless"),
+        _ => false,
+    }
+}
+
+/// Findings produced by one migration operation, evaluated against the
+/// column state just before and just after it is (hypothetically) applied.
+/// DB-03/DB-05/DB-06/DB-08/DB-09/DB-10 (#490, #491) are all cases where the
+/// old code either encoded the forbidden state as kernel-action
+/// disabledness (so the checker never saw it), checked only one of several
+/// documented operations, or fired without consulting its rule gate.
+#[allow(clippy::too_many_lines)]
+fn migration_op_findings(
+    system: &DbSystem,
+    migration: &DbMigration,
+    operation: &DbMigrationOp,
+    before: &ColumnStates,
+    after: &ColumnStates,
+    assumptions: &[Value],
+) -> Vec<Value> {
+    let mut findings = Vec::new();
+    let element = reference(&operation.column);
+    let before_exists = before
+        .get(&operation.column)
+        .copied()
+        .unwrap_or_default()
+        .exists;
+
+    // not_null_after_backfill: `add ... not_null` and `set_not_null` both
+    // reach this state; DB-03 was that `set_not_null`'s violating
+    // trajectory was made unreachable at the kernel level instead of
+    // reported.
+    if matches!(operation.op.as_str(), "add" | "set_not_null")
+        && rule_enabled(system, "not_null_after_backfill")
+    {
+        let after_cell = after.get(&operation.column).copied().unwrap_or_default();
+        if after_cell.not_null && !after_cell.backfilled {
+            let mut finding = common_finding(
+                "not_null_before_backfill",
+                "not_null_after_backfill",
+                assumptions,
+            );
+            finding.insert("migration".to_owned(), json!(migration.name));
+            finding.insert("schema_element".to_owned(), json!(element));
+            finding.insert(
+                "witness".to_owned(),
+                json!({"schema_version": migration.to_schema, "operation": operation.op, "column": element}),
+            );
+            finding.insert(
+                "minimal_conflict_set".to_owned(),
+                json!({"migration": migration.name, "schema_element": element}),
+            );
+            finding.insert(
+                "repair_candidates".to_owned(),
+                json!([
+                    {"kind": "compat_shim", "weakens_spec": false, "description": format!("backfill {element} before setting it not_null")},
+                    {"kind": "migration_change", "weakens_spec": false, "description": format!("keep {element} nullable until a later migration")},
+                    {"kind": "declaration_change", "weakens_spec": true, "description": "remove the not_null marker only if the product contract truly allows nulls"}
+                ]),
+            );
+            findings.push(Value::Object(finding));
+        }
+    }
+
+    let annotations = operation_annotations(migration, operation);
+
+    // destructive_operations_annotated: DB-08 was that `destructive` was
+    // never accepted (only `irreversible` was) and that a drop of an
+    // already-absent column still fired.
+    if operation.op == "drop"
+        && before_exists
+        && rule_enabled(system, "destructive_operations_annotated")
+        && !annotations.contains("destructive")
+        && !annotations.contains("irreversible")
+    {
+        let mut finding = common_finding(
+            "destructive_migration_unannotated",
+            "destructive_operations_annotated",
+            assumptions,
+        );
+        finding.insert("migration".to_owned(), json!(migration.name));
+        finding.insert("schema_element".to_owned(), json!(element));
+        finding.insert(
+            "minimal_conflict_set".to_owned(),
+            json!({"migration": migration.name, "schema_element": element}),
+        );
+        finding.insert(
+            "repair_candidates".to_owned(),
+            destructive_repairs(&element),
+        );
+        findings.push(Value::Object(finding));
+    }
+
+    // preservation_transforms_annotated: DB-09 was that `irreversible` was
+    // never accepted as a preservation classification (only
+    // `lossless`/`lossy` were).
+    if matches!(operation.op.as_str(), "split" | "merge")
+        && rule_enabled(system, "preservation_transforms_annotated")
+        && !annotations.contains("lossless")
+        && !annotations.contains("lossy")
+        && !annotations.contains("irreversible")
+    {
+        let mut finding = common_finding(
+            "preservation_transform_unannotated",
+            "preservation_transforms_annotated",
+            assumptions,
+        );
+        finding.insert("migration".to_owned(), json!(migration.name));
+        finding.insert("schema_element".to_owned(), json!(element));
+        finding.insert(
+            "minimal_conflict_set".to_owned(),
+            json!({"migration": migration.name, "schema_element": element}),
+        );
+        finding.insert(
+            "repair_candidates".to_owned(),
+            preservation_repairs(&element),
+        );
+        findings.push(Value::Object(finding));
+    }
+
+    // data_preserved: DB-06 was that dropping an existing column never
+    // produced `data_preservation_loss` (only split/merge did).
+    if rule_enabled(system, "data_preserved")
+        && breaks_preservation(operation, &annotations, before_exists)
+    {
+        let mut finding = common_finding("data_preservation_loss", "data_preserved", assumptions);
+        finding.insert("migration".to_owned(), json!(migration.name));
+        finding.insert("schema_element".to_owned(), json!(element));
+        finding.insert(
+            "minimal_conflict_set".to_owned(),
+            json!({"migration": migration.name, "schema_element": element}),
+        );
+        finding.insert(
+            "repair_candidates".to_owned(),
+            preservation_repairs(&element),
+        );
+        findings.push(Value::Object(finding));
+    }
+
+    // rollback_equivalent: DB-05 was that `rollback_not_equivalent` only
+    // ever fired for `drop`, never for a lossy rollbackable split/merge.
+    if rule_enabled(system, "rollback_equivalent")
+        && migration
+            .annotations
+            .iter()
+            .any(|item| item == "rollbackable")
+        && breaks_preservation(operation, &annotations, before_exists)
+    {
+        let mut finding = common_finding(
+            "rollback_not_equivalent",
+            "rollback_equivalent",
+            assumptions,
+        );
+        finding.insert("migration".to_owned(), json!(migration.name));
+        finding.insert("schema_element".to_owned(), json!(element));
+        finding.insert(
+            "minimal_conflict_set".to_owned(),
+            json!({"migration": migration.name, "schema_element": element}),
+        );
+        finding.insert("repair_candidates".to_owned(), rollback_repairs(&element));
+        findings.push(Value::Object(finding));
+    }
+
+    findings
+}
+
+/// The `accepts`/`responds`/`provides` capability set contributed by every
+/// `active` or `supported` artifact live at `(schema, flags)`. `may_exist`
+/// artifacts are never providers (`docs/DESIGN-db.md` "an active or
+/// supported provider").
+fn provided_capability(
+    environment: &DbEnvironment,
+    system: &DbSystem,
+    schema: i64,
+    flags: &BTreeMap<String, String>,
+    capability_name: &str,
+) -> BTreeSet<DbColumnRef> {
+    environment
+        .artifacts
+        .iter()
+        .filter(|entry| matches!(entry.role.as_str(), "active" | "supported"))
+        .filter(|entry| {
+            let range = window(entry, environment);
+            range.0 <= schema && schema <= range.1 && conditions_match(entry, flags)
+        })
+        .filter_map(|entry| artifact_by_name(system, &entry.artifact))
+        .flat_map(|artifact| capability(artifact, capability_name))
+        .cloned()
+        .collect()
 }
 
 #[allow(clippy::too_many_lines)]
 fn findings(system: &DbSystem, assumptions: &[Value]) -> Vec<Value> {
     let mut findings = Vec::new();
+
+    // Materialize column state after every migration (DB-11 / #490): reads
+    // and writes are checked against the actual state reached at each
+    // snapshot instead of "a drop operation exists somewhere in the
+    // source," which both missed an initially absent column with a live
+    // reader and false-fired on a column dropped then re-added later.
+    let mut states: BTreeMap<i64, ColumnStates> = BTreeMap::new();
+    let mut sources: BTreeMap<i64, Option<String>> = BTreeMap::new();
+    let mut current_state = initial_column_states(system);
+    states.insert(system.database.initial_schema, current_state.clone());
+    sources.insert(system.database.initial_schema, None);
+
     for migration in &system.migrations {
         for operation in &migration.ops {
-            let element = reference(&operation.column);
-            if operation.op == "add" && operation.nullability.as_deref() == Some("not_null") {
-                let mut finding = common_finding(
-                    "not_null_before_backfill",
-                    "not_null_after_backfill",
-                    assumptions,
-                );
-                finding.insert("migration".to_owned(), json!(migration.name));
-                finding.insert("schema_element".to_owned(), json!(element));
-                finding.insert("witness".to_owned(), json!({"schema_version": migration.to_schema, "operation": "add", "column": element}));
-                finding.insert(
-                    "minimal_conflict_set".to_owned(),
-                    json!({"migration": migration.name, "schema_element": element}),
-                );
-                finding.insert("repair_candidates".to_owned(), json!([
-                    {"kind": "compat_shim", "weakens_spec": false, "description": format!("backfill {element} before setting it not_null")},
-                    {"kind": "migration_change", "weakens_spec": false, "description": format!("keep {element} nullable until a later migration")},
-                    {"kind": "declaration_change", "weakens_spec": true, "description": "remove the not_null marker only if the product contract truly allows nulls"}
-                ]));
-                findings.push(Value::Object(finding));
-            }
-            if rule_enabled(system, "destructive_operations_annotated")
-                && operation.op == "drop"
-                && !operation
-                    .annotations
-                    .iter()
-                    .any(|item| item == "irreversible")
-            {
-                let mut finding = common_finding(
-                    "destructive_migration_unannotated",
-                    "destructive_operations_annotated",
-                    assumptions,
-                );
-                finding.insert("migration".to_owned(), json!(migration.name));
-                finding.insert("schema_element".to_owned(), json!(element));
-                finding.insert(
-                    "minimal_conflict_set".to_owned(),
-                    json!({"migration": migration.name, "schema_element": element}),
-                );
-                finding.insert(
-                    "repair_candidates".to_owned(),
-                    json!([
-                        {"kind": "annotation_change", "weakens_spec": false},
-                        {"kind": "compat_shim", "weakens_spec": false}
-                    ]),
-                );
-                findings.push(Value::Object(finding));
-            }
-            if matches!(operation.op.as_str(), "split" | "merge") {
-                let (kind, rule) = if operation.annotations.iter().any(|item| item == "lossy") {
-                    ("data_preservation_loss", "data_preserved")
-                } else if !operation.annotations.iter().any(|item| item == "lossless") {
-                    (
-                        "preservation_transform_unannotated",
-                        "preservation_transforms_annotated",
-                    )
-                } else {
-                    continue;
-                };
-                let mut finding = common_finding(kind, rule, assumptions);
-                finding.insert("migration".to_owned(), json!(migration.name));
-                finding.insert("schema_element".to_owned(), json!(element));
-                findings.push(Value::Object(finding));
-            }
-            if migration
-                .annotations
-                .iter()
-                .any(|item| item == "rollbackable")
-                && operation.op == "drop"
-            {
-                let mut finding = common_finding(
-                    "rollback_not_equivalent",
-                    "rollback_equivalent",
-                    assumptions,
-                );
-                finding.insert("migration".to_owned(), json!(migration.name));
-                finding.insert("schema_element".to_owned(), json!(element));
-                findings.push(Value::Object(finding));
-            }
-            if operation.op == "drop" {
-                for environment in &system.environments {
-                    for entry in &environment.artifacts {
-                        let Some(artifact) = artifact_by_name(system, &entry.artifact) else {
-                            continue;
-                        };
-                        let range = window(entry, environment);
-                        if range.1 < migration.to_schema {
+            let before_state = current_state.clone();
+            apply_migration_op(&mut current_state, operation);
+            findings.extend(migration_op_findings(
+                system,
+                migration,
+                operation,
+                &before_state,
+                &current_state,
+                assumptions,
+            ));
+        }
+        states.insert(migration.to_schema, current_state.clone());
+        sources.insert(migration.to_schema, Some(migration.name.clone()));
+    }
+
+    let reads_enabled = rule_enabled(system, "all_active_reads_exist")
+        || rule_enabled(system, "removed_only_after_unused");
+    let writes_enabled = rule_enabled(system, "all_active_writes_exist")
+        || rule_enabled(system, "removed_only_after_unused");
+    let calls_enabled = rule_enabled(system, "api_calls_accepted");
+    let expects_enabled = rule_enabled(system, "api_responses_expected");
+    let offline_enabled = rule_enabled(system, "offline_payloads_accepted");
+    let requires_enabled = rule_enabled(system, "artifact_capabilities_provided");
+
+    for environment in &system.environments {
+        for schema in environment.schema_window.0..=environment.schema_window.1 {
+            let state = states.get(&schema).cloned().unwrap_or_default();
+            let source = sources.get(&schema).cloned().flatten();
+            for flags in flag_snapshots(environment) {
+                let accepts = provided_capability(environment, system, schema, &flags, "accepts");
+                let responds = provided_capability(environment, system, schema, &flags, "responds");
+                let provides = provided_capability(environment, system, schema, &flags, "provides");
+
+                // Every declared entry is checked as a consumer regardless
+                // of role (DB-02 / #490): an `active` artifact that itself
+                // `calls`/`expects`/`emits_offline`/`requires` was
+                // previously classified only as a provider and never
+                // checked. `provided_capability` above already restricts
+                // *providers* to active/supported (DB-07 / #491): a
+                // `supported` provider's `accepts`/`responds`/`provides`
+                // used to be ignored entirely.
+                let active_entries = environment.artifacts.iter().filter(|entry| {
+                    let range = window(entry, environment);
+                    range.0 <= schema && schema <= range.1 && conditions_match(entry, &flags)
+                });
+
+                for entry in active_entries {
+                    let Some(artifact) = artifact_by_name(system, &entry.artifact) else {
+                        continue;
+                    };
+
+                    for (capability_name, kind, rule, gate) in [
+                        (
+                            "reads",
+                            "column_removed_while_still_read",
+                            "all_active_reads_exist",
+                            reads_enabled,
+                        ),
+                        (
+                            "writes",
+                            "column_removed_while_still_written",
+                            "all_active_writes_exist",
+                            writes_enabled,
+                        ),
+                    ] {
+                        if !gate {
                             continue;
                         }
-                        for (capability_name, kind, rule) in [
-                            (
-                                "reads",
-                                "column_removed_while_still_read",
-                                "all_active_reads_exist",
-                            ),
-                            (
-                                "writes",
-                                "column_removed_while_still_written",
-                                "all_active_writes_exist",
-                            ),
-                        ] {
-                            if !capability(artifact, capability_name).contains(&operation.column) {
+                        for column in capability(artifact, capability_name) {
+                            if state.get(column).copied().unwrap_or_default().exists {
                                 continue;
                             }
+                            let column_element = reference(column);
                             let mut finding = common_finding(kind, rule, assumptions);
                             finding.insert("environment".to_owned(), json!(environment.name));
-                            finding.insert("migration".to_owned(), json!(migration.name));
-                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert("migration".to_owned(), json!(source));
+                            finding.insert("schema_element".to_owned(), json!(column_element));
                             finding.insert("artifact".to_owned(), json!(artifact.name));
                             finding.insert("artifact_version".to_owned(), json!(artifact.name));
-                            finding.insert("witness".to_owned(), json!({"environment_role": entry.role, "schema_version": migration.to_schema, "declared_capability": capability_name}));
-                            finding.insert("minimal_conflict_set".to_owned(), json!({"environment": environment.name, "artifact": artifact.name, "migration": migration.name, "schema_element": element}));
+                            finding.insert(
+                                "witness".to_owned(),
+                                json!({"environment_role": entry.role, "schema_version": schema, "declared_capability": capability_name}),
+                            );
+                            finding.insert(
+                                "minimal_conflict_set".to_owned(),
+                                json!({"environment": environment.name, "artifact": artifact.name, "migration": source, "schema_element": column_element}),
+                            );
                             finding.insert(
                                 "repair_candidates".to_owned(),
                                 compat_repairs(
                                     capability_name,
                                     &artifact.name,
-                                    &element,
+                                    &column_element,
                                     &environment.name,
                                 ),
+                            );
+                            findings.push(Value::Object(finding));
+                        }
+                    }
+
+                    if calls_enabled {
+                        for called in capability(artifact, "calls") {
+                            if accepts.contains(called) {
+                                continue;
+                            }
+                            let element = reference(called);
+                            let mut finding = common_finding(
+                                "api_call_not_accepted",
+                                "api_calls_accepted",
+                                assumptions,
+                            );
+                            finding.insert("environment".to_owned(), json!(environment.name));
+                            finding.insert("artifact".to_owned(), json!(artifact.name));
+                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert(
+                                "witness".to_owned(),
+                                json!({"schema_version": schema, "flags": flags}),
+                            );
+                            finding.insert(
+                                "minimal_conflict_set".to_owned(),
+                                json!({"environment": environment.name, "artifact": artifact.name, "schema_element": element, "flags": flags}),
+                            );
+                            findings.push(Value::Object(finding));
+                        }
+                    }
+
+                    if expects_enabled {
+                        for expected in capability(artifact, "expects") {
+                            if responds.contains(expected) {
+                                continue;
+                            }
+                            let element = reference(expected);
+                            // DB-12 (#492): the documented rule for this
+                            // finding is `api_responses_expected`
+                            // (`docs/LANGUAGE.md`), not an undocumented
+                            // `api_response_fields_available`.
+                            let mut finding = common_finding(
+                                "api_response_field_missing",
+                                "api_responses_expected",
+                                assumptions,
+                            );
+                            finding.insert("environment".to_owned(), json!(environment.name));
+                            finding.insert("artifact".to_owned(), json!(artifact.name));
+                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert(
+                                "witness".to_owned(),
+                                json!({"schema_version": schema, "flags": flags}),
+                            );
+                            finding.insert(
+                                "minimal_conflict_set".to_owned(),
+                                json!({"environment": environment.name, "artifact": artifact.name, "schema_element": element, "flags": flags}),
+                            );
+                            findings.push(Value::Object(finding));
+                        }
+                    }
+
+                    if offline_enabled {
+                        for emitted in capability(artifact, "emits_offline") {
+                            let ttl = artifact.offline_ttls.get(emitted).copied().unwrap_or(0);
+                            // DB-14 (#490): the payload's obligation
+                            // extends across its declared finite TTL
+                            // window, not only the emitting schema.
+                            let end = (schema + ttl).min(environment.schema_window.1);
+                            let Some(failing_tick) = (schema..=end).find(|tick| {
+                                !provided_capability(environment, system, *tick, &flags, "accepts")
+                                    .contains(emitted)
+                            }) else {
+                                continue;
+                            };
+                            let element = reference(emitted);
+                            let mut finding = common_finding(
+                                "offline_payload_not_accepted",
+                                "offline_payloads_accepted",
+                                assumptions,
+                            );
+                            finding.insert("environment".to_owned(), json!(environment.name));
+                            finding.insert("artifact".to_owned(), json!(artifact.name));
+                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert(
+                                "witness".to_owned(),
+                                json!({"schema_version": schema, "ttl_ticks": ttl, "unaccepted_schema_version": failing_tick}),
+                            );
+                            findings.push(Value::Object(finding));
+                        }
+                    }
+
+                    if requires_enabled {
+                        for required in capability(artifact, "requires") {
+                            if provides.contains(required) {
+                                continue;
+                            }
+                            let element = reference(required);
+                            let mut finding = common_finding(
+                                "required_capability_missing",
+                                "artifact_capabilities_provided",
+                                assumptions,
+                            );
+                            finding.insert("environment".to_owned(), json!(environment.name));
+                            finding.insert("artifact".to_owned(), json!(artifact.name));
+                            finding.insert("schema_element".to_owned(), json!(element));
+                            finding.insert(
+                                "witness".to_owned(),
+                                json!({"declared_capability": "requires", "schema_version": schema}),
+                            );
+                            finding.insert(
+                                "minimal_conflict_set".to_owned(),
+                                json!({"environment": environment.name, "artifact": artifact.name, "schema_element": element}),
                             );
                             findings.push(Value::Object(finding));
                         }
@@ -391,140 +948,6 @@ fn findings(system: &DbSystem, assumptions: &[Value]) -> Vec<Value> {
         }
     }
 
-    for environment in &system.environments {
-        for schema in environment.schema_window.0..=environment.schema_window.1 {
-            for flags in flag_snapshots(environment) {
-                let active = environment
-                    .artifacts
-                    .iter()
-                    .filter(|entry| {
-                        entry.role == "active" && {
-                            let range = window(entry, environment);
-                            range.0 <= schema
-                                && schema <= range.1
-                                && conditions_match(entry, &flags)
-                        }
-                    })
-                    .filter_map(|entry| artifact_by_name(system, &entry.artifact))
-                    .collect::<Vec<_>>();
-                let consumers = environment
-                    .artifacts
-                    .iter()
-                    .filter(|entry| {
-                        entry.role != "active" && {
-                            let range = window(entry, environment);
-                            range.0 <= schema
-                                && schema <= range.1
-                                && conditions_match(entry, &flags)
-                        }
-                    })
-                    .filter_map(|entry| artifact_by_name(system, &entry.artifact))
-                    .collect::<Vec<_>>();
-                let responses = active
-                    .iter()
-                    .flat_map(|artifact| capability(artifact, "responds"))
-                    .cloned()
-                    .collect::<BTreeSet<_>>();
-                let accepts = active
-                    .iter()
-                    .flat_map(|artifact| capability(artifact, "accepts"))
-                    .cloned()
-                    .collect::<BTreeSet<_>>();
-                let provides = active
-                    .iter()
-                    .flat_map(|artifact| capability(artifact, "provides"))
-                    .cloned()
-                    .collect::<BTreeSet<_>>();
-                for consumer in &consumers {
-                    for called in capability(consumer, "calls") {
-                        if accepts.contains(called) {
-                            continue;
-                        }
-                        let element = reference(called);
-                        let mut finding = common_finding(
-                            "api_call_not_accepted",
-                            "api_calls_accepted",
-                            assumptions,
-                        );
-                        finding.insert("environment".to_owned(), json!(environment.name));
-                        finding.insert("artifact".to_owned(), json!(consumer.name));
-                        finding.insert("schema_element".to_owned(), json!(element));
-                        finding.insert(
-                            "witness".to_owned(),
-                            json!({"schema_version": schema, "flags": flags}),
-                        );
-                        finding.insert(
-                            "minimal_conflict_set".to_owned(),
-                            json!({"environment": environment.name, "artifact": consumer.name, "schema_element": element, "flags": flags}),
-                        );
-                        findings.push(Value::Object(finding));
-                    }
-                    for expected in capability(consumer, "expects") {
-                        if responses.contains(expected) {
-                            continue;
-                        }
-                        let element = reference(expected);
-                        let mut finding = common_finding(
-                            "api_response_field_missing",
-                            "api_response_fields_available",
-                            assumptions,
-                        );
-                        finding.insert("environment".to_owned(), json!(environment.name));
-                        finding.insert("artifact".to_owned(), json!(consumer.name));
-                        finding.insert("schema_element".to_owned(), json!(element));
-                        finding.insert(
-                            "witness".to_owned(),
-                            json!({"schema_version": schema, "flags": flags}),
-                        );
-                        finding.insert("minimal_conflict_set".to_owned(), json!({"environment": environment.name, "artifact": consumer.name, "schema_element": element, "flags": flags}));
-                        findings.push(Value::Object(finding));
-                    }
-                    for emitted in capability(consumer, "emits_offline") {
-                        if accepts.contains(emitted) {
-                            continue;
-                        }
-                        let element = reference(emitted);
-                        let ttl = consumer.offline_ttls.get(emitted).copied().unwrap_or(0);
-                        let mut finding = common_finding(
-                            "offline_payload_not_accepted",
-                            "offline_payloads_accepted",
-                            assumptions,
-                        );
-                        finding.insert("environment".to_owned(), json!(environment.name));
-                        finding.insert("artifact".to_owned(), json!(consumer.name));
-                        finding.insert("schema_element".to_owned(), json!(element));
-                        finding.insert(
-                            "witness".to_owned(),
-                            json!({"schema_version": schema, "ttl_ticks": ttl}),
-                        );
-                        findings.push(Value::Object(finding));
-                    }
-                }
-                for artifact in active.iter().chain(consumers.iter()) {
-                    for required in capability(artifact, "requires") {
-                        if provides.contains(required) {
-                            continue;
-                        }
-                        let element = reference(required);
-                        let mut finding = common_finding(
-                            "required_capability_missing",
-                            "artifact_capabilities_provided",
-                            assumptions,
-                        );
-                        finding.insert("environment".to_owned(), json!(environment.name));
-                        finding.insert("artifact".to_owned(), json!(artifact.name));
-                        finding.insert("schema_element".to_owned(), json!(element));
-                        finding.insert(
-                            "witness".to_owned(),
-                            json!({"declared_capability": "requires", "schema_version": schema}),
-                        );
-                        finding.insert("minimal_conflict_set".to_owned(), json!({"environment": environment.name, "artifact": artifact.name, "schema_element": element}));
-                        findings.push(Value::Object(finding));
-                    }
-                }
-            }
-        }
-    }
     let mut seen = BTreeSet::new();
     findings.retain(|finding| {
         let key = (
@@ -564,22 +987,173 @@ pub fn check_db(system: &DbSystem) -> Result<Value, DbToolError> {
     }))
 }
 
+/// Validate a runtime observation payload against
+/// `schemas/fslc/db/observation.v0.schema.json` and return its event array.
+///
+/// # Errors
+///
+/// Returns [`DbToolError`] when the payload is not an array or
+/// `{"events": [...]}`, when a declared `schema_version` does not equal
+/// `fsl-db-observation.v0`, or when an event is not an object, is missing a
+/// required field, has a wrongly typed field, or uses an unknown
+/// `capability` (DB-505).
+fn validate_observation_payload(payload: &Value) -> Result<&[Value], DbToolError> {
+    let events = match payload {
+        Value::Array(items) => items.as_slice(),
+        Value::Object(fields) => {
+            if let Some(version) = fields.get("schema_version") {
+                match version.as_str() {
+                    Some(text) if text == OBSERVATION_SCHEMA_VERSION => {}
+                    Some(text) => {
+                        return Err(tool_error(
+                            format!(
+                                "unsupported observation schema_version '{text}'; expected '{OBSERVATION_SCHEMA_VERSION}'"
+                            ),
+                            None,
+                        ));
+                    }
+                    None => {
+                        return Err(tool_error(
+                            "observation schema_version must be a string".to_owned(),
+                            None,
+                        ));
+                    }
+                }
+            }
+            match fields.get("events") {
+                Some(Value::Array(items)) => items.as_slice(),
+                Some(_) => {
+                    return Err(tool_error(
+                        "observation 'events' must be an array".to_owned(),
+                        None,
+                    ));
+                }
+                None => {
+                    return Err(tool_error(
+                        "observation JSON must be an array or {\"events\": [...]}".to_owned(),
+                        None,
+                    ));
+                }
+            }
+        }
+        _ => {
+            return Err(tool_error(
+                "observation JSON must be an array or {\"events\": [...]}".to_owned(),
+                None,
+            ));
+        }
+    };
+    for (index, event) in events.iter().enumerate() {
+        validate_observation_event(index, event)?;
+    }
+    Ok(events)
+}
+
+fn validate_observation_event(index: usize, event: &Value) -> Result<(), DbToolError> {
+    let Value::Object(fields) = event else {
+        return Err(tool_error(
+            format!("observation event {index} must be an object"),
+            None,
+        ));
+    };
+    for field in ["environment", "artifact", "target"] {
+        match fields.get(field) {
+            Some(Value::String(_)) => {}
+            Some(_) => {
+                return Err(tool_error(
+                    format!("observation event {index} field '{field}' must be a string"),
+                    None,
+                ));
+            }
+            None => {
+                return Err(tool_error(
+                    format!("observation event {index} is missing required field '{field}'"),
+                    None,
+                ));
+            }
+        }
+    }
+    match fields.get("schema_version") {
+        Some(value) if value.is_i64() || value.is_u64() => {}
+        Some(_) => {
+            return Err(tool_error(
+                format!("observation event {index} field 'schema_version' must be an integer"),
+                None,
+            ));
+        }
+        None => {
+            return Err(tool_error(
+                format!("observation event {index} is missing required field 'schema_version'"),
+                None,
+            ));
+        }
+    }
+    match fields.get("capability") {
+        Some(Value::String(value)) if OBSERVATION_CAPABILITIES.contains(&value.as_str()) => {}
+        Some(Value::String(value)) => {
+            return Err(tool_error(
+                format!("observation event {index} has unknown capability '{value}'"),
+                None,
+            ));
+        }
+        Some(_) => {
+            return Err(tool_error(
+                format!("observation event {index} field 'capability' must be a string"),
+                None,
+            ));
+        }
+        None => {
+            return Err(tool_error(
+                format!("observation event {index} is missing required field 'capability'"),
+                None,
+            ));
+        }
+    }
+    if let Some(flags) = fields.get("flags") {
+        let Value::Object(flags) = flags else {
+            return Err(tool_error(
+                format!("observation event {index} field 'flags' must be an object"),
+                None,
+            ));
+        };
+        for (name, value) in flags {
+            if !value.is_string() {
+                return Err(tool_error(
+                    format!("observation event {index} flag '{name}' must be a string"),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn event_flags(event: &Value) -> BTreeMap<String, String> {
+    event
+        .get("flags")
+        .and_then(Value::as_object)
+        .map(|flags| {
+            flags
+                .iter()
+                .filter_map(|(key, value)| {
+                    value.as_str().map(|value| (key.clone(), value.to_owned()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Compare runtime observation events with a database compatibility document.
 ///
 /// # Errors
 ///
-/// Returns [`DbToolError`] when the event payload is not an array or an object
-/// containing an `events` array.
+/// Returns [`DbToolError`] when the document contains an invalid reference,
+/// or when the observation payload fails the `fsl-db-observation.v0`
+/// envelope/event validation (DB-505).
 #[allow(clippy::too_many_lines)]
 pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolError> {
     validate_db(system)?;
-    let events = payload
-        .as_array()
-        .or_else(|| payload.get("events").and_then(Value::as_array))
-        .ok_or_else(|| DbToolError {
-            message: "observation JSON must be an array or {\"events\": [...]}".to_owned(),
-            span: None,
-        })?;
+    let events = validate_observation_payload(payload)?;
     let mut observation_assumptions = assumptions(system);
     observation_assumptions.push(json!({
         "id": "DB-ASSUME-OBSERVABILITY-COVERAGE",
@@ -607,6 +1181,11 @@ pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolErr
             .get("schema_version")
             .and_then(Value::as_i64)
             .unwrap_or_default();
+        // DB-506 (#506): honor the event's feature-flag snapshot instead of
+        // only matching schema range, both when deciding whether the
+        // observed artifact is declared in the window and when looking up
+        // an accepting provider for `calls`.
+        let flags = event_flags(event);
         let environment = system
             .environments
             .iter()
@@ -616,7 +1195,7 @@ pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolErr
             environment.artifacts.iter().any(|entry| {
                 entry.artifact == artifact_name && {
                     let range = window(entry, environment);
-                    range.0 <= schema && schema <= range.1
+                    range.0 <= schema && schema <= range.1 && conditions_match(entry, &flags)
                 }
             })
         });
@@ -645,7 +1224,9 @@ pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolErr
                     entry.role != "may_exist"
                         && {
                             let range = window(entry, environment);
-                            range.0 <= schema && schema <= range.1
+                            range.0 <= schema
+                                && schema <= range.1
+                                && conditions_match(entry, &flags)
                         }
                         && artifact_by_name(system, &entry.artifact).is_some_and(|provider| {
                             capability(provider, "accepts").contains(&target_ref)
@@ -674,6 +1255,7 @@ pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolErr
                 "capability": capability_name,
                 "target": target,
                 "reason": reason,
+                "flags": flags,
             }),
         );
         finding.insert(
@@ -694,7 +1276,7 @@ pub fn observe_db(system: &DbSystem, payload: &Value) -> Result<Value, DbToolErr
         "result": if observed.is_empty() { "observed_conformant" } else { "observed_mismatch" },
         "dialect": DIALECT,
         "finding_schema_version": FINDING_SCHEMA,
-        "observation_schema_version": "fsl-db-observation.v0",
+        "observation_schema_version": OBSERVATION_SCHEMA_VERSION,
         "dbsystem": system.name,
         "assumptions": observation_assumptions,
         "findings": observed,

--- a/rust/fsl-tools/src/db_import.rs
+++ b/rust/fsl-tools/src/db_import.rs
@@ -67,32 +67,46 @@ fn import_sql(text: &str, name: &str) -> DbImport {
         let words = statement.split_whitespace().collect::<Vec<_>>();
         let upper = statement.to_ascii_uppercase();
         if upper.starts_with("CREATE TABLE") {
-            let Some(open) = statement.find('(') else {
-                continue;
-            };
-            let Some(close) = statement.rfind(')') else {
-                continue;
-            };
-            let table = clean(statement["CREATE TABLE".len()..open].trim()).to_owned();
-            for definition in statement[open + 1..close].split(',') {
-                let parts = definition.split_whitespace().collect::<Vec<_>>();
-                if parts.len() < 2
-                    || matches!(
-                        parts[0].to_ascii_uppercase().as_str(),
-                        "PRIMARY" | "FOREIGN" | "UNIQUE" | "CONSTRAINT"
-                    )
-                {
-                    continue;
+            // A malformed statement (missing/unbalanced parentheses) must
+            // still surface as `unsupported_sql`, not be silently dropped
+            // (#507): the caller has no other signal that the table was
+            // never imported.
+            match (statement.find('('), statement.rfind(')')) {
+                (Some(open), Some(close)) if close > open => {
+                    let table = clean(statement["CREATE TABLE".len()..open].trim()).to_owned();
+                    for definition in statement[open + 1..close].split(',') {
+                        let parts = definition.split_whitespace().collect::<Vec<_>>();
+                        if parts.len() < 2
+                            || matches!(
+                                parts[0].to_ascii_uppercase().as_str(),
+                                "PRIMARY" | "FOREIGN" | "UNIQUE" | "CONSTRAINT"
+                            )
+                        {
+                            continue;
+                        }
+                        columns.push(SqlColumn {
+                            table: table.clone(),
+                            name: clean(parts[0]).to_owned(),
+                            kind: parts[1].to_owned(),
+                            present: true,
+                            backfilled: true,
+                            not_null: definition.to_ascii_uppercase().contains("NOT NULL"),
+                        });
+                    }
                 }
-                columns.push(SqlColumn {
-                    table: table.clone(),
-                    name: clean(parts[0]).to_owned(),
-                    kind: parts[1].to_owned(),
-                    present: true,
-                    backfilled: true,
-                    not_null: definition.to_ascii_uppercase().contains("NOT NULL"),
-                });
+                _ => {
+                    warnings.push(json!({"kind":"unsupported_sql","statement":statement,"message":"SQL importer supports CREATE TABLE, ALTER TABLE ADD/DROP/RENAME COLUMN, and UPDATE ... SET for backfill"}));
+                }
             }
+        } else if words.len() >= 6
+            && upper.starts_with("ALTER TABLE")
+            && words[3].eq_ignore_ascii_case("DROP")
+            && words[4].eq_ignore_ascii_case("COLUMN")
+        {
+            let table = clean(words[2]).to_owned();
+            let column = clean(words[5]).to_owned();
+            let index = migrations.len() + 1;
+            migrations.push(format!("\n  migration m{index}_drop_column from {} to {index} {{\n    drop {table}.{column} irreversible;\n  }}\n",index-1));
         } else if words.len() >= 7
             && upper.starts_with("ALTER TABLE")
             && words[3].eq_ignore_ascii_case("ADD")
@@ -216,6 +230,14 @@ fn import_sql(text: &str, name: &str) -> DbImport {
             .and_then(|item| item.split_whitespace().next())
         {
             final_refs.push(add.trim_end_matches(';').to_owned());
+        }
+        if let Some(drop) = migration
+            .split("    drop ")
+            .nth(1)
+            .and_then(|item| item.split_whitespace().next())
+        {
+            let dropped = drop.trim_end_matches(';').to_owned();
+            final_refs.retain(|item| item != &dropped);
         }
     }
     final_refs.sort();

--- a/rust/fsl-tools/tests/db_findings_regressions.rs
+++ b/rust/fsl-tools/tests/db_findings_regressions.rs
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for the `fslc db check` false-green/false-firing audit:
+//! issues #490 (8 missing detections) and #491 (4 false firings), plus the
+//! undocumented `failed_rule` name in #492. Each test pins one symptom
+//! (`DB-NN` in the issue text) with, where applicable, both a violating and
+//! a compliant variant so a fix that only silences or only adds findings
+//! shows up as a failure here.
+
+use fsl_syntax::DbSystem;
+use serde_json::Value;
+
+fn system(source: &str) -> DbSystem {
+    fsl_syntax::parse_db_system(source).unwrap_or_else(|error| panic!("parse dbsystem: {error}"))
+}
+
+fn check(source: &str) -> Value {
+    fsl_tools::check_db(&system(source)).unwrap_or_else(|error| panic!("check_db: {error}"))
+}
+
+fn kinds(result: &Value) -> Vec<&str> {
+    result["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .map(|finding| finding["kind"].as_str().expect("finding kind"))
+        .collect()
+}
+
+fn failed_rules(result: &Value) -> Vec<&str> {
+    result["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .map(|finding| finding["failed_rule"].as_str().expect("failed_rule"))
+        .collect()
+}
+
+// DB-01 (#490): an unknown `rule` name in `check compatibility` used to be
+// accepted and silently select nothing, so a typo turned a real violation
+// into a zero-obligation `verified_under_assumptions`.
+#[test]
+fn db01_unknown_rule_name_is_rejected() {
+    const SOURCE: &str = r"
+dbsystem Db01 {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..0; active server_v1 when schema 0..0; }
+  check compatibility { rule not_null_after_backfil; }
+}";
+    let error = fsl_tools::validate_db(&system(SOURCE)).expect_err("typo rule must be rejected");
+    assert!(
+        error
+            .message
+            .contains("unknown db compatibility rule 'not_null_after_backfil'"),
+        "{}",
+        error.message
+    );
+    assert!(
+        error.message.contains("not_null_after_backfill"),
+        "{}",
+        error.message
+    );
+}
+
+#[test]
+fn db01_known_rule_name_is_accepted() {
+    const SOURCE: &str = r"
+dbsystem Db01Control {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..0; active server_v1 when schema 0..0; }
+  check compatibility { rule not_null_after_backfill; }
+}";
+    fsl_tools::validate_db(&system(SOURCE)).expect("documented rule name must be accepted");
+}
+
+// DB-02 (#490): an `active` artifact's own `calls`/`expects`/`emits_offline`
+// declarations were never checked; the artifact was only ever consulted as
+// a provider.
+#[test]
+fn db02_active_role_consumer_capabilities_are_checked() {
+    const SOURCE: &str = r"
+dbsystem Db02 {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact client_v1 { calls api.X; expects response.y; emits_offline api.Z ttl 1; }
+  environment prod { schema 0..0; active client_v1 when schema 0..0; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    let mut found = kinds(&result);
+    found.sort_unstable();
+    assert_eq!(
+        found,
+        [
+            "api_call_not_accepted",
+            "api_response_field_missing",
+            "offline_payload_not_accepted",
+        ]
+    );
+}
+
+// DB-03 (#490): `set_not_null` without a prior `backfill` made the kernel
+// action unreachable (the violating trajectory was disabled, not reported),
+// so the migration verified vacuously instead of failing
+// `not_null_after_backfill`.
+#[test]
+fn db03_set_not_null_without_backfill_is_detected() {
+    const SOURCE: &str = r"
+dbsystem Db03 {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column email: Text absent; }
+  }
+  migration add_email from 0 to 1 { add users.email nullable; }
+  migration require_email from 1 to 2 { set_not_null users.email; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..2; active server_v1 when schema 0..2; }
+  check compatibility { rule not_null_after_backfill; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["not_null_before_backfill"]);
+}
+
+#[test]
+fn db03_set_not_null_after_backfill_is_safe() {
+    const SOURCE: &str = r"
+dbsystem Db03Control {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column email: Text absent; }
+  }
+  migration add_email from 0 to 1 { add users.email nullable; }
+  migration backfill_email from 1 to 2 { backfill users.email; }
+  migration require_email from 2 to 3 { set_not_null users.email; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..3; active server_v1 when schema 0..3; }
+  check compatibility { rule not_null_after_backfill; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+// DB-04 (#490): an `environment schema lo..hi` window could include a
+// schema version never reached by the declared migration plan.
+#[test]
+fn db04_unreachable_environment_schema_is_rejected() {
+    const SOURCE: &str = r"
+dbsystem Db04 {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column nickname: Text absent; }
+  }
+  migration add_nickname from 0 to 1 { add users.nickname nullable; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..2; active server_v1 when schema 0..1; }
+}";
+    let error =
+        fsl_tools::validate_db(&system(SOURCE)).expect_err("unreachable schema must be rejected");
+    assert!(
+        error
+            .message
+            .contains("environment 'prod' includes schema 2, which is not reachable"),
+        "{}",
+        error.message
+    );
+}
+
+#[test]
+fn db04_reachable_environment_schema_is_accepted() {
+    const SOURCE: &str = r"
+dbsystem Db04Control {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column nickname: Text absent; }
+  }
+  migration add_nickname from 0 to 1 { add users.nickname nullable; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+}";
+    fsl_tools::validate_db(&system(SOURCE)).expect("reachable schema window must be accepted");
+}
+
+// DB-05 (#490): `rollback_not_equivalent` only ever fired for `drop`; a
+// lossy rollbackable `split`/`merge` never produced it.
+#[test]
+fn db05_rollback_not_equivalent_fires_for_lossy_split() {
+    const SOURCE: &str = r"
+dbsystem Db05 {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 rollbackable {
+    split users.full_name into users.first_name, users.last_name lossy;
+  }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule rollback_equivalent; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["rollback_not_equivalent"]);
+}
+
+#[test]
+fn db05_rollback_equivalent_lossless_split_is_safe() {
+    const SOURCE: &str = r"
+dbsystem Db05Control {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 rollbackable {
+    split users.full_name into users.first_name, users.last_name lossless;
+  }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule rollback_equivalent; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+// DB-06 (#490): `data_preserved` never fired for dropping an existing
+// column (only split/merge were checked).
+#[test]
+fn db06_data_preservation_loss_fires_for_existing_column_drop() {
+    const SOURCE: &str = r"
+dbsystem Db06 {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column legacy: Text present backfilled nullable; }
+  }
+  migration drop_legacy from 0 to 1 { drop users.legacy irreversible; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule data_preserved; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["data_preservation_loss"]);
+}
+
+#[test]
+fn db06_dropping_an_already_absent_column_is_safe() {
+    const SOURCE: &str = r"
+dbsystem Db06Control {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column ghost: Text absent; }
+  }
+  migration drop_ghost from 0 to 1 { drop users.ghost irreversible; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule data_preserved; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+// DB-07 (#491): a `supported` provider's `accepts`/`responds`/`provides`
+// was ignored; only `active` counted as a provider.
+#[test]
+fn db07_supported_provider_is_honored() {
+    const SOURCE: &str = r"
+dbsystem Db07 {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact p { accepts api.X; responds response.y; provides cap.z; }
+  artifact c { calls api.X; expects response.y; requires cap.z; }
+  environment prod { schema 0..0; supported p when schema 0..0; may_exist c when schema 0..0; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+#[test]
+fn db07_may_exist_is_still_not_a_provider() {
+    const SOURCE: &str = r"
+dbsystem Db07Control {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact p { accepts api.X; responds response.y; provides cap.z; }
+  artifact c { calls api.X; expects response.y; requires cap.z; }
+  environment prod { schema 0..0; may_exist p when schema 0..0; may_exist c when schema 0..0; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    let mut found = kinds(&result);
+    found.sort_unstable();
+    assert_eq!(
+        found,
+        [
+            "api_call_not_accepted",
+            "api_response_field_missing",
+            "required_capability_missing",
+        ]
+    );
+}
+
+// DB-08 (#491): `destructive` (as opposed to `irreversible`) was never
+// accepted, and a drop of an already-absent column still fired.
+#[test]
+fn db08_destructive_annotation_and_absent_column_are_safe() {
+    const SOURCE: &str = r"
+dbsystem Db08 {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column c: Text present backfilled nullable;
+      column ghost: Text absent;
+    }
+  }
+  migration drop_c from 0 to 1 { drop users.c destructive; drop users.ghost; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+#[test]
+fn db08_genuinely_unannotated_existing_drop_is_still_caught() {
+    const SOURCE: &str = r"
+dbsystem Db08Control {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column c: Text present backfilled nullable; }
+  }
+  migration drop_c from 0 to 1 { drop users.c; }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["destructive_migration_unannotated"]);
+}
+
+// DB-09 (#491): `irreversible` was never accepted as a preservation
+// classification for `split`/`merge` (only `lossless`/`lossy` were).
+#[test]
+fn db09_irreversible_split_annotation_is_accepted() {
+    const SOURCE: &str = r"
+dbsystem Db09 {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 {
+    split users.full_name into users.first_name, users.last_name irreversible;
+  }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule preservation_transforms_annotated; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+#[test]
+fn db09_unannotated_split_is_still_caught() {
+    const SOURCE: &str = r"
+dbsystem Db09Control {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 {
+    split users.full_name into users.first_name, users.last_name;
+  }
+  artifact server_v1 { reads users.id; }
+  environment prod { schema 0..1; active server_v1 when schema 0..1; }
+  check compatibility { rule preservation_transforms_annotated; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["preservation_transform_unannotated"]);
+}
+
+// DB-10 (#491): only `destructive_operations_annotated` respected rule
+// selection; every other finding kind (including the opt-in
+// `data_preserved`/`rollback_equivalent`) fired unconditionally.
+#[test]
+fn db10_opt_in_rule_stays_off_when_not_selected() {
+    const SOURCE: &str = r"
+dbsystem Db10 {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 rollbackable {
+    split users.full_name into users.first_name, users.last_name lossy;
+  }
+  artifact server_v1 { reads users.id, users.first_name, users.last_name; }
+  environment prod { schema 0..1; active server_v1 when schema 1..1; }
+  check compatibility { rule all_active_reads_exist; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+#[test]
+fn db10_opt_in_rule_fires_when_selected() {
+    const SOURCE: &str = r"
+dbsystem Db10Control {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+  migration split_full_name from 0 to 1 rollbackable {
+    split users.full_name into users.first_name, users.last_name lossy;
+  }
+  artifact server_v1 { reads users.id, users.first_name, users.last_name; }
+  environment prod { schema 0..1; active server_v1 when schema 1..1; }
+  check compatibility { rule all_active_reads_exist; rule rollback_equivalent; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["rollback_not_equivalent"]);
+}
+
+// DB-11 (#490): reads/writes were checked against "a drop op exists
+// somewhere in the source" instead of materialized column state, both
+// missing an initially absent column with a live reader and false-firing
+// on a column dropped then re-added.
+#[test]
+fn db11_column_dropped_then_readded_is_safe() {
+    const SOURCE: &str = r"
+dbsystem Db11Readd {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column legacy: Text present backfilled nullable; }
+  }
+  migration drop_legacy from 0 to 1 { drop users.legacy irreversible; }
+  migration readd_legacy from 1 to 2 { add users.legacy nullable; }
+  artifact server_v1 { reads users.id, users.legacy; }
+  environment prod { schema 0..2; active server_v1 when schema 2..2; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+#[test]
+fn db11_initially_absent_column_with_reader_is_caught() {
+    const SOURCE: &str = r"
+dbsystem Db11Absent {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column ghost: Text absent; }
+  }
+  artifact server_v1 { reads users.id, users.ghost; }
+  environment prod { schema 0..0; active server_v1 when schema 0..0; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["column_removed_while_still_read"]);
+}
+
+// DB-12 (#492): `api_response_field_missing`'s `failed_rule` must be the
+// documented `api_responses_expected`, not an undocumented name.
+#[test]
+fn db12_api_response_field_missing_uses_documented_rule_name() {
+    const SOURCE: &str = r"
+dbsystem Db12 {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  artifact server_v2 { responds response.email_normalized; }
+  artifact ios_v1 { expects response.email; }
+  environment prod { schema 0..0; active server_v2 when schema 0..0; may_exist ios_v1 when schema 0..0; }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["api_response_field_missing"]);
+    assert_eq!(failed_rules(&result), ["api_responses_expected"]);
+}
+
+// DB-14 (#490): an offline payload's TTL window never extended the
+// acceptance obligation past the emitting schema snapshot.
+#[test]
+fn db14_offline_ttl_window_extends_obligation() {
+    const SOURCE: &str = r"
+dbsystem Db14 {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  migration noop from 0 to 1 { backfill users.id; }
+  artifact server_v0 { accepts api.X; }
+  artifact server_v1 { accepts api.Y; }
+  artifact ios_v1 { emits_offline api.X ttl 2; }
+  environment prod {
+    schema 0..1;
+    active server_v0 when schema 0..0;
+    active server_v1 when schema 1..1;
+    active ios_v1 when schema 0..0;
+  }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "violated");
+    assert_eq!(kinds(&result), ["offline_payload_not_accepted"]);
+    let witness = &result["findings"][0]["witness"];
+    assert_eq!(witness["ttl_ticks"], 2);
+    assert_eq!(witness["unaccepted_schema_version"], 1);
+}
+
+#[test]
+fn db14_offline_ttl_window_accepted_throughout_is_safe() {
+    const SOURCE: &str = r"
+dbsystem Db14Control {
+  database app { schema 0 table users { column id: Int present backfilled not_null; } }
+  migration noop from 0 to 1 { backfill users.id; }
+  artifact server_v0 { accepts api.X; }
+  artifact server_v1 { accepts api.X, api.Y; }
+  artifact ios_v1 { emits_offline api.X ttl 2; }
+  environment prod {
+    schema 0..1;
+    active server_v0 when schema 0..0;
+    active server_v1 when schema 1..1;
+    active ios_v1 when schema 0..0;
+  }
+}";
+    let result = check(SOURCE);
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}

--- a/rust/fsl-tools/tests/db_import_regressions.rs
+++ b/rust/fsl-tools/tests/db_import_regressions.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #507: the SQL importer did not implement
+//! documented `ALTER TABLE ... DROP COLUMN`, and a malformed `CREATE TABLE`
+//! could bypass the required `unsupported_sql` warning entirely.
+
+fn warning_kinds(warnings: &[serde_json::Value]) -> Vec<&str> {
+    warnings
+        .iter()
+        .map(|warning| warning["kind"].as_str().expect("warning kind"))
+        .collect()
+}
+
+// `docs/DESIGN-db.md` "Importer Boundary" documents DROP COLUMN as
+// supported, but no branch ever produced a `drop` migration op for it.
+#[test]
+fn import_sql_supports_drop_column() {
+    const SQL: &str = "CREATE TABLE t (id INT, doomed TEXT);\nALTER TABLE t DROP COLUMN doomed;";
+    let imported = fsl_tools::import_db(SQL, "DropProbe", "sql");
+    assert!(imported.warnings.is_empty(), "{:?}", imported.warnings);
+    assert!(
+        imported.source.contains("drop t.doomed irreversible;"),
+        "{}",
+        imported.source
+    );
+    // The dropped column must not remain in the final artifact's
+    // reads/writes, otherwise the generated dbsystem itself would fail
+    // `all_active_reads_exist`.
+    let artifact = imported
+        .source
+        .split("artifact imported_artifact {")
+        .nth(1)
+        .expect("artifact block");
+    assert!(!artifact.contains("doomed"), "{artifact}");
+    assert!(artifact.contains("t.id"), "{artifact}");
+
+    // The generated source must itself check cleanly.
+    let system = fsl_syntax::parse_db_system(&imported.source).expect("parse generated dbsystem");
+    let result = fsl_tools::check_db(&system).expect("check_db");
+    assert_eq!(result["result"], "verified_under_assumptions", "{result}");
+}
+
+// A `CREATE TABLE` with an unbalanced/missing parenthesis used to be
+// silently skipped (`continue`), producing neither a table nor a warning.
+#[test]
+fn import_sql_warns_on_malformed_create_table() {
+    const SQL: &str = "CREATE TABLE good (id INT);\nCREATE TABLE broken (id INT;";
+    let imported = fsl_tools::import_db(SQL, "BrokenProbe", "sql");
+    assert_eq!(warning_kinds(&imported.warnings), ["unsupported_sql"]);
+    assert!(
+        imported.source.contains("table good"),
+        "{}",
+        imported.source
+    );
+    assert!(!imported.source.contains("broken"), "{}", imported.source);
+}
+
+// Control: well-formed `CREATE TABLE`/`ADD COLUMN`/`RENAME COLUMN` must
+// still import cleanly with no warnings (no regression from the DROP
+// COLUMN and malformed-CREATE-TABLE fixes).
+#[test]
+fn import_sql_well_formed_statements_still_import_cleanly() {
+    const SQL: &str = "CREATE TABLE users (id INT NOT NULL);\nALTER TABLE users ADD COLUMN nickname TEXT;\nALTER TABLE users RENAME COLUMN nickname TO display_name;";
+    let imported = fsl_tools::import_db(SQL, "RenameProbe", "sql");
+    assert!(imported.warnings.is_empty(), "{:?}", imported.warnings);
+    assert!(
+        imported.source.contains("display_name"),
+        "{}",
+        imported.source
+    );
+}

--- a/rust/fsl-tools/tests/db_observe_regressions.rs
+++ b/rust/fsl-tools/tests/db_observe_regressions.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for `fslc db observe` runtime-observation gaps: #505
+//! (envelope/event validation) and #506 (feature-flag snapshots).
+
+use fsl_syntax::DbSystem;
+use serde_json::{Value, json};
+
+const SYSTEM: &str = r"
+dbsystem Db505 {
+  database app {
+    schema 0
+    table users { column id: Int present backfilled not_null; column email_normalized: Text absent; }
+  }
+  migration add_email_normalized from 0 to 1 { add users.email_normalized nullable; }
+  artifact server_legacy { responds response.email; }
+  artifact server_new { reads users.email_normalized; responds response.email_normalized; }
+  environment prod {
+    schema 0..1;
+    flag email_v2 { off, on } default off;
+    active server_legacy when schema 0..1 when flag email_v2=off;
+    active server_new when schema 1..1 when flag email_v2=on;
+  }
+}";
+
+fn system() -> DbSystem {
+    fsl_syntax::parse_db_system(SYSTEM).expect("parse dbsystem")
+}
+
+fn observe(payload: &Value) -> Result<Value, fsl_tools::DbToolError> {
+    fsl_tools::observe_db(&system(), payload)
+}
+
+// #505: a wrong root `schema_version` used to be silently accepted (shared
+// with the frozen Python reference), then the event evaluated as if it
+// were the current envelope.
+#[test]
+fn observe_rejects_wrong_root_schema_version() {
+    let error = observe(&json!({"schema_version": "wrong.v9", "events": []}))
+        .expect_err("wrong root schema_version must be rejected");
+    assert!(error.message.contains("wrong.v9"), "{}", error.message);
+}
+
+// #505: a non-object event used to be defaulted into a fabricated witness
+// (empty strings, schema version 0) instead of being rejected.
+#[test]
+fn observe_rejects_non_object_event() {
+    let error = observe(&json!({"schema_version": "fsl-db-observation.v0", "events": [null]}))
+        .expect_err("a null event must be rejected");
+    assert!(error.message.contains("event 0"), "{}", error.message);
+    assert!(error.message.contains("object"), "{}", error.message);
+}
+
+// #505: a missing required field used to be defaulted (e.g. capability
+// silently treated as empty) instead of raising a located parse error.
+#[test]
+fn observe_rejects_event_missing_required_field() {
+    let error = observe(&json!({"events": [{
+        "environment": "prod",
+        "schema_version": 0,
+        "artifact": "server_legacy",
+        "target": "users.id"
+    }]}))
+    .expect_err("a missing 'capability' field must be rejected");
+    assert!(error.message.contains("capability"), "{}", error.message);
+}
+
+// #505: an unknown capability value outside the closed vocabulary
+// (reads/writes/calls/requires/provides) used to pass through untyped.
+#[test]
+fn observe_rejects_unknown_capability() {
+    let error = observe(&json!({"events": [{
+        "environment": "prod",
+        "schema_version": 0,
+        "artifact": "server_legacy",
+        "capability": "deletes",
+        "target": "users.id"
+    }]}))
+    .expect_err("an unknown capability must be rejected");
+    assert!(error.message.contains("deletes"), "{}", error.message);
+}
+
+// #505 control: a well-formed envelope/event must still validate and
+// evaluate normally (this is the shape `docs/DESIGN-db.md` documents).
+#[test]
+fn observe_accepts_well_formed_envelope() {
+    let result = observe(
+        &json!({"schema_version": "fsl-db-observation.v0", "events": [{
+            "environment": "prod",
+            "schema_version": 1,
+            "artifact": "server_new",
+            "capability": "reads",
+            "target": "users.email_normalized",
+            "flags": {"email_v2": "on"}
+        }]}),
+    )
+    .expect("well-formed observation must be accepted");
+    assert_eq!(result["result"], "observed_conformant", "{result}");
+}
+
+// #506: `server_new` is only declared active at schema 1 under
+// `email_v2=on`. An event claiming schema 1 but `email_v2=off` used to be
+// reported conformant because the observer ignored the flag snapshot
+// entirely.
+#[test]
+fn observe_flag_mismatch_is_unsupported_artifact() {
+    let result = observe(
+        &json!({"schema_version": "fsl-db-observation.v0", "events": [{
+            "environment": "prod",
+            "schema_version": 1,
+            "artifact": "server_new",
+            "capability": "reads",
+            "target": "users.email_normalized",
+            "flags": {"email_v2": "off"}
+        }]}),
+    )
+    .expect("well-formed observation must be accepted");
+    assert_eq!(result["result"], "observed_mismatch", "{result}");
+    assert_eq!(
+        result["findings"][0]["kind"],
+        "unsupported_artifact_observed"
+    );
+    assert_eq!(
+        result["findings"][0]["witness"]["flags"],
+        json!({"email_v2": "off"})
+    );
+}
+
+// #506 control: the matching flag variant must stay conformant (paired
+// with the mismatch test above so a fix cannot just reject every flagged
+// observation).
+#[test]
+fn observe_flag_match_is_conformant() {
+    let result = observe(
+        &json!({"schema_version": "fsl-db-observation.v0", "events": [{
+            "environment": "prod",
+            "schema_version": 1,
+            "artifact": "server_new",
+            "capability": "reads",
+            "target": "users.email_normalized",
+            "flags": {"email_v2": "on"}
+        }]}),
+    )
+    .expect("well-formed observation must be accepted");
+    assert_eq!(result["result"], "observed_conformant", "{result}");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -222,7 +222,12 @@ artifact profiles into the same snapshot model; missing providers report
 evidence only (`observed_mismatch`, not formal violation) and `fslc db import`
 for SQL DDL or minimal Prisma schema importers. Production-data preservation and
 DB-engine evidence use JSON schemas under `schemas/fslc/db/` with
-`formal_result: "not_run"`, not `verified`/`proved`.
+`formal_result: "not_run"`, not `verified`/`proved`. An unrecognized `check
+compatibility` rule name and an environment schema window the migration plan
+never reaches both fail validation with exit 2. `fslc db observe` validates its
+event envelope against `schemas/fslc/db/observation.v0.schema.json`
+(exit 2 on a malformed record) and honors each event's `flags` snapshot the same
+way `fslc db check` does.
 
 Functional DDD / async effect dialect (v0; expands to the same kernel and
 reports stable fsl-domain findings):


### PR DESCRIPTION
## Problem

Six `fslc db` defects. One is a false green, four are the mirror image (a checker that cries wolf), and two are runtime-observation gaps.

| Issue | Before |
|---|---|
| **#490** | `check compatibility` missed **8 detections** — real violations passed as `verified_under_assumptions` / exit 0. `AGENTS.md` calls a confidently-green false negative more dangerous than a crash. |
| **#491** | **4 false firings** against already-annotated migrations and supported providers. A checker that reports violations that are not there gets muted, which costs the same as missing them. |
| **#492** | `api_response_field_missing` reported a `failed_rule` name that appears in no documentation, so a consumer keying on the documented rule set could not match it. |
| **#505** | Runtime observation envelopes were evaluated without being validated first. |
| **#506** | Feature-flag snapshots were not honored during runtime observation. |
| **#507** | `DROP COLUMN` was not imported, and a malformed `CREATE TABLE` produced no warning. |

## Contract change

The detections and the false firings were fixed together, in the `findings()` structure PR #531 established for #469 rather than as a second parallel path, so `db check`'s reachable finding kinds stay a single closed set. Rule selection is honored, so an opt-in rule fires when selected and stays silent when not. For #492 the documented rule-name set is the contract and the emitted name was corrected to match it.

## Test evidence

**Corpus is unchanged.** A `db check` sweep over every `examples/db/*.fsl` file, main binary versus this branch, shows **0 differences** in `result` or finding count. That is the expected outcome, not a sign the fix is inert: these issues were found by auditing documented rules against the implementation, not by a corpus file failing, so the corpus never exercised the affected paths. The evidence for the fix is therefore in the new tests, and the fact that the corpus does not move is itself the regression control for #491 — the four false firings would have changed corpus verdicts had they been "fixed" by loosening.

New tests, 24 in `rust/fsl-tools/tests/db_findings_regressions.rs` plus `db_import_regressions.rs` and `db_observe_regressions.rs`, are deliberately **paired per rule**:

```
db01_unknown_rule_name_is_rejected          db01_known_rule_name_is_accepted
db03_set_not_null_without_backfill_is_detected   db03_set_not_null_after_backfill_is_safe
db04_unreachable_environment_schema_is_rejected  db04_reachable_environment_schema_is_accepted
db05_rollback_not_equivalent_fires_for_lossy_split
db09_unannotated_split_is_still_caught      db10_opt_in_rule_fires_when_selected
```

Each added detection has a companion asserting a legitimately-compliant migration still passes, and each removed false firing has a companion asserting the genuinely-violating case is still caught. #490 and #491 pull in opposite directions, so a one-sided fix would look green while breaking the other half — the pairing is what makes that impossible to ship.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (136 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/DESIGN-db.md`, `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 1:1), `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #490, fixes #491, fixes #492, fixes #505, fixes #506, fixes #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
