### PR TITLE
ci: add optimistic post-merge validation

### DIFF
--- a/.github/scripts/report-post-merge-ci.mjs
+++ b/.github/scripts/report-post-merge-ci.mjs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { appendFile, readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const POST_MERGE_LABEL = "ci/post-merge";
+
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "stale",
+  "startup_failure",
+  "timed_out",
+]);
+
+class ApiError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function encodeKey(value) {
+  return Buffer.from(String(value), "utf8").toString("base64url");
+}
+
+export function issueMarker(workflowId, jobName) {
+  return `<!-- post-merge-ci:${workflowId}:${encodeKey(jobName)} -->`;
+}
+
+function workflowMarkerPrefix(workflowId) {
+  return `<!-- post-merge-ci:${workflowId}:`;
+}
+
+export function occurrenceMarker(runId, jobId) {
+  return `<!-- post-merge-ci-occurrence:${runId}:${encodeKey(jobId)} -->`;
+}
+
+export function isNewerRun(candidate, current) {
+  if (candidate.run_number !== current.run_number) {
+    return candidate.run_number > current.run_number;
+  }
+  return (candidate.run_attempt ?? 1) > (current.run_attempt ?? 1);
+}
+
+function recoveryMarker(runId, runAttempt, issueNumber) {
+  return `<!-- post-merge-ci-recovery:${runId}:${runAttempt}:${issueNumber} -->`;
+}
+
+export function failingJobs(workflowRun, jobs) {
+  const failures = jobs.filter((job) => FAILURE_CONCLUSIONS.has(job.conclusion));
+  const leafFailures = failures.filter((job) => job.name !== "product gate");
+  if (leafFailures.length > 0) {
+    return leafFailures;
+  }
+  if (failures.length > 0 || workflowRun.conclusion === "success") {
+    return failures;
+  }
+
+  return [
+    {
+      id: `workflow-${workflowRun.id}`,
+      name: "product gate workflow",
+      conclusion: workflowRun.conclusion ?? "unknown",
+      html_url: workflowRun.html_url,
+      steps: [],
+    },
+  ];
+}
+
+function failedStepNames(job) {
+  return (job.steps ?? [])
+    .filter((step) => FAILURE_CONCLUSIONS.has(step.conclusion))
+    .map((step) => step.name);
+}
+
+function shortSha(sha) {
+  return sha.slice(0, 12);
+}
+
+function pullRequestSummary(pullRequests) {
+  const merged = pullRequests.filter((pull) => pull.merged_at);
+  if (merged.length === 0) {
+    return "No associated merged pull request was returned by GitHub.";
+  }
+
+  return merged
+    .map((pull) => `[#${pull.number}](${pull.html_url})`)
+    .join(", ");
+}
+
+export function buildIssueBody({ repository, workflowRun, job, pullRequests }) {
+  const marker = issueMarker(workflowRun.workflow_id, job.name);
+  const occurrence = occurrenceMarker(workflowRun.id, job.id);
+  const steps = failedStepNames(job);
+  const commitUrl = `https://github.com/${repository}/commit/${workflowRun.head_sha}`;
+  const jobLine = job.html_url
+    ? `[${job.name}](${job.html_url})`
+    : job.name;
+
+  return [
+    marker,
+    occurrence,
+    "",
+    "The trusted post-merge product gate failed on the default branch.",
+    "",
+    `- Commit: [\`${shortSha(workflowRun.head_sha)}\`](${commitUrl})`,
+    `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Job: ${jobLine}`,
+    `- Conclusion: \`${job.conclusion}\``,
+    `- Associated PR: ${pullRequestSummary(pullRequests)}`,
+    `- Failed steps: ${steps.length > 0 ? steps.map((step) => `\`${step}\``).join(", ") : "No failed step metadata was available."}`,
+    "",
+    "Logs are intentionally not copied into this issue. Use the workflow and job links above.",
+    "Keep this issue open until a later product-gate run proves that this job recovered on `main`.",
+  ].join("\n");
+}
+
+function occurrenceComment({ workflowRun, job }) {
+  return [
+    occurrenceMarker(workflowRun.id, job.id),
+    `The failure recurred on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
+    "",
+    `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Job: [${job.name}](${job.html_url ?? workflowRun.html_url})`,
+    `- Conclusion: \`${job.conclusion}\``,
+  ].join("\n");
+}
+
+function recoveryComment({ workflowRun, issue }) {
+  return [
+    recoveryMarker(
+      workflowRun.id,
+      workflowRun.run_attempt ?? 1,
+      issue.number,
+    ),
+    `Recovered on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
+    "",
+    `Product-gate run [${workflowRun.id}](${workflowRun.html_url}) completed successfully for this job. Reopen the issue if the failure recurs.`,
+  ].join("\n");
+}
+
+async function issueContains(client, issue, marker) {
+  if ((issue.body ?? "").includes(marker)) {
+    return true;
+  }
+  const comments = await client.listIssueComments(issue.number);
+  return comments.some((comment) => (comment.body ?? "").includes(marker));
+}
+
+export async function reconcilePostMerge({ client, repository, workflowRun }) {
+  const triggeringRunId = workflowRun.id;
+  const latestCompletedRun = await client.latestCompletedWorkflowRun(
+    workflowRun.workflow_id,
+    workflowRun.head_branch,
+  );
+  if (latestCompletedRun && isNewerRun(latestCompletedRun, workflowRun)) {
+    workflowRun = latestCompletedRun;
+  }
+  workflowRun.repository = { full_name: repository };
+
+  await client.ensureLabel(POST_MERGE_LABEL);
+
+  const [jobs, issues, pullRequests] = await Promise.all([
+    client.listJobs(workflowRun.id),
+    client.listIssues(POST_MERGE_LABEL),
+    client.listAssociatedPullRequests(workflowRun.head_sha),
+  ]);
+
+  const failures = failingJobs(workflowRun, jobs);
+  const failureNames = new Set(failures.map((job) => job.name));
+  const matchingIssues = issues.filter(
+    (issue) =>
+      !issue.pull_request &&
+      (issue.body ?? "").includes(workflowMarkerPrefix(workflowRun.workflow_id)),
+  );
+  let created = 0;
+  let updated = 0;
+  let closed = 0;
+
+  for (const job of failures) {
+    const marker = issueMarker(workflowRun.workflow_id, job.name);
+    const occurrence = occurrenceMarker(workflowRun.id, job.id);
+    const issue = matchingIssues.find((candidate) =>
+      (candidate.body ?? "").includes(marker),
+    );
+
+    if (!issue) {
+      await client.createIssue({
+        title: `[post-merge CI] ${job.name} failed on main`,
+        body: buildIssueBody({ repository, workflowRun, job, pullRequests }),
+        labels: [POST_MERGE_LABEL],
+      });
+      created += 1;
+      continue;
+    }
+
+    let changed = false;
+    if (!(await issueContains(client, issue, occurrence))) {
+      await client.createIssueComment(
+        issue.number,
+        occurrenceComment({ workflowRun, job }),
+      );
+      changed = true;
+    }
+    if (issue.state !== "open") {
+      await client.updateIssue(issue.number, { state: "open" });
+      issue.state = "open";
+      changed = true;
+    }
+    if (changed) {
+      updated += 1;
+    }
+  }
+
+  for (const issue of matchingIssues) {
+    if (issue.state !== "open") {
+      continue;
+    }
+    const currentJob = jobs.find((job) =>
+      (issue.body ?? "").includes(
+        issueMarker(workflowRun.workflow_id, job.name),
+      ),
+    );
+    const recovered =
+      workflowRun.conclusion === "success" ||
+      (currentJob?.conclusion === "success" && !failureNames.has(currentJob.name));
+
+    if (!recovered) {
+      continue;
+    }
+
+    const marker = recoveryMarker(
+      workflowRun.id,
+      workflowRun.run_attempt ?? 1,
+      issue.number,
+    );
+    if (!(await issueContains(client, issue, marker))) {
+      await client.createIssueComment(
+        issue.number,
+        recoveryComment({ workflowRun, issue }),
+      );
+    }
+    await client.updateIssue(issue.number, { state: "closed" });
+    closed += 1;
+  }
+
+  const result = { created, updated, closed, failures: failures.length };
+  if (workflowRun.id !== triggeringRunId) {
+    result.redirectedFromRunId = triggeringRunId;
+    result.reconciledRunId = workflowRun.id;
+  }
+  return result;
+}
+
+export class GitHubRestClient {
+  constructor({ token, repository }) {
+    const [owner, repo] = repository.split("/");
+    if (!owner || !repo) {
+      throw new Error(`invalid GITHUB_REPOSITORY: ${repository}`);
+    }
+    this.token = token;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  async request(method, path, body) {
+    const response = await fetch(`https://api.github.com${path}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "fsl-post-merge-ci-reporter",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new ApiError(
+        response.status,
+        `GitHub API ${method} ${path} failed (${response.status}): ${text}`,
+      );
+    }
+    return text ? JSON.parse(text) : null;
+  }
+
+  repoPath(suffix) {
+    return `/repos/${this.owner}/${this.repo}${suffix}`;
+  }
+
+  async listJobs(runId) {
+    const response = await this.request(
+      "GET",
+      this.repoPath(`/actions/runs/${runId}/jobs?filter=latest&per_page=100`),
+    );
+    return response.jobs;
+  }
+
+  async latestCompletedWorkflowRun(workflowId, branch) {
+    const response = await this.request(
+      "GET",
+      this.repoPath(
+        `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&event=push&status=completed&per_page=100`,
+      ),
+    );
+    return response.workflow_runs.reduce(
+      (latest, run) => (!latest || isNewerRun(run, latest) ? run : latest),
+      null,
+    );
+  }
+
+  async ensureLabel(name) {
+    const labelPath = this.repoPath(`/labels/${encodeURIComponent(name)}`);
+    try {
+      await this.request("GET", labelPath);
+    } catch (error) {
+      if (!(error instanceof ApiError) || error.status !== 404) {
+        throw error;
+      }
+      await this.request("POST", this.repoPath("/labels"), {
+        name,
+        color: "b60205",
+        description: "Failure detected by the post-merge product gate",
+      });
+    }
+  }
+
+  async listIssues(label) {
+    return this.request(
+      "GET",
+      this.repoPath(
+        `/issues?state=all&labels=${encodeURIComponent(label)}&per_page=100`,
+      ),
+    );
+  }
+
+  async listAssociatedPullRequests(sha) {
+    return this.request(
+      "GET",
+      this.repoPath(`/commits/${sha}/pulls?per_page=100`),
+    );
+  }
+
+  async listIssueComments(number) {
+    return this.request(
+      "GET",
+      this.repoPath(`/issues/${number}/comments?per_page=100`),
+    );
+  }
+
+  async createIssue(issue) {
+    return this.request("POST", this.repoPath("/issues"), issue);
+  }
+
+  async createIssueComment(number, body) {
+    return this.request(
+      "POST",
+      this.repoPath(`/issues/${number}/comments`),
+      { body },
+    );
+  }
+
+  async updateIssue(number, update) {
+    return this.request(
+      "PATCH",
+      this.repoPath(`/issues/${number}`),
+      update,
+    );
+  }
+}
+
+async function main() {
+  const event = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH, "utf8"),
+  );
+  const workflowRun = event.workflow_run;
+  const repository =
+    event.repository?.full_name ?? process.env.GITHUB_REPOSITORY;
+
+  if (
+    workflowRun.event !== "push" ||
+    workflowRun.head_branch !== event.repository.default_branch
+  ) {
+    console.log("Ignoring a workflow run that is not a default-branch push.");
+    return;
+  }
+
+  const client = new GitHubRestClient({
+    token: process.env.GITHUB_TOKEN,
+    repository,
+  });
+  const result = await reconcilePostMerge({
+    client,
+    repository,
+    workflowRun,
+  });
+  const summary = `Post-merge CI reconciliation: ${JSON.stringify(result)}`;
+  console.log(summary);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  POST_MERGE_LABEL,
+  occurrenceMarker,
+  reconcilePostMerge,
+} from "./report-post-merge-ci.mjs";
+
+class FakeClient {
+  constructor({
+    jobs = [],
+    issues = [],
+    comments = [],
+    pulls = [],
+    latestRun = null,
+  } = {}) {
+    this.jobs = jobs;
+    this.issues = issues;
+    this.comments = comments;
+    this.pulls = pulls;
+    this.latestRun = latestRun;
+    this.labels = new Set();
+    this.nextIssue = 100;
+  }
+
+  async ensureLabel(name) {
+    this.labels.add(name);
+  }
+
+  async listJobs() {
+    return this.jobs;
+  }
+
+  async latestCompletedWorkflowRun() {
+    return this.latestRun;
+  }
+
+  async listIssues() {
+    return this.issues;
+  }
+
+  async listAssociatedPullRequests() {
+    return this.pulls;
+  }
+
+  async listIssueComments(number) {
+    return this.comments.filter((comment) => comment.issue === number);
+  }
+
+  async createIssue(issue) {
+    const created = {
+      ...issue,
+      number: this.nextIssue,
+      state: "open",
+    };
+    this.nextIssue += 1;
+    this.issues.push(created);
+    return created;
+  }
+
+  async createIssueComment(number, body) {
+    this.comments.push({ issue: number, body });
+  }
+
+  async updateIssue(number, update) {
+    Object.assign(
+      this.issues.find((issue) => issue.number === number),
+      update,
+    );
+  }
+}
+
+function workflowRun(overrides = {}) {
+  return {
+    id: 41,
+    workflow_id: 7,
+    run_number: 12,
+    run_attempt: 1,
+    conclusion: "failure",
+    event: "push",
+    head_branch: "main",
+    head_sha: "0123456789abcdef0123456789abcdef01234567",
+    html_url: "https://github.com/ymm-oss/fsl/actions/runs/41",
+    ...overrides,
+  };
+}
+
+function failedWindowsJob(overrides = {}) {
+  return {
+    id: 90,
+    name: "native Z3 4.16 (windows-latest)",
+    conclusion: "failure",
+    html_url: "https://github.com/ymm-oss/fsl/actions/jobs/90",
+    steps: [
+      { name: "Set up job", conclusion: "success" },
+      { name: "Test pinned native solver", conclusion: "failure" },
+    ],
+    ...overrides,
+  };
+}
+
+test("creates one actionable issue for a failed job", async () => {
+  const client = new FakeClient({
+    jobs: [
+      failedWindowsJob(),
+      {
+        id: 99,
+        name: "product gate",
+        conclusion: "failure",
+        html_url: "https://github.com/ymm-oss/fsl/actions/jobs/99",
+        steps: [{ name: "Require complete product evidence", conclusion: "failure" }],
+      },
+    ],
+    pulls: [
+      {
+        number: 247,
+        html_url: "https://github.com/ymm-oss/fsl/pull/247",
+        merged_at: "2026-07-26T00:00:00Z",
+      },
+    ],
+  });
+
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun(),
+  });
+
+  assert.deepEqual(result, {
+    created: 1,
+    updated: 0,
+    closed: 0,
+    failures: 1,
+  });
+  assert.deepEqual(client.labels, new Set([POST_MERGE_LABEL]));
+  assert.equal(client.issues.length, 1);
+  assert.match(client.issues[0].title, /windows-latest/);
+  assert.doesNotMatch(client.issues[0].title, /^.*product gate.*$/);
+  assert.match(client.issues[0].body, /Test pinned native solver/);
+  assert.match(client.issues[0].body, /#247/);
+  assert.doesNotMatch(client.issues[0].body, /log output/i);
+});
+
+test("deduplicates the same run and comments once for a later recurrence", async () => {
+  const client = new FakeClient({ jobs: [failedWindowsJob()] });
+  const firstRun = workflowRun();
+
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: firstRun,
+  });
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: firstRun,
+  });
+
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.comments.length, 0);
+
+  const laterRun = workflowRun({
+    id: 42,
+    head_sha: "1123456789abcdef0123456789abcdef01234567",
+  });
+  client.jobs = [failedWindowsJob({ id: 91 })];
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: laterRun,
+  });
+
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.comments.length, 1);
+  assert.ok(client.comments[0].body.includes(occurrenceMarker(42, 91)));
+});
+
+test("closes the matching open issue after the job recovers", async () => {
+  const client = new FakeClient({ jobs: [failedWindowsJob()] });
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun(),
+  });
+
+  client.jobs = [
+    failedWindowsJob({
+      id: 92,
+      conclusion: "success",
+      steps: [{ name: "Test pinned native solver", conclusion: "success" }],
+    }),
+  ];
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun({
+      id: 43,
+      conclusion: "success",
+      head_sha: "2123456789abcdef0123456789abcdef01234567",
+    }),
+  });
+
+  assert.equal(result.closed, 1);
+  assert.equal(client.issues[0].state, "closed");
+  assert.match(client.comments[0].body, /Recovered on/);
+});
+
+test("reports a workflow-level failure when no failed job metadata exists", async () => {
+  const client = new FakeClient({ jobs: [] });
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun({ conclusion: "startup_failure" }),
+  });
+
+  assert.equal(result.created, 1);
+  assert.equal(result.failures, 1);
+  assert.match(client.issues[0].title, /product gate workflow/);
+  assert.match(client.issues[0].body, /No failed step metadata/);
+});
+
+test("reports the product aggregate when it is the only failed job", async () => {
+  const client = new FakeClient({
+    jobs: [
+      {
+        id: 101,
+        name: "product gate",
+        conclusion: "failure",
+        html_url: "https://github.com/ymm-oss/fsl/actions/jobs/101",
+        steps: [
+          {
+            name: "Require complete product evidence",
+            conclusion: "failure",
+          },
+        ],
+      },
+    ],
+  });
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun(),
+  });
+
+  assert.equal(result.created, 1);
+  assert.equal(result.failures, 1);
+  assert.match(client.issues[0].title, /\bproduct gate\b/);
+  assert.match(client.issues[0].body, /Require complete product evidence/);
+});
+
+test("redirects an out-of-order event to the latest completed product gate", async () => {
+  const client = new FakeClient({
+    latestRun: {
+      id: 50,
+      workflow_id: 7,
+      run_number: 13,
+      run_attempt: 1,
+      conclusion: "failure",
+      event: "push",
+      head_branch: "main",
+      head_sha: "4123456789abcdef0123456789abcdef01234567",
+      html_url: "https://github.com/ymm-oss/fsl/actions/runs/50",
+    },
+    jobs: [failedWindowsJob({ id: 95 })],
+  });
+
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun({ conclusion: "success" }),
+  });
+
+  assert.deepEqual(result, {
+    created: 1,
+    updated: 0,
+    closed: 0,
+    failures: 1,
+    redirectedFromRunId: 41,
+    reconciledRunId: 50,
+  });
+  assert.match(client.issues[0].body, /actions\/runs\/50/);
+  assert.match(client.issues[0].body, /`4123456789ab`/);
+});
+
+test("reopens the canonical issue when a recovered job fails again", async () => {
+  const client = new FakeClient({ jobs: [failedWindowsJob()] });
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun(),
+  });
+
+  client.jobs = [
+    failedWindowsJob({
+      id: 92,
+      conclusion: "success",
+      steps: [{ name: "Test pinned native solver", conclusion: "success" }],
+    }),
+  ];
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun({
+      id: 43,
+      run_number: 13,
+      conclusion: "success",
+      head_sha: "2123456789abcdef0123456789abcdef01234567",
+    }),
+  });
+  assert.equal(client.issues[0].state, "closed");
+
+  client.jobs = [failedWindowsJob({ id: 94 })];
+  const result = await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun({
+      id: 44,
+      run_number: 14,
+      head_sha: "3123456789abcdef0123456789abcdef01234567",
+    }),
+  });
+
+  assert.equal(result.created, 0);
+  assert.equal(result.updated, 1);
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.issues[0].state, "open");
+});
+
+test("records recovery separately for repeated attempts of one workflow run", async () => {
+  const client = new FakeClient({ jobs: [failedWindowsJob()] });
+  await reconcilePostMerge({
+    client,
+    repository: "ymm-oss/fsl",
+    workflowRun: workflowRun(),
+  });
+
+  for (const [runAttempt, conclusion, jobId] of [
+    [2, "success", 96],
+    [3, "failure", 97],
+    [4, "success", 98],
+  ]) {
+    client.jobs = [
+      failedWindowsJob({
+        id: jobId,
+        conclusion,
+        steps: [
+          {
+            name: "Test pinned native solver",
+            conclusion,
+          },
+        ],
+      }),
+    ];
+    await reconcilePostMerge({
+      client,
+      repository: "ymm-oss/fsl",
+      workflowRun: workflowRun({
+        run_attempt: runAttempt,
+        conclusion,
+      }),
+    });
+  }
+
+  const recoveryComments = client.comments.filter((comment) =>
+    comment.body.includes("post-merge-ci-recovery"),
+  );
+  assert.equal(recoveryComments.length, 2);
+  assert.notEqual(recoveryComments[0].body, recoveryComments[1].body);
+  assert.equal(client.issues[0].state, "closed");
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: product gate
 
 env:
   MACOSX_DEPLOYMENT_TARGET: "14.0"
@@ -17,9 +17,22 @@ on:
 permissions:
   contents: read
 
+# During rollout, pull requests into main keep the full product gate until the
+# `merge readiness` context is installed in the main ruleset. Once the ruleset
+# is switched, set the repository variable FSL_OPTIMISTIC_CI=enabled. Product
+# gates for main pushes, schedules, manual runs, and production promotions never
+# honor that opt-out.
+concurrency:
+  group: product-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   rust-workspace:
     name: rust workspace
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'main' ||
+      vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -38,6 +51,10 @@ jobs:
 
   wasm:
     name: WASM
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'main' ||
+      vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -78,6 +95,10 @@ jobs:
 
   rust-native-z3:
     name: native Z3 4.16 (${{ matrix.os }})
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'main' ||
+      vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
@@ -97,3 +118,61 @@ jobs:
       - name: Test pinned native solver and BMC crates
         working-directory: rust
         run: cargo test --locked -p fsl-solver-z3 -p fsl-verifier -p fslc-rust
+
+  production-native-z3-linux:
+    name: native Z3 4.16 (ubuntu-latest)
+    if: github.event_name == 'pull_request' && github.base_ref == 'production'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Test pinned native solver and BMC crates
+        working-directory: rust
+        run: cargo test --locked -p fsl-solver-z3 -p fsl-verifier -p fslc-rust
+
+  product-gate:
+    name: product gate
+    if: >-
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        github.base_ref != 'main' ||
+        vars.FSL_OPTIMISTIC_CI != 'enabled'
+      )
+    needs:
+      - rust-workspace
+      - wasm
+      - rust-native-z3
+      - production-native-z3-linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require complete product evidence
+        env:
+          RUST_WORKSPACE: ${{ needs.rust-workspace.result }}
+          WASM: ${{ needs.wasm.result }}
+          NATIVE_Z3: ${{ needs.rust-native-z3.result }}
+          PRODUCTION_NATIVE_Z3_LINUX: ${{ needs.production-native-z3-linux.result }}
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          failures=0
+          for result in "$RUST_WORKSPACE" "$WASM" "$NATIVE_Z3"; do
+            if [ "$result" != "success" ]; then
+              failures=1
+            fi
+          done
+          if [ "$BASE_REF" = "production" ] && [ "$PRODUCTION_NATIVE_Z3_LINUX" != "success" ]; then
+            failures=1
+          fi
+          if [ "$failures" -ne 0 ]; then
+            echo "product gate failed: rust=$RUST_WORKSPACE wasm=$WASM native-z3=$NATIVE_Z3 production-linux=$PRODUCTION_NATIVE_Z3_LINUX" >&2
+            exit 1
+          fi

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           workspaces: rust -> target
 
-      - name: Check every Rust target
+      - name: Check the native-Z3-free Rust surface
         run: ./tools/check-merge-readiness.sh compile
 
   core-contracts:

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: merge readiness
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merge-readiness-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  rust-compile:
+    name: merge readiness / Rust compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Check every Rust target
+        run: ./tools/check-merge-readiness.sh compile
+
+  core-contracts:
+    name: merge readiness / core contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Check solver-independent contracts
+        run: ./tools/check-merge-readiness.sh core
+
+  automation-contracts:
+    name: merge readiness / automation contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test post-merge issue reconciliation
+        run: ./tools/check-merge-readiness.sh automation
+
+  merge-readiness:
+    name: merge readiness
+    if: always()
+    needs:
+      - rust-compile
+      - core-contracts
+      - automation-contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every readiness lane
+        env:
+          RUST_COMPILE: ${{ needs.rust-compile.result }}
+          CORE_CONTRACTS: ${{ needs.core-contracts.result }}
+          AUTOMATION_CONTRACTS: ${{ needs.automation-contracts.result }}
+        shell: bash
+        run: |
+          failures=0
+          for result in "$RUST_COMPILE" "$CORE_CONTRACTS" "$AUTOMATION_CONTRACTS"; do
+            if [ "$result" != "success" ]; then
+              failures=1
+            fi
+          done
+          if [ "$failures" -ne 0 ]; then
+            echo "merge readiness failed: compile=$RUST_COMPILE core=$CORE_CONTRACTS automation=$AUTOMATION_CONTRACTS" >&2
+            exit 1
+          fi

--- a/.github/workflows/post-merge-ci-reporter.yml
+++ b/.github/workflows/post-merge-ci-reporter.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: post-merge CI reporter
+
+on:
+  workflow_run:
+    workflows: ["product gate"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+# Only one reporter mutates the deduplicated issue set at a time. If product
+# gates finish faster than reporting, GitHub coalesces pending reporters toward
+# the newest default-branch health state while the product-gate evidence itself
+# remains attached to every merged commit.
+concurrency:
+  group: post-merge-ci-reporter
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: reconcile post-merge CI issue
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Test reporter contract
+        run: node --test .github/scripts/report-post-merge-ci.test.mjs
+
+      - name: Create, update, or resolve CI issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/report-post-merge-ci.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,11 @@ The complete required product gate has one Rust-native entrypoint and does not e
 ./tools/check-native-integration.sh
 ```
 
+Pull requests into `main` may use the bounded `merge readiness` gate defined in
+`docs/DESIGN-ci.md`; it is not product verification. Every merged `main` state and every
+production/release promotion must still receive the complete product evidence. Do not hide a
+post-merge product-gate failure or treat its automatically created issue as a waiver.
+
 Python is optional and is used only for changes explicitly scoped to the frozen compatibility
 reference or Python-based repository hooks. Native solver changes should also run
 the focused `fsl-solver-z3`, `fsl-verifier`, and `fslc-rust` tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   production promotion. Failed post-merge jobs now create or update
   deduplicated `ci/post-merge` issues and close them only after observed
   recovery; rollout is fail-safe behind the `FSL_OPTIMISTIC_CI` repository
-  variable.
+  variable. The readiness compile lane deliberately excludes native-Z3 and
+  default-feature builds, which remain mandatory post-merge evidence.
 - Native `analyze`'s TSG projection now emits `requirement`/`acceptance`/
   `forbidden`/`kpi` nodes and `covers` edges for a standalone `.fsl`/
   requirements spec, not only for a `.toml` project manifest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   failure and echoing `helpful` on both the proof and CTI (#473).
 
 ### Added
+- Added an optimistic CI lane with one stable, parallelized `merge readiness`
+  context for pull requests and merge queues, while preserving the complete
+  Rust/WASM/macOS/Windows product gate for every merged `main` state and
+  production promotion. Failed post-merge jobs now create or update
+  deduplicated `ci/post-merge` issues and close them only after observed
+  recovery; rollout is fail-safe behind the `FSL_OPTIMISTIC_CI` repository
+  variable.
 - Native `analyze`'s TSG projection now emits `requirement`/`acceptance`/
   `forbidden`/`kpi` nodes and `covers` edges for a standalone `.fsl`/
   requirements spec, not only for a `.toml` project manifest.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -23,18 +23,22 @@ reverted; they are not informational warnings.
 `main`. The ruleset requires only its always-present `merge readiness` aggregator. The aggregator
 fails unless all of these independent lanes succeed:
 
-1. `cargo check --workspace --all-targets --locked` catches compile and feature-integration drift
-   across the complete authoritative Rust workspace.
+1. `cargo check` over the explicit `fsl-syntax`, `fsl-core`, `fsl-runtime`, `fsl-solver`,
+   `fsl-solver-z3js`, `fsl-verifier`, `fsl-tools`, `fsl-wasm`, and `fsl-lsp` package set with
+   `--no-default-features --locked` catches compile and dependency-integration drift across the
+   authoritative native-Z3-free Rust surface without paying the vendored native-Z3 build cost
+   before merge.
 2. Formatting, the `fsl-syntax`, `fsl-core`, `fsl-runtime`, and backend-neutral `fsl-solver` tests,
    plus the runtime/WASM dependency negative controls, protect the solver-independent semantic
    foundation.
 3. The post-merge issue reporter contract tests protect failure creation, duplicate suppression,
    recurrence updates, recovery closure, and workflow-level failure handling.
 
-The lanes run in parallel through `tools/check-merge-readiness.sh`. Clippy, native Z3 verification,
-the complete LSP/corpus suites, the full workspace test/build, JavaScript solver probes, and browser
-Worker validation remain product-gate evidence. A green readiness check must never be rendered or
-documented as a fully verified product.
+The lanes run in parallel through `tools/check-merge-readiness.sh`. Native-CLI/default-feature
+compilation, all-target compilation, Clippy, native Z3 verification, the complete LSP/corpus suites,
+the full workspace test/build, JavaScript solver probes, and browser Worker validation remain
+product-gate evidence. A green readiness check must never be rendered or documented as a fully
+verified product.
 
 Superseded runs for the same pull request are cancelled. Merge-group runs are not cancelled and the
 workflow handles GitHub's `merge_group` event directly, so a merge queue can validate the combined

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -1,0 +1,115 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Optimistic merge and post-merge product validation
+
+Status: Accepted
+
+## Decision
+
+Pull requests into `main` have one stable required context, `merge readiness`. It is a bounded,
+short-latency confidence gate, not a claim that the product is fully verified. The complete
+Rust/WASM/native-platform product gate runs after every push to `main`, on schedule, on manual
+dispatch, and before promotion to `production`.
+
+This deliberately changes `main` from "every supported platform was green before merge" to
+"reviewed changes passed a bounded readiness gate and every merged state is then fully validated."
+A post-merge failure can therefore expose a temporarily broken `main`. The failed check and its
+deduplicated issue are blocking evidence for production/release promotion and must be repaired or
+reverted; they are not informational warnings.
+
+## Merge readiness contract
+
+`.github/workflows/merge-readiness.yml` runs for `pull_request` and `merge_group` events targeting
+`main`. The ruleset requires only its always-present `merge readiness` aggregator. The aggregator
+fails unless all of these independent lanes succeed:
+
+1. `cargo check --workspace --all-targets --locked` catches compile and feature-integration drift
+   across the complete authoritative Rust workspace.
+2. Formatting, the `fsl-syntax`, `fsl-core`, `fsl-runtime`, and backend-neutral `fsl-solver` tests,
+   plus the runtime/WASM dependency negative controls, protect the solver-independent semantic
+   foundation.
+3. The post-merge issue reporter contract tests protect failure creation, duplicate suppression,
+   recurrence updates, recovery closure, and workflow-level failure handling.
+
+The lanes run in parallel through `tools/check-merge-readiness.sh`. Clippy, native Z3 verification,
+the complete LSP/corpus suites, the full workspace test/build, JavaScript solver probes, and browser
+Worker validation remain product-gate evidence. A green readiness check must never be rendered or
+documented as a fully verified product.
+
+Superseded runs for the same pull request are cancelled. Merge-group runs are not cancelled and the
+workflow handles GitHub's `merge_group` event directly, so a merge queue can validate the combined
+candidate against current `main`.
+
+## Product gate contract
+
+`.github/workflows/ci.yml` is named `product gate`. A trusted `main` push runs all of these jobs in
+parallel:
+
+- the complete Rust-native integration phase from `tools/check-native-integration.sh rust`;
+- the production WASM/browser phase from `tools/check-native-integration.sh wasm`;
+- focused native-Z3 tests on macOS and Windows.
+
+Scheduled and manual runs use the same evidence. Pull requests into `production` also run the
+complete product gate and emit the Linux native-Z3 compatibility context expected by the production
+ruleset. Release jobs retain their independent four-target build, smoke, ABI, LSP, and packaging
+checks. An always-running `product gate` aggregator fails unless every required lane emitted
+successful evidence; an accidentally skipped lane cannot make the workflow confidently green.
+
+Product-gate runs for merged commits are not cancelled. Each merged state therefore retains its own
+portable evidence and failure attribution even when agents merge changes quickly.
+
+## Failure reporting contract
+
+`.github/workflows/post-merge-ci-reporter.yml` listens for completed `product gate` runs. It acts
+only when the triggering run was a push to the repository's default branch. The workflow receives
+read access to Actions, contents, and pull requests, and write access only to issues.
+
+For each failed, timed-out, cancelled, stale, startup-failed, or action-required job, the reporter:
+
+- creates the `ci/post-merge` label when necessary;
+- creates one canonical issue keyed by the product-gate workflow ID and stable job name, reopening
+  the same issue after a later recurrence;
+- records the commit, associated merged pull request, run, job, conclusion, and failed step names;
+- copies no build log text or secret-bearing output into the issue;
+- adds one occurrence comment for a later failing run instead of opening a duplicate;
+- closes the matching issue only after that job, or the complete product gate, succeeds on a later
+  `main` run.
+
+An unsuccessful workflow with no failed-job metadata gets a workflow-level issue, so startup and
+orchestration failures do not disappear. Re-running the reporter for the same product-gate run is
+idempotent. Before mutating issues, the reporter queries the latest completed trusted push run for
+the same workflow. When an older `run_number`/`run_attempt` event arrives, it reconciles that latest
+run instead of the stale trigger; out-of-order platform completion cannot overwrite newer
+default-branch health or cancel the only reporter for a persistent newer failure.
+
+Reporter jobs are also serialized to avoid duplicate-creation races. When product gates finish
+faster than reporting, GitHub may coalesce pending reporter runs toward the newest default-branch
+health state; the underlying product-gate result remains attached to every merged commit, and any
+failure that persists at the current `main` head remains an open issue.
+When a concrete lane and the aggregate `product gate` job fail together, only the concrete lane is
+reported; the aggregate is reported on its own only when it is the sole available failure.
+
+## Safe rollout and rollback
+
+The workflow change must land before the ruleset changes; otherwise existing pull requests cannot
+produce the new required context. Roll out in this order:
+
+1. Merge the workflow change under the existing four required product checks. Until activation,
+   pull requests into `main` continue running the full product gate.
+2. In the `main` repository ruleset, add `merge readiness`, then remove `rust workspace`, `WASM`,
+   `native Z3 4.16 (macos-15)`, and `native Z3 4.16 (windows-latest)` from the required contexts.
+3. Set the repository Actions variable `FSL_OPTIMISTIC_CI=enabled`. This disables the redundant full
+   product gate on pull requests into `main`; main pushes, schedules, manual runs, and production
+   promotions ignore the variable.
+4. Optionally enable auto-merge and a merge queue after the `merge_group` check is observed.
+
+Rollback is fail-safe: delete or change `FSL_OPTIMISTIC_CI`, restore the four product contexts in the
+main ruleset, and keep `merge readiness` as additional evidence. No source or product artifact
+migration is involved.
+
+## Non-goals
+
+- Treating issue creation as a substitute for repair, revert, or release blocking.
+- Hiding platform failures with `continue-on-error`.
+- Trusting agent-authored verification claims in place of independent GitHub-hosted execution.
+- Changing FSL language, Kernel, CLI/JSON, LSP, Worker, or frozen Python compatibility behavior.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -23,11 +23,11 @@ reverted; they are not informational warnings.
 `main`. The ruleset requires only its always-present `merge readiness` aggregator. The aggregator
 fails unless all of these independent lanes succeed:
 
-1. `cargo check` over the explicit `fsl-syntax`, `fsl-core`, `fsl-runtime`, `fsl-solver`,
-   `fsl-solver-z3js`, `fsl-verifier`, `fsl-tools`, `fsl-wasm`, and `fsl-lsp` package set with
-   `--no-default-features --locked` catches compile and dependency-integration drift across the
+1. `cargo check --workspace --exclude fsl-solver-z3 --exclude fslc-rust
+   --no-default-features --locked` catches compile and dependency-integration drift across the
    authoritative native-Z3-free Rust surface without paying the vendored native-Z3 build cost
-   before merge.
+   before merge. Excluding the native CLI package as a workspace root avoids its Z3-only helper
+   binaries; its library still compiles transitively through the LSP and WASM crates.
 2. Formatting, the `fsl-syntax`, `fsl-core`, `fsl-runtime`, and backend-neutral `fsl-solver` tests,
    plus the runtime/WASM dependency negative controls, protect the solver-independent semantic
    foundation.

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -60,9 +60,9 @@ gate; changes to those hooks must invoke the two named tests directly.
 ## Merge readiness and product evidence
 
 Pull requests into `main` use the bounded `merge readiness` contract from
-[`DESIGN-ci.md`](DESIGN-ci.md). It compiles every Rust target and tests the solver-independent
-semantic foundation, dependency negative controls, and post-merge automation, but it is not the
-required product integration gate defined above.
+[`DESIGN-ci.md`](DESIGN-ci.md). It compiles the native-Z3-free Rust surface and tests the
+solver-independent semantic foundation, dependency negative controls, and post-merge automation,
+but it is not the required product integration gate defined above.
 
 Every merged `main` state still executes the complete Rust/WASM gate plus focused native-Z3 tests on
 macOS and Windows. Pull requests into `production` and tag-driven releases retain full

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -57,11 +57,24 @@ The Claude/Codex environment tests execute Python repository hooks, not the FSL 
 They remain focused manual tooling checks and are deliberately outside the required native product
 gate; changes to those hooks must invoke the two named tests directly.
 
-## Timing and portability
+## Merge readiness and product evidence
+
+Pull requests into `main` use the bounded `merge readiness` contract from
+[`DESIGN-ci.md`](DESIGN-ci.md). It compiles every Rust target and tests the solver-independent
+semantic foundation, dependency negative controls, and post-merge automation, but it is not the
+required product integration gate defined above.
+
+Every merged `main` state still executes the complete Rust/WASM gate plus focused native-Z3 tests on
+macOS and Windows. Pull requests into `production` and tag-driven releases retain full
+cross-platform evidence. A platform-specific failure may therefore be detected after merge, but it
+must create a tracked issue and prevents promotion rather than being hidden or allowlisted.
+
+## Historical timing and portability
 
 Immediately before this change, the separate Python contract job took 67 seconds on GitHub Actions,
 including 44 seconds in pytest, while the Rust/WASM job took about 10 minutes on a cold runner. The
 single gate removes the Python environment and job rather than hiding it behind another wrapper.
-Native solver tests continue on Linux, macOS ARM, macOS Intel, and Windows for every change; generated
-artifact digests normalize path separators, checked-in FSL source uses LF on every runner, and
-testgen templates normalize line endings so identical text has one cross-platform identity.
+Native solver tests continue on Linux, macOS, and Windows for every merged main state and production
+promotion; generated artifact digests normalize path separators, checked-in FSL source uses LF on
+every runner, and testgen templates normalize line endings so identical text has one cross-platform
+identity.

--- a/docs/RUST-PORTING.md
+++ b/docs/RUST-PORTING.md
@@ -128,7 +128,7 @@ Status as of 2026-07-12:
 | browser Worker asset loading / COOP+COEP | isolated Chrome loaded the bundled Worker, separate Emscripten JS/WASM and pthread script with no console errors; `crossOriginIsolated=true`, `sat`, model `x=42` | **proved in browser** |
 | JS term bridge | observed roughly 29k–42k terms/s at 1,000 terms and 60k terms/s at 10,000 terms on the development machine | **start with typed per-term calls** |
 | v1 native scope | issue #195 requests a full replacement, including db/AI/domain and report generators in Phase 3 | **decided: no permanent Python command fallback** |
-| CI and native targets | PR parity runs Rust stable + Python 3.12 + Node 22 + Chrome on Ubuntu; main/scheduled runs add native Z3 tests on Linux, macOS, and Windows | **implemented for the current kernel slice** |
+| CI and native targets | PR readiness compiles the complete Rust workspace and tests the solver-independent core on Ubuntu; every merged main state runs the complete Rust/WASM gate plus native Z3 tests on Linux, macOS, and Windows | **implemented; see `DESIGN-ci.md`** |
 
 The Phase-0 syntax, dependency, browser, and decision gates are complete. The
 Phase-1 semantic kernel is complete: resolver-backed compose lowering, the typed
@@ -151,10 +151,14 @@ semantics and pass every cross-backend gate.
 The supported native release matrix is
 `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`,
 `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc`. Pull requests keep one
-fast Ubuntu Rust/parity/browser job. Once `fsl-solver-z3` lands, pushes to main
-and releases add Linux/macOS/Windows native jobs; browser parity remains an
-Ubuntu headless-Chrome job. A target is not advertised until the native Z3
-backend and CLI smoke corpus run on that target in CI.
+stable `merge readiness` context backed by parallel Ubuntu compile,
+solver-independent semantic, dependency-boundary, and automation-contract
+lanes. It is not product verification. Pushes to main and production
+promotions run the complete Rust/WASM product gate plus Linux/macOS/Windows
+native evidence; browser parity remains an Ubuntu headless-Chrome job. A target
+is not advertised until the native Z3 backend and CLI smoke corpus run on that
+target in the product gate. See [`DESIGN-ci.md`](DESIGN-ci.md) for rollout,
+failure reporting, and release-blocking semantics.
 
 ## 5. Commands
 

--- a/docs/RUST-PORTING.md
+++ b/docs/RUST-PORTING.md
@@ -128,7 +128,7 @@ Status as of 2026-07-12:
 | browser Worker asset loading / COOP+COEP | isolated Chrome loaded the bundled Worker, separate Emscripten JS/WASM and pthread script with no console errors; `crossOriginIsolated=true`, `sat`, model `x=42` | **proved in browser** |
 | JS term bridge | observed roughly 29k–42k terms/s at 1,000 terms and 60k terms/s at 10,000 terms on the development machine | **start with typed per-term calls** |
 | v1 native scope | issue #195 requests a full replacement, including db/AI/domain and report generators in Phase 3 | **decided: no permanent Python command fallback** |
-| CI and native targets | PR readiness compiles the complete Rust workspace and tests the solver-independent core on Ubuntu; every merged main state runs the complete Rust/WASM gate plus native Z3 tests on Linux, macOS, and Windows | **implemented; see `DESIGN-ci.md`** |
+| CI and native targets | PR readiness compiles the native-Z3-free Rust surface and tests the solver-independent core on Ubuntu; every merged main state runs the complete Rust/WASM gate plus native Z3 tests on Linux, macOS, and Windows | **implemented; see `DESIGN-ci.md`** |
 
 The Phase-0 syntax, dependency, browser, and decision gates are complete. The
 Phase-1 semantic kernel is complete: resolver-backed compose lowering, the typed

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+check_compile() {
+  cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --locked
+}
+
+check_core_contracts() {
+  cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+  cargo test \
+    --manifest-path rust/Cargo.toml \
+    --locked \
+    -p fsl-syntax \
+    -p fsl-core \
+    -p fsl-runtime \
+    -p fsl-solver
+  ./tools/check-native-integration.sh boundaries
+}
+
+check_automation() {
+  node --test .github/scripts/report-post-merge-ci.test.mjs
+}
+
+case "${1:-all}" in
+  compile)
+    check_compile
+    ;;
+  core)
+    check_core_contracts
+    ;;
+  automation)
+    check_automation
+    ;;
+  all)
+    check_core_contracts
+    check_compile
+    check_automation
+    ;;
+  *)
+    echo "usage: $0 [all|compile|core|automation]" >&2
+    exit 2
+    ;;
+esac

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -9,15 +9,9 @@ cd "$root"
 check_compile() {
   cargo check \
     --manifest-path rust/Cargo.toml \
-    -p fsl-syntax \
-    -p fsl-core \
-    -p fsl-runtime \
-    -p fsl-solver \
-    -p fsl-solver-z3js \
-    -p fsl-verifier \
-    -p fsl-tools \
-    -p fsl-wasm \
-    -p fsl-lsp \
+    --workspace \
+    --exclude fsl-solver-z3 \
+    --exclude fslc-rust \
     --no-default-features \
     --locked
 }

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -7,7 +7,19 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
 check_compile() {
-  cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --locked
+  cargo check \
+    --manifest-path rust/Cargo.toml \
+    -p fsl-syntax \
+    -p fsl-core \
+    -p fsl-runtime \
+    -p fsl-solver \
+    -p fsl-solver-z3js \
+    -p fsl-verifier \
+    -p fsl-tools \
+    -p fsl-wasm \
+    -p fsl-lsp \
+    --no-default-features \
+    --locked
 }
 
 check_core_contracts() {

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -24,6 +24,10 @@ check_rust() {
   cargo test --manifest-path rust/Cargo.toml --workspace --exclude fsl-lsp --locked
   cargo build --manifest-path rust/Cargo.toml --workspace --locked
 
+  check_boundaries
+}
+
+check_boundaries() {
   assert_dependency_absent fsl-runtime 'fsl-solver|z3' 'fsl-runtime must remain solver-independent'
   assert_dependency_absent fsl-wasm 'fsl-solver-z3 v' 'fsl-wasm must not depend on the native Z3 backend'
 }
@@ -44,12 +48,15 @@ case "${1:-all}" in
   wasm)
     check_wasm
     ;;
+  boundaries)
+    check_boundaries
+    ;;
   all)
     check_rust
     check_wasm
     ;;
   *)
-    echo "usage: $0 [all|rust|wasm]" >&2
+    echo "usage: $0 [all|rust|wasm|boundaries]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Problem

Every pull request currently waits for the complete Ubuntu Rust, WASM, macOS Z3,
and Windows Z3 matrix. Recent runs are normally gated for roughly 16 minutes by
both `rust workspace` and Windows, which makes parallel AI-driven delivery wait
on duplicate pre- and post-merge evidence.

The full matrix is still valuable: the recent observed PR failures were
Windows-only. This change therefore moves product assurance in time instead of
deleting it.

Linked issue: none (direct repository request).

## Contract change

- Add one stable `merge readiness` context for pull requests and merge queues
  targeting `main`.
  - native-Z3-free workspace compile with default features disabled; new
    workspace members are included fail-closed
  - solver-independent syntax/core/runtime/solver tests and dependency negative
    controls
  - post-merge reporter contract tests
- Keep the complete authoritative product gate for every `main` push, schedule,
  manual run, and production promotion.
  - full Rust-native integration, default features, and every target
  - WASM/browser integration
  - macOS and Windows native Z3
  - stable aggregate that rejects skipped/cancelled evidence
- Restore the Linux native-Z3 context currently required by the production
  ruleset.
- Add a trusted `workflow_run` reporter with least-privilege `issues: write`.
  - one canonical `ci/post-merge` issue per workflow/job
  - recurrence comments and reopen after recovery
  - close only after observed recovery
  - no build logs copied into issues
  - out-of-order/coalesced reporters always reconcile the latest completed
    product run
- Record the accepted operational contract in `docs/DESIGN-ci.md`, and align
  contributor/Rust-port/changelog authority.

## Safe rollout after merge

This PR is fail-safe: because `FSL_OPTIMISTIC_CI` is currently unset, the
existing four required checks still run for this rollout PR and for later PRs
until activation.

1. Merge this PR under the current required checks.
2. In the `main` ruleset, require `merge readiness`, then remove:
   - `rust workspace`
   - `WASM`
   - `native Z3 4.16 (macos-15)`
   - `native Z3 4.16 (windows-latest)`
3. Set repository Actions variable `FSL_OPTIMISTIC_CI=enabled`.
4. Optionally enable auto-merge / merge queue after the `merge_group` check is
   observed.

Rollback is to unset the variable and restore the four product contexts; no
source or artifact migration is involved.

## Verification

- native-Z3-free compile from an empty target directory: 10.56 seconds
  (the first full-workspace attempt took 15m55s, almost entirely in vendored Z3)
- solver-independent core contract suite
- `./tools/check-native-integration.sh rust`
- `./tools/check-native-integration.sh wasm`
- reporter regression suite: 8/8 passed
- `shellcheck` on both changed shell entrypoints
- actionlint v1.7.12 on all changed/new workflows
- `git diff --check`
- independent review; the package-allowlist fail-open finding was corrected

## Risk and operating posture

A platform-specific failure can temporarily exist on `main`; that is the
explicit latency tradeoff. The product check remains red, creates/reopens an
actionable issue, and blocks production/release promotion. The issue is
evidence and a repair queue, not a waiver.
