### PR TITLE
fix(lsp): derive declaration and binder indexes from accepted syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,11 @@ the focused `fsl-solver-z3`, `fsl-verifier`, and `fslc-rust` tests.
   evidence contract. Do not allowlist verdict, location, assurance, or exit-code differences.
 - A language feature moves with its grammar/lowering, typed model, symbolic and concrete semantics,
   regression cases, `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/reference.md`, a design
-  note, and `CHANGELOG.md`. `docs/LANGUAGE.ja.md` is a second canonical source kept section-aligned
+  note, and `CHANGELOG.md`. A new declaration, binder, or reference form additionally moves with
+  `rust/fsl-lsp/src/index.rs` and a targeted role/scope test, or it silently loses
+  definition/references/rename/documentSymbol with no parse failure to surface the gap;
+  `rust/fsl-lsp/tests/corpus.rs` only asserts that every identifier is indexed as something.
+  `docs/LANGUAGE.ja.md` is a second canonical source kept section-aligned
   1:1 with `docs/LANGUAGE.md` (same count/order of `## ` sections) — `tools/build_site_reference.py`
   fails loudly on drift; see `docs/DESIGN-docs-site.md` D7. A new dialect's top-level construct (and
   any new `examples/`/`specs/` directory) additionally moves with `tests/dialect_registry.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   diagnostics").
 
 ### Fixed
+- The native LSP's document index now recognizes `def` declarations and their
+  parameters, aggregate/quantifier binders written with a `name: Type` form
+  (`count(c: Id where ...)`, `sum(...)`, `unique(...)`, `exactlyOne(...)`,
+  `forall`/`exists`), `is some(v)` pattern binders, named `preservation NAME {
+  ... }` governance blocks, and every name in a comma-separated `actor A, B`
+  list — each previously indexed as an ordinary reference with no matching
+  declaration, so `textDocument/definition`/`references`/`rename` returned
+  nothing and `documentSymbol` omitted them. Also fixed a `reachable`/`domain`
+  collision: both name a top-level declaration keyword (`reachable NAME {
+  expr }`, `domain SpecName { ... }`) and a relation builtin call
+  (`reachable(r, a, b)`, `domain(r)`); an unconditional keyword match
+  previously consumed the identifier immediately following either builtin
+  call as a brand-new self-defining declaration, corrupting the referenced
+  state variable's definition/reference set (#504).
 - `fslc db check` no longer reports a confidently green `verified_under_assumptions`
   over a genuine compatibility violation. `validate_db` now rejects a `check
   compatibility` rule name outside the closed vocabulary and an `environment

--- a/docs/DESIGN-rust-lsp.md
+++ b/docs/DESIGN-rust-lsp.md
@@ -79,6 +79,15 @@ The index may classify tokens only after authoritative parsing succeeds. Context
 is an index projection, not a second parser: it cannot accept a document, lower syntax, or invent
 semantic validity.
 
