### PR TITLE
fix(lsp): stop an @ annotation swallowing the following declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,29 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   diagnostics").
 
 ### Fixed
+- The native LSP's document index no longer lets an `@` annotation swallow the
+  declaration that follows it. `@requirement("REQ-COMMAND", "…")` shares its
+  name with the `requirement NAME { … }` declaration keyword, and the index
+  handled no `@` at all, so the annotation armed a pending declaration that
+  nothing between there and the next identifier disarmed — the *next line's*
+  construct keyword was consumed as the declaration name. In
+  `examples/annotations/annotated_domain.fsl` that registered a Property symbol
+  literally named `command` and left `command Place { … }`'s real name `Place`
+  with no declaration at all, so definition/references/rename returned nothing
+  and `documentSymbol` listed a construct keyword. 13 sites across the four
+  `examples/annotations/*.fsl` files were affected, every one of them from
+  `@requirement`. Nothing from `@` through the annotation's closing `)` may now
+  declare anything or consume a pending declaration, in any dialect; non-keyword
+  names inside an annotation stay references. Resolved by position, not by
+  removing `requirement` from the declaration keywords, which would have broken
+  the real declaration form (#551).
+- `rust/fsl-lsp/tests/corpus.rs` now also asserts, over every corpus file, that
+  a declaration keyword owning a name has actually declared that name
+  (`DocumentIndex::misprojected_declarations`). The previous whole-corpus check
+  only required every identifier to have *some* entry, which a swallowed name
+  satisfies as a reference to nothing, so it passed while roles and scopes were
+  wrong. This is the drift detector the `#504`/`#551` class of index bug had
+  been missing (#551).
 - The native LSP's document index now recognizes `def` declarations and their
   parameters, aggregate/quantifier binders written with a `name: Type` form
   (`count(c: Id where ...)`, `sum(...)`, `unique(...)`, `exactlyOne(...)`,

--- a/docs/DESIGN-rust-lsp.md
+++ b/docs/DESIGN-rust-lsp.md
@@ -84,9 +84,28 @@ contextual walk (`declaration_keyword`, the quantifier/aggregate/pattern binder 
 `INDEX_KEYWORDS` in `rust/fsl-lsp/src/index.rs`), or it silently loses navigation
 (`textDocument/definition`, `references`, `rename`, `documentSymbol`) without a parse failure to
 surface the gap. A language feature's coupled change (grammar/lowering, typed model, semantics,
-docs) therefore also covers `rust/fsl-lsp/src/index.rs`. `rust/fsl-lsp/tests/corpus.rs` only
-asserts that every identifier has some symbol-or-reference entry, not that its role or scope is
-correct, so a new declaration or binder form needs its own targeted unit test (issue #504).
+docs) therefore also covers `rust/fsl-lsp/src/index.rs`. A new declaration or binder form still
+needs its own targeted unit test, because the corpus gate below asserts contract properties rather
+than per-construct roles (issue #504).
+
+The walk is keyword-driven, so a construct keyword may only start a declaration where the grammar
+puts one. Two positions in `rust/fsl-syntax` reuse those same words and stay excluded:
+`reachable(r, a, b)` and `domain(r)` are relation builtin calls, and `@name(args)` is an annotation
+(`annotation_parse::annotation`, shared by `parser.rs`, `domain.rs`, `db.rs`, and `ai.rs`). An
+annotation never declares. `@requirement("R", "t")` would otherwise arm a pending declaration that
+nothing disarms before the next identifier, so the *following line's* construct keyword is consumed
+as the declaration name and the real name loses its declaration entirely (issue #551). Nothing from
+`@` through the closing `)` may declare anything or consume a pending declaration; non-keyword names
+inside an annotation stay references. The collision is resolved by position, never by removing a
+word from `declaration_keyword` — `requirement NAME { ... }` is itself a real declaration form.
+
+`rust/fsl-lsp/tests/corpus.rs` asserts two whole-corpus properties. `unindexed_identifiers` requires
+every non-keyword identifier to have some entry; it cannot see a wrong role, because a swallowed
+name is still indexed as a reference to nothing. `misprojected_declarations` adds the scope property
+that a declaration keyword owning a name has actually declared that name, and fails loudly when a
+construct keyword is consumed in a name position it does not occupy. It skips positions where the
+next token is not an identifier (builtin calls, annotations, block-opening `until`/`leadsTo`) and
+`action` inside a `refinement` document, where `action impl(args) -> abs` maps rather than declares.
 
 Open buffers take precedence over files on disk. Imports and workspace references load through a
 document resolver that first consults the store and then the filesystem relative to the owning

--- a/rust/fsl-lsp/src/index.rs
+++ b/rust/fsl-lsp/src/index.rs
@@ -59,6 +59,7 @@ pub struct ImportBinding {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DocumentIndex {
     source: String,
+    refinement: bool,
     pub symbols: Vec<Symbol>,
     pub references: Vec<Reference>,
     pub imports: Vec<ImportBinding>,
@@ -112,37 +113,50 @@ impl DocumentIndex {
         let mut expected: Option<(SymbolRole, Option<Context>)> = None;
         let mut awaiting_block: Option<(Context, Option<String>)> = None;
         let mut list_role: Option<(SymbolRole, Option<Context>)> = None;
+        let mut in_annotation = false;
         let mut declaration_offsets = BTreeSet::new();
 
         for (index, token) in tokens.iter().enumerate() {
             match &token.kind {
                 TokenKind::Ident(name) => {
-                    if let Some((role, context)) = expected.take() {
-                        add_symbol(source, token, name, role, None, &mut symbols);
-                        declaration_offsets.insert(token.span.start.offset);
-                        awaiting_block = context.map(|context| {
-                            let owner = matches!(context, Context::Action | Context::Other)
-                                .then(|| name.clone());
-                            (context, owner)
-                        });
-                        continue;
-                    }
-                    // `reachable` and `domain` each name both a top-level
-                    // declaration keyword (`reachable NAME { expr }`, `domain
-                    // SpecName { ... }`) and a relation builtin call
-                    // (`reachable(r, a, b)`, `domain(r)`). Only the
-                    // declaration form starts a new declaration; a following
-                    // `(` is always the builtin call, which is a keyword like
-                    // every other builtin and owns no local name.
-                    let builtin_call = matches!(name.as_str(), "reachable" | "domain")
-                        && token_symbol(tokens.get(index + 1)) == Some("(");
-                    if !builtin_call && let Some((role, context)) = declaration_keyword(name) {
-                        expected = role.map(|role| (role, context));
-                        list_role = (name == "actor").then_some(expected).flatten();
-                        if role.is_none() {
-                            awaiting_block = context.map(|context| (context, None));
+                    // `@name(args)` is an annotation, never a declaration. Its
+                    // name path collides head-on with `declaration_keyword`
+                    // (`@requirement("R", "t")` against the real
+                    // `requirement NAME { ... }` form), and its symbol-path
+                    // arguments sit exactly where the binder and enum-member
+                    // heuristics fire, so no identifier from `@` through the
+                    // closing `)` may start a declaration or consume a pending
+                    // one. Names that are not keywords stay references, which
+                    // is what `unindexed_identifiers` requires of them.
+                    if !in_annotation {
+                        if let Some((role, context)) = expected.take() {
+                            add_symbol(source, token, name, role, None, &mut symbols);
+                            declaration_offsets.insert(token.span.start.offset);
+                            awaiting_block = context.map(|context| {
+                                let owner = matches!(context, Context::Action | Context::Other)
+                                    .then(|| name.clone());
+                                (context, owner)
+                            });
+                            continue;
                         }
-                        continue;
+                        // `reachable` and `domain` each name both a top-level
+                        // declaration keyword (`reachable NAME { expr }`,
+                        // `domain SpecName { ... }`) and a relation builtin
+                        // call (`reachable(r, a, b)`, `domain(r)`). Only the
+                        // declaration form starts a new declaration; a
+                        // following `(` is always the builtin call, which is a
+                        // keyword like every other builtin and owns no local
+                        // name.
+                        let builtin_call = matches!(name.as_str(), "reachable" | "domain")
+                            && token_symbol(tokens.get(index + 1)) == Some("(");
+                        if !builtin_call && let Some((role, context)) = declaration_keyword(name) {
+                            expected = role.map(|role| (role, context));
+                            list_role = (name == "actor").then_some(expected).flatten();
+                            if role.is_none() {
+                                awaiting_block = context.map(|context| (context, None));
+                            }
+                            continue;
+                        }
                     }
                     if is_keyword(name) {
                         continue;
@@ -185,7 +199,9 @@ impl DocumentIndex {
                                 == Some("some")
                             && token_ident(index.checked_sub(3).and_then(|i| tokens.get(i)))
                                 == Some("is");
-                    let role = if quantifier_binder || pattern_binder {
+                    let role = if in_annotation {
+                        None
+                    } else if quantifier_binder || pattern_binder {
                         Some(SymbolRole::Variable)
                     } else if next_is_colon {
                         match context {
@@ -223,13 +239,27 @@ impl DocumentIndex {
                         });
                     }
                 }
+                // `@` opens an annotation and its closing `)` ends it.
+                // `annotation_parse::annotation` is the one grammar every
+                // dialect uses (`parser.rs`, `domain.rs`, `db.rs`, `ai.rs`):
+                // `@` path `(` args `)`, where `(` is mandatory and an
+                // argument is a string, integer, Boolean, or dotted symbol
+                // path — never a parenthesized expression. With no nesting
+                // possible the first `)` always closes the annotation.
+                TokenKind::Symbol(symbol) if symbol == "@" => {
+                    in_annotation = true;
+                }
+                TokenKind::Symbol(symbol) if symbol == ")" => {
+                    in_annotation = false;
+                }
                 TokenKind::Symbol(symbol) if symbol == "," => {
                     // `actor A, B` continues one declaration list, but the
                     // parser also ends the list on a trailing comma followed
                     // by the next item keyword (`actor A, entity Case`), so
-                    // only a non-keyword name re-arms the pending role.
-                    let continues_list =
-                        token_ident(tokens.get(index + 1)).is_some_and(|next| !is_keyword(next));
+                    // only a non-keyword name re-arms the pending role. A
+                    // comma between annotation arguments separates no list.
+                    let continues_list = !in_annotation
+                        && token_ident(tokens.get(index + 1)).is_some_and(|next| !is_keyword(next));
                     if continues_list && let Some(pending) = list_role {
                         expected = Some(pending);
                     }
@@ -265,6 +295,7 @@ impl DocumentIndex {
         let imports = import_bindings(source, &tokens);
         Ok(Self {
             source: source.to_owned(),
+            refinement,
             symbols,
             references,
             imports,
@@ -339,6 +370,67 @@ impl DocumentIndex {
     #[must_use]
     pub fn import_for_alias(&self, alias: &str) -> Option<&ImportBinding> {
         self.imports.iter().find(|binding| binding.alias == alias)
+    }
+
+    /// Return declaration-name positions the index failed to declare.
+    ///
+    /// A declaration keyword that owns a name (`action`, `invariant`, `entity`,
+    /// `command`, ...) is followed in the grammar by that name, so whenever the
+    /// very next token is an identifier the index must have declared a symbol
+    /// there. `unindexed_identifiers` cannot see this: a swallowed name is
+    /// still indexed, just as a reference to nothing, and a keyword registered
+    /// as a symbol in its place is still an entry. Positions where the next
+    /// token is not an identifier are skipped, because the keyword is then not
+    /// introducing a name — `reachable(r, a, b)` and `domain(r)` are relation
+    /// builtin calls, `@requirement("R", "t")` is an annotation, and
+    /// `until`/`leadsTo` open a block.
+    ///
+    /// `action` is skipped in a `refinement` document for the same reason:
+    /// there `action impl_name(args) -> abs_name` maps an implementation
+    /// action onto an abstract one, so the name is a cross-spec reference and
+    /// `apply_refinement_hints` demotes it on purpose.
+    #[must_use]
+    pub fn misprojected_declarations(&self) -> Vec<String> {
+        let declared = self
+            .symbols
+            .iter()
+            .map(|symbol| {
+                (
+                    symbol.selection_range.start.line,
+                    symbol.selection_range.start.character,
+                )
+            })
+            .collect::<HashSet<_>>();
+        fsl_syntax::lex(&self.source).map_or_else(
+            |_| Vec::new(),
+            |tokens| {
+                tokens
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, token)| {
+                        let TokenKind::Ident(keyword) = &token.kind else {
+                            return None;
+                        };
+                        if self.refinement && keyword == "action" {
+                            return None;
+                        }
+                        declaration_keyword(keyword)?.0?;
+                        let name = tokens.get(index + 1)?;
+                        let TokenKind::Ident(name_text) = &name.kind else {
+                            return None;
+                        };
+                        let position = span_range(&self.source, name.span).start;
+                        (!declared.contains(&(position.line, position.character))).then(|| {
+                            format!(
+                                "{}:{}: `{keyword} {name_text}` declares nothing",
+                                position.line + 1,
+                                position.character + 1
+                            )
+                        })
+                    })
+                    .collect()
+            },
+        )
     }
 
     /// Return non-keyword identifiers that have neither declaration nor reference coverage.
@@ -1161,5 +1253,135 @@ mod tests {
             .find(|symbol| symbol.name == "Case")
             .expect("Case must be declared by `entity Case`");
         assert_eq!(case.role, SymbolRole::Type);
+    }
+
+    /// Issue #551 evidence, reduced from `examples/annotations/annotated_domain.fsl`.
+    const ISSUE_551_PROBE: &str = r#"domain AnnotatedOrders {
+  implementation_profile functional_ddd
+
+  aggregate Order {
+    id OrderId
+
+    state {
+      placed: Bool = false;
+    }
+
+    @requirement("REQ-COMMAND", "placing an order is traceable")
+    command Place {
+      input order_id: OrderId
+    }
+
+    event Placed { order_id: OrderId }
+
+    decide Place {
+      emits Placed
+    }
+
+    evolve Placed {
+      placed = true
+    }
+  }
+}"#;
+
+    /// `@requirement(...)` is an annotation; `requirement NAME { ... }` is a
+    /// declaration. Before this fix the shared name made the annotation arm a
+    /// pending `(Property, Other)` declaration that nothing between there and
+    /// the next identifier disarmed, so the *next line's* construct keyword —
+    /// `command` — was consumed as the declaration name and the real name
+    /// `Place` was left with no declaration at all.
+    #[test]
+    fn annotation_named_like_a_declaration_keyword_does_not_swallow_the_declaration() {
+        let index = DocumentIndex::build(ISSUE_551_PROBE, None).expect("valid domain");
+        assert!(
+            !index.symbols.iter().any(|symbol| symbol.name == "command"),
+            "{:?}",
+            index.symbols
+        );
+        let place = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "Place")
+            .expect("`command Place` must declare Place");
+        assert_eq!(place.role, SymbolRole::Function);
+        assert!(index.misprojected_declarations().is_empty());
+    }
+
+    /// The positive control for the fix above: resolving the collision by
+    /// dropping `requirement` from `declaration_keyword` would also pass that
+    /// negative control, and would break this — `requirement NAME "text"
+    /// { ... }` is a real declaration form.
+    #[test]
+    fn a_real_requirement_declaration_still_declares_its_name() {
+        let source = r#"requirements Support {
+  type CaseId = 0..1
+  state { done: Bool }
+  init { done = false }
+  requirement REQ-1 "a case can finish" {
+    action finish() {
+      done = true
+    }
+  }
+}"#;
+        let index = DocumentIndex::build(source, None).expect("valid requirements");
+        let requirement = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "REQ")
+            .expect("`requirement REQ-1` must declare its ID");
+        assert_eq!(requirement.role, SymbolRole::Property);
+        assert!(index.misprojected_declarations().is_empty());
+    }
+
+    /// `annotation_parse::annotation` makes `(` mandatory and accepts a dotted
+    /// path with an empty argument list, so `@doc.control()` — not a bare
+    /// `@undecided` — is the no-argument form. Every segment of the path is a
+    /// name position, so a trailing segment that collides with
+    /// `declaration_keyword` (`control`) swallows the next declaration exactly
+    /// like a single-segment `@requirement` does, and an empty argument list
+    /// leaves no token between the name and the declaration to recover on.
+    #[test]
+    fn empty_argument_and_dotted_annotations_do_not_swallow_the_declaration() {
+        let source = ISSUE_551_PROBE.replace(
+            r#"@requirement("REQ-COMMAND", "placing an order is traceable")"#,
+            "@doc.control()",
+        );
+        let index = DocumentIndex::build(&source, None).expect("valid domain");
+        let place = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "Place")
+            .expect("`command Place` must declare Place");
+        assert_eq!(place.role, SymbolRole::Function);
+        assert!(index.misprojected_declarations().is_empty());
+    }
+
+    /// An annotation's symbol-path arguments sit exactly where the aggregate
+    /// binder heuristic fires (`count(c: T ...)`), so `@count(binder)` would
+    /// otherwise declare its arguments as scoped Variables. Nothing between
+    /// `@` and the closing `)` may declare anything, and non-keyword argument
+    /// names stay references, which `unindexed_identifiers` requires.
+    #[test]
+    fn annotation_arguments_declare_nothing_and_stay_references() {
+        let source = ISSUE_551_PROBE.replace(
+            r#"@requirement("REQ-COMMAND", "placing an order is traceable")"#,
+            "@count(swallowed, alsoSwallowed)",
+        );
+        let index = DocumentIndex::build(&source, None).expect("valid domain");
+        for argument in ["swallowed", "alsoSwallowed"] {
+            assert!(
+                !index.symbols.iter().any(|symbol| symbol.name == argument),
+                "{argument} must not be declared: {:?}",
+                index.symbols
+            );
+            assert!(
+                index
+                    .references
+                    .iter()
+                    .any(|reference| reference.name == argument),
+                "{argument} must stay a reference: {:?}",
+                index.references
+            );
+        }
+        assert!(index.misprojected_declarations().is_empty());
     }
 }

--- a/rust/fsl-lsp/tests/corpus.rs
+++ b/rust/fsl-lsp/tests/corpus.rs
@@ -42,6 +42,10 @@ fn valid_corpus_is_parsed_and_every_identifier_is_indexed() {
                         missing.join(", ")
                     ));
                 }
+                let misprojected = index.misprojected_declarations();
+                if !misprojected.is_empty() {
+                    failures.push(format!("{}: {}", path.display(), misprojected.join(", ")));
+                }
             }
             Err(error) => failures.push(format!("{}: {error}", path.display())),
         }


### PR DESCRIPTION
## Problem

`rust/fsl-lsp/src/index.rs` handled no `@` token at all. An annotation whose name is also a
declaration keyword therefore armed a pending declaration that nothing disarmed — `(`, the string
arguments, `,` and `)` all fall through the token walk — so the **next identifier**, which is the
following line's construct keyword, was consumed as the declaration name and the real name lost its
declaration entirely.

At `examples/annotations/annotated_domain.fsl:35` this registered a Property symbol literally named
`command`, while `Place` appeared only as a reference — at its own declaration site and at line 43.
`textDocument/definition` on `Place` resolved to nothing.

There is no parse failure when this happens, which is why it survived: the document is valid and
`check` is clean. The index is simply wrong.

### Scope, measured as an index diff

The figure in #551 (and in PR #553's body) said 8 sites. **That was wrong, and so was the criterion
behind it** — it counted declared symbols whose *name* is a declaration keyword, using a hand-written
keyword list. Both halves fail: the list omitted `projection`/`init`/`acceptance`/`forbidden`, and the
swallowed token need not be a declaration keyword at all. `requires_human_approval`, `when`, `check`
and `rule` are each swallowed in `annotated_ai_component.fsl` and none of them is one.

Re-measured by diffing the full symbol set of every `.fsl` under `examples/` and `specs/` before and
after — no criterion invented, so nothing can be missed:

- **17 spurious symbols disappear**, across the four `examples/annotations/*.fsl` files, every one
  from `@requirement`.
- **11 real declarations are recovered** (plus `order_id`, the parameter of a recovered action):
  `tool RefundPayment`, `forbidden DeleteCustomerData`, `transition submit`, `acceptance AC`,
  `migration add_nickname`, `command Place`, `decide Place`, `evolve Placed`,
  `invariant NoShippingUnplaced`, `effect Ship`, `projection OrderObservedState`.

The two numbers differ because six of the swallow sites (`init`, `when`, `check`, `rule`,
`requires_human_approval`) sit where the grammar declares no name — they produce a spurious symbol but
lose nothing. The correction is recorded on #551.

## Contract change

None. `TokenKind::Symbol("@")` sets an `in_annotation` flag that `)` clears; inside it nothing may
declare or consume a pending declaration.

That single flag is **exact, not approximate**: `annotation_parse::annotation` is the one grammar all
four dialect parsers use (`parser.rs`, `domain.rs`, `db.rs`, `ai.rs`), `(` is mandatory, and
`annotation_value` accepts only a string, integer, Boolean, or symbol path — **never a parenthesized
expression**. With no nesting possible the first `)` always closes the annotation. Verified against
`rust/fsl-syntax/src/annotation_parse.rs` rather than assumed.

The collision is resolved **by position, never by removing `requirement` from `declaration_keyword`** —
that would break the real `requirement NAME { … }` form. Non-keyword annotation names stay
*references* rather than being skipped outright, because `unindexed_identifiers` requires every
identifier to be indexed as something; the defect is arming `expected`, not emitting a reference.

## Part 2: the drift detector

`rust/fsl-lsp/tests/corpus.rs` gains a whole-corpus scope property via
`DocumentIndex::misprojected_declarations`: a declaration keyword that owns a name must actually have
declared that name. `unindexed_identifiers` structurally could never see this class — a swallowed name
is still indexed, just as a reference to nothing.

This is the assertion #504 deliberately deferred because it could not pass. It covers **exactly the
11-site lost-declaration class**, which is the class that breaks navigation; the six spurious-only
sites are out of reach because `init`/`when`/`check`/`rule` own no name in the grammar, and the
property that would catch them — "no declared symbol's name is a keyword" — is **unsound**, since
`enum E { push }` is accepted FSL. The general sound property was chosen over the bug-shaped complete
one.

Two exclusions, both language properties rather than allowlists of files or symbols:

- positions where the next token is not an identifier (relation builtin calls, annotations,
  block-opening `until`/`leadsTo`) — nothing is being named there;
- `action` in a `refinement` document, where `action impl(args) -> abs` maps rather than declares and
  `apply_refinement_hints` demotes the name deliberately.

The two corpus symbols named like keywords — `action push()` in `examples/gallery/valid/tiny_turnstile.fsl`
and `fair action respond(…)` in `examples/nfr/support_sla.fsl` — need **no exemption at all**: they pass
because `action` genuinely declares them. FSL has no reserved-word list, and the property is correct
about that.

## Test evidence

Ablation reproduced independently here, not taken on report. Neutralising only the `in_annotation`
arming and rebuilding:

- `valid_corpus_is_parsed_and_every_identifier_is_indexed` fails naming **exactly the same 11 sites**
  the index diff identified as lost declarations — an agreement between two independent measurements,
  not one method checking itself.
- three unit tests fail: `annotation_named_like_a_declaration_keyword_does_not_swallow_the_declaration`,
  `empty_argument_and_dotted_annotations_do_not_swallow_the_declaration`,
  `annotation_arguments_declare_nothing_and_stay_references`.
- 22 pre-existing tests stay green.

`a_real_requirement_declaration_still_declares_its_name` passes under that ablation, which is correct —
it is not the control for *this* fix. It is the control against the **wrong** fix: dropping
`requirement` from `declaration_keyword` hides the bug from both the corpus check and the first unit
test, and this control is what catches it. That sub-ablation was run separately.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh` all exit 0.

## Two corrections to the original task framing

Both were reported rather than worked around silently:

1. A bare no-argument `@undecided` is **not accepted syntax** — `annotation_parse::annotation` makes
   `(` mandatory. The real no-argument form is `@ns.name()`, and `@doc.control()` was used instead,
   which doubles as a stronger control since a dotted path's trailing segment collides the same way.
2. "Skip the annotation name and its arguments", read literally, breaks `corpus.rs`: `@undecided` and
   `@kind` are not in `is_keyword`, so today they are references, and dropping them makes
   `unindexed_identifiers` flag them.

## Scope note

#552 — the root structure under this bug and #504, where `DocumentIndex::build` requires
`parse_document` to succeed, uses the authoritative AST for one boolean, discards it, and re-derives
declarations from tokens — is **deliberately untouched**. Part 2 matters precisely because it restores
drift detection without waiting for that restructuring.

## Documentation

`docs/DESIGN-rust-lsp.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
