### PR TITLE
fix(cli): give type and semantics errors a loc on every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   by kind). Raw blocks stay unvalidated: garbage inside `ai_action`,
   `ai_contract`, `authority`, `retriever`, or `trust_boundary` still passes
   `check`, because those are contractually block boundaries only (#542).
+- `type` and `semantics` errors now carry `loc` on every spec-reading command,
+  completing the `docs/DESIGN-v1.md` §7.2 clause that guarantees a location for
+  `parse`/`name`/`type`/`semantics`. Issue 484 delivered the `parse` half; the
+  other half returned `loc: null` everywhere, including `check`, so the §8
+  repair protocol could not mechanically locate a `type`/`name` failure from
+  the output JSON alone. `SpecLoadError::Semantic` now carries the structured
+  diagnostic instead of a flattened `String`, and `ModelError` carries the span
+  of the construct that failed — a kernel `spec` registers no lowering origins,
+  so the three corpus goldens previously had no location to report at all. The
+  reported position is the offending construct, not the enclosing declaration:
+  the state field for an unknown type, the `struct` declaration for a
+  non-scalar field (`TypeExpr` carries no span of its own), and the *second*
+  write for a duplicate assignment. Messages are unchanged — the span is a new
+  field that `ModelError`'s Display deliberately ignores — and no `kind`
+  moves. A diagnostic that names no construct in the reported file still omits
+  `loc` rather than emitting a `{line: 0, column: 0}` placeholder;
+  `docs/DESIGN-v1.md` now states that exception explicitly instead of leaving
+  the clause overstating the implementation (#555).
 - Every spec-reading native command now classifies a syntax error the way
   `check` does: `kind: "parse"` with `diagnostic_code: "FSL-PARSE"` and a
   `loc`. `rust/fslc/src/main.rs`'s `load_kernel_model` flattened the frontend's

--- a/docs/DESIGN-v1.md
+++ b/docs/DESIGN-v1.md
@@ -521,7 +521,17 @@ Differences from v0:
 
 The error classification is a fixed closed set, and the fields each
 classification has are guaranteed by the schema (`parse`/`name`/`type`/
-`semantics` always have `loc`).
+`semantics` always have `loc`), with one exception: a `semantics` diagnostic
+that names no construct in the file the envelope reports on omits `loc` rather
+than inventing one. That is exactly three cases — a rejected CLI selection
+(`--property`, `--exclude`, `--instances`/`--values`), a whole-document shape
+mismatch (`spec has no state block`, `expected refinement mapping`), and a
+diagnostic whose subject is a different file than the reported one (the
+`analyze --project` manifest and the refinement mapping it names, since `loc`
+carries no file). An absent `loc` means the location is unknown; `line: 0` is
+never emitted, because a position that does not exist misleads a repair agent
+more than no position does. Every diagnostic that does name a construct in the
+reported file carries `loc`, on every command (issue 555).
 
 ### 7.3 Value Display and the Invisibility of Lowering
 

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -347,8 +347,9 @@ fn rewrite_component_item(item: SpecItem, component: &Component) -> SpecItem {
             members,
             symmetric,
         },
-        SpecItem::Struct { name, fields } => SpecItem::Struct {
+        SpecItem::Struct { name, fields, span } => SpecItem::Struct {
             name: prefix(alias, &name),
+            span,
             fields: fields
                 .into_iter()
                 .map(|(name, ty)| (name, rewrite_type(ty, component)))

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -2115,6 +2115,7 @@ pub(crate) fn lower_domain_surface(
                         ))
                     })
                     .collect::<Result<Vec<_>, CoreError>>()?,