+Every accepted declaration and binder form in `rust/fsl-syntax` needs a matching entry in this
+contextual walk (`declaration_keyword`, the quantifier/aggregate/pattern binder checks, and
+`INDEX_KEYWORDS` in `rust/fsl-lsp/src/index.rs`), or it silently loses navigation
+(`textDocument/definition`, `references`, `rename`, `documentSymbol`) without a parse failure to
+surface the gap. A language feature's coupled change (grammar/lowering, typed model, semantics,
+docs) therefore also covers `rust/fsl-lsp/src/index.rs`. `rust/fsl-lsp/tests/corpus.rs` only
+asserts that every identifier has some symbol-or-reference entry, not that its role or scope is
+correct, so a new declaration or binder form needs its own targeted unit test (issue #504).
+
 Open buffers take precedence over files on disk. Imports and workspace references load through a
 document resolver that first consults the store and then the filesystem relative to the owning
 document. Closing a buffer discards its overlay and republishes diagnostics from disk only after a

--- a/rust/fsl-lsp/src/index.rs
+++ b/rust/fsl-lsp/src/index.rs
@@ -111,6 +111,7 @@ impl DocumentIndex {
         let mut contexts: Vec<(Context, Option<String>)> = Vec::new();
         let mut expected: Option<(SymbolRole, Option<Context>)> = None;
         let mut awaiting_block: Option<(Context, Option<String>)> = None;
+        let mut list_role: Option<(SymbolRole, Option<Context>)> = None;
         let mut declaration_offsets = BTreeSet::new();
 
         for (index, token) in tokens.iter().enumerate() {
@@ -126,8 +127,18 @@ impl DocumentIndex {
                         });
                         continue;
                     }
-                    if let Some((role, context)) = declaration_keyword(name) {
+                    // `reachable` and `domain` each name both a top-level
+                    // declaration keyword (`reachable NAME { expr }`, `domain
+                    // SpecName { ... }`) and a relation builtin call
+                    // (`reachable(r, a, b)`, `domain(r)`). Only the
+                    // declaration form starts a new declaration; a following
+                    // `(` is always the builtin call, which is a keyword like
+                    // every other builtin and owns no local name.
+                    let builtin_call = matches!(name.as_str(), "reachable" | "domain")
+                        && token_symbol(tokens.get(index + 1)) == Some("(");
+                    if !builtin_call && let Some((role, context)) = declaration_keyword(name) {
                         expected = role.map(|role| (role, context));
+                        list_role = (name == "actor").then_some(expected).flatten();
                         if role.is_none() {
                             awaiting_block = context.map(|context| (context, None));
                         }
@@ -152,23 +163,47 @@ impl DocumentIndex {
                             == Some("{")
                             || token_symbol(index.checked_sub(1).and_then(|i| tokens.get(i)))
                                 == Some(","));
-                    let role = if next_is_colon {
+                    // A binder introduced by `forall`/`exists`, or the first
+                    // parameter of an aggregate call (`count(c: T where ...)`,
+                    // `sum(...)`, `unique(...)`, `exactlyOne(...)`), declares a
+                    // local name regardless of the enclosing declaration
+                    // context and regardless of whether it uses the `name: T`
+                    // or `name in ...` binder form.
+                    let binder_after_aggregate_paren =
+                        token_symbol(index.checked_sub(1).and_then(|i| tokens.get(i))) == Some("(")
+                            && matches!(
+                                token_ident(index.checked_sub(2).and_then(|i| tokens.get(i))),
+                                Some("count" | "sum" | "unique" | "exactlyOne")
+                            );
+                    let quantifier_binder = matches!(previous, Some("forall" | "exists"))
+                        || binder_after_aggregate_paren;
+                    // `x is some(v)` binds `v` for the rest of the guarded
+                    // expression, the same as a `let`.
+                    let pattern_binder =
+                        token_symbol(index.checked_sub(1).and_then(|i| tokens.get(i))) == Some("(")
+                            && token_ident(index.checked_sub(2).and_then(|i| tokens.get(i)))
+                                == Some("some")
+                            && token_ident(index.checked_sub(3).and_then(|i| tokens.get(i)))
+                                == Some("is");
+                    let role = if quantifier_binder || pattern_binder {
+                        Some(SymbolRole::Variable)
+                    } else if next_is_colon {
                         match context {
                             Some(Context::Action) => Some(SymbolRole::Parameter),
                             Some(Context::State) => Some(SymbolRole::Variable),
                             Some(Context::Struct) => Some(SymbolRole::Property),
                             _ => None,
                         }
-                    } else if enum_member
-                        || matches!(previous, Some("as" | "let" | "forall" | "exists"))
-                    {
+                    } else if enum_member || matches!(previous, Some("as" | "let")) {
                         Some(SymbolRole::Variable)
                     } else {
                         None
                     };
                     if let Some(role) = role {
                         let scoped = matches!(role, SymbolRole::Parameter)
-                            || matches!(previous, Some("as" | "let" | "forall" | "exists"));
+                            || quantifier_binder
+                            || pattern_binder
+                            || matches!(previous, Some("as" | "let"));
                         add_symbol(
                             source,
                             token,
@@ -188,20 +223,34 @@ impl DocumentIndex {
                         });
                     }
                 }
+                TokenKind::Symbol(symbol) if symbol == "," => {
+                    // `actor A, B` continues one declaration list, but the
+                    // parser also ends the list on a trailing comma followed
+                    // by the next item keyword (`actor A, entity Case`), so
+                    // only a non-keyword name re-arms the pending role.
+                    let continues_list =
+                        token_ident(tokens.get(index + 1)).is_some_and(|next| !is_keyword(next));
+                    if continues_list && let Some(pending) = list_role {
+                        expected = Some(pending);
+                    }
+                }
                 TokenKind::Symbol(symbol) if symbol == "{" => {
                     let inherited = contexts.last().and_then(|(_, owner)| owner.clone());
                     contexts.push(awaiting_block.take().unwrap_or((Context::Other, inherited)));
+                    list_role = None;
                 }
                 TokenKind::Symbol(symbol) if symbol == "}" => {
                     contexts.pop();
                     awaiting_block = None;
                     expected = None;
+                    list_role = None;
                 }
                 TokenKind::Symbol(symbol)
                     if symbol == ";"
                         && !matches!(awaiting_block, Some((Context::Action | Context::Top, _))) =>
                 {
                     awaiting_block = None;
+                    list_role = None;
                 }
                 _ => {}
             }
@@ -612,7 +661,7 @@ fn declaration_keyword(value: &str) -> Option<(Option<SymbolRole>, Option<Contex
         "enum" => (Some(SymbolRole::Type), Some(Context::Enum)),
         "struct" | "table" => (Some(SymbolRole::Type), Some(Context::Struct)),
         "action" | "transition" | "tool" | "command" | "effect" | "migration" | "decide"
-        | "evolve" => (Some(SymbolRole::Function), Some(Context::Action)),
+        | "evolve" | "def" => (Some(SymbolRole::Function), Some(Context::Action)),
         "invariant" | "trans" | "reachable" | "until" | "unless" | "leadsTo" | "property"
         | "requirement" | "acceptance" | "forbidden" | "control" | "policy" | "goal" | "claim"
         | "expectation" => (Some(SymbolRole::Property), Some(Context::Other)),
@@ -620,6 +669,7 @@ fn declaration_keyword(value: &str) -> Option<(Option<SymbolRole>, Option<Contex
         | "environment" | "artifact" | "column" | "variable" => {
             (Some(SymbolRole::Variable), Some(Context::Other))
         }
+        "preservation" => (Some(SymbolRole::Namespace), Some(Context::Other)),
         "state" => (None, Some(Context::State)),
         "init" | "verify" => (None, Some(Context::Other)),
         _ => return None,
@@ -643,6 +693,7 @@ const INDEX_KEYWORDS: &[&str] = &[
     "forall",
     "exists",
     "in",
+    "where",
     "terminal",
     "decreases",
     "within",
@@ -696,7 +747,6 @@ const INDEX_KEYWORDS: &[&str] = &[
     "delegates",
     "require",
     "satisfied_by",
-    "preservation",
     "before",
     "after",
     "checked_by",
@@ -902,5 +952,214 @@ mod tests {
                 .iter()
                 .all(|range| range.start.line == 4)
         );
+    }
+
+    /// Issue #504 evidence: the minimal accepted `spec` probing `def`, an
+    /// aggregate binder, an `is some(v)` pattern binder, and the
+    /// `reachable`/`domain` relation builtins.
+    const ISSUE_504_PROBE: &str = r"spec Probe {
+  type Id = 0..1
+  def eligible(x: Id) = x == 0
+  state { maybe: Option<Id>, edge: relation Id -> Id }
+  invariant UsesDef { eligible(0) }
+  invariant Agg { count(c: Id where c == 0) >= 0 }
+  invariant Pattern { maybe is some(v) and v == 0 }
+  invariant Relation { reachable(edge, 0, 1) and domain(edge).contains(0) }
+}";
+
+    /// `def eligible(x: Id) = x == 0` must declare `eligible` as a navigable
+    /// `Function` symbol and `x` as a `Parameter` scoped to it, and the call
+    /// `eligible(0)` and the body's `x == 0` must resolve back to them.
+    /// Before this fix, `def` was entirely absent from `declaration_keyword`,
+    /// so `eligible`/`x` were indexed as ordinary references with no
+    /// declaration to resolve to (`definition_at` returned `None`).
+    #[test]
+    fn def_declares_a_function_symbol_with_a_scoped_parameter() {
+        let index = DocumentIndex::build(ISSUE_504_PROBE, Some("probe.fsl")).expect("valid index");
+        let call_site = Position::new(4, 22); // `eligible(0)` inside UsesDef
+        let definition = index
+            .definition_at(call_site)
+            .expect("eligible(0) must resolve");
+        assert_eq!(definition.name, "eligible");
+        assert_eq!(definition.role, SymbolRole::Function);
+
+        let param_use = Position::new(2, 24); // the `x` inside `x == 0`
+        let param_definition = index
+            .definition_at(param_use)
+            .expect("the parameter use of x must resolve");
+        assert_eq!(param_definition.role, SymbolRole::Parameter);
+        assert_eq!(param_definition.owner.as_deref(), Some("eligible"));
+        let param_references = index.references_at(Position::new(2, 15), true);
+        assert_eq!(param_references.len(), 2, "{param_references:?}");
+    }
+
+    /// `count(c: Id where c == 0)` must declare `c` as a `Variable` binder
+    /// scoped to the enclosing invariant, resolvable from both `where c ==
+    /// 0`. Before this fix, a `name: Type` binder only got a role inside
+    /// `Context::Action`/`Context::State`/`Context::Struct`; inside an
+    /// invariant's `Context::Other` it fell through to `None` and was
+    /// indexed as a plain reference with no declaration.
+    #[test]
+    fn aggregate_binder_declares_a_scoped_variable() {
+        let index = DocumentIndex::build(ISSUE_504_PROBE, Some("probe.fsl")).expect("valid index");
+        let binder_use = Position::new(5, 36); // `c` inside `where c == 0`
+        let definition = index
+            .definition_at(binder_use)
+            .expect("the aggregate binder use of c must resolve");
+        assert_eq!(definition.name, "c");
+        assert_eq!(definition.role, SymbolRole::Variable);
+        assert_eq!(definition.owner.as_deref(), Some("Agg"));
+    }
+
+    /// A `forall`/`exists` binder must declare its name as a `Variable`
+    /// scoped to the enclosing declaration in the `name: Type` form too, not
+    /// only the `name in ...` form. Before this fix the typed form was
+    /// matched first by `next_is_colon`, which outside
+    /// `Context::Action`/`State`/`Struct` yields no role at all, so an
+    /// invariant's quantifier binder was indexed as a plain reference.
+    #[test]
+    fn forall_and_exists_typed_binders_declare_scoped_variables() {
+        let source = r"spec Quant {
+  type Id = 0..1
+  state { seen: Set<Id> }
+  invariant Every { forall i: Id { seen.contains(i) } }
+  invariant Any { exists j: Id { seen.contains(j) } }
+}";
+        let index = DocumentIndex::build(source, None).expect("valid index");
+        for (name, owner) in [("i", "Every"), ("j", "Any")] {
+            let binder = index
+                .symbols
+                .iter()
+                .find(|symbol| symbol.name == name)
+                .unwrap_or_else(|| panic!("{name} must be declared, got {:?}", index.symbols));
+            assert_eq!(binder.role, SymbolRole::Variable);
+            assert_eq!(binder.owner.as_deref(), Some(owner));
+            let use_site = index
+                .references
+                .iter()
+                .find(|reference| reference.name == name)
+                .unwrap_or_else(|| panic!("{name} must be used in the body"));
+            let definition = index
+                .definition_at(use_site.range.start)
+                .expect("the binder use must resolve");
+            assert_eq!(definition.selection_range, binder.selection_range);
+        }
+    }
+
+    /// `maybe is some(v) and v == 0` must declare `v` as a `Variable`
+    /// pattern binder scoped to the enclosing invariant, resolvable from the
+    /// guarded use `v == 0`. Before this fix, `is some(name)` was not
+    /// recognized as a binder position at all.
+    #[test]
+    fn is_some_pattern_binder_declares_a_scoped_variable() {
+        let index = DocumentIndex::build(ISSUE_504_PROBE, Some("probe.fsl")).expect("valid index");
+        let binder_use = Position::new(6, 43); // `v` inside `v == 0`
+        let definition = index
+            .definition_at(binder_use)
+            .expect("the pattern binder use of v must resolve");
+        assert_eq!(definition.name, "v");
+        assert_eq!(definition.role, SymbolRole::Variable);
+        assert_eq!(definition.owner.as_deref(), Some("Pattern"));
+    }
+
+    /// `reachable` and `domain` each name both a top-level declaration
+    /// keyword (`reachable NAME { expr }`, `domain SpecName { ... }`) and a
+    /// relation builtin call. `reachable(edge, 0, 1) and
+    /// domain(edge).contains(0)` must not spuriously declare a second `edge`
+    /// symbol from either builtin call; the state declaration must stay the
+    /// only `edge` symbol, and every use of `edge` must resolve to it.
+    /// Before this fix, the unconditional `declaration_keyword` match
+    /// consumed the identifier immediately following `reachable`/`domain` as
+    /// a brand-new declaration, corrupting `edge`'s definition/reference set
+    /// with a self-defining duplicate. The builtin call names themselves stay
+    /// keywords and own no index entry, like every other builtin.
+    #[test]
+    fn reachable_and_domain_builtin_calls_do_not_shadow_the_relation_declaration() {
+        let index = DocumentIndex::build(ISSUE_504_PROBE, Some("probe.fsl")).expect("valid index");
+        let edge_symbols = index
+            .symbols
+            .iter()
+            .filter(|symbol| symbol.name == "edge")
+            .count();
+        assert_eq!(edge_symbols, 1, "{:?}", index.symbols);
+        assert!(
+            !index
+                .references
+                .iter()
+                .any(|reference| matches!(reference.name.as_str(), "reachable" | "domain")),
+            "{:?}",
+            index.references
+        );
+
+        let state_declaration = Position::new(3, 29);
+        for use_position in [
+            Position::new(7, 33), // reachable(edge, ...)
+            Position::new(7, 56), // domain(edge)
+        ] {
+            let definition = index
+                .definition_at(use_position)
+                .expect("edge use must resolve");
+            assert_eq!(definition.selection_range.start, state_declaration);
+        }
+    }
+
+    /// A named `preservation NAME { ... }` governance block must declare
+    /// `NAME` as a navigable symbol. Before this fix, `preservation` was
+    /// absent from `declaration_keyword`, so the block name was indexed as
+    /// an ordinary reference with no declaration.
+    #[test]
+    fn named_preservation_block_declares_a_symbol() {
+        let source = r#"governance Controls { control CTRL "control" preservation Reform { preserve CTRL } }"#;
+        let index = DocumentIndex::build(source, None).expect("valid governance");
+        let reform = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "Reform")
+            .expect("preservation block name must be declared");
+        assert_eq!(reform.role, SymbolRole::Namespace);
+    }
+
+    /// `actor Customer, Manager` must declare every comma-separated name,
+    /// not only the first. Before this fix, `expected` (the pending
+    /// declaration role/context) was consumed by the first identifier and
+    /// never re-armed at the following `,`, so `Manager` fell through to an
+    /// ordinary reference with no declaration.
+    #[test]
+    fn comma_separated_actor_list_declares_every_name() {
+        let source = "business Actors { actor Customer, Manager entity Case }\n\
+             verify { instances Case = 1 }";
+        let index = DocumentIndex::build(source, None).expect("valid business");
+        for name in ["Customer", "Manager"] {
+            let symbol = index
+                .symbols
+                .iter()
+                .find(|symbol| symbol.name == name)
+                .unwrap_or_else(|| panic!("{name} must be declared"));
+            assert_eq!(symbol.role, SymbolRole::Variable);
+        }
+    }
+
+    /// `rust/fsl-syntax/src/parser.rs`'s `open_ident_list` also ends an
+    /// `actor` list on a trailing comma followed by the next item keyword, so
+    /// `actor Customer, entity Case` declares one actor and one entity. The
+    /// pending-role re-arm must not consume that keyword: a naive re-arm at
+    /// every `,` declared a symbol literally named `entity` and left `Case`
+    /// an unresolved reference.
+    #[test]
+    fn actor_list_terminated_by_a_trailing_comma_does_not_consume_the_next_keyword() {
+        let source = "business Actors { actor Customer, entity Case }\n\
+             verify { instances Case = 1 }";
+        let index = DocumentIndex::build(source, None).expect("valid business");
+        assert!(
+            !index.symbols.iter().any(|symbol| symbol.name == "entity"),
+            "{:?}",
+            index.symbols
+        );
+        let case = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "Case")
+            .expect("Case must be declared by `entity Case`");
+        assert_eq!(case.role, SymbolRole::Type);
     }
 }


