### PR TITLE
fix: three missing vacuity lanes, self-retiring parity exclusions, and a cross-file diagnostic location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   failure and echoing `helpful` on both the proof and CTI (#473).
 
 ### Added
+- Native `verify` now reports the three remaining `docs/DESIGN-vacuity.md` §2
+  lanes — `always_true_requires`, `tautology_over_frozen`, and
+  `urgency_freeze` — closing the last of issue 465. A spec whose only emptiness
+  was one of them previously came back `result:"verified"` / exit 0 even under
+  `--vacuity error`; the three-line reproduction (a `Bool` set by `init`,
+  assigned by no action, asserted as an invariant) now exits 2 with
+  `kind:"tautology_over_frozen"` and `trace_type:"vacuity"`. All three are
+  proved in `fsl-verifier`, so `fsl-runtime` stays solver-independent, and all
+  three report identically on `--engine bmc`, `explicit`, and `induction`.
+
+  Unlike the frozen Python reference, the native lanes decide "always true over
+  all reachable states" over the **declared type space** rather than over the
+  states an unrolling happened to witness, so no verdict moves with `--depth`.
+  Python reports `examples/causal/funnel.fsl`'s `requires visits < 100` as dead
+  at depth 8 because `visits` only reaches 8; with `visits: 0..100` declared,
+  native correctly stays silent at every depth. The lanes are sound and
+  deliberately incomplete: an unproven obligation, an `unknown` backend
+  verdict, a compose-synchronized action, a generated declaration, and an
+  action that was never enabled all yield no finding.
 - Added an optimistic CI lane with one stable, parallelized `merge readiness`
   context for pull requests and merge queues, while preserving the complete
   Rust/WASM/macOS/Windows product gate for every merged `main` state and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `members`, the same shape `SpecItem::Struct` gained in #555 and the same the
   domain surface already used, and the diagnostic attaches the offending
   member's own span (#576).
+- The native<->Worker parity corpus's `unsupportedDocuments` exclusions in
+  `rust/fsl-wasm/test-browser.mjs` are now self-retiring. The map excluded 32
+  refinement/agent/causal documents from the comparison and recorded only a
+  document type, so if the Worker ever gained a verb for one of them the
+  exclusion would keep suppressing the comparison forever -- the shape that
+  left #556's divergent path with zero corpus coverage. Each entry now carries
+  the measured reason it holds, and every excluded document is probed on the
+  Worker alone: the recorded premise is that the Worker cannot analyze it, and
+  the day that stops being true the harness fails and names the entry to
+  remove. The compared-pair count is unchanged at 351 -- no exclusion was
+  retired and no document newly compared -- and the run now also reports
+  `exclusionProbes`. This stays a capability exclusion, not a
+  tolerated-difference allowlist: the envelopes are still not compared for
+  these documents and no verdict, location, or exit-code difference is
+  allowlisted (#568).
 - The fsl-ai project check's unexecutable-`require` spec error (#542) now
   carries a `loc` pointing at the offending clause's own line and column.
   `rust/fsl-syntax/src/ai_project.rs` tracked no positions at all, so the error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   tolerated-difference allowlist: the envelopes are still not compared for
   these documents and no verdict, location, or exit-code difference is
   allowlisted (#568).
+- A kernel-stage failure inside a `use ... from` component now reports the
+  parent's `use` declaration as its `loc`, and names the component's own path
+  and position in the message. The two used to be mixed: the path came from the
+  parent (`source_file`) while the line and column came from the component's
+  parser, so `check` on
+  `examples/gallery/errors/semantics_compose_component_parse_failure.fsl`
+  reported `…:7:18` — and line 7 of that file is a comment. A location in the
+  wrong file is worse than none, and `docs/DESIGN-v1.md` G2 requires the output
+  JSON alone to say where the problem is. `loc` is `{line, column}` with no
+  `file` in all five of its `docs/DESIGN-v1.md` examples, so it can only mean a
+  position in the file the envelope is about; the `use` declaration is that
+  position, and it is also the line to look at first. The message now reads
+  `component "<component>" failed to parse (<inner> at <component>:<l>:<c>) at
+  <parent>:<use line>:<use column>`, naming both files explicitly. An
+  unreadable component is re-anchored the same way, instead of reporting `1:1`.
+  Native and the browser Worker share the loader, so both return the identical
+  string; the file is a parity corpus case, so
+  `./tools/check-native-integration.sh` checks that on every run (#567).
 - The fsl-ai project check's unexecutable-`require` spec error (#542) now
   carries a `loc` pointing at the offending clause's own line and column.
   `rust/fsl-syntax/src/ai_project.rs` tracked no positions at all, so the error

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -256,11 +256,26 @@ solver-independent crates used by both delivery surfaces:
   warnings. It consumes only the checked model and backend-neutral result
   facts. The remaining three `docs/DESIGN-vacuity.md` §2 lanes
   (`always_true_requires`, `tautology_over_frozen`, `urgency_freeze`) are
-  solver-dependent and are not yet implemented on the Rust side (#465);
-  `--vacuity` selects over the closed 5-kind set in
-  `fsl-core::VACUITY_KINDS`, not a `"vacuous_"` name-prefix check, so the
-  three unimplemented lanes fail closed by absence rather than by a
-  misclassified warning once they are added.
+  solver-dependent, so `fsl-verifier::vacuity` proves them and carries them
+  out of the verifier as `BmcResult.vacuity`. The frontend renders that into
+  warning JSON and passes it back into `verification_warnings`, which keeps
+  the documented warning order in one place without giving `fsl-runtime` a
+  solver dependency. `--vacuity` selects over the closed 5-kind set in
+  `fsl-core::VACUITY_KINDS`, not a `"vacuous_"` name-prefix check.
+- The solver-dependent lanes run after every witness, reachable, and deadlock
+  trace has been projected. They quantify over freshly named states and never
+  read the unrolled ones, but a query still moves the backend's internal
+  state, and the native and browser Z3 builds may then resolve an
+  under-determined model differently — which the byte-compared evidence
+  contract reports as a parity failure. No new query may run before the
+  evidence it could perturb.
+- Backend-neutral analysis must keep its symbolic-state allocation independent
+  of the spec's size. Every constraint a probe needs is asserted inside a
+  `push`/`pop`, so one reusable state per analysis is enough; allocating one
+  per invariant or per action instance multiplies the live Z3 term count by
+  the corpus's largest spec and exhausts the browser backend's bounded heap,
+  where the failure surfaces as a Worker that stops answering rather than as a
+  diagnosable error.
 - Shared warnings use typed `kind` values for downstream selection. In
   particular, induction removes bounded `kind:"deadlock"` warnings through
   `fsl-runtime::induction_warnings`; frontends never classify a warning by

--- a/docs/DESIGN-vacuity.md
+++ b/docs/DESIGN-vacuity.md
@@ -43,6 +43,33 @@ bugs. Conventionally `kind:"vacuous"` referred only to init unsatisfiability.
    every action. This is depth-independent and intentionally incomplete: if the initial or
    inductive proof fails, no warning is emitted.
 
+### Native lanes 3–5: "over all reachable states" is decided over the type space
+
+The frozen Python reference discharges lane 3 from the states an unrolling actually witnesses:
+a clause survives to a warning when nothing within depth K falsified it. That reports a real
+guard as dead merely because the bound was too small. `examples/causal/funnel.fsl` declares
+`state { visits: 0..100 }` and `requires visits < 100`; at depth 8 `visits` reaches only 8, so
+Python warns — and the warning disappears when `--depth` rises. A judgment that moves with the
+bound is not evidence of a hollow spec (issue #465).
+
+The native implementation (`fsl-verifier::vacuity`) therefore decides all three solver-dependent
+lanes over the **declared type space**, which is a superset of the reachable states: for clause
+`j`, `type bounds ∧ clauses[..j] ∧ ¬clauses[j]` unsat means the clause cannot be false in any
+reachable state at any depth. `visits == 100` is inside `0..100`, so `funnel.fsl` is correctly
+silent. Every lane is a bounded number of one-shot queries over freshly named states, and each
+verdict is therefore independent of `--depth`.
+
+This is sound and deliberately incomplete in the same direction as lane 5: a clause that is dead
+for a reason the type space cannot see goes unreported, and an `unknown` backend verdict yields
+no finding. The exploration contributes exactly one input, action coverage, and only to suppress
+lane 3 for actions that were never enabled.
+
+Two exclusions keep the lanes pointed at authored text. Generated declarations are skipped, and
+so is any declaration without a source location: some dialect lowerings synthesize an entire
+catalog kernel (the governance catalog's `_governance_catalog_ok` over a frozen generated Bool)
+with a zero span rather than a `generated_only` origin, and warning about that scaffolding is
+noise in every governance spec.
+
 ### Reason for excluding compose-synchronized actions (important)
 
 `deposit_audited = bank.submit_deposit || audit.deposit` inherits `requires a > 0` from both

--- a/examples/gallery/errors/README.md
+++ b/examples/gallery/errors/README.md
@@ -30,7 +30,7 @@ of JSON output actually confirmed with `fslc`.
 
 ```json
 // semantics_compose_component_parse_failure.fsl
-{"result":"error","kind":"semantics","message":"expected expression at examples/gallery/errors/semantics_compose_component_parse_failure.fsl:7:18"}
+{"result":"error","kind":"semantics","message":"component \"semantics_compose_broken_component.fsl\" failed to parse (expected expression at semantics_compose_broken_component.fsl:7:18) at examples/gallery/errors/semantics_compose_component_parse_failure.fsl:13:3","loc":{"line":13,"column":3}}
 ```
 
 `semantics_compose_component_parse_failure.fsl`, with its
@@ -40,6 +40,10 @@ failure comes from resolving and lowering the component; the component's syntax
 error is not this document's own syntax error, so it stays `semantics` on both
 surfaces rather than becoming `parse`. No corpus case reached that stage
 before, which is why the Worker could classify all of it as `parse` undetected.
+The reported `loc` is the parent's `use` declaration, not the component's
+position: `loc` carries no `file`, so a component line reported against the
+parent's path pointed at whatever sat there — here, a comment (issue #567). The
+component's own path and position stay in the message.
 
 ```json
 // vacuous_contradictory_init.fsl

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -152,16 +152,77 @@ impl ComponentNames {
     }
 }
 
+/// Re-anchor a failure that happened *inside* a component onto the parent's
+/// `use ... from` declaration (issue #567).
+///
+/// `loc` is `{line, column}` with no `file` (`docs/DESIGN-v1.md`), so it can
+/// only ever mean "a position in the file the envelope names". A component's
+/// line and column reported against the parent's path therefore points at
+/// whatever happens to sit there — for the compose error gallery fixture, a
+/// comment. The position now belongs to the `use` declaration, which really is
+/// in the parent and really is the line to look at, and the component's own
+/// path and position move into the message so nothing is lost.
+fn component_error(
+    path: &str,
+    use_span: fsl_syntax::Span,
+    error: &CoreError,
+    verb: &str,
+) -> CoreError {
+    CoreError {
+        message: format!(
+            "component \"{path}\" {verb} ({} at {path}:{}:{})",
+            error.message, error.line, error.column
+        ),
+        line: use_span.start.line,
+        column: use_span.start.column,
+        // Not propagated from `error`. What this value reports is a compose-level
+        // failure to load a component, anchored at the parent's `use`
+        // declaration — it is not itself a name-resolution failure, and
+        // `docs/DESIGN-v1.md` §8's repair branch for `name` ("add a declaration
+        // or change a type") would be wrong advice at that location. The
+        // component's own classification survives inside the message, together
+        // with its path and position (issue 565's flag, issue 567's anchoring).
+        name_resolution: false,
+        // The origin's span is the `use` declaration, which really is in the
+        // parent, so `with_source_file` stamps the parent path onto a position
+        // that exists there. Carrying the component's span here is what let the
+        // rendered message pair the parent's path with the component's line.
+        origin: Some(Box::new(crate::OriginChain {
+            id: crate::OriginId(format!(
+                "compose:use:{}:{}",
+                use_span.start.offset, use_span.end.offset
+            )),
+            dialect: "compose".to_owned(),
+            primary: Some(crate::OriginSite {
+                source_file: None,
+                span: Some(use_span),
+                dialect: "compose".to_owned(),
+                declaration_path: vec!["use".to_owned(), path.to_owned()],
+            }),
+            secondary: Vec::new(),
+            lowering_steps: Vec::new(),
+            generated: false,
+        })),
+    }
+}
+
 fn parse_component(
     source: &str,
+    path: &str,
     use_span: fsl_syntax::Span,
 ) -> Result<(SurfaceSpec, Annotations), CoreError> {
-    let parsed = parse_document(SourceFile::new(source))?;
+    let parsed = parse_document(SourceFile::new(source)).map_err(|error| {
+        component_error(path, use_span, &CoreError::from(error), "failed to parse")
+    })?;
     let SurfaceDocument::Spec(spec) = parsed.surface else {
         return Err(error_at("compose use must reference a spec", use_span));
     };
-    let spec = PredicateExpander::new(&spec)?.expand(spec)?;
-    Ok((expand_spec_domains(spec)?, parsed.annotations))
+    let spec = PredicateExpander::new(&spec)
+        .and_then(|expander| expander.expand(spec))
+        .map_err(|error| component_error(path, use_span, &error, "failed to lower"))?;
+    let spec = expand_spec_domains(spec)
+        .map_err(|error| component_error(path, use_span, &error, "failed to lower"))?;
+    Ok((spec, parsed.annotations))
 }
 
 fn composed_kernel(
@@ -212,8 +273,10 @@ pub fn lower_compose(
         if components.contains_key(alias) {
             return Err(error_at(format!("duplicate alias '{alias}'"), *span));
         }
-        let source = resolver.read(path)?;
-        let (spec, annotations) = parse_component(&source, *span)?;
+        let source = resolver
+            .read(path)
+            .map_err(|error| component_error(path, *span, &error, "could not be read"))?;
+        let (spec, annotations) = parse_component(&source, path, *span)?;
         component_annotations.extend(annotations.source_order().iter().cloned());
         order.push(alias.clone());
         components.insert(

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -2080,10 +2080,18 @@ pub fn lower_requirements(requirements: SurfaceRequirements) -> Result<KernelSpe
             sync: false,
             annotations: Annotations::default(),
         });
-        extra_origins.push((
-            crate::action_target("tick"),
-            OriginChain::generated_only("requirements:sla-tick", "requirements"),
-        ));
+        let mut tick_origin = OriginChain::generated_only("requirements:sla-tick", "requirements");
+        if !urgent.is_empty() {
+            // The `urgent` action names are consumed structurally into
+            // `requires not(<enabled ...>)` above and are not otherwise
+            // recoverable from the Kernel. The `urgency_freeze` vacuity lane
+            // needs them to name the actions that freeze time.
+            tick_origin.lowering_steps.push(crate::LoweringStep {
+                kind: crate::URGENT_ACTIONS_STEP.to_owned(),
+                detail: Some(urgent.join(",")),
+            });
+        }
+        extra_origins.push((crate::action_target("tick"), tick_origin));
         for (
             index,
             (name, bound, span, metadata, requirement_id, requirement_text, requirement_span),

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -17,8 +17,8 @@ pub use fsl_syntax::{
     AggregateKind as KernelAggregateKind, Annotation, AnnotationError,
     AnnotationRegistry as KernelAnnotationRegistry, AnnotationValue, Annotations,
     Binder as KernelBinder, CorrespondenceOrigin, Expr as KernelExpr, HelpfulAction,
-    LValue as KernelLValue, Pattern, QualifiedName, RequirementLink, Statement as KernelStatement,
-    SymbolPath,
+    LValue as KernelLValue, Pattern, QualifiedName, RequirementLink, Span,
+    Statement as KernelStatement, SymbolPath,
 };
 
 mod compose;
@@ -59,8 +59,9 @@ pub use model::{
 };
 pub use origin::{
     INIT_TARGET, LoweringStep, OriginChain, OriginId, OriginRegistry, OriginSite, SPEC_TARGET,
-    TERMINAL_TARGET, TraceabilityRegistry, action_guard_target, action_statement_target,
-    action_target, init_statement_target, property_target, state_target, type_target,
+    TERMINAL_TARGET, TraceabilityRegistry, URGENT_ACTIONS_STEP, action_guard_target,
+    action_statement_target, action_target, init_statement_target, property_target, state_target,
+    type_target,
 };
 pub use public_kernel::{
     KERNEL_SCHEMA_ID, KERNEL_SCHEMA_VERSION, KERNEL_V1_SCHEMA_ID, KERNEL_V1_SCHEMA_VERSION,

--- a/rust/fsl-core/src/model.rs
+++ b/rust/fsl-core/src/model.rs
@@ -92,6 +92,11 @@ pub struct ActionDef {
     pub ensures: Vec<Expr>,
     pub ensure_spans: Vec<Span>,
     pub fair: bool,
+    /// Set by compose expansion for a synchronized action. Its `requires` are
+    /// inherited copies from several components, so per-clause redundancy
+    /// diagnostics must not treat a duplicated component guard as removable
+    /// (`docs/DESIGN-vacuity.md` §2).
+    pub sync: bool,
     pub meta: Option<MetaTag>,
     pub annotations: Annotations,
 }
@@ -684,6 +689,7 @@ impl ModelBuilder {
                     fair,
                     meta,
                     span,
+                    sync,
                     ..
                 } => {
                     let origin = self.origins.diagnostic_origin(&action_target(name));
@@ -692,10 +698,14 @@ impl ModelBuilder {
                             model_error(format!("duplicate action '{name}'")).with_origin(origin)
                         );
                     }
-                    actions.push(
-                        self.action(name, params, items, *span, *fair, meta.clone())
-                            .map_err(|error| error.with_origin(origin))?,
-                    );
+                    let mut action = self
+                        .action(name, params, items, *span, *fair, meta.clone())
+                        .map_err(|error| error.with_origin(origin))?;
+                    // Carried outside `action` so its argument list stays
+                    // within the workspace Clippy budget; `sync` is a compose
+                    // marker, not part of the action's own lowering.
+                    action.sync = *sync;
+                    actions.push(action);
                 }
                 SpecItem::Invariant {
                     name,
@@ -1116,6 +1126,7 @@ impl ModelBuilder {
             ensures,
             ensure_spans,
             fair,
+            sync: false,
             meta,
             annotations: self
                 .annotations

--- a/rust/fsl-core/src/origin.rs
+++ b/rust/fsl-core/src/origin.rs
@@ -184,3 +184,9 @@ pub fn property_target(kind: &str, name: &str) -> String {
 }
 
 pub const TERMINAL_TARGET: &str = "terminal";
+
+/// [`LoweringStep::kind`] recording, on the generated requirements `tick`
+/// action, the comma-separated `urgent` action names that were consumed
+/// structurally into its `requires not(<enabled ...>)` guard. The
+/// `urgency_freeze` vacuity lane needs them to name what freezes time.
+pub const URGENT_ACTIONS_STEP: &str = "urgent_actions";

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2169,7 +2169,14 @@ fn exists_wrap(binders: &[Binder], expr: Expr) -> Expr {
         })
 }
 
-/// Build solver-independent verification warnings shared by native and browser frontends.
+/// Build the verification warnings shared by native and browser frontends.
+///
+/// The two reachability vacuity lanes are computed here and stay
+/// solver-independent. `solver_vacuity` carries the already-rendered
+/// `docs/DESIGN-vacuity.md` §2 lanes 3–5 that only `fsl-verifier` can decide;
+/// passing them in keeps the documented warning order (model → vacuity →
+/// deadlock → action coverage) owned by one function without giving
+/// `fsl-runtime` a solver dependency.
 #[must_use]
 pub fn verification_warnings(
     model: &KernelModel,
@@ -2178,6 +2185,7 @@ pub fn verification_warnings(
     deadlock_step: Option<usize>,
     deadlock_state: Option<&State>,
     action_coverage: &BTreeMap<String, bool>,
+    solver_vacuity: &[JsonValue],
 ) -> Vec<JsonValue> {
     let mut warnings = model_warnings(model);
     for property in &model.invariants {
@@ -2254,6 +2262,7 @@ pub fn verification_warnings(
             warnings.push(warning);
         }
     }
+    warnings.extend(solver_vacuity.iter().cloned());
     if warn_deadlock && let Some(step) = deadlock_step {
         let summary = deadlock_state.map_or_else(String::new, |state| state_summary(model, state));
         warnings.push(json!({

--- a/rust/fsl-runtime/tests/diagnostics.rs
+++ b/rust/fsl-runtime/tests/diagnostics.rs
@@ -25,8 +25,15 @@ fn vacuous_leadsto_is_reported_when_the_trigger_is_unreachable() {
          action finish() { requires pending pending = false done = true } \
          leadsTo Served { pending ~> done } }",
     );
-    let warnings =
-        fsl_runtime::verification_warnings(&unreachable, 3, false, None, None, &BTreeMap::new());
+    let warnings = fsl_runtime::verification_warnings(
+        &unreachable,
+        3,
+        false,
+        None,
+        None,
+        &BTreeMap::new(),
+        &[],
+    );
     assert!(
         warnings
             .iter()
@@ -44,7 +51,7 @@ fn vacuous_leadsto_is_reported_when_the_trigger_is_unreachable() {
          leadsTo Served { pending ~> done } }",
     );
     let warnings =
-        fsl_runtime::verification_warnings(&reachable, 3, false, None, None, &BTreeMap::new());
+        fsl_runtime::verification_warnings(&reachable, 3, false, None, None, &BTreeMap::new(), &[]);
     assert!(
         !warnings
             .iter()

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -13,6 +13,7 @@ use crate::trace::project_trace;
 use crate::transition::{
     ActionInstance, action_guards, action_instances, init_constraints, transition_constraint,
 };
+use crate::vacuity::{VacuityFinding, retain_covered, static_findings};
 use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, concrete_value, i64_index, logical_equal,
     symbolic_state,
@@ -56,6 +57,9 @@ pub struct BmcResult {
     pub deadlock_trace: Option<Vec<TraceStep>>,
     pub action_coverage: BTreeMap<String, bool>,
     pub frontier_progress: bool,
+    /// Solver-dependent vacuity facts (`docs/DESIGN-vacuity.md` §2 lanes 3–5).
+    /// Depth-independent by construction; see [`crate::vacuity`].
+    pub vacuity: Vec<VacuityFinding>,
 }
 
 /// Explore all symbolic executions up to `depth` using a backend-neutral SMT solver.
@@ -168,6 +172,7 @@ async fn verify_bounded_config<S: SmtSolver>(
             .map(|action| (action.name.clone(), false))
             .collect(),
         frontier_progress: false,
+        vacuity: Vec::new(),
     };
     let mut pending_reachables = model
         .reachables
@@ -260,6 +265,23 @@ async fn verify_bounded_config<S: SmtSolver>(
         let unrolled_depth = states.len() - 1;
         result.leadsto_violation =
             check_leadstos(solver, model, &states, &choices, &instances, unrolled_depth).await?;
+    }
+    // The solver-dependent vacuity lanes run last, after every witness,
+    // reachable, and deadlock trace has been projected. They ask nothing about
+    // the unrolled states — each lane quantifies over freshly named ones — but
+    // a query still moves the backend's internal state, and two Z3 builds may
+    // then resolve an under-determined model differently. The native and
+    // browser evidence contract is byte-compared, so no new query may run
+    // before the evidence it could perturb.
+    //
+    // By this point the unrolling has asserted a mandatory forward transition
+    // out of every state, which a spec that deadlocks on every path makes
+    // globally unsatisfiable. In such a session every query answers `unsat`
+    // and every lane would fire on nothing. Report no vacuity rather than a
+    // fabricated one.
+    if session_satisfiable(solver).await? {
+        result.vacuity = static_findings(model, solver, &instances).await?;
+        retain_covered(&mut result.vacuity, &result.action_coverage);
     }
     Ok(result)
 }
@@ -880,6 +902,12 @@ async fn check_leadstos<S: SmtSolver>(
         }
     }
     Ok(None)
+}
+
+/// Whether the accumulated unrolling session still has a model at all.
+async fn session_satisfiable<S: SmtSolver>(solver: &mut S) -> Result<bool, VerifyError> {
+    solver.set_query_context("vacuity", "session");
+    Ok(matches!(solver.check().await?, SatResult::Sat))
 }
 
 async fn probe_not<S: SmtSolver>(solver: &mut S, condition: &S::Term) -> Result<bool, VerifyError> {

--- a/rust/fsl-verifier/src/lib.rs
+++ b/rust/fsl-verifier/src/lib.rs
@@ -11,6 +11,7 @@ mod refinement;
 mod symmetry;
 mod trace;
 mod transition;
+mod vacuity;
 mod value;
 
 use std::error::Error;
@@ -32,6 +33,7 @@ pub use induction::{
     prove_ranked_leadstos,
 };
 pub use refinement::{ProgressCheck, check_refinement_progress};
+pub use vacuity::{VacuityFinding, model_vacuity_findings};
 pub use value::{Bindings, SymbolicState, SymbolicValue};
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/fsl-verifier/src/vacuity.rs
+++ b/rust/fsl-verifier/src/vacuity.rs
@@ -1,0 +1,705 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Solver-dependent vacuity lanes (`docs/DESIGN-vacuity.md` §2 lanes 3–5).
+//!
+//! The two reachability lanes (`vacuous_implication`, `vacuous_leadsto`) are
+//! solver-independent and live in `fsl-runtime`. The three lanes here need Z3,
+//! so they must stay on this side of the `fsl-runtime`/`fsl-solver` boundary
+//! (`AGENTS.md`: `fsl-runtime` must remain independent of `fsl-solver`).
+//!
+//! Every lane is a **bounded number of one-shot queries over freshly named
+//! states**, decided before the bounded-model-checking unrolling accumulates
+//! path constraints. That placement is what makes them depth-independent:
+//! each judgment quantifies over the declared type space, which is a superset
+//! of the reachable states, so "unsat" here means "unsat in every reachable
+//! state at every depth". A judgment that would disappear at a larger `--depth`
+//! is never produced (issue #465, accepted resolution (b)).
+//!
+//! Inconclusive backends never produce a finding: `SatResult::Unknown` is
+//! treated as "not proven", the same fail-quiet direction the lanes take for
+//! every other unproven obligation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_core::{
+    ActionDef, KernelBinder as Binder, KernelExpr as Expr, KernelLValue as LValue, KernelModel,
+    KernelStatement as Statement, PropertyDef, Span,
+};
+use fsl_solver::{SatResult, SmtSolver};
+
+use crate::VerifyError;
+use crate::eval::eval;
+use crate::transition::{ActionInstance, action_guards, init_constraints, transition_constraint};
+use crate::value::{
+    Bindings, SymbolicState, bool_term, bounds, i64_index, logical_equal,
+    symbolic_state_with_suffix,
+};
+
+/// One proven solver-dependent vacuity fact, carried backend-neutrally to the
+/// frontend that renders warning JSON.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VacuityFinding {
+    /// A user invariant that holds for every dynamics because the state it
+    /// depends on is pinned by init and never assigned by any action.
+    TautologyOverFrozen {
+        invariant: String,
+        span: Span,
+        frozen_vars: Vec<String>,
+    },
+    /// The generated `tick` action of a requirements `deadline` is dead
+    /// because the generated urgent condition is an inductive invariant.
+    UrgencyFreeze {
+        span: Span,
+        /// The generated deadline invariants rendered vacuous by the freeze.
+        /// The first one carries the requirement metadata for the warning.
+        deadlines: Vec<String>,
+    },
+    /// A `requires` clause that cannot be false in any type-valid state once
+    /// its preceding clauses hold, for every instance of the action.
+    AlwaysTrueRequires {
+        action: String,
+        span: Span,
+        clause_index: usize,
+    },
+}
+
+impl VacuityFinding {
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::TautologyOverFrozen { .. } => "tautology_over_frozen",
+            Self::UrgencyFreeze { .. } => "urgency_freeze",
+            Self::AlwaysTrueRequires { .. } => "always_true_requires",
+        }
+    }
+
+    /// The declaration the warning is named after.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::TautologyOverFrozen { invariant, .. } => invariant,
+            Self::UrgencyFreeze { .. } => "tick",
+            Self::AlwaysTrueRequires { action, .. } => action,
+        }
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Self::TautologyOverFrozen { span, .. }
+            | Self::UrgencyFreeze { span, .. }
+            | Self::AlwaysTrueRequires { span, .. } => *span,
+        }
+    }
+}
+
+/// Prove the solver-dependent vacuity lanes for a model whose exploration was
+/// carried out by a solver-free engine.
+///
+/// The lanes are properties of the model rather than of the exploration, so the
+/// explicit-state engine reports exactly what bounded model checking reports;
+/// `action_coverage` is the only exploration input, and it is used solely to
+/// suppress `always_true_requires` for actions that were never enabled.
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] for unsupported symbolic expressions or backend
+/// failures.
+pub async fn model_vacuity_findings<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    action_coverage: &BTreeMap<String, bool>,
+) -> Result<Vec<VacuityFinding>, VerifyError> {
+    let instances = crate::transition::action_instances(solver, model)?;
+    let mut findings = static_findings(model, solver, &instances).await?;
+    retain_covered(&mut findings, action_coverage);
+    Ok(findings)
+}
+
+/// Prove every solver-dependent vacuity lane that does not depend on the
+/// exploration bound.
+///
+/// Runs against freshly named states inside `push`/`pop`, so it neither reads
+/// nor leaves any constraint on the caller's unrolling session.
+///
+/// `always_true_requires` findings are returned unfiltered; the caller must
+/// drop the ones whose action never became enabled (`docs/DESIGN-vacuity.md` §2
+/// excludes coverage-false actions, which are already reported by their own
+/// warning).
+///
+/// # Errors
+///
+/// Returns [`VerifyError`] for unsupported symbolic expressions or backend
+/// failures. An `unknown` backend verdict is not an error; it yields no
+/// finding.
+pub(crate) async fn static_findings<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    instances: &[ActionInstance<S::Term>],
+) -> Result<Vec<VacuityFinding>, VerifyError> {
+    let mut findings = frozen_tautologies(model, solver).await?;
+    if let Some(finding) = urgency_freeze(model, solver, instances).await? {
+        findings.push(finding);
+    }
+    findings.extend(always_true_requires(model, solver, instances).await?);
+    Ok(findings)
+}
+
+/// State variables no action ever assigns.
+///
+/// `transition_constraint` frames every unassigned state variable forward
+/// unchanged, so such a variable equals its init value in every reachable
+/// state. The walk must stay complete: a missed assignment form would call a
+/// live variable frozen and manufacture a false positive.
+fn frozen_state_vars(model: &KernelModel) -> BTreeSet<String> {
+    let mut assigned = BTreeSet::new();
+    for action in &model.actions {
+        collect_assigned_roots(&action.statements, &mut assigned);
+    }
+    model
+        .state
+        .iter()
+        .map(|(name, _)| name.clone())
+        .filter(|name| !assigned.contains(name))
+        .collect()
+}
+
+fn collect_assigned_roots(statements: &[Statement], out: &mut BTreeSet<String>) {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, .. } => {
+                out.insert(lvalue_root(target).to_owned());
+            }
+            Statement::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                collect_assigned_roots(then_statements, out);
+                collect_assigned_roots(else_statements, out);
+            }
+            Statement::ForAll { statements, .. } => collect_assigned_roots(statements, out),
+        }
+    }
+}
+
+fn lvalue_root(target: &LValue) -> &str {
+    match target {
+        LValue::Var(name) | LValue::Index(name, _) => name,
+        LValue::Field(inner, _) => lvalue_root(inner),
+    }
+}
+
+/// State variables an expression may read.
+///
+/// Only used to decide whether a lane is worth a query; both an over- and an
+/// under-approximation stay sound, because the query itself quantifies over
+/// the whole type space either way.
+fn referenced_state_vars(model: &KernelModel, expr: &Expr) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    collect_vars(expr, &mut names);
+    names
+        .into_iter()
+        .filter(|name| model.state.iter().any(|(state, _)| state == name))
+        .collect()
+}
+
+fn collect_vars(expr: &Expr, out: &mut BTreeSet<String>) {
+    match expr {
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::EnumMember { .. } => {}
+        Expr::Var(name) => {
+            out.insert(name.clone());
+        }
+        Expr::Some(inner)
+        | Expr::Neg(inner)
+        | Expr::Not(inner)
+        | Expr::Field(inner, _)
+        | Expr::UnaryNamed { expr: inner, .. }
+        | Expr::Stage { entity: inner, .. } => collect_vars(inner, out),
+        Expr::Set(items) | Expr::Seq(items) => {
+            for item in items {
+                collect_vars(item, out);
+            }
+        }
+        Expr::Struct { fields, .. } => {
+            for (_, value) in fields {
+                collect_vars(value, out);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for arg in args {
+                collect_vars(arg, out);
+            }
+        }
+        Expr::Method { receiver, args, .. } => {
+            collect_vars(receiver, out);
+            for arg in args {
+                collect_vars(arg, out);
+            }
+        }
+        Expr::Index(left, right)
+        | Expr::Binary { left, right, .. }
+        | Expr::BinaryNamed { left, right, .. } => {
+            collect_vars(left, out);
+            collect_vars(right, out);
+        }
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            collect_vars(condition, out);
+            collect_vars(then_expr, out);
+            collect_vars(else_expr, out);
+        }
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => {
+            collect_vars(first, out);
+            collect_vars(second, out);
+            collect_vars(third, out);
+        }
+        Expr::Is { expr, .. } => collect_vars(expr, out),
+        Expr::Quantified { binder, body, .. } => {
+            collect_binder_vars(binder, out);
+            collect_vars(body, out);
+        }
+        Expr::Aggregate { binder, value, .. } => {
+            collect_binder_vars(binder, out);
+            if let Some(value) = value {
+                collect_vars(value, out);
+            }
+        }
+    }
+}
+
+fn collect_binder_vars(binder: &Binder, out: &mut BTreeSet<String>) {
+    match binder {
+        Binder::Typed { where_expr, .. } => {
+            if let Some(where_expr) = where_expr {
+                collect_vars(where_expr, out);
+            }
+        }
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
+            collect_vars(lo, out);
+            collect_vars(hi, out);
+            if let Some(where_expr) = where_expr {
+                collect_vars(where_expr, out);
+            }
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            collect_vars(collection, out);
+            if let Some(where_expr) = where_expr {
+                collect_vars(where_expr, out);
+            }
+        }
+    }
+}
+
+fn is_generated_invariant(model: &KernelModel, name: &str) -> bool {
+    model
+        .property_origin("invariant", name)
+        .is_some_and(|origin| origin.generated)
+}
+
+fn is_generated_action(model: &KernelModel, name: &str) -> bool {
+    model
+        .action_origin(name)
+        .is_some_and(|origin| origin.generated)
+}
+
+/// Whether a declaration points at real source text.
+///
+/// `OriginChain::generated` alone does not separate authored declarations from
+/// generated ones: some dialect lowerings synthesize a whole catalog kernel
+/// (the governance catalog's `_governance_catalog_ok`, whose `_governance_ok`
+/// is a generated Bool that is true at init and assigned by nothing) and give
+/// the synthetic declarations a zero span instead of a `generated_only`
+/// origin. Source lines are 1-based, so line 0 means "no source text behind
+/// this". `docs/DESIGN-vacuity.md` §2 scopes these lanes to **user**
+/// declarations; a warning that cannot point at anything the author wrote is
+/// noise, and it is the frozen scaffolding of every governance spec.
+fn is_source_backed(span: Span) -> bool {
+    span.start.line > 0
+}
+
+fn all_bounds<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    state: &SymbolicState<S::Term>,
+) -> Result<Vec<S::Term>, VerifyError> {
+    model
+        .state
+        .iter()
+        .map(|(name, _)| {
+            bounds(
+                solver,
+                model,
+                state
+                    .get(name)
+                    .ok_or_else(|| VerifyError::new(format!("missing state '{name}'")))?,
+            )
+        })
+        .collect()
+}
+
+/// Lane 4 — `tautology_over_frozen`.
+///
+/// Sound because every reachable state agrees with some init state on the
+/// frozen variables (nothing assigns them) and satisfies the declared type
+/// bounds. If no such state can falsify the invariant, the invariant holds
+/// everywhere for reasons independent of the dynamics, which is exactly the
+/// hollow-invariant claim. Unlike the frozen Python reference this leaves init
+/// symbolic instead of picking one completed init model, so a non-deterministic
+/// init cannot make the judgment depend on an arbitrary witness.
+async fn frozen_tautologies<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+) -> Result<Vec<VacuityFinding>, VerifyError> {
+    let frozen = frozen_state_vars(model);
+    if frozen.is_empty() {
+        return Ok(Vec::new());
+    }
+    // One pair of probe states for the whole lane: every constraint below is
+    // asserted inside `proven_unsat`'s push/pop, so nothing carries between
+    // invariants. Allocating per invariant instead would multiply the Z3 term
+    // count by the invariant count for no gain, which matters most in the
+    // browser backend's bounded heap.
+    let init = symbolic_state_with_suffix(solver, model, "vac_frozen_init")?;
+    let state = symbolic_state_with_suffix(solver, model, "vac_frozen")?;
+    let bound_terms = all_bounds(solver, model, &state)?;
+    let init_terms = init_constraints(solver, model, &init)?;
+    let mut findings = Vec::new();
+    for property in &model.invariants {
+        if is_generated_invariant(model, &property.name) || !is_source_backed(property.span) {
+            continue;
+        }
+        let frozen_vars = referenced_state_vars(model, &property.expr)
+            .intersection(&frozen)
+            .cloned()
+            .collect::<Vec<_>>();
+        if frozen_vars.is_empty() {
+            continue;
+        }
+        let mut terms = init_terms.clone();
+        for name in &frozen_vars {
+            let missing = || VerifyError::new(format!("missing state '{name}'"));
+            terms.push(logical_equal(
+                solver,
+                model,
+                state.get(name).ok_or_else(missing)?,
+                init.get(name).ok_or_else(missing)?,
+            )?);
+        }
+        terms.extend(bound_terms.iter().cloned());
+        let mut bindings = Bindings::new();
+        let value = eval(solver, model, &property.expr, &state, &mut bindings, None)?;
+        terms.push(solver.not(bool_term(&value)?)?);
+        solver.set_query_context("vacuity", &property.name);
+        if proven_unsat(solver, &terms).await? {
+            findings.push(VacuityFinding::TautologyOverFrozen {
+                invariant: property.name.clone(),
+                span: property.span,
+                frozen_vars,
+            });
+        }
+    }
+    Ok(findings)
+}
+
+/// The generated deadline invariants a requirements `time`/`deadline` block
+/// lowers to.
+fn deadline_invariants(model: &KernelModel) -> Vec<&PropertyDef> {
+    model
+        .invariants
+        .iter()
+        .filter(|property| {
+            property.name.starts_with("_deadline_") && is_generated_invariant(model, &property.name)
+        })
+        .collect()
+}
+
+/// The unique generated `tick` action, if the spec has one.
+fn generated_tick(model: &KernelModel) -> Option<&ActionDef> {
+    let mut ticks = model.actions.iter().filter(|action| action.name == "tick");
+    let tick = ticks.next()?;
+    if ticks.next().is_some() || !is_generated_action(model, "tick") {
+        return None;
+    }
+    Some(tick)
+}
+
+/// The structural `requires not(<urgent>)` guard the `tick` generator emits.
+fn tick_urgent_expr(tick: &ActionDef) -> Option<&Expr> {
+    match tick.requires.as_slice() {
+        [Expr::Not(inner)] => Some(inner),
+        _ => None,
+    }
+}
+
+/// The age state variables the generated `forall* (age <= bound)` deadline
+/// invariants constrain. `None` when any deadline has an unexpected shape,
+/// which suppresses the lane rather than guessing.
+fn deadline_age_refs(deadlines: &[&PropertyDef]) -> Option<BTreeSet<String>> {
+    let mut refs = BTreeSet::new();
+    for property in deadlines {
+        let mut expr = &property.expr;
+        while let Expr::Quantified {
+            quantifier, body, ..
+        } = expr
+        {
+            if quantifier != "forall" {
+                break;
+            }
+            expr = body;
+        }
+        let Expr::Binary { op, left, .. } = expr else {
+            return None;
+        };
+        if op != "<=" {
+            return None;
+        }
+        refs.insert(state_root_expr(left)?);
+    }
+    Some(refs)
+}
+
+fn state_root_expr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Var(name) => Some(name.clone()),
+        Expr::Index(base, _) => match &**base {
+            Expr::Var(name) => Some(name.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn non_tick_assigns_any(model: &KernelModel, roots: &BTreeSet<String>) -> bool {
+    model.actions.iter().any(|action| {
+        if action.name == "tick" {
+            return false;
+        }
+        let mut assigned = BTreeSet::new();
+        collect_assigned_roots(&action.statements, &mut assigned);
+        !assigned.is_disjoint(roots)
+    })
+}
+
+/// Lane 5 — `urgency_freeze`.
+///
+/// Sound because `urgent && type bounds` is proven to be a genuine inductive
+/// invariant: it holds in every init state and every action preserves it. The
+/// generated `tick` guard is `not urgent`, so `tick` is enabled in no reachable
+/// state, the age variables (which nothing but `tick` assigns) never advance,
+/// and the deadline invariants hold for want of time passing. Both obligations
+/// are single-step queries over fresh states, so the verdict does not move with
+/// `--depth`. Intentionally incomplete: an unproven obligation emits nothing.
+async fn urgency_freeze<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    instances: &[ActionInstance<S::Term>],
+) -> Result<Option<VacuityFinding>, VerifyError> {
+    let deadlines = deadline_invariants(model);
+    if deadlines.is_empty() || instances.is_empty() {
+        return Ok(None);
+    }
+    let Some(tick) = generated_tick(model) else {
+        return Ok(None);
+    };
+    let Some(urgent) = tick_urgent_expr(tick) else {
+        return Ok(None);
+    };
+    let Some(age_refs) = deadline_age_refs(&deadlines) else {
+        return Ok(None);
+    };
+    if age_refs.is_empty() || non_tick_assigns_any(model, &age_refs) {
+        return Ok(None);
+    }
+
+    solver.set_query_context("vacuity", "tick");
+    let init = symbolic_state_with_suffix(solver, model, "vac_urgency_init")?;
+    let mut base = init_constraints(solver, model, &init)?;
+    base.push(solver.not(&strengthened_urgent(solver, model, urgent, &init)?)?);
+    if !proven_unsat(solver, &base).await? {
+        return Ok(None);
+    }
+
+    let current = symbolic_state_with_suffix(solver, model, "vac_urgency_cur")?;
+    let next = symbolic_state_with_suffix(solver, model, "vac_urgency_next")?;
+    let choice = solver.constant("__vac_urgency_choice", &fsl_solver::Sort::Int)?;
+    let mut step = vec![
+        solver.ge(&choice, &solver.int_value(0))?,
+        solver.lt(&choice, &solver.int_value(i64_index(instances.len())?))?,
+        strengthened_urgent(solver, model, urgent, &current)?,
+        transition_constraint(solver, model, instances, &current, &next, &choice)?,
+    ];
+    step.push(solver.not(&strengthened_urgent(solver, model, urgent, &next)?)?);
+    if !proven_unsat(solver, &step).await? {
+        return Ok(None);
+    }
+
+    Ok(Some(VacuityFinding::UrgencyFreeze {
+        span: tick.require_spans.first().copied().unwrap_or(tick.span),
+        deadlines: deadlines
+            .iter()
+            .map(|property| property.name.clone())
+            .collect(),
+    }))
+}
+
+/// `urgent && <every declared type bound>`, the predicate proven inductive by
+/// the `urgency_freeze` lane. Carrying the bounds inside the induction is what
+/// keeps the proof self-contained: nothing is assumed from the bounded
+/// exploration that produced the `verified` verdict.
+fn strengthened_urgent<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    urgent: &Expr,
+    state: &SymbolicState<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    let mut bindings = Bindings::new();
+    let value = eval(solver, model, urgent, state, &mut bindings, None)?;
+    let mut terms = vec![bool_term(&value)?.clone()];
+    terms.extend(all_bounds(solver, model, state)?);
+    Ok(solver.and(&terms)?)
+}
+
+/// Lane 3 — `always_true_requires`.
+///
+/// For clause `j` of an action, ask whether `type bounds && clauses[..j] &&
+/// not clauses[j]` is unsatisfiable. The declared type space is a superset of
+/// the reachable states, so an unsatisfiable answer means the clause cannot be
+/// false in any reachable state at any depth — the property
+/// `docs/DESIGN-vacuity.md` §2 lane 3 actually asks for. The frozen Python
+/// reference instead discharges the clause from states witnessed within
+/// `--depth`, which reports a guard as dead merely because the bound was too
+/// small (issue #465: `examples/causal/funnel.fsl`'s `requires visits < 100`
+/// with `visits: 0..100`). That depth artifact is deliberately not inherited.
+///
+/// The clause must be implied for **every** instance of the action, matching
+/// the reference's per-action suppression: one instance that can falsify the
+/// clause makes it a real guard.
+///
+/// Synchronized compose actions are excluded because their clauses are
+/// inherited copies from several components, where a duplicated guard is the
+/// intended "each component defends its own contract" design rather than
+/// removable redundancy. Generated actions are excluded as authored-code
+/// diagnostics.
+async fn always_true_requires<S: SmtSolver>(
+    model: &KernelModel,
+    solver: &mut S,
+    instances: &[ActionInstance<S::Term>],
+) -> Result<Vec<VacuityFinding>, VerifyError> {
+    // One probe state for the whole lane, for the same reason as
+    // `frozen_tautologies`: the guards differ between instances only through
+    // their concrete parameter bindings, never through the state.
+    let state = symbolic_state_with_suffix(solver, model, "vac_requires")?;
+    let bound_terms = all_bounds(solver, model, &state)?;
+    let mut findings = Vec::new();
+    for (action_index, action) in model.actions.iter().enumerate() {
+        if action.sync
+            || action.requires.is_empty()
+            || is_generated_action(model, &action.name)
+            || !action.require_spans.iter().copied().all(is_source_backed)
+        {
+            continue;
+        }
+        let mut implied = vec![true; action.requires.len()];
+        let mut checked = false;
+        for instance in instances {
+            if instance.action_index != action_index {
+                continue;
+            }
+            let (guards, _) = action_guards(solver, model, action, &state, &instance.params)?;
+            if guards.len() != action.requires.len() {
+                // A `let` between clauses cannot change the count, but never
+                // index a mismatched pair: skip the whole action instead.
+                implied.fill(false);
+                break;
+            }
+            checked = true;
+            for (clause_index, guard) in guards.iter().enumerate() {
+                if !implied[clause_index] {
+                    continue;
+                }
+                let mut terms = bound_terms.clone();
+                terms.extend(guards[..clause_index].iter().cloned());
+                terms.push(solver.not(guard)?);
+                solver.set_query_context("vacuity", &action.name);
+                if !proven_unsat(solver, &terms).await? {
+                    implied[clause_index] = false;
+                }
+            }
+            if implied.iter().all(|entry| !entry) {
+                break;
+            }
+        }
+        if !checked {
+            continue;
+        }
+        findings.extend(implied.iter().enumerate().filter(|(_, entry)| **entry).map(
+            |(clause_index, _)| {
+                VacuityFinding::AlwaysTrueRequires {
+                    action: action.name.clone(),
+                    span: action
+                        .require_spans
+                        .get(clause_index)
+                        .copied()
+                        .unwrap_or(action.span),
+                    clause_index,
+                }
+            },
+        ));
+    }
+    Ok(findings)
+}
+
+/// Whether the conjunction of `terms` is *proven* unsatisfiable.
+///
+/// An `unknown` backend verdict answers `false`: a vacuity lane may only fire
+/// on a discharged proof obligation, never on the absence of a countermodel.
+async fn proven_unsat<S: SmtSolver>(
+    solver: &mut S,
+    terms: &[S::Term],
+) -> Result<bool, VerifyError> {
+    solver.push();
+    for term in terms {
+        if let Err(error) = solver.assert(term) {
+            solver.pop(1)?;
+            return Err(error.into());
+        }
+    }
+    let checked = solver.check().await;
+    let popped = solver.pop(1);
+    let result = checked?;
+    popped?;
+    Ok(matches!(result, SatResult::Unsat))
+}
+
+/// Drop `always_true_requires` findings for actions that were never enabled
+/// within the explored bound. `docs/DESIGN-vacuity.md` §2 lane 3 puts
+/// coverage-false actions out of scope: they already carry their own
+/// never-enabled warning, and every clause of a dead action is trivially
+/// redundant given the preceding ones.
+pub(crate) fn retain_covered(
+    findings: &mut Vec<VacuityFinding>,
+    coverage: &BTreeMap<String, bool>,
+) {
+    findings.retain(|finding| match finding {
+        VacuityFinding::AlwaysTrueRequires { action, .. } => {
+            coverage.get(action).copied().unwrap_or(false)
+        }
+        _ => true,
+    });
+}

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -747,6 +747,7 @@ mod tests {
             deadlock_trace: Some(vec![initial]),
             action_coverage: BTreeMap::from([("blocked".to_owned(), false)]),
             frontier_progress: false,
+            vacuity: Vec::new(),
         };
 
         let envelope = render_verify(
@@ -820,6 +821,7 @@ mod tests {
             deadlock_trace: Some(Vec::new()),
             action_coverage: BTreeMap::new(),
             frontier_progress: false,
+            vacuity: Vec::new(),
         };
         let options = Options {
             depth: 4,

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -74,6 +74,31 @@ const candidates = [
   ...await collectFslFiles(join(repository, "specs")),
   ...await collectFslFiles(join(repository, "examples")),
 ].sort();
+// Documents the Worker has no verb for, and therefore cannot be compared
+// against the native CLI. Each entry records the document type and the
+// *measured* reason the exclusion holds, so the next reader does not re-derive
+// it. `workerSignature` below turns each entry into a self-retiring one: the
+// harness probes the Worker for every excluded document and fails loudly when
+// the Worker's behaviour no longer matches the recorded premise, i.e. when the
+// exclusion has become unnecessary (#568). This is a *capability* exclusion,
+// never a tolerated-difference allowlist: the native<->Worker envelopes are
+// still not compared for these documents, and no verdict, location, or
+// exit-code difference is allowlisted anywhere.
+const unsupportedReasons = {
+  refinement:
+    "the Worker exposes only check/verify over Kernel specs and has no `refine` verb. NOTE (measured "
+    + "on the post-#574 tree): native and Worker check/verify envelopes now AGREE for every refinement "
+    + "document in the corpus, so this exclusion no longer suppresses any divergence and is retirable. "
+    + "Retiring it adds 54 compared cases and is a corpus-scope decision tracked separately -- the probe "
+    + "below only detects the Worker gaining a verb, not this agreement-staleness (#568)",
+  agent:
+    "native `check` runs the lenient fsl-ai agent analysis (result \"ok\", dialect fsl-ai-agent.v0); "
+    + "the Worker has no agent path at all and stops at the kernel lowering gate",
+  causal:
+    "standalone causal models bypass dialect dispatch (docs/DESIGN-causal.md); native answers with the "
+    + "causal envelope (`causal_model_checked`, no `versions` block) which the shared parity normalizer "
+    + "cannot validate, so there is no comparable pair to build",
+};
 const unsupportedDocuments = new Map(Object.entries({
   "examples/agentic_rag/agentic_rag_design_refines_requirements.fsl": "refinement",
   "examples/agentic_rag/agentic_rag_requirements_refines_business.fsl": "refinement",
@@ -109,6 +134,7 @@ const unsupportedDocuments = new Map(Object.entries({
   "examples/causal/subscription_retention.fsl": "causal",
 }));
 const observedUnsupported = new Set();
+const exclusionProbes = [];
 const parityCases = [];
 for (const path of candidates) {
   const repositoryPath = relative(repository, path).split("\\").join("/");
@@ -131,6 +157,19 @@ for (const path of candidates) {
       throw new Error(`unreviewed unsupported ${documentType} document: ${repositoryPath}`);
     }
     observedUnsupported.add(repositoryPath);
+    // Not compared against native -- probed on the Worker alone, so that the
+    // day the Worker grows a verb for this document type the recorded premise
+    // stops matching and the exclusion fails instead of silently persisting.
+    exclusionProbes.push({
+      id: `exclusion-${exclusionProbes.length}`,
+      cmd: "check",
+      path: repositoryPath,
+      source: await readFile(path, "utf8"),
+      source_file: repositoryPath,
+      files: {},
+      options: {},
+      documentType,
+    });
     continue;
   }
   if (unsupportedDocuments.has(repositoryPath)) {
@@ -188,7 +227,11 @@ parityCases.push({
   options: {},
   expected_status: 2,
 });
-await writeFile(join(dist, "parity-cases.json"), `${JSON.stringify(parityCases)}\n`, "utf8");
+await writeFile(
+  join(dist, "parity-cases.json"),
+  `${JSON.stringify([...parityCases, ...exclusionProbes])}\n`,
+  "utf8",
+);
 const mime = {
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
@@ -344,6 +387,29 @@ for (let index = 0; index < parityCases.length; index += 1) {
     });
   }
 }
+// #568: an exclusion that is no longer needed must fail, not stay green. Each
+// excluded document is probed on the Worker; the recorded premise is that the
+// Worker cannot analyze it. `check` on a document the Worker has no verb for
+// stops at the kernel lowering gate (refinement/agent) or fails the surface
+// parse (causal) -- either way it never produces an analysis. The day the
+// Worker gains the verb, `result` stops being `"error"` and this fails,
+// naming the entry to remove.
+const staleExclusions = [];
+for (let index = 0; index < exclusionProbes.length; index += 1) {
+  const probe = exclusionProbes[index];
+  const envelope = browser.parityEnvelopes[parityCases.length + index];
+  if (envelope?.result !== "error") {
+    staleExclusions.push(
+      `${probe.path}: the Worker now returns ${JSON.stringify(envelope?.result)} for this `
+      + `${probe.documentType} document, so the unsupportedDocuments entry is stale. `
+      + `Recorded reason: ${unsupportedReasons[probe.documentType]}. `
+      + `Remove the entry and let the document join the compared corpus, or update the reason.`,
+    );
+  }
+}
+if (staleExclusions.length > 0) {
+  throw new Error(`stale parity-corpus exclusions:\n${staleExclusions.join("\n")}`);
+}
 if (mismatches.length > 0) {
   const report = JSON.stringify({
     schema: "fsl-native-wasm-parity-failure.v1",
@@ -359,4 +425,5 @@ console.log(JSON.stringify({
   cancelled: true,
   nativeParity: true,
   parityCases: parityCases.length,
+  exclusionProbes: exclusionProbes.length,
 }, null, 2));

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -764,6 +764,28 @@ fn insert_helpful_rank_failure_json(
     }
 }
 
+/// Prove the solver-dependent vacuity lanes (`docs/DESIGN-vacuity.md` §2 lanes
+/// 3–5) for a run decided by the solver-free explicit-state engine.
+///
+/// The lanes describe the model, not the exploration, so `--engine explicit`
+/// must surface the same vacuity kinds `--engine bmc` does; letting the engine
+/// choice change which kinds `--vacuity error` can see would be exactly the
+/// exit-code divergence `docs/DESIGN-rust-port.md` forbids. A solver or
+/// semantics failure is surfaced, never swallowed.
+fn explicit_vacuity_findings(
+    model: &KernelModel,
+    action_coverage: &std::collections::BTreeMap<String, bool>,
+) -> Result<Vec<fsl_verifier::VacuityFinding>, (Value, i32)> {
+    let mut solver = fsl_solver_z3::Z3Solver::new()
+        .map_err(|error| (error_output("internal", &error.to_string()), 3))?;
+    block_on_native(fsl_verifier::model_vacuity_findings(
+        model,
+        &mut solver,
+        action_coverage,
+    ))
+    .map_err(|error| (error_output("semantics", &error.to_string()), 2))
+}
+
 pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
     let started = Instant::now();
     let model = match load_selected_model(request.selection) {
@@ -787,6 +809,10 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
         Ok(result) => result,
         Err(error) => return (semantic_error_output(&error.to_string()), 2),
     };
+    let vacuity = match explicit_vacuity_findings(&model, &result.action_coverage) {
+        Ok(findings) => findings,
+        Err(output) => return output,
+    };
     finish_explicit_output(fslc_rust::verification_output::render_explicit_output(
         envelope(),
         &model,
@@ -794,6 +820,7 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
         checked_bounds.as_ref(),
         request.deadlock,
         started.elapsed().as_secs_f64(),
+        &vacuity,
     ))
 }
 
@@ -838,6 +865,10 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
         Ok(result) => result,
         Err(error) => return (semantic_error_output(&error.to_string()), 2),
     };
+    let vacuity = match explicit_vacuity_findings(&model, &result.action_coverage) {
+        Ok(findings) => findings,
+        Err(output) => return output,
+    };
     let (output, status) =
         finish_explicit_output(fslc_rust::verification_output::render_explicit_output(
             envelope(),
@@ -846,6 +877,7 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
             checked_bounds.as_ref(),
             request.deadlock,
             started.elapsed().as_secs_f64(),
+            &vacuity,
         ));
     if output.get("result").and_then(Value::as_str) == Some("unknown_budget") {
         return auto_fallback_to_bmc(request, &budget_fallback_reason(&output), "budget");
@@ -2317,6 +2349,7 @@ mod tests {
             None,
             DeadlockMode::Ignore,
             0.0,
+            &[],
         );
         let (output, status) = finish_explicit_output(rendered);
         assert_eq!(status, 3);

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -12,7 +12,7 @@ use fsl_core::{
     state_json, trace_json,
 };
 use fsl_solver::VerificationStatistics;
-use fsl_verifier::{BmcResult, BmcViolation};
+use fsl_verifier::{BmcResult, BmcViolation, VacuityFinding};
 use serde_json::{Map, Value, json};
 
 /// Deadlock reporting policy shared by native and browser verification.
@@ -957,8 +957,9 @@ pub fn render_explicit_output(
     checked_bounds: Option<&BTreeSet<String>>,
     deadlock: DeadlockMode,
     elapsed_s: f64,
+    vacuity: &[VacuityFinding],
 ) -> Result<(Value, i32), String> {
-    let compatible = explicit_as_bmc(result);
+    let compatible = explicit_as_bmc(result, vacuity);
     replay_bmc_witnesses(model, &compatible, None)?;
     let statistics = VerificationStatistics::default();
 
@@ -1044,7 +1045,11 @@ pub fn render_explicit_output(
     ))
 }
 
-fn explicit_as_bmc(result: &fsl_runtime::ExplicitResult) -> BmcResult {
+/// Project a solver-free explicit-state result onto the bounded-verification
+/// shape. `vacuity` carries the solver-decided lanes proved separately by the
+/// caller: the explicit engine has no solver, but the lanes are properties of
+/// the model rather than of the exploration, so the same findings apply.
+fn explicit_as_bmc(result: &fsl_runtime::ExplicitResult, vacuity: &[VacuityFinding]) -> BmcResult {
     BmcResult {
         spec: result.spec.clone(),
         depth: result.depth,
@@ -1080,6 +1085,7 @@ fn explicit_as_bmc(result: &fsl_runtime::ExplicitResult) -> BmcResult {
         deadlock_trace: result.deadlock_trace.clone(),
         action_coverage: result.action_coverage.clone(),
         frontier_progress: !result.closure && !result.budget_exceeded,
+        vacuity: vacuity.to_vec(),
     }
 }
 
@@ -1673,7 +1679,139 @@ fn shared_warnings(
             .and_then(|trace| trace.last())
             .map(|entry| &entry.state),
         &result.action_coverage,
+        &solver_vacuity_warnings(model, result),
     )
+}
+
+/// Render the solver-decided vacuity lanes (`docs/DESIGN-vacuity.md` §2 lanes
+/// 3–5) that `fsl-verifier` proved for this model.
+///
+/// None of the messages mention `--depth`: unlike the two reachability lanes,
+/// these judgments quantify over the declared type space and therefore hold at
+/// every bound (issue #465).
+fn solver_vacuity_warnings(model: &KernelModel, result: &BmcResult) -> Vec<Value> {
+    result
+        .vacuity
+        .iter()
+        .map(|finding| vacuity_warning(model, finding))
+        .collect()
+}
+
+fn vacuity_warning(model: &KernelModel, finding: &VacuityFinding) -> Value {
+    let label = display_name(finding.name());
+    let (message, hint) = match finding {
+        VacuityFinding::TautologyOverFrozen { frozen_vars, .. } => {
+            let names = frozen_vars
+                .iter()
+                .map(|name| display_name(name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            (
+                format!(
+                    "invariant '{label}' is a tautology over frozen state ({names}): it holds for all dynamics because every state variable it depends on is never modified by any action"
+                ),
+                "make such variables 'const', or add the action that should modify them".to_owned(),
+            )
+        }
+        VacuityFinding::UrgencyFreeze { deadlines, .. } => {
+            let urgent = urgent_action_labels(model);
+            let urgent_text = if urgent.is_empty() {
+                "the generated urgent condition".to_owned()
+            } else {
+                urgent
+                    .iter()
+                    .map(|name| format!("'{name}'"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            let deadline_text = deadlines
+                .iter()
+                .map(|name| format!("'{}'", display_name(name)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            (
+                format!(
+                    "urgent condition for action(s) {urgent_text} holds initially and is preserved by every action, so generated action 'tick' is never enabled; time is frozen and deadline invariant(s) {deadline_text} are vacuously satisfied"
+                ),
+                "use the deadline-urgency pattern: make only the action guarded by deadline arrival (for example, requires age >= K) urgent".to_owned(),
+            )
+        }
+        VacuityFinding::AlwaysTrueRequires { .. } => (
+            format!(
+                "action '{label}' has a requires clause that is always true when the preceding clauses hold — no value the declared types allow can falsify it"
+            ),
+            "this requires clause is not acting as a constraint; decide whether the model is missing state where it matters, or the clause is redundant".to_owned(),
+        ),
+    };
+    let mut warning = json!({
+        "kind": finding.kind(),
+        "name": label,
+        "message": message,
+        "hint": hint,
+    });
+    if let Value::Object(entry) = &mut warning {
+        entry.insert("loc".to_owned(), finding.span().python_loc());
+        if matches!(finding, VacuityFinding::TautologyOverFrozen { .. }) {
+            entry.insert(
+                "faithfulness_class".to_owned(),
+                json!("frozen_only_invariant"),
+            );
+            entry.insert(
+                "recommended_action".to_owned(),
+                json!("run mutate to check kill-rate"),
+            );
+        }
+        insert_vacuity_requirement(entry, model, finding);
+    }
+    warning
+}
+
+/// Attach the requirement metadata of the declaration the finding blames: the
+/// invariant, the action, or — for `urgency_freeze`, whose blamed `tick` is
+/// generated — the first deadline invariant it renders vacuous.
+fn insert_vacuity_requirement(
+    entry: &mut Map<String, Value>,
+    model: &KernelModel,
+    finding: &VacuityFinding,
+) {
+    match finding {
+        VacuityFinding::TautologyOverFrozen {
+            invariant: name, ..
+        } => {
+            if let Some(property) = model.invariants.iter().find(|entry| entry.name == *name) {
+                insert_requirement_metadata(entry, &property.annotations, property.meta.as_ref());
+            }
+        }
+        VacuityFinding::UrgencyFreeze { deadlines, .. } => {
+            if let Some(property) = deadlines
+                .first()
+                .and_then(|name| model.invariants.iter().find(|entry| entry.name == *name))
+            {
+                insert_requirement_metadata(entry, &property.annotations, property.meta.as_ref());
+            }
+        }
+        VacuityFinding::AlwaysTrueRequires { action: name, .. } => {
+            if let Some(action) = model.actions.iter().find(|entry| entry.name == *name) {
+                insert_requirement_metadata(entry, &action.annotations, action.meta.as_ref());
+            }
+        }
+    }
+}
+
+/// The `urgent` action names the requirements lowering consumed into the
+/// generated `tick` guard, recorded on `tick`'s origin because the Kernel
+/// keeps only the expanded `requires not(<enabled ...>)`.
+fn urgent_action_labels(model: &KernelModel) -> Vec<String> {
+    model
+        .action_origin("tick")
+        .into_iter()
+        .flat_map(|origin| origin.lowering_steps.iter())
+        .filter(|step| step.kind == fsl_core::URGENT_ACTIONS_STEP)
+        .filter_map(|step| step.detail.as_ref())
+        .flat_map(|detail| detail.split(','))
+        .filter(|name| !name.is_empty())
+        .map(display_name)
+        .collect()
 }
 
 fn invariant_names_selected(
@@ -1879,6 +2017,7 @@ mod tests {
             None,
             DeadlockMode::Ignore,
             0.0,
+            &[],
         );
         assert!(rendered.is_err());
     }
@@ -1896,7 +2035,7 @@ mod tests {
         let explicit =
             fsl_runtime::verify_explicit(model.clone(), 0, 100).expect("run explicit verification");
         assert!(!explicit.closure);
-        let compatible = explicit_as_bmc(&explicit);
+        let compatible = explicit_as_bmc(&explicit, &[]);
         let statistics = VerificationStatistics::default();
         let (bmc, bmc_status) = render_bmc_output(
             test_envelope(),
@@ -1917,6 +2056,7 @@ mod tests {
             None,
             DeadlockMode::Ignore,
             0.0,
+            &[],
         )
         .expect("explicit evidence replays");
         let explicit_envelope = explicit_output.as_object_mut().expect("explicit envelope");

--- a/rust/fslc/tests/fixtures/vacuity_capacity_guard.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_capacity_guard.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-firing control for `always_true_requires`: a capacity guard that the
+// declared bound can falsify. Reaching `slots == 3` takes three steps, so a
+// depth-derived judgment would call this dead at `--depth 2` — the false
+// positive issue #465 rules out. The type space says otherwise.
+spec CapacityGuard {
+  state { slots: 0..3 }
+  init { slots = 0 }
+  action take() {
+    requires slots < 3
+    slots = slots + 1
+  }
+  invariant Bounded { slots >= 0 and slots <= 3 }
+}

--- a/rust/fslc/tests/fixtures/vacuity_coverage_false_requires.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_coverage_false_requires.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-firing control for `always_true_requires`: the second clause is
+// trivially implied by the first, but `impossible` is never enabled and
+// already carries its own never-enabled warning
+// (`docs/DESIGN-vacuity.md` §2 puts coverage-false actions out of scope).
+spec CoverageFalseSuppressesRequires {
+  state { x: Int }
+  init { x = 0 }
+  action noop() { x = x }
+  action impossible() {
+    requires x == 1
+    requires x == 1
+    x = x
+  }
+  invariant Stable { x == 0 }
+}

--- a/rust/fslc/tests/fixtures/vacuity_deadline_urgency_pattern.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_deadline_urgency_pattern.fsl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-firing control for `urgency_freeze`: the documented deadline-urgency
+// pattern makes only the deadline-guarded action urgent, so the urgent
+// condition is false at init and `tick` really runs.
+requirements DeadlineUrgencyPattern {
+  const SLA = 1
+  state { pending: Bool }
+  init { pending = true }
+  action respond_due() {
+    requires pending
+    requires age >= SLA
+    pending = false
+  }
+  time {
+    urgent respond_due
+    age age while pending
+  }
+  requirement NFR-1 "deadline" { deadline age <= SLA }
+}

--- a/rust/fslc/tests/fixtures/vacuity_frozen_ghost.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_frozen_ghost.fsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `ghost` is set by init and assigned by no action, so `FrozenGhost` holds for
+// every dynamics: the hollow invariant of issue #465's headline reproduction.
+spec FrozenGhostTautology {
+  state { ghost: Bool, x: Bool }
+  init {
+    ghost = true
+    x = false
+  }
+  action flip() { x = not x }
+  invariant FrozenGhost { ghost }
+}

--- a/rust/fslc/tests/fixtures/vacuity_frozen_plus_dynamic.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_frozen_plus_dynamic.fsl
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-firing control for `tautology_over_frozen`: the invariant reads the
+// frozen `ghost` but its truth still depends on the dynamic `x`, so it is not
+// a tautology over the frozen values alone.
+spec FrozenPlusDynamic {
+  state { ghost: Bool, x: Bool }
+  init {
+    ghost = true
+    x = false
+  }
+  action keep_x_dynamic() { x = false }
+  invariant DependsOnDynamic { ghost => not x }
+}

--- a/rust/fslc/tests/fixtures/vacuity_redundant_requires.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_redundant_requires.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `st != Cancelled` cannot be false once `st == Paid` holds, for any value the
+// enum allows — a dead ornament rather than a guard.
+spec ConditionedRequires {
+  enum St { Paid, Cancelled }
+  state { st: St }
+  init { st = Paid }
+  action cancel() { st = Cancelled }
+  action pay() "REQ-A: paid action" {
+    requires st == Paid
+    requires st != Cancelled
+    st = Paid
+  }
+  invariant TypeOk { st == Paid or st == Cancelled }
+}

--- a/rust/fslc/tests/fixtures/vacuity_urgency_freeze.fsl
+++ b/rust/fslc/tests/fixtures/vacuity_urgency_freeze.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// `spin` is always enabled and declared urgent, so the generated `tick` guard
+// `not(enabled spin)` is false in every reachable state: time never advances
+// and the deadline invariant is satisfied for want of a clock.
+requirements UrgencyFreezeTrap {
+  state { pending: Bool }
+  init { pending = true }
+  action spin() { pending = pending }
+  time {
+    urgent spin
+    age age while pending
+  }
+  requirement NFR-1 "deadline" { deadline age <= 0 }
+}

--- a/rust/fslc/tests/issue_567_cross_file_diagnostic_loc.rs
+++ b/rust/fslc/tests/issue_567_cross_file_diagnostic_loc.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #567: a kernel-stage failure inside a
+//! `use ... from` component reported the *parent* document's path with the
+//! *component's* line and column, so `loc` pointed at whatever happened to sit
+//! at that position in the parent — for the compose error-gallery fixture, a
+//! comment line. `docs/DESIGN-v1.md` G2 requires the output JSON alone to say
+//! where the problem is, and a location in the wrong file is worse than none.
+//!
+//! `loc` is `{line, column}` with no `file`, so it can only ever mean "a
+//! position in the file the envelope is about". The position is therefore the
+//! parent's `use` declaration — which really is in the parent, and really is
+//! the line to look at — and the component's own path and position moved into
+//! the message. Neither file's identity is left implicit.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+const PARENT: &str = "examples/gallery/errors/semantics_compose_component_parse_failure.fsl";
+const COMPONENT: &str = "semantics_compose_broken_component.fsl";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+/// The text at `loc` inside the parent document, so the assertion is about
+/// what the position actually points at rather than about two numbers.
+fn text_at(loc: &Value) -> String {
+    let source = std::fs::read_to_string(workspace_root().join(PARENT)).expect("read parent");
+    let line = usize::try_from(loc["line"].as_u64().expect("loc.line")).expect("line fits usize");
+    let column =
+        usize::try_from(loc["column"].as_u64().expect("loc.column")).expect("column fits usize");
+    let text = source.lines().nth(line - 1).expect("loc.line exists");
+    text.chars().skip(column - 1).collect()
+}
+
+#[test]
+fn the_location_points_at_the_use_declaration_in_the_parent() {
+    let (value, status) = run(&["check", PARENT]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["kind"], "semantics", "{value}");
+    // Exact position, not "not null": a present-but-wrong location is the
+    // defect, and `loc: {line: 7, column: 18}` was present the whole time.
+    assert_eq!(value["loc"]["line"], 13, "{value}");
+    assert_eq!(value["loc"]["column"], 3, "{value}");
+    // And what actually sits there is the `use` declaration that pulls in the
+    // broken component — pinning the numbers alone would survive the file
+    // being re-indented into pointing somewhere else again.
+    assert!(
+        text_at(&value["loc"]).starts_with("use "),
+        "loc points at {:?}, not a `use` declaration",
+        text_at(&value["loc"])
+    );
+}
+
+#[test]
+fn the_message_names_both_files_and_both_positions() {
+    let (value, _) = run(&["check", PARENT]);
+    let message = value["message"].as_str().expect("message");
+    // The component, with its own path and its own position.
+    assert!(message.contains(COMPONENT), "{message}");
+    assert!(
+        message.contains(&format!("{COMPONENT}:7:18")),
+        "the component's own position must survive in the message: {message}"
+    );
+    // The parent, with the `use` line.
+    assert!(message.contains(&format!("{PARENT}:13:3")), "{message}");
+    // The defect was pairing the parent's path with the component's position.
+    assert!(
+        !message.contains(&format!("{PARENT}:7:18")),
+        "parent path is still paired with the component's position: {message}"
+    );
+}
+
+#[test]
+fn every_spec_reading_command_reports_the_same_corrected_location() {
+    // The loader is shared, so a command that skipped this path would be the
+    // interesting case.
+    for args in [
+        vec!["check", PARENT],
+        vec!["verify", PARENT, "--depth", "2"],
+        vec!["explain", PARENT],
+        vec!["analyze", PARENT],
+    ] {
+        let (value, status) = run(&args);
+        assert_eq!(status, 2, "{args:?}: {value}");
+        assert_eq!(value["loc"]["line"], 13, "{args:?}: {value}");
+        assert_eq!(value["loc"]["column"], 3, "{args:?}: {value}");
+        assert!(
+            value["message"]
+                .as_str()
+                .is_some_and(|message| message.contains(COMPONENT)),
+            "{args:?}: {value}"
+        );
+    }
+}
+
+#[test]
+fn an_unreadable_component_is_located_at_its_own_use_declaration() {
+    // Same class: the read failure carried `1:1`, which in the parent is the
+    // `compose` keyword rather than the import that failed.
+    let directory = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!(
+        "issue-567-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&directory).expect("create scratch directory");
+    let path = directory.join("missing_component.fsl");
+    std::fs::write(
+        &path,
+        "compose MissingComponent {\n  use Absent as absent from \"absent.fsl\"\n  state { x: Int }\n  init { x = 0 }\n  invariant I { x >= 0 }\n}\n",
+    )
+    .expect("write scratch spec");
+    let (value, status) = run(&["check", &path.display().to_string()]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["loc"]["line"], 2, "{value}");
+    assert_eq!(value["loc"]["column"], 3, "{value}");
+    assert!(
+        value["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("absent.fsl")),
+        "{value}"
+    );
+}
+
+// --- positive: a healthy compose is untouched -----------------------------
+
+#[test]
+fn a_healthy_compose_document_still_checks() {
+    // Re-anchoring must not touch the success path, and `specs/bank_system.fsl`
+    // is the corpus compose that loads two real components.
+    let (value, status) = run(&["check", "specs/bank_system.fsl"]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok", "{value}");
+}

--- a/rust/fslc/tests/vacuity_solver_lanes.rs
+++ b/rust/fslc/tests/vacuity_solver_lanes.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative controls for the #465 residual: the three solver-dependent
+//! `docs/DESIGN-vacuity.md` §2 lanes — `always_true_requires`,
+//! `tautology_over_frozen`, `urgency_freeze` — were entirely unimplemented in
+//! native `fslc`, so a hollow spec whose only emptiness was one of them came
+//! back `result:"verified"`/exit 0 even under `--vacuity error`. Each lane is
+//! pinned three ways: it fires (exit 2, `kind`, `trace_type:"vacuity"`), it
+//! routes through `--vacuity warn|ignore`, and it stays silent on a legitimate
+//! spec of the same shape.
+//!
+//! The lanes are proved over the declared type space rather than over states
+//! witnessed within `--depth`, so `depth_does_not_change_the_verdict` and
+//! `a_capacity_guard_is_never_reported_as_dead` pin the accepted resolution of
+//! issue #465: a warning that would disappear at a larger `--depth` is never
+//! emitted.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn verify(fixture: &str, depth: &str, vacuity: &str) -> (Value, i32) {
+    run_cli(&[
+        "verify",
+        fixture,
+        "--depth",
+        depth,
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        vacuity,
+        "--no-cache",
+    ])
+}
+
+fn warning_kinds(output: &Value) -> Vec<String> {
+    output["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .filter_map(|warning| warning["kind"].as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+const FROZEN_GHOST: &str = "rust/fslc/tests/fixtures/vacuity_frozen_ghost.fsl";
+const FROZEN_PLUS_DYNAMIC: &str = "rust/fslc/tests/fixtures/vacuity_frozen_plus_dynamic.fsl";
+const URGENCY_FREEZE: &str = "rust/fslc/tests/fixtures/vacuity_urgency_freeze.fsl";
+const DEADLINE_PATTERN: &str = "rust/fslc/tests/fixtures/vacuity_deadline_urgency_pattern.fsl";
+const REDUNDANT_REQUIRES: &str = "rust/fslc/tests/fixtures/vacuity_redundant_requires.fsl";
+const CAPACITY_GUARD: &str = "rust/fslc/tests/fixtures/vacuity_capacity_guard.fsl";
+const COVERAGE_FALSE_REQUIRES: &str =
+    "rust/fslc/tests/fixtures/vacuity_coverage_false_requires.fsl";
+
+/// Issue #465's headline reproduction: this spec checks nothing and used to
+/// pass `--vacuity error` with exit 0.
+#[test]
+fn tautology_over_frozen_fails_closed_under_vacuity_error() {
+    let (output, status) = verify(FROZEN_GHOST, "3", "error");
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "tautology_over_frozen");
+    assert_eq!(output["trace_type"], "vacuity");
+    let finding = &output["findings"][0];
+    assert_eq!(finding["name"], "FrozenGhost");
+    assert_eq!(finding["faithfulness_class"], "frozen_only_invariant");
+    assert_eq!(
+        finding["recommended_action"],
+        "run mutate to check kill-rate"
+    );
+    assert!(
+        finding["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("ghost")),
+        "the message must name the frozen state: {output:#}"
+    );
+}
+
+#[test]
+fn tautology_over_frozen_routes_through_warn_and_ignore() {
+    let (warned, status) = verify(FROZEN_GHOST, "3", "warn");
+    assert_eq!(status, 0, "{warned:#}");
+    assert_eq!(warned["result"], "verified");
+    assert!(
+        warning_kinds(&warned).contains(&"tautology_over_frozen".to_owned()),
+        "{warned:#}"
+    );
+
+    let (ignored, status) = verify(FROZEN_GHOST, "3", "ignore");
+    assert_eq!(status, 0, "{ignored:#}");
+    assert!(
+        !warning_kinds(&ignored).contains(&"tautology_over_frozen".to_owned()),
+        "{ignored:#}"
+    );
+}
+
+/// Non-firing control: an invariant that reads frozen state but whose truth
+/// still depends on a dynamic variable is a real invariant.
+#[test]
+fn an_invariant_that_depends_on_dynamic_state_is_not_a_frozen_tautology() {
+    let (output, status) = verify(FROZEN_PLUS_DYNAMIC, "3", "error");
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+}
+
+#[test]
+fn urgency_freeze_fails_closed_under_vacuity_error() {
+    let (output, status) = verify(URGENCY_FREEZE, "3", "error");
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "urgency_freeze");
+    assert_eq!(output["trace_type"], "vacuity");
+    let finding = &output["findings"][0];
+    assert_eq!(finding["name"], "tick");
+    assert_eq!(finding["requirement"]["id"], "NFR-1");
+    let message = finding["message"].as_str().expect("urgency_freeze message");
+    assert!(
+        message.contains("'spin'"),
+        "the message must name the urgent action: {output:#}"
+    );
+    assert!(
+        message.contains("generated action 'tick' is never enabled"),
+        "{output:#}"
+    );
+}
+
+#[test]
+fn urgency_freeze_routes_through_warn_and_ignore() {
+    let (warned, status) = verify(URGENCY_FREEZE, "3", "warn");
+    assert_eq!(status, 0, "{warned:#}");
+    assert!(
+        warning_kinds(&warned).contains(&"urgency_freeze".to_owned()),
+        "{warned:#}"
+    );
+
+    let (ignored, status) = verify(URGENCY_FREEZE, "3", "ignore");
+    assert_eq!(status, 0, "{ignored:#}");
+    assert!(
+        !warning_kinds(&ignored).contains(&"urgency_freeze".to_owned()),
+        "{ignored:#}"
+    );
+}
+
+/// Non-firing control: the documented deadline-urgency pattern must stay
+/// clean, otherwise the lane punishes the shape `docs/LANGUAGE.md` recommends.
+#[test]
+fn the_deadline_urgency_pattern_is_not_reported_as_a_freeze() {
+    let (output, status) = verify(DEADLINE_PATTERN, "4", "error");
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    assert_eq!(output["action_coverage"]["tick"], true);
+}
+
+#[test]
+fn always_true_requires_fails_closed_under_vacuity_error() {
+    let (output, status) = verify(REDUNDANT_REQUIRES, "2", "error");
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "always_true_requires");
+    assert_eq!(output["trace_type"], "vacuity");
+    let findings = output["findings"].as_array().expect("findings array");
+    assert_eq!(findings.len(), 1, "{output:#}");
+    assert_eq!(findings[0]["name"], "pay");
+    assert_eq!(findings[0]["requirement"]["id"], "REQ-A");
+    assert!(
+        findings[0]["message"]
+            .as_str()
+            .is_some_and(|message| !message.contains("depth")),
+        "the judgment is depth-independent, so the message must not cite a depth: {output:#}"
+    );
+}
+
+#[test]
+fn always_true_requires_routes_through_warn_and_ignore() {
+    let (warned, status) = verify(REDUNDANT_REQUIRES, "2", "warn");
+    assert_eq!(status, 0, "{warned:#}");
+    assert!(
+        warning_kinds(&warned).contains(&"always_true_requires".to_owned()),
+        "{warned:#}"
+    );
+
+    let (ignored, status) = verify(REDUNDANT_REQUIRES, "2", "ignore");
+    assert_eq!(status, 0, "{ignored:#}");
+    assert!(
+        !warning_kinds(&ignored).contains(&"always_true_requires".to_owned()),
+        "{ignored:#}"
+    );
+}
+
+/// The accepted resolution of issue #465, in miniature: `slots < 3` is only
+/// falsifiable three steps in, so a depth-derived judgment would report it as
+/// dead at `--depth 2`. The declared bound `0..3` says it is a real guard, and
+/// that answer must not move with the bound.
+#[test]
+fn a_capacity_guard_is_never_reported_as_dead() {
+    for depth in ["1", "2", "8"] {
+        let (output, status) = verify(CAPACITY_GUARD, depth, "error");
+        assert_eq!(status, 0, "depth {depth}: {output:#}");
+        assert_eq!(output["result"], "verified", "depth {depth}");
+    }
+}
+
+/// `examples/causal/funnel.fsl` is the case the issue names: `requires
+/// visits < 100` with `visits: 0..100` reaches only `visits == 8` at depth 8,
+/// which the frozen Python reference reports as `always_true_requires`. A
+/// warning that disappears when `--depth` rises is not evidence of a hollow
+/// spec, so native must stay silent at every depth.
+#[test]
+fn depth_does_not_change_the_verdict() {
+    for depth in ["3", "8", "16"] {
+        let (output, status) = run_cli(&[
+            "verify",
+            "examples/causal/funnel.fsl",
+            "--depth",
+            depth,
+            "--deadlock",
+            "ignore",
+            "--vacuity",
+            "error",
+            "--no-cache",
+        ]);
+        assert_eq!(status, 0, "depth {depth}: {output:#}");
+        assert!(
+            !warning_kinds(&output).contains(&"always_true_requires".to_owned()),
+            "depth {depth}: {output:#}"
+        );
+    }
+}
+
+/// Non-firing control: the second clause of `impossible` is trivially implied
+/// by the first, but the action is never enabled and already carries its own
+/// never-enabled warning.
+#[test]
+fn a_coverage_false_action_does_not_produce_always_true_requires() {
+    let (output, status) = verify(COVERAGE_FALSE_REQUIRES, "2", "error");
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    assert_ne!(output["action_coverage"]["impossible"], true);
+}
+
+/// Non-firing control: a compose-synchronized action inherits `a > 0` from
+/// both `bank.submit_deposit` and `audit.deposit`. That duplication is the
+/// intended "each component defends its own contract" design, not removable
+/// redundancy (`docs/DESIGN-vacuity.md` §2), and every clause is checked in
+/// the right context when the component spec is verified on its own.
+#[test]
+fn a_synchronized_compose_action_is_not_flagged_for_duplicate_guards() {
+    let (output, status) = run_cli(&[
+        "verify",
+        "specs/bank_system.fsl",
+        "--depth",
+        "4",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    assert_eq!(output["action_coverage"]["deposit_audited"], true);
+}
+
+/// The lanes describe the model, not the exploration, so `--engine explicit`
+/// (solver-free BFS) and `--engine induction` must report the same kind as
+/// bounded model checking. An engine-dependent vacuity verdict would be
+/// exactly the exit-code divergence `docs/DESIGN-rust-port.md` forbids.
+#[test]
+fn every_engine_reports_the_same_vacuity_kind() {
+    for (fixture, depth, kind) in [
+        (FROZEN_GHOST, "3", "tautology_over_frozen"),
+        (URGENCY_FREEZE, "3", "urgency_freeze"),
+        (REDUNDANT_REQUIRES, "2", "always_true_requires"),
+    ] {
+        for engine in ["bmc", "explicit", "induction"] {
+            let (output, status) = run_cli(&[
+                "verify",
+                fixture,
+                "--depth",
+                depth,
+                "--deadlock",
+                "ignore",
+                "--vacuity",
+                "error",
+                "--engine",
+                engine,
+                "--no-cache",
+            ]);
+            assert_eq!(status, 2, "{engine}: {output:#}");
+            assert_eq!(output["kind"], kind, "{engine}: {output:#}");
+            assert_eq!(output["trace_type"], "vacuity", "{engine}: {output:#}");
+        }
+    }
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -876,7 +876,11 @@ verifying the component spec on its own), and **an invariant that depends only o
 frozen state variable no action ever assigns to and is dynamically always true**
 (`tautology_over_frozen` — a dead ghost; make it `const`, or suspect a missing
 action that should change it), and a generated deadline `tick` proven dead because
-urgency freezes time (`urgency_freeze`). `--vacuity error` gives
+urgency freezes time (`urgency_freeze`). The last three are decided over the
+declared type space rather than over the states reached within `--depth`, so
+their verdict never moves with the bound: `requires visits < 100` on
+`visits: 0..100` is a real guard and stays unreported even at a depth that
+never reaches 100. `--vacuity error` gives
 `result:"error"`; `--vacuity ignore` disables it.
 
 ## 7. CLI and JSON essentials


### PR DESCRIPTION
Three independent fixes, one commit each. Their file sets are disjoint apart from `CHANGELOG.md`
(measured before combining), and none pins behaviour another changes, so they share one CI run
rather than three serial ones. Each commit remains independently revertable.

---

# 1. `--vacuity error` passed a hollow spec (#465)

Three of the five documented vacuity kinds had no native implementation — `always_true_requires`,
`tautology_over_frozen`, `urgency_freeze` — so a specification whose invariant holds for reasons
independent of its dynamics returned exit 0 and `result:"verified"`. PR #503 landed the other half of
#465; this is the residual.

```
fslc verify <FrozenGhostTautology> --depth 3 --deadlock ignore --vacuity error
  before: exit 0, result "verified", zero warnings
  after:  exit 2, kind "tautology_over_frozen", trace_type "vacuity"
```

Re-measured independently on this branch.

## Encodings

All three live in `rust/fsl-verifier/src/vacuity.rs`, as a **bounded number of one-shot Z3 queries
over freshly named states**, so no verdict depends on `--depth`. `Unknown` never produces a finding.

**`tautology_over_frozen`** — `frozen` = state variables no action assigns; `transition_constraint`
frames them forward unchanged, so they equal their init value in every reachable state. For each
source-backed non-generated invariant with a frozen reference, ask whether
`init(s0) ∧ s|frozen = s0|frozen ∧ typebounds(s) ∧ ¬inv(s)` is unsat. Unsat over that superset of the
reachable states means the invariant holds independently of the dynamics. **Init is left symbolic** —
stricter than the frozen reference, which picks one completed init model, so a nondeterministic init
cannot make the verdict depend on an arbitrary witness.

**`urgency_freeze`** — a static prefilter, then two queries proving `X ∧ typebounds` is a genuine
inductive invariant: `init ∧ ¬(X ∧ bounds)` unsat, and
`(X ∧ bounds)(cur) ∧ trans(cur,next) ∧ ¬(X ∧ bounds)(next)` unsat. Carrying the bounds **inside** the
induction is deliberate: nothing is assumed from the bounded exploration that produced `verified`.
`X` inductive means `tick`'s guard `¬X` never holds, so ages never advance and the deadline
invariants hold for want of a clock.

**`always_true_requires`** — for clause `j`, `typebounds ∧ clauses[..j] ∧ ¬clauses[j]` unsat for
**every** instance. The declared type space is a superset of the reachable states, so unsat means the
clause cannot be false at any depth.

### A deviation from the brief, flagged not buried

The brief expected `always_true_requires` inside the BMC unrolling loop. It is **static** instead —
and that is precisely why the accepted option (b) is sounder: option (b) says emit no depth-derived
judgement, and a type-space query has no depth to derive from.

## Depth artifacts

A warning that disappears when you raise `--depth` is not evidence of a hollow spec. The frozen
reference warns on `examples/causal/funnel.fsl` because at depth 8 `visits` only reaches 8, while
`visits: 0..100` makes `visits < 100` a real guard.

Verified independently on this branch: `funnel.fsl` produces **no warning at depths 3, 8 and 16**
(exit 0 at each). A synthetic capacity guard likewise produces none at depths 1, 2 and 8. Ablation D
below proves these have teeth.

## Test evidence

Seven ablations, each with `git diff HEAD --stat` asserted non-empty when applied and empty after
restore. `vacuity.rs` is new, so `git checkout HEAD~1 -- <path>` cannot revert it and reverting only
the dependent files leaves the tree non-compiling; an in-place rewrite with the same guard is the
sound equivalent, and worktree-local for the same reason. No `git stash` at any point.

| # | ablation | failures |
|---|---|---|
| A | all three lanes removed | 7 — all six lane tests plus `every_engine_reports_the_same_vacuity_kind` |
| B | compose-sync exclusion removed | `a_synchronized_compose_action_is_not_flagged_for_duplicate_guards` |
| C | coverage gate removed | `a_coverage_false_action_does_not_produce_always_true_requires` |
| D | type space replaced by depth-0 init states | 4, incl. `a_capacity_guard_is_never_reported_as_dead`, `depth_does_not_change_the_verdict` |
| E | only `tautology_over_frozen` removed | its two tests plus `every_engine` |
| F | only `urgency_freeze` removed | its two tests plus `every_engine` |
| G | only `always_true_requires` removed | its two tests plus `every_engine` |

**E/F/G exist because A alone is not enough.** A proves the suite detects the three lanes'
*collective* absence — exactly where a lane whose negative control silently never ran would hide.

**Non-firing controls** (13 tests): a frozen-plus-dynamic invariant; the documented deadline-urgency
pattern; a coverage-false action; a compose-synchronized action (`specs/bank_system.fsl`). A detector
that fires on healthy specs is a false red and its own regression.

**Corpus sweep**: all 119 verifying specs produce **0 findings**. It initially produced 6, all
`_governance_catalog_ok` — a synthetic catalog kernel the governance lowering emits with a zero span
instead of a `generated_only` origin. The lanes now require a **source-backed declaration**, derived
from `docs/DESIGN-vacuity.md` §2's "user invariant" scoping. **No exclusion was widened to go green.**

## Runtime/solver boundary

All three lanes are in `fsl-verifier`. `cargo tree -p fsl-runtime --edges normal` shows only
`fsl-core` and `serde_json` — verified independently. `check-native-integration.sh boundaries` exits
0. `verification_warnings` gained one parameter carrying already-rendered JSON, so warning ordering
stays owned by one function without a solver dependency.

## A defect introduced and fixed mid-task

The first version ran the lanes **before** the BMC unrolling, changing which equally-valid witness
each Z3 build picked; the browser gate failed on `examples/consulting/tobe_expense.fsl` and
`examples/e2e/1_business.fsl` with native `auto_approve` vs wasm `mgr_approve`. The lanes now run
after every witness is projected, guarded by a session-satisfiability check for the
all-paths-deadlock case. Recorded in `docs/DESIGN-rust-port.md`.

## Tradeoff not fixed

The lanes run even under `--vacuity ignore`, findings filtered afterwards, matching the existing
`vacuous_implication` precedent. Measured at 118 of 1507 solver checks (7.8%) and 8.1% of solver time
on a 30-spec sample. Removing it needs a signature change across the native and Worker callers.

---

# 2. Parity-corpus exclusions could not go stale loudly (#568)

`unsupportedDocuments` in `rust/fsl-wasm/test-browser.mjs` excludes documents from the native↔Worker
comparison, and **nothing detected when an exclusion stopped being needed**. That is not
hypothetical: measured stage-by-stage, 29 of the 35 corpus files that fail to load do so at the
kernel stage, and every one of them is excluded — which is why #556's divergent path had zero corpus
coverage and surfaced only by accident.

Each entry now records its **measured** reason and every excluded document is probed on the Worker
alone; the probe fails naming the entry when the premise stops holding. `exclusionProbes: 32` now
appears in the harness output alongside `parityCases`.

The model followed is `tests/test_dialect_conformance.py::test_exclusion_still_holds`, which asserts
each exclusion's premise and says "remove the exclusion" when it fails —
**not** `corpus_check_sweep.rs`'s `GOVERNANCE_FIXTURE_EXCLUSIONS`, which is a reasoned skip list that
never asserts anything. (The issue text cited a `KNOWN_DB_DOUBLE_ASSIGNMENT_GAP` constant as the
model; it does not exist anywhere in the repository. Corrected on #568.)

## Per-type reasons, measured verb by verb

| type | count | reason | verdict |
|---|---:|---|---|
| refinement | 28 | Worker has no `refine` verb, but check/verify envelopes now **agree** post-#574 | **stale** |
| agent | 1 | native `check` runs the lenient fsl-ai agent analysis (`result:"ok"`); Worker has no agent path (`result:"error"`) | justified |
| causal | 3 | native answers `causal_model_checked` with **no `versions` block**, which `parity.mjs::validateEnvelope` rejects — no comparable pair can be built | justified |

**The count is 32, not the 29 the issue stated.**

## The finding that came out of measuring it

**All 28 refinement exclusions are already stale**, and it was the base-recheck step that caught it.
Measured on the original base, `specs/cart_refines.fsl` showed a genuine divergence and the exclusion
looked justified — then the recheck showed `main` had moved to include #574, and after rebasing the
same forced comparison is **green at 411 cases**. Reporting before that rebase would have asserted
the opposite of the truth. Retiring them adds 54 compared cases and is a corpus-scope decision, so it
is filed separately as **#577** rather than folded in.

## Honest limit, recorded at the point of use

**The shipped probe detects "the Worker gained a verb". It does not detect the agreement-staleness
that is actually present**, and stays green on those 28 entries. The stronger fail-on-agreement form
would go red immediately on all 28, which is why retiring them (#577) is the precondition rather than
a follow-up. That limitation is written into the entry's own reason text, not only in review.

Control, by measurement: giving one excluded document a source the Worker *can* analyze turns the
harness **red** — `specs/cart_refines.fsl: the Worker now returns "ok" for this refinement document,
so the unsupportedDocuments entry is stale... Remove the entry`. Ablation: pre-fix the harness is
green at 351 cases with **no `exclusionProbes` field at all** — no code path examined excluded
documents, so nothing could have detected it.

---

# 3. A cross-file diagnostic pointed at nothing (#567)

A kernel failure inside a `use ... from` component reported the **parent's path** with the
**component's** line and column. On the compose error fixture the message said `…:7:18`, but line 7
of that file is a comment; `7:18` is the component's `init { count = }`. A `loc` that exists but
names the wrong construct is worse than no `loc` — `docs/DESIGN-v1.md` G2 assumes the position is
correct, and "not null" cannot tell the two apart.

## The decision, made before implementing

`docs/DESIGN-v1.md` defines `loc` as `{line, column}` in all five of its examples — **no `file`** — so
it can only ever mean "a position in the file the envelope names". Recorded on #567 before the work
started:

- **Chosen**: report the parent's `use ... from` line, and name the component's path *and* position in
  the message. The reported position is genuinely correct and is the line to look at.
- Rejected: adding `file` to `loc` — an envelope change touching every `loc` site and consumer, plus
  the pre-existing `lint`-has-`file` / `check`-does-not split, for a rare case.
- Rejected: dropping the `loc` — regresses G2 and undoes #484 and #555.

## Test evidence

Verified independently on this branch:

```
loc = {13, 3}  →  line 13: "  use GallerySemanticsComposeBrokenComponent as broken"
                              ^ column 3
msg = component "…_broken_component.fsl" failed to parse
      (expected expression at …_broken_component.fsl:7:18)      ← the component's real position
      at …_component_parse_failure.fsl:13:3                     ← the parent's use line
```

Both files are now named with their own positions. `kind` stays `semantics`, so #556's parity
contract is unaffected — native and Worker still return the identical string.

Anchoring the position alone was not sufficient: `From<ParseError>` builds an origin holding the
component's span, which `with_source_file` then stamps the parent's path onto. The re-anchored error
also needed an origin whose span is the `use` declaration, or `with_source_file` — a no-op without an
origin — would have dropped the parent path from the message entirely.

Ablation (revert only `rust/fsl-core/src/compose.rs`, diff non-empty at 5+/60−) fails
`the_location_points_at_the_use_declaration_in_the_parent`,
`the_message_names_both_files_and_both_positions`,
`every_spec_reading_command_reports_the_same_corrected_location`,
`an_unreadable_component_is_located_at_its_own_use_declaration`, printing the original mixed string.
`a_healthy_compose_document_still_checks` passes both ways — correct for a positive control.

---

## Combining these three surfaced one conflict, and the gate caught it

#567 was based on `a93f109`, before #565 merged, so its new `CoreError` construction site lacked the
`name_resolution` field and **the tree did not compile**. Resolved as `false`: what that value reports
is a compose-level failure to load a component, anchored at the parent's `use` declaration — not
itself a name-resolution failure, and §8's `name` repair branch ("add a declaration or change a
type") would be wrong advice at that location. The component's own classification survives in the
message.

This is the interaction that separate pull requests would have surfaced at rebase time. Combining
moved it to combine time, where the same gate caught it and forced the same decision — but it would
have been invisible without running the full gate locally.

## Gate

`FMT_EXIT=0`, `CLIPPY_EXIT=0`, `TEST_EXIT=0`, `NATIVE_EXIT=0` — `nativeParity: true`,
`parityCases: 359`, `exclusionProbes: 32`.

## Documentation

`docs/DESIGN-vacuity.md`, `docs/DESIGN-rust-port.md`, `skills/fsl/reference.md`,
`examples/gallery/errors/README.md`, `CHANGELOG.md` `[Unreleased]`.

## Linked issues

Fixes #465, fixes #568, fixes #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
