### PR TITLE
fix(core): locate a duplicate enum member at the repeated declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   the diagnostic carried no span of its own, so it fell back to the
   message-derived heuristic, which finds the *earlier* `x` and pointed a repair
   agent at the innocent declaration (#565).
+- A `duplicate enum member` diagnostic now points at the repeated member rather
+  than the first declaration of that name. `SpecItem::Enum` carried no
+  per-member span, so the report fell back to `source_diagnostic`'s
+  message-derived heuristic — the first token matching the quoted name — which
+  for a *duplicate* is the earlier, innocent declaration by construction. For
+  `enum E { A, B } enum F { B, C }` it named `B` in `E` (2:15) instead of the
+  redeclaration in `F` (3:12). A `loc` that exists but names the wrong construct
+  is worse than none: `docs/DESIGN-v1.md` G2 assumes the position is correct.
+  `SpecItem::Enum` now carries `member_spans` positionally parallel to
+  `members`, the same shape `SpecItem::Struct` gained in #555 and the same the
+  domain surface already used, and the diagnostic attaches the offending
+  member's own span (#576).
 - The fsl-ai project check's unexecutable-`require` spec error (#542) now
   carries a `loc` pointing at the offending clause's own line and column.
   `rust/fsl-syntax/src/ai_project.rs` tracked no positions at all, so the error

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -344,10 +344,12 @@ fn rewrite_component_item(item: SpecItem, component: &Component) -> SpecItem {
         SpecItem::Enum {
             name,
             members,
+            member_spans,
             symmetric,
         } => SpecItem::Enum {
             name: prefix(alias, &name),
             members,
+            member_spans,
             symmetric,
         },
         SpecItem::Struct { name, fields, span } => SpecItem::Struct {

--- a/rust/fsl-core/src/db.rs
+++ b/rust/fsl-core/src/db.rs
@@ -307,6 +307,7 @@ pub(crate) fn lower_db_surface(system: &DbSystem) -> (SurfaceSpec, OriginRegistr
         SpecItem::Enum {
             name: "Column".to_owned(),
             members: columns.keys().map(column_member).collect(),
+            member_spans: Vec::new(),
             symmetric: false,
         },
         SpecItem::State(vec![

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -940,6 +940,7 @@ pub fn lower_business(business: SurfaceBusiness) -> Result<KernelSpec, CoreError
         items.push(SpecItem::Enum {
             name: process_enum(&process.name),
             members: process.stages.clone(),
+            member_spans: Vec::new(),
             symmetric: false,
         });
     }
@@ -1635,6 +1636,7 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
         items.push(SpecItem::Enum {
             name: process_enum(&process.process.name),
             members: process.process.stages.clone(),
+            member_spans: Vec::new(),
             symmetric: false,
         });
     }
@@ -2516,6 +2518,7 @@ pub fn lower_ai_component(component: fsl_syntax::AiComponent) -> Result<KernelSp
                 .iter()
                 .map(|tool| members[tool.name.as_str()].clone())
                 .collect(),
+            member_spans: Vec::new(),
             symmetric: false,
         },
         SpecItem::State(vec![

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -2066,6 +2066,8 @@ pub(crate) fn lower_domain_surface(
                     .iter()
                     .map(|member| format!("{}_{}", ty.name, member))
                     .collect(),
+                // The domain surface already records each member's span.
+                member_spans: ty.member_spans.clone(),
                 symmetric: false,
             }),
             "range" | "external" => {
@@ -2143,6 +2145,8 @@ pub(crate) fn lower_domain_surface(
             .iter()
             .map(|member| status_member(effect, member))
             .collect(),
+            // Generated effect-status members have no source text.
+            member_spans: Vec::new(),
             symmetric: false,
         });
         items.push(SpecItem::Type {

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -952,6 +952,7 @@ impl ModelBuilder {
                 SpecItem::Enum {
                     name,
                     members,
+                    member_spans,
                     symmetric,
                 } => {
                     let origin = self.origins.diagnostic_origin(&type_target(name));
@@ -963,11 +964,21 @@ impl ModelBuilder {
                         },
                     )
                     .map_err(|error| error.with_origin(origin.clone()))?;
-                    for member in members {
+                    for (index, member) in members.iter().enumerate() {
                         if self.enum_members.contains_key(member) {
-                            return Err(model_error(format!("duplicate enum member '{member}'"))
-                                .with_origin(origin)
-                                .into_name_resolution());
+                            let mut duplicate =
+                                model_error(format!("duplicate enum member '{member}'"))
+                                    .with_origin(origin)
+                                    .into_name_resolution();
+                            // The repeated occurrence, not the first one. Left
+                            // unlocated the report falls back to the first
+                            // token matching the quoted name, which for a
+                            // duplicate is the earlier, innocent declaration by
+                            // construction (issue 576).
+                            if let Some(span) = member_spans.get(index) {
+                                duplicate = duplicate.at(*span);
+                            }
+                            return Err(duplicate);
                         }
                         self.enum_members.insert(
                             member.clone(),

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -1430,10 +1430,11 @@ impl<'a> Parser<'a> {
             self.bump();
             let name = self.expect_ident()?;
             self.expect_symbol("{")?;
-            let members = self.ident_list("}")?;
+            let (members, member_spans) = self.ident_list_with_spans("}")?;
             return Ok(SpecItem::Enum {
                 name,
                 members,
+                member_spans,
                 symmetric,
             });
         }
@@ -1949,19 +1950,28 @@ impl<'a> Parser<'a> {
         Some(MetaTag::parse(&value, token.span))
     }
 
-    fn ident_list(&mut self, close: &str) -> Result<Vec<String>, ParseError> {
+    /// A comma-separated name list, with each name's span, so a diagnostic can
+    /// name the offending occurrence rather than the first one that matches
+    /// (issue 576).
+    fn ident_list_with_spans(
+        &mut self,
+        close: &str,
+    ) -> Result<(Vec<String>, Vec<Span>), ParseError> {
         let mut values = Vec::new();
+        let mut spans = Vec::new();
         if self.eat_symbol(close) {
-            return Ok(values);
+            return Ok((values, spans));
         }
         loop {
+            let span = self.peek().span;
             values.push(self.expect_ident()?);
+            spans.push(span);
             if self.eat_symbol(close) {
-                return Ok(values);
+                return Ok((values, spans));
             }
             self.expect_symbol(",")?;
             if self.eat_symbol(close) {
-                return Ok(values);
+                return Ok((values, spans));
             }
         }
     }

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -127,6 +127,14 @@ pub enum SpecItem {
     Enum {
         name: String,
         members: Vec<String>,
+        /// The span of each member, positionally parallel to `members`.
+        ///
+        /// A duplicate-member diagnostic must name the *repeated* occurrence.
+        /// Without this the report falls back to the first token matching the
+        /// name, which for a duplicate is the earlier, innocent declaration by
+        /// construction (issue 576). Generated enums carry an empty vector;
+        /// the diagnostic then keeps whatever location its origin supplies.
+        member_spans: Vec<Span>,
         symmetric: bool,
     },
     Struct {
@@ -884,6 +892,7 @@ impl SpecItem {
                 name,
                 members,
                 symmetric,
+                ..
             } => {
                 let mut values = vec![json!("enum"), json!(name), json!(members)];
                 if *symmetric {

--- a/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
+++ b/rust/fslc/tests/issue_484_parse_diagnostic_matrix.rs
@@ -459,3 +459,56 @@ fn name_resolution_messages_are_unchanged_and_classify_without_message_matching(
 
     std::fs::remove_dir_all(&directory).expect("remove fixture directory");
 }
+/// A duplicate declaration and the exact position that must be reported for it.
+///
+/// For a *duplicate* diagnostic, `source_diagnostic`'s message-derived fallback
+/// — the first token matching the quoted name — is wrong by construction: a
+/// duplicate is the same name appearing twice, so the first match is always the
+/// earlier, innocent declaration. Carrying the span on the diagnostic is the
+/// only correct direction, and the one issues 484, 555 and 565 all took
+/// (issue 576).
+const DUPLICATE_DECLARATION_POSITIONS: &[(&str, &str, u64, u64)] = &[
+    // `enum F { B, C }` on line 3 — the redeclaration of `B`, not the `B` in
+    // `enum E { A, B }` on line 2 at column 15.
+    (
+        "spec DupEnum {\n  enum E { A, B }\n  enum F { B, C }\n  state { e: E }\n  init { e = A }\n  action stay() { e = e }\n}\n",
+        "duplicate enum member 'B'",
+        3,
+        12,
+    ),
+    // The sibling case, `duplicate state variable`, landed with issue 565 and
+    // is pinned by `NAME_FIXTURE_LINE`/`NAME_FIXTURE_COLUMN` in the
+    // every-command test above, so it is deliberately not repeated here.
+];
+
+/// A `loc` that exists but names the wrong construct is worse than no `loc`:
+/// `docs/DESIGN-v1.md` G2 assumes the position is *correct*, and for a
+/// duplicate the wrong one accuses the declaration that is not the problem.
+///
+/// The classification is deliberately not asserted here — it is issue 565's
+/// subject and moves independently — so this stays a pure position contract.
+#[test]
+fn a_duplicate_declaration_is_located_at_the_repeated_occurrence() {
+    let directory = fixture_directory("duplicate-declaration-loc");
+
+    for (index, (source, message, line, column)) in
+        DUPLICATE_DECLARATION_POSITIONS.iter().enumerate()
+    {
+        let spec = write_fixture(&directory, &format!("duplicate_{index}.fsl"), source);
+        let (output, status) = run_cli(&["check", &spec]);
+        assert_eq!(status, 2, "{message}: {output}");
+        assert_eq!(output["message"], *message, "{message}: {output}");
+        assert_eq!(
+            output["loc"]["line"].as_u64(),
+            Some(*line),
+            "{message}: {output}"
+        );
+        assert_eq!(
+            output["loc"]["column"].as_u64(),
+            Some(*column),
+            "{message}: {output}"
+        );
+    }
+
+    std::fs::remove_dir_all(&directory).expect("remove fixture directory");
+}


### PR DESCRIPTION
## Problem

`duplicate enum member` reported the **first** declaration, not the duplicate.

`SpecItem::Enum` carried no per-member span, so the diagnostic fell through to `source_diagnostic`'s
message-derived heuristic — which finds the first token matching the quoted name. For a *duplicate*
that is wrong **by construction**: a duplicate is the same name appearing twice, so the first match is
always the earlier, innocent declaration.

```fsl
enum E { A, B }   // line 2, column 15 — reported
enum F { B, C }   // line 3, column 12 — the actual redeclaration
```

A `loc` that exists but names the wrong construct is worse than no `loc`: `docs/DESIGN-v1.md` G2
assumes the position is *correct*, and here it accuses the declaration that is not the problem.
"Not null" cannot distinguish the two.

## Contract change

None. `SpecItem::Enum` now carries `member_spans` parallel to `members` — the `SpecItem::Struct` shape
#555 introduced, and what the domain surface already had — and the diagnostic attaches the offending
member's own span.

Domain-lowered enums pass their existing `member_spans` through. Generated enums (db columns, process
stages, ai tools, effect statuses) carry an empty vector and keep their origin's location, since their
members have no source text. `ident_list` had no callers left and is deleted rather than left as a
wrapper.

**The message heuristic is deliberately not made smarter.** Carrying the span is the only correct
direction for this class, and it is the one #484, #555 and #565 all took.

## Test evidence

Measured independently on the rebased branch: `kind:"name"`, `loc:{line:3, column:12}`,
`message:"duplicate enum member 'B'"`. Line 2 column 15 is the `B` in `enum E`; line 3 column 12 is the
`B` in `enum F`. Before: `semantics` with no `loc` at all.

Ablation in the required shape — committed first, `git checkout HEAD~1 -- rust/fsl-core rust/fsl-syntax`,
`git diff HEAD --stat` non-empty before and empty after:
`a_duplicate_declaration_is_located_at_the_repeated_occurrence` fails reporting
`loc {"line":2,"column":15}`. The six pre-existing matrix tests stay green.

Gate: `FMT_EXIT=0`, `CLIPPY_EXIT=0`, `TEST_EXIT=0`, `NATIVE_EXIT=0`.

## Rebase across #565

#565 landed first and gave this same diagnostic its `name` classification via
`.into_name_resolution()`, while this branch attaches its span. **Both sides are required and the
merge keeps both** — the resolution is `.with_origin(origin).into_name_resolution()` followed by
`.at(span)`, not either alone.

The test file merges the same way: #565's `NAME_DIAGNOSTICS` message-drift table and every-command
`kind` assertions sit alongside this branch's `DUPLICATE_DECLARATION_POSITIONS` position contract. The
two check different properties of the same diagnostic — classification and location — and neither
subsumes the other.

The position table's note is updated: it previously said it would gain a `duplicate state variable`
row once #565 landed. #565 pins that case through `NAME_FIXTURE_LINE`/`NAME_FIXTURE_COLUMN` in the
every-command test, so the row is deliberately not duplicated here.

## Provenance

Found while fixing #565: the state-variable half of this defect was fixed there, and #565's test
deliberately pinned this diagnostic's `kind` and message but **not** its `loc`, so no green test ever
claimed the wrong position was right.

## Documentation

`CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