### PR DESCRIPTION
## Problem

The native LSP's document index recognized a subset of the accepted syntax, so several declaration
and binder forms were indexed as ordinary references with no matching declaration. There is no parse
failure when this happens — the document is valid, it simply loses navigation
(`textDocument/definition`, `references`, `rename`, `documentSymbol`) silently.

Missing forms: `def` declarations and their parameters; binders written `name: Type` inside
aggregates (`count(c: Id where …)`, `sum`, `unique`, `exactlyOne`) and `forall`/`exists`;
`is some(v)` pattern binders; named `preservation NAME { … }` blocks; and every name after the first
in a comma-separated `actor A, B` list.

Plus one active corruption rather than an omission: `reachable` and `domain` each name **both** a
top-level declaration keyword (`reachable NAME { expr }`, `domain SpecName { … }`) **and** a relation
builtin call (`reachable(r, a, b)`, `domain(r)`). The unconditional keyword match consumed the
identifier following either builtin call as a brand-new self-defining declaration, which corrupts the
referenced state variable's definition and reference set.

## Contract change

None to the language or CLI. The index now covers the declaration/binder forms above, disambiguating
the `reachable`/`domain` collision by lookahead: a following `(` is always the builtin call, which is
a keyword like every other builtin and owns no local name.

`docs/DESIGN-rust-lsp.md` gains the rule this issue exposed: every accepted declaration and binder
form in `rust/fsl-syntax` needs a matching entry in the contextual walk, or it silently loses
navigation with no parse failure to surface the gap — so a language feature's coupled change also
covers `rust/fsl-lsp/src/index.rs`. `AGENTS.md`'s coupled-change bullet says the same, because that
list is what contributors actually read. This is knowledge distillation, not scope creep: the gap
was invisible precisely because no rule named the surface.

