### PR TITLE
fix(domain): fold nested verdicts, drive real replay detection, and reject unknown arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   only), and `generated:true` origin provenance on the SLA-synthesized
   `tick` action and `_deadline_*` invariants (previously indistinguishable
   from authored declarations) (#530).
+- `fslc domain check` now folds a nested kernel's non-`verified`/`proved`
+  result (`violated`, `reachable_failed`, `unknown_cti`, `unknown_budget`)
+  into the top-level verdict and exit code instead of unconditionally
+  reporting `result:"verified_under_assumptions"`/`formal_result:"verified"`/
+  exit 0 regardless of what `kernel.result` actually said — a confidently
+  green false negative on a domain whose aggregate invariant the kernel
+  proves violated. `run_domain_check` also now returns a non-{0,1} `verify`
+  status (spec error, internal error) verbatim instead of letting it reach
+  `check_domain` and be misread as a kernel result, and the internal
+  `stable_kernel_projection` allowlist gained the violated-path evidence
+  keys (`loc`, `violated_at_step`, `violating_bindings`, `blame`,
+  `last_action`, `trace`) so the nested `kernel` stays a replayable
+  counterexample rather than only the bare verdict string (#515).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,6 +408,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   keys (`loc`, `violated_at_step`, `violating_bindings`, `blame`,
   `last_action`, `trace`) so the nested `kernel` stays a replayable
   counterexample rather than only the bare verdict string (#515).
+- `fslc domain replay` now actually drives a concrete Monitor over the
+  lowered domain/effect model — stepping `command` and `effect_completion`
+  log entries as real action calls — instead of only maintaining a
+  `(effect, correlation_id)` bookkeeping set. Previously only 1 of the 4
+  documented detection categories (completion without a prior request)
+  could fire; a rejected command, a duplicate irreversible effect commit,
+  and a lifecycle ordering mismatch (e.g. a completion observed after the
+  aggregate moved into a state that rejects it) all silently passed as
+  `conformance_checked`/exit 0. `unknown_domain_event`, `unknown_effect`,
+  `effect_completion_event_not_declared`, and `unknown_runtime_event_kind`
+  (including a `{"kind": ...}`-keyed log entry, which previously evaluated
+  zero log lines and still reported success) are also now detected, and
+  `final_state`/`assumptions` are populated from the same Monitor and
+  assumption computation `domain analyze` already uses instead of always
+  returning `{}`/`[]` (#518).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `final_state`/`assumptions` are populated from the same Monitor and
   assumption computation `domain analyze` already uses instead of always
   returning `{}`/`[]` (#518).
+- `fslc domain replay` and `fslc domain analyze` now reject an unrecognized
+  trailing argument (`result:"error"`/`kind:"usage"`/exit 2), matching
+  every other `domain` subcommand and the rest of the CLI, instead of
+  silently discarding it and returning a result computed without it (#516).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/rust/fsl-tools/src/domain.rs
+++ b/rust/fsl-tools/src/domain.rs
@@ -135,8 +135,19 @@ pub fn check_domain(domain: &DomainSpec, kernel: &Value) -> Result<Value, fsl_co
             json!({"result":"violated","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"formal_result":"not_run","findings":findings,"assumptions":assumptions,"kernel_source":kernel_source}),
         )
     } else {
+        // The nested kernel is the ground truth for the aggregate-invariant
+        // verdict: only "verified"/"proved" may report success. Every other
+        // kernel result (violated, reachable_failed, unknown_cti,
+        // unknown_budget, ...) must fold through to the top-level verdict,
+        // matching the frozen Python reference's `domain_check.py`.
+        let kernel_result = kernel.get("result").cloned().unwrap_or(Value::Null);
+        let result = if matches!(kernel_result.as_str(), Some("verified" | "proved")) {
+            "verified_under_assumptions"
+        } else {
+            "violated"
+        };
         Ok(
-            json!({"result":"verified_under_assumptions","dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"spec":domain.name,"formal_result":"verified","kernel":kernel,"findings":findings,"assumptions":assumptions,"generated_actions":actions(domain)}),
+            json!({"result":result,"dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"spec":domain.name,"formal_result":kernel_result,"kernel":kernel,"findings":findings,"assumptions":assumptions,"generated_actions":actions(domain)}),
         )
     }
 }

--- a/rust/fsl-tools/src/domain.rs
+++ b/rust/fsl-tools/src/domain.rs
@@ -5,7 +5,12 @@ use serde_json::{Value, json};
 
 use crate::domain_naming::snake;
 
-fn assumptions(domain: &DomainSpec) -> Vec<Value> {
+/// The standing `fsl-domain` assumptions for a domain document. Exposed for
+/// `fslc domain replay`'s wiring, which needs the same finite-domain-model /
+/// generated-scaffold / saga-observed-history set that `check`/`analyze`
+/// already compute here, rather than a duplicated copy.
+#[must_use]
+pub fn assumptions(domain: &DomainSpec) -> Vec<Value> {
     let mut values = vec![
         json!({"id":"DOMAIN-ASSUME-FINITE-DOMAIN-MODEL","text":"domain IDs and undeclared scalar input types are modeled as finite 0..1 ranges unless declared explicitly"}),
         json!({"id":"DOMAIN-ASSUME-GENERATED-SCAFFOLD","text":"generated Functional DDD code is an implementation scaffold; runtime conformance still requires an adapter/replay evidence boundary"}),

--- a/rust/fsl-tools/src/lib.rs
+++ b/rust/fsl-tools/src/lib.rs
@@ -110,8 +110,8 @@ pub use document_render::{
     AppliedApproval, AppliedApprovals, RenderedDocument, render_requirements_document,
 };
 pub use domain::{
-    analyze_domain, check_domain, domain_adapter_files, domain_kernel_source, domain_scaffold,
-    domain_scaffold_metadata,
+    analyze_domain, assumptions as domain_assumptions, check_domain, domain_adapter_files,
+    domain_kernel_source, domain_scaffold, domain_scaffold_metadata,
 };
 pub use html::render_html_report;
 pub use ledger::{render_ledger, render_ledger_with_approvals};

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5900,6 +5900,15 @@ fn stable_kernel_projection(kernel: Value) -> Value {
             "completeness",
             "invariant",
             "violation_kind",
+            // Replayable evidence for a violated/reachable_failed/unknown_cti/
+            // unknown_budget kernel result (AGENTS.md: "Do not allowlist
+            // verdict, location, assurance, or exit-code differences").
+            "loc",
+            "violated_at_step",
+            "violating_bindings",
+            "blame",
+            "last_action",
+            "trace",
         ]
         .into_iter()
         .filter_map(|key| {
@@ -6589,7 +6598,12 @@ fn run_domain_check(
         }
     };
     let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
-    if status == 2 {
+    // Only a definitive kernel verdict (status 0 = verified/proved, status 1 =
+    // violated/reachable_failed/unknown_cti/unknown_budget) has a `result`
+    // that `check_domain` can safely fold into the top-level verdict. Any
+    // other status (2 = spec error, 3 = internal error, ...) must return the
+    // kernel envelope verbatim rather than let it be misread downstream.
+    if status != 0 && status != 1 {
         return apply_domain_edition((kernel, status), path, path, edition);
     }
     let result = match fsl_tools::check_domain(&domain, &stable_kernel_projection(kernel)) {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6704,6 +6704,119 @@ fn run_domain_generate(
     wrap_specialized(result)
 }
 
+/// Coerce a runtime-log JSON scalar to the finite integer domain that
+/// `DOMAIN-ASSUME-FINITE-DOMAIN-MODEL` models domain IDs and correlation
+/// values as, mirroring the frozen Python reference's `_coerce_int`
+/// (`src/fslc/domain_replay.py`): best-effort, defaulting to 0 rather than
+/// rejecting the log entry outright.
+#[allow(clippy::cast_possible_truncation)]
+fn domain_replay_coerce_int(value: &Value) -> FslValue {
+    let parsed = match value {
+        Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_f64().map(|value| value as i64)),
+        Value::String(text) => text.trim().parse::<i64>().ok(),
+        Value::Bool(flag) => Some(i64::from(*flag)),
+        _ => None,
+    };
+    FslValue::Int(parsed.unwrap_or(0))
+}
+
+fn domain_replay_params(
+    entry: &Map<String, Value>,
+) -> std::collections::BTreeMap<String, FslValue> {
+    entry
+        .get("params")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flatten()
+        .map(|(key, value)| (key.clone(), domain_replay_coerce_int(value)))
+        .collect()
+}
+
+/// `entry.get("correlation_id")`, falling back to `params.correlation_id`,
+/// stringified — mirrors `_correlation_value` in the Python reference.
+fn domain_replay_correlation_value(entry: &Map<String, Value>) -> Option<String> {
+    let value = entry.get("correlation_id").cloned().or_else(|| {
+        entry
+            .get("params")
+            .and_then(Value::as_object)
+            .and_then(|params| params.get("correlation_id"))
+            .cloned()
+    })?;
+    Some(match value {
+        Value::String(text) => text,
+        Value::Number(number) => number.to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        other => other.to_string(),
+    })
+}
+
+/// The event-name field of an effect's `correlation_id Event.field` clause,
+/// i.e. the action parameter that carries the correlation value. Mirrors
+/// `_correlation_field` in the Python reference: it operates on the rendered
+/// `Event.field` source text rather than the parsed expression, so it needs
+/// no access to `fsl-core`'s private domain-lowering resolver.
+fn domain_replay_correlation_field(effect: &fsl_syntax::DomainEffect) -> Option<String> {
+    let rendered = effect.correlation_id.as_ref()?.render_source();
+    Some(match rendered.rsplit_once('.') {
+        Some((_, field)) => field.to_owned(),
+        None => rendered,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn domain_replay_finding(
+    kind: &str,
+    domain: &str,
+    step_index: usize,
+    failed_rule: &str,
+    witness: &Value,
+    repair: &[&str],
+    effect: Option<&str>,
+) -> Value {
+    let mut finding = json!({
+        "schema_version":"fsl-domain-finding.v0",
+        "fsl":"fsl-domain-effect.v0",
+        "result":"violated",
+        "kind":kind,
+        "severity":"error",
+        "domain":domain,
+        "failed_rule":failed_rule,
+        "guarantee_kind":"runtime_observed",
+        "evidence":{"kind":"runtime_replay","formal_proof":false,"step_index":step_index},
+        "witness":witness,
+        "repair_candidates":repair.iter().map(|text| json!({"kind":"implementation_or_model_change","weakens_spec":false,"description":text})).collect::<Vec<_>>(),
+        "assumptions":[],
+    });
+    if let Some(effect) = effect
+        && let Value::Object(object) = &mut finding
+    {
+        object.insert("effect".to_owned(), json!(effect));
+    }
+    finding
+}
+
+/// Step a lowered domain/effect action (`{aggregate}_{command}` or
+/// `{effect}_complete_{outcome}`) against the concrete Monitor. Returns
+/// `Ok(true)` when the model accepted the step, `Ok(false)` when the action
+/// exists but was rejected (unsatisfied guard, partial op, or an unknown
+/// action name — the model has no such transition at all), and never an
+/// `Err`: an evaluation failure is itself evidence the log does not conform,
+/// not an internal error, so it folds into "rejected" rather than aborting
+/// the whole replay (fail-closed, not fail-crash).
+fn domain_replay_step(
+    monitor: &mut fsl_runtime::Monitor,
+    action_name: &str,
+    params: &std::collections::BTreeMap<String, FslValue>,
+) -> bool {
+    match monitor.attempt(action_name, params) {
+        Ok(stepped) => stepped.violation.is_none(),
+        Err(_) => false,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
 fn run_domain_replay(path: &Path, logs: &Path) -> (Value, i32) {
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
@@ -6713,50 +6826,266 @@ fn run_domain_replay(path: &Path, logs: &Path) -> (Value, i32) {
         Ok(events) => events,
         Err(error) => return (error_output("parse", &error), 2),
     };
-    let mut pending = std::collections::BTreeSet::new();
-    let mut observed = std::collections::BTreeSet::new();
+    let model = match load_model(path) {
+        Ok(model) => model,
+        Err(error) => return (semantic_error_output(&error), 2),
+    };
+    let mut monitor = match fsl_runtime::Monitor::new(model.clone()) {
+        Ok(monitor) => monitor,
+        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+    };
+
+    let mut pending: std::collections::BTreeSet<(String, String)> =
+        std::collections::BTreeSet::new();
+    let mut completed: std::collections::BTreeSet<(String, String)> =
+        std::collections::BTreeSet::new();
+    let mut observed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut findings = Vec::new();
     let mut steps = 0_usize;
+    let name = domain.name.as_str();
+
     for (index, event) in events.iter().enumerate() {
-        match event.get("event").and_then(Value::as_str) {
-            Some("domain_event") => {
-                if let Some(name) = event.get("name").and_then(Value::as_str) {
-                    observed.insert(name.to_owned());
-                }
+        let Some(entry) = event.as_object() else {
+            findings.push(domain_replay_finding(
+                "unknown_runtime_event_kind",
+                name,
+                index,
+                "runtime_log_event_kind_supported",
+                &json!({"log":event}),
+                &["use event kind command, domain_event, effect_request, or effect_completion"],
+                None,
+            ));
+            continue;
+        };
+        let kind = entry
+            .get("event")
+            .and_then(Value::as_str)
+            .or_else(|| entry.get("kind").and_then(Value::as_str));
+        match kind {
+            Some("command") => {
+                let aggregate_name = entry.get("aggregate").and_then(Value::as_str);
+                let command_name = entry.get("command").and_then(Value::as_str);
+                let action_name = aggregate_name.zip(command_name).and_then(|(a, c)| {
+                    let aggregate = domain.aggregates.iter().find(|agg| agg.name == a)?;
+                    aggregate
+                        .commands
+                        .iter()
+                        .any(|command| command.name == c)
+                        .then(|| format!("{}_{}", snake_case(a), snake_case(c)))
+                });
+                let params = domain_replay_params(entry);
+                let ok = action_name
+                    .as_deref()
+                    .is_some_and(|action| domain_replay_step(&mut monitor, action, &params));
                 steps += 1;
+                if !ok {
+                    findings.push(domain_replay_finding(
+                        "command_rejected_by_model",
+                        name,
+                        index,
+                        "runtime_command_must_be_enabled_by_domain_model",
+                        &json!({"log":event}),
+                        &["change the implementation command path or update the FSL decide/evolve model"],
+                        None,
+                    ));
+                }
+            }
+            Some("domain_event") => {
+                let event_name = entry
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .or_else(|| entry.get("domain_event").and_then(Value::as_str));
+                let declared = event_name.is_some_and(|event_name| {
+                    domain
+                        .aggregates
+                        .iter()
+                        .any(|aggregate| aggregate.events.iter().any(|e| e.name == event_name))
+                });
+                if declared {
+                    observed.insert(event_name.unwrap_or_default().to_owned());
+                } else {
+                    findings.push(domain_replay_finding(
+                        "unknown_domain_event",
+                        name,
+                        index,
+                        "runtime_event_declared_in_domain",
+                        &json!({"event":event_name}),
+                        &[&format!(
+                            "declare event {} in an aggregate or fix the runtime log",
+                            event_name.unwrap_or_default()
+                        )],
+                        None,
+                    ));
+                }
             }
             Some("effect_request") => {
-                if let (Some(effect), Some(correlation)) = (
-                    event.get("effect").and_then(Value::as_str),
-                    event.get("correlation_id").and_then(Value::as_str),
-                ) {
-                    pending.insert((effect.to_owned(), correlation.to_owned()));
-                }
+                let effect_name = entry.get("effect").and_then(Value::as_str);
+                let Some(effect) = effect_name
+                    .and_then(|name| domain.effects.iter().find(|effect| effect.name == name))
+                else {
+                    findings.push(domain_replay_finding(
+                        "unknown_effect",
+                        name,
+                        index,
+                        "runtime_effect_declared_in_domain",
+                        &json!({"effect":effect_name}),
+                        &["declare the effect or fix the runtime log"],
+                        None,
+                    ));
+                    continue;
+                };
+                let Some(correlation) = domain_replay_correlation_value(entry) else {
+                    findings.push(domain_replay_finding(
+                        "uncorrelated_async_completion",
+                        name,
+                        index,
+                        "effect_request_has_correlation_id",
+                        &json!({"log":event}),
+                        &[&format!(
+                            "include correlation_id in effect_request for {}",
+                            effect.name
+                        )],
+                        Some(&effect.name),
+                    ));
+                    continue;
+                };
+                pending.insert((effect.name.clone(), correlation));
             }
             Some("effect_completion") => {
-                let effect = event
-                    .get("effect")
+                let effect_name = entry.get("effect").and_then(Value::as_str);
+                let Some(effect) = effect_name
+                    .and_then(|name| domain.effects.iter().find(|effect| effect.name == name))
+                else {
+                    findings.push(domain_replay_finding(
+                        "unknown_effect",
+                        name,
+                        index,
+                        "runtime_effect_declared_in_domain",
+                        &json!({"effect":effect_name}),
+                        &["declare the effect or fix the runtime log"],
+                        None,
+                    ));
+                    continue;
+                };
+                let event_name = entry
+                    .get("name")
                     .and_then(Value::as_str)
-                    .unwrap_or_default();
-                let correlation = event
-                    .get("correlation_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                if let Some(name) = event.get("name").and_then(Value::as_str) {
-                    observed.insert(name.to_owned());
+                    .or_else(|| entry.get("domain_event").and_then(Value::as_str))
+                    .or_else(|| entry.get("outcome").and_then(Value::as_str));
+                if !event_name.is_some_and(|event_name| {
+                    effect
+                        .outcome_events()
+                        .iter()
+                        .any(|outcome| **outcome == event_name)
+                }) {
+                    findings.push(domain_replay_finding(
+                        "effect_completion_event_not_declared",
+                        name,
+                        index,
+                        "effect_completion_uses_declared_outcome",
+                        &json!({"effect":effect.name,"event":event_name}),
+                        &[&format!(
+                            "add {} to effect {} outcomes or fix the runtime log",
+                            event_name.unwrap_or_default(),
+                            effect.name
+                        )],
+                        Some(&effect.name),
+                    ));
+                    continue;
                 }
-                if !pending.remove(&(effect.to_owned(), correlation.to_owned())) {
-                    findings.push(json!({"schema_version":"fsl-domain-finding.v0","fsl":"fsl-domain-effect.v0","result":"violated","kind":"uncorrelated_async_completion","severity":"error","domain":domain.name,"failed_rule":"async_completion_correlated","guarantee_kind":"runtime_observed","witness":{"event_index":index,"effect":effect,"correlation_id":correlation}}));
+                let event_name = event_name.unwrap_or_default();
+                let Some(correlation) = domain_replay_correlation_value(entry) else {
+                    findings.push(domain_replay_finding(
+                        "uncorrelated_async_completion",
+                        name,
+                        index,
+                        "effect_completion_has_correlation_id",
+                        &json!({"log":event}),
+                        &[&format!(
+                            "include correlation_id in effect_completion for {}",
+                            effect.name
+                        )],
+                        Some(&effect.name),
+                    ));
+                    continue;
+                };
+                let key = (effect.name.clone(), correlation.clone());
+                if !pending.contains(&key) {
+                    findings.push(domain_replay_finding(
+                        "uncorrelated_async_completion",
+                        name,
+                        index,
+                        "completion_requires_prior_request",
+                        &json!({"effect":effect.name,"correlation_id":correlation}),
+                        &["record effect_request before completion or fix correlation_id mapping"],
+                        Some(&effect.name),
+                    ));
                 }
+                if effect.irreversible && completed.contains(&key) {
+                    findings.push(domain_replay_finding(
+                        "duplicate_irreversible_effect_commit",
+                        name,
+                        index,
+                        "irreversible_effect_completes_at_most_once_per_correlation",
+                        &json!({"effect":effect.name,"correlation_id":correlation}),
+                        &["deduplicate completion handling by idempotency_key/correlation_id"],
+                        Some(&effect.name),
+                    ));
+                }
+                let action_name = format!(
+                    "{}_complete_{}",
+                    snake_case(&effect.name),
+                    snake_case(event_name)
+                );
+                let mut params = domain_replay_params(entry);
+                if let Some(field) = domain_replay_correlation_field(effect) {
+                    params
+                        .entry(field)
+                        .or_insert_with(|| domain_replay_coerce_int(&json!(correlation)));
+                }
+                let ok = domain_replay_step(&mut monitor, &action_name, &params);
                 steps += 1;
+                if !ok {
+                    findings.push(domain_replay_finding(
+                        "effect_completion_rejected_by_model",
+                        name,
+                        index,
+                        "effect_completion_matches_pending_lifecycle",
+                        &json!({"log":event}),
+                        &["ensure request and completion ordering matches the fsl-effect lifecycle"],
+                        Some(&effect.name),
+                    ));
+                }
+                completed.insert(key.clone());
+                pending.remove(&key);
+                observed.insert(event_name.to_owned());
             }
-            Some("command") => steps += 1,
-            _ => {}
+            _ => {
+                findings.push(domain_replay_finding(
+                    "unknown_runtime_event_kind",
+                    name,
+                    index,
+                    "runtime_log_event_kind_supported",
+                    &json!({"log":event}),
+                    &["use event kind command, domain_event, effect_request, or effect_completion"],
+                    None,
+                ));
+            }
         }
     }
-    wrap_specialized(
-        json!({"result":if findings.is_empty(){"conformance_checked"}else{"nonconformant"},"dialect":"fsl-domain-effect.v0","finding_schema_version":"fsl-domain-finding.v0","domain":domain.name,"guarantee_kind":"runtime_observed","steps_checked":steps,"events_observed":observed,"pending_effects":pending.iter().map(|(effect,correlation)|json!({"effect":effect,"correlation_id":correlation})).collect::<Vec<_>>(),"findings":findings,"final_state":{},"assumptions":[]}),
-    )
+    wrap_specialized(json!({
+        "result":if findings.is_empty(){"conformance_checked"}else{"nonconformant"},
+        "dialect":"fsl-domain-effect.v0",
+        "finding_schema_version":"fsl-domain-finding.v0",
+        "domain":domain.name,
+        "guarantee_kind":"runtime_observed",
+        "steps_checked":steps,
+        "events_observed":observed,
+        "pending_effects":pending.iter().map(|(effect,correlation)|json!({"effect":effect,"correlation_id":correlation})).collect::<Vec<_>>(),
+        "findings":findings,
+        "final_state":fslc_rust::state_json(&monitor.state),
+        "assumptions":fsl_tools::domain_assumptions(&domain),
+    }))
 }
 
 #[allow(clippy::too_many_lines)]

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3046,6 +3046,20 @@ fn ai_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32), St
     }
 }
 
+/// Reject a residual argument the way every other `domain` subcommand's own
+/// `while let Some(option) = args.next() { ... _ => return Err(...) }` loop
+/// already does, for the subcommands (`analyze`, `replay`) that take no
+/// options of their own and so have no such loop to fall through to.
+fn reject_extra_domain_args(
+    args: &mut impl Iterator<Item = String>,
+    subcommand: &str,
+) -> Result<(), String> {
+    match args.next() {
+        Some(option) => Err(format!("unknown domain {subcommand} option '{option}'")),
+        None => Ok(()),
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn domain_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32), String> {
     let subcommand = args
@@ -3061,7 +3075,10 @@ fn domain_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32)
                 parse_specialized_verify_options(&mut args, true)?;
             Ok(run_domain_check(&path, depth, &deadlock, &engine, &edition))
         }
-        "analyze" => Ok(run_domain_analyze(&path)),
+        "analyze" => {
+            reject_extra_domain_args(&mut args, "analyze")?;
+            Ok(run_domain_analyze(&path))
+        }
         "expand" => {
             let output = parse_optional_output(&mut args)?;
             let result = run_domain_expand(&path, output.as_deref());
@@ -3116,6 +3133,7 @@ fn domain_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32)
                 args.next()
                     .ok_or_else(|| "--logs requires a path".to_owned())?,
             );
+            reject_extra_domain_args(&mut args, "replay")?;
             Ok(run_domain_replay(&path, &logs))
         }
         "testgen" => {

--- a/rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl
+++ b/rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #515 negative control: `neverClosed` is violated by a single `CloseDoc`.
+// `domain check` must fold the nested kernel's `violated` result to the
+// top-level verdict instead of reporting `verified_under_assumptions`/exit 0.
+domain BrokenDomain {
+  implementation_profile functional_ddd
+
+  enum Status { Open, Closed }
+
+  aggregate Doc {
+    id DocId
+
+    state {
+      status: Status = Open;
+    }
+
+    command CloseDoc {}
+    event DocClosed {}
+
+    decide CloseDoc {
+      requires status == Open
+      emits DocClosed
+    }
+
+    evolve DocClosed {
+      status = Closed
+    }
+
+    invariant neverClosed { status == Open }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_515_domain_clean_invariant.fsl
+++ b/rust/fslc/tests/fixtures/issue_515_domain_clean_invariant.fsl
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #515 positive control: same shape as issue_515_domain_broken_invariant.fsl
+// but with a genuinely provable invariant, so `domain check` must still
+// report `verified_under_assumptions`/exit 0 (the fix must not over-trigger).
+domain OkDomain {
+  implementation_profile functional_ddd
+
+  enum Status { Open, Closed }
+
+  aggregate Doc {
+    id DocId
+
+    state {
+      status: Status = Open;
+    }
+
+    command CloseDoc {}
+    event DocClosed {}
+
+    decide CloseDoc {
+      requires status == Open
+      emits DocClosed
+    }
+
+    evolve DocClosed {
+      status = Closed
+    }
+
+    invariant openOrClosed { status == Open || status == Closed }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_518_clean.jsonl
+++ b/rust/fslc/tests/fixtures/issue_518_clean.jsonl
@@ -1,0 +1,4 @@
+{"event":"command","aggregate":"Msg","command":"SendMsg","params":{"ref_id":"r1"}}
+{"event":"domain_event","aggregate":"Msg","name":"MsgSent","params":{"ref_id":"r1"}}
+{"event":"effect_request","effect":"Deliver","correlation_id":"r1"}
+{"event":"effect_completion","effect":"Deliver","name":"Delivered","correlation_id":"r1","params":{"ref_id":"r1"}}

--- a/rust/fslc/tests/fixtures/issue_518_completion_without_request.jsonl
+++ b/rust/fslc/tests/fixtures/issue_518_completion_without_request.jsonl
@@ -1,0 +1,1 @@
+{"event":"effect_completion","effect":"Deliver","name":"Delivered","correlation_id":"r1","params":{"ref_id":"r1"}}

--- a/rust/fslc/tests/fixtures/issue_518_domain_replay.fsl
+++ b/rust/fslc/tests/fixtures/issue_518_domain_replay.fsl
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #518: a self-contained domain/effect model exercising all four documented
+// `domain replay` detection categories (rejected command, completion
+// without request, duplicate irreversible completion, lifecycle ordering
+// mismatch) plus the schema's remaining runtime finding kinds.
+domain MinReplay {
+  implementation_profile functional_ddd
+
+  enum MsgStatus { New, Sent, Cancelled }
+  enum DeliveryStatus { NotRequested, Requested, Done, Failed }
+
+  aggregate Msg {
+    id MsgId
+
+    state {
+      status: MsgStatus = New;
+      delivery: DeliveryStatus = NotRequested;
+    }
+
+    command SendMsg {
+      input ref_id: RefId
+    }
+    command CancelMsg {}
+
+    event MsgSent {
+      ref_id: RefId
+    }
+    event MsgCancelled {}
+    event Delivered {
+      ref_id: RefId
+    }
+    event DeliveryFailed {
+      ref_id: RefId
+    }
+
+    decide SendMsg {
+      requires status == New
+      emits MsgSent
+    }
+
+    decide CancelMsg {
+      requires status == Sent
+      emits MsgCancelled
+    }
+
+    evolve MsgSent {
+      status = Sent
+      delivery = Requested
+    }
+
+    evolve MsgCancelled {
+      status = Cancelled
+    }
+
+    evolve Delivered {
+      requires status != Cancelled
+      delivery = Done
+    }
+
+    evolve DeliveryFailed {
+      delivery = Failed
+    }
+  }
+
+  effect Deliver {
+    async
+    irreversible
+    idempotency_key Msg.id
+    correlation_id MsgSent.ref_id
+    handles MsgSent
+    emits one_of [Delivered, DeliveryFailed]
+    retry {
+      max_attempts 2
+      backoff exponential
+    }
+    timeout after 5m emits DeliveryFailed
+    compensation {
+      emits DeliveryFailed
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_518_duplicate_irreversible.jsonl
+++ b/rust/fslc/tests/fixtures/issue_518_duplicate_irreversible.jsonl
@@ -1,0 +1,6 @@
+{"event":"command","aggregate":"Msg","command":"SendMsg","params":{"ref_id":"r1"}}
+{"event":"domain_event","aggregate":"Msg","name":"MsgSent","params":{"ref_id":"r1"}}
+{"event":"effect_request","effect":"Deliver","correlation_id":"r1"}
+{"event":"effect_completion","effect":"Deliver","name":"Delivered","correlation_id":"r1","params":{"ref_id":"r1"}}
+{"event":"effect_request","effect":"Deliver","correlation_id":"r1"}
+{"event":"effect_completion","effect":"Deliver","name":"Delivered","correlation_id":"r1","params":{"ref_id":"r1"}}

--- a/rust/fslc/tests/fixtures/issue_518_lifecycle_mismatch.jsonl
+++ b/rust/fslc/tests/fixtures/issue_518_lifecycle_mismatch.jsonl
@@ -1,0 +1,6 @@
+{"event":"command","aggregate":"Msg","command":"SendMsg","params":{"ref_id":"r1"}}
+{"event":"domain_event","aggregate":"Msg","name":"MsgSent","params":{"ref_id":"r1"}}
+{"event":"effect_request","effect":"Deliver","correlation_id":"r1"}
+{"event":"command","aggregate":"Msg","command":"CancelMsg","params":{}}
+{"event":"domain_event","aggregate":"Msg","name":"MsgCancelled","params":{}}
+{"event":"effect_completion","effect":"Deliver","name":"Delivered","correlation_id":"r1","params":{"ref_id":"r1"}}

--- a/rust/fslc/tests/fixtures/issue_518_rejected_command.jsonl
+++ b/rust/fslc/tests/fixtures/issue_518_rejected_command.jsonl
@@ -1,0 +1,3 @@
+{"event":"command","aggregate":"Msg","command":"SendMsg","params":{"ref_id":"r1"}}
+{"event":"domain_event","aggregate":"Msg","name":"MsgSent","params":{"ref_id":"r1"}}
+{"event":"command","aggregate":"Msg","command":"SendMsg","params":{"ref_id":"r1"}}

--- a/rust/fslc/tests/issue_515_domain_check_false_green.rs
+++ b/rust/fslc/tests/issue_515_domain_check_false_green.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #515: `fslc domain check` must fold a nested
+//! kernel's `violated` (or any other non-`verified`/`proved` result) into
+//! the top-level verdict, exit code, and evidence — instead of hardcoding
+//! `result:"verified_under_assumptions"`/`formal_result:"verified"`/exit 0
+//! regardless of what the embedded `kernel.result` actually says.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+const BROKEN: &str = "rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl";
+const CLEAN: &str = "rust/fslc/tests/fixtures/issue_515_domain_clean_invariant.fsl";
+
+/// The headline false green: a domain whose aggregate invariant the kernel
+/// finds violated must return `result:"violated"`/exit 1 from `domain
+/// check`, not `verified_under_assumptions`/exit 0. Verified against the
+/// same fixture's `verify` result so the two never disagree.
+#[test]
+fn domain_check_folds_a_violated_kernel_into_the_top_level_verdict() {
+    // sanity: the fixture's raw kernel path really is violated.
+    let (verify, verify_status) = run(&["verify", BROKEN, "--depth", "4"]);
+    assert_eq!(verify_status, 1, "{verify:#}");
+    assert_eq!(verify["result"], "violated");
+
+    let (check, status) = run(&["domain", "check", BROKEN, "--depth", "4"]);
+    assert_eq!(status, 1, "{check:#}");
+    assert_eq!(check["result"], "violated");
+    assert_eq!(check["formal_result"], "violated");
+    assert_eq!(check["kernel"]["result"], "violated");
+    assert_eq!(check["kernel"]["invariant"], "neverClosed");
+}
+
+/// The fix must survive an engine switch: `--engine induction` reaches the
+/// same `check_domain` call with a differently-shaped kernel result, and
+/// must not regress to the old hardcoded green.
+#[test]
+fn domain_check_folds_a_violated_kernel_under_induction_too() {
+    let (check, status) = run(&["domain", "check", BROKEN, "--engine", "induction"]);
+    assert_eq!(status, 1, "{check:#}");
+    assert_eq!(check["result"], "violated");
+    assert_eq!(check["kernel"]["result"], "violated");
+}
+
+/// Replayable evidence (AGENTS.md: "Do not allowlist verdict, location,
+/// assurance, or exit-code differences") must survive the stable-kernel
+/// projection on the violated path, not just the bare verdict string.
+#[test]
+fn domain_check_preserves_violation_evidence_in_the_nested_kernel() {
+    let (check, _status) = run(&["domain", "check", BROKEN, "--depth", "4"]);
+    let kernel = &check["kernel"];
+    assert!(kernel["loc"].is_object(), "{check:#}");
+    assert!(kernel["violated_at_step"].is_u64(), "{check:#}");
+    assert!(kernel["blame"].is_object(), "{check:#}");
+    assert!(kernel["last_action"].is_object(), "{check:#}");
+    assert!(
+        kernel["trace"].as_array().is_some_and(|t| !t.is_empty()),
+        "{check:#}"
+    );
+}
+
+/// Regression control (both directions of the negative control, per
+/// AGENTS.md's bug-fixing altitude guidance): a genuinely provable
+/// aggregate invariant must still return `verified_under_assumptions`/exit
+/// 0, so folding the kernel verdict through does not over-trigger.
+#[test]
+fn domain_check_still_reports_verified_for_a_genuinely_clean_domain() {
+    let (check, status) = run(&["domain", "check", CLEAN, "--depth", "4"]);
+    assert_eq!(status, 0, "{check:#}");
+    assert_eq!(check["result"], "verified_under_assumptions");
+    assert_eq!(check["formal_result"], "verified");
+    assert_eq!(check["kernel"]["result"], "verified");
+}

--- a/rust/fslc/tests/issue_516_domain_cli_extra_args.rs
+++ b/rust/fslc/tests/issue_516_domain_cli_extra_args.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #516: `fslc domain replay` and `fslc domain
+//! analyze` must reject an unrecognized trailing argument as
+//! `result:"error"`/`kind:"usage"`/exit 2, matching every other `domain`
+//! subcommand (`check`/`expand`/`generate`/`testgen`) and the rest of the
+//! CLI, instead of silently discarding it and returning a result computed
+//! without it.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+const SPEC: &str = "examples/domain/order_async_effect.fsl";
+const LOGS: &str = "examples/domain/order_async_effect_replay.jsonl";
+
+#[test]
+fn domain_replay_rejects_an_unknown_trailing_flag() {
+    let (output, status) = run(&[
+        "domain",
+        "replay",
+        SPEC,
+        "--logs",
+        LOGS,
+        "--no-such-flag",
+        "--depth",
+        "99",
+        "zzz",
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "usage");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("--no-such-flag")),
+        "{output:#}"
+    );
+}
+
+#[test]
+fn domain_replay_rejects_a_bare_unknown_flag() {
+    let (output, status) = run(&["domain", "replay", SPEC, "--logs", LOGS, "--bogus"]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["kind"], "usage");
+}
+
+#[test]
+fn domain_replay_rejects_an_extra_positional_argument() {
+    let (output, status) = run(&["domain", "replay", SPEC, "--logs", LOGS, "EXTRA"]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["kind"], "usage");
+}
+
+#[test]
+fn domain_analyze_rejects_an_unknown_trailing_flag() {
+    let (output, status) = run(&["domain", "analyze", SPEC, "--bogus"]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "usage");
+}
+
+/// Regression control: the correct, documented invocations of both
+/// subcommands must keep succeeding, so rejecting residual arguments does
+/// not over-trigger on well-formed calls.
+#[test]
+fn domain_replay_and_analyze_still_succeed_without_extra_arguments() {
+    let (replay, replay_status) = run(&["domain", "replay", SPEC, "--logs", LOGS]);
+    assert_eq!(replay_status, 0, "{replay:#}");
+
+    let (analyze, analyze_status) = run(&["domain", "analyze", SPEC]);
+    assert_eq!(analyze_status, 0, "{analyze:#}");
+    assert_eq!(analyze["result"], "analyzed");
+}

--- a/rust/fslc/tests/issue_518_domain_replay_detection.rs
+++ b/rust/fslc/tests/issue_518_domain_replay_detection.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #518: `fslc domain replay` must actually drive a
+//! Monitor over the lowered domain/effect model instead of only tracking a
+//! `(effect, correlation_id)` bookkeeping set. Each of the four detection
+//! categories `docs/DESIGN-domain.md`/`docs/DESIGN-effect.md` promise must
+//! independently produce `result:"nonconformant"`/exit 1 with the
+//! documented finding `kind` — proving detection, not just a new field
+//! existing (the class of thing #468 already established: "the detector
+//! exists but detects nothing" is a defect in its own right).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+const SPEC: &str = "rust/fslc/tests/fixtures/issue_518_domain_replay.fsl";
+
+fn finding_kinds(output: &Value) -> Vec<&str> {
+    output["findings"]
+        .as_array()
+        .expect("findings array")
+        .iter()
+        .map(|finding| finding["kind"].as_str().expect("finding.kind"))
+        .collect()
+}
+
+fn replay(logs: &str) -> (Value, i32) {
+    run(&[
+        "domain",
+        "replay",
+        SPEC,
+        "--logs",
+        &format!("rust/fslc/tests/fixtures/{logs}"),
+    ])
+}
+
+/// Detection category 1/4: a command the model's own guard rejects
+/// (`SendMsg` twice in a row) must surface as `command_rejected_by_model`,
+/// not be silently accepted.
+#[test]
+fn detects_a_rejected_command() {
+    let (output, status) = replay("issue_518_rejected_command.jsonl");
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant");
+    assert_eq!(finding_kinds(&output), ["command_rejected_by_model"]);
+    assert_eq!(output["steps_checked"], 2);
+}
+
+/// Detection category 2/4 (the one lane that already worked before this
+/// fix): a completion with no prior request must still be flagged.
+#[test]
+fn detects_a_completion_without_a_prior_request() {
+    let (output, status) = replay("issue_518_completion_without_request.jsonl");
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant");
+    let kinds = finding_kinds(&output);
+    assert!(
+        kinds.contains(&"uncorrelated_async_completion"),
+        "{output:#}"
+    );
+}
+
+/// Detection category 3/4: an irreversible effect committing twice for the
+/// same correlation id must be flagged, even though the pending set is
+/// legitimately refilled by an intervening `effect_request`.
+#[test]
+fn detects_a_duplicate_irreversible_effect_commit() {
+    let (output, status) = replay("issue_518_duplicate_irreversible.jsonl");
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant");
+    assert!(
+        finding_kinds(&output).contains(&"duplicate_irreversible_effect_commit"),
+        "{output:#}"
+    );
+}
+
+/// Detection category 4/4: a completion observed after the aggregate moved
+/// into a state the model's own `evolve ... requires` rejects (delivery
+/// completing after the message was cancelled) must be flagged.
+#[test]
+fn detects_a_lifecycle_ordering_mismatch() {
+    let (output, status) = replay("issue_518_lifecycle_mismatch.jsonl");
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant");
+    assert!(
+        finding_kinds(&output).contains(&"effect_completion_rejected_by_model"),
+        "{output:#}"
+    );
+}
+
+/// Every finding must satisfy the published fsl-domain finding schema:
+/// `schema_version`, `fsl`, `result`, `kind`, `severity`, `domain`,
+/// `failed_rule`, `guarantee_kind`, `evidence`, `witness`,
+/// `repair_candidates`, `assumptions` all present with the right shapes.
+#[test]
+fn findings_satisfy_the_published_finding_schema_shape() {
+    let (output, _status) = replay("issue_518_rejected_command.jsonl");
+    let finding = &output["findings"][0];
+    assert_eq!(finding["schema_version"], "fsl-domain-finding.v0");
+    assert_eq!(finding["fsl"], "fsl-domain-effect.v0");
+    assert_eq!(finding["result"], "violated");
+    assert_eq!(finding["severity"], "error");
+    assert!(finding["failed_rule"].is_string());
+    assert_eq!(finding["guarantee_kind"], "runtime_observed");
+    assert_eq!(finding["evidence"]["kind"], "runtime_replay");
+    assert_eq!(finding["evidence"]["formal_proof"], false);
+    assert!(finding["witness"].is_object());
+    assert!(finding["repair_candidates"].is_array());
+    assert!(finding["assumptions"].is_array());
+}
+
+/// Regression control: a conformant log over the same model must still
+/// report `conformance_checked`/exit 0, so driving the Monitor does not
+/// over-trigger on the success path.
+#[test]
+fn replay_still_reports_conformance_checked_for_a_clean_log() {
+    let (output, status) = replay("issue_518_clean.jsonl");
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "conformance_checked");
+    assert_eq!(output["findings"].as_array().unwrap().len(), 0);
+    assert_eq!(output["steps_checked"], 2);
+}
+
+/// `final_state` and `assumptions` must be populated from the same Monitor
+/// and assumption computation `domain analyze` already uses, not `{}`/`[]`.
+#[test]
+fn replay_populates_final_state_and_assumptions() {
+    let (output, _status) = replay("issue_518_clean.jsonl");
+    let final_state = output["final_state"].as_object().expect("final_state");
+    assert!(!final_state.is_empty(), "{output:#}");
+
+    let (analyze, _status) = run(&["domain", "analyze", SPEC]);
+    assert_eq!(output["assumptions"], analyze["assumptions"]);
+}


### PR DESCRIPTION
## Problem

Three `domain` defects: one false green, one detector that reported a check it never performed, and one silently discarded input.

**#515 — `domain check` folded a nested kernel's `violated` into `verified_under_assumptions` / exit 0.** A nested kernel reporting a real violation was reported upward as a qualified success. `AGENTS.md` calls a confidently-green false negative more dangerous than a crash, and this is the compound-aggregation shape of it: the child said `violated` and the parent said something that reads as passing.

**#518 — `domain replay` missed 3 of the 4 detection categories `docs/` names, and still returned `conformance_checked`.** The verdict asserted a conformance check that largely did not happen — the same class as a detector that exists but cannot fire.

**#516 — `domain replay` / `analyze` silently discarded an unknown trailing argument.** A user who mistypes a flag gets a result computed without it, with nothing said.

## Contract change

- **#515** — the nested kernel verdict now folds into `domain check`'s top-level result instead of being absorbed. A child failure cannot be promoted to a parent success.
- **#518** — `domain replay` drives a concrete Monitor for real detection rather than reporting `conformance_checked` off a partial check.
- **#516** — an unknown trailing argument is rejected rather than dropped.

## Test evidence

Each fix carries a negative control in `rust/*/tests/` that fails when the fix is reverted, with the revert-and-confirm result recorded per issue.

The two acceptance criteria that mattered most here, because a one-sided fix would look green:

- **#515 needs both directions.** The nested-violation case must become a loud, correctly classified failure with the right exit code, **and** a genuinely clean nested kernel must still return success. A fix that only stops reporting success would pass a test that checks the first half alone.
- **#518's control must show each missing category actually detecting.** A test asserting that a new field is present would pass against a detector that never fires — which is precisely the state the issue reports.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (149 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (kept 1:1 section-aligned), `docs/DESIGN-domain.md`, `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #515, fixes #516, fixes #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
