### PR TITLE
feat(analyze): project TSG control nodes and scenario step ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,9 +129,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `covers` edges, rather than being silently dropped, so
   `disconnected_requirement` (`--profile ai-review`) can detect it.
   `requirement_property_graph` and `--focus requirement:ID` previously had
-  zero edges/always failed for a standalone spec; both now work. `control`
-  nodes and `starts_with`/`precedes` edges remain unimplemented on native
-  (#495, partial — see `docs/DESIGN-analysis.md` §2).
+  zero edges/always failed for a standalone spec; both now work (#495).
+- Native `analyze`'s TSG projection now also emits the remaining documented
+  vocabulary: `starts_with`/`precedes` step edges and `control` nodes. An
+  acceptance/forbidden case gains a `starts_with` edge to the action its first
+  step calls and a `precedes` edge to each later step's action, running
+  scenario → action and carrying the 0-based `step` index (the direction and
+  split the frozen reference fixes in `src/fslc/analysis/tsg.py`); the index is
+  part of the edge id, so a case that calls one action twice keeps both edges.
+  `control` nodes project governance/business `control ID "text"` catalog
+  entries, which have no Kernel-lowered form. Because scenario nodes
+  previously had no outgoing edge at all, `unanchored_property`'s
+  scenario-anchor suppression (`scenario_actions && kind == "reachable"`) could
+  never apply, so a `reachable` anchored by an acceptance scenario was reported
+  as unanchored — a structurally guaranteed false positive that the step edges
+  remove. No review finding reads `control` nodes yet; the edge vocabulary has
+  no `satisfies` kind, so a control node carries only its `declares` edge
+  (#495).
 - Added an evidence-gated `fsl-design-family.v0` sidecar prototype with three
   maintained three-variant dogfood families, native check/verify/refine/diff
   orchestration tests, raw producer and deterministic digest controls, and an

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -136,9 +136,18 @@ is the `disconnected_requirement` review signal, not a dropped node.
 `acceptance`/`forbidden` scenario nodes are requirements-dialect-only (they
 have no Kernel-lowered form, so building them needs source text, not just
 the checked model) and gain a `covers` edge from any `@requirement(...)`
-requirement that names them. KPI nodes project `kpi NAME = count ENTITY in
-STAGE` declarations. Control nodes and the `starts_with`/`precedes` edge
-kinds are not yet implemented on native (#495).
+requirement that names them, plus a `starts_with` edge to the action their
+first step calls and a `precedes` edge to the action of every later step. A
+step edge runs scenario → action and carries the 0-based `step` index, so a
+scenario that calls one action twice keeps one edge per step. This is what
+makes `unanchored_property` skip a `reachable` an acceptance scenario
+anchors; without the step edges that suppression can never apply. KPI nodes
+project `kpi NAME = count ENTITY in STAGE` declarations. `control` nodes
+project governance/business `control ID "text"` catalog entries, which
+likewise survive only in source text. A control is a catalog entry, not a
+property, and the edge vocabulary has no `satisfies` kind, so a control node
+carries only its `declares` edge and no review finding reads control nodes
+today.
 
 Stable edge kinds include `declares`, `covers`, `has_guard`, `has_effect`,
 `has_ensures`, `reads`, `writes`, `checks`, `starts_with`, and `precedes`.

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -12075,7 +12075,7 @@ fn ai_review_output(
     acceptance: &[(String, KernelExpr)],
     path: &Path,
 ) -> Value {
-    let tsg = enrich_tsg_with_requirements_scenarios(fsl_tools::build_tsg(model), model, path);
+    let tsg = enrich_tsg_from_source(fsl_tools::build_tsg(model), model, path);
     let mut findings = fsl_tools::structural_review_findings(&tsg);
     let unconstrained_states = findings
         .iter()
@@ -12161,26 +12161,23 @@ fn ai_review_output(
     Value::Object(output)
 }
 
-/// Enrich a TSG with requirements-dialect scenario nodes `build_tsg` cannot
-/// see: acceptance/forbidden test cases live only in requirements-dialect
-/// surface syntax (`fsl_core::requirements_trace_contract`), not the lowered
-/// `KernelModel`, so they need source text, not just the checked model.
-/// Adds `acceptance:<id>`/`forbidden:<id>` nodes (declared by the spec) and
-/// a `covers` edge from any `@requirement(...)`-annotated requirement to the
-/// scenario it exercises — creating the `requirement:<id>` node too if it
-/// is not already present (a requirement cited only on a scenario, never on
-/// a Kernel target `build_tsg` itself sees, would otherwise leave a `covers`
-/// edge pointing at a node that does not exist). A no-op for a file that is
-/// not a requirements document, or when the source cannot be re-read.
-fn enrich_tsg_with_requirements_scenarios(
-    mut tsg: Value,
-    model: &KernelModel,
-    path: &Path,
-) -> Value {
+/// Add the TSG node and edge kinds that survive only in the source text.
+///
+/// Acceptance/forbidden cases (`fsl_core::requirements_trace_contract`) and
+/// governance/business `control` catalog entries have no Kernel-lowered form,
+/// so they cannot be reconstructed from [`KernelModel`] the way
+/// `requirement`/`kpi` nodes are — they need the source, not just the checked
+/// model. A requirement cited only on a scenario, never on a Kernel target
+/// `build_tsg` itself sees, gets its `requirement:<id>` node created here so
+/// its `covers` edge never dangles. A no-op when the source cannot be re-read,
+/// or for a document that declares neither cases nor controls.
+///
+/// Both single-file entry points (`analyze` and `analyze --profile ai-review`)
+/// call this once. The `.toml` project-manifest path builds its own prefixed
+/// multi-layer graph from `build_tsg` alone and so has none of these
+/// source-only kinds; that predates this function.
+fn enrich_tsg_from_source(mut tsg: Value, model: &KernelModel, path: &Path) -> Value {
     let Ok(source) = std::fs::read_to_string(path) else {
-        return tsg;
-    };
-    let Ok(Some(contract)) = fsl_core::requirements_trace_contract(&source) else {
         return tsg;
     };
     let mut known_ids = tsg["nodes"]
@@ -12192,6 +12189,43 @@ fn enrich_tsg_with_requirements_scenarios(
     let mut node_additions = Vec::new();
     let mut edge_additions = Vec::new();
     let spec_id = format!("spec:{}", model.name);
+    add_scenario_items(
+        &source,
+        &spec_id,
+        &mut known_ids,
+        &mut node_additions,
+        &mut edge_additions,
+    );
+    add_control_items(
+        &source,
+        &spec_id,
+        &mut known_ids,
+        &mut node_additions,
+        &mut edge_additions,
+    );
+    if let Some(nodes) = tsg.get_mut("nodes").and_then(Value::as_array_mut) {
+        nodes.extend(node_additions);
+        nodes.sort_by_key(|node| node["id"].as_str().unwrap_or_default().to_owned());
+    }
+    if let Some(edges) = tsg.get_mut("edges").and_then(Value::as_array_mut) {
+        edges.extend(edge_additions);
+        edges.sort_by_key(|edge| edge["id"].as_str().unwrap_or_default().to_owned());
+    }
+    tsg
+}
+
+/// Project `acceptance`/`forbidden` cases, the requirements that cover them,
+/// and their step ordering.
+fn add_scenario_items(
+    source: &str,
+    spec_id: &str,
+    known_ids: &mut std::collections::BTreeSet<String>,
+    node_additions: &mut Vec<Value>,
+    edge_additions: &mut Vec<Value>,
+) {
+    let Ok(Some(contract)) = fsl_core::requirements_trace_contract(source) else {
+        return;
+    };
     for (kind, cases) in [
         ("acceptance", &contract.acceptance),
         ("forbidden", &contract.forbidden),
@@ -12200,7 +12234,7 @@ fn enrich_tsg_with_requirements_scenarios(
             let id = format!("{kind}:{}", case.id);
             node_additions.push(project_analysis_node(&id, kind, &case.id));
             known_ids.insert(id.clone());
-            edge_additions.push(project_analysis_edge(&spec_id, "declares", &id));
+            edge_additions.push(project_analysis_edge(spec_id, "declares", &id));
             for requirement in requirement_metadata(&case.annotations, None) {
                 let Some(requirement_id) = requirement.get("id").and_then(Value::as_str) else {
                     continue;
@@ -12213,24 +12247,87 @@ fn enrich_tsg_with_requirements_scenarios(
                         requirement_id,
                     ));
                     edge_additions.push(project_analysis_edge(
-                        &spec_id,
+                        spec_id,
                         "declares",
                         &requirement_node_id,
                     ));
                 }
                 edge_additions.push(project_analysis_edge(&requirement_node_id, "covers", &id));
             }
+            // Step ordering. The frozen reference
+            // (`src/fslc/analysis/tsg.py` `_add_scenario_steps`) fixes both the
+            // direction and the split: the edge runs scenario -> action, the
+            // first step is `starts_with`, every later step is `precedes`, and
+            // the id carries the step index so a scenario that calls the same
+            // action twice does not collapse into one edge.
+            for (index, step) in case.steps.iter().enumerate() {
+                let action_id = format!("action:{}", step.name);
+                // A validated case can only name a declared action, so this
+                // holds in practice; skipping rather than fabricating an
+                // `action` node keeps the graph free of invented declarations
+                // and of dangling edges either way.
+                if !known_ids.contains(&action_id) {
+                    continue;
+                }
+                let kind = if index == 0 {
+                    "starts_with"
+                } else {
+                    "precedes"
+                };
+                edge_additions.push(json!({
+                    "id": format!("edge:{id}:step:{index}:{action_id}"),
+                    "kind": kind,
+                    "from": id,
+                    "to": action_id,
+                    "step": index,
+                }));
+            }
         }
     }
-    if let Some(nodes) = tsg.get_mut("nodes").and_then(Value::as_array_mut) {
-        nodes.extend(node_additions);
-        nodes.sort_by_key(|node| node["id"].as_str().unwrap_or_default().to_owned());
+}
+
+/// Project governance/business `control` catalog entries.
+///
+/// `docs/LANGUAGE.md` §"control" states a control "does not generate a property
+/// by itself; it is a catalog entry", so lowering leaves nothing behind for
+/// `build_tsg` to find.
+fn add_control_items(
+    source: &str,
+    spec_id: &str,
+    known_ids: &mut std::collections::BTreeSet<String>,
+    node_additions: &mut Vec<Value>,
+    edge_additions: &mut Vec<Value>,
+) {
+    let Ok(document) = fsl_syntax::parse_surface_document(source) else {
+        return;
+    };
+    let controls: Vec<&String> = match &document {
+        fsl_syntax::SurfaceDocument::Governance(governance) => governance
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                fsl_syntax::GovernanceItem::Control { id, .. } => Some(id),
+                _ => None,
+            })
+            .collect(),
+        fsl_syntax::SurfaceDocument::Business(business) => business
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                fsl_syntax::BusinessItem::Control { id, .. } => Some(id),
+                _ => None,
+            })
+            .collect(),
+        _ => return,
+    };
+    for control in controls {
+        let id = format!("control:{control}");
+        if !known_ids.insert(id.clone()) {
+            continue;
+        }
+        node_additions.push(project_analysis_node(&id, "control", control));
+        edge_additions.push(project_analysis_edge(spec_id, "declares", &id));
     }
-    if let Some(edges) = tsg.get_mut("edges").and_then(Value::as_array_mut) {
-        edges.extend(edge_additions);
-        edges.sort_by_key(|edge| edge["id"].as_str().unwrap_or_default().to_owned());
-    }
-    tsg
 }
 
 #[derive(Clone)]
@@ -12853,7 +12950,7 @@ fn run_analyze(
         let acceptance = analysis_acceptance_predicates(path);
         return (ai_review_output(&model, &acceptance, path), 0);
     }
-    let tsg = enrich_tsg_with_requirements_scenarios(fsl_tools::build_tsg(&model), &model, path);
+    let tsg = enrich_tsg_from_source(fsl_tools::build_tsg(&model), &model, path);
     match fsl_tools::analyze_tsg(tsg, projection, focus) {
         Ok(analysis @ Value::Object(_)) => finish_analysis(
             analysis,

--- a/rust/fslc/tests/fixtures/analyze_scenario_anchored_reachable.fsl
+++ b/rust/fslc/tests/fixtures/analyze_scenario_anchored_reachable.fsl
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Detector fixture for the `unanchored_property` scenario-anchor clause
+// (`rust/fsl-tools/src/analysis.rs`: `scenario_actions && kind == "reachable"`).
+// Not a corpus specification — it is shaped to isolate one branch.
+//
+// `AllClosed` deliberately reads no state, so the earlier
+// `!reads.is_empty() && !reads.is_disjoint(&related)` disjunct cannot suppress
+// it and the scenario-anchor clause is the only thing that can. That clause
+// needs a scenario -> action edge, which on native only exists once acceptance
+// step ordering is projected (#495). `AC-1` supplies exactly one such step.
+requirements ScenarioAnchoredReachable {
+  number Amount
+
+  process Ticket with amount: Amount {
+    stages Open, Closed
+    initial Open
+
+    transition close Open -> Closed by Agent
+      with a: Amount
+      when a > 0
+      set amount = a
+      covers REQ-1 "An agent closes a ticket"
+  }
+
+  reachable AllClosed { true }
+
+  acceptance AC-1 "close one ticket" {
+    close(0, 1)
+    expect Ticket 0 in Closed
+  }
+}
+verify {
+  instances Ticket = 2
+  values Amount = 0..2
+}

--- a/rust/fslc/tests/issue_495_tsg_requirement_metadata.rs
+++ b/rust/fslc/tests/issue_495_tsg_requirement_metadata.rs
@@ -12,6 +12,13 @@
 //! `requirement_property_graph` always had zero edges,
 //! `--focus requirement:ID` always failed, and `disconnected_requirement`
 //! could never fire — a detector that exists but detects nothing.
+//!
+//! The second half covers the remaining documented vocabulary: `control`
+//! nodes and the `starts_with`/`precedes` step edges. Their detection-power
+//! payload is the mirror image of the first half's — scenario nodes had no
+//! outgoing edge at all, so `unanchored_property`'s scenario-anchor
+//! suppression could never apply and reported a scenario-anchored `reachable`
+//! as unanchored.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -161,6 +168,173 @@ fn acceptance_and_forbidden_nodes_appear_and_are_covered_by_requirements() {
         .filter_map(|node| node["id"].as_str())
         .collect::<std::collections::BTreeSet<_>>();
     for edge in edges {
+        assert!(
+            node_ids.contains(edge["from"].as_str().unwrap_or_default()),
+            "dangling edge.from: {edge:#}"
+        );
+        assert!(
+            node_ids.contains(edge["to"].as_str().unwrap_or_default()),
+            "dangling edge.to: {edge:#}"
+        );
+    }
+}
+
+/// Acceptance/forbidden step ordering must use the direction and the
+/// first-step/later-step split the frozen reference fixes
+/// (`src/fslc/analysis/tsg.py` `_add_scenario_steps`): the edge runs
+/// scenario -> action, step 0 is `starts_with`, every later step is
+/// `precedes`. Before the fix no scenario node had *any* outgoing edge, so
+/// both documented edge kinds (`docs/DESIGN-analysis.md` §2) were never
+/// emitted by native at all.
+#[test]
+fn scenario_step_edges_use_the_frozen_reference_direction_and_split() {
+    let (output, status) = run(&[
+        "analyze",
+        "examples/e2e/2_requirements.fsl",
+        "--projection",
+        "tsg",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    let edges = output["edges"].as_array().expect("edges array");
+    let steps = edges
+        .iter()
+        .filter(|edge| matches!(edge["kind"].as_str(), Some("starts_with" | "precedes")))
+        .collect::<Vec<_>>();
+    assert!(!steps.is_empty(), "{output:#}");
+    // `acceptance AC-1 { submit(0, 1) auto_approve(0) pay(0) }`.
+    let expected = [
+        ("starts_with", "action:submit", 0),
+        ("precedes", "action:auto_approve", 1),
+        ("precedes", "action:pay", 2),
+    ];
+    for (kind, action, step) in expected {
+        assert!(
+            steps.iter().any(|edge| {
+                edge["kind"] == kind
+                    && edge["from"] == "acceptance:AC-1"
+                    && edge["to"] == action
+                    && edge["step"] == serde_json::json!(step)
+            }),
+            "missing {kind} step {step} to {action}: {output:#}"
+        );
+    }
+    // Direction is load-bearing: consumers read the TSG as structural truth,
+    // and `requirement_property_graph` only keeps an edge whose endpoints are
+    // both selected. Never action -> scenario.
+    assert!(
+        !steps.iter().any(|edge| edge["from"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("action:")),
+        "{output:#}"
+    );
+    assert_graph_has_no_dangling_edge(&output);
+}
+
+/// A scenario that calls the same action twice must keep one edge per step:
+/// the step index is part of the edge id, so the two do not collapse.
+#[test]
+fn repeated_actions_in_one_scenario_keep_one_edge_per_step() {
+    let (output, status) = run(&[
+        "analyze",
+        "examples/annotations/annotated_claims.fsl",
+        "--projection",
+        "tsg",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    let edges = output["edges"].as_array().expect("edges array");
+    // `forbidden NEG-1 { submit(0) submit(0) }` — the same action twice.
+    let repeated = edges
+        .iter()
+        .filter(|edge| edge["from"] == "forbidden:NEG-1" && edge["to"] == "action:submit")
+        .collect::<Vec<_>>();
+    assert_eq!(repeated.len(), 2, "{output:#}");
+    assert_eq!(repeated[0]["kind"], "starts_with", "{output:#}");
+    assert_eq!(repeated[0]["step"], serde_json::json!(0), "{output:#}");
+    assert_eq!(repeated[1]["kind"], "precedes", "{output:#}");
+    assert_eq!(repeated[1]["step"], serde_json::json!(1), "{output:#}");
+    let ids = edges
+        .iter()
+        .filter(|edge| matches!(edge["kind"].as_str(), Some("starts_with" | "precedes")))
+        .filter_map(|edge| edge["id"].as_str())
+        .collect::<Vec<_>>();
+    assert!(!ids.is_empty(), "{output:#}");
+    let unique = ids.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        ids.len(),
+        unique.len(),
+        "duplicate step edge id: {output:#}"
+    );
+    assert!(ids.iter().all(|id| id.contains(":step:")), "{output:#}");
+}
+
+/// `control` catalog entries have no Kernel-lowered form
+/// (`docs/LANGUAGE.md`: "does not generate a property by itself; it is a
+/// catalog entry"), so before the fix a governance catalog declaring two
+/// controls projected zero `control` nodes even though
+/// `requirement_property_graph` already selected that node kind.
+#[test]
+fn governance_control_catalog_entries_appear_in_the_tsg() {
+    let (output, status) = run(&[
+        "analyze",
+        "examples/consulting/governance_controls.fsl",
+        "--projection",
+        "tsg",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    let nodes = output["nodes"].as_array().expect("nodes array");
+    for id in ["control:CTRL-1", "control:CTRL-2"] {
+        let node = nodes
+            .iter()
+            .find(|node| node["id"] == id)
+            .unwrap_or_else(|| panic!("{id} missing: {output:#}"));
+        assert_eq!(node["kind"], "control", "{output:#}");
+    }
+    let edges = output["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|edge| {
+            edge["kind"] == "declares"
+                && edge["from"] == "spec:ExpenseTransformationControls"
+                && edge["to"] == "control:CTRL-1"
+        }),
+        "{output:#}"
+    );
+    assert_graph_has_no_dangling_edge(&output);
+}
+
+/// The detection-power half. `unanchored_property` suppresses a `reachable`
+/// that an acceptance scenario anchors by driving an action
+/// (`rust/fsl-tools/src/analysis.rs`: `scenario_actions && kind ==
+/// "reachable"`). That clause needs a scenario -> action edge, and before the
+/// fix no scenario node had any outgoing edge on native, so the clause was
+/// structurally dead and the finding was a guaranteed false positive.
+#[test]
+fn a_scenario_anchored_reachable_is_not_reported_as_unanchored() {
+    let (output, status) = run(&[
+        "analyze",
+        "rust/fslc/tests/fixtures/analyze_scenario_anchored_reachable.fsl",
+        "--profile",
+        "ai-review",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    let findings = output["findings"].as_array().expect("findings array");
+    assert!(
+        !findings.iter().any(|finding| {
+            finding["finding_type"] == "unanchored_property"
+                && finding["involved_nodes"] == serde_json::json!(["reachable:AllClosed"])
+        }),
+        "{output:#}"
+    );
+}
+
+fn assert_graph_has_no_dangling_edge(output: &Value) {
+    let node_ids = output["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    for edge in output["edges"].as_array().expect("edges array") {
         assert!(
             node_ids.contains(edge["from"].as_str().unwrap_or_default()),
             "dangling edge.from: {edge:#}"


### PR DESCRIPTION
## Problem

`docs/DESIGN-analysis.md` lists `control` among the stable node kinds and `starts_with`/`precedes`
among the stable edge kinds, and `docs/GUIDE-analyze.ja.md` lists both to users — while the native
implementation emitted neither. The design note recorded the gap explicitly ("not yet implemented on
native (#495)"), so the documented graph vocabulary promised two edge kinds nothing ever produced.

Measured on `examples/e2e/2_requirements.fsl`: **0** step edges before, **5** after.

## The task framing was wrong, and the implementation does not follow it

The issue and the task brief both assumed `starts_with`/`precedes` were **process/stage topology**,
requiring a source-level `process`/`stages` traversal. That is not what these edges mean. The frozen
reference pins them unambiguously in `src/fslc/analysis/tsg.py::_add_scenario_steps`:

```python
self.edges.append(edge(
    scenario_id,
    "precedes" if idx else "starts_with",
    action_id,
    edge_id=f"edge:{scenario_id}:step:{idx}:{action_id}",
    step=idx,
))
```

They are **acceptance/forbidden scenario step ordering**: the edge runs scenario → action, the first
step is `starts_with`, every later step is `precedes`, and the 0-based index rides on the edge.
`tests/test_analysis_tsg.py:98` asserts exactly that. Verified at source before accepting.

Following the brief would have shipped edges with the wrong endpoints under kinds whose meaning was
also wrong — and it would have looked correct. It also makes the residual far smaller than assumed:
no process/stage traversal is needed at all, because `RequirementsTraceCase` already carries `steps`.

**Second corrected inference: no linking edge for controls.** The brief asked for an edge from a
`policy`/`goal` that `satisfies` a control. There is no `satisfies` edge kind — `grep satisfies` across
`docs/DESIGN-analysis.md` and `docs/GUIDE-analyze.ja.md` is empty — and the frozen
`_add_kpis_and_controls` calls `_cover_meta` for kpis and deliberately not for controls. Inventing one
would extend the documented vocabulary, which is a contract change and not this issue. A control node
carries only its `declares` edge.

## Contract change

None. Both kinds now match the frozen reference.

`enrich_tsg_with_requirements_scenarios` becomes `enrich_tsg_from_source` — one source pass with two
collectors, not a third traversal. Both single-file entry points call it once, as before. Step edge ids
carry the index (`edge:{scenario}:step:{i}:{action}`) so `forbidden NEG-1 { submit(0) submit(0) }`
keeps two edges rather than collapsing to one. A step whose action has no node is skipped rather than
fabricating one; a validated case cannot name an undeclared action, so this is a guard, not a fallback.

## Detection power — stated plainly

**This adds no new detector. It removes a structurally guaranteed false positive.**

`unanchored_property` suppresses a `reachable` that an acceptance scenario anchors by driving an
action — `scenario_actions && property["kind"] == "reachable"` at `rust/fsl-tools/src/analysis.rs:158`.
`scenario_actions` requires an edge from a scenario node to an action node, and scenario nodes
previously had **no outgoing edge at all**. The clause was dead for every input, so the finding always
fired. Verified independently on the isolating fixture:

- before: `STRUCT-UNANCHORED-PROPERTY-0001` / `unanchored_property` on `reachable:AllClosed`
- after: no findings

And the honest limit: **no existing corpus file changes.** All 56 requirements/governance/business
specs under `examples/` and `specs/` were swept with `--profile ai-review` before and after and the
finding sets are byte-identical. Every corpus `reachable` is either skipped earlier for carrying
requirement metadata or reads state an action also touches.

Likewise **no finding reads `control` nodes.** `disconnected_requirement` accepts `control` as a
`covers` target, but `covers` edges come from `model.requirement_targets()`, which scans lowered Kernel
targets, and controls are never lowered — so no `covers → control:*` edge can exist. Control nodes are
isolated by construction today. Nothing in the code, docs, or changelog claims otherwise.

## Test evidence

Ablation (revert `rust/fslc/src/main.rs` only) fails
`scenario_step_edges_use_the_frozen_reference_direction_and_split`,
`repeated_actions_in_one_scenario_keep_one_edge_per_step`,
`governance_control_catalog_entries_appear_in_the_tsg`, and
`a_scenario_anchored_reachable_is_not_reported_as_unanchored`; all six pre-existing cases in the same
file pass.

**One weak test was caught during ablation and strengthened.** The repeated-action case originally
passed on revert *vacuously* — with zero step edges, "no duplicate ids" is trivially true. It now
asserts both edges from `forbidden:NEG-1` to `action:submit` with their kinds and step indexes, and
fails on revert.

The graph-wide dangling-edge check added by PR #533 was run first and passes over both new corpus
graphs.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Documentation

`docs/DESIGN-analysis.md` — the "not yet implemented on native (#495)" sentence is **removed**, not
narrowed, because both halves landed, and replaced with the actual semantics (direction, split, step
index, the `unanchored_property` consequence) plus an explicit statement that a control node carries
only `declares` and that no finding reads control nodes. PR #533's own `CHANGELOG.md` entry, which
still claimed these remain unimplemented, is corrected. `docs/GUIDE-analyze.ja.md` needed no change —
it already listed both edge kinds and `control` as stable, which is now true. No `LANGUAGE.md` change:
no language form moved. `tests/dialect_registry.py` needed no entry — `governance` is already
registered and no new top-level construct was added.

## Known gap, filed as #558

The `.toml` project-manifest path gets **none** of these source-only kinds: `project_traceability_output`
calls `fsl_tools::build_tsg(&model)` per layer and nothing else, and `build_tsg` structurally cannot see
constructs that are never lowered. This is pre-existing — `acceptance`/`forbidden` scenario nodes have
never appeared there either — so #495's comment claim that both paths share one build → enrich →
dispatch is accurate for the projection dispatch but not for the enrichment. The gap is documented in
the function's doc comment and in the design note rather than left silent.

Related constraint recorded there: `Builder::build()` drops a `covers` edge whose target node does not
exist yet, and it runs before enrichment — so closing #558, or ever adding a `satisfies` vocabulary,
requires changing that ordering too.

## Linked issues

Fixes #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
