### PR TITLE
fix(mutate,html,ai)!: derive the mutate exit code from the result, add the Deadline column, and project the missing ai check fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   Verdicts and exit codes are unaffected, and no review finding changes — the
   manifest path accepts only `--projection traceability_graph`, so no structural
   detector runs there at all (#558).
+- Native `fslc ai check` on an fsl-ai project now emits the six fields the
+  frozen reference's `analyze_ai_project` emits and native omitted:
+  `ai_project`, `assumptions`, `datasets`, `dialect`, `evaluators`, and
+  `failure_modes`. `evaluators` and `failure_modes` were not merely
+  unprojected — the Rust project parser did not descend into `evaluator` /
+  `failure_mode` blocks at all, so the data did not exist; it now records their
+  names, the only thing the reference projects. `skills/fsl/reference.md`
+  already documented `failure_mode` as listed under `failure_modes`, so the
+  skill AI agents read promised output native had never produced; the skill was
+  right and the implementation moved to match it. Native's `ai check` output
+  now equals the frozen reference on all 13 of its keys, and
+  `tools/check_rust_phase3_commands.py`'s `ai-project-check` projection — which
+  compared only six of them, and is why the gap went unnoticed — now compares
+  the whole set (#563).
 - `fslc html`'s property table now renders the "Deadline" column
   `docs/DESIGN-html-report.md` specifies. `grep -ci deadline
   rust/fsl-tools/src/html.rs` was 0: the caption half of that design paragraph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   Verdicts and exit codes are unaffected, and no review finding changes — the
   manifest path accepts only `--projection traceability_graph`, so no structural
   detector runs there at all (#558).
+- `fslc html`'s property table now renders the "Deadline" column
+  `docs/DESIGN-html-report.md` specifies. `grep -ci deadline
+  rust/fsl-tools/src/html.rs` was 0: the caption half of that design paragraph
+  landed with #525 and this was its unimplemented remainder, so a
+  `leadsTo ... within` deadline was invisible in the report. The column is
+  conditional, as the same paragraph's no-`none`-filler rule requires — it
+  appears only when some property declares a deadline, a property that declares
+  none gets an empty cell rather than a filler, and a spec with no deadline
+  anywhere renders no column at all. `explain`'s `skeleton` properties now also
+  carry `within` for a `leadsTo ... within`, additively and only when declared,
+  matching the frozen reference's `_property_skeleton` (#564).
 - **Breaking (exit code).** `fslc mutate` on a spec whose baseline already
   fails now exits 1 instead of 0. `mutate` re-emits the baseline `verify`
   envelope verbatim when the baseline does not verify, but derived its exit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   Verdicts and exit codes are unaffected, and no review finding changes — the
   manifest path accepts only `--projection traceability_graph`, so no structural
   detector runs there at all (#558).
+- **Breaking (exit code).** `fslc mutate` on a spec whose baseline already
+  fails now exits 1 instead of 0. `mutate` re-emits the baseline `verify`
+  envelope verbatim when the baseline does not verify, but derived its exit
+  code from `result == "error"` alone, so every other non-success verdict fell
+  through to 0 and `result:"violated"` returned a green exit — a mutation score
+  is meaningless over a spec that already fails, and a gate reading only the
+  exit code saw a pass. `docs/LANGUAGE.md`'s exit-code table maps `violated`
+  to 1 with no per-command exemption, and `scenarios`/`testgen` re-emit the
+  same envelope and already exited 1. The status is now a total match over the
+  results a mutation run can carry (`mutate_exit_status`): `mutated`/
+  `verified`/`proved` → 0, `violated`/`reachable_failed`/`unknown_cti`/
+  `unknown_budget` → 1, `error` → the code the envelope was already classified
+  with, and anything unmapped → 3 rather than silently 0. Mapping the whole
+  vocabulary also closed a second reachable false green in the same command:
+  `--from <unreadable file>` returned `result:"error"`, `kind:"io"` with exit 0
+  and now exits 2 (#554).
 - Native `fslc mutate` now defaults to 200 built-in mutants instead of 100,
   matching the `max_mutants` default its own published CLI contract
   (`rust/fslc/cli-contract.json`) advertises and the 200 fixed by

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -163,6 +163,14 @@ pub struct AiProject {
     pub name: String,
     pub components: Vec<AiComponent>,
     pub datasets: Vec<AiDataset>,
+    /// Declared `evaluator` names. Only the name is modelled: the frozen
+    /// reference's `analyze_ai_project` projects nothing else, and no command
+    /// checks an evaluator's body against evidence (issue #563).
+    pub evaluators: Vec<String>,
+    /// Declared `failure_mode` names, modelled for the same reason as
+    /// [`AiProject::evaluators`] -- `skills/fsl/reference.md` calls these
+    /// tracked metadata, not a verified claim.
+    pub failure_modes: Vec<String>,
     pub statistical_properties: Vec<AiStatisticalProperty>,
     pub observed_properties: Vec<AiObservedProperty>,
     pub migrations: Vec<AiMigration>,
@@ -330,6 +338,12 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
                     .push(parse_ai_component(&block.text).map_err(|error| error.to_string())?);
             }
             "dataset" => project.datasets.push(parse_dataset(block)),
+            // Descended only far enough to record the name: these are tracked
+            // metadata the frozen reference lists under `evaluators` /
+            // `failure_modes`, and dropping them entirely is what left native's
+            // `ai check` short of the reference (issue #563).
+            "evaluator" => project.evaluators.push(block.name.clone()),
+            "failure_mode" => project.failure_modes.push(block.name.clone()),
             "statistical_property" => project
                 .statistical_properties
                 .push(parse_statistical_property(block, source)?),

--- a/rust/fsl-tools/src/html.rs
+++ b/rust/fsl-tools/src/html.rs
@@ -615,15 +615,45 @@ fn property_assurance(property: &Value, verification: &Value) -> String {
     })
 }
 
+/// The declared `leadsTo ... within` deadline of one property row, if it has
+/// one. A property carries `within` only when it declares a deadline
+/// (`model_skeleton` omits the key otherwise), so this is also the test for
+/// whether the Deadline column exists at all.
+fn property_deadline(property: &Value) -> Option<&Value> {
+    property.get("within").filter(|within| !within.is_null())
+}
+
 fn properties_section(properties: &[Value], checks: &[Value], verification: &Value) -> String {
+    // Conditional column: `docs/DESIGN-html-report.md` puts the Deadline column
+    // in the table only when at least one property declares a deadline, under
+    // the same rule that forbids `none` filler cells for absent requirement
+    // captions. Rendering it always with empty cells would violate the spec it
+    // implements.
+    let has_deadline = properties
+        .iter()
+        .any(|property| property_deadline(property).is_some());
     let mut rows = String::new();
     for property in properties {
+        let deadline_cell = if has_deadline {
+            property_deadline(property).map_or_else(
+                || "<td></td>".to_owned(),
+                |within| {
+                    format!(
+                        "<td><span class=\"chip fair\">within {}</span></td>",
+                        escape(&text(within))
+                    )
+                },
+            )
+        } else {
+            String::new()
+        };
         let _ = write!(
             rows,
-            "<tr><td>{}</td><td><code>{}</code>{}</td><td>{}</td><td>{}</td></tr>",
+            "<tr><td>{}</td><td><code>{}</code>{}</td>{}<td>{}</td><td>{}</td></tr>",
             escape(&text(&property["kind"])),
             escape(&text(&property["name"])),
             requirement_caption(&property["requirement"]),
+            deadline_cell,
             escape(&property_assurance(property, verification)),
             escape(&text(&property["body_text"]))
         );
@@ -646,6 +676,10 @@ fn properties_section(properties: &[Value], checks: &[Value], verification: &Val
             escape(&source)
         );
     }
+    let empty_properties_row = format!(
+        "<tr><td colspan=\"{}\">No user properties.</td></tr>",
+        if has_deadline { 5 } else { 4 }
+    );
     format!(
         r#"
       <section class="section" id="properties">
@@ -658,7 +692,7 @@ fn properties_section(properties: &[Value], checks: &[Value], verification: &Val
         <div class="stack">
           <div class="panel table-wrap">
             <table>
-              <thead><tr><th>Kind</th><th>Name</th><th>Assurance</th><th>Body</th></tr></thead>
+              <thead><tr><th>Kind</th><th>Name</th>{}<th>Assurance</th><th>Body</th></tr></thead>
               <tbody>{}</tbody>
             </table>
           </div>
@@ -671,8 +705,13 @@ fn properties_section(properties: &[Value], checks: &[Value], verification: &Val
         </div>
       </section>
 "#,
+        if has_deadline {
+            "<th>Deadline</th>"
+        } else {
+            ""
+        },
         if rows.is_empty() {
-            "<tr><td colspan=\"4\">No user properties.</td></tr>"
+            empty_properties_row.as_str()
         } else {
             &rows
         },

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -10084,29 +10084,28 @@ fn run_mutate(
 ) -> (Value, i32) {
     let (baseline, status) = run_verify(path, depth, "warn", "bmc", DEFAULT_EXPLICIT_BUDGET, 1);
     if status != 0 || baseline.get("result").and_then(Value::as_str) != Some("verified") {
-        // A non-`verified` baseline still scores 0 (an unverified spec has no
-        // mutation score, not a failure), but a *spec error* keeps its own exit
-        // code: `docs/LANGUAGE.md` maps parse/type/semantics/io to 2 with no
-        // per-command exemption, and exit 0 on an unparseable spec is a green
-        // gate over a spec that was never analysed.
-        let baseline_status = baseline_error_status(&baseline, status);
+        // The baseline envelope is re-emitted verbatim, so its own `result`
+        // decides the exit code through `docs/LANGUAGE.md`'s table: `violated`
+        // and the other row-1 verdicts exit 1, and a *spec error* keeps the
+        // code the baseline already classified.
+        let baseline_status = mutate_exit_status(&baseline, status);
         return (baseline, baseline_status);
     }
     let model = match load_model(path) {
         Ok(model) => model,
-        Err(error) => return (spec_load_error_output(&error), 2),
+        Err(error) => return mutate_error(spec_load_error_output(&error)),
     };
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
-        Err(error) => return (error_output("io", &error.to_string()), 0),
+        Err(error) => return mutate_error(error_output("io", &error.to_string())),
     };
     let trace_contract = match fsl_core::requirements_trace_contract(&source) {
         Ok(contract) => contract,
-        Err(error) => return (semantic_error_output(&error.to_string()), 0),
+        Err(error) => return mutate_error(semantic_error_output(&error.to_string())),
     };
     let document = match parse_surface_document(path) {
         Ok(document) => document,
-        Err(error) => return (semantic_error_output(&error), 0),
+        Err(error) => return mutate_error(semantic_error_output(&error)),
     };
     let action_labels = mutation_action_labels(&document);
     let spec = match document {
@@ -10118,14 +10117,14 @@ fn run_mutate(
                 fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
             match fsl_core::parse_kernel_source(&source, &resolver) {
                 Ok(kernel) => kernel.into_syntax(),
-                Err(error) => return (semantic_error_output(&error.to_string()), 0),
+                Err(error) => return mutate_error(semantic_error_output(&error.to_string())),
             }
         }
         _ => {
-            return (
-                error_output("semantics", "mutate expects a spec-like FSL file"),
-                0,
-            );
+            return mutate_error(error_output(
+                "semantics",
+                "mutate expects a spec-like FSL file",
+            ));
         }
     };
     let all_mutants = fsl_tools::enumerate_builtin_mutants(&spec);
@@ -10258,7 +10257,7 @@ fn run_mutate(
     if let Some(external_path) = external_mutants {
         let candidates = match load_external_mutations(external_path, &source) {
             Ok(candidates) => candidates,
-            Err(error) => return (error_output("io", &error), 0),
+            Err(error) => return mutate_error(error_output("io", &error)),
         };
         for candidate in candidates {
             if let Some(invalid) = candidate.invalid.clone() {
@@ -15705,14 +15704,42 @@ fn model_error_output(error: &fsl_core::ModelError) -> Value {
     )
 }
 
-/// Keep a spec-error envelope's own exit code when a command would otherwise
-/// downgrade a non-success baseline to 0.
-fn baseline_error_status(baseline: &Value, status: i32) -> i32 {
-    if baseline.get("result").and_then(Value::as_str) == Some("error") {
-        status
-    } else {
-        0
+/// `docs/LANGUAGE.md`'s exit-code table applied to an envelope `mutate`
+/// returns, as a *total* match over the result vocabulary a mutation run can
+/// carry.
+///
+/// `mutate` re-emits its baseline `verify` envelope verbatim when the baseline
+/// does not verify, so the baseline's `result` -- not merely the fact that it
+/// is "not verified" -- decides the exit code. Deriving the status from
+/// `result == "error"` alone let every other non-success value fall through to
+/// 0, so `violated` exited 0 (issue #554): a mutation score is meaningless
+/// over a spec that already fails, and a gate reading only the exit code saw a
+/// pass. `scenarios` and `testgen` re-emit the same baseline envelope and
+/// already exit 1.
+///
+/// `error_status` is the classified spec-error code the caller already holds
+/// (2 for parse/type/semantics/io, or whatever the baseline reported), so an
+/// error envelope is never re-classified here.
+fn mutate_exit_status(output: &Value, error_status: i32) -> i32 {
+    match output.get("result").and_then(Value::as_str) {
+        // Exit-code table row 0.
+        Some("mutated" | "verified" | "proved") => 0,
+        // Row 1. A baseline `verify` cannot produce that row's remaining
+        // members (`nonconformant`, `refinement_failed`, `sweep_failed`,
+        // `observed_mismatch`); those belong to other commands.
+        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
+        Some("error") => error_status,
+        // An unmapped result is an internal inconsistency, never a silent
+        // success -- falling through to 0 is exactly how #554 arose.
+        _ => 3,
     }
+}
+
+/// Pair a `mutate` error envelope with the exit code the table gives it, so no
+/// early return can re-introduce a hard-coded status.
+fn mutate_error(output: Value) -> (Value, i32) {
+    let status = mutate_exit_status(&output, 2);
+    (output, status)
 }
 
 /// Render a spec-loading failure through the class the loader preserved, so

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -7780,6 +7780,13 @@ fn model_skeleton(model: &KernelModel, spec_kind: &str) -> Value {
         let mut value = json!({"name":fslc_rust::display_name(&property.name),"kind":"leadsTo","body_text":format!("{} ~> {}",fslc_rust::source_expr_text(model,&property.before),fslc_rust::source_expr_text(model,&property.after)),"requirement":Value::Null});
         if let Value::Object(value) = &mut value {
             insert_requirement_metadata(value, &property.annotations, property.meta.as_ref());
+            // Present only for a `leadsTo ... within`, never as a null filler:
+            // `fslc html`'s Deadline column exists exactly when some property
+            // carries one (`docs/DESIGN-html-report.md`), and the frozen
+            // reference's `_property_skeleton` omits the key the same way.
+            if let Some(within) = property.within {
+                value.insert("within".to_owned(), json!(within));
+            }
         }
         properties.push(value);
     }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6311,8 +6311,14 @@ fn run_ai_project_check(source: &str, path: &Path) -> (Value, i32) {
             return (output, 2);
         }
     };
+    // Field set and order mirror the frozen reference's `analyze_ai_project`
+    // (`src/fslc/ai_project.py`). Native previously omitted `dialect`,
+    // `ai_project`, `datasets`, `evaluators`, `failure_modes`, and
+    // `assumptions`; `skills/fsl/reference.md` documents `failure_modes` as
+    // output, so agents were told to expect a field native never produced
+    // (issue #563).
     wrap_specialized(
-        json!({"result":"ai_project_analyzed","formal_result":"not_run","components":project.components.iter().map(|component|&component.name).collect::<Vec<_>>(),"statistical_properties":project.statistical_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"observed_properties":project.observed_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"migrations":project.migrations.iter().map(|migration|&migration.name).collect::<Vec<_>>(),"raw_blocks":project.raw_blocks.iter().map(|block|json!({"kind":block.kind,"name":block.name})).collect::<Vec<_>>(),"findings":[]}),
+        json!({"result":"ai_project_analyzed","dialect":"fsl-ai-project.v0","formal_result":"not_run","ai_project":project.name,"components":project.components.iter().map(|component|&component.name).collect::<Vec<_>>(),"datasets":project.datasets.iter().map(|dataset|&dataset.name).collect::<Vec<_>>(),"evaluators":project.evaluators,"failure_modes":project.failure_modes,"statistical_properties":project.statistical_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"observed_properties":project.observed_properties.iter().map(|property|&property.name).collect::<Vec<_>>(),"migrations":project.migrations.iter().map(|migration|&migration.name).collect::<Vec<_>>(),"raw_blocks":project.raw_blocks.iter().map(|block|json!({"kind":block.kind,"name":block.name})).collect::<Vec<_>>(),"assumptions":[{"id":"AI-ASSUME-EXTERNAL-EVIDENCE-JOBS","text":"statistical, migration, and observed AI declarations are external evidence jobs and do not add probability semantics to fslc verify"}],"findings":[]}),
     )
 }
 

--- a/rust/fslc/tests/issue_554_mutate_exit_status.rs
+++ b/rust/fslc/tests/issue_554_mutate_exit_status.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #554: `fslc mutate` re-emits its baseline
+//! `verify` envelope verbatim when the baseline does not verify, but derived
+//! the exit code from `result == "error"` alone. Every other non-success
+//! result therefore fell through to 0, so a spec whose baseline is already
+//! `violated` returned `result:"violated"` with exit 0 — a mutation score is
+//! meaningless over a spec that already fails, and a gate reading only the
+//! exit code saw a pass. `docs/LANGUAGE.md`'s exit-code table maps `violated`
+//! to 1 with no per-command exemption, and `scenarios`/`testgen` re-emit the
+//! same envelope and already exit 1.
+//!
+//! The status now comes from `mutate_exit_status`, a total match over the
+//! result vocabulary a mutation run can carry.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+const VIOLATED_BASELINE: &str = "examples/gallery/errors/violated_invariant_counter.fsl";
+const HEALTHY_SPEC: &str = "specs/cart_v1.fsl";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+// --- negative: a violated baseline must not exit 0 ------------------------
+
+#[test]
+fn a_violated_baseline_exits_one() {
+    let (value, status) = run(&["mutate", VIOLATED_BASELINE, "--max-mutants", "3"]);
+    assert_eq!(value["result"], "violated", "{value}");
+    assert_eq!(status, 1, "{value}");
+}
+
+#[test]
+fn mutate_and_testgen_agree_on_the_same_violated_baseline() {
+    // Both commands re-emit the baseline `verify` envelope; `testgen` already
+    // exited 1, so a disagreement here is the defect rather than a judgement
+    // call about what `mutate` should do.
+    let (mutated, mutate_status) = run(&["mutate", VIOLATED_BASELINE, "--max-mutants", "3"]);
+    let (generated, testgen_status) = run(&["testgen", VIOLATED_BASELINE, "--depth", "3"]);
+    assert_eq!(mutated["result"], generated["result"], "{mutated}");
+    assert_eq!(mutate_status, testgen_status);
+}
+
+#[test]
+fn an_unreadable_external_mutant_file_is_a_spec_error() {
+    // Reachable only once the baseline verifies, so it is a second site of the
+    // same defect: it returned `result:"error"` with exit 0 before the status
+    // became a total function of `result`.
+    let (value, status) = run(&[
+        "mutate",
+        HEALTHY_SPEC,
+        "--max-mutants",
+        "0",
+        "--from",
+        "does/not/exist.jsonl",
+    ]);
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "io", "{value}");
+    assert_eq!(status, 2, "{value}");
+}
+
+#[test]
+fn a_spec_that_does_not_load_still_exits_two() {
+    // The #484 behavior this commit must not disturb.
+    let (value, status) = run(&[
+        "mutate",
+        "examples/gallery/errors/parse_missing_expression.fsl",
+        "--max-mutants",
+        "3",
+    ]);
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "parse", "{value}");
+    assert_eq!(status, 2, "{value}");
+}
+
+// --- positive: a healthy spec still scores and exits 0 --------------------
+
+#[test]
+fn a_healthy_spec_still_mutates_and_exits_zero() {
+    let (value, status) = run(&["mutate", HEALTHY_SPEC, "--max-mutants", "3"]);
+    assert_eq!(value["result"], "mutated", "{value}");
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["summary"]["total"], 3, "{value}");
+}

--- a/rust/fslc/tests/issue_563_ai_check_project_fields.rs
+++ b/rust/fslc/tests/issue_563_ai_check_project_fields.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #563: native `fslc ai check` on an fsl-ai
+//! project omitted six fields the frozen reference's `analyze_ai_project`
+//! (`src/fslc/ai_project.py`) emits — `ai_project`, `assumptions`, `datasets`,
+//! `dialect`, `evaluators`, `failure_modes`. `evaluators` and `failure_modes`
+//! were not merely unprojected: the Rust project parser did not descend into
+//! `evaluator` / `failure_mode` blocks at all, so the data did not exist.
+//! `skills/fsl/reference.md` states `failure_mode` is listed under
+//! `failure_modes`, so the skill promised agents output native never produced.
+//!
+//! Key presence alone cannot distinguish an empty array from a missing
+//! projection, so the controls assert the actual declared names from
+//! `examples/ai/support_answer_quality.fsl`, which declares one `dataset`, one
+//! `evaluator`, and one `failure_mode`.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+const PROJECT: &str = "examples/ai/support_answer_quality.fsl";
+
+/// Every key `analyze_ai_project` returns, measured against the frozen
+/// reference rather than restated from the issue text.
+const FROZEN_KEYS: &[&str] = &[
+    "ai_project",
+    "assumptions",
+    "components",
+    "datasets",
+    "dialect",
+    "evaluators",
+    "failure_modes",
+    "formal_result",
+    "migrations",
+    "observed_properties",
+    "raw_blocks",
+    "result",
+    "statistical_properties",
+];
+
+/// Keys native adds on top of the frozen set. `fsl`/`versions` are the native
+/// envelope; `findings` is native's fsl-ai finding contract, carried by every
+/// `ai` result and not part of this change.
+const NATIVE_ONLY_KEYS: &[&str] = &["findings", "fsl", "versions"];
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn ai_check(spec: &str) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["ai", "check", spec])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn every_frozen_reference_field_is_present() {
+    let (value, status) = ai_check(PROJECT);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ai_project_analyzed", "{value}");
+    let object = value.as_object().expect("object envelope");
+    let missing = FROZEN_KEYS
+        .iter()
+        .filter(|key| !object.contains_key(**key))
+        .collect::<Vec<_>>();
+    assert!(missing.is_empty(), "missing {missing:?} from {value}");
+}
+
+#[test]
+fn native_adds_no_field_beyond_its_envelope_and_findings() {
+    // Guards the other direction: a stray key is as much a contract drift as a
+    // missing one.
+    let (value, _) = ai_check(PROJECT);
+    let object = value.as_object().expect("object envelope");
+    let extra = object
+        .keys()
+        .filter(|key| {
+            !FROZEN_KEYS.contains(&key.as_str()) && !NATIVE_ONLY_KEYS.contains(&key.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert!(extra.is_empty(), "unexpected {extra:?} in {value}");
+}
+
+#[test]
+fn the_previously_missing_fields_carry_their_declared_names() {
+    // The load-bearing assertion: an empty array would satisfy key presence
+    // while proving nothing, so pin the names the fixture actually declares.
+    let (value, _) = ai_check(PROJECT);
+    assert_eq!(value["ai_project"], "support_answer_quality", "{value}");
+    assert_eq!(value["dialect"], "fsl-ai-project.v0", "{value}");
+    assert_eq!(value["datasets"], json!(["SupportEvalV3"]), "{value}");
+    assert_eq!(
+        value["evaluators"],
+        json!(["SupportAnswerJudge"]),
+        "{value}"
+    );
+    assert_eq!(value["failure_modes"], json!(["Hallucination"]), "{value}");
+    assert_eq!(
+        value["assumptions"],
+        json!([{
+            "id": "AI-ASSUME-EXTERNAL-EVIDENCE-JOBS",
+            "text": "statistical, migration, and observed AI declarations are external evidence jobs and do not add probability semantics to fslc verify",
+        }]),
+        "{value}"
+    );
+}
+
+#[test]
+fn the_fields_that_already_worked_are_unchanged() {
+    let (value, _) = ai_check(PROJECT);
+    assert_eq!(value["formal_result"], "not_run", "{value}");
+    assert_eq!(
+        value["components"],
+        json!(["SupportAnswerAgent"]),
+        "{value}"
+    );
+    assert_eq!(
+        value["statistical_properties"],
+        json!(["LooseQuality", "StrictQuality"]),
+        "{value}"
+    );
+    assert_eq!(
+        value["observed_properties"],
+        json!(["SupportAgentOperationalQuality"]),
+        "{value}"
+    );
+    assert_eq!(value["migrations"], json!(["PromptV7ToV8"]), "{value}");
+    assert_eq!(value["findings"], json!([]), "{value}");
+    // `evaluator` and `failure_mode` are parsed declarations, so they must not
+    // also appear as un-descended raw blocks.
+    let raw_kinds = value["raw_blocks"]
+        .as_array()
+        .expect("raw_blocks")
+        .iter()
+        .map(|block| block["kind"].as_str().unwrap_or_default().to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(!raw_kinds.contains("evaluator"), "{value}");
+    assert!(!raw_kinds.contains("failure_mode"), "{value}");
+}

--- a/rust/fslc/tests/issue_564_html_deadline_column.rs
+++ b/rust/fslc/tests/issue_564_html_deadline_column.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #564: `docs/DESIGN-html-report.md` specifies
+//! that the property table's "Deadline" column appears when at least one
+//! property declares a `leadsTo ... within`, under the same rule that forbids
+//! `none` filler cells for an absent requirement caption. `html.rs` had no
+//! such column at all — `grep -ci deadline` was 0. The caption half of that
+//! same design paragraph landed with #525; this is its remainder.
+//!
+//! Because the column is *conditional* output, the load-bearing control is the
+//! negative one: a spec with no `within` must produce no column, not a column
+//! of empty cells.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+/// The corpus spec whose kernel `leadsTo` actually carries a `within`.
+///
+/// `examples/nfr/{sla_worker,support_sla,sla_worker_kernel}.fsl` declare NFR
+/// deadlines, but those lower into generated `_deadline_*` invariants before
+/// the report is rendered, so none of them reaches this column.
+const DEADLINE_SPEC: &str = "examples/nfr/bounded_response.fsl";
+const NO_DEADLINE_SPEC: &str = "specs/cart_v1.fsl";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!(
+        "issue-564-{label}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&path).expect("create scratch directory");
+    path
+}
+
+/// Render one report and return its `#properties` table section.
+fn properties_section(spec: &str, label: &str) -> String {
+    let output_path = scratch_dir(label).join("report.html");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "html",
+            spec,
+            "--depth",
+            "3",
+            "-o",
+            &output_path.display().to_string(),
+        ])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let envelope: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(envelope["result"], "generated", "{envelope}");
+    let html = std::fs::read_to_string(&output_path).expect("read report");
+    html.split_once("id=\"properties\"")
+        .expect("properties section")
+        .1
+        .split_once("</section>")
+        .expect("properties section end")
+        .0
+        .to_owned()
+}
+
+fn row_named<'a>(section: &'a str, name: &str) -> &'a str {
+    section
+        .split("<tr>")
+        .find(|row| row.contains(&format!("<code>{name}</code>")))
+        .and_then(|row| row.split("</tr>").next())
+        .unwrap_or_else(|| panic!("no row for {name} in {section}"))
+}
+
+// --- negative: no deadline anywhere means no column at all ----------------
+
+#[test]
+fn a_spec_without_a_within_renders_no_deadline_column() {
+    let section = properties_section(NO_DEADLINE_SPEC, "absent");
+    assert!(!section.contains("<th>Deadline</th>"), "{section}");
+    // Not merely a missing header: the rows must keep their four cells, so an
+    // always-rendered column of empty cells cannot pass this.
+    let row = row_named(&section, "SoldOut");
+    assert_eq!(row.matches("<td").count(), 4, "{row}");
+    assert!(!row.contains("chip fair"), "{row}");
+}
+
+// --- positive: the column appears, and only where a deadline exists --------
+
+#[test]
+fn a_declared_within_renders_the_deadline_column() {
+    let section = properties_section(DEADLINE_SPEC, "present");
+    assert!(section.contains("<th>Deadline</th>"), "{section}");
+    let deadline_row = row_named(&section, "RespondsInTwo");
+    assert!(
+        deadline_row.contains("<td><span class=\"chip fair\">within 2</span></td>"),
+        "{deadline_row}"
+    );
+}
+
+#[test]
+fn a_property_without_a_deadline_gets_an_empty_cell_not_a_filler() {
+    // Same report as above: `EventuallyResponds` has no `within`, so its cell
+    // is empty rather than a "none" chip, and the two rows must still line up
+    // with the header.
+    let section = properties_section(DEADLINE_SPEC, "mixed");
+    let plain_row = row_named(&section, "EventuallyResponds");
+    assert!(plain_row.contains("<td></td>"), "{plain_row}");
+    assert!(!plain_row.contains("chip fair"), "{plain_row}");
+    assert!(!plain_row.contains("none"), "{plain_row}");
+    assert_eq!(plain_row.matches("<td").count(), 5, "{plain_row}");
+    assert_eq!(
+        row_named(&section, "RespondsInTwo").matches("<td").count(),
+        5,
+        "{section}"
+    );
+}

--- a/tools/check_rust_phase3_commands.py
+++ b/tools/check_rust_phase3_commands.py
@@ -83,7 +83,11 @@ def project(name: str, value: dict[str, Any]) -> Any:
     if name == "ai-check":
         return {key: value.get(key) for key in ("result", "dialect", "ai_component", "formal_result")} | {"findings": findings}
     if name == "ai-project-check":
-        return {key: value.get(key) for key in ("result", "formal_result", "components", "statistical_properties", "observed_properties", "migrations")}
+        # Every key `analyze_ai_project` emits. This projection used to cover
+        # only six of them, which is why native could omit `ai_project`,
+        # `assumptions`, `datasets`, `dialect`, `evaluators`, and
+        # `failure_modes` without the comparison noticing (issue #563).
+        return {key: value.get(key) for key in ("result", "dialect", "formal_result", "ai_project", "components", "datasets", "evaluators", "failure_modes", "statistical_properties", "observed_properties", "migrations", "raw_blocks", "assumptions")}
     if name == "ai-replay":
         return {"result": value.get("result"), "events_checked": value.get("events_checked"), "violations": [item.get("violation") for item in value.get("findings", [])]}
     if name in {"ai-eval", "ai-regress", "ai-drift"}:


### PR DESCRIPTION
## Problem

Three defects on three surfaces, three separate commits.

**#554 — `mutate` returned `result:"violated"` with exit 0.** `docs/LANGUAGE.md` maps `violated` to 1.
A mutation score is meaningless when the baseline already fails — you cannot kill mutants of a spec
that does not hold — and a CI script gating on exit code read it as a pass.

**#564 — the `html` property table had no Deadline column.** `docs/DESIGN-html-report.md:78-82`
specifies one that "only appears when at least one property has a `leadsTo ... within`".
`grep -ci deadline rust/fsl-tools/src/html.rs` was **0**. The same design paragraph's caption half was
implemented by #525; this is its remainder.

**#563 — native `ai check` omitted six fields the frozen reference emits**: `ai_project`,
`assumptions`, `datasets`, `dialect`, `evaluators`, `failure_modes`. `evaluators` and `failure_modes`
were not merely unprojected — the Rust project parser did not read `evaluator` / `failure_mode` blocks
at all. Meanwhile `skills/fsl/reference.md` promised `failure_modes`, so the skill AI agents read
described output native had never produced.

## #554 found a second false green in the same command

Mapping every `result` value deliberately — rather than patching the `violated` case — paid for
itself. Six error returns after the baseline check were hard-coded to exit 0, and one is reachable:

```
mutate <healthy spec> --from does/not/exist.jsonl
  before: result:"error", kind:"io", exit 0
  after:  exit 2
```

Same class #484 fixed for the load path and missed for these. All six now route through `mutate_error`
so no site can reintroduce a literal.

The status is now `mutate_exit_status`, a **total** match: `mutated`/`verified`/`proved` → 0,
`violated`/`reachable_failed`/`unknown_cti`/`unknown_budget` → 1, `error` → the code the envelope was
already classified with, and **unmapped → 3, not 0**. A value silently reaching 0 is how the defect
arose, so the fall-through is loud.

### The exit-code survey: nothing else to file

Every verdict `docs/LANGUAGE.md` maps to 1 exits 1 on the command that produces it — `violated`,
`reachable_failed`, `unknown_cti`, `unknown_budget` (`verify`), `nonconformant` (`replay`),
`refinement_failed` (`refine`), `sweep_failed` (`sweep`), `observed_mismatch` (`db observe`).

The sibling class the defect belongs to — commands that re-emit a baseline `verify` envelope — was
probed on the same violated fixture: `scenarios` and `testgen` return `violated`/exit 1; `explain`,
`html`, `ledger`, `typestate` return their own row-0 results. **`mutate` was the only divergence**, and
`mutate_and_testgen_agree_on_the_same_violated_baseline` pins that agreement going forward.

## #564: a correction that mattered for the control

The three corpus files the issue-side brief named do **not** reach this column.
`examples/nfr/{sla_worker,support_sla,sla_worker_kernel}.fsl` declare NFR deadlines, but those lower
into generated `_deadline_*` invariants before the report renders, so their kernel `leadsTo` properties
carry no `within` — measured via `explain`'s skeleton on all three: zero properties with `within`.
**Testing against them would have passed while the column stayed unimplemented.**
`examples/nfr/bounded_response.fsl` (`leadsTo RespondsInTwo { stage == 1 ~> within 2 stage == 3 }`) is
the corpus spec that actually declares one, and it is what the controls use.

Verified independently on the rebased branch:

| input | result |
|---|---|
| `bounded_response.fsl` | Deadline column present; `RespondsInTwo` renders `within 2` |
| same report, `EventuallyResponds` (no `within`) | **empty cell**, no `none` filler |
| `specs/cart_v1.fsl` (no `within` anywhere) | **no column at all** |

`model_skeleton` carries `within` additively and only when declared, matching the frozen
`_property_skeleton`. `property_deadline` is the single helper both the column condition and the cell
use — no second source of truth.

## #563: direction decided before implementing

**The implementation moved.** Checked for a deliberate drop first: no accepted `docs/DESIGN-*.md` fixes
`ai_project_analyzed`'s field set as a subset, `docs/LANGUAGE.md` only names the result value, and every
other native `ai` result already carries `dialect` and `assumptions` — so the absence reads as
omission, not intent. `skills/fsl/reference.md` was right, so it needs **no change**.

Native's `ai check` now equals the frozen reference on all 13 keys, verified by running both and
diffing every key (`differences: NONE`), with `findings` the only native addition beyond the envelope.
Re-verified here: the key set is now
`ai_project, assumptions, components, datasets, dialect, evaluators, failure_modes, findings,
formal_result, fsl, migrations, observed_properties, raw_blocks, result, statistical_properties`.

**No new corpus was needed** — `examples/ai/support_answer_quality.fsl` already declares
`dataset SupportEvalV3`, `evaluator SupportAnswerJudge` and `failure_mode Hallucination`, so the
controls assert those declared names and an empty array cannot pass.

Detection-power note: `tools/check_rust_phase3_commands.py`'s `ai-project-check` projection compared
only **6 of the 13 keys**, which is *why* the parity harness never saw this gap. It now compares the
full set, and native and Python match under it. Same shape as #556.

## Test evidence

Ablations, all via `git checkout <ref> -- <path>` with the revert confirmed to have landed:

- **#554** fails `a_violated_baseline_exits_one` (0 vs 1),
  `an_unreadable_external_mutant_file_is_a_spec_error` (0 vs 2),
  `mutate_and_testgen_agree_on_the_same_violated_baseline`. The positive control and the #484
  spec-error guard pass both ways — neither behaviour changed.
- **#564** fails `a_declared_within_renders_the_deadline_column`,
  `a_property_without_a_deadline_gets_an_empty_cell_not_a_filler`.
  `a_spec_without_a_within_renders_no_deadline_column` **passes both ways** — stated plainly: pre-fix
  no column exists anywhere, so it cannot detect absence. It exists to reject the
  always-rendered-with-empty-cells implementation the design forbids, which it does catch.
- **#563** fails `every_frozen_reference_field_is_present` and
  `the_previously_missing_fields_carry_their_declared_names` (`ai_project` Null vs
  "support_answer_quality"). `native_adds_no_field_beyond_its_envelope_and_findings` and
  `the_fields_that_already_worked_are_unchanged` **pass both ways** — pre-fix native had strictly
  fewer keys.

All three behaviours re-measured independently on the rebased binary.

Gate on the rebased base: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked
-D warnings`, `cargo test --workspace --locked`, and `./tools/check-native-integration.sh` all exit 0.

## Documentation

`CHANGELOG.md` `[Unreleased]` — three entries; #554 is a breaking exit-code change and says so.
`skills/fsl/reference.md` unchanged for #563, deliberately: the skill was already correct.

## Linked issues

Fixes #554, fixes #564, fixes #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
