### PR TITLE
fix(migrate,runtime)!: check unchanged input and reject nondeterministic init instead of defaulting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,6 +427,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   trailing argument (`result:"error"`/`kind:"usage"`/exit 2), matching
   every other `domain` subcommand and the rest of the CLI, instead of
   silently discarding it and returning a result computed without it (#516).
+- `Monitor::new` (the solver-independent concrete interpreter `replay` and
+  BMC's concrete pre-scan build on) now runs the same deterministic-init gate
+  the explicit engine's own construction check already had, instead of
+  silently default-filling any state component `init` leaves free and
+  treating that one arbitrary value as the specification's initial state.
+  Previously `replay` compared an observed trace's initial state against
+  that default and falsely reported `initial_state_mismatch` on a BMC-valid
+  trace whose free component held a different, equally admissible value. A
+  caller that already has its own complete concrete initial state (an
+  observed replay trace's own step 0, an explicit `--from-state`/
+  `--initial-state` snapshot, or a BMC witness's first state) is unaffected:
+  it now builds through the new `Monitor::from_state`, which has nothing to
+  ask `init` to compute and so is not subject to the gate.
+  `initial_state_mismatch` is still fully checked whenever `init` determines
+  every state variable; when it does not, the whole state is trusted from
+  the caller rather than compared component-wise (#519).
 - Native semantic diff now evaluates OLD forbidden arguments in the OLD typed
   model and reports missing actions, incompatible arity, or incompatible NEW
   argument domains as explicit `unknown` findings instead of a false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,6 +427,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   trailing argument (`result:"error"`/`kind:"usage"`/exit 2), matching
   every other `domain` subcommand and the rest of the CLI, instead of
   silently discarding it and returning a result computed without it (#516).
+- `fslc lint`/`fslc migrate` now checked-model-validate every input,
+  unconditionally, instead of only validating a file `plan_migration` found
+  legacy syntax to rewrite. Previously an input with no legacy tokens for
+  `plan_migration` to fix was never checked at all — a spec with a genuine
+  type error, or a canonical requirements spec whose `implements ... from`
+  target had moved, could still report `lint`/`migrate` exit 0 purely
+  because it happened to have nothing to migrate, while the identical defect
+  with one unrelated legacy token present correctly failed. The new
+  pre-flight (shared by both commands through `load_migration_plan`) mirrors
+  `fslc check`'s own kind/location convention exactly, so the same input
+  gets the same verdict from both commands. `refinement`/`agent` dialects
+  are excluded (same carve-out `fmt --check` already uses: a mapping file
+  has no `state` block by design), and a refused plan (a legacy construct
+  `plan_migration` recognizes but cannot machine-apply, e.g. `&&`) is also
+  excluded, since no pre-migration checked model exists to compare for such
+  input in the first place (#517).
 - `Monitor::new` (the solver-independent concrete interpreter `replay` and
   BMC's concrete pre-scan build on) now runs the same deterministic-init gate
   the explicit engine's own construction check already had, instead of

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -96,6 +96,18 @@ Concrete execution requires a deterministic initial state. Static check at
   + hint "runtime monitor requires a deterministic init".
 - All existing specs satisfy this (a spec that does not satisfy it passes verify
   but errors in Monitor — prompting a fix on the spec side).
+- This gate lives in `Monitor::new` itself (#519), not only in the explicit
+  engine's own construction check (`explicit::check_deterministic_init`, which
+  `Monitor::new` now reuses) — every caller that asks `Monitor::new` to compute
+  the concrete initial state from `init` gets it, including `replay`'s witness
+  reconstruction and BMC's concrete pre-scan (`find_boundary_violation`).
+  A caller that already has its own complete concrete initial state — an
+  observed replay trace's own step 0, an explicit `--from-state`/
+  `--initial-state` snapshot, or a BMC witness's first state — is not asking
+  `init` to compute anything, so it builds through `Monitor::from_state`
+  instead and is unaffected by this gate: `init` may leave a component free
+  (BMC explores every admissible value there), and a concrete run pinned to
+  one already-admissible value has nothing left for the gate to check.
 
 ### 1.4 Expression evaluation
 
@@ -146,6 +158,15 @@ Output:
 ```
 
 exit code: conformant = 0, nonconformant = 1, input/spec error = 2.
+
+A versioned trace's declared `initial` state is compared against `init`'s own
+computed initial state only when `init` fully determines one (every state
+variable, not component-wise); when it does not, the trace's own `initial` is
+used as the concrete starting point directly instead (see §1.3's
+`Monitor::from_state` note, #519), and `initial_state_mismatch` is not
+checked for that run at all — there is currently no per-component fallback
+that still cross-checks a state variable init *does* fully determine while
+skipping only the ones a free component shares a root with.
 
 ## 3. `fslc testgen` — generation of a conformance-test skeleton
 

--- a/docs/DESIGN-migration.md
+++ b/docs/DESIGN-migration.md
@@ -13,6 +13,20 @@ taxonomies `deprecated`, `non_canonical`, `ambiguous_intent`, or
 `unsupported_in_edition`, severity, exact span, edition, canonical replacement,
 and whether its edits are machine-applicable.
 
+The "check failure" half of exit 2 is unconditional per input, shared by
+`lint` and `migrate` (#517): every input is checked-model-validated
+regardless of whether it happens to contain any legacy syntax for
+`plan_migration` to find and rewrite — a spec that fails `fslc check` gets
+`kind:"semantics"`/`kind:"type"` and exit 2 from `lint`/`migrate` exactly as
+it would from `check`, not a silent exit 0 just because there was nothing to
+migrate. As with `fmt --check`, `refinement`/`agent` dialects are not a
+standalone check target and are excluded from this validation (a mapping
+file has no `state` block by design). A refused plan (a legacy construct
+`plan_migration` recognizes but cannot machine-apply, e.g. `&&`) is also
+excluded: per the `&&` note below, no pre-migration checked model exists to
+compare for such input in the first place, so the check applies only to
+input `plan_migration` itself did not already refuse.
+
 Each lint operand may be a file or directory. Directory operands expand
 recursively to regular `*.fsl` files; symlink entries and other extensions are
 skipped while walking them, and the combined file set is deduplicated and sorted

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -98,7 +98,8 @@ pub fn explicit_unsupported_reason(model: &KernelModel) -> Option<String> {
 /// Returns [`RuntimeError`] when init is nondeterministic, partially assigned, or cannot be
 /// evaluated concretely.
 pub fn deterministic_initial_state(model: &KernelModel) -> Result<State, RuntimeError> {
-    check_deterministic_init(model)?;
+    // `Monitor::new` itself now runs this same deterministic-init gate, so
+    // there is no separate check to run here.
     Ok(Monitor::new(model.clone())?.state)
 }
 
@@ -420,7 +421,7 @@ fn collect_assigned_init_roots(statements: &[Statement], assigned: &mut BTreeSet
     }
 }
 
-fn check_deterministic_init(model: &KernelModel) -> Result<(), RuntimeError> {
+pub(crate) fn check_deterministic_init(model: &KernelModel) -> Result<(), RuntimeError> {
     let (assigned, _) = walk_init(
         &model.init,
         BTreeMap::new(),

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1663,8 +1663,16 @@ pub fn check_refinement(
             action: None,
             changes: BTreeMap::new(),
         }];
-        let mut initial_alpha_monitor = Monitor::new(abstraction.clone())?;
-        initial_alpha_monitor.state = alpha_initial.clone();
+        // `alpha_initial` is already a complete concrete abs state (the
+        // impl initial state mapped through the refinement correspondence),
+        // so there is nothing for the abstraction's own `init` to compute —
+        // `Monitor::from_state` skips it entirely rather than demanding a
+        // determinism `abstraction.init` may not have (issue #519's gate
+        // interacting with #493's nondeterministic-abs-init support: a
+        // nondeterministic abs init is intentionally never fully
+        // deterministic, so `Monitor::new(abstraction...)` fails closed here
+        // even for a genuinely correct refinement).
+        let initial_alpha_monitor = Monitor::from_state(abstraction.clone(), alpha_initial.clone());
         if let Some(violation) = initial_alpha_monitor.current_violation()? {
             let kind = if violation.kind == "type_bound" {
                 "map_out_of_bounds"
@@ -1839,13 +1847,16 @@ pub fn check_refinement(
                         .zip(values)
                         .map(|(param, value)| (param.name().to_owned(), value))
                         .collect::<BTreeMap<_, _>>();
-                    let mut abs_monitor = Monitor::new(abstraction.clone())?;
-                    abs_monitor.state = abstract_action_state(
+                    // See the step-0 `Monitor::from_state` note above: this
+                    // state is already fully computed, so there is nothing
+                    // for `abstraction.init` to determine here either.
+                    let abs_state = abstract_action_state(
                         &alpha_before,
                         abstraction,
                         abs_action,
                         &expected_params,
                     )?;
+                    let mut abs_monitor = Monitor::from_state(abstraction.clone(), abs_state);
                     let Some(abs_enabled) =
                         refinement_action_instance(&abs_monitor, abs_action, expected_params)?
                     else {
@@ -1876,8 +1887,7 @@ pub fn check_refinement(
                     }
                 }
             }
-            let mut alpha_monitor = Monitor::new(abstraction.clone())?;
-            alpha_monitor.state = alpha_after.clone();
+            let alpha_monitor = Monitor::from_state(abstraction.clone(), alpha_after.clone());
             if let Some(violation) = alpha_monitor.current_violation()? {
                 let kind = if violation.kind == "type_bound" {
                     "map_out_of_bounds"

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -811,13 +811,40 @@ impl Monitor {
         }
     }
 
+    /// Build a monitor whose initial state is exactly `state`, without
+    /// running `model`'s init at all.
+    ///
+    /// For a caller that already has a complete concrete initial state —
+    /// an observed replay trace's own step 0, an explicit
+    /// `--initial-state` snapshot, or a BMC witness's first state — there
+    /// is nothing left for init to compute. `init` may legitimately leave
+    /// some state free (a symbolic engine explores every admissible
+    /// value), so building through [`Monitor::new`] here would wrongly
+    /// demand a determinism [`Monitor::new`] does not need to provide
+    /// (#519).
+    #[must_use]
+    pub fn from_state(model: KernelModel, state: State) -> Self {
+        Self {
+            model,
+            state,
+            step: 0,
+        }
+    }
+
     /// Initialize a solver-independent concrete monitor.
     ///
     /// # Errors
     ///
-    /// Returns [`RuntimeError`] when default construction or sequential init
-    /// execution fails.
+    /// Returns [`RuntimeError`] when init does not deterministically assign
+    /// every state variable (component-wise; see
+    /// `docs/DESIGN-bridge.md` "Determinism of init") or sequential init
+    /// execution fails. A model whose init leaves some state free is
+    /// admissible to `verify`/BMC, which explores every admissible value —
+    /// concrete execution has no such freedom to explore, so construction
+    /// fails closed instead of picking one arbitrary default value and
+    /// silently treating it as the specification's initial state.
     pub fn new(model: KernelModel) -> Result<Self, RuntimeError> {
+        explicit::check_deterministic_init(&model)?;
         let mut state = model
             .state
             .iter()
@@ -2270,10 +2297,13 @@ fn replay_trace_with_initial(
     if first.step != 0 || first.action.is_some() {
         return Err(runtime_error("trace must begin with an action-free step 0"));
     }
-    let mut monitor = Monitor::new(model)?;
-    if let Some(initial_state) = initial_state {
-        monitor.state.clone_from(initial_state);
-    }
+    // A caller-provided initial state (the trace's own witnessed step 0, or
+    // an explicit `--initial-state`) makes `Monitor::from_state` the right
+    // constructor here — see its doc comment (#519).
+    let mut monitor = match initial_state {
+        Some(initial_state) => Monitor::from_state(model, initial_state.clone()),
+        None => Monitor::new(model)?,
+    };
     if monitor.state != first.state {
         return Err(runtime_error(
             "trace initial state does not match Monitor init",

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -358,30 +358,38 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             Ok(deadlock) => deadlock,
             Err(message) => return error(solver_version, "usage", message),
         };
-    match fsl_runtime::find_boundary_violation(model.clone(), request.options.depth) {
-        Ok(Some((violation, trace))) => {
-            let statistics = fsl_solver::VerificationStatistics::default();
-            return fslc_rust::verification_output::render_boundary_output(
-                envelope(solver_version),
-                &model,
-                &violation,
-                &trace,
-                &fslc_rust::verification_output::BmcOutputOptions {
-                    depth: request.options.depth,
-                    deadlock,
-                    checked_bounds: None,
-                    elapsed_s: (performance_now() - started) / 1000.0,
-                    statistics: &statistics,
-                },
-            )
-            .0;
-        }
-        Ok(None) => {}
-        Err(failure) => {
-            return fslc_rust::verification_output::render_semantic_error(
-                envelope(solver_version),
-                &failure.to_string(),
-            );
+    // Mirrors the native CLI's `prepare_bmc` (`fslc/src/verification.rs`):
+    // this pre-scan is an optional shortcut ahead of the full solve below
+    // and needs a deterministic concrete initial state to run at all
+    // (#519). Skip it rather than failing the whole command when a model's
+    // init legitimately leaves some state free — the full solve below
+    // still explores every admissible initial value symbolically.
+    if fsl_runtime::deterministic_initial_state(&model).is_ok() {
+        match fsl_runtime::find_boundary_violation(model.clone(), request.options.depth) {
+            Ok(Some((violation, trace))) => {
+                let statistics = fsl_solver::VerificationStatistics::default();
+                return fslc_rust::verification_output::render_boundary_output(
+                    envelope(solver_version),
+                    &model,
+                    &violation,
+                    &trace,
+                    &fslc_rust::verification_output::BmcOutputOptions {
+                        depth: request.options.depth,
+                        deadlock,
+                        checked_bounds: None,
+                        elapsed_s: (performance_now() - started) / 1000.0,
+                        statistics: &statistics,
+                    },
+                )
+                .0;
+            }
+            Ok(None) => {}
+            Err(failure) => {
+                return fslc_rust::verification_output::render_semantic_error(
+                    envelope(solver_version),
+                    &failure.to_string(),
+                );
+            }
         }
     }
     let mut solver = fsl_solver_z3js::Z3JsSolver::new();

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -3974,20 +3974,32 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
                     2,
                 );
             }
-            let initial = match replay_snapshot_json(initial, &model) {
-                Ok(initial) => initial,
+            let initial_state = match load_snapshot_value_object(initial, &model) {
+                Ok(state) => state,
                 Err(error) => return (error_output("io", &error), 2),
             };
+            let initial = fslc_rust::state_json(&initial_state);
             let events = match validate_versioned_replay_events(&model, &trace.events) {
                 Ok(events) => events,
                 Err(error) => return (error_output("io", &error), 2),
             };
-            (Some(initial), events)
+            (Some((initial_state, initial)), events)
         }
     };
+    // `model`'s init may legitimately leave some state free (#519): try the
+    // model's own deterministic init first (so a genuinely wrong observed
+    // initial state is still caught below as `initial_state_mismatch`), and
+    // only fall back to the trace's own observed initial state — already
+    // type-validated above — when init cannot determine one on its own.
+    // With no observed initial state to fall back to (a `Legacy` trace),
+    // there is nothing to build the monitor from, so surface the original
+    // deterministic-init error.
     let mut monitor = match fsl_runtime::Monitor::new(model.clone()) {
         Ok(monitor) => monitor,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => match &observed_initial {
+            Some((state, _)) => fsl_runtime::Monitor::from_state(model.clone(), state.clone()),
+            None => return (semantic_error_output(&error.to_string()), 2),
+        },
     };
     let mut bounded_liveness = if matches!(
         &trace.contract,
@@ -4001,7 +4013,7 @@ fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
     } else {
         None
     };
-    if let Some(observed) = observed_initial {
+    if let Some((_, observed)) = observed_initial {
         let expected = fslc_rust::state_json(&monitor.state);
         let mismatches = json_mismatches(&expected, &observed, "");
         if !mismatches.is_empty() {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -707,7 +707,64 @@ fn load_migration_plan(
         .map_err(|error| error_output("io", &format!("{}: {error}", path.display())))?;
     let plan = fslc_rust::migration::plan_migration(&source, &path.to_string_lossy(), edition)
         .map_err(|error| migration_plan_error_output(&source, path, &error))?;
+    // A refused plan (`plan.refused()`) means `plan_migration` itself already
+    // found a legacy construct it cannot machine-apply — e.g. `&&`, which is
+    // not tokenizable under the current grammar at all and is recognized via
+    // a dedicated raw-text pre-scan (`unsupported_double_ampersands`) before
+    // any real parsing is attempted. Running the strict checked-model
+    // pre-flight on that same raw source would only fail redundantly (or, for
+    // `&&`, with a confusing generic parse error) on exactly the construct
+    // `migrate`/`lint` already correctly report as `migration_refused`/an
+    // `unsupported_in_edition` finding, so skip it in that case.
+    if !plan.refused() {
+        validate_migration_input_semantics(&source, path)?;
+    }
     Ok((source, plan))
+}
+
+/// Unconditional structural pre-flight shared by `run_lint` and `run_migrate`
+/// through `load_migration_plan` (#517): a spec that would fail `fslc check`
+/// must not silently pass `lint`/`migrate` just because it happens to have
+/// no legacy syntax for `plan_migration` to find and fix — `plan_migration`
+/// only parses far enough to find legacy tokens, never type-checks or
+/// resolves `implements ... from`, so a spec's checked-model well-formedness
+/// was previously only validated on the changed-file path
+/// (`validate_migration_semantics`), never on an unchanged one.
+///
+/// Mirrors `run_check`'s own gate exactly, so the same input gets the same
+/// verdict on both commands: `parse`/`build_model` failures are
+/// `kind:"semantics"` (`load_model`'s convention); an unresolvable
+/// requirements `implements ... from` target is `kind:"type"`
+/// (`implements_error_output`'s convention), located when a span is
+/// available. Reuses the same dialect carve-out as `validate_fmt_semantics`:
+/// `refinement`/`agent` dialects are not a standalone check target
+/// (`fslc check specs/cart_refines.fsl` itself fails "spec has no state
+/// block"; neither `check` nor `fmt --check` nor this pre-flight treats
+/// that as a `lint`/`migrate` defect).
+fn validate_migration_input_semantics(source: &str, path: &Path) -> Result<(), Value> {
+    let dialect = fsl_syntax::dialect_keyword(source)
+        .map_err(|error| semantic_error_output(&error.to_string()))?;
+    if matches!(dialect, "refinement" | "agent") {
+        return Ok(());
+    }
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let resolver = fsl_core::FsResolver::new(base);
+    let kernel = fsl_core::parse_kernel_source_with_file(source, &resolver, path.to_string_lossy())
+        .map_err(|error| semantic_error_output(&error.to_string()))?;
+    let model =
+        fsl_core::build_model(kernel).map_err(|error| semantic_error_output(&error.to_string()))?;
+    if matches!(
+        fsl_syntax::parse_surface_document(source),
+        Ok(fsl_syntax::SurfaceDocument::Requirements(_))
+    ) {
+        fsl_core::requirements_implements(source, &resolver, &model).map_err(|error| {
+            error.span.map_or_else(
+                || error_output("type", &error.message),
+                |span| located_error_output("type", &error.message, span),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn validate_migration_semantics(before: &str, after: &str, path: &Path) -> Result<(), String> {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -936,7 +936,17 @@ fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc
         request.selection.property,
         request.selection.excluded,
     );
-    if checked_bounds.is_none() && request.initial_state.is_none() {
+    // `find_boundary_violation` is a concrete pre-scan: an optional
+    // shortcut ahead of the full Z3-backed solve below, not the source of
+    // verify's soundness. It needs a deterministic concrete initial state
+    // to run at all (#519); a model whose init leaves some state free is
+    // still fully supported by `solve_bmc`, which explores every
+    // admissible initial value symbolically, so skip the shortcut rather
+    // than failing the whole command when it does not apply.
+    if checked_bounds.is_none()
+        && request.initial_state.is_none()
+        && fsl_runtime::deterministic_initial_state(&model).is_ok()
+    {
         match fsl_runtime::find_boundary_violation(model.clone(), request.depth) {
             Ok(Some((violation, trace))) => {
                 let statistics = fsl_solver::VerificationStatistics::default();

--- a/rust/fslc/tests/edition_migrator.rs
+++ b/rust/fslc/tests/edition_migrator.rs
@@ -201,8 +201,10 @@ fn builtin_id_policy_reports_each_surface_kind_without_rewriting_ids() {
     let path = directory.write(
         "ids.fsl",
         r#"requirements Checkout {
+  state { done: Bool }
+  init { done = false }
   requirement REQ-1 "requirement" { }
-  action reject() { }
+  action reject() { done = true }
   acceptance AC-1 "acceptance" { expect true }
   forbidden NEG-1 "forbidden" { reject() expect rejected }
 }
@@ -341,9 +343,11 @@ acceptance = "TEST-{number}"
     let source = directory.write(
         "custom.fsl",
         r#"requirements Checkout {
+  state { done: Bool }
+  init { done = false }
   requirement PAY-42 "requirement" { }
   acceptance TEST-7 "acceptance" { expect true }
-  action reject() { }
+  action reject() { done = true }
   forbidden FB-CHECKOUT-001 "forbidden" { reject() expect rejected }
 }
 "#,
@@ -627,4 +631,192 @@ fn multi_file_prepare_io_failure_leaves_every_input_unchanged() {
     assert_eq!(output.status.code(), Some(2));
     assert_eq!(text(&first), first_source);
     assert_eq!(text(&second), second_source);
+}
+
+// #517: `lint`/`migrate` previously only ran checked-model validation on the
+// changed-file path, so an input with no legacy syntax for `plan_migration`
+// to find and fix skipped it entirely — a spec that fails `fslc check`
+// could still report `lint`/`migrate` exit 0. The fix adds an unconditional
+// pre-flight in `load_migration_plan`, shared by both commands, mirroring
+// `run_check`'s own kind/location convention exactly.
+
+/// Positive control required alongside the false-green fix: a genuinely
+/// valid, already-canonical spec with no legacy syntax at all (an
+/// unchanged input, in the issue's own sense — nothing for
+/// `plan_migration` to find or fix) must still pass the new unconditional
+/// pre-flight and report `lint`/`migrate` exit 0, exactly as it did before
+/// this fix. The pre-flight closes a false green; it must not introduce a
+/// false red on well-formed input.
+#[test]
+fn genuinely_valid_unchanged_input_still_passes_lint_and_migrate() {
+    let directory = FixtureDir::new();
+    let source = "spec Sound {\n  state { n: 0..3 }\n  init { n = 0 }\n  action bump() {\n    requires n < 3\n    n = n + 1\n  }\n  invariant Bound { n >= 0 }\n}\n";
+    let path = directory.write("sound.fsl", source);
+    let path = path.to_str().expect("UTF-8 path");
+
+    assert_eq!(run(&["check", path]).status.code(), Some(0));
+
+    let migrated = run(&["migrate", path, "--edition", "next"]);
+    assert_eq!(migrated.status.code(), Some(0));
+    let migrated = json(&migrated);
+    assert_eq!(migrated["result"], "migrated", "{migrated:#}");
+    assert_eq!(migrated["changed"], 0, "{migrated:#}");
+    assert_eq!(migrated["files"][0]["changed"], false, "{migrated:#}");
+    assert_eq!(
+        migrated["files"][0]["findings"].as_array().map(Vec::len),
+        Some(0),
+        "{migrated:#}"
+    );
+
+    let linted = run(&["lint", path, "--edition", "next"]);
+    assert_eq!(linted.status.code(), Some(0));
+    assert_eq!(json(&linted)["finding_count"], 0);
+}
+
+#[test]
+fn check_failing_spec_without_legacy_syntax_still_fails_lint_and_migrate() {
+    let directory = FixtureDir::new();
+    let source = "spec Broken {\n  state { n: 0..3 }\n  init { n = 0 }\n  action bump() {\n    requires n < 3\n    n = true\n  }\n  invariant Bound { n >= 0 }\n}\n";
+    let path = directory.write("type_error_clean.fsl", source);
+    let path = path.to_str().expect("UTF-8 path");
+
+    let checked = json(&run(&["check", path]));
+    assert_eq!(checked["result"], "error", "{checked:#}");
+    assert_eq!(checked["kind"], "semantics", "{checked:#}");
+
+    let migrated = run(&["migrate", path, "--edition", "next"]);
+    assert_eq!(migrated.status.code(), Some(2));
+    let migrated = json(&migrated);
+    assert_eq!(migrated["result"], "error", "{migrated:#}");
+    assert_eq!(migrated["kind"], "semantics", "{migrated:#}");
+    assert_eq!(migrated["message"], checked["message"], "{migrated:#}");
+
+    let linted = run(&["lint", path, "--edition", "next"]);
+    assert_eq!(linted.status.code(), Some(2));
+    let linted = json(&linted);
+    assert_eq!(linted["result"], "error", "{linted:#}");
+    assert_eq!(linted["kind"], "semantics", "{linted:#}");
+    assert_eq!(linted["message"], checked["message"], "{linted:#}");
+}
+
+/// Pins the asymmetry the issue reports: the exact same type error, with and
+/// without one unrelated legacy string-metadata token, must get the exact
+/// same `migrate`/`lint` verdict — not exit 0 only because
+/// `plan_migration` happened to find a legacy token to fix first.
+#[test]
+fn legacy_token_presence_does_not_change_the_check_failure_verdict() {
+    let directory = FixtureDir::new();
+    let clean = directory.write(
+        "type_error_clean.fsl",
+        "spec Broken {\n  state { n: 0..3 }\n  init { n = 0 }\n  action bump() {\n    requires n < 3\n    n = true\n  }\n  invariant Bound { n >= 0 }\n}\n",
+    );
+    let legacy = directory.write(
+        "type_error_legacy.fsl",
+        "spec Broken {\n  state { n: 0..3 }\n  init { n = 0 }\n  action bump() \"REQ-1: bump\" {\n    requires n < 3\n    n = true\n  }\n  invariant Bound { n >= 0 }\n}\n",
+    );
+    let clean = clean.to_str().expect("UTF-8 path");
+    let legacy = legacy.to_str().expect("UTF-8 path");
+
+    let clean_migrate = run(&["migrate", clean, "--edition", "next"]);
+    let legacy_migrate = run(&["migrate", legacy, "--edition", "next"]);
+    assert_eq!(clean_migrate.status.code(), Some(2));
+    assert_eq!(legacy_migrate.status.code(), Some(2));
+    let (clean_migrate, legacy_migrate) = (json(&clean_migrate), json(&legacy_migrate));
+    assert_eq!(
+        clean_migrate["kind"], legacy_migrate["kind"],
+        "{legacy_migrate:#}"
+    );
+    assert_eq!(
+        clean_migrate["message"], legacy_migrate["message"],
+        "{legacy_migrate:#}"
+    );
+
+    let clean_lint = run(&["lint", clean, "--edition", "next"]);
+    let legacy_lint = run(&["lint", legacy, "--edition", "next"]);
+    assert_eq!(clean_lint.status.code(), Some(2));
+    assert_eq!(legacy_lint.status.code(), Some(2));
+}
+
+#[test]
+fn canonical_requirements_spec_with_a_missing_implements_target_still_fails_lint_and_migrate() {
+    let directory = FixtureDir::new();
+    let source = "requirements Broken {\n  implements CartPolicy from \"moved_business.fsl\" {\n  }\n\n  state {\n    n: 0..3\n  }\n\n  init {\n    n = 0\n  }\n\n  action bump() {\n    requires n < 3\n    n = n + 1\n  }\n}\n";
+    let path = directory.write("moved_canon.fsl", source);
+    let path = path.to_str().expect("UTF-8 path");
+
+    let checked = json(&run(&["check", path]));
+    assert_eq!(checked["kind"], "type", "{checked:#}");
+    assert!(checked["loc"]["line"].as_u64().is_some(), "{checked:#}");
+
+    let migrated = run(&["migrate", path, "--edition", "next"]);
+    assert_eq!(migrated.status.code(), Some(2));
+    let migrated = json(&migrated);
+    assert_eq!(migrated["kind"], "type", "{migrated:#}");
+    assert_eq!(migrated["loc"], checked["loc"], "{migrated:#}");
+
+    let linted = run(&["lint", path, "--edition", "next"]);
+    assert_eq!(linted.status.code(), Some(2));
+    let linted = json(&linted);
+    assert_eq!(linted["kind"], "type", "{linted:#}");
+    assert_eq!(linted["loc"], checked["loc"], "{linted:#}");
+
+    // Regression control cited in the issue as an adjacent, intentionally
+    // separate symptom (`validate_fmt_semantics` does not resolve
+    // `requirements_implements`) — `fmt --check` staying exit 0 here is not
+    // this fix's concern and must not change.
+    let formatted = run(&["fmt", path, "--check", "--edition", "next"]);
+    assert_eq!(formatted.status.code(), Some(0));
+}
+
+/// Negative control: a valid spec that also has legacy syntax to migrate
+/// must keep working exactly as before this fix — the pre-flight must not
+/// reject well-formed input.
+#[test]
+fn valid_spec_with_legacy_syntax_still_migrates_and_lints() {
+    let directory = FixtureDir::new();
+    let source = "spec Good {\n  state { n: 0..3 }\n  init { n = 0 }\n  action bump() \"REQ-1: bump\" {\n    requires n < 3\n    n = n + 1\n  }\n  invariant Bound { n >= 0 }\n}\n";
+    let path = directory.write("good_legacy.fsl", source);
+    let path = path.to_str().expect("UTF-8 path");
+
+    assert_eq!(run(&["check", path]).status.code(), Some(0));
+
+    let migrated = run(&["migrate", path, "--edition", "next"]);
+    assert_eq!(migrated.status.code(), Some(0));
+    let migrated = json(&migrated);
+    assert_eq!(migrated["result"], "migrated", "{migrated:#}");
+    assert_eq!(migrated["changed"], 1, "{migrated:#}");
+    assert_eq!(migrated["files"][0]["changed"], true, "{migrated:#}");
+
+    let linted = run(&["lint", path, "--edition", "next"]);
+    assert_eq!(linted.status.code(), Some(1));
+    let linted = json(&linted);
+    assert!(
+        linted["finding_count"].as_u64().unwrap_or(0) > 0,
+        "{linted:#}"
+    );
+}
+
+/// Regression control: a `refinement`-dialect input (no `state` block —
+/// `fslc check` itself fails "spec has no state block" for this dialect,
+/// since a refinement spec is not a standalone check target) must keep
+/// returning exit 0 from `lint`/`migrate`, exactly as before this fix —
+/// the same carve-out `validate_fmt_semantics` already uses.
+#[test]
+fn refinement_dialect_is_still_not_a_standalone_lint_migrate_target() {
+    let directory = FixtureDir::new();
+    let source = "refinement Empty {\n  impl Impl\n  abs Abs\n}\n";
+    let path = directory.write("refinement_only.fsl", source);
+    let path = path.to_str().expect("UTF-8 path");
+
+    let checked = json(&run(&["check", path]));
+    assert_eq!(checked["result"], "error", "{checked:#}");
+
+    assert_eq!(
+        run(&["migrate", path, "--edition", "next"]).status.code(),
+        Some(0)
+    );
+    assert_eq!(
+        run(&["lint", path, "--edition", "next"]).status.code(),
+        Some(0)
+    );
 }

--- a/rust/fslc/tests/fixtures/issue_519_bad_post_action_state.v1.json
+++ b/rust/fslc/tests/fixtures/issue_519_bad_post_action_state.v1.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "PartialBool",
+  "initial": {"m": {"0": false, "1": true}},
+  "events": [
+    {"tick": 1, "action": "set_zero", "params": {}, "state": {"m": {"0": false, "1": true}}}
+  ]
+}

--- a/rust/fslc/tests/fixtures/issue_519_full_bool.fsl
+++ b/rust/fslc/tests/fixtures/issue_519_full_bool.fsl
@@ -1,0 +1,22 @@
+spec FullBool {
+  type Key = 0..1
+
+  state {
+    m: Map<Key, Bool>
+  }
+
+  init {
+    forall k: Key {
+      m[k] = false
+    }
+  }
+
+  action set_zero() {
+    requires not m[0]
+    m[0] = true
+  }
+
+  invariant KeyZeroSane {
+    m[0] == false or m[0] == true
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_519_full_correct.v1.json
+++ b/rust/fslc/tests/fixtures/issue_519_full_correct.v1.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "FullBool",
+  "initial": {"m": {"0": false, "1": false}},
+  "events": [
+    {"tick": 1, "action": null, "params": {}, "state": {"m": {"0": false, "1": false}}}
+  ]
+}

--- a/rust/fslc/tests/fixtures/issue_519_full_wrong_initial.v1.json
+++ b/rust/fslc/tests/fixtures/issue_519_full_wrong_initial.v1.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "FullBool",
+  "initial": {"m": {"0": true, "1": false}},
+  "events": [
+    {"tick": 1, "action": null, "params": {}, "state": {"m": {"0": true, "1": false}}}
+  ]
+}

--- a/rust/fslc/tests/fixtures/issue_519_legacy_no_initial.json
+++ b/rust/fslc/tests/fixtures/issue_519_legacy_no_initial.json
@@ -1,0 +1,3 @@
+[
+  {"action": "set_zero"}
+]

--- a/rust/fslc/tests/fixtures/issue_519_partial_bool.fsl
+++ b/rust/fslc/tests/fixtures/issue_519_partial_bool.fsl
@@ -1,0 +1,20 @@
+spec PartialBool {
+  type Key = 0..1
+
+  state {
+    m: Map<Key, Bool>
+  }
+
+  init {
+    m[0] = false
+  }
+
+  action set_zero() {
+    requires not m[0]
+    m[0] = true
+  }
+
+  invariant KeyZeroSane {
+    m[0] == false or m[0] == true
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_519_valid_free_component.v1.json
+++ b/rust/fslc/tests/fixtures/issue_519_valid_free_component.v1.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://fsl.dev/schemas/fslc/kernel/replay-trace.v1.schema.json",
+  "schema_version": "1.1.0",
+  "kernel_schema_version": "1.0.0",
+  "spec": "PartialBool",
+  "initial": {"m": {"0": false, "1": true}},
+  "events": [
+    {"tick": 1, "action": null, "params": {}, "state": {"m": {"0": false, "1": true}}}
+  ]
+}

--- a/rust/fslc/tests/issue_519_monitor_deterministic_init.rs
+++ b/rust/fslc/tests/issue_519_monitor_deterministic_init.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for #519.
+//!
+//! `Monitor::new` used to default-fill any state component `init` left
+//! unassigned (e.g. a `Map` key never written) instead of rejecting a
+//! nondeterministic init the way the explicit engine's construction gate
+//! already did. `replay` then compared an observed initial state — which
+//! may legitimately differ on the free component, since BMC explores every
+//! admissible value there — against that one arbitrary default, and
+//! falsely reported `initial_state_mismatch` on a BMC-valid trace.
+//!
+//! The fix adds the same deterministic-init gate to `Monitor::new` itself,
+//! and separately teaches every caller that already has its own complete
+//! concrete initial state (a BMC witness's first state, or a replay
+//! trace's own observed initial state) to build the monitor directly from
+//! that state instead of demanding `Monitor::new`'s determinism.
+//!
+//! The controls below check both directions per the review requirement:
+//! a BMC-valid initial state must stop being falsely reported as violated,
+//! and a genuinely nonconformant trace must still be reported as such.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+/// The core #519 fix: a replay trace whose observed initial state assigns
+/// a value BMC admits for a component `init` leaves free (`m[1]`) must be
+/// accepted, not rejected as `initial_state_mismatch` against Monitor's
+/// old arbitrary default for that component.
+#[test]
+fn replay_accepts_a_bmc_valid_initial_state_that_leaves_a_component_free() {
+    let (output, status) = run(&[
+        "replay",
+        fixture("issue_519_partial_bool.fsl").to_str().unwrap(),
+        "--trace",
+        fixture("issue_519_valid_free_component.v1.json")
+            .to_str()
+            .unwrap(),
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "conformant", "{output:#}");
+    assert_eq!(output["final_state"]["m"]["1"], true, "{output:#}");
+}
+
+/// Required negative control: this fix must not turn into a blanket
+/// "always accept the observed initial state" — a trace whose *later*
+/// step does not match the real concrete transition must still be
+/// reported nonconformant.
+#[test]
+fn replay_still_rejects_a_genuinely_wrong_post_action_state() {
+    let (output, status) = run(&[
+        "replay",
+        fixture("issue_519_partial_bool.fsl").to_str().unwrap(),
+        "--trace",
+        fixture("issue_519_bad_post_action_state.v1.json")
+            .to_str()
+            .unwrap(),
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant", "{output:#}");
+    assert_eq!(output["violation"]["kind"], "state_mismatch", "{output:#}");
+}
+
+/// Regression control: when `init` deterministically assigns every
+/// component (no free component at all), `Monitor::new` still succeeds
+/// directly and a genuinely wrong observed initial state is still caught
+/// as `initial_state_mismatch` exactly as before this fix.
+#[test]
+fn replay_still_rejects_a_wrong_initial_state_when_init_is_fully_deterministic() {
+    let (output, status) = run(&[
+        "replay",
+        fixture("issue_519_full_bool.fsl").to_str().unwrap(),
+        "--trace",
+        fixture("issue_519_full_wrong_initial.v1.json")
+            .to_str()
+            .unwrap(),
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "nonconformant", "{output:#}");
+    assert_eq!(
+        output["violation"]["kind"], "initial_state_mismatch",
+        "{output:#}"
+    );
+}
+
+/// Positive control (from the issue): a fully deterministic
+/// `forall`-initialized spec, replayed with a correct trace, remains
+/// conformant.
+#[test]
+fn replay_still_accepts_a_correct_trace_when_init_is_fully_deterministic() {
+    let (output, status) = run(&[
+        "replay",
+        fixture("issue_519_full_bool.fsl").to_str().unwrap(),
+        "--trace",
+        fixture("issue_519_full_correct.v1.json").to_str().unwrap(),
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "conformant", "{output:#}");
+}
+
+/// Named negative control from the issue itself: with no observed initial
+/// state to fall back on at all (a `Legacy` trace carries none), a
+/// nondeterministic init has nothing to build a concrete Monitor from and
+/// must still fail Monitor/replay construction with `kind:"semantics"`,
+/// exit 2 — this fix must not silently pick an initial state on its own.
+#[test]
+fn replay_still_fails_closed_with_no_observed_initial_state_to_fall_back_on() {
+    let (output, status) = run(&[
+        "replay",
+        fixture("issue_519_partial_bool.fsl").to_str().unwrap(),
+        "--trace",
+        fixture("issue_519_legacy_no_initial.json")
+            .to_str()
+            .unwrap(),
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error", "{output:#}");
+    assert_eq!(output["kind"], "semantics", "{output:#}");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not assign state variable")),
+        "{output:#}"
+    );
+}
+
+/// Sanity control: the explicit engine's own construction gate
+/// (`check_deterministic_init`, which `Monitor::new` now reuses) is
+/// unaffected by this fix and still fails closed the same way.
+#[test]
+fn explicit_engine_still_fails_closed_for_nondeterministic_init() {
+    let (output, status) = run(&[
+        "verify",
+        fixture("issue_519_partial_bool.fsl").to_str().unwrap(),
+        "--depth",
+        "4",
+        "--engine",
+        "explicit",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["kind"], "semantics", "{output:#}");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -867,7 +867,9 @@ urgency freezes time (`urgency_freeze`). `--vacuity error` gives
 ```
 fslc check <f>                                  # syntax / names / types only; f = .fsl or .md (literate)
 fslc lint <path>... [--edition current|next] [--project fsl-project.toml] # edition + ID-policy findings; never mutates
+                                                 # exit 0 no findings, 1 findings exist, 2 I/O or check failure (unconditional per input, refused legacy tokens excepted)
 fslc migrate <path>... --edition next [--write] # dry run by default; atomic validated write set
+                                                 # exit 0 migrated, 2 refused/I/O/check failure (same check-failure contract as lint)
 fslc fmt <f|-> [--edition current|next]         # canonical source on stdout; input is never mutated
 fslc fmt <path>... --check                      # JSON; exit 0 clean, 1 changed, 2 error
 fslc kernel <f> [--kernel-version 1|2]          # normalized typed Kernel JSON (default v1)

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -964,7 +964,12 @@ complete post-transition `state`. Trace schema 1.1 adds explicit stutter as
 state. Equal-state stutters may be inserted/deleted, while unreported concrete
 intermediates are outside invariant judgment. Optional `timestamp` is opaque
 and ignored. Trace v1 accepts Kernel 1.0.0/2.0.0. Ill-shaped/incomplete input is exit 2; typed
-state divergence is exit 1 with leaf mismatches. Bare arrays/`{events}` are the
+state divergence is exit 1 with leaf mismatches. `initial` is checked against
+`init`'s own computed initial state only when `init` fully determines one; if
+`init` leaves any state variable free (BMC explores every admissible value
+there), `initial` is trusted as the concrete starting point directly instead
+of failing `initial_state_mismatch` against an arbitrary default value for
+that variable. Bare arrays/`{events}` are the
 unversioned action-only compatibility adapter; testgen/verifier traces are not
 replay input. See `docs/DESIGN-replay-trace.md`.
 


### PR DESCRIPTION
## Problem

Two defects in opposite directions, both from an evaluator or a gate substituting a convenient approximation for the contract.

**#517 — `migrate` and `lint` skipped `check` on unchanged input, so an invalid spec passed both.** A spec with a genuine type error but no legacy syntax to migrate went straight through, exit 0. The asymmetry is what makes it a false green rather than a missing feature: the *same* type error was reported when the file happened to contain one unrelated legacy token, and silently accepted when it did not.

**#519 — the Monitor's partial-`init` defaulting made `replay` report a false violation.** `Monitor::new` filled any variable `init` never assigns with its type's default and then compared against that fabricated seed, so an initial state BMC accepts was reported as non-conformant. A false *red* on a valid trace, and a break of the symbolic/concrete/BFS agreement invariant.

## Contract change

**#517** — an unconditional checked-model pre-flight in `load_migration_plan`, shared by `run_lint` and `run_migrate`, following `run_check`'s own kind and location conventions. Two scoping decisions that were not obvious from the issue text and are worth stating:

- The pre-flight runs **after** `plan_migration`, not before. Run first, a genuinely unparseable file gets misclassified `kind:"semantics"` when `plan_migration`'s own parse path already reports the more precise `kind:"parse"`. That is the same envelope-misclassification class as #484.
- It is skipped when `plan.refused()` is true. `&&` is lexically rejected by the current grammar outright, and `docs/DESIGN-migration.md` already documents that "no pre-migration checked model exists to compare" for it — so applying the pre-flight there would fail redundantly and mask the correct `migration_refused` / `unsupported_in_edition` reporting. This follows an accepted decision rather than inventing an exemption.

**#519** — `Monitor::new` now rejects a nondeterministic init instead of silently defaulting it. Closing that gate surfaced two **second-order regressions** which are fixed in the same commit: BMC's concrete pre-scan and `replay`'s own initial-state handling both called `Monitor::new` unconditionally and would have hard-failed on any spec with legitimately free init — which is exactly what BMC is supposed to tolerate. A fix that closed the false red on `replay` while breaking BMC's tolerance would have passed its own test.

## Test evidence

Both fixes carry negative controls that fail when reverted, confirmed by revert-and-confirm.

**#517**, both required directions:
- False green closed: a type error with no legacy syntax now returns `kind:"semantics"` / exit 2 from both commands; a canonical requirements spec with a missing `implements ... from` target returns `kind:"type"` / exit 2 with the location matching `check` exactly. The A/A′ asymmetry — same type error, with and without one unrelated legacy token — is pinned to the same exit code.
- Valid input still accepted: `genuinely_valid_unchanged_input_still_passes_lint_and_migrate` asserts a canonical spec with zero legacy syntax still gets exit 0 / `changed:0` / `finding_count:0` from both commands.
- The `refinement` / `agent` dialect carve-out is preserved, matching `fmt --check`'s existing exclusion.

Revert check: stashing `rust/fslc/src/main.rs` by explicit label made exactly the three fix-dependent tests fail (`check_failing_spec_without_legacy_syntax_still_fails_lint_and_migrate`, `legacy_token_presence_does_not_change_the_check_failure_verdict`, `canonical_requirements_spec_with_a_missing_implements_target_still_fails_lint_and_migrate` — all `Some(0)` where `Some(2)` is expected), with the positive control and everything else still passing. Restored: 21/21.

**Two existing fixtures were relying on the bug.** `requirements Checkout { … }` with no `state` block passed `lint`/`migrate` only because the check was being skipped — the exact gap #517 reports. Those fixtures were given a minimal `state`/`init` block rather than widening the carve-out, because widening it would have **reopened the issue this PR closes**. `corpus_check_sweep.rs`'s accepted contract confirms "no state block" is a `refinement`-dialect standalone-check exemption only, not a `requirements`-dialect one, and the real corpus has zero requirements-dialect specs with a genuinely empty state.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (147 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/DESIGN-migration.md`, `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (kept 1:1 section-aligned), `skills/fsl/reference.md`, `CHANGELOG.md` `[Unreleased]`. Both issues are marked breaking, so the entries state what output changes.

## Scope note

#524 (`mutate`'s default mutant cap) and #525 (`html` property-row assurance and requirement caption) were split out of this branch and will follow separately, so these two finished fixes are not queued behind unstarted work.

## Linked issues

Fixes #517, fixes #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
