### PR TITLE
fix(runtime): make reachable(r, a, a) non-reflexive on every engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   directory (same idiom as `rust/fslc/tests/chain_cli.rs`'s `scratch_dir`),
   which needs no `exists()`/`remove_dir_all()` step at all — closing the
   race window rather than narrowing it (#546).
+- Native `reachable(r, a, a)` is now non-reflexive on every engine: true
+  only via a real path of one or more edges back to `a`, never a free
+  zero-hop `a == a` step. `rust/fsl-runtime/src/lib.rs`'s concrete
+  `relation_reachable` (used by the `--engine explicit` BFS oracle, and by
+  the default engine's own trace-replay consistency check) started its BFS
+  frontier at `[source]` and checked `current == target` before traversing
+  any edge, so it reported self-reachability as trivially true for *any*
+  relation, including an empty one -- a free zero-hop step the symbolic
+  evaluator's convention never took. Neither `docs/LANGUAGE.md` nor
+  `docs/LANGUAGE.ja.md` previously stated whether `reachable` was
+  reflexive; both now document the non-reflexive contract explicitly.
+  Matches the frozen Python reference's `_relation_reachable`
+  (`src/fslc/runtime.py`) and native BMC exactly -- confirmed by direct
+  code reading and by running the frozen `verify`/`scenarios` commands
+  against the same repro spec, both `violated_at_step:1`, not the reflexive
+  `0` the pre-fix native concrete engine reported. Before the fix an empty
+  relation disagreed between engines (`violated_at_step` 0 vs. 1) and a
+  multi-hop-cycle spec made the default engine's own trace-replay
+  consistency check fail outright (`kind:"internal"`,
+  `"trace state mismatch"`, exit 3), since BMC's concrete replay of its own
+  symbolic counterexample used the same disagreeing evaluator (#502).
 - `relation A -> B` state is now usable end to end in the native symbolic
   verifier: `r = Set {}` types and evaluates as the empty relation (both
   `fslc check` and the concrete Monitor previously rejected or mistyped it),

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -577,7 +577,12 @@ invariant OnlyEligible { forall c: Claim { approved[c] => eligible(c) } }
   `reachable(r, a, b)`、`acyclic(r)`、`functional(r)`、`injective(r)`、
   `domain(r)`、`range(r)`。`reachable` と `acyclic` は自己関係
   (`relation T -> T`)を要求します。端点の型/アリティのエラーは修復ヒントを
-  含みます。
+  含みます。`reachable(r, a, a)` は構造上**反射的ではありません**——`a` から
+  `a` に戻る、1本以上の辺からなる本物のパスがある場合にのみ真です(空の関係
+  や非巡回の関係では、すべての `a` について `reachable(r, a, a) == false`)。
+  反射的な読みだと、任意の非空ドメインで `not reachable(r, a, a)` が構造上
+  充足不能になり、述語から意味が失われます。「`r` のどこにも自己ループや
+  サイクルがない」を述べるには `acyclic(r)` を使ってください。
 - ensures / trans の内側のみ: `old(expr)` で遷移前の状態を読む
 - leadsTo ブロックの内側のみ: `P ~> Q`(応答プロパティ。一般式の演算子階層の一部ではありません)。
   Q の前に有界の締め切り `within K` を、応答本体の後に induction のランキング用の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -594,6 +594,12 @@ variable capture instead of inventing internal binder names. See
   `reachable(r, a, b)`, `acyclic(r)`, `functional(r)`, `injective(r)`,
   `domain(r)`, `range(r)`. `reachable` and `acyclic` require a self-relation
   (`relation T -> T`); endpoint type/arity errors include repair hints.
+  `reachable(r, a, a)` is **not** reflexive by construction: it is true only
+  if a real path of one or more edges leads from `a` back to `a` (so an empty
+  or acyclic relation gives `reachable(r, a, a) == false` for every `a`). A
+  reflexive reading would make `not reachable(r, a, a)` unsatisfiable by
+  construction for any inhabited domain, draining the predicate of meaning;
+  use `acyclic(r)` to state "no self-loops or cycles anywhere in `r`".
 - Inside ensures / trans only: read the pre-transition state with `old(expr)`
 - Inside a leadsTo block only: `P ~> Q` (response property. not part of the operator hierarchy of general expressions);
   optional `within K` before Q for a bounded deadline, and optional

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -321,7 +321,7 @@ pub fn eval(
             third,
         } if name == "rel_reachable" => relation_reachable(
             eval(first, state, bindings, model, old_state)?,
-            eval(second, state, bindings, model, old_state)?,
+            &eval(second, state, bindings, model, old_state)?,
             &eval(third, state, bindings, model, old_state)?,
         ),
         Expr::TernaryNamed { name, .. } => Err(runtime_error(format!(
@@ -586,14 +586,29 @@ fn binder_where_holds(
 
 fn relation_reachable(
     relation: Value,
-    source: Value,
+    source: &Value,
     target: &Value,
 ) -> Result<Value, RuntimeError> {
     let Value::Relation(edges) = relation else {
         return Err(runtime_error("reachable() requires a relation"));
     };
-    let mut seen = BTreeSet::from([source.clone()]);
-    let mut frontier = vec![source];
+    // Non-reflexive: `reachable(r, a, a)` is true only via a real path of
+    // one or more edges back to `a`, never a free zero-hop `a == a` step
+    // (`docs/LANGUAGE.md`'s relation section; matches the frozen Python
+    // reference's `_relation_reachable` in `src/fslc/runtime.py`, and this
+    // crate's own symbolic evaluator). The frontier starts at `source`'s
+    // *direct successors*, not `source` itself, so an empty or acyclic
+    // relation never reports self-reachability by construction. `source`
+    // itself is deliberately left out of `seen` here, so a cycle that
+    // leads back to `source` still re-enqueues it -- needed to detect
+    // `reachable(r, a, a)` via a multi-hop cycle through `a`.
+    let mut seen = BTreeSet::new();
+    let mut frontier = Vec::new();
+    for (_, next) in edges.iter().filter(|(from, _)| from == source) {
+        if seen.insert(next.clone()) {
+            frontier.push(next.clone());
+        }
+    }
     while let Some(current) = frontier.pop() {
         if &current == target {
             return Ok(Value::Bool(true));
@@ -645,7 +660,7 @@ fn eval_relation_unary(
                 for (_, next) in edges.iter().filter(|(source, _)| source == &node) {
                     if as_bool(relation_reachable(
                         Value::Relation(edges.clone()),
-                        next.clone(),
+                        next,
                         &node,
                     )?)? {
                         return Ok(Value::Bool(false));

--- a/rust/fslc/tests/fixtures/issue_502_reachable_cycle.fsl
+++ b/rust/fslc/tests/fixtures/issue_502_reachable_cycle.fsl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The cycle-through-`a` shape: no direct `(0, 0)` edge, but a 2-hop cycle
+// `0 -> 1 -> 0` exists after both actions have fired. Both a reflexive and
+// a non-reflexive `reachable` agree this makes `0` reachable from `0` via
+// the real path -- this shape does not distinguish the two conventions
+// either, it is a regression control that the fix still finds a multi-hop
+// cycle back to the source (not only a direct self-loop).
+spec ReachableCycle {
+  type Node = 0..1
+  state { r: relation Node -> Node }
+  init { r = Set {} }
+
+  action step1() {
+    r = r.add(0, 1)
+  }
+
+  action step2() {
+    r = r.add(1, 0)
+  }
+
+  invariant NoTrivialSelfReach { not reachable(r, 0, 0) }
+}

--- a/rust/fslc/tests/fixtures/issue_502_reachable_empty.fsl
+++ b/rust/fslc/tests/fixtures/issue_502_reachable_empty.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The empty-relation shape: this is the *only* one of the three shapes in
+// this issue's negative control that distinguishes a reflexive from a
+// non-reflexive `reachable(r, a, a)`. With zero edges there is no path of
+// any length from 0 back to 0, so a non-reflexive reading keeps the
+// invariant true at init; only the first `link` action can violate it.
+spec ReachableEmpty {
+  type Node = 0..1
+  state { r: relation Node -> Node }
+  init { r = Set {} }
+
+  action link(a: Node, b: Node) {
+    r = r.add(a, b)
+  }
+
+  invariant NoTrivialSelfReach { not reachable(r, 0, 0) }
+}

--- a/rust/fslc/tests/fixtures/issue_502_reachable_selfloop.fsl
+++ b/rust/fslc/tests/fixtures/issue_502_reachable_selfloop.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The self-loop shape: a genuine `(0, 0)` edge exists after `loop_0`. Both
+// a reflexive and a non-reflexive `reachable` agree this makes `0`
+// reachable from `0` -- this shape does not distinguish the two
+// conventions, it is a regression control that the fix does not stop
+// detecting a *real* self-loop.
+spec ReachableSelfLoop {
+  type Node = 0..1
+  state { r: relation Node -> Node }
+  init { r = Set {} }
+
+  action loop_0() {
+    r = r.add(0, 0)
+  }
+
+  invariant NoTrivialSelfReach { not reachable(r, 0, 0) }
+}

--- a/rust/fslc/tests/issue_502_reachable_reflexivity.rs
+++ b/rust/fslc/tests/issue_502_reachable_reflexivity.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Dual-engine negative control for #502: `reachable(r, a, a)` must give the
+//! same verdict under the default (BMC) engine and `--engine explicit`
+//! (the solver-free concrete Monitor's BFS oracle), on the same spec, for
+//! the same reason. Before the fix, `rust/fsl-runtime/src/lib.rs`'s
+//! concrete `relation_reachable` started its BFS frontier at `[source]`
+//! and checked `current == target` before traversing any edge, so it
+//! reported `reachable(r, a, a)` as trivially true for *any* relation
+//! (including an empty one) -- a free zero-hop step the symbolic
+//! evaluator's non-reflexive convention never took. `docs/LANGUAGE.md`'s
+//! relation section now states the contract explicitly: `reachable(r, a,
+//! a)` is true only via a real path of one or more edges.
+//!
+//! Only the empty-relation shape distinguishes the two conventions: a
+//! self-loop or a multi-hop cycle back to `a` is `reachable` either way, so
+//! those two shapes are regression controls (the fix must not stop
+//! detecting a *real* cycle), not part of the discriminating evidence.
+//! Before the fix, all three shapes disagreed between engines in some
+//! form -- the empty and self-loop fixtures disagreed on
+//! `violated_at_step` (0 vs. 1: the reflexive concrete Monitor found *any*
+//! reachable state, including init, already violating), and the cycle
+//! fixture made the default engine's own trace-replay consistency check
+//! fail outright (`kind:"internal"`, `"trace state mismatch at step 2"`,
+//! exit 3) because BMC's own concrete replay of its symbolic counterexample
+//! used the same disagreeing concrete evaluator.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn verify(fixture: &str, depth: &str, engine: Option<&str>) -> (Value, i32) {
+    let path = format!("rust/fslc/tests/fixtures/{fixture}");
+    let mut arguments = vec!["verify", &path, "--depth", depth, "--no-cache"];
+    if let Some(engine) = engine {
+        arguments.extend(["--engine", engine]);
+    }
+    run_cli(&arguments)
+}
+
+/// Assert the default (BMC) and `--engine explicit` verdicts for the same
+/// fixture agree exactly on `result`, `violation_kind`, and
+/// `violated_at_step` -- a dual-engine control, not two single-engine
+/// assertions that could each independently pass against a wrong but
+/// *consistent* convention.
+fn assert_engines_agree(fixture: &str, depth: &str, expected_violated_at_step: i64) {
+    let (bmc, bmc_status) = verify(fixture, depth, None);
+    let (explicit, explicit_status) = verify(fixture, depth, Some("explicit"));
+
+    assert_eq!(bmc_status, 1, "bmc status for {fixture}: {bmc:#}");
+    assert_eq!(
+        explicit_status, 1,
+        "explicit status for {fixture}: {explicit:#}"
+    );
+    assert_eq!(bmc["result"], "violated", "{fixture}: {bmc:#}");
+    assert_eq!(explicit["result"], "violated", "{fixture}: {explicit:#}");
+    assert_eq!(
+        bmc["violation_kind"], explicit["violation_kind"],
+        "{fixture}: bmc={bmc:#} explicit={explicit:#}"
+    );
+    assert_eq!(bmc["violation_kind"], "invariant", "{fixture}: {bmc:#}");
+    assert_eq!(
+        bmc["violated_at_step"], explicit["violated_at_step"],
+        "{fixture}: bmc={bmc:#} explicit={explicit:#}"
+    );
+    assert_eq!(
+        bmc["violated_at_step"], expected_violated_at_step,
+        "{fixture}: {bmc:#}"
+    );
+}
+
+/// The discriminating shape: an empty relation. Non-reflexive `reachable`
+/// keeps the invariant true at init (no path exists yet), so both engines
+/// must agree the first violation is the first `link` action, not init
+/// itself.
+#[test]
+fn reachable_is_non_reflexive_for_an_empty_relation_on_both_engines() {
+    assert_engines_agree("issue_502_reachable_empty.fsl", "1", 1);
+}
+
+/// Regression control: a genuine self-loop is reachable either way.
+#[test]
+fn reachable_still_detects_a_genuine_self_loop_on_both_engines() {
+    assert_engines_agree("issue_502_reachable_selfloop.fsl", "1", 1);
+}
+
+/// Regression control: a genuine multi-hop cycle back to the source is
+/// reachable either way.
+#[test]
+fn reachable_still_detects_a_multi_hop_cycle_through_the_source_on_both_engines() {
+    assert_engines_agree("issue_502_reachable_cycle.fsl", "2", 2);
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -745,6 +745,9 @@ cannot be assigned both inline and in `init`.
 - Relation: `.contains(a,b) .add(a,b) .remove(a,b)`,
   `reachable(r,a,b) acyclic(r) functional(r) injective(r) domain(r) range(r)`.
   `reachable`/`acyclic` require a self-relation (`relation T -> T`).
+  `reachable(r,a,a)` is **not reflexive**: true only via a real path of ≥1
+  edges back to `a` (empty/acyclic `r` gives `false`, never a free 0-hop
+  `a==a`). Use `acyclic(r)` for "no self-loops or cycles anywhere".
 - conditional expression: `if c then a else b` in any expression position;
   `c` is Bool, both branches have one logical type and are checked statically,
   while only the selected branch is evaluated


### PR DESCRIPTION
## Problem

`reachable(r, a, a)` meant different things to different engines. The same spec, same binary, same invariant:

```fsl
spec ReachableSelf {
  type Node = 0..1
  state { r: relation Node -> Node }
  init { r = Set {} }
  action link(a: Node, b: Node) { r = r.add(a, b) }
  invariant NoTrivialSelfReach { not reachable(r, 0, 0) }
}
```

`verify --depth 1` reported `violated_at_step: 1`; `verify --engine explicit --depth 1` reported `violated_at_step: 0`. The concrete Monitor's BFS starts its frontier at `[source]` and tests `current == target` before traversing any edge, so `reachable(r, a, a)` held for a relation with **zero edges**; the symbolic encoding required at least one real edge.

This is a direct break of `AGENTS.md`'s invariant that symbolic verification, the concrete Monitor and solver-free BFS must agree. It is not a false green — both engines report `violated` and exit 1 — but they disagree on *when*, so the counterexample and its trace depend on which engine ran.

## Root cause: the contract was never written down

The disagreement predates the native port. `runtime.py` was reflexive and `bmc.py` was not — **the frozen reference disagreed with itself**, and both halves were ported faithfully, so the divergence came along intact. That is why "match the Python reference" is not a sufficient justification here and why the issue could sit unnoticed: with neither `docs/LANGUAGE.md` nor `docs/LANGUAGE.ja.md` stating whether `reachable` is reflexive, **neither implementation was wrong**.

So the fix is a contract decision first and a code change second.

## Contract change

`reachable(r, a, b)` is **non-reflexive**: it holds when a path of one or more edges leads from `a` to `b`, never via a free zero-hop `a == a` step. Both LANGUAGE files now state this (kept 1:1 section-aligned), so the question cannot go unanswered again.

The reasoning, recorded in the commit body: a reflexive reading makes `not reachable(r, a, a)` unsatisfiable by construction, which drains the predicate of meaning — an author writing it can only ever get a violation. Non-reflexive gives it the useful reading "`a` lies on a cycle". It also matches the convention `tests/test_relation.py`'s existing `NoSelfReach` case already assumes, so the frozen suite's expectation is preserved rather than inverted.

## Test evidence

Both engines now agree, verified independently:

| engine | before | after |
|---|---|---|
| default (BMC) | `violated` / `invariant` / **step 1** | `violated` / `invariant` / **step 1** |
| `--engine explicit` | `violated` / `invariant` / **step 0** | `violated` / `invariant` / **step 1** |

Step 1 is the correct consequence of the chosen convention: with an empty relation `reachable(r, 0, 0)` is false, so nothing is violated at step 0; the violation appears once `link(0, 0)` adds a real self-loop.

The control is **dual-engine by construction** — the same spec asserted to produce the same `result`, `violation_kind` and `violated_at_step` under both engines, rather than two separate single-engine tests that could each pass while disagreeing with each other. Coverage spans the three shapes that matter, and **only the empty-relation case distinguishes the two conventions**: a real self-loop and a cycle through `a` are reachable under either reading and would pass against a wrong choice.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (147 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation and skills

`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` (section counts verified still 1:1), `CHANGELOG.md` `[Unreleased]`.

## Provenance

Found while implementing #467 (native relation-typed operations), not by the original audit — the disagreement only became reproducible once relation-typed state could survive the Public Kernel, which #467 delivered. Deliberately held until #467 merged rather than backported, so the control could be written against real relation semantics instead of a stub.

## Linked issues

Fixes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
