### PR TITLE
fix(cli): classify name-resolution failures as kind:"name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Fixed
+- Native now emits `kind:"name"` for name-resolution failures instead of
+  collapsing them into `semantics`, making every member of the
+  `docs/DESIGN-v1.md` §7.2 closed set reachable. `duplicate state variable`,
+  `duplicate enum member`, `duplicate def`, `duplicate parameter in def`,
+  `def ... parameter is shadowed by binder`, and `undefined predicate` were all
+  reported as `semantics`, sending an agent following the §8 repair protocol
+  down the wrong branch. `CoreError` and `ModelError` now carry the
+  classification the frontend already determined, and it survives through
+  `SpecLoadError` to the one renderer — the same direction as #484, rather than
+  adding patterns to the message-string classifier, which has no text these
+  diagnostics share and would silently reclassify them on any wording change.
+  Messages are byte-identical and no other `kind` moves.
+  `examples/gallery/errors/name_duplicate_state_variable.fsl` is the corpus
+  golden the classification never had; its absence is why this survived #484 and
+  #555. Its `loc` now names the redeclaration rather than the first binding:
+  the diagnostic carried no span of its own, so it fell back to the
+  message-derived heuristic, which finds the *earlier* `x` and pointed a repair
+  agent at the innocent declaration (#565).
 - The fsl-ai project check's unexecutable-`require` spec error (#542) now
   carries a `loc` pointing at the offending clause's own line and column.
   `rust/fsl-syntax/src/ai_project.rs` tracked no positions at all, so the error

--- a/examples/gallery/README.md
+++ b/examples/gallery/README.md
@@ -31,6 +31,7 @@ JSON is enough.
 | `parse` | `errors/parse_missing_expression.fsl` | `{"result":"error","kind":"parse","expected":"one of: ..."}` |
 | `type` | `errors/type_undeclared_type.fsl` | `unknown type 'UserId'` |
 | `type` | `errors/type_struct_set_field.fsl` | `struct field ... has non-scalar type` |
+| `name` | `errors/name_duplicate_state_variable.fsl` | `duplicate state variable 'x'` |
 | `semantics` | `errors/semantics_duplicate_assignment.fsl` | `double assignment to 'x' on the same execution path` |
 | `vacuous` | `errors/vacuous_contradictory_init.fsl` | `init constraints are unsatisfiable` |
 | `invariant` | `errors/violated_invariant_counter.fsl` | `{"result":"violated","violation_kind":"invariant"}` |

--- a/examples/gallery/errors/README.md
+++ b/examples/gallery/errors/README.md
@@ -19,6 +19,11 @@ of JSON output actually confirmed with `fslc`.
 ```
 
 ```json
+// name_duplicate_state_variable.fsl
+{"result":"error","kind":"name","message":"duplicate state variable 'x'"}
+```
+
+```json
 // semantics_duplicate_assignment.fsl
 {"result":"error","kind":"semantics","message":"double assignment to 'x' on the same execution path"}
 ```

--- a/examples/gallery/errors/name_duplicate_state_variable.fsl
+++ b/examples/gallery/errors/name_duplicate_state_variable.fsl
@@ -1,0 +1,9 @@
+// expected-command: check
+// expected-result: error
+// expected-kind: name
+spec GalleryNameDuplicateStateVariable {
+  state { x: Bool, x: Bool }
+  init { x = true }
+  action flip() { x = not x }
+  invariant Ok { true or not x }
+}

--- a/examples/gallery/errors/name_reserved_declaration.fsl
+++ b/examples/gallery/errors/name_reserved_declaration.fsl
@@ -1,6 +1,6 @@
 // expected-command: check
 // expected-result: error
-// expected-kind: semantics
+// expected-kind: name
 //
 // Issue #570. `true`, `false`, and `none` resolve to literals in every
 // expression, so a declaration with one of those names can never be read back.
@@ -11,9 +11,10 @@
 // read. All three engines agreed, so symbolic/concrete/BFS agreement did not
 // catch it.
 //
-// `expected-kind` is `semantics` because that is what native classifies it as
-// today; `docs/DESIGN-v1.md` §7.2 puts a reserved-word diagnostic in the `name`
-// class, which native does not yet emit anywhere (issue #565).
+// `expected-kind` is `name`, the class `docs/DESIGN-v1.md` §7.2 puts a
+// reserved-word diagnostic in and the one the frozen reference emits from
+// `_check_reserved`. Issue #570 landed this as `semantics` only because the
+// `name` classification did not exist yet; issue #565 added it.
 spec GalleryNameReservedDeclaration {
   state { true: Bool }
   init { true = false }

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -43,6 +43,7 @@ impl FileResolver for FsResolver {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         })
     }
 }
@@ -72,6 +73,7 @@ pub fn parse_kernel_source(
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         }),
     }?;
     kernel
@@ -316,6 +318,7 @@ fn error_at(message: impl Into<String>, span: fsl_syntax::Span) -> CoreError {
         line: span.start.line,
         column: span.start.column,
         origin: None,
+        name_resolution: false,
     }
 }
 
@@ -957,6 +960,7 @@ fn sync_action(
             line: action.span.start.line,
             column: action.span.start.column,
             origin: None,
+            name_resolution: false,
         })?;
         let source = component
             .spec
@@ -969,6 +973,7 @@ fn sync_action(
                 line: action.span.start.line,
                 column: action.span.start.column,
                 origin: None,
+                name_resolution: false,
             })?;
         // Fairness is not inherited through synchronization (docs/LANGUAGE.md
         // "Compose"): capture the constituent's own `fair` marker here, before
@@ -1072,6 +1077,7 @@ fn resolve_alias_qualified_name(
                 line: 1,
                 column: 1,
                 origin: None,
+                name_resolution: false,
             });
         }
         Ok(QualifiedName {

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -1197,6 +1197,7 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
         line: span.start.line,
         column: span.start.column,
         origin: None,
+        name_resolution: false,
     }
 }
 

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -67,6 +67,7 @@ fn error_at(message: impl Into<String>, span: Span) -> CoreError {
             }],
             generated: false,
         })),
+        name_resolution: false,
     }
 }
 
@@ -1858,7 +1859,8 @@ impl<'a> Resolver<'a> {
                     return Err(error_at(
                         format!("duplicate enum member '{member}' in '{}'", ty.name),
                         ty.member_spans.get(index).copied().unwrap_or(ty.span),
-                    ));
+                    )
+                    .into_name_resolution());
                 }
             }
         }

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -86,9 +86,24 @@ pub struct CoreError {
     pub line: u32,
     pub column: u32,
     pub origin: Option<Box<OriginChain>>,
+    /// Whether this is a name-resolution failure — a declaration that is
+    /// duplicated, missing, or shadowed.
+    ///
+    /// `docs/DESIGN-v1.md` §7.2 fixes `kind` as a closed set whose `name`
+    /// member covers exactly these. Carrying the classification on the error
+    /// keeps it out of message-string matching, which cannot survive a message
+    /// edit (issue 565, the direction issue 484 established).
+    pub name_resolution: bool,
 }
 
 impl CoreError {
+    /// Classify this diagnostic as a name-resolution failure.
+    #[must_use]
+    pub fn into_name_resolution(mut self) -> Self {
+        self.name_resolution = true;
+        self
+    }
+
     #[must_use]
     pub fn with_source_file(mut self, source_file: impl AsRef<str>) -> Self {
         if let Some(origin) = &mut self.origin {
@@ -145,6 +160,7 @@ impl From<ParseError> for CoreError {
                 lowering_steps: Vec::new(),
                 generated: false,
             })),
+            name_resolution: false,
         }
     }
 }
@@ -260,6 +276,7 @@ pub fn parse_direct_kernel_spec(source: &str) -> Result<KernelSpec, CoreError> {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         });
     };
     let mut kernel = lower_direct_spec(spec)?;
@@ -293,6 +310,7 @@ fn validate_direct_scope_overrides(
         line: 1,
         column: 1,
         origin: None,
+        name_resolution: false,
     };
     if (!instances.is_empty() || !values.is_empty()) && entities.is_empty() && numbers.is_empty() {
         return Err(error(
@@ -389,6 +407,7 @@ pub fn parse_kernel_source_with_bounds(
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         }),
     }?;
     kernel.annotations.extend(SPEC_TARGET, parsed.annotations);
@@ -552,7 +571,9 @@ impl PredicateExpander {
                 continue;
             };
             if definitions.contains_key(name) {
-                return Err(core_error(format!("duplicate def '{name}'"), *span));
+                return Err(
+                    core_error(format!("duplicate def '{name}'"), *span).into_name_resolution()
+                );
             }
             // `def` items are inlined and dropped before `build_model` runs, so
             // this is the only point at which the definition's own name is
@@ -576,17 +597,18 @@ impl PredicateExpander {
                 .map(|(name, _)| name.clone())
                 .collect::<Vec<_>>();
             if names.iter().collect::<HashSet<_>>().len() != names.len() {
-                return Err(core_error(
-                    format!("duplicate parameter in def '{name}'"),
-                    *span,
-                ));
+                return Err(
+                    core_error(format!("duplicate parameter in def '{name}'"), *span)
+                        .into_name_resolution(),
+                );
             }
             let bound = bound_vars(value);
             if let Some(shadowed) = names.iter().filter(|name| bound.contains(*name)).min() {
                 return Err(core_error(
                     format!("def '{name}' parameter is shadowed by binder '{shadowed}'"),
                     *span,
-                ));
+                )
+                .into_name_resolution());
             }
             definitions.insert(
                 name.clone(),
@@ -618,6 +640,7 @@ impl PredicateExpander {
                 line: definition.line,
                 column: definition.column,
                 origin: None,
+                name_resolution: false,
             });
         }
         stack.push(name.to_owned());
@@ -632,7 +655,8 @@ impl PredicateExpander {
         } = expr
         {
             let Some(definition) = self.definitions.get(name) else {
-                return Err(core_error(format!("undefined predicate '{name}'"), *span));
+                return Err(core_error(format!("undefined predicate '{name}'"), *span)
+                    .into_name_resolution());
             };
             if args.len() != definition.params.len() {
                 return Err(core_error(
@@ -1028,7 +1052,8 @@ impl PredicateExpander {
     fn expand_expr(&self, expr: Expr, stack: &mut Vec<String>) -> Result<Expr, CoreError> {
         if let Expr::Call { name, args, span } = expr {
             let Some(definition) = self.definitions.get(&name) else {
-                return Err(core_error(format!("undefined predicate '{name}'"), span));
+                return Err(core_error(format!("undefined predicate '{name}'"), span)
+                    .into_name_resolution());
             };
             if stack.contains(&name) {
                 let mut cycle = stack.clone();
@@ -1188,6 +1213,7 @@ fn core_error(message: String, span: fsl_syntax::Span) -> CoreError {
         line: span.start.line,
         column: span.start.column,
         origin: None,
+        name_resolution: false,
     }
 }
 

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -404,9 +404,19 @@ pub struct ModelError {
     /// would change every existing message. The CLI reports this as the `loc`
     /// that `docs/DESIGN-v1.md` §7.2 guarantees (issue 555).
     pub span: Option<Span>,
+    /// Whether this is a name-resolution failure. See
+    /// [`crate::CoreError::name_resolution`] (issue 565).
+    pub name_resolution: bool,
 }
 
 impl ModelError {
+    /// Classify this diagnostic as a name-resolution failure.
+    #[must_use]
+    fn into_name_resolution(mut self) -> Self {
+        self.name_resolution = true;
+        self
+    }
+
     fn with_origin(mut self, origin: Option<crate::OriginChain>) -> Self {
         self.origin = origin.map(Box::new);
         self
@@ -528,6 +538,7 @@ impl ModelBuilder {
             message: error.message,
             origin: Some(Box::new(source_origin("annotation", error.span, None))),
             span: Some(error.span),
+            name_resolution: false,
         })?;
         let state_names = self
             .spec
@@ -586,9 +597,13 @@ impl ModelBuilder {
                                 "duplicate state variable '{}'",
                                 field.name
                             ))
-                            .with_origin(
-                                self.origins.diagnostic_origin(&state_target(&field.name)),
-                            ));
+                            .with_origin(self.origins.diagnostic_origin(&state_target(&field.name)))
+                            // The redeclaration, not the first binding: the
+                            // registry origin and the message-derived fallback
+                            // both name the innocent earlier `field.name`
+                            // (issues 555, 565).
+                            .at(field.span)
+                            .into_name_resolution());
                         }
                         if let Some(initializer) = &field.initializer {
                             if let Some(form) = unsupported_inline_form(initializer) {
@@ -951,7 +966,8 @@ impl ModelBuilder {
                     for member in members {
                         if self.enum_members.contains_key(member) {
                             return Err(model_error(format!("duplicate enum member '{member}'"))
-                                .with_origin(origin));
+                                .with_origin(origin)
+                                .into_name_resolution());
                         }
                         self.enum_members.insert(
                             member.clone(),
@@ -1915,5 +1931,6 @@ fn model_error(message: impl Into<String>) -> ModelError {
         message: message.into(),
         origin: None,
         span: None,
+        name_resolution: false,
     }
 }

--- a/rust/fsl-core/src/reserved.rs
+++ b/rust/fsl-core/src/reserved.rs
@@ -56,6 +56,13 @@ fn reject(name: &str, position: &str, span: Option<Span>) -> ModelError {
         message: reserved_message(name, position),
         origin: None,
         span,
+        // A reserved word used as a declaration name is a name-resolution
+        // failure: `docs/DESIGN-v1.md` §7.2 places it under `name`, and the
+        // frozen reference emits `kind="name"` from `_check_reserved`. Issue
+        // 570 landed this diagnostic as `semantics` only because the `name`
+        // classification did not exist yet (issue 565), and recorded the move
+        // as pending.
+        name_resolution: true,
     }
 }
 

--- a/rust/fsl-core/tests/duplicate_writes.rs
+++ b/rust/fsl-core/tests/duplicate_writes.rs
@@ -12,6 +12,7 @@ impl FileResolver for EmptyResolver {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         })
     }
 }

--- a/rust/fsl-core/tests/governance_contract.rs
+++ b/rust/fsl-core/tests/governance_contract.rs
@@ -13,6 +13,7 @@ impl FileResolver for MemoryResolver {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         })
     }
 }

--- a/rust/fsl-lsp/src/server.rs
+++ b/rust/fsl-lsp/src/server.rs
@@ -94,6 +94,7 @@ impl fsl_core::FileResolver for StoreResolver<'_> {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         })
     }
 }

--- a/rust/fsl-tools/src/causal.rs
+++ b/rust/fsl-tools/src/causal.rs
@@ -1507,6 +1507,7 @@ pub(crate) mod tests {
                 line: 1,
                 column: 1,
                 origin: None,
+                name_resolution: false,
             })
         }
     }

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -67,6 +67,7 @@ impl FileResolver for MemoryResolver {
             line: 1,
             column: 1,
             origin: None,
+            name_resolution: false,
         })
     }
 }
@@ -108,13 +109,15 @@ fn implements_error(
     output
 }
 
-/// Render a solver or verifier failure, which names no construct in the source
-/// and so carries no `loc` (issue 555).
+/// Render a solver or verifier failure, which names no construct in the source:
+/// it carries no `loc` (issue 555) and resolves no name, so it keeps the
+/// message-based classification (issue 565).
 fn verifier_error(solver_version: &str, failure: &impl std::fmt::Display) -> Value {
     fslc_rust::verification_output::render_semantic_error(
         envelope(solver_version),
         &failure.to_string(),
         None,
+        false,
     )
 }
 
@@ -141,13 +144,14 @@ fn build(request: &Request, solver_version: &str) -> Result<(KernelModel, Vec<Va
     // the checked KernelModel below.
     let diagnostics = kernel.diagnostics().to_vec();
     let model = fsl_core::build_model(kernel).map_err(|failure| {
-        // The same span the native CLI reports for this diagnostic, so the
-        // Worker envelope does not diverge from `fslc` (issue 555).
+        // The same span and classification the native CLI reports, so the
+        // Worker envelope does not diverge from `fslc` (issues 555, 565).
         let loc = fslc_rust::verification_output::model_error_loc(&failure);
         fslc_rust::verification_output::render_semantic_error(
             envelope(solver_version),
             &failure.to_string(),
             loc,
+            failure.name_resolution,
         )
     })?;
     Ok((model, diagnostics))

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5453,14 +5453,15 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     .find(|diagnostic| diagnostic.kind != "migration")
     {
         // `check` returns here before it reaches `load_kernel_model`, so the
-        // location has to travel through this branch too, or `check` alone
-        // reports `loc: null` for a diagnostic every other command locates
-        // (issue 555).
+        // location and classification have to travel through this branch too,
+        // or `check` alone reports `loc: null` and `semantics` for a diagnostic
+        // every other command locates and classifies (issues 555, 565).
         return (
             fslc_rust::verification_output::render_semantic_error(
                 envelope(),
                 &diagnostic.message,
                 diagnostic.located.then(|| diagnostic.span.python_loc()),
+                diagnostic.kind == "name",
             ),
             2,
         );
@@ -15701,19 +15702,22 @@ fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {
 }
 
 fn semantic_error_output(message: &str) -> Value {
-    fslc_rust::verification_output::render_semantic_error(envelope(), message, None)
+    fslc_rust::verification_output::render_semantic_error(envelope(), message, None, false)
 }
 
 /// Render a typed-model failure with the location the model recorded for the
-/// construct that failed.
+/// construct that failed and the classification the frontend determined, so a
+/// name-resolution failure reports `kind:"name"` rather than collapsing into
+/// `semantics`.
 ///
 /// The message is unchanged from what every command already rendered; only
-/// `loc` is added (issue 555).
+/// `loc` and `kind` move (issues 555, 565).
 fn model_error_output(error: &fsl_core::ModelError) -> Value {
     fslc_rust::verification_output::render_semantic_error(
         envelope(),
         &error.to_string(),
         fslc_rust::verification_output::model_error_loc(error),
+        error.name_resolution,
     )
 }
 

--- a/rust/fslc/src/source_diagnostic.rs
+++ b/rust/fslc/src/source_diagnostic.rs
@@ -87,7 +87,7 @@ pub fn diagnostics_with_model(
 fn core_diagnostic(source: &str, error: &fsl_core::CoreError) -> SourceDiagnostic {
     let message = error.to_string();
     SourceDiagnostic {
-        kind: crate::verification_output::semantic_error_kind(&message),
+        kind: crate::verification_output::diagnostic_kind(&message, error.name_resolution),
         code: "FSL-SEMANTIC".to_owned(),
         message,
         span: error
@@ -108,7 +108,7 @@ fn core_diagnostic(source: &str, error: &fsl_core::CoreError) -> SourceDiagnosti
 
 fn model_diagnostic(source: &str, error: &fsl_core::ModelError) -> SourceDiagnostic {
     let message = error.to_string();
-    let kind = crate::verification_output::semantic_error_kind(&message);
+    let kind = crate::verification_output::diagnostic_kind(&message, error.name_resolution);
     let located = error
         .span
         .or_else(|| {
@@ -121,10 +121,10 @@ fn model_diagnostic(source: &str, error: &fsl_core::ModelError) -> SourceDiagnos
         .or_else(|| diagnostic_span_from_message(source, &message));
     SourceDiagnostic {
         kind,
-        code: if kind == "type" {
-            "FSL-TYPE".to_owned()
-        } else {
-            "FSL-SEMANTIC".to_owned()
+        code: match kind {
+            "type" => "FSL-TYPE".to_owned(),
+            "name" => "FSL-NAME".to_owned(),
+            _ => "FSL-SEMANTIC".to_owned(),
         },
         message,
         span: located.unwrap_or_else(|| point_span(source, 1, 1)),

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -47,6 +47,9 @@ pub enum SpecLoadError {
 pub struct SemanticDiagnostic {
     pub message: String,
     pub loc: Option<Value>,
+    /// Whether the failure was resolving a name, which `docs/DESIGN-v1.md`
+    /// §7.2 classifies `kind:"name"` (issue 565).
+    pub name_resolution: bool,
 }
 
 impl SemanticDiagnostic {
@@ -57,6 +60,7 @@ impl SemanticDiagnostic {
         Self {
             message: message.into(),
             loc: None,
+            name_resolution: false,
         }
     }
 
@@ -68,16 +72,19 @@ impl SemanticDiagnostic {
         Self {
             message: message.into(),
             loc: crate::verification_output::origin_loc(origin),
+            name_resolution: false,
         }
     }
 
     /// A typed-model failure, located by the span it recorded for itself or by
-    /// its enclosing construct's lowering origin.
+    /// its enclosing construct's lowering origin, and classified by whether it
+    /// was resolving a name.
     #[must_use]
     pub fn from_model_error(error: &fsl_core::ModelError) -> Self {
         Self {
             message: error.to_string(),
             loc: crate::verification_output::model_error_loc(error),
+            name_resolution: error.name_resolution,
         }
     }
 }
@@ -150,6 +157,7 @@ pub fn render_spec_load_error(mut output: Map<String, Value>, error: &SpecLoadEr
             output,
             &diagnostic.message,
             diagnostic.loc.clone(),
+            diagnostic.name_resolution,
         ),
     }
 }

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -115,16 +115,18 @@ pub fn model_error_loc(error: &fsl_core::ModelError) -> Option<Value> {
 /// Render a model-construction error using the public semantic classification.
 ///
 /// `docs/DESIGN-v1.md` §7.2 guarantees `loc` for `parse`/`name`/`type`/
-/// `semantics`. This is the single dispatch point for the `type`/`semantics`
-/// half, so the location travels with the diagnostic instead of being
-/// reconstructed per command (issue 555, completing issue 484).
+/// `semantics` and fixes `kind` as a closed set including `name`. This is the
+/// single dispatch point for that whole half of the set, so both the location
+/// (issue 555) and the classification (issue 565) travel with the diagnostic
+/// instead of being reconstructed per command.
 #[must_use]
 pub fn render_semantic_error(
     mut output: Map<String, Value>,
     message: &str,
     loc: Option<Value>,
+    name_resolution: bool,
 ) -> Value {
-    let kind = semantic_error_kind(message);
+    let kind = diagnostic_kind(message, name_resolution);
     output.insert("result".to_owned(), json!("error"));
     output.insert("kind".to_owned(), json!(kind));
     output.insert("message".to_owned(), json!(message));
@@ -188,6 +190,24 @@ pub fn render_governance_error(
         json!({"line": error.line, "column": error.column}),
     );
     Value::Object(output)
+}
+
+/// The classification for a typed diagnostic, preferring the class the frontend
+/// determined over matching on the message text.
+///
+/// `docs/DESIGN-v1.md` §7.2's closed set includes `name`, which no message
+/// pattern can identify: `duplicate state variable 'x'`,
+/// `duplicate enum member 'B'` and `undefined predicate 'p'` share no prefix or
+/// suffix, and a classifier keyed on message text silently reclassifies a
+/// diagnostic whenever its wording changes. The frontend already knows, so it
+/// says so (issue 565).
+#[must_use]
+pub fn diagnostic_kind(message: &str, name_resolution: bool) -> &'static str {
+    if name_resolution {
+        "name"
+    } else {
+        semantic_error_kind(message)
+    }
 }
 
 /// Classify a typed-model diagnostic identically on every Rust delivery surface.

--- a/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
+++ b/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
@@ -282,9 +282,8 @@ fn a_missing_input_is_io_for_every_spec_reading_command() {
 /// The corpus `type`/`semantics` goldens, with the construct each diagnostic
 /// must point at.
 ///
-/// `examples/gallery/errors/` has no `name`-kind fixture, so that third
-/// classification in the `docs/DESIGN-v1.md` §7.2 clause has no corpus case to
-/// pin here.
+/// The `name` member of that clause is pinned separately, by
+/// `NAME_FIXTURE` below (issue 565).
 const LOCATED_SEMANTIC_FIXTURES: &[(&str, &str, u64, u64)] = &[
     // `state { owner: UserId }` — the state declaration naming the unknown type.
     (
@@ -352,6 +351,111 @@ fn every_spec_reading_command_locates_a_type_or_semantic_error() {
             );
         }
     }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+/// The corpus `name` golden, with the construct its diagnostic must point at.
+///
+/// `docs/DESIGN-v1.md` §7.2 fixes `kind` as a closed set including `name`.
+/// Native reached every member except that one: name-resolution failures were
+/// collapsed into `semantics`, because the only classifier was
+/// `semantic_error_kind`, which matches message text and has no `name` pattern
+/// to match (issue 565).
+const NAME_FIXTURE: &str = "examples/gallery/errors/name_duplicate_state_variable.fsl";
+/// `state { x: Bool, x: Bool }` — the *second* `x`, the redeclaration, not the
+/// first binding and not the enclosing `state` block.
+const NAME_FIXTURE_LINE: u64 = 5;
+const NAME_FIXTURE_COLUMN: u64 = 20;
+
+/// Every native name-resolution diagnostic, with the message each must keep
+/// **byte for byte**.
+///
+/// The classifier still falls back to message matching for `type`, and that
+/// matching is prefix/suffix-based, so any edit to one of these strings can
+/// move a `kind` without touching a classification rule. Pinning the exact text
+/// is what makes that impossible to do silently.
+const NAME_DIAGNOSTICS: &[(&str, &str)] = &[
+    (
+        "spec DupVar {\n  state { x: Bool, x: Bool }\n  init { x = true }\n  action flip() { x = not x }\n}\n",
+        "duplicate state variable 'x'",
+    ),
+    (
+        "spec DupEnum {\n  enum E { A, B }\n  enum F { B, C }\n  state { e: E }\n  init { e = A }\n  action stay() { e = e }\n}\n",
+        "duplicate enum member 'B'",
+    ),
+];
+
+#[test]
+fn every_spec_reading_command_classifies_a_name_resolution_failure_as_name() {
+    let directory = fixture_directory("name-kind-matrix");
+    let trace = write_fixture(
+        &directory,
+        "trace.json",
+        r#"{"schema_version":1,"spec":"Valid","initial":{"value":0},"events":[]}"#,
+    );
+    let other = write_fixture(&directory, "other.fsl", VALID_SOURCE);
+
+    for (name, arguments) in spec_reading_commands(NAME_FIXTURE, &trace, &other) {
+        // `fmt` never lowers to the kernel, so no typed-model diagnostic exists
+        // for it to classify.
+        if name == "fmt" {
+            continue;
+        }
+        let (output, status) = run_cli(&arguments);
+        assert_eq!(output["result"], "error", "{name}: {output}");
+        assert_eq!(output["kind"], "name", "{name}: {output}");
+        assert_eq!(status, 2, "{name}: {output}");
+        assert_eq!(
+            output["message"], "duplicate state variable 'x'",
+            "{name}: {output}"
+        );
+        // Issue 555 gave this half of the clause its `loc`; assert the exact
+        // position for the same reason as the fixtures above, and because a
+        // `name` diagnostic pointing at the first `x` would name the innocent
+        // declaration.
+        assert_eq!(
+            output["loc"]["line"].as_u64(),
+            Some(NAME_FIXTURE_LINE),
+            "{name}: {output}"
+        );
+        assert_eq!(
+            output["loc"]["column"].as_u64(),
+            Some(NAME_FIXTURE_COLUMN),
+            "{name}: {output}"
+        );
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}
+
+/// The classification travels on the diagnostic, so it must not depend on the
+/// message text — and the messages themselves must not drift, because the
+/// surviving `type` rules still match on prefixes and suffixes.
+#[test]
+fn name_resolution_messages_are_unchanged_and_classify_without_message_matching() {
+    let directory = fixture_directory("name-kind-messages");
+
+    for (index, (source, message)) in NAME_DIAGNOSTICS.iter().enumerate() {
+        let spec = write_fixture(&directory, &format!("name_{index}.fsl"), source);
+        let (output, status) = run_cli(&["check", &spec]);
+        assert_eq!(status, 2, "{message}: {output}");
+        assert_eq!(output["kind"], "name", "{message}: {output}");
+        assert_eq!(output["message"], *message, "{message}: {output}");
+    }
+
+    // The positive control for the same edge: `semantic_error_kind`'s surviving
+    // message rules must still produce `type`, not be swept into `name`.
+    let bad_type = write_fixture(&directory, "bad_type.fsl", TYPE_SOURCE);
+    let (output, status) = run_cli(&["check", &bad_type]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["kind"], "type", "{output}");
+    assert_eq!(output["message"], "unknown type 'Missing'", "{output}");
+
+    let no_state = write_fixture(&directory, "no_state.fsl", SEMANTIC_SOURCE);
+    let (output, status) = run_cli(&["check", &no_state]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["kind"], "semantics", "{output}");
 
     std::fs::remove_dir_all(&directory).expect("remove fixture directory");
 }


### PR DESCRIPTION
## Problem

`docs/DESIGN-v1.md:514` declares a closed set —
`"parse" | "name" | "type" | "semantics" | "io" | "internal"`. Name-resolution failures were collapsed
into `semantics`, so the `kind` an AI consumer branches on in §8's repair protocol sent it to the wrong
branch.

Same message text, different classification:

```fsl
spec DupVar { state { x: Bool, x: Bool } … }
```

- native: `kind:"semantics"`, `message:"duplicate state variable 'x'"`
- frozen `src/fslc/model.py:1575`: identical message, `kind="name"`

This is #484's defect class (a closed-set member collapsed into `semantics`) for a different member.
Not a false green — exit 2 and `result` were already correct.

## The issue's framing was wrong in a way that made the defect worse, not better

#565 said native never emits `kind:"name"`. **It does** —
`rust/fslc/src/main.rs` classifies `unknown analyze focus node` as `name` via
`message.starts_with(...)`. So the closed set was reachable, and the accurate statement is narrower and
worse: **the only `name` in native was produced by an ad-hoc message match on one `analyze` path**,
which is precisely the string sniffing this fix is supposed to eliminate. The issue is retitled.

## The inventory splits three ways, not one

**Misclassified — fixed, 6**: `duplicate state variable`, `duplicate enum member` (kernel + domain),
`duplicate def`, `duplicate parameter in def`, `def … parameter is shadowed by binder`,
`undefined predicate`. Native's messages already matched frozen's; only the classification was wrong.
All now `name`, **messages byte-identical**.

**No native counterpart — a missing diagnostic, not a misclassification, 1**: frozen's reserved-keyword
rejection. Not folded in, and that refusal is what made it findable: investigating it showed native
accepted `state { true: Bool }` and returned **`proved`** over the resulting tautology. Filed as
**#570** and fixed separately — a false green, not an omission.

**Diverges more deeply — deliberately left, 1**: frozen's `unknown enum member 'X'`. Native reaches
this through the type checker's generic unresolved-`Expr::Var` path as
`invalid model expression: public Kernel cannot type identifier 'X'`. It is a name-resolution failure
by nature, but it is not the same diagnostic, it fires for any unbound identifier rather than enum
members specifically, `TypecheckError` is a third error type with no `origin`, and existing tests pin
that exact message as `semantics`. Reported rather than forced.

## The `loc` had to be made correct, not merely asserted

The task specified asserting the measured value `line 5, column 20`. **The tree did not produce it** —
the fixture reported `{line:5, column:11}`, and column 11 is the *first* `x`, the innocent binding.
`duplicate state variable` carried no span of its own, so it fell through to `source_diagnostic`'s
message-derived heuristic, which finds the **first** token matching the quoted name.

Asserting 11 would have pinned a `loc` naming the declaration that is not the problem — present but
wrong, which is worse than absent and which "not null" cannot detect. Fixed by attaching `field.span`
via the `.at(…)` mechanism from #555, so 5:20 is now genuinely true.

Verified independently: line 5 is `  state { x: Bool, x: Bool }`; column 11 is the first `x`, column 20
the redeclaration. Branch returns `kind:"name"` / `loc:{5,20}`; `main` returns `semantics` / `loc: None`.

## Test evidence

Ablation shows both halves cleanly: pre-fix the fixture reports `kind:"semantics"` **and**
`loc:{line:5,column:11}`; post-fix `kind:"name"` and `loc:{line:5,column:20}`. Both new tests fail
ablated. All six pre-existing matrix tests stay green — **including #555's
`every_spec_reading_command_locates_a_type_or_semantic_error`**, which is the check that this did not
disturb that work.

`name_resolution_messages_are_unchanged_and_classify_without_message_matching` pins each moved
diagnostic's exact message text, plus a positive control that `type` (`unknown type 'Missing'`) and
`semantics` still classify as before. That guard exists because the reverse hazard is real: during
#555, attaching spans to `ModelError.origin` changed `Display` output and silently reclassified a
`type` diagnostic to `semantics` through `semantic_error_kind`'s suffix match.

Gate on the rebased base: `FMT_EXIT=0`, `CLIPPY_EXIT=0`, `TEST_EXIT=0`, `NATIVE_EXIT=0`.

## Rebase note

This branch was rebased across #556, which relocated `SpecLoadError`, `SemanticDiagnostic`,
`kernel_load_error`, `surface_parse_failure` and the render dispatch from `main.rs` into
`rust/fslc/src/spec_load.rs`. Main's post-#556 version was taken and the `name_resolution` layer ported
into the new file, rather than reapplying to `main.rs`.

**A hazard found doing it, now a team rule**: resolving the `main.rs` conflict with
`git checkout --ours` takes the upstream version of the **entire file**, not just the conflicted hunks,
silently discarding three non-conflicting call-site edits elsewhere in it. The build caught it only
because those edits changed an arity — **a same-arity edit would have vanished with the gates still
green**.

## Known residual

`duplicate enum member` has the same wrong-`loc` signature just fixed for state variables:
`SpecItem::Enum` carries no per-member span, so it also falls back to the first match and names the
earlier declaration. This PR's test pins its `kind` and message but **deliberately not its `loc`**, so
nothing green claims that location is right. Filed as **#576** and fixed separately.

## Documentation

`CHANGELOG.md` `[Unreleased]`. No `docs/DESIGN-v1.md` change — the closed set is fully reachable and
the reserved-word gap was a missing check, not an unreachable member.

## Rebase across #570

#570 (reserved declaration names) merged first and added `rust/fsl-core/src/reserved.rs`, whose
`ModelError` construction predates this branch's new `name_resolution` field. **git auto-merged the
rebase textually and the tree did not compile** — a defect the gate caught and inspection would not
have.

Resolved by setting `name_resolution: true` on the reserved-word diagnostic. That is the change #570's
author recorded as pending rather than a judgement made here: `docs/DESIGN-v1.md` §7.2 places a
reserved-word diagnostic in the `name` class, the frozen reference emits `kind="name"` from
`_check_reserved`, and #570's own fixture is named `name_reserved_declaration.fsl` and carried a
comment saying `semantics` was temporary "because native does not yet emit `name` anywhere (issue
#565)".

Measured after the change: `kind:"name"`, `loc:{line:2, column:11}`, exit 2. The fixture's
`expected-kind` and its explanatory comment move from `semantics` to `name` in the same commit, so the
gallery no longer documents a classification that is no longer true.

## Linked issues

Fixes #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
