### PR TITLE
ci: run the complete Linux product evidence on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,21 @@ on:
 permissions:
   contents: read
 
-# During rollout, pull requests into main keep the full product gate until the
-# `merge readiness` context is installed in the main ruleset. Once the ruleset
-# is switched, set the repository variable FSL_OPTIMISTIC_CI=enabled. Product
-# gates for main pushes, schedules, manual runs, and production promotions never
-# honor that opt-out.
+# The Linux evidence — `rust workspace` and `WASM` — runs on every pull request.
+# It is where the tests live: 103 of the repository's 124 integration test files
+# sit in `fslc`, `fsl-tools`, `fsl-verifier` and `fsl-lsp`, none of which the
+# bounded `merge readiness` gate compiles or runs, and its `cargo check` carries
+# no `--all-targets`, so a type error or a failing assertion in any of them used
+# to reach main and surface only after the merge.
+#
+# Only the cross-platform matrix — `native Z3 4.16` on macOS and Windows — stays
+# post-merge under FSL_OPTIMISTIC_CI, reported by the post-merge CI reporter.
+# That is where platform failures have actually occurred (Windows PATH and
+# `core.autocrlf` line endings), and Windows is the slowest job in the gate, so
+# deferring it is what buys the merge-throughput this split is for.
+#
+# Product gates for main pushes, schedules, manual runs, and production
+# promotions never honor that opt-out.
 concurrency:
   group: product-gate-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -29,10 +39,6 @@ concurrency:
 jobs:
   rust-workspace:
     name: rust workspace
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'main' ||
-      vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -51,10 +57,6 @@ jobs:
 
   wasm:
     name: WASM
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'main' ||
-      vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 - Pull requests into `main` now run the complete Linux product evidence — `rust workspace`
   and `WASM` — instead of deferring it to after the merge. Only the cross-platform
   `native Z3 4.16` matrix (macOS, Windows) stays post-merge under `FSL_OPTIMISTIC_CI`. The
