### PR TITLE
fix: catch forall-wrapped vacuous implications and classify refinement argument zero-division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   every non-`statistically_supported` terminal status (`dataset_invalid`,
   `evaluator_untrusted`, `slice_missing`, `insufficient_samples`,
   `inconclusive`) now exits 1 instead of 0 (#510).
+- Native `verify`'s `vacuous_implication` lane now unwraps a
+  `forall`-quantified implication before checking antecedent reachability,
+  not only a bare top-level `Binary{op: "=>"}`. `docs/DESIGN-vacuity.md:22`
+  already documented "a single `=>` directly under `forall*`" as the
+  primary shape, but `verification_warnings` matched only
+  `property.expr` itself being `=>`, so any invariant of the ordinary form
+  `forall x: T { P(x) => Q(x) }` was invisible to the lane: a hollow
+  invariant of this shape verified clean instead of being flagged, and
+  `--vacuity error` had nothing to select. Every leading `forall` is now
+  peeled (nested foralls included, matching the frozen Python reference's
+  `_implication_antecedent_candidate`) and the antecedent is existentially
+  closed over the collected binders (reusing the existing `exists_wrap`
+  helper already used for `leadsTo` triggers) before the reachability
+  check; with zero leading foralls this is a no-op, so the previous
+  top-level-`=>` shape still works unchanged (#486).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   helper already used for `leadsTo` triggers) before the reachability
   check; with zero leading foralls this is a no-op, so the previous
   top-level-`=>` shape still works unchanged (#486).
+- `fslc refine` now classifies a zero divisor in a refinement
+  action-correspondence *argument* expression (`impl_action(a) ->
+  abs_action(a / c)`, where `c` is an impl state variable that can be zero)
+  as a located `refinement_failed`/`kind:"map_partial_op"` finding, joining
+  the existing closed kind set (`abs_requires_failed` / `abs_state_mismatch`
+  / `stutter_changed_abs` / `map_out_of_bounds`). Constructing an abstract
+  action call is action context (`docs/DESIGN-divmod.md` §2.2), not the
+  read-only "mapping expression" §2.3 exempts (a refinement *state* map,
+  distinct from an action-correspondence argument), so it gets the same
+  `partial_op` treatment a division inside the abstract action's own body
+  would. Before this fix `check_refinement` propagated the divisor's raw
+  `RuntimeError` unclassified, surfacing as `result:"error"`,
+  `kind:"type"`, `message:"division by zero"` — neither of the two
+  documented `/0` treatments, and not a member of the refinement contract's
+  kind set. A correspondence whose divisor is always guarded on every
+  reachable impl step is unaffected and still `refines` (#512).
 - `analyze`'s TSG no longer leaks the internal db-dialect `QqDbSepqQ`
   separator sentinel into node labels: a db-dialect invariant/action label
   now matches the display name `verify` reports for the same target (both

--- a/docs/DESIGN-divmod.md
+++ b/docs/DESIGN-divmod.md
@@ -29,7 +29,18 @@ with `+ - * / %`.
    silently relies on 0 is reported as violated** (G5).
 3. **No check in property contexts (invariant/reachable/leadsTo/mapping expressions)**:
    /0 evaluates to 0 (total, so not an indeterminate value). Document the guard idiom
-   `y != 0 => P(x / y)` as a recommendation.
+   `y != 0 => P(x / y)` as a recommendation. "Mapping expressions" here means a
+   refinement **state** map (`map name = expr` / `map name[i: K] = expr`): a read-only
+   view recomputed whenever the mapped state is read, with no state or action of its
+   own — the same shape as an invariant reading a computed value. It does **not**
+   include a refinement **action-correspondence argument** expression
+   (`impl_action(params) -> abs_action(arg_expr, ...)`, `docs/DESIGN-refinement.md`
+   §3): that expression constructs the parameter values for an abstract action
+   *invocation*, the same role a division inside the abstract action's own body would
+   play, so it is action context (rule 2) and gets the same partial_op treatment —
+   surfaced as a refinement-shaped finding, `kind:"map_partial_op"`
+   (`docs/DESIGN-refinement.md` §3), rather than an invariant-shaped one, since there
+   is no invariant to name (issue #512).
 4. **Negative numbers follow SMT-LIB (Euclidean)**: when `b != 0`,
    `a = b * (a / b) + (a % b)` and `0 <= a % b < |b|`.
    - Z3's Int div/mod use this definition (used as-is).

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -498,7 +498,7 @@ Violation:
   "violated_at_step": 3,
   "impl_action": { "name": "rebalance", "params": {...}, "loc": ... },
   "kind": "abs_requires_failed" | "abs_state_mismatch" | "stutter_changed_abs"
-        | "map_out_of_bounds",
+        | "map_out_of_bounds" | "map_partial_op",
   "impl_trace": [ ...existing trace format... ],
   "abs_before": { ...logical state of α(s)... },
   "abs_after_expected": { ...after applying b... } | null,
@@ -586,6 +586,20 @@ change abs's stock) → `impl_checkout` consumes the reserved stock) +
    refine` and `fslc diff` CLI contract).
 10. No regression of existing features (refine is a completely independent CLI
    path).
+11. **action-correspondence argument partial_op (issue #512)**: an
+   action-correspondence argument expression (`impl_action(a) -> abs_action(a / c)`)
+   that divides by an impl state variable which can be zero — distinct from
+   `map_out_of_bounds` (a range problem) and from the impl's own body dividing by
+   zero (`abs_requires_failed`'s precondition, issue #466's `impl_violation`, since
+   here the impl's own body has no division at all) → `map_partial_op`, not an
+   unclassified `kind:"type"` error. `docs/DESIGN-divmod.md` §2.2/§2.3: this is
+   action context, not the read-only "mapping expression" §2.3 exempts, so it gets
+   the same partial_op treatment a division inside the abstract action's own body
+   would. A guarded correspondence (the divisor is never zero on any reachable impl
+   step) still `refines`. Rust coverage: `rust/fsl-runtime/tests/refinement.rs` (the
+   `check_refinement` contract directly) and
+   `rust/fslc/tests/issue_512_refine_map_partial_op.rs` (the `fslc refine` CLI
+   contract).
 
 ## 6. Documentation Reflection
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -531,10 +531,14 @@ invariant OnlyEligible { forall c: Claim { approved[c] => eligible(c) } }
   剰余系に従います(`a == b * (a / b) + (a % b)` かつ `0 <= a % b < |b|`。
   よって `-7 / 2 == -4`、`-7 % 2 == 1`)。ゼロ除算は**全域的に定義**されており、
   `a / 0 == 0` と `a % 0 == 0` は常に評価できます — invariant/trans/reachable/
-  leadsTo/mapping 式で `a / 0` を読んでも評価が失敗することはありません。
-  action の `requires`/本体/`ensures` 内では、ゼロになりうる除数への未ガードの
-  `/`/`%` は値自体が定義されていても `partial_op`(§6 参照)として報告されます —
-  `y != 0 => P(x / y)` や `requires y != 0` でガードしてください。
+  leadsTo/refinement の state map 式で `a / 0` を読んでも評価が失敗することは
+  ありません。action の `requires`/本体/`ensures` 内では、ゼロになりうる除数への
+  未ガードの `/`/`%` は値自体が定義されていても `partial_op`(§6 参照)として
+  報告されます — `y != 0 => P(x / y)` や `requires y != 0` でガードしてください。
+  refinement の action 対応の**引数**式(§10、`impl_action(a) -> abs_action(a / c)`)
+  は、抽象 action 呼び出しを構成するものなので property 文脈の mapping 式ではなく
+  action 文脈であり、同じ `partial_op` 扱いを受けて `kind: "map_partial_op"` として
+  報告されます。
 - 比較: `== != < <= > >=`
 - 論理: `and or not =>`
 - 条件: `if condition then when_true else when_false`。条件は `Bool` で、両方の
@@ -1313,9 +1317,12 @@ fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth
 
 成功: `result: "refines"`(exit 0)。違反: `refinement_failed`(exit 1)で、
 `kind`(`abs_requires_failed` / `abs_state_mismatch` / `stutter_changed_abs` /
-`map_out_of_bounds`)、`impl_trace`、マッピング後の `abs_before` /
-`abs_after_*` を伴います。静的なエラー(マップの欠落、未知の action など)は
-`kind: "type"`(exit 2)です。
+`map_out_of_bounds` / `map_partial_op`)、`impl_trace`、マッピング後の
+`abs_before` / `abs_after_*` を伴います。静的なエラー(マップの欠落、未知の
+action など)は `kind: "type"`(exit 2)です。`map_partial_op` は、action 対応の
+引数式(`impl_action(a) -> abs_action(a / c)`)がゼロになりうる impl の state
+変数で除算しているケースです — action 文脈であり、refinement の state map が
+受ける「チェックなし」の property 文脈ではありません(§3 のゼロ除算規則)。
 
 `refine` はどの対応関係も検査する前に、まず impl spec が `--depth` の範囲内で
 それ自身の型境界や不変条件を破っていないか(内部的に一貫しているか)を検証しま

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -545,11 +545,15 @@ variable capture instead of inventing internal binder names. See
   as `a / b` with whitespace). `/` and `%` are Euclidean for `b != 0`
   (`a == b * (a / b) + (a % b)` and `0 <= a % b < |b|`, so `-7 / 2 == -4` and
   `-7 % 2 == 1`). Division by zero is **totally defined**: `a / 0 == 0` and
-  `a % 0 == 0` always evaluate, so an invariant/trans/reachable/leadsTo/mapping
-  expression that reads `a / 0` never fails to evaluate. Inside an action's
-  `requires`/body/`ensures`, an unguarded `/`/`%` whose divisor can reach zero
-  is still reported as `partial_op` (see §6) even though the value is defined —
-  guard it with `y != 0 => P(x / y)` or `requires y != 0`.
+  `a % 0 == 0` always evaluate, so an invariant/trans/reachable/leadsTo/refinement
+  state-map expression that reads `a / 0` never fails to evaluate. Inside an
+  action's `requires`/body/`ensures`, an unguarded `/`/`%` whose divisor can
+  reach zero is still reported as `partial_op` (see §6) even though the value
+  is defined — guard it with `y != 0 => P(x / y)` or `requires y != 0`. A
+  refinement action-correspondence *argument* expression (§10,
+  `impl_action(a) -> abs_action(a / c)`) is action context, not a property-context
+  mapping expression, since it constructs an abstract action call: it gets the
+  same `partial_op` treatment, surfaced as `kind: "map_partial_op"`.
 - Comparison: `== != < <= > >=`
 - Logical: `and or not =>`
 - Conditional: `if condition then when_true else when_false`. The condition is
@@ -1346,9 +1350,12 @@ fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth
 
 Success: `result: "refines"` (exit 0). Violation: `refinement_failed` (exit 1)
 with `kind` (`abs_requires_failed` / `abs_state_mismatch` / `stutter_changed_abs` /
-`map_out_of_bounds`), `impl_trace`, and the post-mapping `abs_before` /
-`abs_after_*`. A static error (a missing map, an unknown action, etc.) is
-`kind: "type"` (exit 2).
+`map_out_of_bounds` / `map_partial_op`), `impl_trace`, and the post-mapping
+`abs_before` / `abs_after_*`. A static error (a missing map, an unknown action,
+etc.) is `kind: "type"` (exit 2). `map_partial_op` is an action-correspondence
+argument expression (`impl_action(a) -> abs_action(a / c)`) dividing by an impl
+state variable that can be zero — action context (§3/§6's `partial_op` rule),
+not the "no check" property context a refinement *state* map gets.
 
 Before any correspondence is checked, `refine` first verifies that the impl
 spec is internally consistent on its own — does not violate its own type

--- a/docs/intro/design-layer.en.html
+++ b/docs/intro/design-layer.en.html
@@ -150,6 +150,7 @@
       <tr><td>Transition correspondence</td><td>Every design step maps to a requirement action that is <i>enabled</i>, and the update lines up.</td><td><code>abs_requires_failed</code> — the design bypassed an upper guard.</td></tr>
       <tr><td>Stutter</td><td>An action mapped to <code>stutter</code> truly leaves the abstract view unchanged.</td><td><code>stutter_changed_abs</code> — a false "internal-only" claim.</td></tr>
       <tr><td>Mapping range</td><td>Mapped values stay inside the abstract type.</td><td><code>map_out_of_bounds</code> — the projection escaped the abstract domain.</td></tr>
+      <tr><td>Correspondence argument</td><td>An action-correspondence argument expression evaluates without hitting an undefined operation (e.g. a zero divisor).</td><td><code>map_partial_op</code> — the mapping itself is undefined for this reachable value.</td></tr>
     </table>
 
     <div class="vs reveal" style="margin-top:24px">

--- a/docs/intro/design-layer.ja.html
+++ b/docs/intro/design-layer.ja.html
@@ -154,6 +154,7 @@
       <tr><td>遷移の対応</td><td>すべての設計ステップが、<i>有効な</i>要件操作に対応し、更新も一致する。</td><td><code>abs_requires_failed</code> — 設計が上位の条件を迂回した。</td></tr>
       <tr><td>stutter</td><td><code>stutter</code> にした操作が、本当に抽象側を変えない。</td><td><code>stutter_changed_abs</code> — 「内部だけ」という主張が嘘。</td></tr>
       <tr><td>対応値の範囲</td><td>対応づけた値が、抽象の型の範囲に収まる。</td><td><code>map_out_of_bounds</code> — 射影が抽象の範囲を超えた。</td></tr>
+      <tr><td>対応の引数</td><td>action 対応の引数式が、未定義の演算(ゼロ除算など)に当たらずに評価できる。</td><td><code>map_partial_op</code> — この到達可能な値に対して、対応づけ自体が未定義。</td></tr>
     </table>
 
     <div class="vs reveal" style="margin-top:24px">

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1774,10 +1774,38 @@ pub fn check_refinement(
                             runtime_error(format!("unknown abstract action '{name}'"))
                         })?;
                     let mut bindings = enabled.params.clone();
-                    let values = args
+                    let values = match args
                         .iter()
                         .map(|expr| eval(expr, &monitor.state, &mut bindings, &eval_model, None))
-                        .collect::<Result<Vec<_>, _>>()?;
+                        .collect::<Result<Vec<_>, _>>()
+                    {
+                        Ok(values) => values,
+                        // An action-correspondence argument expression (not
+                        // the impl action's own body -- that self-violation
+                        // is already excluded above) hit an undefined
+                        // operation for this reachable impl instance, e.g. a
+                        // `/`/`%` divisor that is zero only through the
+                        // mapping's argument expression. `docs/DESIGN-divmod.md`
+                        // §2.2's action-context partial_op check applies here
+                        // by the same G5 rationale (constructing an abstract
+                        // action call is action context, not the read-only
+                        // "mapping expression" §2.3 exempts): this must be a
+                        // located refinement finding, not an unclassified
+                        // internal error that the CLI defaults to `kind:"type"`.
+                        Err(error) if is_partial_operation_error(&error.message) => {
+                            check.failure = Some(refinement_failure(
+                                "map_partial_op",
+                                Some("step"),
+                                step + 1,
+                                &child_trace,
+                                Some(alpha_before.clone()),
+                                Some(alpha_after.clone()),
+                                Some(alpha_after),
+                            ));
+                            return Ok(check);
+                        }
+                        Err(error) => return Err(error),
+                    };
                     let expected_params = abs_action
                         .params
                         .iter()

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2101,13 +2101,39 @@ pub fn verification_warnings(
 ) -> Vec<JsonValue> {
     let mut warnings = model_warnings(model);
     for property in &model.invariants {
-        let Expr::Binary { op, left, .. } = &property.expr else {
+        // `docs/DESIGN-vacuity.md`'s primary `vacuous_implication` shape is a
+        // single `=>` directly under `forall*`: peel every leading `forall`
+        // (nested foralls included, matching the frozen Python reference's
+        // `_implication_antecedent_candidate`), then existentially close the
+        // antecedent over the collected binders before checking
+        // reachability. With zero leading foralls this is a no-op
+        // (`exists_wrap` over an empty slice returns the antecedent
+        // unchanged), so the original top-level-`=>` shape still works.
+        let mut binders = Vec::new();
+        let mut inner = &property.expr;
+        while let Expr::Quantified {
+            quantifier,
+            binder,
+            body,
+        } = inner
+        {
+            if quantifier != "forall" {
+                break;
+            }
+            binders.push(binder.clone());
+            inner = body;
+        }
+        let Expr::Binary { op, left, .. } = inner else {
             continue;
         };
         if op != "=>" {
             continue;
         }
-        if matches!(expression_reachable(model.clone(), left, depth), Ok(false)) {
+        let antecedent = exists_wrap(&binders, (**left).clone());
+        if matches!(
+            expression_reachable(model.clone(), &antecedent, depth),
+            Ok(false)
+        ) {
             let mut warning = json!({
                 "kind": "vacuous_implication",
                 "name": display_name(&property.name),

--- a/rust/fsl-runtime/tests/refinement.rs
+++ b/rust/fsl-runtime/tests/refinement.rs
@@ -252,3 +252,75 @@ fn check_refinement_finds_a_self_violation_reachable_only_from_a_nondeterministi
         checked.failure
     );
 }
+
+const DIVMAP_ABS: &str = "spec DivMapAbs { state { q: 0..10 } init { q = 0 } \
+     action go(v in 0..10) { q = v } }";
+
+/// Negative control for #512: an action-correspondence *argument* expression
+/// (`go2(a) -> go(a / c)`) that divides by a state variable that can be zero
+/// -- distinct from the impl action's own body, which has no division at all
+/// here -- must be reported as a located `refinement_failed` /
+/// `kind:"map_partial_op"` finding. Before the fix, the divisor's own
+/// `eval()` call inside `check_refinement`'s action-correspondence handling
+/// was not wrapped in `with_total_division` (correctly so: this is action
+/// context per `docs/DESIGN-divmod.md` §2.2, not the read-only "mapping
+/// expression" §2.3 exempts) but its `RuntimeError` was propagated raw via
+/// `?` instead of being classified, so it surfaced as an unclassified
+/// internal error the CLI stamps `kind:"type"` -- neither of the two
+/// documented divide-by-zero treatments.
+#[test]
+fn check_refinement_reports_map_partial_op_for_a_zero_divisor_in_a_correspondence_argument() {
+    let implementation = model(
+        "spec DivMapImpl { state { q: 0..10, c: 0..5 } init { q = 0  c = 1 } \
+         action set_c(v in 0..5) { c = v } \
+         action go2(a in 0..10) { q = a } }",
+    );
+    let abstraction = model(DIVMAP_ABS);
+    let mapping = parse_refinement(
+        "refinement M { impl DivMapImpl abs DivMapAbs map q = q \
+         action set_c(v) -> stutter action go2(a) -> go(a / c) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 3)
+        .expect("check_refinement runs");
+
+    assert!(
+        checked.impl_violation.is_none(),
+        "the impl's own body never divides; this is a mapping-argument defect, not a self-violation: {:?}",
+        checked.impl_violation
+    );
+    let failure = checked
+        .failure
+        .expect("the zero-divisor correspondence argument must be reported, not silently ignored");
+    assert_eq!(failure.kind, "map_partial_op");
+}
+
+/// Regression control: the same action-correspondence argument division,
+/// but guarded so the divisor is never zero on any reachable impl step, must
+/// still `refines` -- the fix must not turn a legitimately total mapping
+/// into a false `map_partial_op`.
+#[test]
+fn check_refinement_still_refines_when_the_correspondence_divisor_is_always_guarded() {
+    let implementation = model(
+        "spec DivMapImplGuarded { state { q: 0..10, c: 0..5 } init { q = 0  c = 1 } \
+         action set_c(v in 0..5) { requires v != 0  c = v } \
+         action go2(a in 0..10) { q = a / c } }",
+    );
+    let abstraction = model(DIVMAP_ABS);
+    let mapping = parse_refinement(
+        "refinement M { impl DivMapImplGuarded abs DivMapAbs map q = q \
+         action set_c(v) -> stutter action go2(a) -> go(a / c) }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 3)
+        .expect("check_refinement runs");
+
+    assert!(checked.impl_violation.is_none());
+    assert!(checked.failure.is_none(), "failure: {:?}", checked.failure);
+}

--- a/rust/fslc/tests/fixtures/issue_486_vacuous_forall_implication.fsl
+++ b/rust/fslc/tests/fixtures/issue_486_vacuous_forall_implication.fsl
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `active[i]` is never assigned `true` by any action, so the antecedent of
+// the forall-wrapped implication below is unreachable within any depth.
+// Before #486, native `vacuous_implication` only matched an invariant whose
+// *top-level* expression was `Binary{op: "=>"}`; a `forall`-quantified
+// implication (the shape `docs/DESIGN-vacuity.md:22` documents as the
+// primary case) was never unwrapped, so this hollow invariant verified
+// clean instead of being flagged.
+spec ForallVacuousImplication {
+  type Id = 0..1
+  state { active: Map<Id, Bool> }
+  init { forall i: Id { active[i] = false } }
+
+  action stay(i: Id) {
+    active[i] = active[i]
+  }
+
+  invariant NeverActivated {
+    forall i: Id { active[i] => false }
+  }
+}

--- a/rust/fslc/tests/injection_detector_matrix.rs
+++ b/rust/fslc/tests/injection_detector_matrix.rs
@@ -23,22 +23,6 @@ const DEPTH: &str = "4";
 const DIFF_MUTATE_DEPTH: &str = "3";
 const DIFF_MUTATE_MAX: &str = "30";
 
-/// Files where the primary detector is a known, filed, native-only gap.
-/// Native `vacuous_implication` (`rust/fsl-runtime/src/lib.rs`) only matches
-/// an invariant whose *top-level* expression is `Binary{op: "=>"}`; it does
-/// not unwrap a `forall`-quantified implication, which is the shape
-/// `docs/DESIGN-vacuity.md:22-24` documents as the primary case. See issue
-/// #486 (filed while repairing issue #485; distinct from issue #465, which
-/// covers the four vacuity kinds that are entirely unimplemented).
-/// `bank__unreachable_antecedent.fsl` is unaffected: its implication is not
-/// wrapped in `forall`. This pins the *current* gap exactly, so the assertion
-/// fails loudly (forcing an update) once #486 is fixed rather than silently
-/// staying green.
-const KNOWN_NATIVE_VACUITY_FORALL_GAP: &[&str] = &[
-    "order_workflow__unreachable_antecedent.fsl",
-    "return_system__unreachable_antecedent.fsl",
-];
-
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -326,7 +310,6 @@ fn native_injected_corpus_primary_blind_matrix() {
 
     let scratch = scratch_dir();
     let mut failures = Vec::new();
-    let mut known_gap_regressions = Vec::new();
 
     for path in &paths {
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
@@ -335,20 +318,7 @@ fn native_injected_corpus_primary_blind_matrix() {
         let cells = measure(path, &case_headers, &scratch);
 
         let primary = primary_detector(inject);
-        let primary_caught = cells[primary].caught;
-        if KNOWN_NATIVE_VACUITY_FORALL_GAP.contains(&file_name) {
-            // Pin the current, filed-as-#486 gap exactly: this must stay
-            // "not caught" until #486 lands. If it starts catching, this
-            // assertion fails and forces the exclusion to be removed instead
-            // of silently going green.
-            if primary_caught {
-                known_gap_regressions.push(format!(
-                    "{file_name}: primary {primary} now catches (remove from \
-                     KNOWN_NATIVE_VACUITY_FORALL_GAP and close issue #486): {}",
-                    cells[primary].signal
-                ));
-            }
-        } else if !primary_caught {
+        if !cells[primary].caught {
             failures.push(format!(
                 "{file_name}: primary {primary} did not catch {inject}: {}",
                 cells[primary].signal
@@ -364,10 +334,5 @@ fn native_injected_corpus_primary_blind_matrix() {
         }
     }
 
-    assert!(
-        known_gap_regressions.is_empty(),
-        "{}",
-        known_gap_regressions.join("\n")
-    );
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/rust/fslc/tests/issue_486_vacuous_forall_implication.rs
+++ b/rust/fslc/tests/issue_486_vacuous_forall_implication.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Negative control for #486: native `vacuous_implication`
+//! (`rust/fsl-runtime/src/lib.rs::verification_warnings`) must unwrap a
+//! `forall`-quantified implication before checking antecedent reachability,
+//! not only a bare top-level `Binary{op: "=>"}`. This is the shape
+//! `docs/DESIGN-vacuity.md:22` documents as the primary case. Before the
+//! fix, `issue_486_vacuous_forall_implication.fsl` verified clean (no
+//! `vacuous_implication` warning at all, so `--vacuity error` never fired)
+//! because the top-level expression of the invariant is a `forall`, not a
+//! `=>`. Reverting the fix reproduces that: `assert_eq!(status, 2)` below
+//! fails (`verified`/exit 0 instead of `error`/exit 2).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const FIXTURE: &str = "rust/fslc/tests/fixtures/issue_486_vacuous_forall_implication.fsl";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (serde_json::Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn a_forall_wrapped_implication_is_flagged_vacuous_by_default() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    let warnings = output["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_implication"
+                && warning["name"] == "NeverActivated"),
+        "expected a vacuous_implication warning for NeverActivated: {output:#}"
+    );
+}
+
+/// Before #486, this forall-wrapped implication was invisible to
+/// `verification_warnings` (its top-level expression is `forall`, not
+/// `=>`), so `--vacuity error` had nothing to select and this hollow
+/// invariant passed with `result:"verified"`/exit 0. If this regresses,
+/// the assertions below fail.
+#[test]
+fn a_forall_wrapped_implication_fails_closed_under_vacuity_error() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "vacuous_implication");
+    assert_eq!(output["findings"][0]["name"], "NeverActivated");
+}
+
+/// Same fixture on `--engine explicit`: `verification_warnings` is shared
+/// across engines (a single, engine-agnostic diagnostic pass over the
+/// solver-free concrete Monitor's BFS), so the fix must not be BMC-only.
+#[test]
+fn a_forall_wrapped_implication_fails_closed_on_the_explicit_engine_too() {
+    let (output, status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--engine",
+        "explicit",
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "vacuous_implication");
+    assert_eq!(output["findings"][0]["name"], "NeverActivated");
+}

--- a/rust/fslc/tests/issue_512_refine_map_partial_op.rs
+++ b/rust/fslc/tests/issue_512_refine_map_partial_op.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative control for #512: `fslc refine` must classify a zero divisor in
+//! an action-correspondence *argument* expression (`go2(a) -> go(a / c)`,
+//! where `c` is an impl state variable that can be zero) as a located
+//! `result:"refinement_failed"` / `kind:"map_partial_op"` finding, matching
+//! the documented closed set of refinement failure kinds
+//! (`docs/DESIGN-refinement.md`, `docs/LANGUAGE.md`). Before the fix this
+//! surfaced as an unclassified internal error: `result:"error"`,
+//! `kind:"type"`, `message:"division by zero"` -- neither of the two
+//! documented `/0` treatments (`docs/DESIGN-divmod.md` §2.1/§2.3
+//! totalization or §2.2 `partial_op`), and not a member of the refinement
+//! contract's kind set at all.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn write(path: &Path, source: &str) {
+    std::fs::write(path, source).expect("write fixture");
+}
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("fslc-issue-512-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create scratch directory");
+    dir
+}
+
+const ABS: &str = "spec DivMapAbs { state { q: 0..10 } init { q = 0 } \
+     action go(v in 0..10) { q = v } }";
+const IMPL: &str = "spec DivMapImpl { state { q: 0..10, c: 0..5 } init { q = 0  c = 1 } \
+     action set_c(v in 0..5) { c = v } \
+     action go2(a in 0..10) { q = a } }";
+const MAPPING: &str = "refinement M { impl DivMapImpl abs DivMapAbs map q = q \
+     action set_c(v) -> stutter action go2(a) -> go(a / c) }";
+
+/// `fslc refine` on a correspondence argument that can divide by zero must
+/// report `refinement_failed`/exit 1 with `kind:"map_partial_op"`, not an
+/// unclassified `error`/`kind:"type"`.
+#[test]
+fn refine_reports_map_partial_op_for_a_zero_divisor_in_a_correspondence_argument() {
+    let dir = scratch("refine");
+    let implementation = dir.join("impl.fsl");
+    let abstraction = dir.join("abs.fsl");
+    let mapping = dir.join("map.fsl");
+    write(&implementation, IMPL);
+    write(&abstraction, ABS);
+    write(&mapping, MAPPING);
+
+    let (output, status) = run(&[
+        "refine".to_owned(),
+        implementation.display().to_string(),
+        abstraction.display().to_string(),
+        mapping.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "refinement_failed");
+    assert_eq!(output["kind"], "map_partial_op");
+    assert_ne!(output["result"], "error");
+}
+
+/// Regression control: the same correspondence argument division, guarded
+/// so the divisor is never zero on any reachable impl step, must still
+/// `refines`/exit 0.
+#[test]
+fn refine_still_refines_when_the_correspondence_divisor_is_always_guarded() {
+    let dir = scratch("refine-guarded");
+    let implementation = dir.join("impl.fsl");
+    let abstraction = dir.join("abs.fsl");
+    let mapping = dir.join("map.fsl");
+    write(
+        &implementation,
+        "spec DivMapImplGuarded { state { q: 0..10, c: 0..5 } init { q = 0  c = 1 } \
+         action set_c(v in 0..5) { requires v != 0  c = v } \
+         action go2(a in 0..10) { q = a / c } }",
+    );
+    write(&abstraction, ABS);
+    write(
+        &mapping,
+        "refinement M { impl DivMapImplGuarded abs DivMapAbs map q = q \
+         action set_c(v) -> stutter action go2(a) -> go(a / c) }",
+    );
+
+    let (output, status) = run(&[
+        "refine".to_owned(),
+        implementation.display().to_string(),
+        abstraction.display().to_string(),
+        mapping.display().to_string(),
+        "--depth".to_owned(),
+        "3".to_owned(),
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "refines");
+}

--- a/skills/fsl-design-review/SKILL.md
+++ b/skills/fsl-design-review/SKILL.md
@@ -95,6 +95,7 @@ the abstract contract, mapping, or detail guards to obtain a green result.
 | `abs_requires_failed` | The detail layer bypasses an abstract-layer guard (a control shortcut, effectively strengthening a precondition) | LSP violation = not substitutable. `impl_trace` is the forbidden procedure |
 | `abs_state_mismatch` | Observable behavior diverges from the contract | LSP violation (a postcondition-equivalent deviation). Also suspect a misreading of the mapping |
 | `stutter_changed_abs` | An operation claimed to be "internal detail" causes an externally visible change | A break of encapsulation. The stutter declaration is a lie |
+| `map_partial_op` | An action-correspondence argument expression is undefined for a reachable instance (e.g. a divisor that can be zero) | Not a substitutability failure — the mapping itself is broken for this instance. Fix the correspondence expression, not the implementation's behavior |
 | coverage `false` | An action that can never fire = a dead extension point / dead procedure | Equivalent to YAGNI / dead code. Read `blocking_requires` |
 | `unknown_cti` | The contract is true but requires an implicit premise | Discovery of an implicit design premise. If it is a domain truth, make it explicit as an auxiliary invariant |
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1393,6 +1393,15 @@ substituted default — only an *absent* `depth`/`refine_depth` key defaults.
   fidelity failure. Never `refines`, never folded into `refinement_failed`.
   `fslc diff` surfaces the same condition as an `impl_violated` finding and
   fails its gate unconditionally (not `--forbid`-gated).
+- **action-correspondence argument partial_op (#512)**: an
+  action-correspondence argument expression (`impl_action(a) -> abs_action(a
+  / c)`) dividing by an impl state variable that can be zero is action
+  context, not the "no check" property context a refinement state map gets —
+  `kind:"map_partial_op"` (`refinement_failed`, exit 1), distinct from
+  `map_out_of_bounds` (a range problem) and from the impl's own body dividing
+  by zero (caught by the impl self-violation precondition above). A
+  correspondence whose divisor is always guarded on every reachable impl
+  step still `refines`.
 - **nondeterministic `init` (#493)**: a state variable `init` never assigns
   on any path (an `init if` reading an unassigned `Bool`) is a genuinely free
   initial value across its type domain, not a silently defaulted one. The


### PR DESCRIPTION
## Problem

Two defects at semantic seams, both **found while fixing other issues in this batch** rather than by the original audit.

**#486 — `vacuous_implication` never unwrapped a quantified implication.** `verification_warnings` matched only an invariant whose *top-level* expression is `Binary{op:"=>"}`. The ordinary shape

```fsl
invariant NeverOne { forall k: K { x[k] == 1 => false } }
```

— which `docs/DESIGN-vacuity.md:22` documents as the **primary** case ("a single `=>` directly under `forall*`") — was invisible. A hollow invariant of this form verified clean, and `--vacuity error` had nothing to select.

This was independently discovered twice: once while repairing the injected detector corpus for #485, and once while implementing #465's vacuity lanes. It is distinct from #465, whose four kinds are entirely unimplemented — fixing either does not close the other.

**#512 — a zero divisor in a refinement action-correspondence argument produced `kind:"type"`.** With `action bump(v) -> bump(v / d)` where `d` is an impl state variable equal to 0, `fslc refine` returned `result:"error"` / `kind:"type"` / `"division by zero"` / exit 2. That is a *third* behavior, matching neither `docs/DESIGN-divmod.md` §2.1/§2.3 totalization nor §2.2 `partial_op` — and a runtime zero-division is not a type error under either reading.

## Contract change

**#486** — every leading `forall` is peeled (nested included, matching the frozen reference's `_implication_antecedent_candidate`) and the antecedent is existentially closed over the collected binders via the existing `exists_wrap` helper before the reachability check. Zero leading foralls is a no-op, so the previously-matched top-level shape is unaffected. `verification_warnings` is one engine-agnostic pass over the solver-free concrete Monitor BFS shared by every `--engine`, so this cannot introduce a symbolic/concrete disagreement.

**#512 — this settles a contract question `docs/DESIGN-divmod.md` had left open, and extends a documented closed set.** §2.3's "mapping expressions" is now scoped explicitly to refinement **state maps** — read-only state projections, consistent with `docs/DESIGN-refinement.md:451`'s "substituted on the read" — and *not* to action-correspondence arguments, which are computations attached to a transition. The argument evaluation therefore stays in action context (correctly not wrapped in `with_total_division`), but its `RuntimeError` is now classified instead of propagating raw.

**`refinement_failed` gains a fifth kind, `map_partial_op`**, joining `abs_requires_failed` / `abs_state_mismatch` / `stutter_changed_abs` / `map_out_of_bounds`. It sits alongside `map_out_of_bounds`: both mean *the correspondence computation itself is undefined for this reachable instance*, as opposed to `abs_state_mismatch` / `abs_requires_failed`, which report genuine behavioural non-correspondence. **A consumer switching exhaustively on `refinement_failed` kinds must handle `map_partial_op`.**

## Test evidence

Verified independently against a `main` binary:

| case | main | this branch |
|---|---|---|
| forall-wrapped vacuous invariant, `--vacuity error` | `verified` / exit 0 | `error` / `kind:"vacuous_implication"` / exit 2 |
| `examples/gallery/injected/order_workflow__unreachable_antecedent.fsl` | exit 0 (not caught) | exit 2 / `vacuous_implication` |
| `examples/gallery/injected/return_system__unreachable_antecedent.fsl` | exit 0 (not caught) | exit 2 / `vacuous_implication` |

**#486's second control is a pinned exclusion retiring itself.** PR #501 registered exactly this gap in `rust/fslc/tests/injection_detector_matrix.rs` as `KNOWN_NATIVE_VACUITY_FORALL_GAP`, deliberately built to fail loudly if the lane ever started catching. With the fix applied, that list and its special-case branch are **removed** so the two files fall through to the ordinary "primary must be caught" path — no assertion was weakened, verified by reading the diff. The matrix test passes with the exclusion gone. This is the second time in this batch a filed, justified exclusion has caught the fix that closed it; the first was `KNOWN_DB_DOUBLE_ASSIGNMENT_GAP` firing when #475 landed.

That also raises PR #501's honestly-recorded native primary catch rate from **19/21 to 21/21**.

**#512** has negative controls at two levels — `rust/fsl-runtime/tests/refinement.rs` against the `check_refinement` contract directly, and `rust/fslc/tests/issue_512_refine_map_partial_op.rs` against the CLI — both revert-and-confirmed: with the fix stashed, `check_refinement_reports_map_partial_op_...` fails with the raw `RuntimeError { message: "division by zero" }` panic.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (146 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/DESIGN-vacuity.md` and the LANGUAGE files already documented the forall-wrapped shape as primary, so #486 was a pure implementation gap against an accepted contract and needed only a `CHANGELOG.md` entry.

#512 extends a closed set, so every enumeration of it moves: `docs/DESIGN-divmod.md` §2.3 (the "mapping expressions" scoping), `docs/DESIGN-refinement.md` §3 and §5 item 11, `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 18 == 18), `skills/fsl/reference.md`, `skills/fsl-design-review/SKILL.md`'s per-kind table (with the design-principle reading for the new kind: not a substitutability failure, but the mapping being undefined for a reachable instance — so the remedy is to fix the correspondence expression, not the implementation's behaviour), and `docs/intro/design-layer.{en,ja}.html`.

## Linked issues

Fixes #486, fixes #512.

**#502 is deliberately not in this PR.** It was blocked until #467 landed: relation-typed state did not survive the Public Kernel and `eval.rs` stubbed every relation method, so the disagreement could not be reproduced and a control written against it could not have distinguished a correct convention from a stub. #467 merged in PR #540, so it is now unblocked and will follow separately — with the contract written into the LANGUAGE files first, since neither currently states whether `reachable` is reflexive, which is exactly why two implementations could disagree this long without either being "wrong".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
