### PR TITLE
fix(tests): give each test its own fixture path so repeat and parallel runs stop failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `rust/fslc/tests/testgen_contract.rs`'s
+  `symlink_source_name_and_canonical_pytest_path_remain_distinct` no longer
+  panics with `create output-parent symlink: AlreadyExists` on a repeated
+  local run whose previous invocation was interrupted before its own
+  trailing cleanup ran: the fixture directory and both symlinks it creates
+  now live under a fresh, uniquely named scratch directory (same idiom as
+  `rust/fslc/tests/chain_cli.rs`'s `scratch_dir`) instead of a fixed, reused
+  path, so there is nothing left over to collide with on the next run
+  regardless of how the previous one ended (#539).
 - `relation A -> B` state is now usable end to end in the native symbolic
   verifier: `r = Set {}` types and evaluates as the empty relation (both
   `fslc check` and the concrete Monitor previously rejected or mistyped it),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `rust/fslc/tests/chain_cli.rs`'s `scratch_dir`) instead of a fixed, reused
   path, so there is nothing left over to collide with on the next run
   regardless of how the previous one ended (#539).
+- `rust/fslc/tests/domain_codegen_contract.rs`'s
+  `all_five_public_kernel_domain_targets_match_pre_migration_goldens` and
+  `every_valid_domain_corpus_entry_generates_all_five_targets` no longer
+  intermittently fail (a golden digest mismatch or a
+  `clear generated directory: No such file or directory`) when cargo runs
+  them in parallel in the same test binary, the default: both used to
+  `exists()`-then-`remove_dir_all()` a directory under a shared
+  `rust/target/domain-codegen-contract/` parent before generating into it,
+  leaving a window one test's cleanup could race against the other's
+  read/write. Each generation call now gets its own uniquely named scratch
+  directory (same idiom as `rust/fslc/tests/chain_cli.rs`'s `scratch_dir`),
+  which needs no `exists()`/`remove_dir_all()` step at all — closing the
+  race window rather than narrowing it (#546).
 - `relation A -> B` state is now usable end to end in the native symbolic
   verifier: `r = Set {}` types and evaluates as the empty relation (both
   `fslc check` and the concrete Monitor previously rejected or mistyped it),

--- a/rust/fslc/tests/domain_codegen_contract.rs
+++ b/rust/fslc/tests/domain_codegen_contract.rs
@@ -2,8 +2,11 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use sha2::{Digest, Sha256};
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
 
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -11,6 +14,24 @@ fn root() -> PathBuf {
         .and_then(Path::parent)
         .expect("workspace root")
         .to_owned()
+}
+
+/// A fresh scratch directory per call under `rust/target/`, so tests in this
+/// binary — which cargo runs in parallel by default — never race on a
+/// shared generated-output path, and no `exists()`-then-`remove_dir_all`
+/// cleanup step is required (gitignored). Same idiom as
+/// `rust/fslc/tests/chain_cli.rs`'s `scratch_dir` (issue #546).
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = root().join(format!(
+        "rust/target/domain-codegen-contract-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
 }
 
 fn collect_files(directory: &Path, current: &Path, files: &mut Vec<PathBuf>) {
@@ -37,10 +58,7 @@ fn portable_relative_path(path: &Path) -> String {
 
 fn generated_digest(target: &str) -> String {
     let root = root();
-    let directory = root.join(format!("rust/target/domain-codegen-contract/{target}"));
-    if directory.exists() {
-        std::fs::remove_dir_all(&directory).expect("clear generated directory");
-    }
+    let directory = scratch_dir(&format!("target-{target}"));
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args([
             "domain",
@@ -79,12 +97,7 @@ fn assert_generation_succeeds(spec: &str, target: &str) {
         .file_stem()
         .expect("fixture stem")
         .to_string_lossy();
-    let directory = root.join(format!(
-        "rust/target/domain-codegen-contract/corpus/{stem}/{target}"
-    ));
-    if directory.exists() {
-        std::fs::remove_dir_all(&directory).expect("clear generated directory");
-    }
+    let directory = scratch_dir(&format!("corpus-{stem}-{target}"));
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args(["domain", "generate", spec, "--target", target, "-o"])
         .arg(directory)

--- a/rust/fslc/tests/testgen_contract.rs
+++ b/rust/fslc/tests/testgen_contract.rs
@@ -2,8 +2,11 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use sha2::{Digest, Sha256};
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
 
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -11,6 +14,23 @@ fn root() -> PathBuf {
         .and_then(Path::parent)
         .expect("workspace root")
         .to_owned()
+}
+
+/// A fresh scratch directory per call under `rust/target/`, so parallel test
+/// binaries — and repeated runs in the same worktree — never collide and no
+/// cleanup step is required (gitignored). Same idiom as
+/// `rust/fslc/tests/chain_cli.rs`'s `scratch_dir` (issue #539).
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = root().join(format!(
+        "rust/target/testgen-contract-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
 }
 
 fn generated_content(spec: &str, depth: &str, target: &str, stem: &str) -> String {
@@ -137,15 +157,9 @@ fn symlink_source_name_and_canonical_pytest_path_remain_distinct() {
     use std::os::unix::fs::symlink;
 
     let root = root();
-    let fixture_root = root.join("rust/target/testgen-contract");
+    let fixture_root = scratch_dir("symlink");
     let directory = fixture_root.join("path-context");
     let real_output_parent = fixture_root.join("path-output-real");
-    if directory.exists() {
-        std::fs::remove_dir_all(&directory).expect("clear path-context fixture");
-    }
-    if real_output_parent.exists() {
-        std::fs::remove_dir_all(&real_output_parent).expect("clear real output fixture");
-    }
     std::fs::create_dir_all(&directory).expect("create path-context fixture");
     std::fs::create_dir_all(&real_output_parent).expect("create real output directory");
     let generated = directory.join("generated-link");
@@ -174,7 +188,4 @@ fn symlink_source_name_and_canonical_pytest_path_remain_distinct() {
             "SPEC_PATH = Path(__file__).resolve().parent / '../../../../specs/cart_v1.fsl'"
         )
     );
-
-    std::fs::remove_dir_all(&directory).expect("clear path-context fixture");
-    std::fs::remove_dir_all(&real_output_parent).expect("clear real output fixture");
 }


### PR DESCRIPTION
## Problem

Two tests that are unsafe with respect to their own fixtures. Neither is a product defect — no verdict, exit code or verification result changes — but both **degrade the gate's signal**, which costs more than it sounds: an intermittent or repeat-run false red is indistinguishable from a real regression until someone spends time separating them. Both were found during this batch by exactly that cost being paid.

**#539 — `testgen_contract.rs` cannot be run twice in the same worktree.** `symlink_source_name_and_canonical_pytest_path_remain_distinct` clears `real_output_parent` but not the two symlinks it creates alongside it (`generated-link`, `cart-alias.fsl`), which live outside that directory. `symlink(2)` returns `EEXIST` when the destination exists, so the second run dies during fixture setup:

```
create output-parent symlink: Os { code: 17, kind: AlreadyExists, message: "File exists" }
```

CI never sees it, because CI always starts from a clean checkout. It hits only developers and agents running the gate repeatedly — which `AGENTS.md` explicitly asks them to do.

**#546 — `domain_codegen_contract.rs`'s two tests race on a shared output directory.** Both do `exists()` → `remove_dir_all()` → generate against `rust/target/domain-codegen-contract/`, and cargo runs tests in one binary in parallel by default, so one can be clearing while the other reads or clears. Symptoms are a golden-digest mismatch and `clear generated directory: No such file or directory`. `--test-threads=1` passes reliably.

Because it is intermittent, **CI passing is not evidence the race is absent** — and every time it does fire, the cost is separating it from a real regression.

## Contract change

None. Only fixture handling changes; every assertion is untouched.

Both tests now give each test its own output path, following the idiom already established in `rust/fslc/tests/chain_cli.rs`'s `scratch_dir(name)` — "a fresh scratch directory per test under `rust/target/`, so parallel test binaries never collide and no cleanup step is required (gitignored)". Unique paths make the `remove_dir_all` unnecessary, which **closes** the `exists()`-to-remove window rather than narrowing it.

Three alternatives were rejected deliberately:
- `#[serial]` or any serialization attribute — adds a dependency, hides *why* serialization is required, and does not fix #539 at all.
- `--test-threads=1` in the gate — would mask this class of race for every other test too.
- Relaxing either assertion — the tests are correct about what they check; only their setup was unsafe.

## Test evidence

The regression condition for each is the repetition itself, so that is what was measured rather than a single green run.

**#539** — `cargo test -p fslc-rust --test testgen_contract` twice in a row in the same worktree, no cleaning between:

```
run 1: test result: ok. 4 passed; 0 failed
run 2: test result: ok. 4 passed; 0 failed
```

Before the fix, run 2 fails deterministically at fixture setup.

**#546** — `cargo test -p fslc-rust --test domain_codegen_contract` four consecutive times at the **default** parallel setting:

```
run 1: ok. 3 passed; 0 failed
run 2: ok. 3 passed; 0 failed
run 3: ok. 3 passed; 0 failed
run 4: ok. 3 passed; 0 failed
```

A single green run proves nothing for a race, which is why this was run repeatedly and at the default thread count rather than serialized.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, `cargo test --workspace --locked` (146 test binaries, 0 failures), and `./tools/check-native-integration.sh rust` all exit 0.

## Documentation

`CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #539, fixes #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
