### PR TITLE
fix(wasm): classify kernel-stage load failures through native's classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,28 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `loc` rather than emitting a `{line: 0, column: 0}` placeholder;
   `docs/DESIGN-v1.md` now states that exception explicitly instead of leaving
   the clause overstating the implementation (#555).
+- The browser Worker no longer classifies a kernel-stage load failure
+  differently from the native CLI. `rust/fsl-wasm`'s `build()` hard-coded every
+  `fsl_core::parse_kernel_source_with_file` failure to `kind: "parse"`, while
+  native carried the same `CoreError` through `kernel_load_error` and reported
+  `semantics`/`type`/`name` — the same input classified two ways depending on
+  which surface ran it, which `AGENTS.md` forbids allowlisting and which makes
+  `docs/DESIGN-v1.md`'s closed `kind` set meaningless. The classifier and its
+  render dispatch moved out of the `fslc` binary into `fslc_rust::spec_load`
+  (`SpecLoadError`, `kernel_load_error`, `surface_parse_failure`,
+  `render_spec_load_error`) so both surfaces run the same one; the Worker gained
+  no classifier of its own, since a parallel classifier is what diverged.
+  Native's classification is unchanged.
+  Detection power was zero: `examples/gallery/errors/` had no input that fails
+  at the kernel stage while its own top level parses — every such file in
+  `specs/`+`examples/` is a refinement, agent, or causal document the parity
+  harness excludes as unsupported — so the divergence was invisible to
+  `./tools/check-native-integration.sh`.
+  `examples/gallery/errors/semantics_compose_component_parse_failure.fsl` and
+  its `semantics_compose_broken_component.fsl` helper close that hole, taking
+  the native↔Worker parity corpus from 351 to 355 cases, and
+  `rust/fsl-wasm/test-browser.mjs` now fails loudly if the case ever leaves the
+  corpus (#556).
 - Every spec-reading native command now classifies a syntax error the way
   `check` does: `kind: "parse"` with `diagnostic_code: "FSL-PARSE"` and a
   `loc`. `rust/fslc/src/main.rs`'s `load_kernel_model` flattened the frontend's

--- a/examples/gallery/errors/README.md
+++ b/examples/gallery/errors/README.md
@@ -24,6 +24,19 @@ of JSON output actually confirmed with `fslc`.
 ```
 
 ```json
+// semantics_compose_component_parse_failure.fsl
+{"result":"error","kind":"semantics","message":"expected expression at examples/gallery/errors/semantics_compose_component_parse_failure.fsl:7:18"}
+```
+
+`semantics_compose_component_parse_failure.fsl`, with its
+`semantics_compose_broken_component.fsl` helper, is the native↔Worker parity
+control for the kernel stage (issue #556). Its own top level parses, so the
+failure comes from resolving and lowering the component; the component's syntax
+error is not this document's own syntax error, so it stays `semantics` on both
+surfaces rather than becoming `parse`. No corpus case reached that stage
+before, which is why the Worker could classify all of it as `parse` undetected.
+
+```json
 // vacuous_contradictory_init.fsl
 {"result":"error","kind":"vacuous","message":"init constraints are unsatisfiable — the spec has no initial state"}
 ```

--- a/examples/gallery/errors/semantics_compose_broken_component.fsl
+++ b/examples/gallery/errors/semantics_compose_broken_component.fsl
@@ -1,0 +1,8 @@
+// expected-helper: used by semantics_compose_component_parse_failure.fsl
+// expected-command: check
+// expected-result: error
+// expected-kind: parse
+spec GallerySemanticsComposeBrokenComponent {
+  state { count: Int }
+  init { count = }
+}

--- a/examples/gallery/errors/semantics_compose_component_parse_failure.fsl
+++ b/examples/gallery/errors/semantics_compose_component_parse_failure.fsl
@@ -1,0 +1,20 @@
+// expected-command: check
+// expected-result: error
+// expected-kind: semantics
+//
+// The native<->Worker parity control for issue #556. This document's own top
+// level parses, so the failure surfaces while resolving and lowering the
+// component -- `fsl_core::parse_kernel_source_with_file`, the kernel stage.
+// Both surfaces must classify that stage through the same
+// `spec_load::kernel_load_error`: the component's parse failure is not this
+// document's own syntax error, so it stays `semantics`. The Worker used to
+// hard-code the whole stage to `kind:"parse"`, and no corpus case reached it.
+compose GallerySemanticsComposeComponentParseFailure {
+  use GallerySemanticsComposeBrokenComponent as broken
+      from "semantics_compose_broken_component.fsl"
+
+  state { seen: Int }
+  init  { seen = 0 }
+
+  invariant SeenNonNegative { seen >= 0 }
+}

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -122,9 +122,19 @@ fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Va
     let resolver = MemoryResolver {
         files: request.files.clone(),
     };
+    // Classified by the same `kernel_load_error` the native CLI runs and
+    // rendered by the same dispatch. This stage used to be hard-coded to
+    // `kind:"parse"` here while native reported `semantics`/`type` for the very
+    // same input (issue #556); a second classifier on this side is what
+    // produced that divergence, so there must not be one.
     let kernel =
         fsl_core::parse_kernel_source_with_file(&request.source, &resolver, &request.source_file)
-            .map_err(|failure| error(solver_version, "parse", failure.to_string()))?;
+            .map_err(|failure| {
+            fslc_rust::spec_load::render_spec_load_error(
+                envelope(solver_version),
+                &fslc_rust::spec_load::kernel_load_error(&request.source, &failure),
+            )
+        })?;
     // Compose-lowering warnings (e.g. `fair_not_inherited`) are computed while
     // lowering, before `build_model` drops the per-component information that
     // produced them, so they must be captured here rather than derived from

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -166,6 +166,16 @@ const governanceErrorCase = "examples/gallery/errors/governance_missing_before.f
 if (!parityCases.some((testCase) => testCase.path === governanceErrorCase)) {
   throw new Error(`${governanceErrorCase} must remain in the parity corpus`);
 }
+// The only corpus input that fails at the kernel stage
+// (`fsl_core::parse_kernel_source_with_file`) while its own top level parses.
+// Every other kernel-stage failure under specs/+examples/ is a refinement,
+// agent, or causal document this harness excludes as unsupported, so without
+// this case the Worker could classify that whole stage differently from native
+// and no parity run would notice (issue #556).
+const kernelStageCase = "examples/gallery/errors/semantics_compose_component_parse_failure.fsl";
+if (!parityCases.some((testCase) => testCase.path === kernelStageCase)) {
+  throw new Error(`${kernelStageCase} must remain in the parity corpus`);
+}
 const missingGovernanceDependency = "rust/fslc/tests/fixtures/governance_missing_dependency.fsl";
 const missingGovernanceSource = await readFile(join(repository, missingGovernanceDependency), "utf8");
 parityCases.push({

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -11,6 +11,7 @@ pub mod migration;
 pub mod origin_coverage;
 pub mod replay_trace;
 pub mod source_diagnostic;
+pub mod spec_load;
 pub mod verification_output;
 
 pub use fsl_core::{

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -13,6 +13,9 @@ use fsl_core::{
     ParamDef, TraceStep, TypeDef, TypeRef, insert_requirement_metadata, model_warnings,
     requirement_metadata,
 };
+use fslc_rust::spec_load::{
+    SemanticDiagnostic, SpecLoadError, kernel_load_error, surface_parse_failure,
+};
 use serde_json::{Map, Value, json};
 
 mod approval;
@@ -15358,86 +15361,6 @@ fn parse_param_value(
     }
 }
 
-/// A spec-loading failure that keeps the diagnostic class the frontend
-/// determined instead of flattening it to a message string.
-///
-/// `docs/DESIGN-v1.md` §7.2 fixes the error classification as a closed set and
-/// guarantees `loc` for `parse`. Flattening a surface-parse failure into a
-/// `String` erased that class, so every command loading a spec through
-/// [`load_kernel_model`] re-classified a syntax error as `semantics` with no
-/// `loc`, while `check` — which runs the surface parser directly — reported
-/// `parse` with a span.
-///
-/// Issue 555 completed the other half: `Semantic` flattened the typed-model
-/// diagnostic to a `String` too, dropping the span the model had already bound
-/// to the offending construct, so `type` and `semantics` reported `loc: null`
-/// on every command including `check`. It now carries the span alongside the
-/// message.
-#[derive(Debug)]
-enum SpecLoadError {
-    Io(String),
-    Parse(Box<fsl_syntax::ParseError>),
-    Semantic(SemanticDiagnostic),
-}
-
-/// A typed-model spec-load failure with the location the model recorded for the
-/// construct that failed, when it recorded one.
-#[derive(Debug)]
-struct SemanticDiagnostic {
-    message: String,
-    loc: Option<Value>,
-}
-
-impl SemanticDiagnostic {
-    /// A diagnostic raised where no origin is in scope. `loc` stays absent: a
-    /// `{line: 0, column: 0}` placeholder would satisfy the schema while
-    /// pointing a repair agent at a location that does not exist.
-    fn unlocated(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            loc: None,
-        }
-    }
-
-    /// A diagnostic carrying the origin the frontend bound to the offending
-    /// construct. Yields the same `loc` as [`Self::unlocated`] when that origin
-    /// has no span, rather than inventing one.
-    fn located(message: impl Into<String>, origin: Option<&fsl_core::OriginChain>) -> Self {
-        Self {
-            message: message.into(),
-            loc: fslc_rust::verification_output::origin_loc(origin),
-        }
-    }
-
-    /// A typed-model failure, located by the span it recorded for itself or by
-    /// its enclosing construct's lowering origin.
-    fn from_model_error(error: &fsl_core::ModelError) -> Self {
-        Self {
-            message: error.to_string(),
-            loc: fslc_rust::verification_output::model_error_loc(error),
-        }
-    }
-}
-
-impl SpecLoadError {
-    /// A `semantics` failure that owns no construct in the specification: a
-    /// rejected CLI selection, a whole-document shape mismatch, or a diagnostic
-    /// whose span belongs to a different file than the one being reported on.
-    fn unlocated_semantic(message: impl Into<String>) -> Self {
-        Self::Semantic(SemanticDiagnostic::unlocated(message))
-    }
-}
-
-impl std::fmt::Display for SpecLoadError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(message) => formatter.write_str(message),
-            Self::Semantic(diagnostic) => formatter.write_str(&diagnostic.message),
-            Self::Parse(error) => write!(formatter, "{error}"),
-        }
-    }
-}
-
 fn load_model(path: &Path) -> Result<KernelModel, SpecLoadError> {
     load_kernel_model(path).map(|(_, _, model)| model)
 }
@@ -15463,36 +15386,6 @@ fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), S
 fn read_spec_source(path: &Path) -> Result<String, SpecLoadError> {
     std::fs::read_to_string(path)
         .map_err(|error| SpecLoadError::Io(format!("{}: {error}", path.display())))
-}
-
-/// Recover the typed surface-parse diagnostic behind a lowering or projection
-/// failure that only reports a message.
-///
-/// The kernel and document entrypoints run the surface parser themselves and
-/// report the result as a `CoreError`/projection message, so the class is
-/// recovered by re-running the same parser on the failure path only. A compose
-/// document whose *component* fails to parse still lowers its own top level
-/// successfully and therefore stays `semantics`, exactly as `check` reports it.
-fn surface_parse_failure(source: &str) -> Option<fsl_syntax::ParseError> {
-    fsl_syntax::parse_document(fsl_syntax::SourceFile::new(source)).err()
-}
-
-/// Classify a kernel lowering failure, preserving a surface-parse span.
-fn kernel_load_error(source: &str, error: &fsl_core::CoreError) -> SpecLoadError {
-    if let Some(parse_error) = surface_parse_failure(source) {
-        return SpecLoadError::Parse(Box::new(parse_error));
-    }
-    // The substituted "spec has no state block" message describes the document
-    // as a whole rather than the construct the lowering gate stopped at, so it
-    // keeps no location; the original diagnostic keeps whatever origin the
-    // frontend recorded.
-    if error.message == "top-level document has not reached the kernel lowering gate" {
-        return SpecLoadError::Semantic(SemanticDiagnostic::unlocated("spec has no state block"));
-    }
-    SpecLoadError::Semantic(SemanticDiagnostic::located(
-        error.to_string(),
-        error.origin.as_deref(),
-    ))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -15826,17 +15719,7 @@ fn baseline_error_status(baseline: &Value, status: i32) -> i32 {
 /// every spec-reading command emits the envelope `check` emits for the same
 /// file (`kind:"parse"` + `diagnostic_code` + `loc` for a syntax error).
 fn spec_load_error_output(error: &SpecLoadError) -> Value {
-    match error {
-        SpecLoadError::Io(message) => error_output("io", message),
-        SpecLoadError::Parse(error) => surface_parse_error_output(error),
-        SpecLoadError::Semantic(diagnostic) => {
-            fslc_rust::verification_output::render_semantic_error(
-                envelope(),
-                &diagnostic.message,
-                diagnostic.loc.clone(),
-            )
-        }
-    }
+    fslc_rust::spec_load::render_spec_load_error(envelope(), error)
 }
 
 fn finish(output: &mut Map<String, Value>, checked: usize, started: Instant) {

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed spec-load failure shared by the native CLI and the browser Worker.
+//!
+//! Both delivery surfaces load a spec through
+//! `fsl_core::parse_kernel_source_with_file`, and a failure there must be
+//! reported with the same `kind` on both (`AGENTS.md`: "Native CLI and Worker
+//! output must preserve the JSON envelope, exit codes, locations, and
+//! replayable evidence contract"). The Worker used to classify that same
+//! `CoreError` as `kind:"parse"` while native reported `semantics`/`type`
+//! (issue #556), because each surface carried its own classification. There is
+//! now one classifier -- [`kernel_load_error`] -- and one render dispatch --
+//! [`render_spec_load_error`].
+//!
+//! This is the former `main.rs` block relocated, span work from issue #555
+//! included. Native's classification and its locations are unchanged by the
+//! move: a `type`/`semantics` diagnostic still carries the span the model bound
+//! to the offending construct.
+
+use serde_json::{Map, Value, json};
+
+/// A spec-loading failure that keeps the diagnostic class the frontend
+/// determined instead of flattening it to a message string.
+///
+/// `docs/DESIGN-v1.md` §7.2 fixes the error classification as a closed set and
+/// guarantees `loc` for `parse`. Flattening a surface-parse failure into a
+/// `String` erased that class, so every command loading a spec through
+/// `load_kernel_model` re-classified a syntax error as `semantics` with no
+/// `loc`, while `check` -- which runs the surface parser directly -- reported
+/// `parse` with a span.
+///
+/// Issue 555 completed the other half: `Semantic` flattened the typed-model
+/// diagnostic to a `String` too, dropping the span the model had already bound
+/// to the offending construct, so `type` and `semantics` reported `loc: null`
+/// on every command including `check`. It now carries the span alongside the
+/// message.
+#[derive(Debug)]
+pub enum SpecLoadError {
+    Io(String),
+    Parse(Box<fsl_syntax::ParseError>),
+    Semantic(SemanticDiagnostic),
+}
+
+/// A typed-model spec-load failure with the location the model recorded for the
+/// construct that failed, when it recorded one.
+#[derive(Debug)]
+pub struct SemanticDiagnostic {
+    pub message: String,
+    pub loc: Option<Value>,
+}
+
+impl SemanticDiagnostic {
+    /// A diagnostic raised where no origin is in scope. `loc` stays absent: a
+    /// `{line: 0, column: 0}` placeholder would satisfy the schema while
+    /// pointing a repair agent at a location that does not exist.
+    pub fn unlocated(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            loc: None,
+        }
+    }
+
+    /// A diagnostic carrying the origin the frontend bound to the offending
+    /// construct. Yields the same `loc` as [`Self::unlocated`] when that origin
+    /// has no span, rather than inventing one.
+    #[must_use]
+    pub fn located(message: impl Into<String>, origin: Option<&fsl_core::OriginChain>) -> Self {
+        Self {
+            message: message.into(),
+            loc: crate::verification_output::origin_loc(origin),
+        }
+    }
+
+    /// A typed-model failure, located by the span it recorded for itself or by
+    /// its enclosing construct's lowering origin.
+    #[must_use]
+    pub fn from_model_error(error: &fsl_core::ModelError) -> Self {
+        Self {
+            message: error.to_string(),
+            loc: crate::verification_output::model_error_loc(error),
+        }
+    }
+}
+
+impl SpecLoadError {
+    /// A `semantics` failure that owns no construct in the specification: a
+    /// rejected CLI selection, a whole-document shape mismatch, or a diagnostic
+    /// whose span belongs to a different file than the one being reported on.
+    pub fn unlocated_semantic(message: impl Into<String>) -> Self {
+        Self::Semantic(SemanticDiagnostic::unlocated(message))
+    }
+}
+
+impl std::fmt::Display for SpecLoadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(message) => formatter.write_str(message),
+            Self::Semantic(diagnostic) => formatter.write_str(&diagnostic.message),
+            Self::Parse(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+/// Recover the typed surface-parse diagnostic behind a lowering or projection
+/// failure that only reports a message.
+///
+/// The kernel and document entrypoints run the surface parser themselves and
+/// report the result as a `CoreError`/projection message, so the class is
+/// recovered by re-running the same parser on the failure path only. A compose
+/// document whose *component* fails to parse still lowers its own top level
+/// successfully and therefore stays `semantics`, exactly as `check` reports it.
+#[must_use]
+pub fn surface_parse_failure(source: &str) -> Option<fsl_syntax::ParseError> {
+    fsl_syntax::parse_document(fsl_syntax::SourceFile::new(source)).err()
+}
+
+/// Classify a kernel lowering failure, preserving a surface-parse span.
+#[must_use]
+pub fn kernel_load_error(source: &str, error: &fsl_core::CoreError) -> SpecLoadError {
+    if let Some(parse_error) = surface_parse_failure(source) {
+        return SpecLoadError::Parse(Box::new(parse_error));
+    }
+    // The substituted "spec has no state block" message describes the document
+    // as a whole rather than the construct the lowering gate stopped at, so it
+    // keeps no location; the original diagnostic keeps whatever origin the
+    // frontend recorded.
+    if error.message == "top-level document has not reached the kernel lowering gate" {
+        return SpecLoadError::Semantic(SemanticDiagnostic::unlocated("spec has no state block"));
+    }
+    SpecLoadError::Semantic(SemanticDiagnostic::located(
+        error.to_string(),
+        error.origin.as_deref(),
+    ))
+}
+
+/// Render a classified spec-load failure into the public error envelope.
+#[must_use]
+pub fn render_spec_load_error(mut output: Map<String, Value>, error: &SpecLoadError) -> Value {
+    match error {
+        SpecLoadError::Io(message) => {
+            output.insert("result".to_owned(), json!("error"));
+            output.insert("kind".to_owned(), json!("io"));
+            output.insert("message".to_owned(), json!(message));
+            Value::Object(output)
+        }
+        SpecLoadError::Parse(error) => {
+            crate::frontend_output::render_surface_parse_error(output, error)
+        }
+        SpecLoadError::Semantic(diagnostic) => crate::verification_output::render_semantic_error(
+            output,
+            &diagnostic.message,
+            diagnostic.loc.clone(),
+        ),
+    }
+}


### PR DESCRIPTION
## Problem

`rust/fsl-wasm`'s `build()` mapped a kernel-stage `fsl_core::CoreError` to `kind:"parse"`:

```rust
.map_err(|failure| error(solver_version, "parse", failure.to_string()))?;
```

Native carries the same failure through `SpecLoadError` and reports `semantics` / `type` / `name`. Same
input, two different members of a set `docs/DESIGN-v1.md` calls closed — which is what makes it closed
in name only. `AGENTS.md`: "Do not allowlist verdict, location, assurance, or exit-code differences."

Surface *parse* failures did not diverge; `verify()` checks `parse_surface_document` first and #484
routed both sides through `render_surface_parse_error`. The divergence was specifically input that
passes surface parsing and fails at kernel lowering.

## The corpus premise in the issue was wrong, and measuring it changed the deliverable

The issue proposed adding `examples/gallery/errors/type_undeclared_type.fsl` and
`semantics_duplicate_assignment.fsl` to the parity corpus as "ready-made". **Both were already in it.**
The corpus is not a hand-maintained list — `test-browser.mjs` sweeps `specs/` + `examples/` with
`readdir`, and there is already an explicit guard that `semantics_duplicate_assignment.fsl` must remain.
Following the issue would have been a no-op reported as a closed hole.

Every corpus file that fails to load was classified by the stage it fails at:

- **5 fail in `build_model`** (stage 2) — including both files the issue named. Stage 2 already called
  the shared renderer, so these agreed before the change and prove nothing.
- **6 fail surface parsing** — both surfaces already rendered the same envelope. These are the
  "surface path still agrees" control; still green.
- **29 fail at the kernel stage** — the divergent class — and **every one is a refinement, agent or
  causal document excluded via `unsupportedDocuments`.**

So the corpus reached the divergent path **zero** times, but not for the reason the issue gave. The
hole was "no *supported* document type in the corpus fails at the kernel stage."

## The corpus case that actually closes it

`examples/gallery/errors/semantics_compose_component_parse_failure.fsl` — a `compose` whose own top
level parses cleanly and whose component (`semantics_compose_broken_component.fsl`, an
`expected-helper` following the `refinement_failed_*` pattern) has a syntax error. Resolution and
lowering of the component happen in stage 1, and because the component's syntax error is not the
compose document's own, `kernel_load_error` keeps it `semantics` — exactly the case that function's doc
comment describes.

Three other candidates were probed and rejected by measurement: a spec with no `state` block is stage 2;
a compose over a semantically invalid component is stage 2; and a compose naming a nonexistent
component makes the harness itself throw, since it eagerly reads every `from "…"` target.

**Parity corpus: 351 → 355 cases**, both numbers measured by running the gate rather than computed.
`test-browser.mjs` now fails loudly if the case leaves the corpus, matching the guards already on
`semantics_duplicate_assignment.fsl` and `governance_missing_before.fsl`.

## Contract change

None. `SpecLoadError`, `SemanticDiagnostic`, `kernel_load_error`, `surface_parse_failure` and the render
dispatch move from the `fslc` binary into `rust/fslc/src/spec_load.rs` in the lib crate, so the Worker
consumes native's classifier instead of holding a second one. `main.rs` keeps `spec_load_error_output`
as a thin envelope-binding wrapper and imports the rest, leaving its ~10 construction sites and
`verification.rs`'s `use super::SpecLoadError` textually untouched. **No classifier was added to
`fsl-wasm`** — a parallel classifier is what produced this divergence. `fsl-runtime` is untouched, so
the runtime/solver boundary is undisturbed.

## The rebase hazard, and how it was resolved

This branch *moved* the block that #555 (PR #566) had *edited* — the shape where git can resolve
cleanly and still be wrong. Taking the deletion plus this branch's `spec_load.rs` would compile, pass
most tests, and **silently drop #555's span work**.

Resolution: take the deletion on all three `main.rs` conflicts, then rewrite `spec_load.rs` **from
main's post-#555 source**, not from the version this branch had moved. That pulled across
`Semantic(SemanticDiagnostic)` instead of `Semantic(String)`, the `SemanticDiagnostic` type with
`unlocated`/`located`/`from_model_error`, `unlocated_semantic`, `kernel_load_error`'s located/unlocated
split including the deliberate choice to leave "spec has no state block" unlocated, and the 3-arg
`render_semantic_error`.

Verified by measurement, not inspection — #555's exact positions on the rebased tree:

```
type_undeclared_type.fsl            kind=type       loc={line:5,  column:11}
type_struct_set_field.fsl           kind=type       loc={line:6,  column:3}
semantics_duplicate_assignment.fsl  kind=semantics  loc={line:9,  column:5}
```

consistent across `check`, `replay` and `analyze`, with
`every_spec_reading_command_locates_a_type_or_semantic_error` green.

## Test evidence

Ablation (revert only the `fsl-wasm` hunk to `HEAD~1`): `./tools/check-native-integration.sh` exits 1
on **the same two cases and nothing else** — but each now carries **two** differences:

```
semantics_compose_component_parse_failure.fsl | check  | $.kind native "semantics" vs wasm "parse"
                                              |        | $.loc  native {line:7,column:18} vs wasm missing
                                              | verify | (same two)
```

The `$.loc` difference is new since #555 landed: native's kernel-stage semantic error now carries a
span, and the pre-fix Worker dropped that too. **The shared classifier carries both the kind and
#555's location across to the browser — the two fixes compose rather than merely coexist.** Nothing in
the other 353 cases moved.

Gate on the rebased base (`82f0d4e`): `cargo fmt --check` 0, `cargo clippy --workspace --all-targets
--locked -D warnings` 0, `cargo test --workspace --locked` 0, `./tools/check-native-integration.sh` 0
with `nativeParity: true` and `parityCases: 355`.

`corpus_check_sweep` passes with both new fixtures declaring `expected-result: error`; no snapshot
needed regeneration.

## Known residuals, filed rather than folded in

- **#567** — the new fixture's message reads
  `expected expression at …/semantics_compose_component_parse_failure.fsl:7:18`, but line 7 of that
  file is a comment; `7:18` is the *component*'s `init { count = }`. The path comes from `source_file`
  while the line and column come from the component's parser. Both surfaces produce the identical
  string so parity is unaffected, but the diagnostic points a reader at nothing. Pre-existing.
- **#568** — the 29 excluded refinement/agent/causal documents are never compared native↔Worker at all.
  That may be legitimate, but nothing detects when an exclusion goes stale, and these 29 are precisely
  why this bug had zero coverage.

## Documentation

`CHANGELOG.md` `[Unreleased]`, `examples/gallery/errors/README.md`.

## Linked issues

Fixes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
