### PR TITLE
fix(analyze): run TSG source enrichment on the manifest path too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- `fslc analyze` on a `.toml` project manifest now emits the same TSG
+  vocabulary a standalone file emits for the same source. The manifest loop
+  built each layer with `fsl_tools::build_tsg` alone, which only sees the
+  lowered `KernelModel`, so none of the source-only kinds ever appeared on that
+  path — `acceptance`/`forbidden` scenario nodes with their `covers` and
+  `starts_with`/`precedes` edges, and `control` catalog nodes — and the graph
+  vocabulary silently depended on which input form named the spec. Each layer
+  now runs the same source-level enrichment, on its own file
+  and its unprefixed graph, so `<layer>:` prefixing still applies to
+  enrichment-added nodes and two layers declaring the same id stay two nodes.
+  No ordering change was needed: `Builder::build` drops a `covers` edge whose
+  target has no node yet and runs first, but the edges it computes come from
+  `KernelModel::requirement_targets`, which enumerates only `init`, `action:*`,
+  and `property:*` targets and can never name a scenario or a control, and
+  every enrichment-added edge has both endpoints created by the enrichment
+  itself.
+  Verdicts and exit codes are unaffected, and no review finding changes — the
+  manifest path accepts only `--projection traceability_graph`, so no structural
+  detector runs there at all (#558).
 - Native `fslc mutate` now defaults to 200 built-in mutants instead of 100,
   matching the `max_mutants` default its own published CLI contract
   (`rust/fslc/cli-contract.json`) advertises and the 200 fixed by

--- a/docs/DESIGN-analysis.md
+++ b/docs/DESIGN-analysis.md
@@ -149,6 +149,16 @@ property, and the edge vocabulary has no `satisfies` kind, so a control node
 carries only its `declares` edge and no review finding reads control nodes
 today.
 
+The vocabulary does not depend on input form. A `.toml` project manifest runs
+the same source-level enrichment a standalone file runs, once per layer and on
+that layer's own unprefixed graph, so a manifest layer slice carries the node
+and edge kinds that layer's file carries standalone; the `<layer>:` prefix is
+then applied to enrichment-added nodes like any other, so two layers declaring
+the same id stay two nodes. A manifest additionally carries
+`file`/`refinement`/`*_map` nodes and cross-layer edges with no standalone
+equivalent, and renames a layer's `spec` node by role — those are manifest-only
+structure, not a vocabulary difference (#558).
+
 Stable edge kinds include `declares`, `covers`, `has_guard`, `has_effect`,
 `has_ensures`, `reads`, `writes`, `checks`, `starts_with`, and `precedes`.
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -12199,10 +12199,17 @@ fn ai_review_output(
 /// its `covers` edge never dangles. A no-op when the source cannot be re-read,
 /// or for a document that declares neither cases nor controls.
 ///
-/// Both single-file entry points (`analyze` and `analyze --profile ai-review`)
-/// call this once. The `.toml` project-manifest path builds its own prefixed
-/// multi-layer graph from `build_tsg` alone and so has none of these
-/// source-only kinds; that predates this function.
+/// Every entry path runs this: the standalone file, `analyze --profile
+/// ai-review`, and the `.toml` project manifest once per layer, on that
+/// layer's own source and its unprefixed graph, so the layer prefix applies to
+/// what is added here like anything else (#558). `Builder::build` drops a
+/// `covers` edge whose target has no node yet and runs first, but that cannot
+/// reach anything added here: the edges it computes come from
+/// `KernelModel::requirement_targets`, which enumerates only `init`,
+/// `action:*`, and `property:*` targets, so it can never name a scenario or a
+/// control. Every edge added here has both of its endpoints created here,
+/// which is why no deferred resolution or ordering change is needed on any
+/// path.
 fn enrich_tsg_from_source(mut tsg: Value, model: &KernelModel, path: &Path) -> Value {
     let Ok(source) = std::fs::read_to_string(path) else {
         return tsg;
@@ -12454,10 +12461,13 @@ fn project_traceability_output(path: &Path) -> Result<Value, SpecLoadError> {
         };
         let layer_path = base.join(file);
         let model = load_model(&layer_path)?;
-        // `build_tsg` already projects `requirement`/`kpi` nodes and `covers`
-        // edges (#495) from `model.requirement_targets()`/`model.projections`,
-        // so no separate per-layer enrichment step is needed here anymore.
-        let tsg = fsl_tools::build_tsg(&model);
+        // `build_tsg` projects `requirement`/`kpi` nodes and `covers` edges
+        // (#495) from `model.requirement_targets()`/`model.projections`, but it
+        // only ever sees the lowered `KernelModel`. The source-only kinds run
+        // through the same enrichment the standalone path uses, per layer and
+        // on the unprefixed graph, so both input forms yield the same
+        // vocabulary and the layer prefix below still applies uniformly (#558).
+        let tsg = enrich_tsg_from_source(fsl_tools::build_tsg(&model), &model, &layer_path);
         let display = analysis_display_path(&layer_path);
         let file_id = format!("file:{layer}:{display}");
         let mut file_node = project_analysis_node(&file_id, "file", &display);

--- a/rust/fslc/tests/fixtures/manifest_vocabulary/business.fsl
+++ b/rust/fslc/tests/fixtures/manifest_vocabulary/business.fsl
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Manifest-vocabulary fixture, business layer. Declares a `control` catalog
+// entry, which has no Kernel-lowered form and therefore only reaches the graph
+// through the source-level enrichment. Shares the `REQ-SHARED` id with the
+// requirements layer on purpose: the manifest graph must keep the two apart by
+// layer prefix rather than merging them into one node.
+business ManifestVocabularyBusiness {
+  actor Agent
+  entity Item
+
+  process Item {
+    stages Open, Done
+    initial Open
+    transition finish Open -> Done by Agent
+  }
+
+  control CTRL-CLOSURE
+    "Every opened item must reach a closed outcome"
+    owner Agent
+    severity high
+    applies_to Item
+
+  policy REQ-SHARED "every opened item is eventually finished"
+    satisfies CTRL-CLOSURE
+    every Item in Open must eventually be Done
+}
+
+verify {
+  instances Item = 2
+}

--- a/rust/fslc/tests/fixtures/manifest_vocabulary/fsl-project.toml
+++ b/rust/fslc/tests/fixtures/manifest_vocabulary/fsl-project.toml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+[business]
+file = "business.fsl"
+depth = 1
+
+[requirements]
+file = "requirements.fsl"
+depth = 1

--- a/rust/fslc/tests/fixtures/manifest_vocabulary/requirements.fsl
+++ b/rust/fslc/tests/fixtures/manifest_vocabulary/requirements.fsl
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Manifest-vocabulary fixture, requirements layer. Carries the source-only
+// constructs the manifest path used to drop: `acceptance`/`forbidden` cases,
+// their `starts_with`/`precedes` step edges, and the `covers` edge from a
+// case-level `@requirement(...)`. It declares `REQ-SHARED` too, so the
+// manifest graph has to keep the two layers' nodes apart.
+requirements ManifestVocabularyRequirements {
+  type Item = 0..0
+  enum RSt { RDraft, RDone }
+
+  state {
+    req: Map<Item, RSt>
+  }
+  init {
+    forall i: Item { req[i] = RDraft }
+  }
+
+  requirement REQ-SHARED "an item can finish" {
+    action finish(i: Item) maps finish(i) {
+      requires req[i] == RDraft
+      req[i] = RDone
+    }
+  }
+
+  @requirement("REQ-CASE", "the finish path is exercised end to end")
+  acceptance AC-1 "finish moves the item to done" {
+    finish(0)
+    expect req[0] == RDone
+  }
+
+  forbidden FB-1 "an item cannot finish twice" {
+    finish(0)
+    finish(0)
+    expect rejected
+  }
+}

--- a/rust/fslc/tests/issue_558_manifest_tsg_vocabulary.rs
+++ b/rust/fslc/tests/issue_558_manifest_tsg_vocabulary.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! The TSG vocabulary must not depend on which input form named the spec.
+//!
+//! `docs/DESIGN-analysis.md` §2 lists the stable node and edge kinds without
+//! conditioning them on input form, but the project-manifest path built each
+//! layer with `fsl_tools::build_tsg` alone. `build_tsg` sees only the lowered
+//! `KernelModel`, and `acceptance`/`forbidden` cases have no lowered form, so
+//! the same source yielded a different vocabulary depending on whether it was
+//! analyzed standalone or through a `.toml` manifest (#558).
+//!
+//! The check below is a *property over kinds*, not a golden of one graph: it
+//! projects the manifest graph back down per layer and compares kind sets with
+//! the standalone graph of that layer's own file. A golden would freeze one
+//! shape; this keeps detecting divergence as either path grows new kinds.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const MANIFEST: &str = "rust/fslc/tests/fixtures/manifest_vocabulary/fsl-project.toml";
+const LAYERS: [(&str, &str); 2] = [
+    (
+        "business",
+        "rust/fslc/tests/fixtures/manifest_vocabulary/business.fsl",
+    ),
+    (
+        "requirements",
+        "rust/fslc/tests/fixtures/manifest_vocabulary/requirements.fsl",
+    ),
+];
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+/// The manifest graph renames a layer's `spec` node by layer role; that is a
+/// deliberate manifest-only distinction, not a vocabulary difference.
+fn normalized_kind(kind: &str) -> &str {
+    match kind {
+        "business_spec" | "requirements_spec" | "design_spec" => "spec",
+        other => other,
+    }
+}
+
+fn node_kinds(graph: &Value) -> BTreeSet<String> {
+    graph["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|node| node["kind"].as_str())
+        .map(|kind| normalized_kind(kind).to_owned())
+        .collect()
+}
+
+fn edge_kinds(graph: &Value) -> BTreeSet<String> {
+    graph["edges"]
+        .as_array()
+        .expect("edges array")
+        .iter()
+        .filter_map(|edge| edge["kind"].as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Project the manifest graph back down to one layer. A layer-local node id is
+/// `<layer>:<id>` and a layer-local edge id is `edge:<layer>:<original edge
+/// id>`, which always starts `edge:<layer>:edge:`. Cross-layer edges
+/// (`lower_anchor`, the manifest/file `declares` edges, refinement maps) never
+/// take that shape, so they are excluded without an allowlist of kinds.
+fn layer_slice(manifest: &Value, layer: &str) -> Value {
+    let node_prefix = format!("{layer}:");
+    let edge_prefix = format!("edge:{layer}:edge:");
+    let nodes = manifest["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter(|node| {
+            node["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with(&node_prefix))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let edges = manifest["edges"]
+        .as_array()
+        .expect("edges array")
+        .iter()
+        .filter(|edge| {
+            edge["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with(&edge_prefix))
+                && edge["from"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with(&node_prefix))
+                && edge["to"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with(&node_prefix))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    serde_json::json!({"nodes": nodes, "edges": edges})
+}
+
+/// The negative control this gap never had.
+#[test]
+fn manifest_and_standalone_input_agree_on_the_graph_vocabulary() {
+    let (manifest, status) = run(&["analyze", MANIFEST, "--projection", "traceability_graph"]);
+    assert_eq!(status, 0, "{manifest:#}");
+
+    for (layer, file) in LAYERS {
+        let (standalone, status) = run(&["analyze", file, "--projection", "tsg"]);
+        assert_eq!(status, 0, "{layer}: {standalone:#}");
+        let slice = layer_slice(&manifest, layer);
+        assert_eq!(
+            node_kinds(&slice),
+            node_kinds(&standalone),
+            "{layer} node kinds diverge; manifest slice {slice:#}"
+        );
+        assert_eq!(
+            edge_kinds(&slice),
+            edge_kinds(&standalone),
+            "{layer} edge kinds diverge; manifest slice {slice:#}"
+        );
+    }
+}
+
+/// Pin that the property above is not passing vacuously: every source-only
+/// kind must really be present on the manifest side, under its layer prefix.
+/// The requirements layer supplies the scenario nodes and their step edges,
+/// the business layer supplies the `control` catalog entry.
+#[test]
+fn the_manifest_graph_carries_every_source_only_kind() {
+    let (manifest, status) = run(&["analyze", MANIFEST, "--projection", "traceability_graph"]);
+    assert_eq!(status, 0, "{manifest:#}");
+    let ids = manifest["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect::<BTreeSet<_>>();
+    for id in [
+        "requirements:acceptance:AC-1",
+        "requirements:forbidden:FB-1",
+        "business:control:CTRL-CLOSURE",
+    ] {
+        assert!(ids.contains(id), "{id} missing: {manifest:#}");
+    }
+    let edges = manifest["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|edge| {
+            edge["kind"] == "covers"
+                && edge["from"] == "requirements:requirement:REQ-CASE"
+                && edge["to"] == "requirements:acceptance:AC-1"
+        }),
+        "{manifest:#}"
+    );
+    // Step edges keep their direction, kind split, and step index, with both
+    // endpoints carrying the layer prefix.
+    for (kind, from, step) in [
+        ("starts_with", "requirements:acceptance:AC-1", 0),
+        ("starts_with", "requirements:forbidden:FB-1", 0),
+        ("precedes", "requirements:forbidden:FB-1", 1),
+    ] {
+        assert!(
+            edges.iter().any(|edge| {
+                edge["kind"] == kind
+                    && edge["from"] == from
+                    && edge["to"] == "requirements:action:finish"
+                    && edge["step"] == serde_json::json!(step)
+            }),
+            "missing {kind} step {step} from {from}: {manifest:#}"
+        );
+    }
+}
+
+/// Layer identity survives enrichment: `REQ-SHARED` is declared in both layer
+/// files and must stay two distinct nodes, never merge into one.
+#[test]
+fn a_requirement_declared_in_two_layers_stays_two_nodes() {
+    let (manifest, status) = run(&["analyze", MANIFEST, "--projection", "traceability_graph"]);
+    assert_eq!(status, 0, "{manifest:#}");
+    let ids = manifest["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect::<BTreeSet<_>>();
+    assert!(ids.contains("business:requirement:REQ-SHARED"), "{ids:?}");
+    assert!(
+        ids.contains("requirements:requirement:REQ-SHARED"),
+        "{ids:?}"
+    );
+    assert!(!ids.contains("requirement:REQ-SHARED"), "{ids:?}");
+}
+
+/// The graph-wide well-formedness check, over every manifest-layer graph at
+/// once: enrichment must not leave an edge pointing at a node it did not also
+/// create, and layer prefixing must not break an endpoint.
+#[test]
+fn no_manifest_edge_dangles() {
+    for manifest in [
+        MANIFEST,
+        "tests/fixtures/chain/fsl-project.toml",
+        "tests/fixtures/rust_port/project_gap/fsl-project.toml",
+    ] {
+        let (graph, status) = run(&["analyze", manifest, "--projection", "traceability_graph"]);
+        assert_eq!(status, 0, "{manifest}: {graph:#}");
+        let ids = graph["nodes"]
+            .as_array()
+            .expect("nodes array")
+            .iter()
+            .filter_map(|node| node["id"].as_str())
+            .collect::<BTreeSet<_>>();
+        for edge in graph["edges"].as_array().expect("edges array") {
+            assert!(
+                ids.contains(edge["from"].as_str().unwrap_or_default()),
+                "{manifest}: dangling edge.from: {edge:#}"
+            );
+            assert!(
+                ids.contains(edge["to"].as_str().unwrap_or_default()),
+                "{manifest}: dangling edge.to: {edge:#}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`fslc analyze` on a project manifest (`.toml`) emitted none of the source-only node kinds.
`project_traceability_output` called `fsl_tools::build_tsg(&model)` per layer and nothing else, and
`build_tsg` sees only the `KernelModel` — so `acceptance` / `forbidden` scenario nodes, their
`starts_with` / `precedes` step edges, and `control` nodes never appeared. The same spec produced a
different graph vocabulary depending on which input form was used, while `docs/DESIGN-analysis.md`
lists those kinds as stable without conditioning them on input form.

Pre-existing and predating #495: scenario nodes had never appeared on that path. So #495's claim that
both paths share one build → enrich → dispatch is accurate for the projection dispatch but not for the
enrichment.

Not a false green — verdicts and exit codes are unaffected. It is a vocabulary inconsistency on one of
two entry paths.

## The ordering constraint in the issue does not bind, and was not worked around

#558's body claims `Builder::build()` dropping a `covers` edge to a missing target — and running before
enrichment — makes "just call the enrichment" insufficient. Both facts are true; the conclusion is not.

Every edge `build()` computes comes from `KernelModel::requirement_targets()`
(`rust/fsl-core/src/model.rs:284`), which enumerates a **closed set**: `INIT_TARGET`, `action:<name>`,
and `property:{invariant,trans,reachable,leadsTo}:<name>`. It is structurally incapable of naming
`acceptance:*`, `forbidden:*`, or `control:*`, so the drop rule can never reach anything the enrichment
adds.

The mechanism the standalone path relies on is also not deferred resolution or ordering: **the
enrichment owns both endpoints of every edge it adds**, creating a `requirement:<id>` node on first
reference when only a case-level `@requirement(...)` cites it. Calling the same function per layer
inherits that for free, which is why this is one call site rather than a pipeline change. The
derivation is recorded in the function's doc comment so the question does not get re-opened.

The constraint would only begin to bind if a future `satisfies` edge were computed inside `build()`
from model data naming a control. That boundary is noted rather than left implicit. The issue body has
been corrected.

## Contract change

None. One call site in `project_traceability_output`:
`build_tsg(&model)` → `enrich_tsg_from_source(build_tsg(&model), &model, &layer_path)`, per layer, on
the **unprefixed** graph and before `prefixed_analysis_node` / `prefixed_analysis_edge` — so the
`<layer>:` prefix applies to enrichment-added nodes like any other. No third traversal, no duplicated
collector.

Layer identity confirmed by measurement rather than assumed: `REQ-SHARED`, declared in both fixture
layers, stays `business:requirement:REQ-SHARED` and `requirements:requirement:REQ-SHARED` with no
unprefixed form.

## Test evidence

`rust/fslc/tests/issue_558_manifest_tsg_vocabulary.rs` asserts **set equality of node kinds and edge
kinds** between the manifest graph (projected back down per layer) and the standalone graph of that
layer's own file — a property over kinds, not a golden, so it keeps detecting divergence as either path
grows kinds. The absence of exactly this test is why the gap went unrecorded.

Ablation (`git checkout <main> -- rust/fslc/src/main.rs`) fails
`manifest_and_standalone_input_agree_on_the_graph_vocabulary` and
`the_manifest_graph_carries_every_source_only_kind`.
`a_requirement_declared_in_two_layers_stays_two_nodes` and `no_manifest_edge_dangles` pass both ways —
**stated plainly**: they are invariants that must hold before and after, not negative controls.

Independently re-verified on the rebased branch:

| | node kinds |
|---|---|
| before | `action, business_spec, effect, file, guard, leadsTo, phys_state, requirement, requirements_spec, state` |
| after | + **`acceptance`, `forbidden`, `control`** |

with `business:control:CTRL-CLOSURE` and
`starts_with requirements:acceptance:AC-1 → requirements:action:finish step=0`,
`starts_with requirements:forbidden:FB-1 → … step=0`,
`precedes requirements:forbidden:FB-1 → … step=1` — direction, kind split, step index and layer
prefixes all preserved.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh`
(nativeParity true, 351 parity cases) all exit 0.

## Detection power — nothing changes, and nothing can

Stated structurally rather than sampled: the manifest path accepts only
`--projection traceability_graph`; `--profile ai-review` and `--focus` are rejected, so
`structural_review_findings` is unreachable there. **No detector on that path was dead and is now
live.** This is a graph-vocabulary fix for the JSON consumers that read it.

Both existing corpus manifests (`tests/fixtures/chain`, `tests/fixtures/rust_port/project_gap`) are
**byte-identical** before and after, because neither has a layer declaring scenarios.

## Notes from the work

The first post-rebase measurement was **partial** — step edges appeared but `control` came back empty.
That was the fixture, not the mechanism: its business layer was a plain kernel `spec`, and controls
exist only in the governance/business dialects, so there was nothing to project. Rather than report an
untested half as working, the layer was rewritten as a real `business` document declaring
`control CTRL-CLOSURE` with `owner`/`severity`/`applies_to` and a `policy REQ-SHARED satisfies
CTRL-CLOSURE`, and the assertion extended to pin the control node and all three step edges.

Cost of that, declared: making the business layer a real business document broke the requirements
layer's `implements` clause (state lowered to `item_stage`, enum members `Open`/`Done`, and the `Item`
key domains no longer matched). The `implements` block was dropped rather than contorting the fixture —
the two layers are now independent, which costs nothing here since `implements`-derived `lower_anchor`
edges are cross-layer structure the property already excludes.

The stale claim PR #560 added — "the `.toml` project-manifest path … has none of these source-only
kinds; that predates this function" at `rust/fslc/src/main.rs` — is **deleted**, not merged around, and
replaced with a paragraph stating that every entry path runs the enrichment plus the
`requirement_targets` derivation above.

## Documentation

`docs/DESIGN-analysis.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