-  bounded `merge readiness` lane is kept as a sub-minute fail-fast check and its
-  `cargo check` now passes `--all-targets`: without it, test and bench targets were never
-  compiled, so a type error in any test file passed that lane entirely (verified: the same
-  injected error gives exit 0 before and exit 101 after). 103 of the repository's 124
+  bounded `merge readiness` lane is kept as a sub-minute fail-fast check; adding
+  `--all-targets` to its `cargo check` was tried and reverted after measuring 12m42s in
+  CI, since `rust workspace` now compiles and runs those targets on the same pull
+  request. 103 of the repository's 124
   integration test files live in `fslc`, `fsl-tools`, `fsl-verifier` and `fsl-lsp`, none of
   which `merge readiness` runs, so that evidence only reached `main` post-merge
   (`docs/DESIGN-ci.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Changed
+- Pull requests into `main` now run the complete Linux product evidence — `rust workspace`
+  and `WASM` — instead of deferring it to after the merge. Only the cross-platform
+  `native Z3 4.16` matrix (macOS, Windows) stays post-merge under `FSL_OPTIMISTIC_CI`. The
+  bounded `merge readiness` lane is kept as a sub-minute fail-fast check and its
+  `cargo check` now passes `--all-targets`: without it, test and bench targets were never
+  compiled, so a type error in any test file passed that lane entirely (verified: the same
+  injected error gives exit 0 before and exit 101 after). 103 of the repository's 124
+  integration test files live in `fslc`, `fsl-tools`, `fsl-verifier` and `fsl-lsp`, none of
+  which `merge readiness` runs, so that evidence only reached `main` post-merge
+  (`docs/DESIGN-ci.md`).
+
 ### Fixed
 - Native now emits `kind:"name"` for name-resolution failures instead of
   collapsing them into `semantics`, making every member of the

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -6,28 +6,52 @@ Status: Accepted
 
 ## Decision
 
-Pull requests into `main` have one stable required context, `merge readiness`. It is a bounded,
-short-latency confidence gate, not a claim that the product is fully verified. The complete
-Rust/WASM/native-platform product gate runs after every push to `main`, on schedule, on manual
-dispatch, and before promotion to `production`.
+Pull requests into `main` run the **complete Linux evidence** — `merge readiness` as a
+short-latency fail-fast lane, plus `rust workspace` and `WASM`. Only the **cross-platform matrix**,
+`native Z3 4.16` on macOS and Windows, is deferred to after the merge, together with the aggregate
+`product gate` context; that matrix also runs on schedule, on manual dispatch, and before promotion
+to `production`.
 
-This deliberately changes `main` from "every supported platform was green before merge" to
-"reviewed changes passed a bounded readiness gate and every merged state is then fully validated."
-A post-merge failure can therefore expose a temporarily broken `main`. The failed check and its
-deduplicated issue are blocking evidence for production/release promotion and must be repaired or
-reverted; they are not informational warnings.
+This changes `main` from "every supported platform was green before merge" to "every change was
+fully tested on Linux before merge, and the remaining platforms are validated immediately after."
+A post-merge failure can therefore still expose a temporarily broken `main`, but only for a
+platform-specific defect. The failed check and its deduplicated issue are blocking evidence for
+production/release promotion and must be repaired or reverted; they are not informational warnings.
+
+### Why the split falls here
+
+Measured on the batch that motivated this revision:
+
+- **The tests live in the crates the bounded lane excludes.** 103 of 124 integration test files sit
+  in `fslc` (77), `fsl-tools` (16), `fsl-verifier` (8) and `fsl-lsp` (2). `merge readiness` runs 21.
+- **Its compile lane did not build test targets at all** — `cargo check` without `--all-targets` —
+  so a type error or a failing assertion in any of those 103 files reached `main` and surfaced only
+  post-merge. Only `cargo fmt --check` covered them, and only for syntactic breakage. That lane now
+  passes `--all-targets`; it still does not *run* those tests, which is why `rust workspace` moved.
+- **Platform failures have been Windows-specific**: a `python` executable absent from `PATH`, and
+  `core.autocrlf` turning `depth = 2` into `depth = 2\r`. No macOS-specific failure has occurred.
+- **Windows is the slowest job in the gate** (≈17 min against ≈12 min for the Linux workspace), so
+  deferring the matrix is what buys the merge throughput this design is for.
+
+The cost is stated plainly: a pull request into `main` now waits roughly twelve minutes rather than
+forty seconds, and because a branch that falls behind `main` must re-run its checks, a serial chain
+of rebases pays that repeatedly.
 
 ## Merge readiness contract
 
 `.github/workflows/merge-readiness.yml` runs for `pull_request` and `merge_group` events targeting
-`main`. The ruleset requires only its always-present `merge readiness` aggregator. The aggregator
-fails unless all of these independent lanes succeed:
+`main`. It is now the **fail-fast lane**: it returns in well under a minute, so obvious breakage is
+reported in seconds rather than after the twelve-minute Linux workspace job. It is no longer the
+only pre-merge evidence, and it was never sufficient on its own. The aggregator fails unless all of
+these independent lanes succeed:
 
-1. `cargo check --workspace --exclude fsl-solver-z3 --exclude fslc-rust
+1. `cargo check --workspace --exclude fsl-solver-z3 --exclude fslc-rust --all-targets
    --no-default-features --locked` catches compile and dependency-integration drift across the
    authoritative native-Z3-free Rust surface without paying the vendored native-Z3 build cost
    before merge. Excluding the native CLI package as a workspace root avoids its Z3-only helper
    binaries; its library still compiles transitively through the LSP and WASM crates.
+   `--all-targets` is load-bearing: without it, test and bench targets are never compiled, and a
+   type error in a test file passes this lane entirely.
 2. Formatting, the `fsl-syntax`, `fsl-core`, `fsl-runtime`, and backend-neutral `fsl-solver` tests,
    plus the runtime/WASM dependency negative controls, protect the solver-independent semantic
    foundation.
@@ -49,9 +73,14 @@ candidate against current `main`.
 `.github/workflows/ci.yml` is named `product gate`. A trusted `main` push runs all of these jobs in
 parallel:
 
-- the complete Rust-native integration phase from `tools/check-native-integration.sh rust`;
-- the production WASM/browser phase from `tools/check-native-integration.sh wasm`;
-- focused native-Z3 tests on macOS and Windows.
+- the complete Rust-native integration phase from `tools/check-native-integration.sh rust`
+  (`rust workspace`);
+- the production WASM/browser phase from `tools/check-native-integration.sh wasm` (`WASM`);
+- focused native-Z3 tests on macOS and Windows (`native Z3 4.16`).
+
+**The first two carry no event condition and therefore also run on every pull request**, which is
+what makes the Linux evidence pre-merge. Only `native Z3 4.16` and the aggregate `product gate`
+context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into `main`.
 
 Scheduled and manual runs use the same evidence. Pull requests into `production` also run the
 complete product gate and emit the Linux native-Z3 compatibility context expected by the production
@@ -98,18 +127,27 @@ reported; the aggregate is reported on its own only when it is the sole availabl
 The workflow change must land before the ruleset changes; otherwise existing pull requests cannot
 produce the new required context. Roll out in this order:
 
-1. Merge the workflow change under the existing four required product checks. Until activation,
-   pull requests into `main` continue running the full product gate.
-2. In the `main` repository ruleset, add `merge readiness`, then remove `rust workspace`, `WASM`,
-   `native Z3 4.16 (macos-15)`, and `native Z3 4.16 (windows-latest)` from the required contexts.
-3. Set the repository Actions variable `FSL_OPTIMISTIC_CI=enabled`. This disables the redundant full
-   product gate on pull requests into `main`; main pushes, schedules, manual runs, and production
-   promotions ignore the variable.
-4. Optionally enable auto-merge and a merge queue after the `merge_group` check is observed.
+1. Merge the workflow change. `rust workspace` and `WASM` begin running on pull requests
+   immediately, as visible but not-yet-required evidence.
+2. In the `main` repository ruleset, add `rust workspace` and `WASM` alongside `merge readiness`.
+   `native Z3 4.16 (macos-15)` and `native Z3 4.16 (windows-latest)` stay out of the required set —
+   they are the deferred cross-platform matrix.
+3. Leave `FSL_OPTIMISTIC_CI=enabled`. It now governs only the cross-platform matrix and the
+   aggregate `product gate` context; main pushes, schedules, manual runs, and production promotions
+   ignore it as before.
 
-Rollback is fail-safe: delete or change `FSL_OPTIMISTIC_CI`, restore the four product contexts in the
-main ruleset, and keep `merge readiness` as additional evidence. No source or product artifact
-migration is involved.
+Rollback is fail-safe and has two independent levers. To return the Linux evidence to post-merge,
+restore the `if:` conditions on `rust workspace` and `WASM` and drop them from the ruleset. To return
+to a fully pre-merge gate, delete or change `FSL_OPTIMISTIC_CI` and restore all four product contexts
+in the main ruleset. No source or product artifact migration is involved either way.
+
+### Why the ruleset step is not optional
+
+A job that runs on a pull request but is not a required context is *advisory*: it can fail while the
+merge still succeeds. Until step 2 lands, this change buys visibility, not enforcement — and the
+gap it exists to close is precisely one that a disciplined developer already covers by running
+`./tools/check-native-integration.sh` locally. The point of the change is to stop depending on that
+discipline, which step 1 alone does not achieve.
 
 ## Non-goals
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -24,34 +24,43 @@ Measured on the batch that motivated this revision:
 
 - **The tests live in the crates the bounded lane excludes.** 103 of 124 integration test files sit
   in `fslc` (77), `fsl-tools` (16), `fsl-verifier` (8) and `fsl-lsp` (2). `merge readiness` runs 21.
-- **Its compile lane did not build test targets at all** — `cargo check` without `--all-targets` —
+- **Its compile lane does not build test targets at all** — `cargo check` without `--all-targets` —
   so a type error or a failing assertion in any of those 103 files reached `main` and surfaced only
-  post-merge. Only `cargo fmt --check` covered them, and only for syntactic breakage. That lane now
-  passes `--all-targets`; it still does not *run* those tests, which is why `rust workspace` moved.
+  post-merge. Only `cargo fmt --check` covered them, and only for syntactic breakage. Adding
+  `--all-targets` there was tried and **reverted**: measured at 12m42s in CI, it destroys the lane's
+  reason to exist, and it is redundant once `rust workspace` compiles and runs those targets
+  pre-merge.
 - **Platform failures have been Windows-specific**: a `python` executable absent from `PATH`, and
   `core.autocrlf` turning `depth = 2` into `depth = 2\r`. No macOS-specific failure has occurred.
-- **Windows is the slowest job in the gate** (≈17 min against ≈12 min for the Linux workspace), so
-  deferring the matrix is what buys the merge throughput this design is for.
+- **Windows is the slowest job in the gate** (≈17 min, against ≈12 min for the Linux workspace on a
+  warm cache and ≈18 min cold), so deferring the matrix is what buys the merge throughput this
+  design is for.
 
-The cost is stated plainly: a pull request into `main` now waits roughly twelve minutes rather than
-forty seconds, and because a branch that falls behind `main` must re-run its checks, a serial chain
-of rebases pays that repeatedly.
+The cost is stated plainly: a pull request into `main` now waits for `rust workspace`, measured at
+18m17s on a cold cache and around twelve minutes warm, rather than forty seconds. Because a branch
+that falls behind `main` must re-run its checks, a serial chain of rebases pays that repeatedly. Two
+mitigations already exist and are worth using before the cost is treated as inherent: independent
+changes can share one pull request with one commit per topic, and `merge-readiness.yml` already
+handles `merge_group`, so a merge queue can validate several candidates as one batch once `ci.yml`
+gains the same trigger.
 
 ## Merge readiness contract
 
 `.github/workflows/merge-readiness.yml` runs for `pull_request` and `merge_group` events targeting
-`main`. It is now the **fail-fast lane**: it returns in well under a minute, so obvious breakage is
-reported in seconds rather than after the twelve-minute Linux workspace job. It is no longer the
-only pre-merge evidence, and it was never sufficient on its own. The aggregator fails unless all of
-these independent lanes succeed:
+`main`. It is now the **fail-fast lane**: its slowest measured contract lane is 33s and the aggregator
+4s, so obvious breakage is reported in well under a minute rather than after the Linux workspace job.
+Keeping it that fast is the reason `--all-targets` was reverted below. It is no longer the only
+pre-merge evidence, and it was never sufficient on its own. The aggregator fails unless all of these
+independent lanes succeed:
 
-1. `cargo check --workspace --exclude fsl-solver-z3 --exclude fslc-rust --all-targets
-   --no-default-features --locked` catches compile and dependency-integration drift across the
-   authoritative native-Z3-free Rust surface without paying the vendored native-Z3 build cost
-   before merge. Excluding the native CLI package as a workspace root avoids its Z3-only helper
-   binaries; its library still compiles transitively through the LSP and WASM crates.
-   `--all-targets` is load-bearing: without it, test and bench targets are never compiled, and a
-   type error in a test file passes this lane entirely.
+1. `cargo check --workspace --exclude fsl-solver-z3 --exclude fslc-rust --no-default-features
+   --locked` catches compile and dependency-integration drift across the authoritative
+   native-Z3-free Rust surface without paying the vendored native-Z3 build cost before merge.
+   Excluding the native CLI package as a workspace root avoids its Z3-only helper binaries; its
+   library still compiles transitively through the LSP and WASM crates. **`--all-targets` is
+   deliberately absent**: it was added, measured at 12m42s, and reverted, because this lane's whole
+   value is sub-minute feedback and `rust workspace` already compiles and runs those targets on the
+   same pull request.
 2. Formatting, the `fsl-syntax`, `fsl-core`, `fsl-runtime`, and backend-neutral `fsl-solver` tests,
    plus the runtime/WASM dependency negative controls, protect the solver-independent semantic
    foundation.

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -7,11 +7,16 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
 check_compile() {
+  # `--all-targets` is load-bearing. Without it `cargo check` builds library and
+  # binary targets only, so a type error in a test file passes this lane
+  # entirely — only `cargo fmt --check` below would see such a file, and only
+  # when the breakage is syntactic.
   cargo check \
     --manifest-path rust/Cargo.toml \
     --workspace \
     --exclude fsl-solver-z3 \
     --exclude fslc-rust \
+    --all-targets \
     --no-default-features \
     --locked
 }

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -7,16 +7,16 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
 check_compile() {
-  # `--all-targets` is load-bearing. Without it `cargo check` builds library and
-  # binary targets only, so a type error in a test file passes this lane
-  # entirely — only `cargo fmt --check` below would see such a file, and only
-  # when the breakage is syntactic.
+  # Deliberately no `--all-targets`. It was tried and measured at 12m42s in CI,
+  # which destroys this lane's reason to exist — it is the sub-minute fail-fast
+  # signal, not the gate. Test targets are compiled and run by `rust workspace`,
+  # which now runs on every pull request, so `--all-targets` here buys nothing
+  # and costs the fast feedback.
   cargo check \
     --manifest-path rust/Cargo.toml \
     --workspace \
     --exclude fsl-solver-z3 \
     --exclude fslc-rust \
-    --all-targets \
     --no-default-features \
     --locked
 }


### PR DESCRIPTION
## Problem

`merge readiness` was the only pre-merge gate, and **it does not run where the tests are.**

| | |
|---|---|
| Integration test files it runs | **21** (`fsl-syntax` 3, `fsl-core` 12, `fsl-runtime` 6, `fsl-solver` 0) |
| Integration test files it does not | **103** (`fslc` 77, `fsl-tools` 16, `fsl-verifier` 8, `fsl-lsp` 2) |

Its `cargo check` also carried **no `--all-targets`**, so test and bench targets were never compiled
at all — only `cargo fmt --check` saw those files, and only when the breakage was syntactic. A type
error or a failing assertion anywhere in that 83% reached `main` and surfaced only after the merge.

**Thirteen consecutive green post-merge product gates are not evidence that this was safe.** They are
evidence that every pull request in that run had `./tools/check-native-integration.sh` executed
locally beforehand. The design's safety rested on a discipline it did not enforce — and in the most
recent batch that local run, not CI, caught two rebase-induced breaks: a struct field missing from a
new construction site after a clean textual auto-merge, and a conflict resolution that split an
`assert_eq!(` across hunk boundaries.

## Change

`rust workspace` and `WASM` lose their event conditions and now run on **every pull request**. Only
the cross-platform `native Z3 4.16` matrix and the aggregate `product gate` context still honour
`FSL_OPTIMISTIC_CI` and defer to post-merge.

`tools/check-merge-readiness.sh` was given `--all-targets` and then **reverted** — see the measured
result below.

`merge readiness` is **kept**, as a sub-minute fail-fast lane rather than the whole gate — it
reported the syntactic half of one of those two breaks in seconds instead of after a twelve-minute
workspace job.

### Why the split falls here, measured

- **Platform failures have been Windows-specific**: a `python` executable absent from `PATH`, and
  `core.autocrlf` turning `depth = 2` into `depth = 2\r`. No macOS-specific failure is on record.
- **Windows is the slowest job in the gate** — ≈17 min against ≈12 min for the Linux workspace and
  ≈5 min for WASM. Deferring the matrix is what buys the merge throughput this design exists for.
- The native-Z3 matrix already excludes `ubuntu-latest` with the comment "covered by the full
  rust-workspace test gate above", so moving that gate pre-merge loses no Linux coverage.

## Test evidence, and one thing the measurement overturned

**The `--all-targets` addition was verified by negative control** — the same injected type error in
`rust/fsl-core/tests/action_correspondence.rs` gives `cargo check` exit 0 without the flag and exit
101 with it — **and then reverted anyway.**

The first CI run on this pull request measured `merge readiness / Rust compile` at **12m42s** with
the flag, against seconds without it. That destroys the only property the lane has left: it is the
sub-minute fail-fast signal, not the gate. And it is redundant — the gap the flag closed exists only
while `merge readiness` is the *sole* pre-merge evidence, and the rest of this branch makes
`rust workspace` compile *and run* those same targets on the same pull request. Paying twelve
minutes twice for one coverage buys nothing.

Two timings asserted in the first commit were also wrong and are corrected in the design note:
`rust workspace` is **18m17s** cold (≈12 min warm), and "well under a minute" for merge readiness is
now stated against the measured 33s contract lane rather than assumed.

First-run measurements, all pass: `WASM` 5m28s, `rust workspace` 18m17s,
`merge readiness / core contracts` 33s, `merge readiness` aggregator 4s.

`./tools/check-merge-readiness.sh all` exits 0 on this branch.

The workflow file parses as YAML and the job conditions are as intended — `rust-workspace` and
`wasm` carry no `if:`; `rust-native-z3`, `production-native-z3-linux` and `product-gate` keep theirs.

This pull request is its own first exercise of the change: `rust workspace` and `WASM` should appear
in its own checks.

## Cost, stated plainly

A pull request into `main` now waits for `rust workspace` — measured at 18m17s cold, around twelve
minutes warm — rather than forty seconds, and because a branch that falls behind `main` must re-run
its checks, a serial chain of rebases pays that repeatedly. The batch that motivated this change rebased heavily, so this is a real price rather than
a theoretical one. `Swatinem/rust-cache` is already in use, and `merge-readiness.yml` already handles
`merge_group`, so a merge queue can batch if the cost becomes limiting.

## Rollout step 2 is not in this commit

Adding `rust workspace` and `WASM` to the `main` ruleset's required contexts is a repository settings
change. **Until it lands, the two jobs are visible but advisory** — they can fail while the merge
still succeeds. This commit buys visibility; enforcement needs the ruleset step, and the gap being
closed is precisely one a disciplined developer already covers locally. Recorded in
`docs/DESIGN-ci.md` under "Why the ruleset step is not optional".

## Documentation

`docs/DESIGN-ci.md` — decision, the measured rationale for where the split falls, the merge-readiness
contract, the product-gate contract, and a two-lever rollback. `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Refs #545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