+                span: span_at(ty.loc),
             }),
             other => {
                 return Err(error_at(

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -661,8 +661,9 @@ impl PredicateExpander {
                 hi: Box::new(self.expand_expr(*hi, &mut Vec::new())?),
                 symmetric,
             },
-            SpecItem::Struct { name, fields } => SpecItem::Struct {
+            SpecItem::Struct { name, fields, span } => SpecItem::Struct {
                 name,
+                span,
                 fields: fields
                     .into_iter()
                     .map(|(name, ty)| Ok((name, self.expand_type(ty)?)))

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -396,11 +396,29 @@ fn static_leadsto_int(expr: &Expr, model: &KernelModel) -> Result<i64, ModelErro
 pub struct ModelError {
     pub message: String,
     pub origin: Option<Box<crate::OriginChain>>,
+    /// The diagnostic's own source location, for constructs that carry no
+    /// lowering origin — a kernel `spec` registers none at all.
+    ///
+    /// Deliberately not read by [`fmt::Display`]: the rendered message already
+    /// embeds the origin's location where one exists, and duplicating it here
+    /// would change every existing message. The CLI reports this as the `loc`
+    /// that `docs/DESIGN-v1.md` §7.2 guarantees (issue 555).
+    pub span: Option<Span>,
 }
 
 impl ModelError {
     fn with_origin(mut self, origin: Option<crate::OriginChain>) -> Self {
         self.origin = origin.map(Box::new);
+        self
+    }
+
+    /// Record where the diagnostic happened, keeping a more precise location
+    /// an inner step already recorded.
+    #[must_use]
+    fn at(mut self, span: Span) -> Self {
+        if self.span.is_none() {
+            self.span = Some(span);
+        }
         self
     }
 }
@@ -505,6 +523,7 @@ impl ModelBuilder {
         self.annotations.validate().map_err(|error| ModelError {
             message: error.message,
             origin: Some(Box::new(source_origin("annotation", error.span, None))),
+            span: Some(error.span),
         })?;
         let state_names = self
             .spec
@@ -617,7 +636,13 @@ impl ModelBuilder {
                         state.push((
                             field.name.clone(),
                             self.resolve_type(&field.ty)
-                                .map_err(|error| error.with_origin(origin))?,
+                                .map_err(|error| error.with_origin(origin))
+                                // A kernel `spec` registers no lowering origins,
+                                // so an unresolvable state type would otherwise
+                                // reach the CLI with no location at all. The
+                                // declaration's own span is the construct the
+                                // reader has to edit (issue 555).
+                                .map_err(|error| error.at(field.span))?,
                         ));
                     }
                 }
@@ -937,23 +962,27 @@ impl ModelBuilder {
             }
         }
         for item in &items {
-            if let SpecItem::Struct { name, fields } = item {
+            if let SpecItem::Struct { name, fields, span } = item {
                 let origin = self.origins.diagnostic_origin(&type_target(name));
+                // `TypeExpr` carries no span of its own, so the declaration's
+                // span is the closest true location a field-level type
+                // diagnostic can report (issue 555).
                 let resolved = fields
                     .iter()
                     .map(|(field, ty)| Ok((field.clone(), self.resolve_type(ty)?)))
                     .collect::<Result<Vec<_>, ModelError>>()
-                    .map_err(|error| error.with_origin(origin.clone()))?;
+                    .map_err(|error| error.with_origin(origin.clone()).at(*span))?;
                 for (field, ty) in &resolved {
                     if !self.is_scalar_struct_field(ty) {
                         return Err(model_error(format!(
                             "struct field '{name}.{field}' has non-scalar type"
                         ))
-                        .with_origin(origin));
+                        .with_origin(origin)
+                        .at(*span));
                     }
                 }
                 self.insert_type(name, TypeDef::Struct { fields: resolved })
-                    .map_err(|error| error.with_origin(origin))?;
+                    .map_err(|error| error.with_origin(origin).at(*span))?;
             }
         }
         Ok(())
@@ -1036,11 +1065,13 @@ impl ModelBuilder {
         }
         let mut index_constants = self.consts.clone();
         index_constants.extend(self.enum_members.clone());
-        if duplicate_statement_write(&statements, &index_constants).is_some() {
+        if let Some((_, duplicate_span)) = duplicate_statement_write(&statements, &index_constants)
+        {
             return Err(model_error(
                 "an action may not assign the same state location more than once",
             )
-            .with_origin(self.origins.diagnostic_origin(&action_target(name))));
+            .with_origin(self.origins.diagnostic_origin(&action_target(name)))
+            .at(duplicate_span));
         }
         Ok(ActionDef {
             name: name.to_owned(),
@@ -1286,18 +1317,26 @@ fn const_int(expr: &Expr, consts: &BTreeMap<String, Value>) -> Result<i64, Model
     }
 }
 
+/// One write to a state location, with the span of the statement performing it.
+type StateWrite = (LValue, Span);
+
+/// Find a state location an action writes twice, with the span of the write
+/// that repeats it.
+///
+/// The span travels with the target so the diagnostic can point at the offending
+/// assignment rather than at the action as a whole (issue 555).
 fn duplicate_statement_write(
     statements: &[Statement],
     constants: &BTreeMap<String, Value>,
-) -> Option<LValue> {
+) -> Option<StateWrite> {
     fn writes(
         statements: &[Statement],
         constants: &BTreeMap<String, Value>,
-    ) -> Result<Vec<LValue>, Box<LValue>> {
-        let mut seen = Vec::new();
+    ) -> Result<Vec<StateWrite>, Box<StateWrite>> {
+        let mut seen: Vec<(LValue, Span)> = Vec::new();
         for statement in statements {
             let candidates = match statement {
-                Statement::Assign { target, .. } => vec![target.clone()],
+                Statement::Assign { target, span, .. } => vec![(target.clone(), *span)],
                 Statement::If {
                     then_statements,
                     else_statements,
@@ -1311,26 +1350,26 @@ fn duplicate_statement_write(
                     binder, statements, ..
                 } => {
                     let repeated = writes(statements, constants)?;
-                    if let Some(target) = repeated
+                    if let Some(write) = repeated
                         .iter()
-                        .find(|target| !write_is_injective_for_binder(target, binder))
+                        .find(|(target, _)| !write_is_injective_for_binder(target, binder))
                     {
-                        return Err(Box::new(target.clone()));
+                        return Err(Box::new(write.clone()));
                     }
                     repeated
                 }
             };
-            if let Some(target) = candidates.iter().find(|target| {
+            if let Some(write) = candidates.iter().find(|(target, _)| {
                 seen.iter()
-                    .any(|previous| lvalues_may_alias(previous, target, constants))
+                    .any(|(previous, _)| lvalues_may_alias(previous, target, constants))
             }) {
-                return Err(Box::new(target.clone()));
+                return Err(Box::new(write.clone()));
             }
             seen.extend(candidates);
         }
         Ok(seen)
     }
-    writes(statements, constants).err().map(|target| *target)
+    writes(statements, constants).err().map(|write| *write)
 }
 
 fn write_is_injective_for_binder(target: &LValue, binder: &Binder) -> bool {
@@ -1871,5 +1910,6 @@ fn model_error(message: impl Into<String>) -> ModelError {
     ModelError {
         message: message.into(),
         origin: None,
+        span: None,
     }
 }

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1441,11 +1441,11 @@ impl<'a> Parser<'a> {
             return Err(self.error("symmetric must precede type or enum"));
         }
         if self.peek_ident("struct") {
-            self.bump();
+            let span = self.bump().span;
             let name = self.expect_ident()?;
             self.expect_symbol("{")?;
             let fields = self.field_list()?;
-            return Ok(SpecItem::Struct { name, fields });
+            return Ok(SpecItem::Struct { name, fields, span });
         }
         if self.peek_ident("entity") || self.peek_ident("number") {
             let token = self.bump().clone();

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -132,6 +132,10 @@ pub enum SpecItem {
     Struct {
         name: String,
         fields: Vec<(String, TypeExpr)>,
+        /// The `struct` declaration's own span. `TypeExpr` carries none, so a
+        /// field-level type diagnostic has no closer location to report
+        /// (issue 555).
+        span: Span,
     },
     Entity(String, Span),
     Number(String, Span),
@@ -887,7 +891,7 @@ impl SpecItem {
                 }
                 Value::Array(values)
             }
-            Self::Struct { name, fields } => {
+            Self::Struct { name, fields, .. } => {
                 let fields = fields
                     .iter()
                     .map(|(name, ty)| (name.clone(), ty.python_ast()))

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -108,6 +108,16 @@ fn implements_error(
     output
 }
 
+/// Render a solver or verifier failure, which names no construct in the source
+/// and so carries no `loc` (issue 555).
+fn verifier_error(solver_version: &str, failure: &impl std::fmt::Display) -> Value {
+    fslc_rust::verification_output::render_semantic_error(
+        envelope(solver_version),
+        &failure.to_string(),
+        None,
+    )
+}
+
 fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Value>), Value> {
     let resolver = MemoryResolver {
         files: request.files.clone(),
@@ -121,9 +131,13 @@ fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Va
     // the checked KernelModel below.
     let diagnostics = kernel.diagnostics().to_vec();
     let model = fsl_core::build_model(kernel).map_err(|failure| {
+        // The same span the native CLI reports for this diagnostic, so the
+        // Worker envelope does not diverge from `fslc` (issue 555).
+        let loc = fslc_rust::verification_output::model_error_loc(&failure);
         fslc_rust::verification_output::render_semantic_error(
             envelope(solver_version),
             &failure.to_string(),
+            loc,
         )
     })?;
     Ok((model, diagnostics))
@@ -391,10 +405,7 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             }
             Ok(None) => {}
             Err(failure) => {
-                return fslc_rust::verification_output::render_semantic_error(
-                    envelope(solver_version),
-                    &failure.to_string(),
-                );
+                return verifier_error(solver_version, &failure);
             }
         }
     }
@@ -403,10 +414,7 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
         match fsl_verifier::verify_bounded(&model, &mut solver, request.options.depth).await {
             Ok(result) => result,
             Err(failure) => {
-                return fslc_rust::verification_output::render_semantic_error(
-                    envelope(solver_version),
-                    &failure.to_string(),
-                );
+                return verifier_error(solver_version, &failure);
             }
         };
     if let Err(failure) =

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -760,8 +760,7 @@ fn validate_migration_input_semantics(source: &str, path: &Path) -> Result<(), V
     let resolver = fsl_core::FsResolver::new(base);
     let kernel = fsl_core::parse_kernel_source_with_file(source, &resolver, path.to_string_lossy())
         .map_err(|error| semantic_error_output(&error.to_string()))?;
-    let model =
-        fsl_core::build_model(kernel).map_err(|error| semantic_error_output(&error.to_string()))?;
+    let model = fsl_core::build_model(kernel).map_err(|error| model_error_output(&error))?;
     if matches!(
         fsl_syntax::parse_surface_document(source),
         Ok(fsl_syntax::SurfaceDocument::Requirements(_))
@@ -2128,10 +2127,30 @@ fn load_document_claims_with_label(
         // recover the span and emit the same `kind:"parse"` envelope `check`
         // emits instead of a location-free `semantics` error.
         Err(error) => Err(surface_parse_failure(&source).map_or_else(
-            || document_projection_error_output(&error),
+            || {
+                document_model_failure(&source, base).map_or_else(
+                    || document_projection_error_output(&error),
+                    |failure| model_error_output(&failure),
+                )
+            },
             |error| surface_parse_error_output(&error),
         )),
     }
+}
+
+/// Recover the typed-model diagnostic behind a document-projection failure that
+/// only reports a message.
+///
+/// `fsl_tools::DocumentProjectionError::Other` flattens the `ModelError` to a
+/// `String`, so `document` alone reported a `type`/`semantics` error with no
+/// `loc`. Re-running the same pipeline on the failure path — the recovery
+/// [`surface_parse_failure`] already performs for `parse` — restores it without
+/// widening the `fsl-tools` contract (issue 555). Returns `None` for a
+/// projection failure that is not a model failure, leaving the projector's own
+/// envelope in place.
+fn document_model_failure(source: &str, base: &Path) -> Option<fsl_core::ModelError> {
+    let resolver = fsl_core::FsResolver::new(base);
+    fsl_core::build_model(fsl_core::parse_kernel_source(source, &resolver).ok()?).err()
 }
 
 fn document_diagnostics_error(
@@ -2438,7 +2457,7 @@ fn run_document_generate(
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (model_error_output(&error), 2),
     };
     let mut label_warnings = Vec::new();
     if let Some((glossary, _)) = &loaded_glossary {
@@ -2803,7 +2822,7 @@ fn run_document_check(
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (model_error_output(&error), 2),
     };
     let loaded_glossary = match load_glossary(glossary_path, locale) {
         Ok(loaded) => loaded,
@@ -5430,7 +5449,18 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     .into_iter()
     .find(|diagnostic| diagnostic.kind != "migration")
     {
-        return (semantic_error_output(&diagnostic.message), 2);
+        // `check` returns here before it reaches `load_kernel_model`, so the
+        // location has to travel through this branch too, or `check` alone
+        // reports `loc: null` for a diagnostic every other command locates
+        // (issue 555).
+        return (
+            fslc_rust::verification_output::render_semantic_error(
+                envelope(),
+                &diagnostic.message,
+                diagnostic.located.then(|| diagnostic.span.python_loc()),
+            ),
+            2,
+        );
     }
     if let Err(error) = validate_specialized_document(path) {
         return (semantic_error_output(&error), 2);
@@ -5536,7 +5566,7 @@ fn run_kernel_contract(path: &Path, version: fsl_core::PublicKernelVersion) -> (
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (model_error_output(&error), 2),
     };
     let source_path = portable_path.unwrap_or_else(|| path.to_string_lossy().into_owned());
     match fsl_core::public_kernel_contract_for_version(
@@ -10365,7 +10395,7 @@ fn run_typestate(path: &Path) -> (Value, i32) {
     };
     let model = match fsl_core::build_model(kernel.clone()) {
         Ok(model) => model,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (model_error_output(&error), 2),
     };
     let path_text = path.to_string_lossy();
     let contract = match fsl_core::public_kernel_contract(
@@ -10676,8 +10706,8 @@ fn render_document_for_approval(
     let resolver = fsl_core::FsResolver::new(base);
     let kernel = fsl_core::parse_kernel_source(&source, &resolver)
         .map_err(|error| semantic_error_output(&error.to_string()))?;
-    let model = fsl_core::build_model(kernel.clone())
-        .map_err(|error| semantic_error_output(&error.to_string()))?;
+    let model =
+        fsl_core::build_model(kernel.clone()).map_err(|error| model_error_output(&error))?;
     let applied_glossary = loaded_glossary
         .as_ref()
         .map(|(glossary, digest)| fsl_tools::AppliedGlossary { glossary, digest });
@@ -12399,7 +12429,10 @@ fn prefixed_analysis_edge(layer: &str, edge: &Value) -> Value {
 #[allow(clippy::too_many_lines)]
 fn project_traceability_output(path: &Path) -> Result<Value, SpecLoadError> {
     let source = read_spec_source(path)?;
-    let sections = parse_project_manifest(&source).map_err(SpecLoadError::Semantic)?;
+    // The manifest is TOML, not a specification; its message already names the
+    // manifest line, and a `loc` here would be read as a position in the `.fsl`
+    // file the envelope is reporting on.
+    let sections = parse_project_manifest(&source).map_err(SpecLoadError::unlocated_semantic)?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let manifest = analysis_display_path(path);
     let mut nodes = std::collections::BTreeMap::new();
@@ -12491,16 +12524,21 @@ fn project_traceability_output(path: &Path) -> Result<Value, SpecLoadError> {
             continue;
         };
         let mapping_path = base.join(mapping);
-        let document = parse_surface_document(&mapping_path).map_err(SpecLoadError::Semantic)?;
+        // These three diagnostics come from the refinement *mapping* file, not
+        // from the manifest the envelope reports on. Their spans exist but
+        // index a different source, and `loc` carries no file, so emitting one
+        // would point a repair agent into the wrong document.
+        let document =
+            parse_surface_document(&mapping_path).map_err(SpecLoadError::unlocated_semantic)?;
         let fsl_syntax::SurfaceDocument::Refinement(refinement) = document else {
-            return Err(SpecLoadError::Semantic(
-                "expected refinement mapping".to_owned(),
+            return Err(SpecLoadError::unlocated_semantic(
+                "expected refinement mapping",
             ));
         };
         let mapping_source = read_spec_source(&mapping_path)?;
         let checked_refinement =
             fsl_core::parse_refinement(&mapping_source, &implementation.model, &abstraction.model)
-                .map_err(|error| SpecLoadError::Semantic(error.message))?;
+                .map_err(|error| SpecLoadError::unlocated_semantic(error.message))?;
         let display = analysis_display_path(&mapping_path);
         let refinement_id = format!("refinement:{layer}->{target}:{}", refinement.name);
         let file_id = format!("file:{layer}->{target}:{display}");
@@ -15311,17 +15349,72 @@ fn parse_param_value(
 /// [`load_kernel_model`] re-classified a syntax error as `semantics` with no
 /// `loc`, while `check` — which runs the surface parser directly — reported
 /// `parse` with a span.
+///
+/// Issue 555 completed the other half: `Semantic` flattened the typed-model
+/// diagnostic to a `String` too, dropping the span the model had already bound
+/// to the offending construct, so `type` and `semantics` reported `loc: null`
+/// on every command including `check`. It now carries the span alongside the
+/// message.
 #[derive(Debug)]
 enum SpecLoadError {
     Io(String),
     Parse(Box<fsl_syntax::ParseError>),
-    Semantic(String),
+    Semantic(SemanticDiagnostic),
+}
+
+/// A typed-model spec-load failure with the location the model recorded for the
+/// construct that failed, when it recorded one.
+#[derive(Debug)]
+struct SemanticDiagnostic {
+    message: String,
+    loc: Option<Value>,
+}
+
+impl SemanticDiagnostic {
+    /// A diagnostic raised where no origin is in scope. `loc` stays absent: a
+    /// `{line: 0, column: 0}` placeholder would satisfy the schema while
+    /// pointing a repair agent at a location that does not exist.
+    fn unlocated(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            loc: None,
+        }
+    }
+
+    /// A diagnostic carrying the origin the frontend bound to the offending
+    /// construct. Yields the same `loc` as [`Self::unlocated`] when that origin
+    /// has no span, rather than inventing one.
+    fn located(message: impl Into<String>, origin: Option<&fsl_core::OriginChain>) -> Self {
+        Self {
+            message: message.into(),
+            loc: fslc_rust::verification_output::origin_loc(origin),
+        }
+    }
+
+    /// A typed-model failure, located by the span it recorded for itself or by
+    /// its enclosing construct's lowering origin.
+    fn from_model_error(error: &fsl_core::ModelError) -> Self {
+        Self {
+            message: error.to_string(),
+            loc: fslc_rust::verification_output::model_error_loc(error),
+        }
+    }
+}
+
+impl SpecLoadError {
+    /// A `semantics` failure that owns no construct in the specification: a
+    /// rejected CLI selection, a whole-document shape mismatch, or a diagnostic
+    /// whose span belongs to a different file than the one being reported on.
+    fn unlocated_semantic(message: impl Into<String>) -> Self {
+        Self::Semantic(SemanticDiagnostic::unlocated(message))
+    }
 }
 
 impl std::fmt::Display for SpecLoadError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Io(message) | Self::Semantic(message) => formatter.write_str(message),
+            Self::Io(message) => formatter.write_str(message),
+            Self::Semantic(diagnostic) => formatter.write_str(&diagnostic.message),
             Self::Parse(error) => write!(formatter, "{error}"),
         }
     }
@@ -15341,7 +15434,7 @@ fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), S
             Err(error) => return Err(kernel_load_error(&source, &error)),
         };
     let model = fsl_core::build_model(kernel.clone())
-        .map_err(|error| SpecLoadError::Semantic(error.to_string()))?;
+        .map_err(|error| SpecLoadError::Semantic(SemanticDiagnostic::from_model_error(&error)))?;
     Ok((source, kernel, model))
 }
 
@@ -15371,13 +15464,17 @@ fn kernel_load_error(source: &str, error: &fsl_core::CoreError) -> SpecLoadError
     if let Some(parse_error) = surface_parse_failure(source) {
         return SpecLoadError::Parse(Box::new(parse_error));
     }
-    SpecLoadError::Semantic(
-        if error.message == "top-level document has not reached the kernel lowering gate" {
-            "spec has no state block".to_owned()
-        } else {
-            error.to_string()
-        },
-    )
+    // The substituted "spec has no state block" message describes the document
+    // as a whole rather than the construct the lowering gate stopped at, so it
+    // keeps no location; the original diagnostic keeps whatever origin the
+    // frontend recorded.
+    if error.message == "top-level document has not reached the kernel lowering gate" {
+        return SpecLoadError::Semantic(SemanticDiagnostic::unlocated("spec has no state block"));
+    }
+    SpecLoadError::Semantic(SemanticDiagnostic::located(
+        error.to_string(),
+        error.origin.as_deref(),
+    ))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -15609,12 +15706,17 @@ fn load_model_scoped(path: &Path, scope: &ScopeBounds) -> Result<KernelModel, Sp
     let kernel =
         match fsl_core::parse_kernel_source_with_bounds(&source, &scope.instances, &scope.values) {
             Ok(kernel) => kernel,
+            // A rejected `--instances`/`--values` bound is a CLI argument
+            // defect, not a construct in the spec, so it owns no location.
             Err(error) if error.message.starts_with("--instances/--values") => {
-                return Err(SpecLoadError::Semantic(error.message));
+                return Err(SpecLoadError::Semantic(SemanticDiagnostic::unlocated(
+                    error.message,
+                )));
             }
             Err(error) => return Err(kernel_load_error(&source, &error)),
         };
-    fsl_core::build_model(kernel).map_err(|error| SpecLoadError::Semantic(error.to_string()))
+    fsl_core::build_model(kernel)
+        .map_err(|error| SpecLoadError::Semantic(SemanticDiagnostic::from_model_error(&error)))
 }
 
 fn envelope() -> Map<String, Value> {
@@ -15676,7 +15778,20 @@ fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {
 }
 
 fn semantic_error_output(message: &str) -> Value {
-    fslc_rust::verification_output::render_semantic_error(envelope(), message)
+    fslc_rust::verification_output::render_semantic_error(envelope(), message, None)
+}
+
+/// Render a typed-model failure with the location the model recorded for the
+/// construct that failed.
+///
+/// The message is unchanged from what every command already rendered; only
+/// `loc` is added (issue 555).
+fn model_error_output(error: &fsl_core::ModelError) -> Value {
+    fslc_rust::verification_output::render_semantic_error(
+        envelope(),
+        &error.to_string(),
+        fslc_rust::verification_output::model_error_loc(error),
+    )
 }
 
 /// Keep a spec-error envelope's own exit code when a command would otherwise
@@ -15696,7 +15811,13 @@ fn spec_load_error_output(error: &SpecLoadError) -> Value {
     match error {
         SpecLoadError::Io(message) => error_output("io", message),
         SpecLoadError::Parse(error) => surface_parse_error_output(error),
-        SpecLoadError::Semantic(message) => semantic_error_output(message),
+        SpecLoadError::Semantic(diagnostic) => {
+            fslc_rust::verification_output::render_semantic_error(
+                envelope(),
+                &diagnostic.message,
+                diagnostic.loc.clone(),
+            )
+        }
     }
 }
 

--- a/rust/fslc/src/source_diagnostic.rs
+++ b/rust/fslc/src/source_diagnostic.rs
@@ -8,6 +8,12 @@ pub struct SourceDiagnostic {
     pub code: String,
     pub message: String,
     pub span: Span,
+    /// Whether [`Self::span`] is the diagnostic's real location.
+    ///
+    /// The LSP needs a span for every diagnostic and accepts the start of the
+    /// document as a last resort, but the CLI's `loc` must stay absent rather
+    /// than claim a position the diagnostic does not have (issue 555).
+    pub located: bool,
 }
 
 /// Run the authoritative syntax and typed-model gates and return editor diagnostics.
@@ -41,6 +47,7 @@ pub fn diagnostics_with_model(
                     code: error.code().to_owned(),
                     message: error.to_string(),
                     span: error.span,
+                    located: true,
                 }],
                 None,
             ),
@@ -55,6 +62,7 @@ pub fn diagnostics_with_model(
                     code: error.code().to_owned(),
                     message: error.to_string(),
                     span: error.span,
+                    located: true,
                 }],
                 None,
             );
@@ -88,19 +96,29 @@ fn core_diagnostic(source: &str, error: &fsl_core::CoreError) -> SourceDiagnosti
             .and_then(|origin| origin.primary.as_ref())
             .and_then(|site| site.span)
             .unwrap_or_else(|| point_span(source, error.line, error.column)),
+        // `CoreError` carries `line: 0` as its "unknown" sentinel.
+        located: error.line != 0
+            || error
+                .origin
+                .as_deref()
+                .and_then(|origin| origin.primary.as_ref())
+                .is_some_and(|site| site.span.is_some()),
     }
 }
 
 fn model_diagnostic(source: &str, error: &fsl_core::ModelError) -> SourceDiagnostic {
     let message = error.to_string();
     let kind = crate::verification_output::semantic_error_kind(&message);
-    let span = error
-        .origin
-        .as_deref()
-        .and_then(|origin| origin.primary.as_ref())
-        .and_then(|site| site.span)
-        .or_else(|| diagnostic_span_from_message(source, &message))
-        .unwrap_or_else(|| point_span(source, 1, 1));
+    let located = error
+        .span
+        .or_else(|| {
+            error
+                .origin
+                .as_deref()
+                .and_then(|origin| origin.primary.as_ref())
+                .and_then(|site| site.span)
+        })
+        .or_else(|| diagnostic_span_from_message(source, &message));
     SourceDiagnostic {
         kind,
         code: if kind == "type" {
@@ -109,7 +127,8 @@ fn model_diagnostic(source: &str, error: &fsl_core::ModelError) -> SourceDiagnos
             "FSL-SEMANTIC".to_owned()
         },
         message,
-        span,
+        span: located.unwrap_or_else(|| point_span(source, 1, 1)),
+        located: located.is_some(),
     }
 }
 
@@ -147,6 +166,7 @@ fn migration_diagnostics(source: &str) -> Vec<SourceDiagnostic> {
                         code: code.to_owned(),
                         message: message.to_owned(),
                         span: rewrite.span,
+                        located: true,
                     }
                 })
                 .collect()

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -141,8 +141,10 @@ fn load_selected_model(selection: ModelSelection<'_>) -> Result<KernelModel, Spe
             |scope| load_model_scoped(selection.path, scope),
         )?,
     };
+    // A rejected `--property`/`--exclude` names a property that is absent from
+    // the model, so there is no construct in the source to point at.
     select_properties(&mut model, selection.property, selection.excluded)
-        .map_err(SpecLoadError::Semantic)?;
+        .map_err(SpecLoadError::unlocated_semantic)?;
     Ok(model)
 }
 

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -83,13 +83,54 @@ pub struct BmcOutputOptions<'a> {
     pub statistics: &'a VerificationStatistics,
 }
 
-/// Render a model-construction error using the public semantic classification.
+/// The source location a typed-model diagnostic carries, if the model bound one
+/// to the offending construct.
+///
+/// The span is read back from the origin the model already recorded; it is
+/// never re-derived or synthesised. A construct with no recorded span yields
+/// `None`, and the caller must leave `loc` absent rather than emit the
+/// `line: 0` sentinel, which would point a repair agent at a location that does
+/// not exist (issue 555).
 #[must_use]
-pub fn render_semantic_error(mut output: Map<String, Value>, message: &str) -> Value {
+pub fn origin_loc(origin: Option<&fsl_core::OriginChain>) -> Option<Value> {
+    origin
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .map(fsl_syntax::Span::python_loc)
+}
+
+/// The source location of a typed-model failure.
+///
+/// Prefers the span the diagnostic recorded for itself over the enclosing
+/// construct's lowering origin, so the report names the assignment or field
+/// that failed rather than the declaration containing it.
+#[must_use]
+pub fn model_error_loc(error: &fsl_core::ModelError) -> Option<Value> {
+    error.span.map_or_else(
+        || origin_loc(error.origin.as_deref()),
+        |span| Some(span.python_loc()),
+    )
+}
+
+/// Render a model-construction error using the public semantic classification.
+///
+/// `docs/DESIGN-v1.md` §7.2 guarantees `loc` for `parse`/`name`/`type`/
+/// `semantics`. This is the single dispatch point for the `type`/`semantics`
+/// half, so the location travels with the diagnostic instead of being
+/// reconstructed per command (issue 555, completing issue 484).
+#[must_use]
+pub fn render_semantic_error(
+    mut output: Map<String, Value>,
+    message: &str,
+    loc: Option<Value>,
+) -> Value {
     let kind = semantic_error_kind(message);
     output.insert("result".to_owned(), json!("error"));
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message));
+    if let Some(loc) = loc {
+        output.insert("loc".to_owned(), loc);
+    }
     if message.starts_with("struct field '") && message.ends_with(" has non-scalar type") {
         output.insert(
             "hint".to_owned(),

--- a/rust/fslc/tests/cli_regression.rs
+++ b/rust/fslc/tests/cli_regression.rs
@@ -418,14 +418,19 @@ fn general_conditionals_cross_cli_verification_and_replay_paths() {
 
 #[test]
 fn conditional_type_diagnostics_point_to_the_invalid_child_expression() {
-    for (fixture, location) in [
+    // Issue 555 moved the location out of the message text into the `loc`
+    // field `docs/DESIGN-v1.md` §7.2 guarantees, so the same position is now
+    // asserted structurally and exactly instead of as a message suffix.
+    for (fixture, line, column) in [
         (
             "rust/fslc/tests/fixtures/conditional_type_error.fsl",
-            "at 7:29",
+            7_u64,
+            29_u64,
         ),
         (
             "rust/fslc/tests/fixtures/conditional_const_type_error.fsl",
-            "at 4:37",
+            4,
+            37,
         ),
     ] {
         let (value, status) = run_cli(&["check", fixture]);
@@ -433,10 +438,14 @@ fn conditional_type_diagnostics_point_to_the_invalid_child_expression() {
         assert_eq!(status, 2, "{fixture}");
         assert_eq!(value["result"], "error", "{fixture}");
         assert_eq!(value["kind"], "semantics", "{fixture}");
-        assert!(
-            value["message"]
-                .as_str()
-                .is_some_and(|message| message.ends_with(location)),
+        assert_eq!(
+            value["loc"]["line"].as_u64(),
+            Some(line),
+            "{fixture}: {value}"
+        );
+        assert_eq!(
+            value["loc"]["column"].as_u64(),
+            Some(column),
             "{fixture}: {value}"
         );
     }

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -8241,6 +8241,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29",
+          "loc": {
+            "line": 10,
+            "column": 29
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8265,6 +8269,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'missing_status' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl:10:29",
+          "loc": {
+            "line": 10,
+            "column": 29
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8291,6 +8299,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41",
+          "loc": {
+            "line": 10,
+            "column": 41
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8315,6 +8327,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Cancelled' at rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl:10:41",
+          "loc": {
+            "line": 10,
+            "column": 41
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8341,6 +8357,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37",
+          "loc": {
+            "line": 10,
+            "column": 37
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8365,6 +8385,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "comparison operand type mismatch at rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl:10:37",
+          "loc": {
+            "line": 10,
+            "column": 37
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8511,6 +8535,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41",
+          "loc": {
+            "line": 10,
+            "column": 41
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",
@@ -8535,6 +8563,10 @@
           "result": "error",
           "kind": "semantics",
           "message": "unknown domain symbol 'Status_Draft' at rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl:10:41",
+          "loc": {
+            "line": 10,
+            "column": 41
+          },
           "versions": {
             "verifier": {
               "name": "fslc-rust",

--- a/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
+++ b/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
@@ -278,3 +278,80 @@ fn a_missing_input_is_io_for_every_spec_reading_command() {
 
     std::fs::remove_dir_all(&directory).expect("remove fixture directory");
 }
+
+/// The corpus `type`/`semantics` goldens, with the construct each diagnostic
+/// must point at.
+///
+/// `examples/gallery/errors/` has no `name`-kind fixture, so that third
+/// classification in the `docs/DESIGN-v1.md` §7.2 clause has no corpus case to
+/// pin here.
+const LOCATED_SEMANTIC_FIXTURES: &[(&str, &str, u64, u64)] = &[
+    // `state { owner: UserId }` — the state declaration naming the unknown type.
+    (
+        "examples/gallery/errors/type_undeclared_type.fsl",
+        "type",
+        5,
+        11,
+    ),
+    // `struct Bag { members: Set<K> }` — `TypeExpr` carries no span of its own,
+    // so the declaration is the closest true location.
+    (
+        "examples/gallery/errors/type_struct_set_field.fsl",
+        "type",
+        6,
+        3,
+    ),
+    // The *second* `x = 2`, not the first write and not the enclosing action.
+    (
+        "examples/gallery/errors/semantics_duplicate_assignment.fsl",
+        "semantics",
+        9,
+        5,
+    ),
+];
+
+/// Issue 555: `docs/DESIGN-v1.md` §7.2 guarantees `loc` for `type` and
+/// `semantics`, not only for `parse`. Issue 484 delivered the `parse` half; the
+/// other half returned `loc: null` from every command, including `check`.
+///
+/// The line and column are asserted exactly. "`loc` is not null" cannot
+/// distinguish a correct location from a wrong one, and a `loc` that points at
+/// the wrong construct is a worse outcome for a repair agent than no `loc`.
+#[test]
+fn every_spec_reading_command_locates_a_type_or_semantic_error() {
+    let directory = fixture_directory("semantic-loc-matrix");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"Valid","initial":{"value":0},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+
+    for (fixture, expected_kind, line, column) in LOCATED_SEMANTIC_FIXTURES {
+        for (name, arguments) in spec_reading_commands(fixture, &trace, &other) {
+            // `fmt` never lowers to the kernel and refuses these inputs as
+            // `usage` before any typed-model diagnostic exists.
+            if name == "fmt" {
+                continue;
+            }
+            let (output, status) = run_cli(&arguments);
+            assert_eq!(output["result"], "error", "{fixture}/{name}: {output}");
+            assert_eq!(output["kind"], *expected_kind, "{fixture}/{name}: {output}");
+            assert_eq!(status, 2, "{fixture}/{name}: {output}");
+            // `lint` adds a `file` key to its own `loc`; the guaranteed fields
+            // are `line`/`column` (`docs/DESIGN-v1.md` §7.2).
+            assert_eq!(
+                output["loc"]["line"].as_u64(),
+                Some(*line),
+                "{fixture}/{name}: {output}"
+            );
+            assert_eq!(
+                output["loc"]["column"].as_u64(),
+                Some(*column),
+                "{fixture}/{name}: {output}"
+            );
+        }
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}


### PR DESCRIPTION
## Problem

`docs/DESIGN-v1.md` §7.2 guarantees `parse`/`name`/`type`/`semantics` always have `loc`. #484 (PR #557)
made that true for `parse` on every command. `type` and `semantics` still returned `loc: null` — on
**every** command including `check`. So `docs/DESIGN-v1.md` G2, "where, why, and how to fix it is
mechanically determined from the output JSON alone", was unmet for the repair branch that tells an
agent to add a declaration or change a type.

Not a false green: exit 2 and `kind` were already correct and already consistent across commands after
#484.

## The framing this started from was wrong, and it changed the shape of the fix

The issue and brief said the span was being dropped at the `SpecLoadError::Semantic(String)` boundary,
citing `CoreError`'s non-optional `line`/`column` and that only 2 of 22 literal constructions use
`line: 0`.

That is true of `CoreError`. It is **not** where these diagnostics come from. `type`/`semantics`
diagnostics come from `build_model`, which returns `ModelError` — `{ message: String, origin:
Option<Box<OriginChain>> }`, with no line or column field at all (`rust/fsl-core/src/model.rs:396`).
All three corpus goldens measured `origin=false, span=None` before anything was touched. **The span was
not being dropped; it did not exist.** Carrying `SpecLoadError::Semantic` structurally was necessary but
only about half the work — the rest was giving these diagnostics a location in `fsl-core`.

## The hunk worth reviewing carefully

The first attempt attached the spans to `ModelError.origin`. That silently breaks two things:

1. `ModelError`'s `Display` appends `" at line:column"` when an origin carries a span, so **every
   affected message changes**.
2. `semantic_error_kind` matches message prefixes *and suffixes* —
   `starts_with("struct field '") && ends_with(" has non-scalar type")` at
   `rust/fslc/src/verification_output.rs:159`. With the suffix moved, `struct field '…' has non-scalar
   type` flips from `type` to `semantics`. A **classification change** leaking out of a change that was
   only supposed to add positions, and explicitly out of scope.

It would also have broken `parity.mjs`, which expects the bare message.

The shipped version uses a separate `span` field that `Display` ignores. **Messages are byte-identical
and no `kind` moves** — verified independently against `main` for all three goldens.

## Locations, verified against the source text

`loc` that is present but wrong is worse than `loc: null`, and "not null" cannot tell them apart — so
the assertions pin exact line and column, and each was checked against the file:

| golden | loc | construct |
|---|---|---|
| `type_undeclared_type.fsl` | 5:11 | the state field `owner` in `state { owner: UserId }` |
| `type_struct_set_field.fsl` | 6:3 | the `struct` keyword of `struct Bag { members: Set<K> }` |
| `semantics_duplicate_assignment.fsl` | 9:5 | the **second** `x = 2`, not line 8's `x = 1` |

The third is the point of the fix: it names the repeating write, threaded out of
`duplicate_statement_write`, rather than the first write or the enclosing action.
`SpecItem::Struct` carried no span and `TypeExpr` still carries none, so a span was added to the
surface AST for the second case — the closest true location that exists.

Three commands needed a path beyond the loader: `check` returns from the shared `source_diagnostic`
gate before reaching `load_kernel_model` (this is where `check`'s own `loc: null` came from);
`document generate` owns a third loader whose projector flattens to a `String`, recovered on the
failure path only — the same idiom #557 uses for parse; and the Worker, so browser parity holds.

## Nothing is fabricated

`SourceDiagnostic` now records whether its span is real, because the LSP accepts the document start as
a last resort and the CLI must not report that as a position. **No `line: 0` is ever emitted.**

Four diagnostic classes legitimately have no construct in the reported file and stay absent rather than
inventing one: rejected CLI selections, whole-document shape mismatches, and diagnostics whose subject
is a *different file* than the envelope's (the `analyze --project` manifest and the refinement mapping
it names — `loc` carries no file, so a position there would point into the wrong document).

`docs/DESIGN-v1.md` §7.2 now **names exactly those cases** rather than leaving the clause overstating
the implementation. The clause is not weakened generally and `docs/LANGUAGE.md` is untouched.

## Test evidence

`every_spec_reading_command_locates_a_type_or_semantic_error` extends the #557 matrix: 3 goldens ×
every spec-reading command, asserting exact line and column. Ablating the production change alone fails
it, plus `conditional_type_diagnostics_point_to_the_invalid_child_expression` and the domain baseline;
everything else stays green.

Two fixture/baseline changes, both declared:
- `conditional_type_diagnostics_point_to_the_invalid_child_expression` asserted the location as a
  message suffix (`ends_with("at 7:29")`); it now asserts `loc.line`/`loc.column` exactly — strictly
  stronger, same positions.
- The domain characterization baseline was **regenerated, not hand-edited**: 32 additions, 0 deletions,
  eight new `loc` objects, no message or kind changes.

Independently re-verified on the rebased branch: all three goldens report the locations above with
`kind` unchanged (`type`, `type`, `semantics`), consistent across check/analyze/typestate, and messages
byte-identical to `main`.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Residual, filed as #565

The corpus has **no `name`-kind fixture**, so the third classification in the §7.2 clause has nothing
to pin. Investigating that turned up more than a missing fixture: **native never emits `kind:"name"`
at all.** `duplicate state variable 'x'` returns `kind:"semantics"` where frozen
`src/fslc/model.py:1575` returns the identical message with `kind="name"`. That is #484's defect class
for a different member of the closed set, and it is why the fixture gap went unnoticed.

## Documentation

`docs/DESIGN-v1.md` §7.2 (narrow named exceptions), `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
