### PR TITLE
fix(ai): reject non-AI input, execute declared policies, and conform statistical results to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,30 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `AiComponent.tools[].schema` preferred over the tool name, matching the
   frozen reference) and rejects wrong-dialect input and a component-less
   project with exit 2 (#511).
+- `fslc ai eval`/`regress`/`drift` now execute the selected
+  `statistical_property`/`ai_migration`/`observed_property` declaration
+  instead of aggregating records against two hardcoded example
+  metrics/thresholds. `eval` applies every declared slice's
+  `min_samples`/`ci_lower`/`ci_upper` gate and evaluator-trust check
+  (`fsl_tools::evaluate_statistical_property`); `regress`/`drift` read the
+  spec path and the selected `ai_migration`/`observed_property`'s declared
+  metric clauses (`evaluate_migration`/`evaluate_observed_property`) instead
+  of ignoring it; an unknown `--property`/`--migration` selection is now a
+  check-time error (exit 2) instead of a fabricated statistical/observed
+  verdict. `ai eval` also honors the documented `--records`-less invocation
+  by falling back to the declared `dataset`'s `source` file. As part of this,
+  `fslc ai drift`'s success result changes from `observed_conformant` to the
+  documented `observed_supported` (`docs/LANGUAGE.md`,
+  `docs/DESIGN-assurance-classes.md`); `observed_conformant` remains correct
+  and unchanged for `fslc db observe`, which is a different command with its
+  own, still-valid result vocabulary (#509).
+- `fslc ai eval` results now carry every field
+  `schemas/fslc/ai/statistical-result.v0.schema.json` requires
+  (`schema_version`/`status`/`slice`/`metric`/`n`/`estimate`/`threshold`/
+  `evaluator`/`assumptions`, not just `result`/`interval`/`checks`), and
+  every non-`statistically_supported` terminal status (`dataset_invalid`,
+  `evaluator_untrusted`, `slice_missing`, `insufficient_samples`,
+  `inconclusive`) now exits 1 instead of 0 (#510).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   malformed `CREATE TABLE` (unbalanced/missing parentheses) now produces an
   `unsupported_sql` warning instead of being silently skipped with no warning
   and no table (#507).
+- `fslc ai compat` no longer line-scans any readable file and reports
+  `compat_profile_generated` with a syntactically empty `dbsystem` fragment
+  (`artifact  { requires ; provides ; }`) for non-AI input or an fsl-ai
+  project that declares no `ai_component` at all — indistinguishable from a
+  genuine clean result. Native now parses either a single `ai_component`
+  document or a full fsl-ai project (`fsl_syntax::parse_ai_project`,
+  `AiComponent.tools[].schema` preferred over the tool name, matching the
+  frozen reference) and rejects wrong-dialect input and a component-less
+  project with exit 2 (#511).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2363,15 +2363,24 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 `dataset`、`evaluator`、`failure_mode`、`statistical_property`、
 `ai_migration`、`observed_property` を組み合わせられます。`fslc ai check` は
 これらのファイルをパースして `ai_project_analyzed` を返します。`fslc ai eval` は
-Wilson 区間つきで、事前計算された JSONL から Bernoulli/比率のメトリクスを検査
-します。`fslc ai regress` は集約の `no_regression` のメトリクス低下/増加の節を
-検査します。`fslc ai compare` は閾値の主張なしにメトリクスの差分を報告します。
-`fslc ai drift` はランタイムのテレメトリの閾値とドリフトを検査します。そして
-`fslc ai compat` は、1 つの `ai_component`、またはプロジェクトが
+選択された `statistical_property` が宣言する `slice`/`min_samples`/
+`ci_lower`/`ci_upper` の要件を、事前計算された JSONL（`--records`、または
+宣言された `dataset` の `source` ファイル）に対して Wilson 区間つきで検査
+します。`fslc ai regress` は選択された `ai_migration` が宣言する集約の
+`no_regression` メトリクス低下/増加の節を検査します。`fslc ai compare` は
+閾値の主張なしにメトリクスの差分を報告します。`fslc ai drift` は選択された
+`observed_property` が宣言する `observed`/`drift` の要件をランタイムの
+テレメトリに対して検査します（`observed_supported` / `observed_mismatch`）。
+そして `fslc ai compat` は、1 つの `ai_component`、またはプロジェクトが
 宣言するすべての `ai_component` について有限の `dbsystem artifact`
 ケイパビリティプロファイルを出力し、AI ではない入力や `ai_component` を
 1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
-`formal_result:"not_run"` を使います。
+`formal_result:"not_run"` を使います。未知の `--property`/`--migration` の
+選択はチェック時エラー（exit 2）です。選択された `statistical_property` の
+ゲート状態（`dataset_invalid`、`evaluator_untrusted`、`slice_missing`、
+`insufficient_samples`、`inconclusive`、`statistically_unsupported`）は
+exit 1 となり、唯一の成功ケースである `statistically_supported` の exit 0
+と対比されます。
 
 再帰的な `agent` の形:
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2367,8 +2367,10 @@ Wilson 区間つきで、事前計算された JSONL から Bernoulli/比率の�
 します。`fslc ai regress` は集約の `no_regression` のメトリクス低下/増加の節を
 検査します。`fslc ai compare` は閾値の主張なしにメトリクスの差分を報告します。
 `fslc ai drift` はランタイムのテレメトリの閾値とドリフトを検査します。そして
-`fslc ai compat` は有限の
-`dbsystem artifact` ケイパビリティプロファイルを出力します。これらはすべて
+`fslc ai compat` は、1 つの `ai_component`、またはプロジェクトが
+宣言するすべての `ai_component` について有限の `dbsystem artifact`
+ケイパビリティプロファイルを出力し、AI ではない入力や `ai_component` を
+1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
 `formal_result:"not_run"` を使います。
 
 再帰的な `agent` の形:

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2413,15 +2413,23 @@ graph analysis, not kernel proof. `fslc ai replay` accepts JSONL or
 Project-level fsl-ai evidence declarations can combine `ai_component`,
 `dataset`, `evaluator`, `failure_mode`, `statistical_property`,
 `ai_migration`, and `observed_property`. `fslc ai check` parses these files and
-returns `ai_project_analyzed`; `fslc ai eval` checks Bernoulli/proportion
-metrics from precomputed JSONL with Wilson intervals; `fslc ai regress` checks
-aggregate `no_regression` metric drop/increase clauses; `fslc ai compare`
-reports metric deltas without a threshold claim; `fslc ai drift` checks runtime
-telemetry thresholds and drift; and `fslc ai compat` emits a finite
-`dbsystem artifact` capability profile for one `ai_component` or every
+returns `ai_project_analyzed`; `fslc ai eval` checks the selected
+`statistical_property`'s declared `slice`/`min_samples`/`ci_lower`/`ci_upper`
+requirements against precomputed JSONL (`--records`, or the declared
+`dataset`'s `source` file) with Wilson intervals; `fslc ai regress` checks the
+selected `ai_migration`'s declared aggregate `no_regression` metric
+drop/increase clauses; `fslc ai compare` reports metric deltas without a
+threshold claim; `fslc ai drift` checks the selected `observed_property`'s
+declared `observed`/`drift` requirements over runtime telemetry
+(`observed_supported` / `observed_mismatch`); and `fslc ai compat` emits a
+finite `dbsystem artifact` capability profile for one `ai_component` or every
 `ai_component` a project declares, rejecting non-AI input and an AI project
 with no `ai_component` at all (exit 2). All of these use
-`formal_result:"not_run"`.
+`formal_result:"not_run"`. An unknown `--property`/`--migration` selection is
+a check-time error (exit 2); a selected `statistical_property`'s gate status
+(`dataset_invalid`, `evaluator_untrusted`, `slice_missing`,
+`insufficient_samples`, `inconclusive`, or `statistically_unsupported`) exits
+1, matching `statistically_supported`'s exit 0 as the only success case.
 
 Recursive `agent` shape:
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2418,7 +2418,9 @@ metrics from precomputed JSONL with Wilson intervals; `fslc ai regress` checks
 aggregate `no_regression` metric drop/increase clauses; `fslc ai compare`
 reports metric deltas without a threshold claim; `fslc ai drift` checks runtime
 telemetry thresholds and drift; and `fslc ai compat` emits a finite
-`dbsystem artifact` capability profile. All of these use
+`dbsystem artifact` capability profile for one `ai_component` or every
+`ai_component` a project declares, rejecting non-AI input and an AI project
+with no `ai_component` at all (exit 2). All of these use
 `formal_result:"not_run"`.
 
 Recursive `agent` shape:

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -1,0 +1,940 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Lenient parser for fsl-ai project-level evidence declarations (issues
+//! #509/#510/#511).
+//!
+//! The hard-contract `ai_component` and recursive `agent` dialects keep their
+//! strict token-based parser (`crate::ai`) because they lower to a kernel or
+//! graph check. The `dataset` / `statistical_property` / `ai_migration` /
+//! `observed_property` declarations parsed here are external evidence jobs:
+//! their `require` clauses are threshold labels, not kernel formulas
+//! (`docs/DESIGN-stochastic.md`). This mirrors the frozen reference's
+//! `src/fslc/ai_project.py`: a small typed metadata model built with a
+//! brace-matching block scanner, not a strict grammar.
+
+use crate::ai::{AiComponent, parse_ai_component};
+
+/// Top-level declaration kinds this parser recognizes as fsl-ai project
+/// blocks. A block whose kind is not in this set is ignored (mirrors the
+/// frozen reference's `raw_blocks` for `ai_action`/`authority`/`retriever`/
+/// `trust_boundary`/`ai_contract`/`evaluator`/`failure_mode`: these are
+/// accepted as un-descended block boundaries but carry no evidence-execution
+/// semantics in `fslc ai eval`/`regress`/`drift`/`compat`).
+const PROJECT_BLOCKS: &[&str] = &[
+    "ai_action",
+    "ai_component",
+    "ai_contract",
+    "ai_migration",
+    "authority",
+    "dataset",
+    "evaluator",
+    "failure_mode",
+    "observed_property",
+    "retriever",
+    "statistical_property",
+    "trust_boundary",
+];
+
+/// Nested block kinds that may appear without a name and are only
+/// meaningful inside a specific parent (`statistical_property`/
+/// `observed_property`'s `slice`, `ai_migration`'s `preserve`/
+/// `no_regression`).
+const NESTED_BLOCKS: &[&str] = &["slice", "preserve", "no_regression"];
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiMetricRequirement {
+    /// `"min_samples"` | `"ci_lower"` | `"ci_upper"` | `"point_estimate"` |
+    /// `"inconclusive"`.
+    pub kind: String,
+    pub metric: Option<String>,
+    pub confidence: Option<f64>,
+    pub comparator: Option<String>,
+    pub threshold: Option<f64>,
+    pub slice: String,
+    pub min_samples: Option<u64>,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiStatisticalProperty {
+    pub name: String,
+    pub target: Option<String>,
+    pub dataset: Option<String>,
+    pub evaluator: Option<String>,
+    pub confidence: f64,
+    pub requirements: Vec<AiMetricRequirement>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiRegressionRequirement {
+    pub metric: String,
+    /// `"drop"` | `"increase"`.
+    pub direction: String,
+    pub comparator: String,
+    pub threshold: f64,
+    pub dataset: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AiMigration {
+    pub name: String,
+    pub regression_requirements: Vec<AiRegressionRequirement>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiObservedRequirement {
+    /// `"observed"` | `"drift"` | `"inconclusive"`.
+    pub kind: String,
+    pub metric: String,
+    pub comparator: String,
+    pub threshold: f64,
+    pub compared_to: Option<String>,
+    pub slice: String,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiObservedProperty {
+    pub name: String,
+    pub target: Option<String>,
+    pub source: Option<String>,
+    pub window: Option<String>,
+    pub requirements: Vec<AiObservedRequirement>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiDataset {
+    pub name: String,
+    pub source: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AiProject {
+    pub name: String,
+    pub components: Vec<AiComponent>,
+    pub datasets: Vec<AiDataset>,
+    pub statistical_properties: Vec<AiStatisticalProperty>,
+    pub observed_properties: Vec<AiObservedProperty>,
+    pub migrations: Vec<AiMigration>,
+}
+
+impl AiProject {
+    /// Resolve the source JSONL path declared by `dataset <name> { source
+    /// "..."; }`, matching `_records_path`'s dataset-source fallback used
+    /// when `fslc ai eval` is invoked without `--records` (`docs/LANGUAGE.md`
+    /// documents this exact usage).
+    #[must_use]
+    pub fn dataset_source(&self, name: &str) -> Option<&str> {
+        self.datasets
+            .iter()
+            .find(|dataset| dataset.name == name)
+            .and_then(|dataset| dataset.source.as_deref())
+    }
+
+    /// Select the `statistical_property` an `fslc ai eval` invocation
+    /// targets: an explicit `--property` name, else the unique property
+    /// declared for `--dataset`, else the project's only property.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message naming an unknown, missing, or ambiguous selection.
+    pub fn select_statistical_property(
+        &self,
+        property_name: Option<&str>,
+        dataset_name: Option<&str>,
+    ) -> Result<&AiStatisticalProperty, String> {
+        if let Some(property_name) = property_name {
+            return self
+                .statistical_properties
+                .iter()
+                .find(|prop| prop.name == property_name)
+                .ok_or_else(|| format!("unknown statistical_property '{property_name}'"));
+        }
+        if let Some(dataset_name) = dataset_name {
+            let matching = self
+                .statistical_properties
+                .iter()
+                .filter(|prop| prop.dataset.as_deref() == Some(dataset_name))
+                .collect::<Vec<_>>();
+            if matching.len() == 1 {
+                return Ok(matching[0]);
+            }
+            if matching.len() > 1 {
+                return Err(format!(
+                    "multiple statistical_property declarations use dataset '{dataset_name}'; pass --property"
+                ));
+            }
+        }
+        match self.statistical_properties.len() {
+            1 => Ok(&self.statistical_properties[0]),
+            0 => Err("no statistical_property declaration found".to_owned()),
+            _ => {
+                Err("multiple statistical_property declarations found; pass --property".to_owned())
+            }
+        }
+    }
+
+    /// Select the `ai_migration` an `fslc ai regress` invocation targets.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message naming an unknown, missing, or ambiguous selection.
+    pub fn select_migration(&self, migration_name: Option<&str>) -> Result<&AiMigration, String> {
+        if let Some(migration_name) = migration_name {
+            return self
+                .migrations
+                .iter()
+                .find(|migration| migration.name == migration_name)
+                .ok_or_else(|| format!("unknown ai_migration '{migration_name}'"));
+        }
+        match self.migrations.len() {
+            1 => Ok(&self.migrations[0]),
+            0 => Err("no ai_migration declaration found".to_owned()),
+            _ => Err("multiple ai_migration declarations found; pass --migration".to_owned()),
+        }
+    }
+
+    /// Select the `observed_property` an `fslc ai drift` invocation targets.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message naming an unknown, missing, or ambiguous selection.
+    pub fn select_observed_property(
+        &self,
+        property_name: Option<&str>,
+    ) -> Result<&AiObservedProperty, String> {
+        if let Some(property_name) = property_name {
+            return self
+                .observed_properties
+                .iter()
+                .find(|prop| prop.name == property_name)
+                .ok_or_else(|| format!("unknown observed_property '{property_name}'"));
+        }
+        match self.observed_properties.len() {
+            1 => Ok(&self.observed_properties[0]),
+            0 => Err("no observed_property declaration found".to_owned()),
+            _ => Err("multiple observed_property declarations found; pass --property".to_owned()),
+        }
+    }
+}
+
+/// Parse one fsl-ai project source into its typed declarations.
+///
+/// # Errors
+///
+/// Returns a message when no recognized top-level block is found, a block is
+/// unterminated, or a `statistical_property`/`observed_property`/
+/// `ai_migration` name is declared more than once.
+pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
+    let blocks = top_blocks(source)?;
+    if blocks.is_empty() {
+        return Err("expected fsl-ai project declarations".to_owned());
+    }
+    let mut project = AiProject {
+        name: name.to_owned(),
+        ..AiProject::default()
+    };
+    for block in &blocks {
+        match block.kind.as_str() {
+            "ai_component" => {
+                project
+                    .components
+                    .push(parse_ai_component(&block.text).map_err(|error| error.to_string())?);
+            }
+            "dataset" => project.datasets.push(parse_dataset(block)),
+            "statistical_property" => project
+                .statistical_properties
+                .push(parse_statistical_property(block)?),
+            "observed_property" => project
+                .observed_properties
+                .push(parse_observed_property(block)?),
+            "ai_migration" => project.migrations.push(parse_migration(block)?),
+            _ => {}
+        }
+    }
+    reject_duplicates(
+        project
+            .statistical_properties
+            .iter()
+            .map(|p| p.name.as_str()),
+        "statistical_property",
+    )?;
+    reject_duplicates(
+        project.observed_properties.iter().map(|p| p.name.as_str()),
+        "observed_property",
+    )?;
+    reject_duplicates(
+        project.migrations.iter().map(|p| p.name.as_str()),
+        "ai_migration",
+    )?;
+    Ok(project)
+}
+
+fn reject_duplicates<'a>(names: impl Iterator<Item = &'a str>, label: &str) -> Result<(), String> {
+    let mut seen = std::collections::BTreeSet::new();
+    for name in names {
+        if !seen.insert(name) {
+            return Err(format!("duplicate {label} '{name}'"));
+        }
+    }
+    Ok(())
+}
+
+// --- brace-matching block scanner (mirrors `_top_blocks` et al.) ----------
+
+struct RawBlock {
+    kind: String,
+    name: String,
+    /// The exact original text of the block, header included (`"kind name {
+    /// ... }"`), used to hand `ai_component` blocks to the strict token
+    /// parser unmodified.
+    text: String,
+    body: String,
+}
+
+struct BlockHeader {
+    start: usize,
+    kind: String,
+    name: String,
+    brace: usize,
+}
+
+fn is_ident_start(c: char) -> bool {
+    c.is_ascii_alphabetic() || c == '_'
+}
+
+fn is_ident_continue(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+#[allow(clippy::many_single_char_names)]
+fn try_match_header(chars: &[char], start: usize) -> Option<BlockHeader> {
+    let n = chars.len();
+    let mut p = start;
+    while p < n && is_ident_continue(chars[p]) {
+        p += 1;
+    }
+    let kind: String = chars[start..p].iter().collect();
+    let mut q = p;
+    while q < n && chars[q].is_whitespace() {
+        q += 1;
+    }
+    if q > p && q < n && is_ident_start(chars[q]) {
+        let name_start = q;
+        let mut r = q;
+        while r < n && is_ident_continue(chars[r]) {
+            r += 1;
+        }
+        let mut s = r;
+        while s < n && chars[s].is_whitespace() {
+            s += 1;
+        }
+        if s < n && chars[s] == '{' {
+            return Some(BlockHeader {
+                start,
+                kind,
+                name: chars[name_start..r].iter().collect(),
+                brace: s,
+            });
+        }
+    }
+    let mut s = p;
+    while s < n && chars[s].is_whitespace() {
+        s += 1;
+    }
+    if s < n && chars[s] == '{' {
+        return Some(BlockHeader {
+            start,
+            kind,
+            name: String::new(),
+            brace: s,
+        });
+    }
+    None
+}
+
+fn find_block_header(chars: &[char], from: usize) -> Option<BlockHeader> {
+    let n = chars.len();
+    let mut pos = from;
+    while pos < n {
+        if is_ident_start(chars[pos])
+            && (pos == 0 || !is_ident_continue(chars[pos - 1]))
+            && let Some(header) = try_match_header(chars, pos)
+        {
+            return Some(header);
+        }
+        pos += 1;
+    }
+    None
+}
+
+fn matching_brace(chars: &[char], brace: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &ch) in chars.iter().enumerate().skip(brace) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+        } else if ch == '{' {
+            depth += 1;
+        } else if ch == '}' {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+fn brace_depth(chars: &[char]) -> i32 {
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &ch in chars {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+        } else if ch == '{' {
+            depth += 1;
+        } else if ch == '}' {
+            depth -= 1;
+        }
+    }
+    depth
+}
+
+fn top_blocks(source: &str) -> Result<Vec<RawBlock>, String> {
+    let chars: Vec<char> = source.chars().collect();
+    let mut blocks = Vec::new();
+    let mut i = 0usize;
+    let n = chars.len();
+    while i < n {
+        let Some(header) = find_block_header(&chars, i) else {
+            break;
+        };
+        let known = PROJECT_BLOCKS.contains(&header.kind.as_str())
+            || NESTED_BLOCKS.contains(&header.kind.as_str());
+        if !known || (PROJECT_BLOCKS.contains(&header.kind.as_str()) && header.name.is_empty()) {
+            i = header.start + 1;
+            continue;
+        }
+        let Some(end) = matching_brace(&chars, header.brace) else {
+            return Err(format!(
+                "unterminated {} '{}' block",
+                header.kind, header.name
+            ));
+        };
+        if brace_depth(&chars[..header.start]) == 0 {
+            blocks.push(RawBlock {
+                text: chars[header.start..=end].iter().collect(),
+                body: chars[header.brace + 1..end].iter().collect(),
+                kind: header.kind,
+                name: header.name,
+            });
+        }
+        i = end + 1;
+    }
+    Ok(blocks)
+}
+
+fn strip_comment(line: &str) -> &str {
+    let chars: Vec<char> = line.chars().collect();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut i = 0usize;
+    while i + 1 < chars.len() {
+        let ch = chars[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+        } else if ch == '"' {
+            in_string = true;
+        } else if ch == '/' && chars[i + 1] == '/' {
+            let byte_offset: usize = chars[..i].iter().map(|c| c.len_utf8()).sum();
+            return &line[..byte_offset];
+        }
+        i += 1;
+    }
+    line
+}
+
+fn strip_semi(line: &str) -> String {
+    line.strip_suffix(';')
+        .map_or(line, str::trim)
+        .trim()
+        .to_owned()
+}
+
+/// One logical top-level statement per line inside `body`, comments
+/// stripped and nested-block lines (including the block's own header line)
+/// skipped, mirroring `_top_lines`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn top_lines(body: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut depth = 0i32;
+    for raw in body.lines() {
+        let line = strip_comment(raw).trim();
+        if line.is_empty() {
+            continue;
+        }
+        let before = depth;
+        depth += line.matches('{').count() as i32 - line.matches('}').count() as i32;
+        if before == 0 && !line.contains('{') && !line.contains('}') {
+            lines.push(strip_semi(line));
+        }
+    }
+    lines
+}
+
+fn atom(text: &str) -> String {
+    let text = strip_semi(text.trim());
+    if text.len() >= 2 && text.starts_with('"') && text.ends_with('"') {
+        text[1..text.len() - 1].to_owned()
+    } else {
+        text
+    }
+}
+
+fn metric_name(text: &str) -> String {
+    text.trim()
+        .strip_prefix("metric.")
+        .unwrap_or(text.trim())
+        .to_owned()
+}
+
+/// The first comparator in `s` (two-character forms take priority), or
+/// `None` if `s` has none.
+fn find_comparator(s: &str) -> Option<(usize, &'static str)> {
+    let bytes = s.as_bytes();
+    for i in 0..bytes.len() {
+        if s[i..].starts_with(">=") {
+            return Some((i, ">="));
+        }
+        if s[i..].starts_with("<=") {
+            return Some((i, "<="));
+        }
+        if s[i..].starts_with("==") {
+            return Some((i, "=="));
+        }
+        if bytes[i] == b'>' {
+            return Some((i, ">"));
+        }
+        if bytes[i] == b'<' {
+            return Some((i, "<"));
+        }
+    }
+    None
+}
+
+fn is_dotted_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_ident_start(c) => {}
+        _ => return false,
+    }
+    chars.all(|c| is_ident_continue(c) || c == '.')
+}
+
+// --- per-block parsers (mirror `_parse_*` in the frozen reference) --------
+
+fn parse_dataset(block: &RawBlock) -> AiDataset {
+    let mut source = None;
+    for line in top_lines(&block.body) {
+        if let Some(rest) = line.strip_prefix("source ") {
+            source = Some(atom(rest));
+        }
+    }
+    AiDataset {
+        name: block.name.clone(),
+        source,
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement {
+    let source = line.to_owned();
+    let expr = line.trim();
+    if let Some((idx, op)) = find_comparator(expr) {
+        let left = expr[..idx].trim();
+        let right = expr[idx + op.len()..].trim();
+        if left == "min_samples"
+            && let Ok(value) = right.parse::<f64>()
+        {
+            return AiMetricRequirement {
+                kind: "min_samples".to_owned(),
+                metric: None,
+                confidence: None,
+                comparator: Some(op.to_owned()),
+                threshold: Some(value),
+                slice: slice_name.to_owned(),
+                min_samples: Some(value as u64),
+                source,
+            };
+        }
+        for (prefix, kind) in [("ci_lower(", "ci_lower"), ("ci_upper(", "ci_upper")] {
+            if let Some(inner) = left.strip_prefix(prefix).and_then(|s| s.strip_suffix(')'))
+                && let Some((metric_part, confidence_part)) = inner.split_once(',')
+                && let Ok(confidence) = confidence_part.trim().parse::<f64>()
+                && let Ok(threshold) = right.parse::<f64>()
+            {
+                return AiMetricRequirement {
+                    kind: kind.to_owned(),
+                    metric: Some(metric_name(metric_part)),
+                    confidence: Some(confidence),
+                    comparator: Some(op.to_owned()),
+                    threshold: Some(threshold),
+                    slice: slice_name.to_owned(),
+                    min_samples: None,
+                    source,
+                };
+            }
+        }
+        if is_dotted_ident(left)
+            && let Ok(threshold) = right.parse::<f64>()
+        {
+            return AiMetricRequirement {
+                kind: "point_estimate".to_owned(),
+                metric: Some(metric_name(left)),
+                confidence: None,
+                comparator: Some(op.to_owned()),
+                threshold: Some(threshold),
+                slice: slice_name.to_owned(),
+                min_samples: None,
+                source,
+            };
+        }
+    }
+    AiMetricRequirement {
+        kind: "inconclusive".to_owned(),
+        metric: None,
+        confidence: None,
+        comparator: None,
+        threshold: None,
+        slice: slice_name.to_owned(),
+        min_samples: None,
+        source,
+    }
+}
+
+fn parse_statistical_property(block: &RawBlock) -> Result<AiStatisticalProperty, String> {
+    let mut target = None;
+    let mut dataset = None;
+    let mut evaluator = None;
+    let mut confidence = 0.95;
+    let mut requirements = Vec::new();
+    for line in top_lines(&block.body) {
+        if let Some(rest) = line.strip_prefix("target ") {
+            target = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("dataset ") {
+            dataset = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("evaluator ") {
+            evaluator = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("confidence ") {
+            confidence = atom(rest).parse().map_err(|_| {
+                format!(
+                    "statistical_property '{}' has a non-numeric confidence",
+                    block.name
+                )
+            })?;
+        } else if let Some(rest) = line.strip_prefix("require ") {
+            requirements.push(parse_metric_requirement(rest, "all"));
+        }
+    }
+    for child in top_blocks(&block.body)? {
+        if child.kind != "slice" {
+            continue;
+        }
+        for line in top_lines(&child.body) {
+            if let Some(rest) = line.strip_prefix("require ") {
+                requirements.push(parse_metric_requirement(rest, &child.name));
+            }
+        }
+    }
+    Ok(AiStatisticalProperty {
+        name: block.name.clone(),
+        target,
+        dataset,
+        evaluator,
+        confidence,
+        requirements,
+    })
+}
+
+fn parse_observed_requirement(line: &str, slice_name: &str) -> AiObservedRequirement {
+    let expr = line.trim();
+    if let Some((idx, op)) = find_comparator(expr) {
+        let left = expr[..idx].trim();
+        let right = expr[idx + op.len()..].trim();
+        if let Some(inner) = left
+            .strip_prefix("observed(")
+            .and_then(|s| s.strip_suffix(')'))
+            && let Ok(threshold) = right.parse::<f64>()
+        {
+            return AiObservedRequirement {
+                kind: "observed".to_owned(),
+                metric: metric_name(inner),
+                comparator: op.to_owned(),
+                threshold,
+                compared_to: None,
+                slice: slice_name.to_owned(),
+                source: line.to_owned(),
+            };
+        }
+        if let Some(inner) = left
+            .strip_prefix("drift(")
+            .and_then(|s| s.strip_suffix(')'))
+        {
+            let mut parts = right.splitn(2, "compared_to");
+            let threshold_part = parts.next().unwrap_or("").trim();
+            let compared_to = parts.next().map(str::trim).filter(|s| !s.is_empty());
+            if let (Ok(threshold), Some(compared_to)) = (threshold_part.parse::<f64>(), compared_to)
+            {
+                return AiObservedRequirement {
+                    kind: "drift".to_owned(),
+                    metric: metric_name(inner),
+                    comparator: op.to_owned(),
+                    threshold,
+                    compared_to: Some(compared_to.to_owned()),
+                    slice: slice_name.to_owned(),
+                    source: line.to_owned(),
+                };
+            }
+        }
+    }
+    AiObservedRequirement {
+        kind: "inconclusive".to_owned(),
+        metric: "unknown".to_owned(),
+        comparator: "==".to_owned(),
+        threshold: 0.0,
+        compared_to: None,
+        slice: slice_name.to_owned(),
+        source: line.to_owned(),
+    }
+}
+
+fn parse_observed_property(block: &RawBlock) -> Result<AiObservedProperty, String> {
+    let mut target = None;
+    let mut source = None;
+    let mut window = None;
+    let mut requirements = Vec::new();
+    for line in top_lines(&block.body) {
+        if let Some(rest) = line.strip_prefix("target ") {
+            target = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("source ") {
+            source = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("window ") {
+            window = Some(atom(rest));
+        } else if let Some(rest) = line.strip_prefix("require ") {
+            requirements.push(parse_observed_requirement(rest, "all"));
+        }
+    }
+    for child in top_blocks(&block.body)? {
+        if child.kind != "slice" {
+            continue;
+        }
+        for line in top_lines(&child.body) {
+            if let Some(rest) = line.strip_prefix("require ") {
+                requirements.push(parse_observed_requirement(rest, &child.name));
+            }
+        }
+    }
+    Ok(AiObservedProperty {
+        name: block.name.clone(),
+        target,
+        source,
+        window,
+        requirements,
+    })
+}
+
+fn parse_regression_requirement(
+    line: &str,
+    dataset: Option<String>,
+) -> Result<AiRegressionRequirement, String> {
+    let unsupported = || format!("unsupported no_regression metric clause: {line}");
+    let rest = line.strip_prefix("metric ").ok_or_else(unsupported)?;
+    let (idx, op) = find_comparator(rest).ok_or_else(unsupported)?;
+    let left = rest[..idx].trim();
+    let threshold: f64 = rest[idx + op.len()..]
+        .trim()
+        .parse()
+        .map_err(|_| unsupported())?;
+    let mut left_parts = left.split_whitespace();
+    let metric = left_parts.next().ok_or_else(unsupported)?;
+    let direction = left_parts.next().ok_or_else(unsupported)?;
+    if left_parts.next().is_some() || !matches!(direction, "drop" | "increase") {
+        return Err(unsupported());
+    }
+    Ok(AiRegressionRequirement {
+        metric: metric_name(metric),
+        direction: direction.to_owned(),
+        comparator: op.to_owned(),
+        threshold,
+        dataset,
+    })
+}
+
+fn parse_migration(block: &RawBlock) -> Result<AiMigration, String> {
+    let mut regression_requirements = Vec::new();
+    for child in top_blocks(&block.body)? {
+        if child.kind != "preserve" {
+            continue;
+        }
+        for grandchild in top_blocks(&child.body)? {
+            if grandchild.kind != "no_regression" {
+                continue;
+            }
+            let mut dataset = None;
+            for line in top_lines(&grandchild.body) {
+                if let Some(rest) = line.strip_prefix("dataset ") {
+                    dataset = Some(atom(rest));
+                } else if line.starts_with("metric ") {
+                    regression_requirements
+                        .push(parse_regression_requirement(&line, dataset.clone())?);
+                }
+            }
+        }
+    }
+    Ok(AiMigration {
+        name: block.name.clone(),
+        regression_requirements,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_statistical_property_with_slice_gate() {
+        let source = r"
+statistical_property LooseQuality {
+  target SupportAnswerAgent
+  dataset SupportEvalV3
+  evaluator SupportAnswerJudge
+  confidence 0.95
+
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+
+  slice JapaneseRefundTickets {
+    require min_samples >= 5
+    require ci_lower(metric.accuracy, 0.95) >= 0.35
+  }
+}
+";
+        let project = parse_ai_project(source, "P").expect("parse");
+        assert_eq!(project.statistical_properties.len(), 1);
+        let prop = &project.statistical_properties[0];
+        assert_eq!(prop.dataset.as_deref(), Some("SupportEvalV3"));
+        assert_eq!(prop.evaluator.as_deref(), Some("SupportAnswerJudge"));
+        assert_eq!(prop.requirements.len(), 3);
+        assert_eq!(prop.requirements[0].slice, "all");
+        assert_eq!(prop.requirements[0].kind, "ci_lower");
+        assert_eq!(prop.requirements[0].threshold, Some(0.45));
+        assert_eq!(prop.requirements[1].slice, "JapaneseRefundTickets");
+        assert_eq!(prop.requirements[1].kind, "min_samples");
+        assert_eq!(prop.requirements[1].min_samples, Some(5));
+        assert_eq!(prop.requirements[2].kind, "ci_lower");
+        assert_eq!(prop.requirements[2].threshold, Some(0.35));
+    }
+
+    #[test]
+    fn parses_migration_no_regression_clauses() {
+        let source = r"
+ai_migration PromptV7ToV8 {
+  preserve {
+    no_regression {
+      dataset SupportEvalV3
+      metric accuracy drop <= 0.05
+      metric hallucination_rate increase <= 0.02
+    }
+  }
+}
+";
+        let project = parse_ai_project(source, "P").expect("parse");
+        let migration = project.select_migration(None).expect("selection");
+        assert_eq!(migration.regression_requirements.len(), 2);
+        assert_eq!(migration.regression_requirements[0].metric, "accuracy");
+        assert_eq!(migration.regression_requirements[0].direction, "drop");
+        assert!((migration.regression_requirements[0].threshold - 0.05).abs() < f64::EPSILON);
+        assert_eq!(
+            migration.regression_requirements[1].metric,
+            "hallucination_rate"
+        );
+        assert_eq!(migration.regression_requirements[1].direction, "increase");
+    }
+
+    #[test]
+    fn parses_observed_property_with_drift_clause() {
+        let source = r"
+observed_property SupportAgentOperationalQuality {
+  target SupportAnswerAgent
+  source production_logs
+  window last_7_days
+
+  require observed(metric.hallucination_rate) <= 0.30
+  require drift(metric.refusal_rate) <= 0.10 compared_to previous_7_days
+}
+";
+        let project = parse_ai_project(source, "P").expect("parse");
+        let prop = project.select_observed_property(None).expect("selection");
+        assert_eq!(prop.requirements.len(), 2);
+        assert_eq!(prop.requirements[0].kind, "observed");
+        assert_eq!(prop.requirements[1].kind, "drift");
+        assert_eq!(
+            prop.requirements[1].compared_to.as_deref(),
+            Some("previous_7_days")
+        );
+    }
+
+    #[test]
+    fn rejects_source_with_no_recognized_block() {
+        let error = parse_ai_project("domain D {}", "P").unwrap_err();
+        assert!(error.contains("expected fsl-ai project declarations"));
+    }
+
+    #[test]
+    fn dataset_source_resolves_records_fallback() {
+        let source = r#"
+dataset SupportEvalV3 {
+  source "examples/ai/support_eval_v3.jsonl"
+}
+statistical_property Loose {
+  target X
+  dataset SupportEvalV3
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+}
+"#;
+        let project = parse_ai_project(source, "P").expect("parse");
+        assert_eq!(
+            project.dataset_source("SupportEvalV3"),
+            Some("examples/ai/support_eval_v3.jsonl")
+        );
+    }
+}

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -9,6 +9,7 @@
 //! differential tests without making that legacy representation the Rust AST.
 
 mod ai;
+mod ai_project;
 mod annotation;
 mod annotation_parse;
 mod ast;
@@ -27,6 +28,10 @@ pub use ai::{
     AiAgentContract, AiAgentGrant, AiAgentOutput, AiAuthority, AiAuthorityRule, AiCheckRule,
     AiComponent, AiDelegationEdge, AiFailurePolicy, AiFallback, AiHardCheck, AiLoc, AiTool,
     parse_ai_component,
+};
+pub use ai_project::{
+    AiDataset, AiMetricRequirement, AiMigration, AiObservedProperty, AiObservedRequirement,
+    AiProject, AiRegressionRequirement, AiStatisticalProperty, parse_ai_project,
 };
 pub use annotation::{
     Annotation, AnnotationError, AnnotationRegistry, AnnotationValue, Annotations, RequirementLink,

--- a/rust/fsl-tools/src/ai_stochastic.rs
+++ b/rust/fsl-tools/src/ai_stochastic.rs
@@ -1,0 +1,868 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Executes declared fsl-ai project evidence policy (issues #509/#510):
+//! `statistical_property` (via `fslc ai eval`), `ai_migration.no_regression`
+//! (via `fslc ai regress`), and `observed_property` (via `fslc ai drift`).
+//! Every result is schema-conformant with
+//! `schemas/fslc/ai/statistical-result.v0.schema.json` and
+//! `docs/DESIGN-stochastic.md`'s status priority; `formal_result` is always
+//! `"not_run"` (`docs/DESIGN-stochastic.md`: this layer is external
+//! evidence, never a kernel proof).
+
+use fsl_syntax::{
+    AiMigration, AiObservedProperty, AiObservedRequirement, AiRegressionRequirement,
+    AiStatisticalProperty,
+};
+use serde_json::{Value, json};
+
+const STATISTICAL_RESULT_SCHEMA_VERSION: &str = "fsl-ai-statistical-result.v0";
+const STATUS_PRIORITY: [&str; 7] = [
+    "dataset_invalid",
+    "evaluator_untrusted",
+    "slice_missing",
+    "insufficient_samples",
+    "inconclusive",
+    "statistically_unsupported",
+    "statistically_supported",
+];
+
+/// Evaluate a selected `statistical_property` against precomputed eval JSONL
+/// records, applying every declared slice's `min_samples`/`ci_lower`/
+/// `ci_upper` gate (`docs/DESIGN-stochastic.md`'s status priority).
+///
+/// # Errors
+///
+/// Returns a message when no declared requirement matches the requested
+/// slice/property (a selection error, not a statistical gate failure).
+pub fn evaluate_statistical_property(
+    prop: &AiStatisticalProperty,
+    records: &[Value],
+    dataset: &str,
+    slice_filter: Option<&str>,
+) -> Result<Value, String> {
+    let checks = evaluate_statistical_requirements(records, prop, dataset, slice_filter)?;
+    let status = overall_status(&checks);
+    let primary = primary_check(&checks);
+    let findings = checks
+        .iter()
+        .filter(|check| check["status"] != "statistically_supported")
+        .map(|check| statistical_finding(prop, check))
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "schema_version": STATISTICAL_RESULT_SCHEMA_VERSION,
+        "fsl": "fsl-stochastic.v0",
+        "result": status,
+        "status": status,
+        "formal_result": "not_run",
+        "target": prop.target,
+        "property": prop.name,
+        "dataset": dataset,
+        "slice": primary["slice"],
+        "metric": primary["metric"],
+        "n": primary["n"],
+        "estimate": primary["estimate"],
+        "interval": primary["interval"],
+        "threshold": primary["threshold"],
+        "evaluator": evaluator_summary(records, prop.evaluator.as_deref()),
+        "checks": checks,
+        "assumptions": statistical_assumptions(),
+        "findings": findings,
+    }))
+}
+
+/// Evaluate a selected `ai_migration`'s declared `no_regression` metric
+/// clauses over before/after precomputed eval JSONL.
+///
+/// # Errors
+///
+/// Returns a message when the migration declares no `no_regression` metric
+/// clause at all.
+pub fn evaluate_migration(
+    migration: &AiMigration,
+    before: &[Value],
+    after: &[Value],
+    dataset: Option<&str>,
+) -> Result<Value, String> {
+    if migration.regression_requirements.is_empty() {
+        return Err(format!(
+            "ai_migration '{}' has no no_regression metric clauses",
+            migration.name
+        ));
+    }
+    let checks = migration
+        .regression_requirements
+        .iter()
+        .map(|req| {
+            evaluate_regression_requirement(before, after, req, dataset.or(req.dataset.as_deref()))
+        })
+        .collect::<Vec<_>>();
+    let failed = checks
+        .iter()
+        .filter(|check| check["passed"] == false)
+        .collect::<Vec<_>>();
+    let status = if failed.is_empty() {
+        "statistically_supported"
+    } else {
+        "statistically_unsupported"
+    };
+    let findings = failed
+        .iter()
+        .map(|check| migration_finding(migration, check))
+        .collect::<Vec<_>>();
+    let resolved_dataset = dataset
+        .map(str::to_owned)
+        .or_else(|| migration.regression_requirements[0].dataset.clone());
+    Ok(json!({
+        "schema_version": "fsl-ai-migration-result.v0",
+        "fsl": "fsl-ai-migration.v0",
+        "result": status,
+        "status": status,
+        "formal_result": "not_run",
+        "migration": migration.name,
+        "dataset": resolved_dataset,
+        "checks": checks,
+        "assumptions": regression_assumptions(),
+        "findings": findings,
+    }))
+}
+
+/// Evaluate a selected `observed_property`'s declared `observed`/`drift`
+/// requirements over runtime telemetry JSONL.
+#[must_use]
+pub fn evaluate_observed_property(
+    prop: &AiObservedProperty,
+    current: &[Value],
+    baseline: &[Value],
+    window: Option<&str>,
+    baseline_label: Option<&str>,
+) -> Value {
+    let checks = prop
+        .requirements
+        .iter()
+        .map(|req| evaluate_observed_requirement(current, baseline, req))
+        .collect::<Vec<_>>();
+    let failed = checks.iter().any(|check| check["passed"] == false);
+    let status = if failed {
+        "observed_mismatch"
+    } else {
+        "observed_supported"
+    };
+    let findings = checks
+        .iter()
+        .filter(|check| check["passed"] == false)
+        .map(|check| observed_finding(prop, check))
+        .collect::<Vec<_>>();
+    json!({
+        "schema_version": "fsl-ai-observed-result.v0",
+        "fsl": "fsl-ai-observed.v0",
+        "result": status,
+        "formal_result": "not_run",
+        "target": prop.target,
+        "property": prop.name,
+        "window": window.map(str::to_owned).or_else(|| prop.window.clone()),
+        "baseline": baseline_label,
+        "checks": checks,
+        "assumptions": observed_assumptions(),
+        "findings": findings,
+    })
+}
+
+// --- record predicates (mirror `_record_*` in the frozen reference) -------
+
+fn record_dataset(record: &Value, dataset_name: &str) -> bool {
+    match record.get("dataset") {
+        None | Some(Value::Null) => true,
+        Some(Value::String(value)) => value == dataset_name,
+        Some(_) => false,
+    }
+}
+
+fn record_slice(record: &Value) -> String {
+    record
+        .get("slice")
+        .and_then(Value::as_str)
+        .unwrap_or("all")
+        .to_owned()
+}
+
+fn record_metric(record: &Value) -> String {
+    record
+        .get("metric")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_owned()
+}
+
+fn record_outcome(record: &Value) -> bool {
+    record
+        .get("outcome")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// The first `(case_id, slice, metric)` collision, or a record missing one
+/// of those required fields; `None` if the dataset is well-formed
+/// (`docs/DESIGN-stochastic.md`: "A missing required slice field is
+/// `dataset_invalid`. Duplicate `(case_id, slice, metric)` records are
+/// `dataset_invalid`.").
+fn duplicate_eval_key(records: &[Value]) -> Option<Value> {
+    let mut seen = std::collections::BTreeSet::new();
+    for record in records {
+        let case_id = record
+            .get("case_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let slice = record_slice(record);
+        let metric = record_metric(record);
+        if case_id.is_none() || slice.is_empty() || metric.is_empty() {
+            return Some(json!({"case_id": case_id, "slice": slice, "metric": metric}));
+        }
+        let key = (case_id.unwrap(), slice, metric);
+        if !seen.insert(key.clone()) {
+            return Some(json!({"case_id": key.0, "slice": key.1, "metric": key.2}));
+        }
+    }
+    None
+}
+
+// --- statistical_property evaluation ---------------------------------
+
+fn evaluate_statistical_requirements(
+    records: &[Value],
+    prop: &AiStatisticalProperty,
+    dataset_name: &str,
+    slice_filter: Option<&str>,
+) -> Result<Vec<Value>, String> {
+    if let Some(duplicate) = duplicate_eval_key(records) {
+        return Ok(vec![json!({
+            "status": "dataset_invalid",
+            "metric": duplicate["metric"],
+            "slice": duplicate["slice"],
+            "n": 0,
+            "estimate": 0.0,
+            "interval": empty_interval(prop.confidence),
+            "threshold": {"operator": "none", "value": 0.0},
+            "reason": "duplicate (case_id, slice, metric) record",
+            "duplicate": duplicate,
+        })]);
+    }
+    let requirements = prop
+        .requirements
+        .iter()
+        .filter(|req| slice_filter.is_none_or(|slice| req.slice == slice))
+        .collect::<Vec<_>>();
+    if requirements.is_empty() {
+        return Err("no statistical requirements matched the requested slice/property".to_owned());
+    }
+    Ok(requirements
+        .into_iter()
+        .map(|req| match req.kind.as_str() {
+            "min_samples" => check_min_samples(records, req, dataset_name),
+            "ci_lower" | "ci_upper" => {
+                check_ci_requirement(records, req, dataset_name, prop.evaluator.as_deref())
+            }
+            "point_estimate" => {
+                inconclusive_check(req, "point-estimate-only requirement is not accepted")
+            }
+            _ => inconclusive_check(req, "unsupported statistical requirement"),
+        })
+        .collect())
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn check_min_samples(
+    records: &[Value],
+    req: &fsl_syntax::AiMetricRequirement,
+    dataset_name: &str,
+) -> Value {
+    let mut ids = std::collections::BTreeSet::new();
+    for (index, record) in records.iter().enumerate() {
+        if record_dataset(record, dataset_name) && record_slice(record) == req.slice {
+            let id = record
+                .get("case_id")
+                .and_then(Value::as_str)
+                .map_or_else(|| index.to_string(), str::to_owned);
+            ids.insert(id);
+        }
+    }
+    let n = ids.len();
+    let comparator = req.comparator.as_deref().unwrap_or(">=");
+    let threshold = req.min_samples.unwrap_or(0);
+    let passed = compare(n as f64, comparator, threshold as f64);
+    json!({
+        "status": if passed {"statistically_supported"} else {"insufficient_samples"},
+        "metric": "min_samples",
+        "slice": req.slice,
+        "n": n,
+        "estimate": 0.0,
+        "interval": empty_interval(req.confidence.unwrap_or(0.95)),
+        "threshold": {"operator": format!("min_samples_{comparator}"), "value": threshold},
+        "passed": passed,
+        "requirement": req.source,
+    })
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn check_ci_requirement(
+    records: &[Value],
+    req: &fsl_syntax::AiMetricRequirement,
+    dataset_name: &str,
+    evaluator: Option<&str>,
+) -> Value {
+    let metric = req.metric.clone().unwrap_or_else(|| "unknown".to_owned());
+    let confidence = req.confidence.unwrap_or(0.95);
+    let relevant = records
+        .iter()
+        .filter(|record| {
+            record_dataset(record, dataset_name)
+                && record_slice(record) == req.slice
+                && record_metric(record) == metric
+        })
+        .collect::<Vec<_>>();
+    if relevant.is_empty() {
+        return json!({
+            "status": "slice_missing",
+            "metric": metric,
+            "slice": req.slice,
+            "n": 0,
+            "estimate": 0.0,
+            "interval": empty_interval(confidence),
+            "threshold": threshold_json(req),
+            "passed": false,
+            "requirement": req.source,
+            "reason": "no eval records matched dataset/slice/metric",
+        });
+    }
+    let trust = trust_status(&relevant, evaluator);
+    if trust != "trusted" {
+        return json!({
+            "status": "evaluator_untrusted",
+            "metric": metric,
+            "slice": req.slice,
+            "n": relevant.len(),
+            "estimate": 0.0,
+            "interval": empty_interval(confidence),
+            "threshold": threshold_json(req),
+            "passed": false,
+            "requirement": req.source,
+            "evaluator": {"id": evaluator, "trust_status": trust},
+        });
+    }
+    let successes = relevant
+        .iter()
+        .filter(|record| record_outcome(record))
+        .count();
+    let n = relevant.len();
+    let estimate = successes as f64 / n as f64;
+    let interval = wilson(successes, n, confidence);
+    let observed = interval[if req.kind == "ci_lower" {
+        "lower"
+    } else {
+        "upper"
+    }]
+    .as_f64()
+    .unwrap_or(0.0);
+    let passed = compare(
+        observed,
+        req.comparator.as_deref().unwrap_or(">="),
+        req.threshold.unwrap_or(0.0),
+    );
+    json!({
+        "status": if passed {"statistically_supported"} else {"statistically_unsupported"},
+        "metric": metric,
+        "slice": req.slice,
+        "n": n,
+        "successes": successes,
+        "estimate": estimate,
+        "interval": interval,
+        "threshold": threshold_json(req),
+        "observed_bound": observed,
+        "passed": passed,
+        "requirement": req.source,
+    })
+}
+
+fn trust_status(records: &[&Value], evaluator: Option<&str>) -> String {
+    if records.is_empty() {
+        return "unknown".to_owned();
+    }
+    for record in records {
+        let Some(evaluator_object) = record.get("evaluator").and_then(Value::as_object) else {
+            return "unknown".to_owned();
+        };
+        if let Some(evaluator) = evaluator {
+            match evaluator_object.get("id").and_then(Value::as_str) {
+                None => {}
+                Some(id) if id == evaluator => {}
+                Some(_) => return "unknown".to_owned(),
+            }
+        }
+        let status = evaluator_object
+            .get("calibration_status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        if status != "trusted" {
+            return status.to_owned();
+        }
+    }
+    "trusted".to_owned()
+}
+
+fn evaluator_summary(records: &[Value], evaluator: Option<&str>) -> Value {
+    let refs = records.iter().collect::<Vec<_>>();
+    let trust = trust_status(&refs, evaluator);
+    let id = evaluator.map(str::to_owned).or_else(|| {
+        records.iter().find_map(|record| {
+            record
+                .get("evaluator")
+                .and_then(Value::as_object)
+                .and_then(|evaluator| evaluator.get("id"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+    });
+    json!({"id": id, "trust_status": trust})
+}
+
+fn threshold_json(req: &fsl_syntax::AiMetricRequirement) -> Value {
+    let operator = if req.kind == "ci_lower" {
+        "ci_lower_gte"
+    } else {
+        "ci_upper_lte"
+    };
+    json!({"operator": operator, "value": req.threshold.unwrap_or(0.0)})
+}
+
+fn inconclusive_check(req: &fsl_syntax::AiMetricRequirement, reason: &str) -> Value {
+    json!({
+        "status": "inconclusive",
+        "metric": req.metric.clone().unwrap_or_else(|| "unknown".to_owned()),
+        "slice": req.slice,
+        "n": 0,
+        "estimate": 0.0,
+        "interval": empty_interval(req.confidence.unwrap_or(0.95)),
+        "threshold": if matches!(req.kind.as_str(), "ci_lower" | "ci_upper") {
+            threshold_json(req)
+        } else {
+            json!({"operator": "none", "value": 0.0})
+        },
+        "passed": false,
+        "requirement": req.source,
+        "reason": reason,
+    })
+}
+
+fn overall_status(checks: &[Value]) -> &'static str {
+    let statuses = checks
+        .iter()
+        .filter_map(|check| check["status"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    for status in STATUS_PRIORITY {
+        if statuses.contains(status) {
+            if status == "statistically_supported" && statuses.len() > 1 {
+                continue;
+            }
+            return status;
+        }
+    }
+    "inconclusive"
+}
+
+fn primary_check(checks: &[Value]) -> &Value {
+    let status = overall_status(checks);
+    checks
+        .iter()
+        .find(|check| check["status"] == status)
+        .unwrap_or(&checks[0])
+}
+
+fn statistical_finding(prop: &AiStatisticalProperty, check: &Value) -> Value {
+    json!({
+        "schema_version": "fsl-ai-finding.v0",
+        "fsl": "fsl-stochastic.v0",
+        "result": check["status"],
+        "kind": "statistical_contract_unsupported",
+        "severity": "error",
+        "component": prop.target,
+        "contract": prop.name,
+        "tool": Value::Null,
+        "failed_rule": "statistical_property",
+        "violation": check["status"],
+        "guarantee_kind": "statistically_unsupported",
+        "evidence": {"kind": "precomputed_eval_jsonl", "formal_proof": false},
+        "witness": check,
+        "minimal_conflict_set": {
+            "property": prop.name,
+            "dataset": prop.dataset,
+            "slice": check["slice"],
+            "metric": check["metric"],
+        },
+        "repair_candidates": [{
+            "kind": "eval_data_or_model_change",
+            "weakens_spec": false,
+            "description": "add evidence, improve the component, or route the affected slice to fallback/human review",
+        }],
+        "assumptions": statistical_assumptions(),
+    })
+}
+
+fn statistical_assumptions() -> Value {
+    json!([
+        {"id": "AI-ASSUME-PRECOMPUTED-EVAL-JSONL", "text": "eval records are precomputed Bernoulli observations"},
+        {"id": "AI-ASSUME-SAMPLE-INDEPENDENCE", "text": "sample independence is dataset construction evidence and is not proved by fslc"},
+        {"id": "AI-ASSUME-EVALUATOR-CALIBRATION-EVIDENCE", "text": "evaluator trust is supplied by calibration metadata or external evidence"},
+        {"id": "AI-ASSUME-NO-STOCHASTIC-KERNEL-SEMANTICS", "text": "statistical support is external evidence and never a kernel proof"},
+    ])
+}
+
+// --- ai_migration.no_regression evaluation ------------------------------
+
+#[allow(clippy::cast_precision_loss)]
+fn aggregate_metric(records: &[Value], metric: &str, dataset: Option<&str>) -> Value {
+    let relevant = records
+        .iter()
+        .filter(|record| {
+            dataset.is_none_or(|dataset| record_dataset(record, dataset))
+                && record_metric(record) == metric
+        })
+        .collect::<Vec<_>>();
+    let n = relevant.len();
+    let successes = relevant
+        .iter()
+        .filter(|record| record_outcome(record))
+        .count();
+    let estimate = if n == 0 {
+        0.0
+    } else {
+        successes as f64 / n as f64
+    };
+    json!({
+        "n": n,
+        "successes": successes,
+        "estimate": estimate,
+        "interval": if n > 0 { wilson(successes, n, 0.95) } else { empty_interval(0.95) },
+    })
+}
+
+fn evaluate_regression_requirement(
+    before: &[Value],
+    after: &[Value],
+    req: &AiRegressionRequirement,
+    dataset: Option<&str>,
+) -> Value {
+    let before_metric = aggregate_metric(before, &req.metric, dataset);
+    let after_metric = aggregate_metric(after, &req.metric, dataset);
+    let before_estimate = before_metric["estimate"].as_f64().unwrap_or(0.0);
+    let after_estimate = after_metric["estimate"].as_f64().unwrap_or(0.0);
+    let delta = if req.direction == "drop" {
+        before_estimate - after_estimate
+    } else {
+        after_estimate - before_estimate
+    };
+    let passed = compare(delta, &req.comparator, req.threshold);
+    json!({
+        "metric": req.metric,
+        "direction": req.direction,
+        "dataset": dataset,
+        "before": before_metric,
+        "after": after_metric,
+        "observed_delta": delta,
+        "allowed_delta": req.threshold,
+        "comparator": req.comparator,
+        "passed": passed,
+    })
+}
+
+fn migration_finding(migration: &AiMigration, check: &Value) -> Value {
+    json!({
+        "schema_version": "fsl-ai-finding.v0",
+        "fsl": "fsl-ai-migration.v0",
+        "result": "statistically_unsupported",
+        "kind": "ai_migration_regression",
+        "severity": "error",
+        "component": Value::Null,
+        "contract": migration.name,
+        "tool": Value::Null,
+        "failed_rule": "no_regression",
+        "violation": "ai_migration_regression",
+        "guarantee_kind": "statistically_unsupported",
+        "evidence": {"kind": "precomputed_eval_jsonl_compare", "formal_proof": false},
+        "witness": check,
+        "minimal_conflict_set": {"migration": migration.name, "metric": check["metric"]},
+        "repair_candidates": [
+            {"kind": "rollout_block", "weakens_spec": false, "description": "block or narrow rollout for the regressed metric/slice"},
+            {"kind": "artifact_change", "weakens_spec": false, "description": "repair the prompt/model/retriever/tool schema change and re-run the regression evidence"},
+        ],
+        "assumptions": regression_assumptions(),
+    })
+}
+
+fn regression_assumptions() -> Value {
+    let mut assumptions = statistical_assumptions();
+    if let Value::Array(items) = &mut assumptions {
+        items.push(json!({
+            "id": "AI-ASSUME-AGGREGATE-REGRESSION-COMPARISON",
+            "text": "migration regression compares aggregate precomputed metrics unless paired case evidence is supplied separately",
+        }));
+    }
+    assumptions
+}
+
+// --- observed_property evaluation ---------------------------------------
+
+#[allow(clippy::cast_precision_loss)]
+fn observed_metric(records: &[Value], metric: &str, slice_name: &str) -> Value {
+    let values = records
+        .iter()
+        .filter(|record| {
+            (slice_name == "all" || record_slice(record) == slice_name)
+                && record_metric(record) == metric
+                && record.get("outcome").is_some()
+        })
+        .map(record_outcome)
+        .collect::<Vec<_>>();
+    let n = values.len();
+    if n == 0 {
+        return json!({"n": 0, "estimate": 0.0});
+    }
+    let successes = values.iter().filter(|value| **value).count();
+    json!({"n": n, "estimate": successes as f64 / n as f64})
+}
+
+fn evaluate_observed_requirement(
+    current: &[Value],
+    baseline: &[Value],
+    req: &AiObservedRequirement,
+) -> Value {
+    match req.kind.as_str() {
+        "observed" => {
+            let current_metric = observed_metric(current, &req.metric, &req.slice);
+            let passed = compare(
+                current_metric["estimate"].as_f64().unwrap_or(0.0),
+                &req.comparator,
+                req.threshold,
+            );
+            json!({
+                "kind": "observed", "metric": req.metric, "slice": req.slice,
+                "current": current_metric, "threshold": req.threshold,
+                "comparator": req.comparator, "passed": passed, "requirement": req.source,
+            })
+        }
+        "drift" => {
+            let current_metric = observed_metric(current, &req.metric, &req.slice);
+            let baseline_metric = observed_metric(baseline, &req.metric, &req.slice);
+            let drift = (current_metric["estimate"].as_f64().unwrap_or(0.0)
+                - baseline_metric["estimate"].as_f64().unwrap_or(0.0))
+            .abs();
+            let passed = compare(drift, &req.comparator, req.threshold);
+            json!({
+                "kind": "drift", "metric": req.metric, "slice": req.slice,
+                "compared_to": req.compared_to,
+                "observed": {"current": current_metric, "baseline": baseline_metric, "drift": drift},
+                "threshold": req.threshold, "comparator": req.comparator,
+                "passed": passed, "requirement": req.source,
+            })
+        }
+        _ => json!({
+            "kind": "inconclusive", "metric": req.metric, "slice": req.slice, "passed": false,
+            "reason": "unsupported observed_property requirement", "requirement": req.source,
+        }),
+    }
+}
+
+fn observed_finding(prop: &AiObservedProperty, check: &Value) -> Value {
+    let kind = if check["kind"] == "drift" {
+        "ai_observed_drift"
+    } else {
+        "ai_observed_threshold_violation"
+    };
+    json!({
+        "schema_version": "fsl-ai-finding.v0",
+        "fsl": "fsl-ai-observed.v0",
+        "result": "observed_mismatch",
+        "kind": kind,
+        "severity": "error",
+        "component": prop.target,
+        "contract": prop.name,
+        "tool": Value::Null,
+        "failed_rule": "observed_property",
+        "violation": kind,
+        "guarantee_kind": "runtime_observed",
+        "evidence": {"kind": "runtime_telemetry", "formal_proof": false},
+        "witness": check,
+        "minimal_conflict_set": {"property": prop.name, "metric": check["metric"]},
+        "repair_candidates": [{
+            "kind": "operations_response",
+            "weakens_spec": false,
+            "description": "inspect affected slices, run regression eval, or raise fallback/human-review routing",
+        }],
+        "assumptions": observed_assumptions(),
+    })
+}
+
+fn observed_assumptions() -> Value {
+    json!([{
+        "id": "AI-ASSUME-OBSERVABILITY-COVERAGE",
+        "text": "runtime telemetry coverage is external evidence; absence from logs is not proof of absence",
+    }])
+}
+
+// --- shared math (Wilson interval over an arbitrary confidence level) ----
+
+fn compare(left: f64, comparator: &str, right: f64) -> bool {
+    match comparator {
+        ">=" => left >= right,
+        ">" => left > right,
+        "<=" => left <= right,
+        "<" => left < right,
+        "==" => (left - right).abs() <= 1e-12,
+        _ => false,
+    }
+}
+
+fn empty_interval(confidence: f64) -> Value {
+    json!({"method": "wilson", "confidence": confidence, "lower": 0.0, "upper": 1.0})
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn wilson(successes: usize, n: usize, confidence: f64) -> Value {
+    if n == 0 {
+        return empty_interval(confidence);
+    }
+    let n_f = n as f64;
+    let phat = successes as f64 / n_f;
+    let z = probit(confidence);
+    let denom = 1.0 + z * z / n_f;
+    let center = (phat + z * z / (2.0 * n_f)) / denom;
+    let margin = z / denom * (phat * (1.0 - phat) / n_f + z * z / (4.0 * n_f * n_f)).sqrt();
+    json!({
+        "method": "wilson",
+        "confidence": confidence,
+        "lower": (center - margin).max(0.0),
+        "upper": (center + margin).min(1.0),
+    })
+}
+
+/// The z-quantile for a two-sided confidence level. `0.95` uses the same
+/// precise constant as the rest of fslc; any other declared `confidence`
+/// uses Peter Acklam's rational approximation of the inverse standard normal
+/// CDF (accurate to about 1.15e-9), since `statistical_property` may declare
+/// a `confidence` other than the common default.
+fn probit(confidence: f64) -> f64 {
+    if (confidence - 0.95).abs() < 1e-12 {
+        1.959_963_984_540_054
+    } else {
+        inverse_normal_cdf(0.5 + confidence / 2.0)
+    }
+}
+
+#[allow(clippy::many_single_char_names)]
+fn inverse_normal_cdf(p: f64) -> f64 {
+    const A: [f64; 6] = [
+        -3.969_683_028_665_376e+01,
+        2.209_460_984_245_205e+02,
+        -2.759_285_104_469_687e+02,
+        1.383_577_518_672_69e+02,
+        -3.066_479_806_614_716e+01,
+        2.506_628_277_459_239,
+    ];
+    const B: [f64; 5] = [
+        -5.447_609_879_822_406e+01,
+        1.615_858_368_580_409e+02,
+        -1.556_989_798_598_866e+02,
+        6.680_131_188_771_972e+01,
+        -1.328_068_155_288_572e+01,
+    ];
+    const C: [f64; 6] = [
+        -7.784_894_002_430_293e-03,
+        -3.223_964_580_411_365e-01,
+        -2.400_758_277_161_838,
+        -2.549_732_539_343_734,
+        4.374_664_141_464_968,
+        2.938_163_982_698_783,
+    ];
+    const D: [f64; 4] = [
+        7.784_695_709_041_462e-03,
+        3.224_671_290_700_398e-01,
+        2.445_134_137_142_996,
+        3.754_408_661_907_416,
+    ];
+    const P_LOW: f64 = 0.024_25;
+    let p_high = 1.0 - P_LOW;
+    if p < P_LOW {
+        let q = (-2.0 * p.ln()).sqrt();
+        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    } else if p <= p_high {
+        let q = p - 0.5;
+        let r = q * q;
+        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
+            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
+    } else {
+        let q = (-2.0 * (1.0 - p).ln()).sqrt();
+        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fsl_syntax::parse_ai_project;
+
+    #[test]
+    fn slice_gate_flags_unsupported_even_when_the_combined_estimate_passes() {
+        let source = r"
+statistical_property LooseQuality {
+  target SupportAnswerAgent
+  dataset SupportEvalV3
+  evaluator SupportAnswerJudge
+  confidence 0.95
+
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+
+  slice JapaneseRefundTickets {
+    require min_samples >= 5
+    require ci_lower(metric.accuracy, 0.95) >= 0.35
+  }
+}
+";
+        let project = parse_ai_project(source, "P").expect("parse");
+        let prop = project
+            .select_statistical_property(None, None)
+            .expect("select");
+        let mut records = Vec::new();
+        for i in 0..10 {
+            records.push(json!({"case_id": format!("all-{i}"), "dataset":"SupportEvalV3","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}));
+        }
+        for i in 0..5 {
+            records.push(json!({"case_id": format!("jp-{i}"), "dataset":"SupportEvalV3","slice":"JapaneseRefundTickets","metric":"accuracy","outcome":false,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}));
+        }
+        let result =
+            evaluate_statistical_property(prop, &records, "SupportEvalV3", None).expect("evaluate");
+        assert_eq!(result["status"], "statistically_unsupported");
+        assert_eq!(result["schema_version"], STATISTICAL_RESULT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn duplicate_records_are_dataset_invalid() {
+        let source = r"
+statistical_property Q {
+  target X
+  dataset D
+  evaluator E
+  require ci_lower(metric.accuracy, 0.95) >= 0.5
+}
+";
+        let project = parse_ai_project(source, "P").expect("parse");
+        let prop = project
+            .select_statistical_property(None, None)
+            .expect("select");
+        let records = vec![
+            json!({"case_id":"dup","dataset":"D","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"E","calibration_status":"trusted"}}),
+            json!({"case_id":"dup","dataset":"D","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"E","calibration_status":"trusted"}}),
+        ];
+        let result = evaluate_statistical_property(prop, &records, "D", None).expect("evaluate");
+        assert_eq!(result["status"], "dataset_invalid");
+    }
+}

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod agent;
 mod ai;
+mod ai_stochastic;
 mod analysis;
 mod analysis_export;
 mod analysis_graph;
@@ -41,6 +42,9 @@ mod undecided;
 
 pub use agent::{AgentError, analyze_ai_agent};
 pub use ai::{check_ai, replay_ai};
+pub use ai_stochastic::{
+    evaluate_migration, evaluate_observed_property, evaluate_statistical_property,
+};
 pub use analysis::{
     analyze_model, analyze_tsg, build_tsg, conservation_review_findings, review_finding,
     structural_review_findings,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6382,48 +6382,154 @@ fn run_ai_drift(
         json!({"result":if findings.is_empty(){"observed_conformant"}else{"observed_mismatch"},"formal_result":"not_run","findings":findings}),
     )
 }
+/// The `ai_project` name most fsl-ai project commands report -- derived from
+/// the spec's file stem, mirroring the frozen reference's
+/// `parse_ai_project(src, name=Path(path).stem)`.
+fn ai_project_name(path: &Path) -> String {
+    path.file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("AiProject")
+        .to_owned()
+}
+
+/// `fslc ai compat`: project a `dbsystem artifact` capability profile from
+/// one `ai_component` or every `ai_component` an fsl-ai project declares
+/// (issue #511 -- a non-AI input, or an AI project with no `ai_component` at
+/// all, previously produced a syntactically empty profile that reported
+/// success indistinguishably from a genuine clean result).
 fn run_ai_compat(path: &Path, environment: Option<&str>) -> (Value, i32) {
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
-    let summary = ai_project_summary(&source);
-    let mut requires = Vec::new();
-    for (prefix, value) in [
-        ("model", summary.model),
-        ("prompt", summary.prompt),
-        ("retriever", summary.retriever),
-    ] {
-        if let Some(value) = value {
-            requires.push(format!("{prefix}.{value}"));
-        }
+    let components: Vec<fsl_syntax::AiComponent> =
+        if fslc_rust::frontend_output::is_ai_project(&source) {
+            match fsl_syntax::parse_ai_project(&source, &ai_project_name(path)) {
+                Ok(project) => project.components,
+                Err(error) => return (semantic_error_output(&error), 2),
+            }
+        } else {
+            match parse_surface_document(path) {
+                Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => vec![component],
+                Ok(_) => {
+                    return (
+                        semantic_error_output(
+                            "expected an ai_component or fsl-ai project document",
+                        ),
+                        2,
+                    );
+                }
+                Err(error) => return (semantic_error_output(&error), 2),
+            }
+        };
+    if components.is_empty() {
+        return (
+            semantic_error_output(
+                "ai project declares no ai_component to project a compatibility profile from",
+            ),
+            2,
+        );
     }
-    requires.extend(summary.tools.iter().map(|tool| format!("tool.{tool}")));
+    let profiles = components
+        .iter()
+        .map(ai_compat_component_profile)
+        .collect::<Vec<_>>();
+    let fragment = profiles
+        .iter()
+        .map(ai_compat_profile_block)
+        .collect::<String>();
+    wrap_specialized(json!({
+        "fsl": "fsl-ai-compat-profile.v0",
+        "schema_version": "fsl-ai-compat-profile.v0",
+        "result": "compat_profile_generated",
+        "formal_result": "not_run",
+        "environment": environment,
+        "profiles": profiles,
+        "dbsystem_fragment": fragment,
+        "assumptions": [],
+        "findings": [],
+    }))
+}
+
+fn ai_compat_component_profile(component: &fsl_syntax::AiComponent) -> Value {
+    let mut requires = Vec::new();
+    if let Some(model) = &component.model {
+        requires.push(format!("model.{model}"));
+    }
+    if let Some(prompt) = &component.prompt {
+        requires.push(format!("prompt.{prompt}"));
+    }
+    if let Some(retriever) = &component.retriever {
+        requires.push(format!("retriever.{retriever}"));
+    }
+    for tool in &component.tools {
+        requires.push(format!(
+            "tool.{}",
+            tool.schema.as_deref().unwrap_or(&tool.name)
+        ));
+    }
     requires.sort();
-    let provides = summary
-        .output
+    requires.dedup();
+    let provides = component
+        .output_schema
+        .as_ref()
         .map(|value| vec![format!("output.{value}")])
         .unwrap_or_default();
-    let artifact =
-        summary
-            .component
-            .chars()
-            .enumerate()
-            .fold(String::new(), |mut out, (index, c)| {
-                if c.is_ascii_uppercase() && index > 0 {
-                    out.push('_');
-                }
-                out.push(c.to_ascii_lowercase());
-                out
-            });
-    let fragment = format!(
-        "artifact {artifact} {{\n  requires {};\n  provides {};\n}}\n",
-        requires.join(", "),
-        provides.join(", ")
-    );
-    wrap_specialized(
-        json!({"fsl":"fsl-ai-compat-profile.v0","schema_version":"fsl-ai-compat-profile.v0","result":"compat_profile_generated","formal_result":"not_run","environment":environment,"profiles":[{"artifact":artifact,"component":summary.component,"requires":requires,"provides":provides}],"dbsystem_fragment":fragment,"assumptions":[],"findings":[]}),
-    )
+    json!({
+        "artifact": ai_artifact_name(&component.name),
+        "component": component.name,
+        "requires": requires,
+        "provides": provides,
+    })
+}
+
+/// `PascalCase`/`camelCase` component name to `snake_case` artifact name,
+/// mirroring the frozen reference's `_artifact_name`.
+fn ai_artifact_name(name: &str) -> String {
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::new();
+    for (index, &c) in chars.iter().enumerate() {
+        if c.is_ascii_uppercase() && index > 0 && !chars[index - 1].is_ascii_uppercase() {
+            out.push('_');
+        }
+        out.push(c.to_ascii_lowercase());
+    }
+    out.trim_matches('_').to_owned()
+}
+
+fn ai_compat_profile_block(profile: &Value) -> String {
+    let artifact = profile["artifact"].as_str().unwrap_or_default();
+    let requires = profile["requires"]
+        .as_array()
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let provides = profile["provides"]
+        .as_array()
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let requires_line = if requires.is_empty() {
+        String::new()
+    } else {
+        format!("  requires {requires};\n")
+    };
+    let provides_line = if provides.is_empty() {
+        String::new()
+    } else {
+        format!("  provides {provides};\n")
+    };
+    format!("artifact {artifact} {{\n{requires_line}{provides_line}}}\n")
 }
 
 fn parse_domain_document(path: &Path) -> Result<fsl_syntax::DomainSpec, String> {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5923,7 +5923,17 @@ fn wrap_specialized(result: Value) -> (Value, i32) {
             | "replay_nonconformant"
             | "nonconformant"
             | "statistically_unsupported"
-            | "observed_mismatch",
+            | "observed_mismatch"
+            // fsl-ai statistical gate statuses (issue #510): a result that
+            // gates before producing a Wilson interval -- no dataset/schema
+            // evidence, an untrusted evaluator, too few samples, or an
+            // unsupported requirement shape -- is not a passing evaluation
+            // and must not exit 0 alongside `statistically_supported`.
+            | "dataset_invalid"
+            | "evaluator_untrusted"
+            | "slice_missing"
+            | "insufficient_samples"
+            | "inconclusive",
         ) => 1,
         Some("error") => 2,
         _ => 0,
@@ -6228,160 +6238,6 @@ fn run_ai_compare(
         json!({"fsl":"fsl-ai-migration.v0","schema_version":"fsl-ai-comparison-result.v0","result":"compared","formal_result":"not_run","from":from_label.unwrap_or_else(||before.to_str().unwrap_or_default()),"to":to_label.unwrap_or_else(||after.to_str().unwrap_or_default()),"dataset":dataset,"comparisons":comparisons,"assumptions":[],"findings":[]}),
     )
 }
-fn duplicate_records(events: &[Value]) -> bool {
-    let mut seen = std::collections::BTreeSet::new();
-    events
-        .iter()
-        .filter_map(|event| {
-            Some((
-                event.get("case_id")?.as_str()?,
-                event.get("slice").and_then(Value::as_str).unwrap_or("all"),
-                event.get("metric")?.as_str()?,
-            ))
-        })
-        .any(|key| !seen.insert(key))
-}
-fn run_ai_eval(
-    path: &Path,
-    records: Option<&Path>,
-    dataset: Option<&str>,
-    property: Option<&str>,
-    _slice: Option<&str>,
-) -> (Value, i32) {
-    let Some(records) = records else {
-        return (
-            semantic_error_output("ai eval requires --records for native evaluation"),
-            2,
-        );
-    };
-    let events = match read_json_events(records) {
-        Ok(events) => events,
-        Err(error) => return (error_output("parse", &error), 2),
-    };
-    if duplicate_records(&events) {
-        return wrap_specialized(
-            json!({"result":"dataset_invalid","formal_result":"not_run","findings":[{"kind":"statistical_contract_unsupported","violation":"dataset_invalid"}]}),
-        );
-    }
-    let source = std::fs::read_to_string(path).unwrap_or_default();
-    let selected = property.unwrap_or("");
-    if selected.is_empty() && source.matches("statistical_property ").count() > 1 {
-        return (
-            semantic_error_output(
-                "multiple statistical_property declarations found; pass --property",
-            ),
-            2,
-        );
-    }
-    let stats = metric_summaries(&events, dataset);
-    let accuracy = *stats.get("accuracy").unwrap_or(&(0, 0));
-    let lower = wilson(accuracy.0, accuracy.1)["lower"]
-        .as_f64()
-        .unwrap_or(0.0);
-    let threshold = if selected == "StrictQuality" {
-        0.80
-    } else {
-        0.35
-    };
-    let supported = lower >= threshold;
-    let finding = if supported {
-        vec![]
-    } else {
-        vec![
-            json!({"kind":"statistical_contract_unsupported","minimal_conflict_set":{"property":selected,"dataset":dataset,"slice":"JapaneseRefundTickets","metric":"accuracy"}}),
-        ]
-    };
-    wrap_specialized(
-        json!({"result":if supported{"statistically_supported"}else{"statistically_unsupported"},"formal_result":"not_run","property":selected,"dataset":dataset,"interval":wilson(accuracy.0,accuracy.1),"checks":[{"slice":"all"},{"slice":"JapaneseRefundTickets"}],"findings":finding}),
-    )
-}
-#[allow(clippy::cast_precision_loss)]
-fn run_ai_regress(
-    _path: &Path,
-    before: &Path,
-    after: &Path,
-    dataset: Option<&str>,
-    migration: Option<&str>,
-) -> (Value, i32) {
-    let left = match read_json_events(before) {
-        Ok(v) => metric_summaries(&v, dataset),
-        Err(error) => return (error_output("parse", &error), 2),
-    };
-    let right = match read_json_events(after) {
-        Ok(v) => metric_summaries(&v, dataset),
-        Err(error) => return (error_output("parse", &error), 2),
-    };
-    let mut findings = Vec::new();
-    for (metric, limit, direction) in [
-        ("accuracy", 0.05, "drop"),
-        ("hallucination_rate", 0.02, "increase"),
-    ] {
-        let a = *left.get(metric).unwrap_or(&(0, 0));
-        let b = *right.get(metric).unwrap_or(&(0, 0));
-        let av = if a.0 == 0 {
-            0.0
-        } else {
-            a.1 as f64 / a.0 as f64
-        };
-        let bv = if b.0 == 0 {
-            0.0
-        } else {
-            b.1 as f64 / b.0 as f64
-        };
-        if (direction == "drop" && av - bv > limit) || (direction == "increase" && bv - av > limit)
-        {
-            findings.push(json!({"kind":"ai_migration_regression","minimal_conflict_set":{"migration":migration,"dataset":dataset,"metric":metric}}));
-        }
-    }
-    wrap_specialized(
-        json!({"result":if findings.is_empty(){"statistically_supported"}else{"statistically_unsupported"},"formal_result":"not_run","findings":findings}),
-    )
-}
-#[allow(clippy::cast_precision_loss)]
-fn run_ai_drift(
-    _path: &Path,
-    current: &Path,
-    baseline: Option<&Path>,
-    property: Option<&str>,
-    window: Option<&str>,
-    baseline_label: Option<&str>,
-) -> (Value, i32) {
-    let current = match read_json_events(current) {
-        Ok(v) => metric_summaries(&v, None),
-        Err(error) => return (error_output("parse", &error), 2),
-    };
-    let baseline_stats = baseline
-        .and_then(|path| read_json_events(path).ok())
-        .map(|v| metric_summaries(&v, None))
-        .unwrap_or_default();
-    let mut findings = Vec::new();
-    for metric in current
-        .keys()
-        .chain(baseline_stats.keys())
-        .collect::<std::collections::BTreeSet<_>>()
-    {
-        let a = *baseline_stats.get(metric).unwrap_or(&(0, 0));
-        let b = *current.get(metric).unwrap_or(&(0, 0));
-        let av = if a.0 == 0 {
-            0.0
-        } else {
-            a.1 as f64 / a.0 as f64
-        };
-        let bv = if b.0 == 0 {
-            0.0
-        } else {
-            b.1 as f64 / b.0 as f64
-        };
-        if (metric == "hallucination_rate" && bv > 0.30)
-            || (metric == "refusal_rate" && (bv - av).abs() > 0.10)
-        {
-            findings.push(json!({"kind":"ai_observed_drift","minimal_conflict_set":{"property":property,"metric":metric,"window":window,"baseline":baseline_label}}));
-        }
-    }
-    wrap_specialized(
-        json!({"result":if findings.is_empty(){"observed_conformant"}else{"observed_mismatch"},"formal_result":"not_run","findings":findings}),
-    )
-}
 /// The `ai_project` name most fsl-ai project commands report -- derived from
 /// the spec's file stem, mirroring the frozen reference's
 /// `parse_ai_project(src, name=Path(path).stem)`.
@@ -6390,6 +6246,152 @@ fn ai_project_name(path: &Path) -> String {
         .and_then(std::ffi::OsStr::to_str)
         .unwrap_or("AiProject")
         .to_owned()
+}
+
+fn load_ai_project(path: &Path) -> Result<fsl_syntax::AiProject, (Value, i32)> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| (error_output("io", &error.to_string()), 2))?;
+    fsl_syntax::parse_ai_project(&source, &ai_project_name(path))
+        .map_err(|error| (semantic_error_output(&error), 2))
+}
+
+/// `fslc ai eval`: check a selected `statistical_property`'s declared
+/// slice/threshold/evaluator-trust gates against precomputed eval JSONL
+/// (issue #509 -- the declaration previously had no effect; issue #510 --
+/// the result is now schema-conformant with exit codes routed by
+/// `wrap_specialized`).
+fn run_ai_eval(
+    path: &Path,
+    records: Option<&Path>,
+    dataset: Option<&str>,
+    property: Option<&str>,
+    slice: Option<&str>,
+) -> (Value, i32) {
+    let project = match load_ai_project(path) {
+        Ok(project) => project,
+        Err(failure) => return failure,
+    };
+    let selected = match project.select_statistical_property(property, dataset) {
+        Ok(selected) => selected,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let Some(dataset_name) = dataset
+        .map(str::to_owned)
+        .or_else(|| selected.dataset.clone())
+    else {
+        return (
+            semantic_error_output("statistical_property requires dataset or --dataset"),
+            2,
+        );
+    };
+    let records_path = match records {
+        Some(path) => path.to_path_buf(),
+        None => match project.dataset_source(&dataset_name) {
+            Some(source) if source.contains("://") => {
+                return (
+                    semantic_error_output(&format!(
+                        "dataset '{dataset_name}' source '{source}' is external; pass a local --records JSONL file"
+                    )),
+                    2,
+                );
+            }
+            Some(source) => PathBuf::from(source),
+            None => {
+                return (
+                    semantic_error_output(&format!(
+                        "dataset '{dataset_name}' has no source; pass --records"
+                    )),
+                    2,
+                );
+            }
+        },
+    };
+    let events = match read_json_events(&records_path) {
+        Ok(events) => events,
+        Err(error) => return (error_output("parse", &error), 2),
+    };
+    match fsl_tools::evaluate_statistical_property(selected, &events, &dataset_name, slice) {
+        Ok(result) => wrap_specialized(result),
+        Err(error) => (semantic_error_output(&error), 2),
+    }
+}
+
+/// `fslc ai regress`: check a selected `ai_migration`'s declared
+/// `no_regression` metric clauses (issue #509 -- previously two hardcoded
+/// metric/threshold pairs ran unconditionally and `--migration`/the spec
+/// path were never read).
+fn run_ai_regress(
+    path: &Path,
+    before: &Path,
+    after: &Path,
+    dataset: Option<&str>,
+    migration: Option<&str>,
+) -> (Value, i32) {
+    let project = match load_ai_project(path) {
+        Ok(project) => project,
+        Err(failure) => return failure,
+    };
+    let selected = match project.select_migration(migration) {
+        Ok(selected) => selected,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let before_events = match read_json_events(before) {
+        Ok(events) => events,
+        Err(error) => return (error_output("parse", &error), 2),
+    };
+    let after_events = match read_json_events(after) {
+        Ok(events) => events,
+        Err(error) => return (error_output("parse", &error), 2),
+    };
+    match fsl_tools::evaluate_migration(selected, &before_events, &after_events, dataset) {
+        Ok(result) => wrap_specialized(result),
+        Err(error) => (semantic_error_output(&error), 2),
+    }
+}
+
+/// `fslc ai drift`: check a selected `observed_property`'s declared
+/// `observed`/`drift` requirements against runtime telemetry JSONL (issue
+/// #509 -- previously two hardcoded metric/threshold pairs ran
+/// unconditionally and `--property`/the spec path were never read). The
+/// success result is `observed_supported` (not `observed_conformant`,
+/// which stays `fslc db observe`'s vocabulary --
+/// `docs/DESIGN-assurance-classes.md`/`docs/LANGUAGE.md` document
+/// `observed_supported`/`observed_mismatch` for `ai drift` specifically;
+/// only `ai drift`'s result string was wrong, not `db observe`'s).
+fn run_ai_drift(
+    path: &Path,
+    current: &Path,
+    baseline: Option<&Path>,
+    property: Option<&str>,
+    window: Option<&str>,
+    baseline_label: Option<&str>,
+) -> (Value, i32) {
+    let project = match load_ai_project(path) {
+        Ok(project) => project,
+        Err(failure) => return failure,
+    };
+    let selected = match project.select_observed_property(property) {
+        Ok(selected) => selected,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let current_events = match read_json_events(current) {
+        Ok(events) => events,
+        Err(error) => return (error_output("parse", &error), 2),
+    };
+    let baseline_events = match baseline {
+        Some(path) => match read_json_events(path) {
+            Ok(events) => events,
+            Err(error) => return (error_output("parse", &error), 2),
+        },
+        None => Vec::new(),
+    };
+    wrap_specialized(fsl_tools::evaluate_observed_property(
+        selected,
+        &current_events,
+        &baseline_events,
+        window,
+        baseline_label,
+    ))
 }
 
 /// `fslc ai compat`: project a `dbsystem artifact` capability profile from

--- a/rust/fslc/tests/fixtures/issue_509_drift_custom_threshold.fsl
+++ b/rust/fslc/tests/fixtures/issue_509_drift_custom_threshold.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+observed_property LenientDriftProperty {
+  target SupportAnswerAgent
+  source production_logs
+  window last_7_days
+
+  require observed(metric.hallucination_rate) <= 0.90
+}

--- a/rust/fslc/tests/fixtures/issue_509_migration_custom_threshold.fsl
+++ b/rust/fslc/tests/fixtures/issue_509_migration_custom_threshold.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ai_migration LooseAccuracyMigration {
+  preserve {
+    no_regression {
+      dataset SupportEvalV3
+      metric accuracy drop <= 0.50
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_511_ai_project_without_component.fsl
+++ b/rust/fslc/tests/fixtures/issue_511_ai_project_without_component.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+dataset NoComponentDataset {
+  source "examples/ai/support_eval_v3.jsonl"
+}
+
+statistical_property NoComponentProperty {
+  target MissingComponent
+  dataset NoComponentDataset
+  require ci_lower(metric.accuracy, 0.95) >= 0.5
+}

--- a/rust/fslc/tests/issue_509_ai_declared_policy_execution.rs
+++ b/rust/fslc/tests/issue_509_ai_declared_policy_execution.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #509: native `fslc ai eval`/`regress`/
+//! `drift` aggregated eval/telemetry JSONL with hardcoded example
+//! metrics/thresholds and never read the declared
+//! `statistical_property`/`ai_migration`/`observed_property` selection or
+//! even the spec path (`regress`/`drift` took `_path: &Path` and ignored
+//! it). A spec author's declared slice gate, migration threshold, or
+//! observed-property requirement had no effect on the result.
+//!
+//! Native now parses the selected declaration
+//! (`fsl_syntax::parse_ai_project`) and executes it via
+//! `fsl_tools::evaluate_statistical_property` /
+//! `evaluate_migration` / `evaluate_observed_property`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn write_slice_fail_records() -> PathBuf {
+    // Ten trusted `slice:"all"` accuracy records with `outcome:true` and
+    // five trusted `slice:"JapaneseRefundTickets"` accuracy records with
+    // `outcome:false` -- the exact reproduction from issue #509's evidence.
+    // `examples/ai/support_answer_quality.fsl`'s `LooseQuality` declares an
+    // "all" gate at 0.45 (which this data clears) *and* a separate
+    // `JapaneseRefundTickets` slice gate at 0.35 (which it does not); only a
+    // per-slice-declaration-aware evaluator can see the second gate at all.
+    let mut lines = Vec::new();
+    for index in 0..10 {
+        lines.push(serde_json::json!({
+            "schema_version": "fsl-ai-eval-record.v0",
+            "case_id": format!("all-{index}"),
+            "component": "SupportAnswerAgent",
+            "dataset": "SupportEvalV3",
+            "slice": "all",
+            "metric": "accuracy",
+            "outcome": true,
+            "evaluator": {"id": "SupportAnswerJudge", "calibration_status": "trusted"},
+        }));
+    }
+    for index in 0..5 {
+        lines.push(serde_json::json!({
+            "schema_version": "fsl-ai-eval-record.v0",
+            "case_id": format!("jp-{index}"),
+            "component": "SupportAnswerAgent",
+            "dataset": "SupportEvalV3",
+            "slice": "JapaneseRefundTickets",
+            "metric": "accuracy",
+            "outcome": false,
+            "evaluator": {"id": "SupportAnswerJudge", "calibration_status": "trusted"},
+        }));
+    }
+    let path = std::env::temp_dir().join("issue_509_slice_fail.jsonl");
+    let body = lines
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, body + "\n").expect("write scratch records");
+    path
+}
+
+// --- eval: a declared per-slice gate must be evaluated, not skipped ------
+
+#[test]
+fn eval_flags_a_declared_slice_gate_the_combined_estimate_would_hide() {
+    let records = write_slice_fail_records();
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--records",
+        records.to_str().expect("utf8 path"),
+        "--dataset",
+        "SupportEvalV3",
+        "--property",
+        "LooseQuality",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "statistically_unsupported");
+    let checks = value["checks"].as_array().expect("checks array");
+    let slice_check = checks
+        .iter()
+        .find(|check| check["slice"] == "JapaneseRefundTickets" && check["metric"] == "accuracy")
+        .expect("JapaneseRefundTickets accuracy check");
+    assert_eq!(slice_check["status"], "statistically_unsupported");
+    assert_eq!(slice_check["n"], 5);
+}
+
+// --- eval: the documented positive path is unaffected --------------------
+
+#[test]
+fn eval_supports_the_documented_property_without_records_via_dataset_source() {
+    // `docs/LANGUAGE.md` documents this exact invocation with no
+    // `--records`, relying on the declared `dataset SupportEvalV3 { source
+    // "..."; }` fallback -- the pre-fix implementation required `--records`
+    // unconditionally and rejected this with exit 2.
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--property",
+        "LooseQuality",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "statistically_supported");
+}
+
+// --- regress: unknown migration/property selection must error, not run --
+
+#[test]
+fn regress_rejects_an_unknown_migration_name() {
+    let (value, status) = run(&[
+        "ai",
+        "regress",
+        "examples/ai/support_answer_quality.fsl",
+        "--before-records",
+        "examples/ai/support_eval_v7.jsonl",
+        "--after-records",
+        "examples/ai/support_eval_v8_regressed.jsonl",
+        "--migration",
+        "DoesNotExist",
+    ]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("unknown ai_migration 'DoesNotExist'")),
+        "{value}"
+    );
+}
+
+#[test]
+fn drift_rejects_an_unknown_observed_property_name() {
+    let (value, status) = run(&[
+        "ai",
+        "drift",
+        "examples/ai/support_answer_quality.fsl",
+        "--logs",
+        "examples/ai/runtime_drift_current.jsonl",
+        "--property",
+        "DoesNotExist",
+    ]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("unknown observed_property 'DoesNotExist'")),
+        "{value}"
+    );
+}
+
+#[test]
+fn regress_rejects_a_spec_path_that_does_not_exist() {
+    // The pre-fix implementation took `_path: &Path` and never read it --
+    // even a missing spec produced a statistical verdict.
+    let (value, status) = run(&[
+        "ai",
+        "regress",
+        "tests/fixtures/issue_509_does_not_exist.fsl",
+        "--before-records",
+        "examples/ai/support_eval_v7.jsonl",
+        "--after-records",
+        "examples/ai/support_eval_v8_regressed.jsonl",
+        "--migration",
+        "DoesNotExist",
+    ]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "io");
+}
+
+// --- regress: the declared threshold and declared metric set must govern -
+
+#[test]
+fn regress_uses_the_declared_threshold_and_only_the_declared_metric() {
+    // This fixture declares only `metric accuracy drop <= 0.50` -- looser
+    // than the pre-fix hardcoded 0.05, and it never declares
+    // `hallucination_rate` at all. Real fixtures
+    // (support_eval_v7/v8_regressed) move accuracy 1.0 -> 0.8 (a 0.2 drop,
+    // under 0.50) and hallucination_rate 0.0 -> 0.2. The pre-fix hardcoded
+    // checker would still flag both metrics regardless of this file's
+    // content; a declaration-driven checker passes cleanly because only the
+    // declared, looser accuracy gate applies.
+    let path = fixture("issue_509_migration_custom_threshold.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&[
+        "ai",
+        "regress",
+        &path,
+        "--before-records",
+        "examples/ai/support_eval_v7.jsonl",
+        "--after-records",
+        "examples/ai/support_eval_v8_regressed.jsonl",
+        "--migration",
+        "LooseAccuracyMigration",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "statistically_supported");
+    let checks = value["checks"].as_array().expect("checks array");
+    assert_eq!(checks.len(), 1, "{value}");
+    assert_eq!(checks[0]["metric"], "accuracy");
+    assert_eq!(checks[0]["allowed_delta"], 0.5);
+    assert_eq!(value["findings"].as_array().map(Vec::len), Some(0));
+}
+
+// --- drift: only the declared observed requirement must govern -----------
+
+#[test]
+fn drift_checks_only_the_declared_requirement_not_a_hardcoded_metric() {
+    // This fixture declares only `observed(metric.hallucination_rate) <=
+    // 0.90` -- it never mentions `refusal_rate` at all.
+    // `examples/ai/runtime_drift_current.jsonl` has a real refusal_rate
+    // shift the pre-fix hardcoded checker always flags
+    // (`|current - baseline| > 0.10`) regardless of what the spec declares.
+    // A declaration-driven checker reports `observed_supported` because the
+    // only declared requirement (hallucination_rate <= 0.90) is met.
+    let path = fixture("issue_509_drift_custom_threshold.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&[
+        "ai",
+        "drift",
+        &path,
+        "--logs",
+        "examples/ai/runtime_drift_current.jsonl",
+        "--property",
+        "LenientDriftProperty",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "observed_supported");
+    let checks = value["checks"].as_array().expect("checks array");
+    assert_eq!(checks.len(), 1, "{value}");
+    assert_eq!(checks[0]["metric"], "hallucination_rate");
+    assert_eq!(value["findings"].as_array().map(Vec::len), Some(0));
+}
+
+// --- drift/regress: a real declared violation is still caught ------------
+
+#[test]
+fn regress_still_catches_a_real_declared_regression() {
+    let (value, status) = run(&[
+        "ai",
+        "regress",
+        "examples/ai/support_answer_quality.fsl",
+        "--migration",
+        "PromptV7ToV8",
+        "--before-records",
+        "examples/ai/support_eval_v7.jsonl",
+        "--after-records",
+        "examples/ai/support_eval_v8_regressed.jsonl",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "statistically_unsupported");
+    assert_eq!(value["findings"].as_array().map(Vec::len), Some(2));
+}
+
+#[test]
+fn drift_still_catches_a_real_declared_drift() {
+    let (value, status) = run(&[
+        "ai",
+        "drift",
+        "examples/ai/support_answer_quality.fsl",
+        "--logs",
+        "examples/ai/runtime_drift_current.jsonl",
+        "--baseline-logs",
+        "examples/ai/runtime_drift_baseline.jsonl",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "observed_mismatch");
+    let findings = value["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{value}");
+    assert_eq!(findings[0]["kind"], "ai_observed_drift");
+}

--- a/rust/fslc/tests/issue_510_ai_statistical_schema.rs
+++ b/rust/fslc/tests/issue_510_ai_statistical_schema.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #510: native `fslc ai eval` results did not
+//! conform to `schemas/fslc/ai/statistical-result.v0.schema.json` (a
+//! successful result carried only `fsl,result,formal_result,property,
+//! dataset,interval,checks,findings`, omitting the required
+//! `schema_version,status,slice,metric,n,estimate,threshold,evaluator,
+//! assumptions`) and every non-`statistically_supported` terminal status
+//! (`dataset_invalid`, `evaluator_untrusted`, `insufficient_samples`,
+//! `inconclusive`) exited 0 instead of the documented non-success routing
+//! (`docs/LANGUAGE.md:898-906`).
+//!
+//! Native now builds every eval result through
+//! `fsl_tools::evaluate_statistical_property`, which always emits the full
+//! schema-required field set, and `wrap_specialized` routes every gate
+//! status (not just `statistically_unsupported`) to exit 1.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+/// The schema's required top-level fields
+/// (`schemas/fslc/ai/statistical-result.v0.schema.json`).
+const REQUIRED_FIELDS: &[&str] = &[
+    "schema_version",
+    "result",
+    "status",
+    "formal_result",
+    "dataset",
+    "slice",
+    "metric",
+    "n",
+    "estimate",
+    "interval",
+    "threshold",
+    "evaluator",
+    "assumptions",
+    "findings",
+];
+
+fn assert_schema_conformant(value: &Value) {
+    for field in REQUIRED_FIELDS {
+        assert!(
+            value.get(field).is_some(),
+            "missing required field '{field}': {value}"
+        );
+    }
+    assert_eq!(value["schema_version"], "fsl-ai-statistical-result.v0");
+    assert_eq!(value["formal_result"], "not_run");
+    let interval = value["interval"].as_object().expect("interval object");
+    for field in ["method", "confidence", "lower", "upper"] {
+        assert!(
+            interval.contains_key(field),
+            "interval missing '{field}': {value}"
+        );
+    }
+    assert_eq!(interval["method"], "wilson");
+    let threshold = value["threshold"].as_object().expect("threshold object");
+    for field in ["operator", "value"] {
+        assert!(
+            threshold.contains_key(field),
+            "threshold missing '{field}': {value}"
+        );
+    }
+    let evaluator = value["evaluator"].as_object().expect("evaluator object");
+    assert!(
+        evaluator.contains_key("id"),
+        "evaluator missing 'id': {value}"
+    );
+    assert!(
+        evaluator.contains_key("trust_status"),
+        "evaluator missing 'trust_status': {value}"
+    );
+    assert!(value["n"].is_i64() || value["n"].is_u64(), "{value}");
+    assert!(value["estimate"].is_number(), "{value}");
+    assert!(value["assumptions"].is_array(), "{value}");
+    assert!(value["findings"].is_array(), "{value}");
+}
+
+// --- a successful result now carries every required schema field ---------
+
+#[test]
+fn a_supported_result_is_schema_conformant_and_exits_zero() {
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--property",
+        "LooseQuality",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "statistically_supported");
+    assert_eq!(value["status"], "statistically_supported");
+    assert_schema_conformant(&value);
+    // The pre-fix output shape omitted these entirely.
+    assert!(value.get("slice").is_some_and(Value::is_string), "{value}");
+    assert!(value.get("metric").is_some_and(Value::is_string), "{value}");
+    assert!(value.get("n").is_some(), "{value}");
+}
+
+// --- every gate status is schema-conformant AND exits 1, not 0 -----------
+
+#[test]
+fn duplicate_records_are_dataset_invalid_and_exit_one() {
+    let path = std::env::temp_dir().join("issue_510_duplicate.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            r#"{"schema_version":"fsl-ai-eval-record.v0","case_id":"dup","component":"SupportAnswerAgent","dataset":"SupportEvalV3","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}"#,
+            "\n",
+            r#"{"schema_version":"fsl-ai-eval-record.v0","case_id":"dup","component":"SupportAnswerAgent","dataset":"SupportEvalV3","slice":"all","metric":"accuracy","outcome":true,"evaluator":{"id":"SupportAnswerJudge","calibration_status":"trusted"}}"#,
+            "\n",
+        ),
+    )
+    .expect("write scratch records");
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--records",
+        path.to_str().expect("utf8 path"),
+        "--dataset",
+        "SupportEvalV3",
+        "--property",
+        "LooseQuality",
+    ]);
+    // The pre-fix implementation reported this exact result with exit 0.
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "dataset_invalid");
+    assert_schema_conformant(&value);
+}
+
+#[test]
+fn an_untrusted_evaluator_is_evaluator_untrusted_and_exits_one() {
+    let path = std::env::temp_dir().join("issue_510_untrusted.jsonl");
+    let mut body = String::new();
+    for index in 0..10 {
+        body.push_str(
+            &serde_json::json!({
+                "schema_version": "fsl-ai-eval-record.v0",
+                "case_id": format!("case-{index}"),
+                "component": "SupportAnswerAgent",
+                "dataset": "SupportEvalV3",
+                "slice": "all",
+                "metric": "accuracy",
+                "outcome": true,
+                "evaluator": {"id": "SupportAnswerJudge", "calibration_status": "untrusted"},
+            })
+            .to_string(),
+        );
+        body.push('\n');
+    }
+    std::fs::write(&path, body).expect("write scratch records");
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--records",
+        path.to_str().expect("utf8 path"),
+        "--dataset",
+        "SupportEvalV3",
+        "--property",
+        "LooseQuality",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "evaluator_untrusted");
+    assert_schema_conformant(&value);
+}
+
+#[test]
+fn too_few_samples_is_insufficient_samples_and_exits_one() {
+    // `LooseQuality` declares `slice JapaneseRefundTickets { require
+    // min_samples >= 5; ... }`; supply plenty of "all"-slice records (so
+    // that gate passes cleanly) but only 2 for `JapaneseRefundTickets`.
+    // `insufficient_samples` outranks `statistically_supported`/
+    // `statistically_unsupported` in the status priority regardless of how
+    // the slice's own ci_lower bound happens to land, so the overall result
+    // is deterministically `insufficient_samples` -- a non-success gate
+    // status that must not exit 0.
+    let path = std::env::temp_dir().join("issue_510_insufficient.jsonl");
+    let mut body = String::new();
+    for index in 0..10 {
+        body.push_str(
+            &serde_json::json!({
+                "schema_version": "fsl-ai-eval-record.v0",
+                "case_id": format!("all-{index}"),
+                "component": "SupportAnswerAgent",
+                "dataset": "SupportEvalV3",
+                "slice": "all",
+                "metric": "accuracy",
+                "outcome": true,
+                "evaluator": {"id": "SupportAnswerJudge", "calibration_status": "trusted"},
+            })
+            .to_string(),
+        );
+        body.push('\n');
+    }
+    for index in 0..2 {
+        body.push_str(
+            &serde_json::json!({
+                "schema_version": "fsl-ai-eval-record.v0",
+                "case_id": format!("jp-{index}"),
+                "component": "SupportAnswerAgent",
+                "dataset": "SupportEvalV3",
+                "slice": "JapaneseRefundTickets",
+                "metric": "accuracy",
+                "outcome": true,
+                "evaluator": {"id": "SupportAnswerJudge", "calibration_status": "trusted"},
+            })
+            .to_string(),
+        );
+        body.push('\n');
+    }
+    std::fs::write(&path, body).expect("write scratch records");
+    let (value, status) = run(&[
+        "ai",
+        "eval",
+        "examples/ai/support_answer_quality.fsl",
+        "--records",
+        path.to_str().expect("utf8 path"),
+        "--dataset",
+        "SupportEvalV3",
+        "--property",
+        "LooseQuality",
+    ]);
+    assert_eq!(status, 1, "{value}");
+    assert_eq!(value["result"], "insufficient_samples");
+    assert_schema_conformant(&value);
+    let checks = value["checks"].as_array().expect("checks array");
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["status"] == "insufficient_samples" && check["n"] == 2),
+        "{value}"
+    );
+}

--- a/rust/fslc/tests/issue_511_ai_compat_rejects_non_ai.rs
+++ b/rust/fslc/tests/issue_511_ai_compat_rejects_non_ai.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #511: `fslc ai compat` line-scanned any
+//! readable file with the legacy `ai_project_summary` text scanner and
+//! always reported `compat_profile_generated` with exit 0, even when the
+//! input was not an AI project/component at all -- the generated
+//! `dbsystem` fragment was syntactically empty (`artifact  { requires ;
+//! provides ; }`), a false-success profile indistinguishable from a
+//! genuine clean result.
+//!
+//! Native now parses either a single `ai_component` document or a full
+//! fsl-ai project (`fsl_syntax::parse_ai_project`) and rejects wrong-dialect
+//! input and an AI project with no `ai_component` at all, both with exit 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+// --- negative: non-AI input must be rejected, not emit an empty profile --
+
+#[test]
+fn rejects_a_non_ai_spec_instead_of_an_empty_profile() {
+    let (value, status) = run(&["ai", "compat", "specs/cart_v1.fsl"]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+    // The pre-fix bug reported `compat_profile_generated` with exit 0 and an
+    // empty `artifact  { requires ; provides ; }` fragment for this exact
+    // input; assert that shape is entirely gone, not merely that some error
+    // happened to be returned.
+    assert!(value.get("profiles").is_none(), "{value}");
+    assert!(value.get("dbsystem_fragment").is_none(), "{value}");
+}
+
+#[test]
+fn rejects_an_ai_project_that_declares_no_ai_component() {
+    let path = fixture("issue_511_ai_project_without_component.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "compat", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "semantics");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("no ai_component")),
+        "{value}"
+    );
+}
+
+// --- positive: a genuine AI input still produces a real, non-empty profile
+
+#[test]
+fn a_single_ai_component_produces_a_real_capability_profile() {
+    let (value, status) = run(&["ai", "compat", "examples/ai/refund_agent_tool_safety.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "compat_profile_generated");
+    let profiles = value["profiles"].as_array().expect("profiles array");
+    assert_eq!(profiles.len(), 1, "{value}");
+    assert_eq!(profiles[0]["artifact"], "refund_agent_tool_safety");
+    assert_eq!(profiles[0]["component"], "RefundAgentToolSafety");
+    let requires = profiles[0]["requires"]
+        .as_array()
+        .expect("requires array")
+        .iter()
+        .map(|value| value.as_str().expect("string").to_owned())
+        .collect::<Vec<_>>();
+    // Every declared tool has a schema in this fixture -- the profile must
+    // use `tool.<schema>`, not the pre-fix line-scanner's bare `tool.<name>`.
+    assert!(
+        requires.contains(&"model.refund_model_v1".to_owned()),
+        "{requires:?}"
+    );
+    assert!(
+        requires.contains(&"tool.SearchOrderV1".to_owned()),
+        "{requires:?}"
+    );
+    assert!(
+        !requires.contains(&"tool.SearchOrder".to_owned()),
+        "{requires:?}"
+    );
+    assert_eq!(
+        profiles[0]["provides"],
+        serde_json::json!(["output.RefundDecisionV1"])
+    );
+    let fragment = value["dbsystem_fragment"].as_str().expect("fragment");
+    assert!(
+        fragment.starts_with("artifact refund_agent_tool_safety {"),
+        "{fragment}"
+    );
+    assert!(!fragment.contains("requires ;"), "{fragment}");
+    assert!(!fragment.contains("provides ;"), "{fragment}");
+}
+
+#[test]
+fn an_fsl_ai_project_produces_one_profile_per_declared_component() {
+    let (value, status) = run(&[
+        "ai",
+        "compat",
+        "examples/ai/support_answer_quality.fsl",
+        "--environment",
+        "prod",
+    ]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "compat_profile_generated");
+    assert_eq!(value["environment"], "prod");
+    let profiles = value["profiles"].as_array().expect("profiles array");
+    assert_eq!(profiles.len(), 1, "{value}");
+    assert_eq!(profiles[0]["component"], "SupportAnswerAgent");
+    assert!(
+        profiles[0]["requires"]
+            .as_array()
+            .is_some_and(|values| !values.is_empty()),
+        "{value}"
+    );
+    assert!(
+        profiles[0]["provides"]
+            .as_array()
+            .is_some_and(|values| !values.is_empty()),
+        "{value}"
+    );
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -407,15 +407,26 @@ are checked unconditionally regardless of this block. Use `fslc ai check` for
 `verified_under_assumptions` hard-contract findings and `fslc ai replay --logs`
 for JSONL runtime evidence (`replay_conformant` / `replay_nonconformant`,
 `formal_result:"not_run"`). Statistical quality evidence uses the external
-stochastic checker: `fslc ai eval` over precomputed eval JSONL,
-Bernoulli/proportion metrics, Wilson intervals, and
-`formal_result:"not_run"`. `fslc ai regress` checks aggregate
-`ai_migration.no_regression`, `fslc ai compare` reports metric deltas,
-`fslc ai drift` checks runtime telemetry thresholds/drift, and
-`fslc ai compat` emits DB artifact capability profiles for one `ai_component`
-or every `ai_component` a project declares -- rejecting non-AI input and a
-project with no `ai_component` at all (exit 2) rather than an empty profile.
-These results are never formal proof.
+stochastic checker: `fslc ai eval` checks the selected `statistical_property`'s
+declared `slice`/`min_samples`/`ci_lower`/`ci_upper` requirements against
+precomputed eval JSONL (`--records`, or the declared `dataset`'s `source`
+file), Wilson intervals, and `formal_result:"not_run"`. An unknown
+`--property`/`--migration` selection is a check-time error (exit 2); a
+non-`statistically_supported` gate status (`dataset_invalid`,
+`evaluator_untrusted`, `slice_missing`, `insufficient_samples`,
+`inconclusive`, `statistically_unsupported`) exits 1, and the result carries
+the full `schemas/fslc/ai/statistical-result.v0.schema.json` field set
+(`schema_version`/`status`/`slice`/`metric`/`n`/`estimate`/`threshold`/
+`evaluator`/`assumptions` included, not just `result`/`interval`/`checks`).
+`fslc ai regress` checks the selected `ai_migration`'s declared aggregate
+`no_regression` metric clauses, `fslc ai compare` reports metric deltas,
+`fslc ai drift` checks the selected `observed_property`'s declared
+`observed`/`drift` requirements over runtime telemetry
+(`observed_supported` / `observed_mismatch`), and `fslc ai compat` emits DB
+artifact capability profiles for one `ai_component` or every `ai_component` a
+project declares -- rejecting non-AI input and a project with no
+`ai_component` at all (exit 2) rather than an empty profile. These results
+are never formal proof.
 
 Recursive fsl-ai `agent` composition is checked structurally by
 `fslc ai check` and returns `agent_analyzed` on success:

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -412,8 +412,10 @@ Bernoulli/proportion metrics, Wilson intervals, and
 `formal_result:"not_run"`. `fslc ai regress` checks aggregate
 `ai_migration.no_regression`, `fslc ai compare` reports metric deltas,
 `fslc ai drift` checks runtime telemetry thresholds/drift, and
-`fslc ai compat` emits DB artifact capability profiles. These results are never
-formal proof.
+`fslc ai compat` emits DB artifact capability profiles for one `ai_component`
+or every `ai_component` a project declares -- rejecting non-AI input and a
+project with no `ai_component` at all (exit 2) rather than an empty profile.
+These results are never formal proof.
 
 Recursive fsl-ai `agent` composition is checked structurally by
 `fslc ai check` and returns `agent_analyzed` on success:


### PR DESCRIPTION
## Problem

Three `fslc ai` defects. One emits a success verdict for something it never validated; one accepts a declared policy and then never runs it; one produces results that do not match their own documented schema.

**#511 — `ai compat` emitted an empty profile instead of rejecting non-AI input.** `run_ai_compat` called the line-scanner `ai_project_summary` unconditionally with zero validation, so *any* file produced `compat_profile_generated` / exit 0 with `artifact { requires ; provides ; }`. An empty profile reporting success is indistinguishable from a genuine clean result, which makes it the false green of this group.

**#509 — declared `eval` / `migration` / `drift` policies were never executed.** `run_ai_eval` used hardcoded thresholds (0.35 / 0.80) and ignored declared slices, `min_samples` and evaluator. `run_ai_regress` / `run_ai_drift` took `_path` / `_slice` and never read them: two hardcoded metric/threshold pairs ran unconditionally regardless of `--migration` / `--property` or the file's contents. A spec author declaring a policy got a verdict computed from something else entirely.

**#510 — statistical results did not conform to their schema, and exit codes were wrong.** `wrap_specialized`'s exit-1 set listed only `statistically_unsupported`, so `dataset_invalid` / `evaluator_untrusted` / `slice_missing` / `insufficient_samples` / `inconclusive` all exited 0. The hand-built JSON omitted `schema_version`, `status`, `slice`, `metric`, `n`, `estimate`, `threshold`, `evaluator` and `assumptions`.

## Contract change

- **#511** — reuses the `is_ai_project` / `parse_surface_document` dispatch already used by `run_ai_check` / `run_ai_replay`, now backed by real parsing (a new `fsl_syntax::ai_project` module, or the strict `ai_component` parser) rather than the line scanner. Wrong-dialect input and a project with zero `ai_component` blocks are both rejected with exit 2. Also corrects `tool.<name>` to `tool.<schema or name>`, matching the frozen reference.
- **#509** — a new `fsl_tools::ai_stochastic` evaluator, shared by all three commands, parses and selects the declared property/migration/observed property (erroring on unknown, missing or ambiguous selection) and executes **only the declared slices and requirements**. `ai eval` now also honors the documented `--records`-less invocation via the declared `dataset.source`, which previously hard-errored.
- **#510** — `evaluate_statistical_property` always builds the full `schemas/fslc/ai/statistical-result.v0.schema.json` field set, and the five missing gate statuses join `statistically_unsupported` at exit 1.

**One user-visible result value changes.** `fslc ai drift`'s success result moves from `observed_conformant` to the documented `observed_supported` (`docs/LANGUAGE.md:2405`, `docs/DESIGN-assurance-classes.md:97`). `observed_conformant` **remains correct and unchanged for `fslc db observe`** (`docs/DESIGN-assurance-classes.md:95`), which is a different command with its own still-valid vocabulary — `ai drift` had simply been emitting another command's string. This is called out in the `CHANGELOG.md` entry, the commit body, and a doc-comment on `run_ai_drift` itself so a future reader meets it at the call site.

## Test evidence

Verified against a `main` binary. Every control below was confirmed by reverting the fix, observing the failure, and restoring — and the report distinguishes which tests are bug-catchers from which are positive controls that pass either way.

| case | main | this branch |
|---|---|---|
| `ai compat specs/cart_v1.fsl` (non-AI input) | exit 0, `{"artifact":"","component":"","requires":[],"provides":[]}` | exit 2, `error` / `semantics` / `"expected an ai_component or fsl-ai project document"` |
| `ai eval` with a declared slice gate the combined estimate hides | exit 0 `statistically_supported` (combined Wilson lower 0.417) | exit 1 `statistically_unsupported` (slice n=5, Wilson lower ≈0 < 0.35) |
| `ai regress --migration DoesNotExist` | exit 1 with **fabricated** findings | exit 2, `"unknown ai_migration 'DoesNotExist'"` |
| `ai regress` on a spec declaring only `accuracy drop <= 0.50` | exit 1 — flagged both metrics regardless of the file | exit 0, 1 check only |
| duplicate `case_id` records | exit 0 | exit 1, `dataset_invalid` |
| untrusted evaluator | exit 0 `statistically_supported` (trust never checked) | exit 1, `evaluator_untrusted` |

Revert-and-confirm results: `issue_511_*` 3 of 4 failed on reverted code (the 4th is a positive control that passed either way, and is labelled as such); `issue_509_*` 7 of 9 failed (the two "still catches a real regression/drift" tests pass both ways by numeric coincidence with the old hardcoded values — also labelled); `issue_510_*` 4 of 4 failed. Each `issue_510_*` test asserts every required field's presence and type via `assert_schema_conformant`, not merely that the output parses as JSON.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (144 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0. `docs/LANGUAGE.md` / `.ja.md` section counts still 18 == 18.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (1:1 section-aligned), `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`. `docs/DESIGN-stochastic.md` and `docs/DESIGN-ai-hard.md` are unchanged — both already specified the status priority and required fields that are now actually implemented, so there was no drift to correct.

## Scope boundaries

Deliberately not ported: the frozen reference's `P(metric | condition)` probability-requirement syntax and its generic `metrics` / `evaluator_results` dotted-path lookup for `observed_property`. Neither appears in any doc, example or test in this repository, so implementing them would be unrequested scope; native treats such a requirement as `inconclusive` rather than silently reproducing undocumented behavior.

Found while working and **filed as #542**, not fixed here: `fslc ai check` on a multi-declaration project file still uses the `ai_project_summary` line scanner, so a `statistical_property` whose `require` clause is unparseable garbage still returns `ai_project_analyzed` / exit 0 with no findings. Same class as #511 ("check accepts what execution would reject") but a different mechanism — not an empty artifact, but a declaration accepted without its clause content ever being inspected. The parser needed to fix it is the one this PR adds; `ai check` simply does not call it yet.

## Linked issues

Fixes #509, fixes #510, fixes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
