### PR TITLE
fix(ai): reject duplicate dataset/evaluator names, and stop analysis_conservation racing on a shared path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   (`docs/DESIGN-ci.md`).
 
 ### Fixed
+- `fslc ai check` now rejects duplicate `dataset` and `evaluator` declaration
+  names, which the frozen reference has always rejected
+  (`src/fslc/ai_project.py:237-241`). Native validated only three of the five
+  declaration kinds, so a project declaring `dataset Shared` twice exited 0 and
+  reported `datasets: ['Shared', 'Shared']`. Because a `dataset X` reference
+  resolves by name, two declarations sharing one made resolution depend on
+  declaration order — the false green was silently picking a winner, not merely
+  echoing a name twice (#571).
 - Native now emits `kind:"name"` for name-resolution failures instead of
   collapsing them into `semantics`, making every member of the
   `docs/DESIGN-v1.md` §7.2 closed set reachable. `duplicate state variable`,

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -358,6 +358,13 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
             _ => {}
         }
     }
+    // All five declaration kinds the frozen reference rejects duplicates for
+    // (`src/fslc/ai_project.py:237-241`). `dataset` and `evaluator` were absent
+    // until issue 571: a `dataset X` reference resolves by name, so two
+    // declarations sharing one made the resolution depend on declaration order,
+    // and `datasets` echoed the name twice.
+    reject_duplicates(project.datasets.iter().map(|d| d.name.as_str()), "dataset")?;
+    reject_duplicates(project.evaluators.iter().map(String::as_str), "evaluator")?;
     reject_duplicates(
         project
             .statistical_properties

--- a/rust/fslc/tests/analysis_conservation.rs
+++ b/rust/fslc/tests/analysis_conservation.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::{Value, json};
 
@@ -12,6 +13,27 @@ fn root() -> PathBuf {
         .expect("workspace root")
         .to_owned()
 }
+
+/// A fresh scratch directory per test under `rust/target/`, following the
+/// `scratch_dir` idiom `rust/fslc/tests/chain_cli.rs` already establishes.
+///
+/// The previous fixed path — `rust/target/analysis-conservation-contract` —
+/// was created and `remove_dir_all`ed by a test that runs concurrently with
+/// every other test binary in the workspace, so a repeat or parallel run could
+/// clear the directory another run was reading. A unique path does not narrow
+/// that window, it closes it, and it removes the need to delete anything
+/// (`rust/target/` is gitignored). Issue 572.
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = root().join("rust/target").join(format!(
+        "analysis-conservation-{name}-{}-{id}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+static NEXT_SCRATCH: AtomicUsize = AtomicUsize::new(0);
 
 fn run(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_fslc"))
@@ -111,8 +133,7 @@ fn ai_review_invalid_input_and_unsupported_modes_still_exit_two() {
     assert_eq!(unsupported["result"], "error");
     assert_eq!(unsupported["kind"], "semantics");
 
-    let directory = root().join("rust/target/analysis-conservation-contract");
-    std::fs::create_dir_all(&directory).expect("create invalid fixture directory");
+    let directory = scratch_dir("invalid-input");
     let invalid = directory.join("invalid.fsl");
     std::fs::write(&invalid, "spec Broken { state { value: } }")
         .expect("write invalid analysis fixture");
@@ -124,7 +145,10 @@ fn ai_review_invalid_input_and_unsupported_modes_still_exit_two() {
     ]);
     assert_eq!(invalid.status.code(), Some(2));
     assert_eq!(output_json(&invalid)["result"], "error");
-    std::fs::remove_dir_all(&directory).expect("clear invalid fixture directory");
+    // Safe to remove now, and only now: the path is unique to this test in this
+    // process, so nothing else can be reading it. Deleting a *shared* path is
+    // what produced the race this fixes.
+    std::fs::remove_dir_all(&directory).expect("clear scratch dir");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Two independent defects, both found while verifying earlier fixes in this series.

**#571 — `fslc ai check` accepted duplicate `dataset` / `evaluator` names.**
`reject_duplicates` covered three of the five declaration kinds the frozen reference
rejects duplicates for (`src/fslc/ai_project.py:237-241`). The two that were missing are
precisely the two referenced **by name** from elsewhere in the document, so two
declarations sharing a name made resolution depend on declaration order. This was a false
green, not a cosmetic one: the CLI exited 0 and picked a winner silently.

**#572 — `analysis_conservation` raced on a fixed shared path.**
`ai_review_invalid_input_and_unsupported_modes_still_exit_two` created and `remove_dir_all`ed
a single fixed path (`rust/target/analysis-conservation-contract`) while every other test
binary in the workspace runs concurrently. It failed intermittently under load and passed in
isolation — a false red indistinguishable from a real regression until someone spends the
time separating them, which is the cost issues #539 and #546 were filed for.

## Contract change

`fslc ai check` on a project with a duplicate `dataset` or `evaluator` name now exits **2**
with `duplicate <kind> '<name>'` (`kind: parse`) where it previously exited **0**. This
aligns native with the frozen reference; no other input changes behavior.

`analysis_conservation` gains no new contract — it adopts the `scratch_dir(name)` idiom
`rust/fslc/tests/chain_cli.rs` already establishes. A unique path does not narrow the
exists-then-remove window, it closes it. `--test-threads=1` and a serialization attribute were
both rejected for the reasons recorded when #546 was fixed: the first masks this class of race
for every other test too, the second adds a dependency and hides why serialization is needed.

## Test evidence

Measured in this worktree, rebased onto `62acf02`:

```
FMT_EXIT=0
CLIPPY_EXIT=0
TEST_EXIT=0
NATIVE_EXIT=0
{ "schema": "fsl-wasm-browser.v1", "ok": true, "cancelled": true,
  "nativeParity": true, "parityCases": 359, "exclusionProbes": 32 }
```

#571, before and after:

| input | before | after |
|---|---|---|
| project with two `dataset Shared` | exit 0, `datasets: ['Shared','Shared']` | exit 2, `duplicate dataset 'Shared'` |
| project with two `evaluator` of one name | exit 0 | exit 2 |
| `examples/ai/support_answer_quality.fsl` | exit 0 | exit 0, `datasets=['SupportEvalV3'] evaluators=['SupportAnswerJudge']` |

The third row is the control: a valid project must keep passing, with its names still projected.

#572: one green run proves nothing about a race, so the evidence is the repetition —
**four consecutive** `cargo test -p fslc-rust --test analysis_conservation` runs at the default
thread count all pass, and **zero** scratch directories are left behind.

Closes #571
Closes #572