### PR TITLE
fix(ai): give the fsl-ai project parse error a clause-accurate loc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- The fsl-ai project check's unexecutable-`require` spec error (#542) now
+  carries a `loc` pointing at the offending clause's own line and column.
+  `rust/fsl-syntax/src/ai_project.rs` tracked no positions at all, so the error
+  named the declaration and slice but no position, breaking
+  `docs/DESIGN-v1.md` §7.2's guarantee that every `parse` error has one. Block
+  bodies and their statement lines now carry their char offset through
+  `top_blocks`/`top_lines`, each metric/observed requirement records the
+  position of the clause that produced it, and both `fslc ai check` and the
+  `fslc check` dispatch emit it. A clause nested in a `slice` reports its own
+  line, not the enclosing block's. Which projects are accepted is unchanged
+  (#562, partial -- see below).
+- **Not fixed, recorded:** an unknown *non-*`require` line inside a declaration
+  body is still silently ignored, so acceptance still turns on the line's first
+  word. Closing that requires deciding a closed body grammar, and no current
+  source specifies one: the frozen `src/fslc/ai_project.py` ignores unrecognized
+  lines by construction (an `if`/`elif` chain with no `else`) and downgrades an
+  unparseable `require` to `kind="inconclusive"` rather than erroring;
+  `docs/LANGUAGE.md` and `skills/fsl/reference.md` state only the `require` rule
+  #542 added; and `skills/fsl/reference.md` documents unvalidated block bodies
+  as intended for `ai_action`/`retriever`/`trust_boundary`/`authority`. The one
+  corpus project file additionally uses free-form predicate lines
+  (`language in ["ja", "en"]`, `condition output.claims not_supported_by
+  retrieved.sources`) that both implementations store verbatim and never parse
+  (#562).
 - `fslc analyze` on a `.toml` project manifest now emits the same TSG
   vocabulary a standalone file emits for the same source. The manifest loop
   built each layer with `fsl_tools::build_tsg` alone, which only sees the

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -65,6 +65,10 @@ pub struct AiMetricRequirement {
     pub slice: String,
     pub min_samples: Option<u64>,
     pub source: String,
+    /// 1-based position of the clause's first character in the project
+    /// source, so an unexecutable clause reports a `loc` (#562).
+    pub line: u32,
+    pub column: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -103,6 +107,10 @@ pub struct AiObservedRequirement {
     pub compared_to: Option<String>,
     pub slice: String,
     pub source: String,
+    /// 1-based position of the clause's first character in the project
+    /// source, so an unexecutable clause reports a `loc` (#562).
+    pub line: u32,
+    pub column: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -145,6 +153,9 @@ pub struct AiUnparsedClause {
     pub slice: String,
     /// The clause exactly as written, without its `require ` keyword.
     pub source: String,
+    /// 1-based position of the clause in the project source.
+    pub line: u32,
+    pub column: u32,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -175,6 +186,8 @@ impl AiProject {
                     declaration: property.name.clone(),
                     slice: requirement.slice.clone(),
                     source: requirement.source.clone(),
+                    line: requirement.line,
+                    column: requirement.column,
                 })
         });
         let observed = self.observed_properties.iter().flat_map(|property| {
@@ -187,6 +200,8 @@ impl AiProject {
                     declaration: property.name.clone(),
                     slice: requirement.slice.clone(),
                     source: requirement.source.clone(),
+                    line: requirement.line,
+                    column: requirement.column,
                 })
         });
         statistical.chain(observed).collect()
@@ -299,7 +314,7 @@ impl AiProject {
 /// unterminated, or a `statistical_property`/`observed_property`/
 /// `ai_migration` name is declared more than once.
 pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
-    let blocks = top_blocks(source)?;
+    let blocks = top_blocks(source, 0)?;
     if blocks.is_empty() {
         return Err("expected fsl-ai project declarations".to_owned());
     }
@@ -317,10 +332,10 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
             "dataset" => project.datasets.push(parse_dataset(block)),
             "statistical_property" => project
                 .statistical_properties
-                .push(parse_statistical_property(block)?),
+                .push(parse_statistical_property(block, source)?),
             "observed_property" => project
                 .observed_properties
-                .push(parse_observed_property(block)?),
+                .push(parse_observed_property(block, source)?),
             "ai_migration" => project.migrations.push(parse_migration(block)?),
             kind if RAW_BLOCKS.contains(&kind) => project.raw_blocks.push(AiRawBlock {
                 kind: block.kind.clone(),
@@ -362,6 +377,9 @@ fn reject_duplicates<'a>(names: impl Iterator<Item = &'a str>, label: &str) -> R
 struct RawBlock {
     kind: String,
     name: String,
+    /// Char offset of `body`'s first character within the whole project
+    /// source, so a clause inside it can report its own `loc` (#562).
+    body_offset: usize,
     /// The exact original text of the block, header included (`"kind name {
     /// ... }"`), used to hand `ai_component` blocks to the strict token
     /// parser unmodified.
@@ -500,7 +518,7 @@ fn brace_depth(chars: &[char]) -> i32 {
     depth
 }
 
-fn top_blocks(source: &str) -> Result<Vec<RawBlock>, String> {
+fn top_blocks(source: &str, base: usize) -> Result<Vec<RawBlock>, String> {
     let chars: Vec<char> = source.chars().collect();
     let mut blocks = Vec::new();
     let mut i = 0usize;
@@ -525,6 +543,7 @@ fn top_blocks(source: &str) -> Result<Vec<RawBlock>, String> {
             blocks.push(RawBlock {
                 text: chars[header.start..=end].iter().collect(),
                 body: chars[header.brace + 1..end].iter().collect(),
+                body_offset: base + header.brace + 1,
                 kind: header.kind,
                 name: header.name,
             });
@@ -571,21 +590,54 @@ fn strip_semi(line: &str) -> String {
 /// stripped and nested-block lines (including the block's own header line)
 /// skipped, mirroring `_top_lines`.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-fn top_lines(body: &str) -> Vec<String> {
+fn top_lines(body: &str, base: usize) -> Vec<SourceLine> {
     let mut lines = Vec::new();
     let mut depth = 0i32;
-    for raw in body.lines() {
-        let line = strip_comment(raw).trim();
+    let mut line_start = base;
+    for raw in body.split('\n') {
+        let consumed = raw.chars().count() + 1;
+        let stripped = strip_comment(raw);
+        let line = stripped.trim();
         if line.is_empty() {
+            line_start += consumed;
             continue;
         }
         let before = depth;
         depth += line.matches('{').count() as i32 - line.matches('}').count() as i32;
         if before == 0 && !line.contains('{') && !line.contains('}') {
-            lines.push(strip_semi(line));
+            let indent = stripped.chars().count() - stripped.trim_start().chars().count();
+            lines.push(SourceLine {
+                text: strip_semi(line),
+                offset: line_start + indent,
+            });
         }
+        line_start += consumed;
     }
     lines
+}
+
+/// One `top_lines` statement with the char offset of its first non-space
+/// character in the whole project source.
+struct SourceLine {
+    text: String,
+    offset: usize,
+}
+
+/// Resolve a char offset in `source` to the 1-based `loc` line and column
+/// `docs/DESIGN-v1.md` §7.2 guarantees every `parse` error carries (#562).
+#[allow(clippy::cast_possible_truncation)]
+fn line_column(source: &str, offset: usize) -> (u32, u32) {
+    let mut line = 1u32;
+    let mut column = 1u32;
+    for ch in source.chars().take(offset) {
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
 }
 
 fn atom(text: &str) -> String {
@@ -641,7 +693,8 @@ fn is_dotted_ident(s: &str) -> bool {
 
 fn parse_dataset(block: &RawBlock) -> AiDataset {
     let mut source = None;
-    for line in top_lines(&block.body) {
+    for entry in top_lines(&block.body, block.body_offset) {
+        let line = entry.text.as_str();
         if let Some(rest) = line.strip_prefix("source ") {
             source = Some(atom(rest));
         }
@@ -653,7 +706,11 @@ fn parse_dataset(block: &RawBlock) -> AiDataset {
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement {
+fn parse_metric_requirement(
+    line: &str,
+    slice_name: &str,
+    position: (u32, u32),
+) -> AiMetricRequirement {
     let source = line.to_owned();
     let expr = line.trim();
     if let Some((idx, op)) = find_comparator(expr) {
@@ -669,6 +726,8 @@ fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement
                 comparator: Some(op.to_owned()),
                 threshold: Some(value),
                 slice: slice_name.to_owned(),
+                line: position.0,
+                column: position.1,
                 min_samples: Some(value as u64),
                 source,
             };
@@ -686,6 +745,8 @@ fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement
                     comparator: Some(op.to_owned()),
                     threshold: Some(threshold),
                     slice: slice_name.to_owned(),
+                    line: position.0,
+                    column: position.1,
                     min_samples: None,
                     source,
                 };
@@ -701,6 +762,8 @@ fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement
                 comparator: Some(op.to_owned()),
                 threshold: Some(threshold),
                 slice: slice_name.to_owned(),
+                line: position.0,
+                column: position.1,
                 min_samples: None,
                 source,
             };
@@ -713,18 +776,24 @@ fn parse_metric_requirement(line: &str, slice_name: &str) -> AiMetricRequirement
         comparator: None,
         threshold: None,
         slice: slice_name.to_owned(),
+        line: position.0,
+        column: position.1,
         min_samples: None,
         source,
     }
 }
 
-fn parse_statistical_property(block: &RawBlock) -> Result<AiStatisticalProperty, String> {
+fn parse_statistical_property(
+    block: &RawBlock,
+    source: &str,
+) -> Result<AiStatisticalProperty, String> {
     let mut target = None;
     let mut dataset = None;
     let mut evaluator = None;
     let mut confidence = 0.95;
     let mut requirements = Vec::new();
-    for line in top_lines(&block.body) {
+    for entry in top_lines(&block.body, block.body_offset) {
+        let line = entry.text.as_str();
         if let Some(rest) = line.strip_prefix("target ") {
             target = Some(atom(rest));
         } else if let Some(rest) = line.strip_prefix("dataset ") {
@@ -739,16 +808,25 @@ fn parse_statistical_property(block: &RawBlock) -> Result<AiStatisticalProperty,
                 )
             })?;
         } else if let Some(rest) = line.strip_prefix("require ") {
-            requirements.push(parse_metric_requirement(rest, "all"));
+            requirements.push(parse_metric_requirement(
+                rest,
+                "all",
+                line_column(source, entry.offset),
+            ));
         }
     }
-    for child in top_blocks(&block.body)? {
+    for child in top_blocks(&block.body, block.body_offset)? {
         if child.kind != "slice" {
             continue;
         }
-        for line in top_lines(&child.body) {
+        for entry in top_lines(&child.body, child.body_offset) {
+            let line = entry.text.as_str();
             if let Some(rest) = line.strip_prefix("require ") {
-                requirements.push(parse_metric_requirement(rest, &child.name));
+                requirements.push(parse_metric_requirement(
+                    rest,
+                    &child.name,
+                    line_column(source, entry.offset),
+                ));
             }
         }
     }
@@ -762,7 +840,11 @@ fn parse_statistical_property(block: &RawBlock) -> Result<AiStatisticalProperty,
     })
 }
 
-fn parse_observed_requirement(line: &str, slice_name: &str) -> AiObservedRequirement {
+fn parse_observed_requirement(
+    line: &str,
+    slice_name: &str,
+    position: (u32, u32),
+) -> AiObservedRequirement {
     let expr = line.trim();
     if let Some((idx, op)) = find_comparator(expr) {
         let left = expr[..idx].trim();
@@ -779,6 +861,8 @@ fn parse_observed_requirement(line: &str, slice_name: &str) -> AiObservedRequire
                 threshold,
                 compared_to: None,
                 slice: slice_name.to_owned(),
+                line: position.0,
+                column: position.1,
                 source: line.to_owned(),
             };
         }
@@ -798,6 +882,8 @@ fn parse_observed_requirement(line: &str, slice_name: &str) -> AiObservedRequire
                     threshold,
                     compared_to: Some(compared_to.to_owned()),
                     slice: slice_name.to_owned(),
+                    line: position.0,
+                    column: position.1,
                     source: line.to_owned(),
                 };
             }
@@ -810,16 +896,22 @@ fn parse_observed_requirement(line: &str, slice_name: &str) -> AiObservedRequire
         threshold: 0.0,
         compared_to: None,
         slice: slice_name.to_owned(),
+        line: position.0,
+        column: position.1,
         source: line.to_owned(),
     }
 }
 
-fn parse_observed_property(block: &RawBlock) -> Result<AiObservedProperty, String> {
+fn parse_observed_property(
+    block: &RawBlock,
+    project_source: &str,
+) -> Result<AiObservedProperty, String> {
     let mut target = None;
     let mut source = None;
     let mut window = None;
     let mut requirements = Vec::new();
-    for line in top_lines(&block.body) {
+    for entry in top_lines(&block.body, block.body_offset) {
+        let line = entry.text.as_str();
         if let Some(rest) = line.strip_prefix("target ") {
             target = Some(atom(rest));
         } else if let Some(rest) = line.strip_prefix("source ") {
@@ -827,16 +919,25 @@ fn parse_observed_property(block: &RawBlock) -> Result<AiObservedProperty, Strin
         } else if let Some(rest) = line.strip_prefix("window ") {
             window = Some(atom(rest));
         } else if let Some(rest) = line.strip_prefix("require ") {
-            requirements.push(parse_observed_requirement(rest, "all"));
+            requirements.push(parse_observed_requirement(
+                rest,
+                "all",
+                line_column(project_source, entry.offset),
+            ));
         }
     }
-    for child in top_blocks(&block.body)? {
+    for child in top_blocks(&block.body, block.body_offset)? {
         if child.kind != "slice" {
             continue;
         }
-        for line in top_lines(&child.body) {
+        for entry in top_lines(&child.body, child.body_offset) {
+            let line = entry.text.as_str();
             if let Some(rest) = line.strip_prefix("require ") {
-                requirements.push(parse_observed_requirement(rest, &child.name));
+                requirements.push(parse_observed_requirement(
+                    rest,
+                    &child.name,
+                    line_column(project_source, entry.offset),
+                ));
             }
         }
     }
@@ -878,21 +979,22 @@ fn parse_regression_requirement(
 
 fn parse_migration(block: &RawBlock) -> Result<AiMigration, String> {
     let mut regression_requirements = Vec::new();
-    for child in top_blocks(&block.body)? {
+    for child in top_blocks(&block.body, block.body_offset)? {
         if child.kind != "preserve" {
             continue;
         }
-        for grandchild in top_blocks(&child.body)? {
+        for grandchild in top_blocks(&child.body, child.body_offset)? {
             if grandchild.kind != "no_regression" {
                 continue;
             }
             let mut dataset = None;
-            for line in top_lines(&grandchild.body) {
+            for entry in top_lines(&grandchild.body, grandchild.body_offset) {
+                let line = entry.text.as_str();
                 if let Some(rest) = line.strip_prefix("dataset ") {
                     dataset = Some(atom(rest));
                 } else if line.starts_with("metric ") {
                     regression_requirements
-                        .push(parse_regression_requirement(&line, dataset.clone())?);
+                        .push(parse_regression_requirement(line, dataset.clone())?);
                 }
             }
         }

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -47,9 +47,17 @@ pub fn ai_project_name(source_file: &str) -> &str {
 ///
 /// # Errors
 ///
-/// Returns the parse or unexecutable-clause message, for `kind: "parse"`.
-pub fn parse_checked_ai_project(source: &str, name: &str) -> Result<fsl_syntax::AiProject, String> {
-    let project = fsl_syntax::parse_ai_project(source, name)?;
+/// Returns the parse or unexecutable-clause message, carrying the position of
+/// the first offending clause when there is one, for `kind: "parse"`.
+pub fn parse_checked_ai_project(
+    source: &str,
+    name: &str,
+) -> Result<fsl_syntax::AiProject, AiProjectParseError> {
+    let project =
+        fsl_syntax::parse_ai_project(source, name).map_err(|message| AiProjectParseError {
+            message,
+            position: None,
+        })?;
     let unparsed = project.unparsed_clauses();
     if unparsed.is_empty() {
         return Ok(project);
@@ -64,10 +72,24 @@ pub fn parse_checked_ai_project(source: &str, name: &str) -> Result<fsl_syntax::
         })
         .collect::<Vec<_>>()
         .join("; ");
-    Err(format!(
-        "require clause matches no known fsl-ai evidence clause grammar \
-         (min_samples, ci_lower, ci_upper, a point estimate, observed, or drift): {detail}"
-    ))
+    // `unparsed_clauses` walks declarations in source order, so the first entry
+    // is the first offending clause; report its own line, not its block's.
+    let first = &unparsed[0];
+    Err(AiProjectParseError {
+        message: format!(
+            "require clause matches no known fsl-ai evidence clause grammar \
+             (min_samples, ci_lower, ci_upper, a point estimate, observed, or drift): {detail}"
+        ),
+        position: Some((first.line, first.column)),
+    })
+}
+
+/// An fsl-ai project check failure, carrying the offending clause's position
+/// when the parser resolved one. `docs/DESIGN-v1.md` §7.2 guarantees every
+/// `parse` error carries a `loc` (#562).
+pub struct AiProjectParseError {
+    pub message: String,
+    pub position: Option<(u32, u32)>,
 }
 
 /// Render the multi-declaration AI project check result when applicable,
@@ -82,10 +104,13 @@ pub fn ai_project_check_output(
         return None;
     }
     let spec = ai_project_name(source_file);
-    if let Err(message) = parse_checked_ai_project(source, spec) {
+    if let Err(error) = parse_checked_ai_project(source, spec) {
         output.insert("result".to_owned(), json!("error"));
         output.insert("kind".to_owned(), json!("parse"));
-        output.insert("message".to_owned(), json!(message));
+        output.insert("message".to_owned(), json!(error.message));
+        if let Some((line, column)) = error.position {
+            output.insert("loc".to_owned(), json!({"line": line, "column": column}));
+        }
         return Some((Value::Object(output), 2));
     }
     output.insert("result".to_owned(), json!("ok"));

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6298,7 +6298,15 @@ fn run_ai_project_check(source: &str, path: &Path) -> (Value, i32) {
         &ai_project_name(path),
     ) {
         Ok(project) => project,
-        Err(message) => return (error_output("parse", &message), 2),
+        Err(error) => {
+            let mut output = error_output("parse", &error.message);
+            if let Some((line, column)) = error.position
+                && let Some(object) = output.as_object_mut()
+            {
+                object.insert("loc".to_owned(), json!({"line": line, "column": column}));
+            }
+            return (output, 2);
+        }
     };
     wrap_specialized(
         json!({"result":"ai_project_analyzed","formal_result":"not_run","components":project.components.iter().map(|component|&component.name).collect::<Vec<_>>(),"statistical_properties":project.statistical_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"observed_properties":project.observed_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"migrations":project.migrations.iter().map(|migration|&migration.name).collect::<Vec<_>>(),"raw_blocks":project.raw_blocks.iter().map(|block|json!({"kind":block.kind,"name":block.name})).collect::<Vec<_>>(),"findings":[]}),

--- a/rust/fslc/tests/fixtures/issue_562_nested_slice_clause.fsl
+++ b/rust/fslc/tests/fixtures/issue_562_nested_slice_clause.fsl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The offending clause sits inside a nested `slice` block, below a comment
+// header and a sibling declaration, so a `loc` derived from the enclosing
+// block's position rather than the clause's own line would be visibly wrong.
+
+ai_component Target {
+  model m
+  prompt p
+}
+
+statistical_property Nested {
+  target Target
+  confidence 0.95
+
+  slice JapaneseTickets {
+    require min_samples >= 5
+    require this clause is not executable by ai eval
+  }
+}

--- a/rust/fslc/tests/issue_562_ai_project_clause_loc.rs
+++ b/rust/fslc/tests/issue_562_ai_project_clause_loc.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Issue #562, first half: the fsl-ai project parser tracked no positions, so
+//! the spec error #542 introduced for an unexecutable `require` clause carried
+//! no `loc` at all. `docs/DESIGN-v1.md` §7.2 guarantees every `parse` error
+//! carries one.
+//!
+//! These assert the **exact** line and column of the offending clause, never
+//! merely that `loc` is present: a position derived from the enclosing block
+//! instead of the clause's own line would satisfy "not null" while pointing a
+//! consumer at the wrong line, which is worse than reporting nothing.
+//!
+//! The second half of #562 — rejecting an unknown *non-*`require` line inside
+//! a declaration body — is deliberately not addressed here; it requires
+//! deciding a closed body grammar that no current source specifies. See the
+//! `CHANGELOG.md` entry and the report on the issue.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+/// `require` on line 5, indented two spaces, so column 3.
+#[test]
+fn a_statistical_clause_reports_its_own_line_and_column() {
+    let path = fixture("issue_542_unparseable_statistical_clause.fsl")
+        .display()
+        .to_string();
+    for command in [
+        vec!["ai", "check", &path],
+        // The generic dispatch shares the envelope and must carry it too.
+        vec!["check", &path],
+    ] {
+        let (value, status) = run(&command);
+        assert_eq!(status, 2, "{command:?}: {value}");
+        assert_eq!(value["kind"], "parse", "{command:?}: {value}");
+        assert_eq!(
+            value["loc"],
+            json!({"line": 5, "column": 3}),
+            "{command:?}: {value}"
+        );
+    }
+}
+
+/// The clause sits inside a nested `slice`, on line 18 at column 5. A `loc`
+/// taken from the `statistical_property` block (line 12) or from the `slice`
+/// block (line 16) would be non-null and wrong.
+#[test]
+fn a_clause_nested_in_a_slice_reports_the_clause_line_not_the_block() {
+    let path = fixture("issue_562_nested_slice_clause.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "parse", "{value}");
+    assert_eq!(value["loc"], json!({"line": 18, "column": 5}), "{value}");
+}
+
+/// `observed_property` clauses run through a separate parser; its position
+/// must be resolved the same way. The offending clause is on line 13.
+#[test]
+fn an_observed_clause_reports_its_own_line_and_column() {
+    let path = fixture("issue_542_unparseable_observed_clause.fsl")
+        .display()
+        .to_string();
+    let (value, status) = run(&["ai", "check", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "parse", "{value}");
+    assert_eq!(value["loc"], json!({"line": 13, "column": 3}), "{value}");
+}
+
+/// Positive control. Position tracking must not change which projects are
+/// accepted: the corpus's only fsl-ai project file still analyzes at exit 0,
+/// with its declarations intact. Increasing rejection power at the cost of
+/// valid input would be a different regression.
+#[test]
+fn the_corpus_project_still_analyzes_unchanged() {
+    for command in [
+        vec!["ai", "check", "examples/ai/support_answer_quality.fsl"],
+        vec!["check", "examples/ai/support_answer_quality.fsl"],
+    ] {
+        let (value, status) = run(&command);
+        assert_eq!(status, 0, "{command:?}: {value}");
+        assert!(value.get("loc").is_none(), "{command:?}: {value}");
+    }
+    let (value, _) = run(&["ai", "check", "examples/ai/support_answer_quality.fsl"]);
+    assert_eq!(value["result"], "ai_project_analyzed", "{value}");
+    assert_eq!(
+        value["statistical_properties"],
+        json!(["LooseQuality", "StrictQuality"]),
+        "{value}"
+    );
+    assert_eq!(
+        value["observed_properties"],
+        json!(["SupportAgentOperationalQuality"]),
+        "{value}"
+    );
+}


### PR DESCRIPTION
## Problem

`docs/DESIGN-v1.md` §7.2 guarantees every `parse` error carries a `loc`. The fsl-ai project parser
**tracked no positions at all**, so the parse error #542 introduced named the declaration and slice but
gave no position — and nothing in the message recovered one either.

## Scope: this closes half of #562, deliberately

#562 asked for two things: reject unknown lines inside a declaration body, and give the parse error a
`loc`. **Only the `loc` half is here.** The other half turned out not to be an implementation defect.

The issue's premise was that the three sources specify what declaration bodies may contain and the
implementation does not honour it. Measured, that premise does not hold — **none of them specifies the
body grammar at all**:

- **Frozen `src/fslc/ai_project.py` is open by construction.** `_parse_statistical_property` is an
  `if`/`elif` chain with **no `else`** (verified: zero `else` branches). Unknown lines are dropped. Run
  on the issue's own fixture it returns `ai_project_analyzed` with requirements `[]`.
- **`docs/LANGUAGE.md`** states only the `require`-clause rule #542 added. Silent on every other line.
- **`skills/fsl/reference.md:560-564` documents the opposite** for four constructs: `ai_action`,
  `retriever`, `trust_boundary` and a top-level named `authority` are "recognized only as block
  *boundaries*: the parser does not descend into their body at all, so any text inside — even garbage —
  passes `check`." That is intended, already anchored by
  `issue_542_…::ai_check_still_accepts_garbage_inside_an_unvalidated_raw_block`, so any closed grammar
  must leave those open.
- **The corpus contradicts a closed grammar.** `examples/ai/support_answer_quality.fsl` — the one
  legitimate project file, i.e. the entire positive control — uses free-form predicates inside
  `dataset`'s `population`/`slice` (`language in ["ja", "en"]`, `ticket_type == "refund"`) and in
  `failure_mode` (`condition output.claims not_supported_by retrieved.sources`). Both implementations
  store these verbatim and never parse them; no expression syntax for them is defined anywhere.

Closing the grammar half therefore means **authoring** a closed grammar per declaration,
reverse-engineered from a single corpus sample, while carving out constructs documented as
deliberately open — with exactly the reject-valid-input risk that matters most here. That is a
language-contract decision, not an implementation fix, so it was not attempted. #562 is retitled to
that decision and records the three questions it needs answered; the `CHANGELOG.md` entry says which
half shipped rather than leaving it implicit.

**A consequence worth stating**: the frozen reference does not error on a bad `require` clause either —
it returns `[('inconclusive', …)]` and still `ai_project_analyzed`. So **#542 was already a native-only
tightening**, not parity recovery, which PR #561's body did not say. That divergence is being kept
(native is authoritative, Python is scheduled for deletion, the internal `check`-vs-`eval`
inconsistency stands on its own, the direction is fail-closed, and no corpus parity case regressed) and
is now recorded on #542 rather than left to be rediscovered.

## Contract change

None. `RawBlock` carries its body's char offset, `top_lines` yields each statement with the offset of
its first non-space character, each metric/observed requirement records the position of the clause that
produced it, and both `fslc ai check` and the `fslc check` dispatch emit `loc`.

**Acceptance is unchanged.** Nothing that passed before is rejected now, including the
garbage-non-`require` case — that is the half deliberately left open.

## Test evidence

Positions verified against the source text, because a `loc` that is present but wrong is worse than
`loc: null` and "not null" cannot tell them apart:

| case | loc |
|---|---|
| top-level clause | `{line:5, column:3}` |
| clause nested in a `slice` | `{line:18, column:5}` |
| `observed_property` clause | `{line:13, column:3}` |

The nested case is the discriminating one: the fixture puts the offending clause below a comment
header and a sibling declaration, so a `loc` derived from the enclosing block would report line 12
(`statistical_property`) or line 16 (`slice`) instead. Re-verified independently on the rebased tree —
`{line:18, column:5}` points at the `require` on line 18, not at either enclosing block.

Ablation (`git checkout HEAD~1 -- <3 files>`, revert confirmed non-empty at 37+/172− before drawing a
conclusion) fails `a_statistical_clause_reports_its_own_line_and_column`,
`a_clause_nested_in_a_slice_reports_the_clause_line_not_the_block`, and
`an_observed_clause_reports_its_own_line_and_column`.

Passing both ways, **stated as such rather than counted as coverage**:
`the_corpus_project_still_analyzes_unchanged` (a positive control, which must pass before and after)
and all five of #542's tests.

Independently re-verified: `examples/ai/support_answer_quality.fsl` still returns
`ai_project_analyzed` / exit 0 from both `ai check` and `check`, with 2 statistical and 1 observed
property intact.

Gate on the rebased base (`82f0d4e`): `cargo fmt --check` 0, `cargo clippy --workspace --all-targets
--locked -D warnings` 0, `cargo test --workspace --locked` 0, `./tools/check-native-integration.sh` 0
(nativeParity true, 351 parity cases).

## Coordination

**#563 will conflict with this.** It edits the same `top_blocks` / `top_lines` in
`rust/fsl-syntax/src/ai_project.rs`, whose signatures now take an offset, and any new
`evaluator`/`failure_mode` parser will need to thread it through. Nothing was added to the `ai check`
projection here.

## Documentation

`CHANGELOG.md` `[Unreleased]` — records both the fix and the deliberately-unfixed half.

## Linked issues

Refs #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
