### PR TITLE
fix(cli): propagate typed spec-load errors to every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Every spec-reading native command now classifies a syntax error the way
+  `check` does: `kind: "parse"` with `diagnostic_code: "FSL-PARSE"` and a
+  `loc`. `rust/fslc/src/main.rs`'s `load_kernel_model` flattened the frontend's
+  structured failure into a `String`, so `kernel`, `conformance`, `scenarios`,
+  `explain`, `analyze`, `typestate`, `ledger`, `testgen`, `document generate`,
+  `diff`, `replay`, and `html` re-classified an unparseable file as
+  `kind: "semantics"` with `loc: null`, and `verify`/`sweep` reported
+  `kind: "parse"` with the `loc` dropped — breaking the schema guarantee in
+  `docs/DESIGN-v1.md` §7.2 that `parse` always carries a location, and sending
+  the §8 repair protocol into the wrong branch. The loader now returns a typed
+  `SpecLoadError` (`Io`/`Parse`/`Semantic`) and every consumer renders it
+  through the same `frontend_output::render_surface_parse_error` `check` uses.
+  Exit codes and `result: "error"` were already correct and are unchanged.
+  The browser Worker's `verify` moved with the CLI so the native/Worker parity
+  contract still holds (#484, #497).
+- A missing or unreadable specification is now `kind: "io"` for every command
+  instead of falling through the message-string classifier to
+  `kind: "semantics"`. `fslc analyze` disagreed with itself: one missing input
+  reported `semantics` and the same missing input alongside a second file
+  reported `io`. `check` and `verify` also no longer silently continue when the
+  spec cannot be read (#497).
+- `fslc mutate` on a specification that fails to load now exits 2 instead of 0.
+  A non-`verified` baseline still scores 0, but a spec error keeps its own exit
+  code, as `docs/LANGUAGE.md`'s exit-code table requires with no per-command
+  exemption; exit 0 on an unparseable spec was a green gate over a
+  specification that was never analysed (#484).
 - `rust/fslc/tests/testgen_contract.rs`'s
   `symlink_source_name_and_canonical_pytest_path_remain_distinct` no longer
   panics with `create output-parent symlink: AlreadyExists` on a repeated

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -338,7 +338,13 @@ fn add_frontend_metadata(
 async fn verify(request: &Request, solver_version: &str) -> Value {
     let started = performance_now();
     if let Err(failure) = fsl_syntax::parse_surface_document(&request.source) {
-        return error(solver_version, "parse", failure.to_string());
+        // Same envelope `check` renders, and the one the native CLI now
+        // renders for every spec-reading command: `kind:"parse"` with
+        // `diagnostic_code` and `loc` (#484).
+        return fslc_rust::frontend_output::render_surface_parse_error(
+            envelope(solver_version),
+            &failure,
+        );
     }
     let (model, compose_warnings) = match build(request, solver_version) {
         Ok(built) => built,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -2111,12 +2111,18 @@ fn load_document_claims_with_label(
     path: &Path,
     label: &str,
 ) -> Result<(String, fsl_tools::RequirementClaimSet), Value> {
-    let source =
-        std::fs::read_to_string(path).map_err(|error| error_output("io", &error.to_string()))?;
+    let source = read_spec_source(path).map_err(|error| spec_load_error_output(&error))?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
-    fsl_tools::project_requirement_claims_from_source(&source, Some(label), base)
-        .map(|claims| (source, claims))
-        .map_err(|error| document_projection_error_output(&error))
+    match fsl_tools::project_requirement_claims_from_source(&source, Some(label), base) {
+        Ok(claims) => Ok((source, claims)),
+        // The projector reports a surface-parse failure as a plain message, so
+        // recover the span and emit the same `kind:"parse"` envelope `check`
+        // emits instead of a location-free `semantics` error.
+        Err(error) => Err(surface_parse_failure(&source).map_or_else(
+            || document_projection_error_output(&error),
+            |error| surface_parse_error_output(&error),
+        )),
+    }
 }
 
 fn document_diagnostics_error(
@@ -3998,7 +4004,7 @@ fn format_chain_table(result: &Value) -> String {
 fn run_replay(path: &Path, trace_path: &Path) -> (Value, i32) {
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let raw = match std::fs::read_to_string(trace_path) {
         Ok(raw) => raw,
@@ -4646,7 +4652,7 @@ fn run_log_replay(path: &Path, log_path: &Path, mapping_path: &Path) -> (Value, 
     const NOTE: &str = "leadsTo properties are not checked by replay (finite logs only)";
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let mapping_source = match std::fs::read_to_string(mapping_path) {
         Ok(source) => source,
@@ -4974,7 +4980,7 @@ fn run_scenarios_mode(
 ) -> (Value, i32) {
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     match validate_requirement_traces(path, &model) {
         Ok((Some(failure), _)) => return (failure, 2),
@@ -5353,6 +5359,30 @@ fn format_bindings(binding: &fsl_runtime::Bindings) -> String {
         .join(", ")
 }
 
+/// `check` on an agent document is deliberately lenient: the top-level
+/// `result` stays "ok" even when the structural analysis finds a violation
+/// (matching the frozen reference); `fslc ai check` is the actual gate (exit 1
+/// on `agent_analysis_result: "violated"`). A grant-boundary or other
+/// tree-validation failure is still a hard error here.
+fn agent_check_output(agent: &fsl_syntax::SurfaceAgent) -> (Value, i32) {
+    let analysis = match fsl_tools::analyze_ai_agent(agent) {
+        Ok(analysis) => analysis,
+        Err(error) => return (agent_error_output(&error), 2),
+    };
+    let analysis_result = analysis
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| json!("agent_analyzed"));
+    let mut output = envelope();
+    output.insert("result".to_owned(), json!("ok"));
+    output.insert("spec".to_owned(), json!(agent.name));
+    output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
+    output.insert("warnings".to_owned(), json!([]));
+    output.insert("ai_analysis_result".to_owned(), analysis_result.clone());
+    output.insert("agent_analysis_result".to_owned(), analysis_result);
+    (Value::Object(output), 0)
+}
+
 /// `path` is read for source content (for a literate `.md` input, this is the
 /// materialized, blanked `.literate.fsl` sibling — its line positions match
 /// the original document). `display_path` is stamped into every user-visible
@@ -5360,56 +5390,35 @@ fn format_bindings(binding: &fsl_runtime::Bindings) -> String {
 /// readable output always names the document the caller actually passed in,
 /// never the transient materialization.
 fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
-    if let Ok(source) = std::fs::read_to_string(path) {
-        if let Some(output) = fslc_rust::frontend_output::ai_project_check_output(
-            &source,
-            &display_path.to_string_lossy(),
-            envelope(),
-        ) {
-            return (output, 0);
-        }
-        match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
-            Ok(fsl_syntax::ParsedDocument {
-                surface: fsl_syntax::SurfaceDocument::Agent(agent),
-                ..
-            }) => {
-                // `check` on an agent document is deliberately lenient: the
-                // top-level `result` stays "ok" even when the structural
-                // analysis finds a violation (matching the frozen
-                // reference); `fslc ai check` is the actual gate (exit 1 on
-                // `agent_analysis_result: "violated"`). A grant-boundary or
-                // other tree-validation failure is still a hard error here.
-                let analysis = match fsl_tools::analyze_ai_agent(&agent) {
-                    Ok(analysis) => analysis,
-                    Err(error) => return (agent_error_output(&error), 2),
-                };
-                let analysis_result = analysis
-                    .get("result")
-                    .cloned()
-                    .unwrap_or_else(|| json!("agent_analyzed"));
-                let mut output = envelope();
-                output.insert("result".to_owned(), json!("ok"));
-                output.insert("spec".to_owned(), json!(agent.name));
-                output.insert("dialect".to_owned(), json!("fsl-ai-agent.v0"));
-                output.insert("warnings".to_owned(), json!([]));
-                output.insert("ai_analysis_result".to_owned(), analysis_result.clone());
-                output.insert("agent_analysis_result".to_owned(), analysis_result);
-                return (Value::Object(output), 0);
-            }
-            Ok(_) => {}
-            Err(error) => return (surface_parse_error_output(&error), 2),
-        }
-        let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-        if let Some(diagnostic) = fslc_rust::source_diagnostic::diagnostics(
-            &source,
-            &display_path.to_string_lossy(),
-            &resolver,
-        )
-        .into_iter()
-        .find(|diagnostic| diagnostic.kind != "migration")
-        {
-            return (semantic_error_output(&diagnostic.message), 2);
-        }
+    let source = match read_spec_source(path) {
+        Ok(source) => source,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    if let Some(output) = fslc_rust::frontend_output::ai_project_check_output(
+        &source,
+        &display_path.to_string_lossy(),
+        envelope(),
+    ) {
+        return (output, 0);
+    }
+    match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
+        Ok(fsl_syntax::ParsedDocument {
+            surface: fsl_syntax::SurfaceDocument::Agent(agent),
+            ..
+        }) => return agent_check_output(&agent),
+        Ok(_) => {}
+        Err(error) => return (surface_parse_error_output(&error), 2),
+    }
+    let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
+    if let Some(diagnostic) = fslc_rust::source_diagnostic::diagnostics(
+        &source,
+        &display_path.to_string_lossy(),
+        &resolver,
+    )
+    .into_iter()
+    .find(|diagnostic| diagnostic.kind != "migration")
+    {
+        return (semantic_error_output(&diagnostic.message), 2);
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -5463,7 +5472,7 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
             }
             (Value::Object(output), 0)
         }
-        Err(error) => (semantic_error_output(&error), 2),
+        Err(error) => (spec_load_error_output(&error), 2),
     }
 }
 
@@ -5486,9 +5495,9 @@ fn portable_cli_source_path(path: &Path) -> Result<String, String> {
 }
 
 fn run_kernel_contract(path: &Path, version: fsl_core::PublicKernelVersion) -> (Value, i32) {
-    let source = match std::fs::read_to_string(path) {
+    let source = match read_spec_source(path) {
         Ok(source) => source,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
@@ -5507,13 +5516,10 @@ fn run_kernel_contract(path: &Path, version: fsl_core::PublicKernelVersion) -> (
     let kernel = match parsed {
         Ok(kernel) => kernel,
         Err(error) => {
-            let message =
-                if error.message == "top-level document has not reached the kernel lowering gate" {
-                    "spec has no state block".to_owned()
-                } else {
-                    error.to_string()
-                };
-            return (semantic_error_output(&message), 2);
+            return (
+                spec_load_error_output(&kernel_load_error(&source, &error)),
+                2,
+            );
         }
     };
     let model = match fsl_core::build_model(kernel.clone()) {
@@ -5543,9 +5549,11 @@ fn run_conformance(
     depth: usize,
     version: fsl_core::PublicKernelVersion,
 ) -> (Value, i32) {
-    match load_model(path)
-        .and_then(|model| fslc_rust::conformance_vectors_for_version(&model, depth, version))
-    {
+    let model = match load_model(path) {
+        Ok(model) => model,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    match fslc_rust::conformance_vectors_for_version(&model, depth, version) {
         Ok(mut vectors) => {
             vectors
                 .as_object_mut()
@@ -5713,7 +5721,7 @@ fn run_check_with_tags(
     if status == 0 && strict_tags {
         let model = match load_model(path) {
             Ok(model) => model,
-            Err(error) => return (semantic_error_output(&error), 2),
+            Err(error) => return (spec_load_error_output(&error), 2),
         };
         if let Err(error) = add_strict_tag_warnings(&mut output, &model, path, true, requirements) {
             return (error_output("io", &error), 2);
@@ -6641,7 +6649,9 @@ fn domain_scaffold_inputs(
     path: &Path,
     domain: &fsl_syntax::DomainSpec,
 ) -> Result<(Value, Value), String> {
-    let (source, kernel, model) = load_kernel_model(path)?;
+    // Reached only once the caller has parsed `path` into a `DomainSpec`, so
+    // the load cannot fail with a surface-parse error here.
+    let (source, kernel, model) = load_kernel_model(path).map_err(|error| error.to_string())?;
     let contract = fsl_core::public_kernel_contract(
         &kernel,
         &model,
@@ -6915,7 +6925,7 @@ fn run_domain_replay(path: &Path, logs: &Path) -> (Value, i32) {
     };
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let mut monitor = match fsl_runtime::Monitor::new(model.clone()) {
         Ok(monitor) => monitor,
@@ -8820,7 +8830,7 @@ fn readable_implements_text(path: &Path, model: &KernelModel, depth: usize) -> O
 fn run_explain(path: &Path, depth: usize, readable: bool) -> (Value, i32) {
     let (source, _kernel, model) = match load_kernel_model(path) {
         Ok(loaded) => loaded,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let spec_kind = source_dialect(&source);
     let skeleton = model_skeleton(&model, spec_kind);
@@ -9178,7 +9188,7 @@ fn run_mutate_legacy(
     }
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 0),
+        Err(error) => return (spec_load_error_output(&error), 0),
     };
     let mut mutants = Vec::new();
     let mut discovered = None;
@@ -10036,11 +10046,17 @@ fn run_mutate(
 ) -> (Value, i32) {
     let (baseline, status) = run_verify(path, depth, "warn", "bmc", DEFAULT_EXPLICIT_BUDGET, 1);
     if status != 0 || baseline.get("result").and_then(Value::as_str) != Some("verified") {
-        return (baseline, 0);
+        // A non-`verified` baseline still scores 0 (an unverified spec has no
+        // mutation score, not a failure), but a *spec error* keeps its own exit
+        // code: `docs/LANGUAGE.md` maps parse/type/semantics/io to 2 with no
+        // per-command exemption, and exit 0 on an unparseable spec is a green
+        // gate over a spec that was never analysed.
+        let baseline_status = baseline_error_status(&baseline, status);
+        return (baseline, baseline_status);
     }
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 0),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
@@ -10335,15 +10351,20 @@ fn run_mutate(
 }
 
 fn run_typestate(path: &Path) -> (Value, i32) {
-    let source = match std::fs::read_to_string(path) {
+    let source = match read_spec_source(path) {
         Ok(source) => source,
-        Err(error) => return (error_output("io", &error.to_string()), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
     let kernel = match fsl_core::parse_kernel_source(&source, &resolver) {
         Ok(kernel) => kernel,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            return (
+                spec_load_error_output(&kernel_load_error(&source, &error)),
+                2,
+            );
+        }
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
@@ -10406,7 +10427,7 @@ fn run_testgen(
 ) -> (Value, i32) {
     let (source, kernel, model) = match load_kernel_model(path) {
         Ok(parts) => parts,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let (scenarios, status) = run_scenarios_mode(path, depth, deadlock_mode, !strict);
     if status != 0 {
@@ -10531,7 +10552,7 @@ fn run_html_report(
 ) -> (Value, i32) {
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
@@ -10772,7 +10793,7 @@ fn run_approval_create(
     }
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let (_repo, relative_path, git_commit) = match approval::git_binding(path) {
         Ok(binding) => binding,
@@ -11137,7 +11158,7 @@ fn generate_unapproved_ledger_report(request: &LedgerReportRequest<'_>) -> (Valu
 fn prepare_ledger_report(request: &LedgerReportRequest<'_>) -> Result<PreparedLedgerReport, Value> {
     let model = match load_model(request.path) {
         Ok(model) => model,
-        Err(error) => return Err(semantic_error_output(&error)),
+        Err(error) => return Err(spec_load_error_output(&error)),
     };
     let (verification, _) = run_verify(
         request.path,
@@ -12282,9 +12303,9 @@ fn prefixed_analysis_edge(layer: &str, edge: &Value) -> Value {
 }
 
 #[allow(clippy::too_many_lines)]
-fn project_traceability_output(path: &Path) -> Result<Value, String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    let sections = parse_project_manifest(&source)?;
+fn project_traceability_output(path: &Path) -> Result<Value, SpecLoadError> {
+    let source = read_spec_source(path)?;
+    let sections = parse_project_manifest(&source).map_err(SpecLoadError::Semantic)?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let manifest = analysis_display_path(path);
     let mut nodes = std::collections::BTreeMap::new();
@@ -12376,15 +12397,16 @@ fn project_traceability_output(path: &Path) -> Result<Value, String> {
             continue;
         };
         let mapping_path = base.join(mapping);
-        let document = parse_surface_document(&mapping_path)?;
+        let document = parse_surface_document(&mapping_path).map_err(SpecLoadError::Semantic)?;
         let fsl_syntax::SurfaceDocument::Refinement(refinement) = document else {
-            return Err("expected refinement mapping".to_owned());
+            return Err(SpecLoadError::Semantic(
+                "expected refinement mapping".to_owned(),
+            ));
         };
-        let mapping_source = std::fs::read_to_string(&mapping_path)
-            .map_err(|error| format!("failed to read {}: {error}", mapping_path.display()))?;
+        let mapping_source = read_spec_source(&mapping_path)?;
         let checked_refinement =
             fsl_core::parse_refinement(&mapping_source, &implementation.model, &abstraction.model)
-                .map_err(|error| error.message)?;
+                .map_err(|error| SpecLoadError::Semantic(error.message))?;
         let display = analysis_display_path(&mapping_path);
         let refinement_id = format!("refinement:{layer}->{target}:{}", refinement.name);
         let file_id = format!("file:{layer}->{target}:{display}");
@@ -12743,7 +12765,7 @@ fn run_analyze(
         }
         let analysis = match project_traceability_output(path) {
             Ok(analysis) => analysis,
-            Err(error) => return (error_output("semantics", &error), 2),
+            Err(error) => return (spec_load_error_output(&error), 2),
         };
         return finish_analysis(analysis, None, projection, output_format);
     }
@@ -12768,7 +12790,7 @@ fn run_analyze(
         }
         let model = match load_model(path) {
             Ok(model) => model,
-            Err(error) => return (semantic_error_output(&error), 2),
+            Err(error) => return (spec_load_error_output(&error), 2),
         };
         return (tag_review_output(&model), 0);
     }
@@ -12802,7 +12824,7 @@ fn run_analyze(
     }
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     if projection == "code_audit" {
         let analysis = match code_audit::analyze(&model, code_path.expect("checked above")) {
@@ -13569,11 +13591,11 @@ fn run_diff(
         load_model(old)
     } {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let new_model = match load_model(new) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let mapping_source = match mapping.map(std::fs::read_to_string).transpose() {
         Ok(source) => source,
@@ -14283,11 +14305,11 @@ fn run_refine(
 ) -> (Value, i32) {
     let implementation = match load_model(implementation_path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let abstraction = match load_model(abstraction_path) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let source = match std::fs::read_to_string(mapping_path) {
         Ok(source) => source,
@@ -14731,23 +14753,25 @@ fn run_verify(
     explicit_budget: usize,
     k_ind: usize,
 ) -> (Value, i32) {
-    if let Ok(source) = std::fs::read_to_string(path) {
-        match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
-            Err(error) => return (surface_parse_error_output(&error), 2),
-            Ok(fsl_syntax::ParsedDocument {
-                surface: fsl_syntax::SurfaceDocument::Agent(_),
-                ..
-            }) => {
-                return (
-                    error_output(
-                        "parse",
-                        "agent documents cannot be verified as Kernel specs",
-                    ),
-                    2,
-                );
-            }
-            Ok(_) => {}
+    let source = match read_spec_source(path) {
+        Ok(source) => source,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
+        Err(error) => return (surface_parse_error_output(&error), 2),
+        Ok(fsl_syntax::ParsedDocument {
+            surface: fsl_syntax::SurfaceDocument::Agent(_),
+            ..
+        }) => {
+            return (
+                error_output(
+                    "parse",
+                    "agent documents cannot be verified as Kernel specs",
+                ),
+                2,
+            );
         }
+        Ok(_) => {}
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -15184,25 +15208,82 @@ fn parse_param_value(
     }
 }
 
-fn load_model(path: &Path) -> Result<KernelModel, String> {
+/// A spec-loading failure that keeps the diagnostic class the frontend
+/// determined instead of flattening it to a message string.
+///
+/// `docs/DESIGN-v1.md` §7.2 fixes the error classification as a closed set and
+/// guarantees `loc` for `parse`. Flattening a surface-parse failure into a
+/// `String` erased that class, so every command loading a spec through
+/// [`load_kernel_model`] re-classified a syntax error as `semantics` with no
+/// `loc`, while `check` — which runs the surface parser directly — reported
+/// `parse` with a span.
+#[derive(Debug)]
+enum SpecLoadError {
+    Io(String),
+    Parse(Box<fsl_syntax::ParseError>),
+    Semantic(String),
+}
+
+impl std::fmt::Display for SpecLoadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(message) | Self::Semantic(message) => formatter.write_str(message),
+            Self::Parse(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+fn load_model(path: &Path) -> Result<KernelModel, SpecLoadError> {
     load_kernel_model(path).map(|(_, _, model)| model)
 }
 
-fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), SpecLoadError> {
+    let source = read_spec_source(path)?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
     let kernel =
-        fsl_core::parse_kernel_source_with_file(&source, &resolver, path.to_string_lossy())
-            .map_err(|error| {
-                if error.message == "top-level document has not reached the kernel lowering gate" {
-                    "spec has no state block".to_owned()
-                } else {
-                    error.to_string()
-                }
-            })?;
-    let model = fsl_core::build_model(kernel.clone()).map_err(|error| error.to_string())?;
+        match fsl_core::parse_kernel_source_with_file(&source, &resolver, path.to_string_lossy()) {
+            Ok(kernel) => kernel,
+            Err(error) => return Err(kernel_load_error(&source, &error)),
+        };
+    let model = fsl_core::build_model(kernel.clone())
+        .map_err(|error| SpecLoadError::Semantic(error.to_string()))?;
     Ok((source, kernel, model))
+}
+
+/// Read a spec file, classifying a read failure as `io` rather than letting the
+/// message-string classifier fall through to `semantics` (issue 497: a missing
+/// single analyze input reported `semantics` while the same missing file in a
+/// batch reported `io`).
+fn read_spec_source(path: &Path) -> Result<String, SpecLoadError> {
+    std::fs::read_to_string(path)
+        .map_err(|error| SpecLoadError::Io(format!("{}: {error}", path.display())))
+}
+
+/// Recover the typed surface-parse diagnostic behind a lowering or projection
+/// failure that only reports a message.
+///
+/// The kernel and document entrypoints run the surface parser themselves and
+/// report the result as a `CoreError`/projection message, so the class is
+/// recovered by re-running the same parser on the failure path only. A compose
+/// document whose *component* fails to parse still lowers its own top level
+/// successfully and therefore stays `semantics`, exactly as `check` reports it.
+fn surface_parse_failure(source: &str) -> Option<fsl_syntax::ParseError> {
+    fsl_syntax::parse_document(fsl_syntax::SourceFile::new(source)).err()
+}
+
+/// Classify a kernel lowering failure, preserving a surface-parse span.
+fn kernel_load_error(source: &str, error: &fsl_core::CoreError) -> SpecLoadError {
+    if let Some(parse_error) = surface_parse_failure(source) {
+        return SpecLoadError::Parse(Box::new(parse_error));
+    }
+    SpecLoadError::Semantic(
+        if error.message == "top-level document has not reached the kernel lowering gate" {
+            "spec has no state block".to_owned()
+        } else {
+            error.to_string()
+        },
+    )
 }
 
 #[allow(clippy::too_many_lines)]
@@ -15429,18 +15510,17 @@ fn load_snapshot_value_object(
         .collect()
 }
 
-fn load_model_scoped(path: &Path, scope: &ScopeBounds) -> Result<KernelModel, String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+fn load_model_scoped(path: &Path, scope: &ScopeBounds) -> Result<KernelModel, SpecLoadError> {
+    let source = read_spec_source(path)?;
     let kernel =
-        fsl_core::parse_kernel_source_with_bounds(&source, &scope.instances, &scope.values)
-            .map_err(|error| {
-                if error.message.starts_with("--instances/--values") {
-                    error.message
-                } else {
-                    error.to_string()
-                }
-            })?;
-    fsl_core::build_model(kernel).map_err(|error| error.to_string())
+        match fsl_core::parse_kernel_source_with_bounds(&source, &scope.instances, &scope.values) {
+            Ok(kernel) => kernel,
+            Err(error) if error.message.starts_with("--instances/--values") => {
+                return Err(SpecLoadError::Semantic(error.message));
+            }
+            Err(error) => return Err(kernel_load_error(&source, &error)),
+        };
+    fsl_core::build_model(kernel).map_err(|error| SpecLoadError::Semantic(error.to_string()))
 }
 
 fn envelope() -> Map<String, Value> {
@@ -15503,6 +15583,27 @@ fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {
 
 fn semantic_error_output(message: &str) -> Value {
     fslc_rust::verification_output::render_semantic_error(envelope(), message)
+}
+
+/// Keep a spec-error envelope's own exit code when a command would otherwise
+/// downgrade a non-success baseline to 0.
+fn baseline_error_status(baseline: &Value, status: i32) -> i32 {
+    if baseline.get("result").and_then(Value::as_str) == Some("error") {
+        status
+    } else {
+        0
+    }
+}
+
+/// Render a spec-loading failure through the class the loader preserved, so
+/// every spec-reading command emits the envelope `check` emits for the same
+/// file (`kind:"parse"` + `diagnostic_code` + `loc` for a syntax error).
+fn spec_load_error_output(error: &SpecLoadError) -> Value {
+    match error {
+        SpecLoadError::Io(message) => error_output("io", message),
+        SpecLoadError::Parse(error) => surface_parse_error_output(error),
+        SpecLoadError::Semantic(message) => semantic_error_output(message),
+    }
 }
 
 fn finish(output: &mut Map<String, Value>, checked: usize, started: Instant) {

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -8,10 +8,11 @@ use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 use super::{
-    CliVerifyOptions, ScopeBounds, add_strict_tag_warnings, apply_vacuity_mode, block_on_native,
-    display, envelope, error_output, implements_error_output, implements_result, invariant_names,
-    load_kernel_model, load_model, load_model_scoped, load_snapshot_value_object,
-    load_state_snapshot, select_properties, selected_implicit_bounds, semantic_error_output,
+    CliVerifyOptions, ScopeBounds, SpecLoadError, add_strict_tag_warnings, apply_vacuity_mode,
+    block_on_native, display, envelope, error_output, implements_error_output, implements_result,
+    invariant_names, load_kernel_model, load_model, load_model_scoped, load_snapshot_value_object,
+    load_state_snapshot, read_spec_source, select_properties, selected_implicit_bounds,
+    semantic_error_output, spec_load_error_output, surface_parse_error_output,
     validate_requirement_traces, validate_specialized_document,
 };
 
@@ -132,7 +133,7 @@ fn verification_cost(started: Instant, statistics: &fsl_solver::VerificationStat
         .expect("verification cost serializes")
 }
 
-fn load_selected_model(selection: ModelSelection<'_>) -> Result<KernelModel, String> {
+fn load_selected_model(selection: ModelSelection<'_>) -> Result<KernelModel, SpecLoadError> {
     let mut model = match selection.model {
         Some(model) => model.clone(),
         None => selection.scope.map_or_else(
@@ -140,7 +141,8 @@ fn load_selected_model(selection: ModelSelection<'_>) -> Result<KernelModel, Str
             |scope| load_model_scoped(selection.path, scope),
         )?,
     };
-    select_properties(&mut model, selection.property, selection.excluded)?;
+    select_properties(&mut model, selection.property, selection.excluded)
+        .map_err(SpecLoadError::Semantic)?;
     Ok(model)
 }
 
@@ -248,7 +250,7 @@ fn load_induction_model(
     auxiliary: &[(String, KernelExpr)],
 ) -> Result<KernelModel, CommandResult> {
     let mut model =
-        load_selected_model(selection).map_err(|error| (semantic_error_output(&error), 2))?;
+        load_selected_model(selection).map_err(|error| (spec_load_error_output(&error), 2))?;
     model
         .invariants
         .extend(auxiliary.iter().map(|(name, expr)| fsl_core::PropertyDef {
@@ -764,7 +766,7 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
     let started = Instant::now();
     let model = match load_selected_model(request.selection) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     if model.actions.is_empty() {
         return (semantic_error_output("spec has no actions"), 2);
@@ -812,7 +814,7 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
     let started = Instant::now();
     let model = match load_selected_model(request.selection) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     if model.actions.is_empty() {
         return (semantic_error_output("spec has no actions"), 2);
@@ -930,7 +932,7 @@ fn execute_bmc(
 
 fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc, CommandResult> {
     let model = load_selected_model(request.selection)
-        .map_err(|error| (semantic_error_output(&error), 2))?;
+        .map_err(|error| (spec_load_error_output(&error), 2))?;
     let checked_bounds = selected_implicit_bounds(
         &model,
         request.selection.property,
@@ -1263,7 +1265,7 @@ fn load_lemma_model(
     path: &Path,
     options: &CliVerifyOptions,
 ) -> Result<(KernelModel, std::collections::BTreeSet<String>), CommandResult> {
-    let mut model = load_model(path).map_err(|error| (semantic_error_output(&error), 2))?;
+    let mut model = load_model(path).map_err(|error| (spec_load_error_output(&error), 2))?;
     let occupied_names = model
         .invariants
         .iter()
@@ -1623,7 +1625,7 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value) {
 struct PreparedCliVerification {
     has_scope: bool,
     is_agent_document: bool,
-    model: Result<KernelModel, String>,
+    model: Result<KernelModel, SpecLoadError>,
     initial_state: Option<std::collections::BTreeMap<String, FslValue>>,
     has_trace_contract: bool,
     /// Compose-lowering warnings (e.g. `fair_not_inherited`), computed while
@@ -1698,14 +1700,11 @@ fn prepare_cli_verification(
     path: &Path,
     options: &CliVerifyOptions,
 ) -> Result<PreparedCliVerification, CommandResult> {
-    let is_agent_document = if let Ok(source) = std::fs::read_to_string(path) {
-        match fsl_syntax::parse_surface_document(&source) {
-            Ok(fsl_syntax::SurfaceDocument::Agent(_)) => true,
-            Ok(_) => false,
-            Err(error) => return Err((error_output("parse", &error.to_string()), 2)),
-        }
-    } else {
-        false
+    let source = read_spec_source(path).map_err(|error| (spec_load_error_output(&error), 2))?;
+    let is_agent_document = match fsl_syntax::parse_surface_document(&source) {
+        Ok(fsl_syntax::SurfaceDocument::Agent(_)) => true,
+        Ok(_) => false,
+        Err(error) => return Err((surface_parse_error_output(&error), 2)),
     };
     let has_scope = !options.scope.instances.is_empty() || !options.scope.values.is_empty();
     if let Err(error) = validate_specialized_document(path) {
@@ -1719,7 +1718,7 @@ fn prepare_cli_verification(
     let initial_state = if let Some(snapshot_path) = options.from_state.as_deref() {
         let model = snapshot_model
             .as_ref()
-            .map_err(|error| (semantic_error_output(error), 2))?;
+            .map_err(|error| (spec_load_error_output(error), 2))?;
         match load_state_snapshot(snapshot_path, model) {
             Ok(state) => Some(state),
             Err((kind, error)) => return Err((error_output(&kind, &error), 2)),
@@ -1771,7 +1770,7 @@ fn validate_cli_property_selection(
         None if has_scope => load_model_scoped(path, &options.scope),
         None => load_model(path),
     }
-    .map_err(|error| (semantic_error_output(&error), 2))?;
+    .map_err(|error| (spec_load_error_output(&error), 2))?;
     if options.engine == "induction"
         && let Some(name) = options.property.as_deref()
         && let Some(kind) = model
@@ -2018,7 +2017,7 @@ fn execute_cli_verification(
     };
     let model = match &prepared.model {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(error), 2),
+        Err(error) => return (spec_load_error_output(error), 2),
     };
     let implements = if filtered {
         None
@@ -2203,7 +2202,7 @@ fn add_cli_strict_tag_warnings(
     } else {
         load_model(path)
     }
-    .map_err(|error| (semantic_error_output(&error), 2))?;
+    .map_err(|error| (spec_load_error_output(&error), 2))?;
     add_strict_tag_warnings(output, &model, path, true, options.requirements.as_deref())
         .map_err(|error| (error_output("io", &error), 2))
 }

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -8210,6 +8210,11 @@
           "result": "error",
           "kind": "parse",
           "message": "unexpected character '&' at 6:47",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 47
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8415,6 +8420,11 @@
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:42",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 42
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8470,6 +8480,11 @@
           "result": "error",
           "kind": "parse",
           "message": "expected expression at 6:44",
+          "diagnostic_code": "FSL-PARSE",
+          "loc": {
+            "line": 6,
+            "column": 44
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",

--- a/rust/fslc/tests/issue_190_approval.rs
+++ b/rust/fslc/tests/issue_190_approval.rs
@@ -167,7 +167,13 @@ fn ledger_reports_spec_errors_before_approval_errors() {
         ],
     );
 
-    assert_eq!(output["kind"], "semantics");
+    // The fixture is an unparseable file, so the spec error that has to win
+    // over the missing-approval error is a *syntax* error. This asserted
+    // `kind == "semantics"` only because `load_kernel_model` flattened the
+    // frontend diagnostic to a message string (#484); `ledger` now reports the
+    // classification `check` reports for the same file, with its location.
+    assert_eq!(output["kind"], "parse");
+    assert!(!output["loc"].is_null(), "{output}");
     std::fs::remove_dir_all(root).expect("remove temporary repository");
 }
 

--- a/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
+++ b/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Every spec-reading command must classify a syntax error the way `check`
+//! does.
+//!
+//! `docs/DESIGN-v1.md` §7.2 fixes the error classification as a closed set and
+//! guarantees `loc` for `parse`; `docs/DESIGN-rust-port.md` requires the JSON
+//! envelope to be preserved; `docs/DESIGN-rust-lsp.md` promises that "CLI and
+//! LSP tests compare diagnostic kind and message for parse, type, and semantic
+//! failures". Before this matrix only `check` was exercised, so the CLI could
+//! (and did) report the same unparseable file as `kind:"semantics"` with no
+//! `loc` from every command that loaded the spec through `load_kernel_model`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+/// The corpus parse-error golden. `docs/RUST-PORTING.md` names it as the
+/// shared parse-location parity case.
+const PARSE_FIXTURE: &str = "examples/gallery/errors/parse_missing_expression.fsl";
+/// A spec that parses but declares no state: a genuine `semantics` diagnostic
+/// that must keep reaching the message-string classifier.
+const SEMANTIC_SOURCE: &str = "spec NoState {\n  const value = 1\n}\n";
+/// A spec that parses and lowers but references an undeclared type: issue 497
+/// recorded `kind:"type"` as already correct, so it must not move.
+const TYPE_SOURCE: &str = "spec BadType {\n  state { value: Missing }\n  init { value = 0 }\n}\n";
+const VALID_SOURCE: &str = "spec Valid {\n  state { value: 0..2 }\n  init { value = 0 }\n  action bump() {\n    requires value < 2\n    value = value + 1\n  }\n  invariant Bounded { value <= 2 }\n}\n";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn run_cli_json(arguments: &[&str]) -> Option<Value> {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+fn fixture_directory(name: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!("fsl-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&directory).expect("create fixture directory");
+    directory
+}
+
+fn write_fixture(directory: &Path, name: &str, contents: &str) -> String {
+    let path = directory.join(name);
+    std::fs::write(&path, contents).expect("write fixture");
+    path.to_str().expect("UTF-8 fixture path").to_owned()
+}
+
+/// Every command that reads a specification, with the auxiliary arguments it
+/// needs to reach its spec loader (`replay` needs a trace, `diff` a second
+/// spec).
+fn spec_reading_commands<'a>(
+    spec: &'a str,
+    trace: &'a str,
+    other: &'a str,
+) -> Vec<(&'a str, Vec<&'a str>)> {
+    vec![
+        ("check", vec!["check", spec]),
+        ("lint", vec!["lint", spec]),
+        ("fmt", vec!["fmt", spec, "--check"]),
+        ("mutate", vec!["mutate", spec]),
+        ("verify", vec!["verify", spec, "--depth", "3"]),
+        ("kernel", vec!["kernel", spec]),
+        ("conformance", vec!["conformance", spec]),
+        ("scenarios", vec!["scenarios", spec]),
+        ("explain", vec!["explain", spec]),
+        ("analyze", vec!["analyze", spec]),
+        ("typestate", vec!["typestate", spec]),
+        ("ledger", vec!["ledger", spec]),
+        ("testgen", vec!["testgen", spec]),
+        ("document", vec!["document", "generate", spec]),
+        ("diff", vec!["diff", spec, other]),
+        ("replay", vec!["replay", spec, "--trace", trace]),
+        ("html", vec!["html", spec]),
+        ("sweep", vec!["sweep", spec]),
+    ]
+}
+
+#[test]
+fn every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location() {
+    let directory = fixture_directory("parse-matrix");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"GalleryParseMissingExpression","initial":{"x":0},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+
+    for (name, arguments) in spec_reading_commands(PARSE_FIXTURE, &trace, &other) {
+        let (output, status) = run_cli(&arguments);
+        assert_eq!(output["result"], "error", "{name}: {output}");
+        assert_eq!(output["kind"], "parse", "{name}: {output}");
+        // `lint` adds a `file` key to its own `loc`; the guaranteed fields are
+        // `line`/`column` (`docs/DESIGN-v1.md` §7.2).
+        assert_eq!(output["loc"]["line"], json!(6), "{name}: {output}");
+        assert_eq!(output["loc"]["column"], json!(14), "{name}: {output}");
+        assert_eq!(output["diagnostic_code"], "FSL-PARSE", "{name}: {output}");
+        assert_eq!(status, 2, "{name}: {output}");
+        // Issue 497 recorded "relative-path parse messages do not leak an
+        // absolute path" as already correct; keep it pinned.
+        let message = output["message"].as_str().expect("parse message");
+        assert!(
+            !message.contains(repository_root().to_str().expect("UTF-8 root")),
+            "{name}: {message}"
+        );
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+#[test]
+fn a_genuine_semantic_or_type_error_keeps_its_own_classification() {
+    let directory = fixture_directory("parse-matrix-negative");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"NoState","initial":{},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+    let cases = [
+        ("semantics", SEMANTIC_SOURCE, "no_state.fsl"),
+        ("type", TYPE_SOURCE, "bad_type.fsl"),
+    ];
+
+    for (expected_kind, source, file) in cases {
+        let spec = write_fixture(&directory, file, source);
+        for (name, arguments) in spec_reading_commands(&spec, &trace, &other) {
+            let (output, status) = run_cli(&arguments);
+            assert_eq!(
+                output["result"], "error",
+                "{expected_kind}/{name}: {output}"
+            );
+            // `fmt`/`lint` never lower to the kernel, so they accept a
+            // syntactically valid document; every loader-backed command must
+            // still route the failure to the message-string classifier.
+            if matches!(name, "fmt" | "lint") {
+                continue;
+            }
+            assert_ne!(output["kind"], "parse", "{expected_kind}/{name}: {output}");
+            assert_eq!(
+                output["kind"], expected_kind,
+                "{expected_kind}/{name}: {output}"
+            );
+            assert_eq!(status, 2, "{expected_kind}/{name}: {output}");
+        }
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+#[test]
+fn a_valid_specification_is_never_reclassified_as_a_syntax_error() {
+    let directory = fixture_directory("parse-matrix-positive");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"Valid","initial":{"value":0},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+    let spec = write_fixture(&directory, "valid.fsl", VALID_SOURCE);
+
+    for (name, arguments) in spec_reading_commands(&spec, &trace, &other) {
+        // A success path may emit Markdown or HTML rather than JSON (`ledger`,
+        // `html`); that is already proof it did not emit an error envelope.
+        if let Some(output) = run_cli_json(&arguments) {
+            assert_ne!(output["kind"], "parse", "{name}: {output}");
+        }
+    }
+    let (output, status) = run_cli(&["check", &spec]);
+    assert_eq!(output["result"], "ok", "{output}");
+    assert_eq!(status, 0, "{output}");
+    // `document generate` owns a second loader (`load_document_claims`), so its
+    // accepting path is pinned on a real requirements-dialect corpus file. It
+    // writes the document to stdout, so only the exit code is asserted.
+    let document = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "document",
+            "generate",
+            "examples/agentic_rag/agentic_rag_requirements.fsl",
+        ])
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    assert_eq!(
+        document.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&document.stdout)
+    );
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+#[test]
+fn analyze_agrees_between_single_and_batch_input() {
+    let directory = fixture_directory("analyze-batch-parity");
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+    let missing = directory
+        .join("absent.fsl")
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .to_owned();
+
+    let (single, single_status) = run_cli(&["analyze", PARSE_FIXTURE]);
+    let (batch, batch_status) = run_cli(&["analyze", PARSE_FIXTURE, &other]);
+    assert_eq!(single_status, 2, "{single}");
+    assert_eq!(batch_status, 2, "{batch}");
+    let entry = batch["errors"]
+        .as_array()
+        .expect("batch errors")
+        .iter()
+        .find(|entry| entry["file"] == json!(PARSE_FIXTURE))
+        .expect("batch entry for the parse fixture")
+        .clone();
+    assert_eq!(entry["kind"], single["kind"], "{batch}");
+    assert_eq!(entry["loc"], single["loc"], "{batch}");
+    assert_eq!(entry["message"], single["message"], "{batch}");
+    assert_eq!(entry["kind"], "parse", "{batch}");
+
+    // Issue 497: a missing input classified as `semantics` alone and `io` as
+    // soon as a second input was added.
+    let (single_missing, single_missing_status) = run_cli(&["analyze", &missing]);
+    let (batch_missing, batch_missing_status) = run_cli(&["analyze", &missing, &other]);
+    assert_eq!(single_missing["kind"], "io", "{single_missing}");
+    assert_eq!(batch_missing["kind"], "io", "{batch_missing}");
+    assert_eq!(single_missing_status, 2, "{single_missing}");
+    assert_eq!(batch_missing_status, 2, "{batch_missing}");
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+#[test]
+fn a_missing_input_is_io_for_every_spec_reading_command() {
+    let directory = fixture_directory("missing-input");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"Valid","initial":{"value":0},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+    let missing = directory
+        .join("absent.fsl")
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .to_owned();
+
+    for (name, arguments) in spec_reading_commands(&missing, &trace, &other) {
+        let (output, status) = run_cli(&arguments);
+        assert_eq!(output["result"], "error", "{name}: {output}");
+        assert_eq!(output["kind"], "io", "{name}: {output}");
+        assert_eq!(status, 2, "{name}: {output}");
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}


### PR DESCRIPTION
## Problem

`load_kernel_model` flattened a structured `fsl_core::CoreError` — which carries `line` and
`column` — into a `String`. Every command that loads a spec through it then passed that string to
`verification_output.rs::semantic_error_kind`, a **message-string classifier**, where
`"expected expression at …"` matched nothing and fell to the `else` arm. So a syntax error came back
as `kind:"semantics"` with `loc: null`, while `check` — which does not go through that path — reported
`kind:"parse"` with `loc` for the very same file.

The capability was already in the tree: `source_diagnostic.rs` is the authoritative classifier and
`frontend_output::render_surface_parse_error` is what `check` uses. It simply was not wired to the
other commands. Native was disagreeing with itself about the same file.

Measured on `examples/gallery/errors/parse_missing_expression.fsl`:

| command | before | after |
|---|---|---|
| `check`, `lint`, `fmt --check` | `parse` / 6:14 / exit 2 | unchanged |
| `verify`, `sweep` | `parse` / **null** / exit 2 | `parse` / **6:14** / exit 2 |
| `mutate` | `parse` / 6:14 / exit **0** | `parse` / 6:14 / exit **2** |
| `kernel`, `conformance`, `scenarios`, `explain`, `analyze`, `typestate`, `ledger`, `testgen`, `document generate`, `diff`, `replay`, `html` | **`semantics` / null** / exit 2 | **`parse` / 6:14** / exit 2 |

Every "after" row also carries `diagnostic_code: "FSL-PARSE"`. Independently re-measured on the
rebased branch before merge.

This is a machine-readable-contract break, **not** a false green: `result:"error"` and exit 2 were
already correct everywhere except `mutate`.

## Contract change

None — `docs/DESIGN-v1.md` (`parse`/`name`/`type`/`semantics` always have `loc`),
`docs/DESIGN-rust-port.md` (preserve the JSON envelope; `kind` and `loc` match the reference for the
corpus) and `docs/DESIGN-analysis.md` already stated the correct contract. The implementation moved
to meet it, so no docs change was needed.

`SpecLoadError { Io | Parse(Box<ParseError>) | Semantic }` replaces the `String`, rendered through one
function that dispatches to `error_output("io", …)` / `render_surface_parse_error` /
`semantic_error_output`. `semantic_error_kind` is untouched — the fix carries the type rather than
extending the string sniffing. `read_spec_source` gives every command one IO path, which is what makes
analyze's single-vs-batch disagreement go away (missing input was `semantics` single / `io` batch;
now `io` for both).

The brief proposed separate `Core` and `Model` variants; they rendered identically and neither carries
a `loc`, so they were collapsed into one `Semantic` variant rather than adding a distinction with no
observable difference.

### Two scope changes worth calling out

**`mutate`'s exit code.** The issue text claimed every command already exited 2; measurement showed
`mutate` exiting **0** on an unparseable spec. `docs/LANGUAGE.md`'s exit-code table maps
parse/type/semantics/io to 2 with no per-command exemption, so a spec-*error* baseline now keeps its
own exit code. `violated`/`unknown` baselines still score 0 as before.

**`rust/fsl-wasm`.** `./tools/check-native-integration.sh` failed on the first run (exit 1): the
Worker's `verify` emitted `kind:"parse"` without `loc`/`diagnostic_code`, so fixing the CLI made the
Worker diverge on 3 corpus cases. `AGENTS.md` requires the Worker to move with the CLI, so it now
calls the same renderer (8 lines). This is the gate doing its job — the divergence would otherwise
have been introduced by this PR.

## Test evidence

New `rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs` drives one corpus file through every
spec-reading command as a table rather than 16 near-identical tests. This is where
`docs/DESIGN-rust-lsp.md`'s promise that CLI and LSP diagnostics agree actually becomes checked;
`lsp_diagnostic_contract.rs` ran `check` only.

Ablation (stash `main.rs` + `verification.rs` + the regenerated baseline, rebuild, `--no-fail-fast`):
`every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location`,
`a_genuine_semantic_or_type_error_keeps_its_own_classification`,
`a_missing_input_is_io_for_every_spec_reading_command`,
`analyze_agrees_between_single_and_batch_input`, plus
`ledger_reports_spec_errors_before_approval_errors` all fail. The positive control
`a_valid_specification_is_never_reclassified_as_a_syntax_error` **passes** under ablation, which is
correct — it is not supposed to be able to distinguish. `cli_regression` (22),
`domain_expression_characterization` (3) and `lsp_diagnostic_contract` (1) stay green under ablation.

Independently re-verified here that the refuted sub-claims in #497 still hold: type errors remain
`kind:"type"` and are consistent across check/analyze/replay, and the parse message contains no
absolute path (now pinned by assertion).

**One existing test asserted the bug.** `issue_190_approval.rs:170` asserted `kind == "semantics"` for
a fixture containing "not an FSL document" — it passed only because of this defect. It now asserts
`parse` with a non-null `loc`, preserving its "spec error precedes approval error" intent.

The `domain_characterization` baseline snapshot was regenerated, not hand-edited: +15 lines, three
`verify` entries gaining `diagnostic_code` and `loc`. No verdict, kind, or exit code moved.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Known residuals, filed as issues rather than folded in

- **#555** — `type` and `semantics` errors still return `loc: null` on every command including
  `check`, so `DESIGN-v1`'s "always have `loc`" clause is now exactly half met. Deciding it needs an
  inventory of which diagnostics can carry a span; fabricating a `loc` would be worse than not having
  one, and if some genuinely cannot, it is the contract that should move.
- **#554** — `mutate` returns `result:"violated"` with exit 0 where the table says 1. Adjacent to the
  exit-code branch touched here, pre-existing on `main`, verified independently.
- **#556** — the Worker still maps a kernel-stage `CoreError` to `kind:"parse"` where native says
  `semantics`. Not reached by the parity corpus, which is why only the `loc` half surfaced.

Also known and deliberately left: analyze single vs batch still word a missing-input message
differently (`"file not found: p"` vs `"p: No such file or directory"`) though both are now
`kind:"io"`. Normalizing it means restructuring batch's directory-expansion loop, and
`docs/RUST-PORTING.md` explicitly permits wording differences.

Parse messages no longer repeat the file path (`"expected expression at 6:14"`, byte-identical to
`check`); the location lives in `loc`, and batch mode carries a per-entry `file` field, verified.

## Documentation

`CHANGELOG.md` `[Unreleased]`. No other docs change — the contract was already correct.

## Linked issues

Fixes #484, fixes #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