## Test evidence

Ablation, per the batch rule that a green run is not evidence: reverting `index.rs` makes **7 of the
8 new tests fail** while all 13 pre-existing tests stay green —
`def_declares_a_function_symbol_with_a_scoped_parameter`,
`forall_and_exists_typed_binders_declare_scoped_variables`,
`aggregate_binder_declares_a_scoped_variable`,
`is_some_pattern_binder_declares_a_scoped_variable`,
`named_preservation_block_declares_a_symbol`,
`comma_separated_actor_list_declares_every_name`,
`reachable_and_domain_builtin_calls_do_not_shadow_the_relation_declaration`.
The 8th, `actor_list_terminated_by_a_trailing_comma_does_not_consume_the_next_keyword`, is a per-hunk
control and fails when only the comma re-arm guard is reverted.

That 8th test exists because the first draft of the `actor` list fix was **wrong**:
`open_ident_list` also ends a list on a trailing comma before the next item keyword, so
`business Actors { actor Customer, entity Case }` is accepted syntax and the unguarded comma re-arm
declared a symbol literally named `entity`, leaving `Case` unresolved — the same defect class this
issue is about. Caught and fixed during implementation.

Gate: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`,
`cargo test --workspace --locked` (153 suites), and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Deliberate residual, and two issues filed from it

The issue also asks to strengthen `rust/fsl-lsp/tests/corpus.rs` to assert roles and scopes.
**Not done here, deliberately.** The cheapest sound corpus invariant fails on 15 pre-existing hits
that split two ways, and an allowlist to make it green would violate the repository's own rule
against allowlisting to pass a check.

- 2 are legitimate: `action push()`, `fair action respond(…)` — FSL has no reserved-word list.
- The rest are a **separate, previously unreported bug**, now #551. The index does not handle `@`
  at all, so an annotation whose name collides with a declaration keyword swallows the next
  construct keyword. Measured independently across all 207 corpus files: 8 sites, all from
  `@requirement`. At `examples/annotations/annotated_domain.fsl:35`, `command` is registered as a
  Property symbol and `Place` has **no declaration at all** — it appears only as a reference, at its
  own declaration site and at line 43.

Auditing this diff with the local-optima lens produced #552, the root structure under both #504 and
#551: `DocumentIndex::build` already requires `fsl_syntax::parse_document` to succeed, uses the
resulting authoritative AST for a single boolean, discards it, and then re-derives declarations from
raw tokens — which is the inverse of what `docs/DESIGN-rust-lsp.md` prescribes. Neither #551 nor #552
blocks this PR; both are independent of it.

Also unaddressed and outside the issue's probes: `stages A, B, C` still never declares stage names
(same `open_ident_list`), and a state field literally named `domain` remains misindexed (pre-existing,
unchanged by this PR).

## Documentation

`docs/DESIGN-rust-lsp.md`, `AGENTS.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
