### PR TITLE
fix(ai,html,mutate)!: stop the ai check false green, per-property assurance, and the mutant cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- **Breaking (output).** `fslc html` no longer labels every property row with
+  one report-wide assurance class. `html.rs::assurance` derived a single class
+  from root completeness and `properties_section` reused it for every row, so
+  under `--engine induction` a `reachable` and an ordinary unranked `leadsTo`
+  both rendered `proved(induction)` even though k-induction ranks only
+  invariants and transitions -- a reachability witness comes from the bounded
+  base BMC. In an audit artifact "proved" claims all-depth universal evidence,
+  so this was an assurance misstatement. Property rows now classify per element
+  through the ledger's existing `formal_assurance` rule
+  (`docs/DESIGN-assurance-classes.md`) instead of a second local
+  classification, and the report-wide status row now shares the ledger's
+  `assurance_token`/`assurance_label` pair as well. For
+  `examples/pm/cancel_flow.fsl --engine induction`, `CanRetain`, `CanChurn`,
+  `POL-1`, and `POL-2` change from `proved(induction)` to
+  `bounded(BMC depth 8)`. The same renderer also never called
+  `requirement_caption` for property rows, so invariant/reachable/leadsTo rows
+  dropped the requirement text actions and counterfactuals keep; each row now
+  renders its own caption under the declaration name, escaped, and omits it
+  entirely when the property carries no requirement tag
+  (`docs/DESIGN-html-report.md`) (#525).
 - **Breaking (output).** `fslc ai check` and the `fslc check` dispatch for
   fsl-ai project files no longer accept a declaration whose `require` clauses
   are unparseable. Both ran `ai_project_summary`, a line scanner that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- **Breaking (output).** `fslc ai check` and the `fslc check` dispatch for
+  fsl-ai project files no longer accept a declaration whose `require` clauses
+  are unparseable. Both ran `ai_project_summary`, a line scanner that
+  collected declaration *names* by string prefix and never read a clause body,
+  so a project whose clauses match no known evidence grammar returned
+  `ai_project_analyzed` / `findings: []` / exit 0 from `check` and was then
+  rejected by `eval`/`regress`/`drift`/`compat` -- the confidently green false
+  negative `AGENTS.md` calls more dangerous than a crash. The check stage now
+  reports from `fsl_syntax::parse_ai_project`, the parser those commands
+  already execute, and an unexecutable `require` clause is a spec error
+  (`result:"error"`, `kind:"parse"`, exit 2) naming the declaration, slice, and
+  clause text, matching `docs/LANGUAGE.md`'s exit-code table and the exit 2 the
+  same dialect already returns for non-AI `ai compat` input and an unknown
+  `--property`/`--migration` selection. Reporting from the parser also corrects
+  two `ai check` output fields: `components` is now the declared `ai_component`
+  names (`[]` when none, previously the scanner's placeholder `[""]`), and
+  `raw_blocks` entries carry `{kind, name}` per block as
+  `skills/fsl/reference.md` specifies (previously `{kind}` only, deduplicated
+  by kind). Raw blocks stay unvalidated: garbage inside `ai_action`,
+  `ai_contract`, `authority`, `retriever`, or `trust_boundary` still passes
+  `check`, because those are contractually block boundaries only (#542).
 - Every spec-reading native command now classifies a syntax error the way
   `check` does: `kind: "parse"` with `diagnostic_code: "FSL-PARSE"` and a
   `loc`. `rust/fslc/src/main.rs`'s `load_kernel_model` flattened the frontend's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Native `fslc mutate` now defaults to 200 built-in mutants instead of 100,
+  matching the `max_mutants` default its own published CLI contract
+  (`rust/fslc/cli-contract.json`) advertises and the 200 fixed by
+  `docs/DESIGN-mutate.md`, `skills/fsl/reference.md`, and the frozen
+  `src/fslc/mutate.py` (`DEFAULT_MAX_MUTANTS`). For a model with more than 100
+  candidates the smaller default silently evaluated a different mutant set and
+  reported a different kill count, making native reports incomparable with the
+  documented baseline and skewing hollow-spec triage. Explicit `--max-mutants`
+  behavior is unchanged, and the runtime default is now a single
+  `DEFAULT_MAX_MUTANTS` constant rather than a literal that can drift from the
+  contract (#524).
 - **Breaking (output).** `fslc html` no longer labels every property row with
   one report-wide assurance class. `html.rs::assurance` derived a single class
   from root completeness and `properties_section` reused it for every row, so

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2374,7 +2374,8 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 プロジェクトレベルの fsl-ai エビデンス宣言は、`ai_component`、
 `dataset`、`evaluator`、`failure_mode`、`statistical_property`、
 `ai_migration`、`observed_property` を組み合わせられます。`fslc ai check` は
-これらのファイルをパースして `ai_project_analyzed` を返します。`fslc ai eval` は
+これらのファイルをエビデンス系コマンドと同じパーサでパースして
+`ai_project_analyzed` を返します。`fslc ai eval` は
 選択された `statistical_property` が宣言する `slice`/`min_samples`/
 `ci_lower`/`ci_upper` の要件を、事前計算された JSONL（`--records`、または
 宣言された `dataset` の `source` ファイル）に対して Wilson 区間つきで検査
@@ -2387,7 +2388,12 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 宣言するすべての `ai_component` について有限の `dbsystem artifact`
 ケイパビリティプロファイルを出力し、AI ではない入力や `ai_component` を
 1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
-`formal_result:"not_run"` を使います。未知の `--property`/`--migration` の
+`formal_result:"not_run"` を使います。既知のエビデンス節文法
+（`min_samples`、`ci_lower`、`ci_upper`、点推定、`observed`、`drift`）の
+いずれにも一致しない `require` 節は、`fslc ai check` と `fslc check` の
+どちらでもチェック時の spec エラー（exit 2）であり、解析済みプロジェクト
+とはしません。`eval`/`drift` が実行できないものを check が受理しては
+なりません。未知の `--property`/`--migration` の
 選択はチェック時エラー（exit 2）です。選択された `statistical_property` の
 ゲート状態（`dataset_invalid`、`evaluator_untrusted`、`slice_missing`、
 `insufficient_samples`、`inconclusive`、`statistically_unsupported`）は

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2425,8 +2425,9 @@ graph analysis, not kernel proof. `fslc ai replay` accepts JSONL or
 
 Project-level fsl-ai evidence declarations can combine `ai_component`,
 `dataset`, `evaluator`, `failure_mode`, `statistical_property`,
-`ai_migration`, and `observed_property`. `fslc ai check` parses these files and
-returns `ai_project_analyzed`; `fslc ai eval` checks the selected
+`ai_migration`, and `observed_property`. `fslc ai check` parses these files with
+the same parser the evidence commands run and returns `ai_project_analyzed`;
+`fslc ai eval` checks the selected
 `statistical_property`'s declared `slice`/`min_samples`/`ci_lower`/`ci_upper`
 requirements against precomputed JSONL (`--records`, or the declared
 `dataset`'s `source` file) with Wilson intervals; `fslc ai regress` checks the
@@ -2438,7 +2439,12 @@ declared `observed`/`drift` requirements over runtime telemetry
 finite `dbsystem artifact` capability profile for one `ai_component` or every
 `ai_component` a project declares, rejecting non-AI input and an AI project
 with no `ai_component` at all (exit 2). All of these use
-`formal_result:"not_run"`. An unknown `--property`/`--migration` selection is
+`formal_result:"not_run"`. A `require` clause matching none of the known
+evidence-clause grammars (`min_samples`, `ci_lower`, `ci_upper`, a point
+estimate, `observed`, `drift`) is a spec error (exit 2) at `check` time, in
+both `fslc ai check` and the `fslc check` dispatch: the check stage must not
+report an analyzed project that `eval`/`drift` cannot execute. An unknown
+`--property`/`--migration` selection is
 a check-time error (exit 2); a selected `statistical_property`'s gate status
 (`dataset_invalid`, `evaluator_untrusted`, `slice_missing`,
 `insufficient_samples`, `inconclusive`, or `statistically_unsupported`) exits

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -42,6 +42,17 @@ const PROJECT_BLOCKS: &[&str] = &[
 /// `no_regression`).
 const NESTED_BLOCKS: &[&str] = &["slice", "preserve", "no_regression"];
 
+/// Top-level kinds recognized only as block *boundaries*: the parser never
+/// descends into their body, so their contents carry no checked meaning and
+/// are echoed as bare `{kind, name}` entries (`skills/fsl/reference.md`).
+const RAW_BLOCKS: &[&str] = &[
+    "ai_action",
+    "ai_contract",
+    "authority",
+    "retriever",
+    "trust_boundary",
+];
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AiMetricRequirement {
     /// `"min_samples"` | `"ci_lower"` | `"ci_upper"` | `"point_estimate"` |
@@ -109,6 +120,33 @@ pub struct AiDataset {
     pub source: Option<String>,
 }
 
+/// A declaration recognized only as a block boundary (`RAW_BLOCKS`).
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiRawBlock {
+    pub kind: String,
+    pub name: String,
+}
+
+/// A `require` clause whose text matched no known evidence-clause grammar.
+///
+/// `parse_metric_requirement`/`parse_observed_requirement` are deliberately
+/// lenient and keep such a clause as `kind: "inconclusive"` so the evidence
+/// commands can report it as a gate status instead of crashing. The check
+/// stage has the opposite obligation: it must not report
+/// `ai_project_analyzed` over a declaration no downstream command can
+/// execute (issue #542).
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiUnparsedClause {
+    /// `"statistical_property"` or `"observed_property"`.
+    pub declaration_kind: &'static str,
+    pub declaration: String,
+    /// `"all"` for a clause declared directly in the block body, else the
+    /// enclosing `slice` name.
+    pub slice: String,
+    /// The clause exactly as written, without its `require ` keyword.
+    pub source: String,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AiProject {
     pub name: String,
@@ -117,9 +155,43 @@ pub struct AiProject {
     pub statistical_properties: Vec<AiStatisticalProperty>,
     pub observed_properties: Vec<AiObservedProperty>,
     pub migrations: Vec<AiMigration>,
+    pub raw_blocks: Vec<AiRawBlock>,
 }
 
 impl AiProject {
+    /// Every `require` clause this parser could not classify, in declaration
+    /// order. A non-empty result means the project is not executable by
+    /// `fslc ai eval`/`drift`, so `check` must reject it rather than report
+    /// `ai_project_analyzed` (issue #542).
+    #[must_use]
+    pub fn unparsed_clauses(&self) -> Vec<AiUnparsedClause> {
+        let statistical = self.statistical_properties.iter().flat_map(|property| {
+            property
+                .requirements
+                .iter()
+                .filter(|requirement| requirement.kind == "inconclusive")
+                .map(|requirement| AiUnparsedClause {
+                    declaration_kind: "statistical_property",
+                    declaration: property.name.clone(),
+                    slice: requirement.slice.clone(),
+                    source: requirement.source.clone(),
+                })
+        });
+        let observed = self.observed_properties.iter().flat_map(|property| {
+            property
+                .requirements
+                .iter()
+                .filter(|requirement| requirement.kind == "inconclusive")
+                .map(|requirement| AiUnparsedClause {
+                    declaration_kind: "observed_property",
+                    declaration: property.name.clone(),
+                    slice: requirement.slice.clone(),
+                    source: requirement.source.clone(),
+                })
+        });
+        statistical.chain(observed).collect()
+    }
+
     /// Resolve the source JSONL path declared by `dataset <name> { source
     /// "..."; }`, matching `_records_path`'s dataset-source fallback used
     /// when `fslc ai eval` is invoked without `--records` (`docs/LANGUAGE.md`
@@ -250,6 +322,10 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
                 .observed_properties
                 .push(parse_observed_property(block)?),
             "ai_migration" => project.migrations.push(parse_migration(block)?),
+            kind if RAW_BLOCKS.contains(&kind) => project.raw_blocks.push(AiRawBlock {
+                kind: block.kind.clone(),
+                name: block.name.clone(),
+            }),
             _ => {}
         }
     }

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -31,7 +31,8 @@ pub use ai::{
 };
 pub use ai_project::{
     AiDataset, AiMetricRequirement, AiMigration, AiObservedProperty, AiObservedRequirement,
-    AiProject, AiRegressionRequirement, AiStatisticalProperty, parse_ai_project,
+    AiProject, AiRawBlock, AiRegressionRequirement, AiStatisticalProperty, AiUnparsedClause,
+    parse_ai_project,
 };
 pub use annotation::{
     Annotation, AnnotationError, AnnotationRegistry, AnnotationValue, Annotations, RequirementLink,

--- a/rust/fsl-tools/src/html.rs
+++ b/rust/fsl-tools/src/html.rs
@@ -569,21 +569,50 @@ fn actions_section(actions: &[Value], coverage: &Value) -> String {
     )
 }
 
+/// The depth an assurance label reports, `checked_to_depth` first.
+fn checked_depth(verification: &Value) -> Option<u64> {
+    verification
+        .get("checked_to_depth")
+        .or_else(|| verification.get("depth"))
+        .and_then(Value::as_u64)
+}
+
+/// The report-wide assurance of one verification envelope, for the status
+/// panel. This is a whole-report summary and must never be reused as a
+/// per-property class: see `property_assurance`.
 fn assurance(verification: &Value) -> String {
-    if verification["completeness"] == "unbounded" {
-        "proved(induction)".to_owned()
-    } else if verification["completeness"] == "bounded" {
-        format!(
-            "bounded(BMC depth {})",
-            text(
-                verification
-                    .get("checked_to_depth")
-                    .unwrap_or(&verification["depth"])
-            )
-        )
-    } else {
-        "not_run".to_owned()
+    crate::ledger::assurance_label(
+        crate::ledger::assurance_token(verification),
+        checked_depth(verification),
+    )
+}
+
+/// The html property `kind` to the ledger's element group
+/// (`docs/DESIGN-assurance-classes.md`: "Assurance column per property row
+/// via `classify_element` (kind->group: invariant->invariants,
+/// leadsTo->leadstos, reachable->reachables, trans->transitions)").
+fn property_group(kind: &str) -> Option<&'static str> {
+    match kind {
+        "invariant" => Some("invariants"),
+        "trans" => Some("transitions"),
+        "leadsTo" => Some("leadstos"),
+        "reachable" => Some("reachables"),
+        _ => None,
     }
+}
+
+/// One property row's own assurance class, from the ledger's per-element
+/// rule (issue #525). A reachability witness and action coverage stay
+/// `bounded` even inside an `--engine induction` report, because
+/// k-induction ranks only invariants and leadsTo; labelling them
+/// `proved(induction)` overstates the evidence in an audit artifact.
+fn property_assurance(property: &Value, verification: &Value) -> String {
+    property_group(&text(&property["kind"])).map_or_else(String::new, |group| {
+        crate::ledger::assurance_label(
+            crate::ledger::formal_assurance(group, &text(&property["name"]), verification),
+            checked_depth(verification),
+        )
+    })
 }
 
 fn properties_section(properties: &[Value], checks: &[Value], verification: &Value) -> String {
@@ -591,10 +620,11 @@ fn properties_section(properties: &[Value], checks: &[Value], verification: &Val
     for property in properties {
         let _ = write!(
             rows,
-            "<tr><td>{}</td><td><code>{}</code></td><td>{}</td><td>{}</td></tr>",
+            "<tr><td>{}</td><td><code>{}</code>{}</td><td>{}</td><td>{}</td></tr>",
             escape(&text(&property["kind"])),
             escape(&text(&property["name"])),
-            escape(&assurance(verification)),
+            requirement_caption(&property["requirement"]),
+            escape(&property_assurance(property, verification)),
             escape(&text(&property["body_text"]))
         );
     }

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -653,7 +653,13 @@ pub(crate) fn assurance_label(token: &str, depth: Option<u64>) -> String {
     }
 }
 
-fn formal_assurance(group: &str, name: &str, verification: &Value) -> &'static str {
+/// Classify one spec element (an invariant/leadsTo/reachable/transition by
+/// group and name) against a `verify`/`prove` result. `pub(crate)` so
+/// `html.rs`'s property rows (issue #525) reuse this exact rule rather than
+/// re-deriving it -- re-deriving it locally is how the html report came to
+/// stamp one report-wide class on every row and call a bounded reachability
+/// witness `proved(induction)`.
+pub(crate) fn formal_assurance(group: &str, name: &str, verification: &Value) -> &'static str {
     if verification.get("result").and_then(Value::as_str) == Some("proved") {
         if matches!(group, "invariants" | "transitions") {
             return "proved";

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -130,7 +130,7 @@ fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Va
 }
 
 async fn check(request: &Request, solver_version: &str) -> Value {
-    if let Some(output) = fslc_rust::frontend_output::ai_project_check_output(
+    if let Some((output, _)) = fslc_rust::frontend_output::ai_project_check_output(
         &request.source,
         &request.source_file,
         envelope(solver_version),

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -27,20 +27,67 @@ pub fn render_surface_parse_error(
     Value::Object(output)
 }
 
-/// Render the legacy multi-declaration AI project check result when applicable.
+/// The `ai_project` name project commands report -- the source's file stem,
+/// mirroring the frozen reference's `parse_ai_project(src, name=Path(path).stem)`.
+#[must_use]
+pub fn ai_project_name(source_file: &str) -> &str {
+    std::path::Path::new(source_file)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("AiProject")
+}
+
+/// Parse an fsl-ai project the way the check stage must: a source whose
+/// `require` clauses no evidence command can execute is a spec error, not an
+/// analyzed project (issue #542).
+///
+/// The clause classification is the parser's own
+/// (`AiProject::unparsed_clauses`), never a second grammar -- reimplementing
+/// it here is exactly how `check` and `eval` drifted apart.
+///
+/// # Errors
+///
+/// Returns the parse or unexecutable-clause message, for `kind: "parse"`.
+pub fn parse_checked_ai_project(source: &str, name: &str) -> Result<fsl_syntax::AiProject, String> {
+    let project = fsl_syntax::parse_ai_project(source, name)?;
+    let unparsed = project.unparsed_clauses();
+    if unparsed.is_empty() {
+        return Ok(project);
+    }
+    let detail = unparsed
+        .iter()
+        .map(|clause| {
+            format!(
+                "{} '{}' (slice '{}'): require {}",
+                clause.declaration_kind, clause.declaration, clause.slice, clause.source
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(format!(
+        "require clause matches no known fsl-ai evidence clause grammar \
+         (min_samples, ci_lower, ci_upper, a point estimate, observed, or drift): {detail}"
+    ))
+}
+
+/// Render the multi-declaration AI project check result when applicable,
+/// paired with its process exit code.
 #[must_use]
 pub fn ai_project_check_output(
     source: &str,
     source_file: &str,
     mut output: Map<String, Value>,
-) -> Option<Value> {
+) -> Option<(Value, i32)> {
     if !is_ai_project(source) {
         return None;
     }
-    let spec = std::path::Path::new(source_file)
-        .file_stem()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or("AiProject");
+    let spec = ai_project_name(source_file);
+    if let Err(message) = parse_checked_ai_project(source, spec) {
+        output.insert("result".to_owned(), json!("error"));
+        output.insert("kind".to_owned(), json!("parse"));
+        output.insert("message".to_owned(), json!(message));
+        return Some((Value::Object(output), 2));
+    }
     output.insert("result".to_owned(), json!("ok"));
     output.insert("spec".to_owned(), json!(spec));
     output.insert("dialect".to_owned(), json!("fsl-ai-project.v0"));
@@ -49,7 +96,7 @@ pub fn ai_project_check_output(
         "ai_analysis_result".to_owned(),
         json!("ai_project_analyzed"),
     );
-    Some(Value::Object(output))
+    Some((Value::Object(output), 0))
 }
 
 /// Return whether source uses the legacy multi-declaration AI project dialect.

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -30,6 +30,15 @@ use verification::{
 const CLI_CONTRACT: &str = include_str!("../cli-contract.json");
 const DEFAULT_EXPLICIT_BUDGET: usize = 1_000_000;
 
+/// `mutate`'s built-in mutant cap when `--max-mutants` is omitted. Must equal
+/// the `max_mutants` default the published CLI contract advertises
+/// (`rust/fslc/cli-contract.json`), which `docs/DESIGN-mutate.md`,
+/// `skills/fsl/reference.md`, and the frozen `src/fslc/mutate.py`
+/// (`DEFAULT_MAX_MUTANTS`) all fix at 200: a smaller runtime default silently
+/// evaluates a different mutant set and reports a different kill rate
+/// (issue #524).
+const DEFAULT_MAX_MUTANTS: usize = 200;
+
 struct LiterateState {
     path: PathBuf,
 }
@@ -1171,7 +1180,7 @@ fn command() -> Result<(Value, i32), String> {
             );
             let mut depth = 8_usize;
             let mut readable = false;
-            let mut max_mutants = 100_usize;
+            let mut max_mutants = DEFAULT_MAX_MUTANTS;
             let mut by_requirement = false;
             let mut typescript_only = false;
             let mut external_mutants = None;

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5394,12 +5394,15 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
         Ok(source) => source,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
-    if let Some(output) = fslc_rust::frontend_output::ai_project_check_output(
+    // The fsl-ai project gate carries its own exit code: an unexecutable
+    // `require` clause is a spec error (issue #542), so this may not be
+    // flattened back to a fixed exit 0.
+    if let Some(result) = fslc_rust::frontend_output::ai_project_check_output(
         &source,
         &display_path.to_string_lossy(),
         envelope(),
     ) {
-        return (output, 0);
+        return result;
     }
     match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
         Ok(fsl_syntax::ParsedDocument {
@@ -6053,7 +6056,7 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
     if fslc_rust::frontend_output::is_ai_project(&source) {
-        return run_ai_project_check(&source);
+        return run_ai_project_check(&source, path);
     }
     match parse_surface_document(path) {
         Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => {
@@ -6183,6 +6186,8 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
     wrap_specialized(fsl_tools::replay_ai(&component, &events))
 }
 
+/// The single `ai_component`'s declared runtime contract, scanned from an
+/// fsl-ai project source for `fslc ai replay`'s observed-event comparison.
 #[derive(Default)]
 struct AiProjectSummary {
     component: String,
@@ -6191,10 +6196,6 @@ struct AiProjectSummary {
     retriever: Option<String>,
     output: Option<String>,
     tools: Vec<String>,
-    statistical: Vec<String>,
-    observed: Vec<String>,
-    migrations: Vec<String>,
-    raw_blocks: Vec<String>,
 }
 fn declaration_name(line: &str, prefix: &str) -> Option<String> {
     line.trim()
@@ -6240,38 +6241,28 @@ fn ai_project_summary(source: &str) -> AiProjectSummary {
             if depth <= 0 {
                 in_component = false;
             }
-            continue;
-        }
-        for (prefix, target) in [
-            ("statistical_property ", &mut summary.statistical),
-            ("observed_property ", &mut summary.observed),
-            ("ai_migration ", &mut summary.migrations),
-        ] {
-            if let Some(name) = declaration_name(line, prefix) {
-                target.push(name);
-            }
-        }
-        for kind in [
-            "ai_action",
-            "ai_contract",
-            "authority",
-            "retriever",
-            "trust_boundary",
-        ] {
-            if line.starts_with(&format!("{kind} "))
-                && !summary.raw_blocks.iter().any(|item| item == kind)
-            {
-                summary.raw_blocks.push(kind.to_owned());
-            }
         }
     }
     summary
 }
 
-fn run_ai_project_check(source: &str) -> (Value, i32) {
-    let summary = ai_project_summary(source);
+/// `fslc ai check` on an fsl-ai project file.
+///
+/// The reported declarations come from `fsl_syntax::parse_ai_project` -- the
+/// same parser `eval`/`regress`/`drift`/`compat` execute -- so `check` can no
+/// longer accept a declaration whose clauses those commands reject (issue
+/// #542). Reporting from the line scanner previously produced
+/// `ai_project_analyzed` with exit 0 for clause bodies that were never read.
+fn run_ai_project_check(source: &str, path: &Path) -> (Value, i32) {
+    let project = match fslc_rust::frontend_output::parse_checked_ai_project(
+        source,
+        &ai_project_name(path),
+    ) {
+        Ok(project) => project,
+        Err(message) => return (error_output("parse", &message), 2),
+    };
     wrap_specialized(
-        json!({"result":"ai_project_analyzed","formal_result":"not_run","components":[summary.component],"statistical_properties":summary.statistical,"observed_properties":summary.observed,"migrations":summary.migrations,"raw_blocks":summary.raw_blocks.into_iter().map(|kind|json!({"kind":kind})).collect::<Vec<_>>(),"findings":[]}),
+        json!({"result":"ai_project_analyzed","formal_result":"not_run","components":project.components.iter().map(|component|&component.name).collect::<Vec<_>>(),"statistical_properties":project.statistical_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"observed_properties":project.observed_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"migrations":project.migrations.iter().map(|migration|&migration.name).collect::<Vec<_>>(),"raw_blocks":project.raw_blocks.iter().map(|block|json!({"kind":block.kind,"name":block.name})).collect::<Vec<_>>(),"findings":[]}),
     )
 }
 
@@ -6346,10 +6337,7 @@ fn run_ai_compare(
 /// the spec's file stem, mirroring the frozen reference's
 /// `parse_ai_project(src, name=Path(path).stem)`.
 fn ai_project_name(path: &Path) -> String {
-    path.file_stem()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or("AiProject")
-        .to_owned()
+    fslc_rust::frontend_output::ai_project_name(&path.to_string_lossy()).to_owned()
 }
 
 fn load_ai_project(path: &Path) -> Result<fsl_syntax::AiProject, (Value, i32)> {

--- a/rust/fslc/tests/fixtures/issue_524_mutant_cardinality.fsl
+++ b/rust/fslc/tests/fixtures/issue_524_mutant_cardinality.fsl
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Issue #524 high-cardinality fixture: more built-in mutant candidates than
+// either cap, so a default run and an explicit `--max-mutants` run can be
+// told apart, over a state space small enough that adjudicating 200 mutants
+// stays cheap. `S21` is unreachable in the spec as written, so the invariant
+// is a real constraint an enum-swap mutant can break.
+
+spec MutantCardinality {
+  enum Stage { S00, S01, S02, S03, S04, S05, S06, S07, S08, S09, S10, S11, S12, S13, S14, S15, S16, S17, S18, S19, S20, S21 }
+
+  state { stage: Stage }
+
+  init { stage = S00 }
+
+  action step00() {
+    requires stage == S00
+    stage = S01
+  }
+
+  action step01() {
+    requires stage == S01
+    stage = S02
+  }
+
+  action step02() {
+    requires stage == S02
+    stage = S03
+  }
+
+  action step03() {
+    requires stage == S03
+    stage = S04
+  }
+
+  action step04() {
+    requires stage == S04
+    stage = S05
+  }
+
+  action step05() {
+    requires stage == S05
+    stage = S06
+  }
+
+  action step06() {
+    requires stage == S06
+    stage = S07
+  }
+
+  action step07() {
+    requires stage == S07
+    stage = S08
+  }
+
+  action step08() {
+    requires stage == S08
+    stage = S09
+  }
+
+  action step09() {
+    requires stage == S09
+    stage = S10
+  }
+
+  action step10() {
+    requires stage == S10
+    stage = S11
+  }
+
+  action step11() {
+    requires stage == S11
+    stage = S12
+  }
+
+  invariant NeverFinal { stage != S21 }
+}

--- a/rust/fslc/tests/fixtures/issue_525_escaping.fsl
+++ b/rust/fslc/tests/fixtures/issue_525_escaping.fsl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Issue #525 escaping control: requirement caption text is rendered as
+// markup, so HTML metacharacters in the declared requirement sentence must
+// stay escaped.
+
+spec CaptionEscaping {
+  state { count: Int }
+
+  init { count = 0 }
+
+  action tick() {
+    requires count < 2
+    count = count + 1
+  }
+
+  invariant Bounded "REQ-ESC: <script> & friends must not render as markup" {
+    count >= 0
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_525_leadsto_assurance.fsl
+++ b/rust/fslc/tests/fixtures/issue_525_leadsto_assurance.fsl
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The issue #525 leadsTo control: a report that proves under
+// `--engine induction` (`result:"proved"`, `completeness:"unbounded"`) yet
+// carries an ordinary unranked `leadsTo`, whose row must stay
+// `bounded(BMC depth k)` -- only a ranked response with an explicit unbounded
+// proof may render `proved(induction)`.
+
+business RequestFlow {
+  actor Customer, System
+
+  entity Req
+
+  process Req {
+    stages Open, Answered
+    initial Open
+
+    transition answer Open -> Answered by System
+  }
+
+  policy POL-ANSWER "An open request must always be answered"
+    every Req in Open must eventually be Answered
+
+  goal CanAnswer "Some request reaches the answered stage"
+    some Req can reach Answered
+}
+
+verify {
+  instances Req = 1
+}

--- a/rust/fslc/tests/fixtures/issue_525_property_assurance.fsl
+++ b/rust/fslc/tests/fixtures/issue_525_property_assurance.fsl
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The issue #525 per-property assurance control in one report: under
+// `--engine induction` the invariant row must read `proved(induction)` while
+// the reachable rows stay `bounded(BMC depth k)` (k-induction ranks
+// invariants and transitions; a reachability witness comes only from the
+// bounded base BMC). The two tagged properties must each render their own
+// requirement caption, and the untagged one must render none.
+
+spec PropertyAssuranceRows {
+  type Amount = 0..2
+
+  state { balance: Int }
+
+  init { balance = 0 }
+
+  action deposit(a: Amount) {
+    requires a > 0
+    balance = balance + a
+  }
+
+  action withdraw(a: Amount) {
+    requires a > 0
+    requires balance >= a
+    balance = balance - a
+  }
+
+  invariant NonNegative "REQ-INV: the balance never goes negative" { balance >= 0 }
+
+  reachable Funded "REQ-REACH: a funded balance is reachable" { balance >= 2 }
+
+  reachable Drained { balance == 0 }
+}

--- a/rust/fslc/tests/fixtures/issue_542_unparseable_observed_clause.fsl
+++ b/rust/fslc/tests/fixtures/issue_542_unparseable_observed_clause.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+statistical_property Parseable {
+  target X
+  dataset Eval
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+}
+
+observed_property Operational {
+  target X
+  source production_logs
+  window last_7_days
+  require hallucination_rate is basically fine probably
+}

--- a/rust/fslc/tests/fixtures/issue_542_unparseable_statistical_clause.fsl
+++ b/rust/fslc/tests/fixtures/issue_542_unparseable_statistical_clause.fsl
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+statistical_property Whatever {
+  target X
+  require this is not a valid clause at all !!! ### $$$
+}

--- a/rust/fslc/tests/fixtures/issue_542_unvalidated_raw_block.fsl
+++ b/rust/fslc/tests/fixtures/issue_542_unvalidated_raw_block.fsl
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Positive control for issue #542: `ai_action`/`authority`/`retriever`/
+// `trust_boundary`/`ai_contract` are recognized only as block *boundaries*
+// (`skills/fsl/reference.md`), so garbage inside one is contractually
+// accepted. Only the descended `require` clauses are checked.
+
+ai_action Draft { arbitrary & opaque ? text }
+
+trust_boundary Edge { !!! ### $$$ }
+
+statistical_property Quality {
+  target X
+  dataset Eval
+  require min_samples >= 5
+  require ci_lower(metric.accuracy, 0.95) >= 0.45
+
+  slice JapaneseTickets {
+    require ci_upper(metric.refusal_rate, 0.95) <= 0.30
+  }
+}

--- a/rust/fslc/tests/issue_524_mutate_default_cap.rs
+++ b/rust/fslc/tests/issue_524_mutate_default_cap.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #524: native `fslc mutate` defaulted to 100
+//! built-in mutants while its own published CLI contract
+//! (`rust/fslc/cli-contract.json`), `docs/DESIGN-mutate.md`,
+//! `skills/fsl/reference.md`, and the frozen `src/fslc/mutate.py`
+//! (`DEFAULT_MAX_MUTANTS`) all specify 200. For a model with more than 100
+//! candidates that silently evaluated a different mutant set and reported a
+//! different kill count, making native reports incomparable with the
+//! documented baseline.
+//!
+//! Every pre-existing native mutate test passed an explicit `--max-mutants`,
+//! which is exactly why none of them saw the default.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/issue_524_mutant_cardinality.fsl")
+}
+
+fn find_command<'a>(node: &'a Value, name: &str) -> Option<&'a Value> {
+    if node["path"]
+        .as_array()
+        .is_some_and(|path| path.last().and_then(Value::as_str) == Some(name))
+    {
+        return Some(node);
+    }
+    node["commands"]
+        .as_array()?
+        .iter()
+        .find_map(|child| find_command(child, name))
+}
+
+/// The `max_mutants` default the published CLI contract advertises. The
+/// expectation is read from the contract rather than restated as a second
+/// literal, so a future contract edit cannot drift away from the runtime
+/// default unnoticed. `native_integration.rs` already pins the checked-in
+/// contract to the one the binary publishes.
+fn contract_default_max_mutants() -> u64 {
+    let contract: Value = serde_json::from_str(include_str!("../cli-contract.json"))
+        .expect("checked-in CLI contract");
+    let mutate = find_command(&contract["root"], "mutate").expect("mutate command in contract");
+    mutate["actions"]
+        .as_array()
+        .expect("mutate actions")
+        .iter()
+        .find(|action| action["dest"] == "max_mutants")
+        .and_then(|action| action["default"].as_u64())
+        .expect("published max_mutants default")
+}
+
+fn mutate(extra: &[&str]) -> Value {
+    let mut args = vec![
+        "mutate".to_owned(),
+        fixture().display().to_string(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ];
+    args.extend(extra.iter().map(|value| (*value).to_owned()));
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(&args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(value["result"], "mutated", "{value}");
+    value
+}
+
+#[test]
+fn the_published_contract_still_advertises_two_hundred() {
+    assert_eq!(contract_default_max_mutants(), 200);
+}
+
+#[test]
+fn a_default_run_evaluates_the_same_mutant_set_as_the_contract_default() {
+    let limit = contract_default_max_mutants().to_string();
+    let implicit = mutate(&[]);
+    let explicit = mutate(&["--max-mutants", &limit]);
+    assert_eq!(implicit["summary"], explicit["summary"], "{implicit}");
+    assert_eq!(implicit["mutants"], explicit["mutants"]);
+    assert_eq!(implicit["notes"], explicit["notes"]);
+    // The fixture has more candidates than the cap, so the run really is
+    // truncated: an equal-but-uncapped comparison would prove nothing.
+    assert_eq!(implicit["summary"]["total"], 200, "{}", implicit["summary"]);
+    assert!(
+        implicit["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note.as_str() == Some("mutant cap 200 reached: 374 dropped")),
+        "{}",
+        implicit["notes"]
+    );
+}
+
+#[test]
+fn an_explicit_lower_limit_still_truncates() {
+    // The pre-fix default; explicit `--max-mutants` behavior is unchanged, and
+    // it must stay distinguishable from the default or the test above would
+    // pass for the wrong reason.
+    let explicit = mutate(&["--max-mutants", "100"]);
+    assert_eq!(explicit["summary"]["total"], 100, "{}", explicit["summary"]);
+    assert!(
+        explicit["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note.as_str() == Some("mutant cap 100 reached: 474 dropped")),
+        "{}",
+        explicit["notes"]
+    );
+    let implicit = mutate(&[]);
+    assert_ne!(implicit["summary"], explicit["summary"]);
+}

--- a/rust/fslc/tests/issue_525_html_property_assurance.rs
+++ b/rust/fslc/tests/issue_525_html_property_assurance.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #525: `fslc html --engine induction`
+//! stamped one report-wide assurance class on every property row, so a
+//! `reachable` rendered as `proved(induction)` even though a reachability
+//! witness under induction comes only from the bounded base BMC. In an audit
+//! artifact "proved" means all-depth universal evidence; that is an assurance
+//! misstatement, which `AGENTS.md` names as never allowlistable. The same
+//! renderer also never called `requirement_caption` for property rows, so
+//! invariants/reachables/leadsTo lost the requirement text that actions and
+//! counterfactuals keep (`docs/DESIGN-html-report.md`).
+//!
+//! Property rows now classify per element through `ledger::formal_assurance`,
+//! the rule `fslc ledger` already applies
+//! (`docs/DESIGN-assurance-classes.md`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!(
+        "issue-525-{label}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&path).expect("create scratch directory");
+    path
+}
+
+/// Render one induction report and return its `#properties` table rows.
+fn property_rows(spec: &str, label: &str) -> Vec<String> {
+    let output_path = scratch_dir(label).join("report.html");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "html",
+            &fixture(spec).display().to_string(),
+            "--engine",
+            "induction",
+            "-o",
+            &output_path.display().to_string(),
+        ])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let envelope: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(envelope["result"], "generated", "{envelope}");
+    let html = std::fs::read_to_string(&output_path).expect("read report");
+    let section = html
+        .split_once("id=\"properties\"")
+        .expect("properties section")
+        .1
+        .split_once("</section>")
+        .expect("properties section end")
+        .0
+        .to_owned();
+    section
+        .split("<tr>")
+        .skip(1)
+        .map(|row| row.split("</tr>").next().unwrap_or_default().to_owned())
+        .collect()
+}
+
+fn row_named<'a>(rows: &'a [String], name: &str) -> &'a str {
+    rows.iter()
+        .find(|row| row.contains(&format!("<code>{name}</code>")))
+        .unwrap_or_else(|| panic!("no row for {name} in {rows:#?}"))
+}
+
+// --- negative: one report, two different per-property classes -------------
+
+#[test]
+fn induction_report_proves_the_invariant_but_keeps_reachables_bounded() {
+    // Both assertions read the *same* report: two separate single-property
+    // tests could each pass while disagreeing about what the report says.
+    let rows = property_rows("issue_525_property_assurance.fsl", "mixed");
+    let invariant = row_named(&rows, "NonNegative");
+    assert!(
+        invariant.contains("<td>proved(induction)</td>"),
+        "{invariant}"
+    );
+    let reachable = row_named(&rows, "Funded");
+    assert!(
+        reachable.contains("<td>bounded(BMC depth 8)</td>"),
+        "{reachable}"
+    );
+    assert!(
+        !reachable.contains("proved"),
+        "a reachability witness under induction is bounded: {reachable}"
+    );
+    let untagged_reachable = row_named(&rows, "Drained");
+    assert!(
+        untagged_reachable.contains("<td>bounded(BMC depth 8)</td>"),
+        "{untagged_reachable}"
+    );
+}
+
+#[test]
+fn unranked_leadsto_stays_bounded_inside_a_proved_report() {
+    // `RequestFlow` proves (`result:"proved"`, `completeness:"unbounded"`),
+    // but its `leadsTo` carries no unbounded ranking, so only a bounded claim
+    // is supported.
+    let rows = property_rows("issue_525_leadsto_assurance.fsl", "leadsto");
+    let leadsto = row_named(&rows, "POL-ANSWER");
+    assert!(
+        leadsto.contains("<td>bounded(BMC depth 8)</td>"),
+        "{leadsto}"
+    );
+    assert!(!leadsto.contains("proved"), "{leadsto}");
+    let reachable = row_named(&rows, "CanAnswer");
+    assert!(
+        reachable.contains("<td>bounded(BMC depth 8)</td>"),
+        "{reachable}"
+    );
+}
+
+// --- requirement captions, per row, without leakage -----------------------
+
+#[test]
+fn each_property_row_renders_its_own_requirement_caption() {
+    let rows = property_rows("issue_525_property_assurance.fsl", "captions");
+    let invariant = row_named(&rows, "NonNegative");
+    assert!(
+        invariant
+            .contains("<div class=\"req-caption\">REQ-INV: the balance never goes negative</div>"),
+        "{invariant}"
+    );
+    let reachable = row_named(&rows, "Funded");
+    assert!(
+        reachable
+            .contains("<div class=\"req-caption\">REQ-REACH: a funded balance is reachable</div>"),
+        "{reachable}"
+    );
+    // Two differently tagged rows: neither may show the other's text.
+    assert!(!invariant.contains("REQ-REACH"), "{invariant}");
+    assert!(!reachable.contains("REQ-INV"), "{reachable}");
+}
+
+#[test]
+fn an_untagged_property_row_renders_no_caption() {
+    // `docs/DESIGN-html-report.md`: the caption is "omitted entirely for a row
+    // that has none -- no `none` filler cells".
+    let rows = property_rows("issue_525_property_assurance.fsl", "untagged");
+    let untagged = row_named(&rows, "Drained");
+    assert!(!untagged.contains("req-caption"), "{untagged}");
+    assert!(!untagged.contains("None"), "{untagged}");
+}
+
+#[test]
+fn requirement_caption_text_is_html_escaped() {
+    // The caption is rendered as markup, so its text must stay escaped.
+    let rows = property_rows("issue_525_escaping.fsl", "escaping");
+    let tagged = row_named(&rows, "Bounded");
+    assert!(
+        tagged.contains("&lt;script&gt;") && tagged.contains("&amp;"),
+        "{tagged}"
+    );
+    assert!(!tagged.contains("<script>"), "{tagged}");
+}

--- a/rust/fslc/tests/issue_542_ai_check_rejects_unparseable_clauses.rs
+++ b/rust/fslc/tests/issue_542_ai_check_rejects_unparseable_clauses.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #542: `fslc ai check` (and the generic
+//! `fslc check` dispatch that shares its output) reported
+//! `ai_project_analyzed` with exit 0 for an fsl-ai project whose declaration
+//! bodies were never read. The check stage ran a line scanner that collected
+//! declaration *names* by string prefix, so a `require` clause matching no
+//! known evidence-clause grammar was accepted -- a confidently green verdict
+//! over a project `fslc ai eval`/`drift` cannot execute.
+//!
+//! Native now reports the check stage from `fsl_syntax::parse_ai_project`,
+//! the same parser the evidence commands run, and rejects an unexecutable
+//! clause as a spec error (exit 2, `kind: "parse"`) per `docs/LANGUAGE.md`'s
+//! exit-code table.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+// --- negative: an unexecutable clause must not be reported as analyzed -----
+
+#[test]
+fn ai_check_rejects_an_unparseable_statistical_require_clause() {
+    let path = fixture("issue_542_unparseable_statistical_clause.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "parse");
+    let message = value["message"].as_str().expect("message");
+    assert!(
+        message.contains("statistical_property 'Whatever'"),
+        "{message}"
+    );
+    assert!(
+        message.contains("this is not a valid clause at all"),
+        "{message}"
+    );
+    // The pre-fix bug returned exactly this success envelope for this input;
+    // assert the whole shape is gone, not merely that some error appeared.
+    assert!(value.get("statistical_properties").is_none(), "{value}");
+    assert!(value.get("formal_result").is_none(), "{value}");
+}
+
+#[test]
+fn ai_check_rejects_an_unparseable_observed_require_clause() {
+    let path = fixture("issue_542_unparseable_observed_clause.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "parse");
+    let message = value["message"].as_str().expect("message");
+    assert!(
+        message.contains("observed_property 'Operational'"),
+        "{message}"
+    );
+    // The sibling `statistical_property` in the same file parses cleanly, so
+    // the rejection must name the observed clause and only it.
+    assert!(!message.contains("'Parseable'"), "{message}");
+}
+
+#[test]
+fn generic_check_rejects_the_same_project_as_ai_check() {
+    // `fslc check` dispatches fsl-ai project sources through the same check
+    // output; leaving it green would keep the false green one command away.
+    let path = fixture("issue_542_unparseable_statistical_clause.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error");
+    assert_eq!(value["kind"], "parse");
+    assert!(value.get("ai_analysis_result").is_none(), "{value}");
+}
+
+// --- positive: legitimate project input is still accepted -----------------
+
+#[test]
+fn ai_check_still_analyzes_a_legitimate_project() {
+    let (value, status) = run(&["ai", "check", "examples/ai/support_answer_quality.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ai_project_analyzed");
+    assert_eq!(value["formal_result"], "not_run");
+    assert_eq!(
+        value["components"],
+        serde_json::json!(["SupportAnswerAgent"])
+    );
+    assert_eq!(
+        value["statistical_properties"],
+        serde_json::json!(["LooseQuality", "StrictQuality"])
+    );
+    assert_eq!(
+        value["observed_properties"],
+        serde_json::json!(["SupportAgentOperationalQuality"])
+    );
+    assert_eq!(value["migrations"], serde_json::json!(["PromptV7ToV8"]));
+    assert_eq!(value["findings"], serde_json::json!([]));
+    // `raw_blocks` carries the un-descended declarations as `{kind, name}`
+    // (`skills/fsl/reference.md`), one entry per block.
+    let raw_blocks = value["raw_blocks"].as_array().expect("raw_blocks array");
+    assert!(
+        raw_blocks.iter().any(|block| {
+            block["kind"] == "authority" && block["name"] == "SupportAgentAuthority"
+        }),
+        "{value}"
+    );
+}
+
+#[test]
+fn ai_check_still_accepts_garbage_inside_an_unvalidated_raw_block() {
+    // Raw blocks are recognized only as block boundaries and are
+    // contractually not validated; tightening clause parsing must not start
+    // rejecting them.
+    let path = fixture("issue_542_unvalidated_raw_block.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ai_project_analyzed");
+    assert_eq!(
+        value["statistical_properties"],
+        serde_json::json!(["Quality"])
+    );
+    assert_eq!(
+        value["raw_blocks"],
+        serde_json::json!([
+            {"kind": "ai_action", "name": "Draft"},
+            {"kind": "trust_boundary", "name": "Edge"},
+        ])
+    );
+
+    let (checked, check_status) = run(&["check", &path]);
+    assert_eq!(check_status, 0, "{checked}");
+    assert_eq!(checked["result"], "ok");
+    assert_eq!(checked["ai_analysis_result"], "ai_project_analyzed");
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1210,7 +1210,11 @@ carries an **assurance class** (issue #171): `proved(induction)` (k-induction,
 all depths) / `bounded(BMC depth k)` (BMC, depth k) / `replay-observed`
 (concrete log/trace checked, not a universal claim) / `statistical(Wilson c%)`
 (precomputed eval JSONL, aggregate not per-case) / `not_run` (no formal
-evidence — structural analysis, profiles, comparisons). `--engine induction`
+evidence — structural analysis, profiles, comparisons). The class is
+**per element, not per report**: in an `--engine induction` report only
+invariants and transitions reach `proved(induction)`, while `reachable` rows,
+action coverage, and an unranked `leadsTo` stay `bounded(BMC depth k)` because
+k-induction ranks neither. `--engine induction`
 is required for a requirement to ever show `proved`; `--evidence
 <result.json>` folds a saved fsl-ai/fsl-db/fsl-domain `formal_result:"not_run"`
 producer's output (tagged via a top-level `requirements: [...]` list) into the

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -553,7 +553,11 @@ observed_property <Name> {
 ```
 
 `require` clauses here are threshold labels for external evidence jobs, not
-kernel formulas — they add no probability semantics to `fslc verify`.
+kernel formulas — they add no probability semantics to `fslc verify`. They are
+still parsed at `check` time: a `require` clause matching none of the known
+grammars (`min_samples`, `ci_lower`, `ci_upper`, a point estimate, `observed`,
+`drift`) is a spec error (exit 2) from both `fslc check` and `fslc ai check`,
+because `check` must not accept a project `eval`/`drift` cannot execute.
 `failure_mode <Name> { condition ...; severity ...; }` is parsed and listed by
 name under `ai_project_analyzed`'s `failure_modes`, but no command yet checks
 its content against evidence — it is tracked metadata, not a verified claim.


### PR DESCRIPTION
## Problem

Three defects on three surfaces, in three separate commits so each can be reviewed and reverted alone.

**#542 — `ai check` accepted unparseable clauses and returned exit 0.** `run_ai_project_check` used
`ai_project_summary`, a **line scanner** that collects declaration names via
`strip_prefix("statistical_property ")` and never reads clause bodies. So `check` accepted what
`eval`/`regress`/`drift`/`compat` reject. `AGENTS.md`: "A confidently green false negative is more
dangerous than a crash."

The false green was **one command further out than the issue described**: `fslc check` on the same
file also returned `result:"ok"` / exit 0, since both share
`frontend_output::ai_project_check_output`. Measured before/after on the 4-line reproduction:

| | before | after |
|---|---|---|
| `fslc ai check` | `ai_project_analyzed`, `components:[""]`, exit 0 | `result:"error"`, `kind:"parse"`, exit 2 |
| `fslc check` | `result:"ok"`, exit 0 | `result:"error"`, `kind:"parse"`, exit 2 |
| legitimate project | exit 0 | exit 0 |

The message names the declaration, slice, and clause text. **No new parser was written** —
`fsl_syntax::parse_ai_project` (added by #511, already used by `eval`/`regress`/`drift`/`compat`)
already classifies these; `AiProject::unparsed_clauses()` surfaces what it knows.

**#525 — `html` misstated per-property assurance and dropped requirement captions.** One report-wide
class was applied to every row, so a `reachable` rendered as `proved(induction)` even though a
reachability witness under induction comes only from the bounded base BMC.
`examples/pm/cancel_flow.fsl --engine induction`, measured:

- before: **all 5 property rows `proved(induction)`**, no captions
- after: 4 × `bounded(BMC depth 8)`, 1 × `proved(induction)`, and `CanRetain` carries
  `CanRetain: There exists a case that reaches retention via a retention offer`

**#524 — the native `mutate` default cap was 100 where the contract says 200.** On a
574-candidate fixture at `--depth 2`:

- before: total 100, kill_rate 0.03, "mutant cap 100 reached: 474 dropped"
- after: total 200, kill_rate 0.02, "mutant cap 200 reached: 374 dropped"

## Contract change

**#542 is breaking: exit 2, not a finding.** Basis, recorded in the commit body: `docs/LANGUAGE.md`
defines 2 as spec error (parse/type/semantics/io); the same dialect already exits 2 for non-AI
`ai compat` input (#511) and for an unknown `--property`/`--migration`; other dialects' `check` reports
an unparseable declaration as `error` + exit 2, never `ok` + finding; and the fsl-ai `findings` array
is evidence-level output (`fsl-ai-finding.v0`, `guarantee_kind` + witness) that an unparseable clause
has nothing to fill — a finding would still leave the verdict `ai_project_analyzed`.
`parse_ai_project` already hard-errors on an unsupported `no_regression` clause, so this makes the two
clause families consistent inside one parser.

**#525 is breaking** in its output labels. Fixed by making `ledger::formal_assurance` `pub(crate)` and
calling it per row; the status row also routes through `ledger::assurance_token`/`assurance_label`, so
`html.rs` now carries **no classifier of its own** — the duplication is what let the two drift apart.

**#524**: `cli-contract.json` already published `"dest": "max_mutants", "default": 200`. The runtime
literal was contradicting native's **own** published contract and nothing cross-checked them, so there
was no second literal to update — only a missing anchor. The new test reads the expected limit out of
the contract rather than restating 200.

## Test evidence

**#542 ablation, re-run against the rebased tree** (restoring post-#557 `main`'s `run_check`, verified
by an empty `git diff --stat` on the ablated paths): **5/5 fail** in
`issue_542_ai_check_rejects_unparseable_clauses`. The `generic_check_rejects_the_same_project_as_ai_check`
failure printed the false green verbatim —
`{"result":"ok", …,"ai_analysis_result":"ai_project_analyzed"}`, left 0, right 2.

**#525 ablation**: 4/5 fail —
`induction_report_proves_the_invariant_but_keeps_reachables_bounded`,
`unranked_leadsto_stays_bounded_inside_a_proved_report`,
`each_property_row_renders_its_own_requirement_caption`,
`requirement_caption_text_is_html_escaped`.
`an_untagged_property_row_renders_no_caption` **passes** under ablation — stated plainly rather than
counted as coverage: with no captions before the fix it is trivially true, so it guards the post-fix
layout, not the bug.

**#524 ablation**: 2/3 fail — `a_default_run_evaluates_the_same_mutant_set_as_the_contract_default`,
`an_explicit_lower_limit_still_truncates`. `the_published_contract_still_advertises_two_hundred`
passes by design; it pins the contract value, not runtime behaviour.

All three fixes were independently re-measured on the rebased binary, not accepted on report.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Rebase note

`run_check` had a **semantic** conflict with #557, which refactored it to `read_spec_source` /
`spec_load_error_output` / `agent_check_output` while still doing `return (output, 0)` at the
`ai_project_check_output` call — the literal exit-0 path #542 removes. A marker-only resolution would
have silently restored the false green **and still compiled**. Both sides were kept, and the
resolution site carries a comment saying the fsl-ai gate's own exit code may not be flattened back, so
the next rebase does not undo it. All three `ai_project_check_output` call sites were checked, not just
the conflicted one.

## Corrections to the issue text

- `raw_blocks: []` in the reproduction is **correct** — a `statistical_property` is not a raw block, so
  the issue's suspicion was misdirected. The real deviation was that native emitted `{kind}` deduped by
  kind where `skills/fsl/reference.md` and the frozen reference specify one `{kind, name}` per block.
  Fixed.
- `components` is `[""]`, not `[]` as the issue stated (already corrected on the issue).

## Known residuals, not folded in

1. **#542, same class**: a non-`require` garbage line inside
   `statistical_property`/`observed_property`/`dataset` is still silently ignored. Rejecting it needs
   new grammar.
2. **#542 parity**: native `ai check` still omits `ai_project`, `dialect`, `datasets`, `evaluators`,
   `failure_modes`, `assumptions` that the frozen `analyze_ai_project` emits, and the Rust parser drops
   `evaluator`/`failure_mode` blocks entirely — while `skills/fsl/reference.md` claims `failure_mode`
   is listed under `failure_modes`.
3. **#542 diagnostics**: the new parse error carries no `loc`; the lenient project parser tracks no
   spans.
4. **#525, same renderer**: native `html` has no "Deadline" column, which `docs/DESIGN-html-report.md`
   specifies for `leadsTo … within`. Pre-existing, untouched.

## Documentation

`CHANGELOG.md` `[Unreleased]` — three entries; #542 and #525 state what output changes.
`skills/fsl/reference.md` and `docs/DESIGN-*` where the contracts above are named.

## Linked issues

Fixes #542, fixes #525, fixes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
