### PR TITLE
test(wasm): retire 28 stale parity exclusions, and fix three defects in the harness that let them go stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,15 +83,56 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   asserted by name to remain a compared parity case, the same way
   `duplicateWriteCase`/`governanceErrorCase` are, so a future silent
   re-exclusion fails loudly instead of only showing up as a quiet drop in
-  `parityCases.length`. Evaluated whether #568's Worker-only exclusion probe
-  could be strengthened to also run native and fail on agreement (the general
-  form of the staleness this retirement fixes): measured not adoptable as
-  specified for the 3 remaining causal exclusions, because their native
-  envelope has no `versions` block at all and the shared parity normalizer's
-  `validateEnvelope` throws before an agreement comparison can even run --
-  a normalizer rejection not an agreement, so the strengthening needs its own
-  design decision and is left to a follow-up issue rather than folded in here
-  (#577).
+  `parityCases.length` (#577).
+- Every parity-corpus exclusion is now checked to have native answer
+  non-`error`, before the Worker launches. This closes the blindness that let
+  the 28 retired entries go stale: #568's probe tests only the *Worker* side
+  (`result !== "error"`), which detects agreement only when native answers
+  non-`error` — agreement then forces the Worker non-`error` too. Native
+  answered `error` for all 28 refinement documents, so two sides erroring
+  looked identical whether or not the errors matched, and the probe stayed
+  green for weeks. Native answers non-`error` for all 4 surviving exclusions
+  (`ok` for agent, `causal_model_checked` for the 3 causal), so the cheap
+  Worker-only probe is sound for them — and the day an exclusion is added
+  whose native side errors, this assertion names it instead of silently
+  reverting the corpus to that blind state. Full envelope comparison was
+  evaluated and rejected: the causal envelope carries no `versions` block, so
+  `validateEnvelope` throws before any comparison, which is a normalizer
+  rejection rather than a verdict. The assertion runs in the candidate loop
+  rather than beside the Worker probe because it depends on nothing but
+  native, turning a ~6-minute failure into a sub-second one (#577).
+- The browser parity harness no longer embeds a developer's absolute path.
+  `rust/fsl-wasm/test-browser.mjs` hardcoded one machine's
+  `/Users/<name>/Library/Caches/ms-playwright/chromium_headless_shell-1208/...`
+  Chrome, the only committed line in the repository containing an absolute home
+  path, which `AGENTS.md` forbids. Playwright installs each build under its own
+  version directory and has changed the internal layout between them — both
+  `chrome-mac/headless_shell` and
+  `chrome-headless-shell-<platform>/chrome-headless-shell` exist on a machine
+  with two builds installed — so the version, the platform directory, and the
+  binary name are all discovered rather than spelled out, newest build first
+  (#583).
+- A dropped or half-open Chrome DevTools Protocol connection no longer hangs
+  the browser gate forever. `cdp()` returned a promise that only the message
+  listener could ever settle, with no timeout and no socket `close`/`error`
+  handler, so a response that never arrived hung Node indefinitely; the
+  surrounding `for (attempt < 360)` loop is not a bound when a single `await`
+  inside it never returns. Because the hang left the process to be killed
+  externally, the `finally` that terminates Chrome and removes the profile
+  directory never ran: an orphaned `chrome-headless-shell` (parent gone,
+  4h13m old) and seven leaked profile directories were measured on one machine,
+  and an orphan over two hours old blocked a later gate. `cdp()` now times out
+  naming the method, and both socket `close` and `error` reject every
+  outstanding request, so the failure is loud and the cleanup runs (#584).
+- `rust/fsl-wasm/web/cases.mjs` no longer claims its smoke cases are compared
+  against native. The native comparison keyed on them (`nativeVerdict`) was
+  removed in `d30f456` when the corpus-wide parity run replaced it, but the
+  now-unused `import { cases }` in `test-browser.mjs` and the header comment
+  promising "the parity comparison stays honest" both survived, so the file
+  documented a check that no longer existed. The import is removed and the
+  comment states what is true: these 9 inline sources are Worker smoke cases
+  checked in the browser against their own `expected`, and the 415-case corpus
+  comparison supersedes the removed one (#585).
 - A kernel-stage failure inside a `use ... from` component now reports the
   parent's `use` declaration as its `loc`, and names the component's own path
   and position in the message. The two used to be mixed: the path came from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   tolerated-difference allowlist: the envelopes are still not compared for
   these documents and no verdict, location, or exit-code difference is
   allowlisted (#568).
+- The 28 `refinement`-typed entries in `rust/fsl-wasm/test-browser.mjs`'s
+  `unsupportedDocuments` exclusion map are retired; the compared native<->Worker
+  parity corpus grows from 359 to 415 cases and `exclusionProbes` drops from 32
+  to 4 (agent + 3 causal only). The exclusion premise was measured stale: #574
+  gave native and the Worker one shared classifier (`kernel_load_error`) for a
+  document whose top level parses but is not Kernel-shaped, so `check`/`verify`
+  on every refinement document in the corpus now produce byte-identical
+  `semantics`/"spec has no state block" envelopes on both surfaces -- the
+  exclusion was suppressing zero divergence. `specs/cart_refines.fsl` is now
+  asserted by name to remain a compared parity case, the same way
+  `duplicateWriteCase`/`governanceErrorCase` are, so a future silent
+  re-exclusion fails loudly instead of only showing up as a quiet drop in
+  `parityCases.length`. Evaluated whether #568's Worker-only exclusion probe
+  could be strengthened to also run native and fail on agreement (the general
+  form of the staleness this retirement fixes): measured not adoptable as
+  specified for the 3 remaining causal exclusions, because their native
+  envelope has no `versions` block at all and the shared parity normalizer's
+  `validateEnvelope` throws before an agreement comparison can even run --
+  a normalizer rejection not an agreement, so the strengthening needs its own
+  design decision and is left to a follow-up issue rather than folded in here
+  (#577).
 - A kernel-stage failure inside a `use ... from` component now reports the
   parent's `use` declaration as its `loc`, and names the component's own path
   and position in the message. The two used to be mixed: the path came from the

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -85,12 +85,6 @@ const candidates = [
 // still not compared for these documents, and no verdict, location, or
 // exit-code difference is allowlisted anywhere.
 const unsupportedReasons = {
-  refinement:
-    "the Worker exposes only check/verify over Kernel specs and has no `refine` verb. NOTE (measured "
-    + "on the post-#574 tree): native and Worker check/verify envelopes now AGREE for every refinement "
-    + "document in the corpus, so this exclusion no longer suppresses any divergence and is retirable. "
-    + "Retiring it adds 54 compared cases and is a corpus-scope decision tracked separately -- the probe "
-    + "below only detects the Worker gaining a verb, not this agreement-staleness (#568)",
   agent:
     "native `check` runs the lenient fsl-ai agent analysis (result \"ok\", dialect fsl-ai-agent.v0); "
     + "the Worker has no agent path at all and stops at the kernel lowering gate",
@@ -100,35 +94,7 @@ const unsupportedReasons = {
     + "cannot validate, so there is no comparable pair to build",
 };
 const unsupportedDocuments = new Map(Object.entries({
-  "examples/agentic_rag/agentic_rag_design_refines_requirements.fsl": "refinement",
-  "examples/agentic_rag/agentic_rag_requirements_refines_business.fsl": "refinement",
-  "examples/agentic_rag/negative/guard_bypass_refines_requirements.fsl": "refinement",
-  "examples/agentic_rag/negative/liveness_drop_refines_requirements.fsl": "refinement",
-  "examples/agentic_rag/negative/tool_approval_bypass_refines_requirements.fsl": "refinement",
   "examples/ai/recursive_support_agent.fsl": "agent",
-  "examples/consulting/tobe_refines_asis.fsl": "refinement",
-  "examples/e2e/3_refines_2.fsl": "refinement",
-  "examples/gallery/adversarial/refine_mapping_boundary_map.fsl": "refinement",
-  "examples/gallery/adversarial/governance_semantic_mapping.fsl": "refinement",
-  "examples/gallery/errors/refinement_failed_map.fsl": "refinement",
-  "examples/layers/return_impl_refines.fsl": "refinement",
-  "examples/multi_agent_system/multi_agent_design_refines_requirements.fsl": "refinement",
-  "examples/multi_agent_system/multi_agent_requirements_refines_business.fsl": "refinement",
-  "examples/nfr/sla_worker_refines.fsl": "refinement",
-  "examples/refinement_chain/bot_refines_mid.fsl": "refinement",
-  "examples/refinement_chain/mid_refines_top.fsl": "refinement",
-  "examples/refinement_liveness/design_bypasses_control_refines.fsl": "refinement",
-  "examples/refinement_liveness/design_drops_liveness_progress_refines.fsl": "refinement",
-  "examples/refinement_liveness/design_drops_liveness_refines.fsl": "refinement",
-  "examples/refinement_liveness/design_keeps_liveness_progress_refines.fsl": "refinement",
-  "examples/refinement_liveness/design_keeps_liveness_refines.fsl": "refinement",
-  "examples/ui_spike/ui_refines_req.fsl": "refinement",
-  "examples/validation/order_refund_instant_refines.fsl": "refinement",
-  "examples/validation/order_refund_windowed_refines.fsl": "refinement",
-  "specs/bank_refines.fsl": "refinement",
-  "specs/cart_refines.fsl": "refinement",
-  "specs/seat_refines.fsl": "refinement",
-  "examples/causal/evidence/incident-log-mapping.fsl": "refinement",
   "examples/causal/incident_response.fsl": "causal",
   "examples/causal/marketing_funnel.fsl": "causal",
   "examples/causal/subscription_retention.fsl": "causal",
@@ -152,7 +118,7 @@ for (const path of candidates) {
       .find((line) => line.length > 0);
     if (stripped !== undefined && /^causal\s/.test(stripped)) documentType = "causal";
   }
-  if (["agent", "refinement", "causal"].includes(documentType)) {
+  if (["agent", "causal"].includes(documentType)) {
     if (unsupportedDocuments.get(repositoryPath) !== documentType) {
       throw new Error(`unreviewed unsupported ${documentType} document: ${repositoryPath}`);
     }
@@ -205,12 +171,25 @@ const governanceErrorCase = "examples/gallery/errors/governance_missing_before.f
 if (!parityCases.some((testCase) => testCase.path === governanceErrorCase)) {
   throw new Error(`${governanceErrorCase} must remain in the parity corpus`);
 }
-// The only corpus input that fails at the kernel stage
-// (`fsl_core::parse_kernel_source_with_file`) while its own top level parses.
-// Every other kernel-stage failure under specs/+examples/ is a refinement,
-// agent, or causal document this harness excludes as unsupported, so without
-// this case the Worker could classify that whole stage differently from native
-// and no parity run would notice (issue #556).
+// #577: anchors the retirement of the 28 stale refinement exclusions. Native
+// and Worker check/verify envelopes now agree for every refinement document
+// in the corpus (the exclusion premise measured in #568 no longer holds), so
+// this document must be a compared parity case, not a Worker-only exclusion
+// probe. If a future change silently re-excludes refinement documents, this
+// fails instead of only showing up as a quiet drop in `parityCases.length`.
+const retiredRefinementCase = "specs/cart_refines.fsl";
+if (!parityCases.some((testCase) => testCase.path === retiredRefinementCase)) {
+  throw new Error(`${retiredRefinementCase} must remain in the parity corpus`);
+}
+// The only corpus input whose kernel-stage failure
+// (`fsl_core::parse_kernel_source_with_file`) keeps its own located message
+// instead of the generic substituted "spec has no state block" that
+// refinement documents get (`kernel_load_error` in spec_load.rs) -- while its
+// own top level parses. Every other located kernel-stage failure under
+// specs/+examples/ is an agent or causal document this harness still excludes
+// as unsupported (refinement is now compared directly, #577), so without this
+// case the Worker could classify a located kernel-stage message differently
+// from native and no parity run would notice (issue #556).
 const kernelStageCase = "examples/gallery/errors/semantics_compose_component_parse_failure.fsl";
 if (!parityCases.some((testCase) => testCase.path === kernelStageCase)) {
   throw new Error(`${kernelStageCase} must remain in the parity corpus`);

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -54,6 +54,29 @@ async function command(executable, args, timeoutMs = 300_000) {
   });
 }
 
+const nativeBinary = fileURLToPath(new URL("../target/debug/fslc", import.meta.url));
+async function nativeEnvelope(testCase) {
+  const args = testCase.cmd === "check"
+    ? ["check", testCase.path]
+    : [
+      "verify", testCase.path,
+      "--depth", String(testCase.options.depth),
+      "--deadlock", testCase.options.deadlock,
+      "--no-cache",
+    ];
+  const result = await command(nativeBinary, args, nativeCommandTimeoutMs);
+  if (testCase.expected_status !== undefined && result.status !== testCase.expected_status) {
+    throw new Error(
+      `native CLI exit mismatch for ${testCase.path}: expected ${testCase.expected_status}, got ${result.status}`,
+    );
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`native CLI JSON failure: ${error}\n${result.stderr}`);
+  }
+}
+
 async function collectFslFiles(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
   const nested = await Promise.all(entries.map((entry) => {
@@ -83,7 +106,11 @@ const candidates = [
 // exclusion has become unnecessary (#568). This is a *capability* exclusion,
 // never a tolerated-difference allowlist: the native<->Worker envelopes are
 // still not compared for these documents, and no verdict, location, or
-// exit-code difference is allowlisted anywhere.
+// exit-code difference is allowlisted anywhere. A new entry must also keep
+// native answering non-error for that document (#577, enforced below): once
+// native errors too, the Worker-only probe can no longer tell agreement from
+// a coincidence, which is what let the 28 retired refinement entries go
+// stale silently.
 const unsupportedReasons = {
   agent:
     "native `check` runs the lenient fsl-ai agent analysis (result \"ok\", dialect fsl-ai-agent.v0); "
@@ -123,10 +150,11 @@ for (const path of candidates) {
       throw new Error(`unreviewed unsupported ${documentType} document: ${repositoryPath}`);
     }
     observedUnsupported.add(repositoryPath);
-    // Not compared against native -- probed on the Worker alone, so that the
-    // day the Worker grows a verb for this document type the recorded premise
-    // stops matching and the exclusion fails instead of silently persisting.
-    exclusionProbes.push({
+    // Not compared against native -- probed on the Worker alone below, so
+    // that the day the Worker grows a verb for this document type the
+    // recorded premise stops matching and the exclusion fails instead of
+    // silently persisting (#568).
+    const probe = {
       id: `exclusion-${exclusionProbes.length}`,
       cmd: "check",
       path: repositoryPath,
@@ -135,7 +163,26 @@ for (const path of candidates) {
       files: {},
       options: {},
       documentType,
-    });
+    };
+    exclusionProbes.push(probe);
+    // That Worker-only probe is sound only because native also answers
+    // non-error for this document: agreement then forces the Worker
+    // non-error too, which the probe below already catches -- no envelope
+    // comparison needed. If native answered "error" instead, a Worker error
+    // would be indistinguishable from real agreement, which is exactly the
+    // blindness that let the 28 refinement entries retired in #577 go stale
+    // silently (both sides erroring looked the same whether or not the two
+    // errors actually matched). Checked here, before the ~6-minute Worker
+    // run, because it depends on nothing but native.
+    const probeNativeEnvelope = await nativeEnvelope(probe);
+    if (probeNativeEnvelope.result === "error") {
+      throw new Error(
+        `${repositoryPath}: native's own result is "error" for this ${documentType} document, so `
+        + `a Worker-only probe cannot distinguish real native<->Worker agreement from two unrelated `
+        + `errors that both happen to be "error". Compare the pair explicitly (native vs Worker `
+        + `envelope) or retire the entry, the way the 28 refinement entries were retired in #577.`,
+      );
+    }
     continue;
   }
   if (unsupportedDocuments.has(repositoryPath)) {
@@ -318,28 +365,6 @@ if (details.ok !== "true") {
 }
 const browser = JSON.parse(details.text);
 if (!browser.cancelled) throw new Error("Worker cancellation did not complete");
-const nativeBinary = fileURLToPath(new URL("../target/debug/fslc", import.meta.url));
-async function nativeEnvelope(testCase) {
-  const args = testCase.cmd === "check"
-    ? ["check", testCase.path]
-    : [
-      "verify", testCase.path,
-      "--depth", String(testCase.options.depth),
-      "--deadlock", testCase.options.deadlock,
-      "--no-cache",
-    ];
-  const result = await command(nativeBinary, args, nativeCommandTimeoutMs);
-  if (testCase.expected_status !== undefined && result.status !== testCase.expected_status) {
-    throw new Error(
-      `native CLI exit mismatch for ${testCase.path}: expected ${testCase.expected_status}, got ${result.status}`,
-    );
-  }
-  try {
-    return JSON.parse(result.stdout);
-  } catch (error) {
-    throw new Error(`native CLI JSON failure: ${error}\n${result.stderr}`);
-  }
-}
 const native = [];
 for (const testCase of parityCases) {
   native.push(await nativeEnvelope(testCase));
@@ -373,6 +398,14 @@ for (let index = 0; index < parityCases.length; index += 1) {
 // parse (causal) -- either way it never produces an analysis. The day the
 // Worker gains the verb, `result` stops being `"error"` and this fails,
 // naming the entry to remove.
+//
+// This Worker-only check is sound only because native also answers
+// non-error for every excluded document, which is asserted separately in the
+// candidate-collection loop above, before the Worker even runs (#577): when
+// native is non-error, Worker/native agreement forces the Worker non-error
+// too, so this check alone already catches staleness -- no envelope
+// comparison needed. See the comment on that earlier assertion for why it
+// would be unsound to skip.
 const staleExclusions = [];
 for (let index = 0; index < exclusionProbes.length; index += 1) {
   const probe = exclusionProbes[index];

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -351,11 +351,37 @@ async function devtoolsPort() {
 }
 let nextId = 1;
 const pending = new Map();
+const cdpTimeoutMs = 30_000;
+// Unlike command(), which has always had a timeout, a dropped or half-open
+// CDP connection used to leave the returned promise unsettled forever: the
+// message listener is the only thing that ever resolved or rejected a
+// pending entry, so a response that never arrives hung node indefinitely,
+// and the `for (attempt < 360)` probe loop below is not actually a bound
+// once a single `await cdp(...)` inside it never returns (#584). Both the
+// per-call timeout here and rejectPending's socket close/error handlers
+// below turn that hang into a loud, named failure, which lets the
+// surrounding `finally` still run and clean up the child process and
+// profile directory.
 function cdp(socket, method, params = {}) {
   const id = nextId;
   nextId += 1;
   socket.send(JSON.stringify({ id, method, params }));
-  return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`CDP method "${method}" timed out after ${cdpTimeoutMs}ms`));
+    }, cdpTimeoutMs);
+    pending.set(id, {
+      resolve: (value) => { clearTimeout(timeout); resolve(value); },
+      reject: (error) => { clearTimeout(timeout); reject(error); },
+    });
+  });
+}
+function rejectPending(error) {
+  for (const [id, waiter] of pending) {
+    pending.delete(id);
+    waiter.reject(error);
+  }
 }
 let details;
 try {
@@ -364,6 +390,8 @@ try {
   const page = targets.find((target) => target.type === "page");
   if (!page) throw new Error("Chrome did not expose a page target");
   const socket = new WebSocket(page.webSocketDebuggerUrl);
+  socket.addEventListener("close", () => rejectPending(new Error("CDP socket closed with requests outstanding")));
+  socket.addEventListener("error", () => rejectPending(new Error("CDP socket error with requests outstanding")));
   socket.addEventListener("message", ({ data }) => {
     const message = JSON.parse(data);
     if (!message.id || !pending.has(message.id)) return;

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawn } from "node:child_process";
-import { createReadStream, existsSync, statSync } from "node:fs";
+import { createReadStream, existsSync, readdirSync, statSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { createServer } from "node:http";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -280,9 +280,45 @@ const server = createServer((request, response) => {
 await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
 const { port } = server.address();
 
+// Playwright installs each downloaded browser under its own version-numbered
+// directory, and the platform subdirectory inside it is itself
+// version-dependent, not just architecture-dependent: measured on this box,
+// chromium_headless_shell-1208 nests
+// chrome-headless-shell-mac-arm64/chrome-headless-shell, while the older
+// chromium_headless_shell-1187 nests chrome-mac/headless_shell -- a
+// different directory name *and* a different executable basename, not a
+// mac-arm64/mac-x64 suffix swap. Neither the version number nor the platform
+// directory name is worth hardcoding (an Intel Mac's
+// chrome-headless-shell-mac-x64 would silently never match a hardcoded
+// mac-arm64 path), so every version directory's actual subdirectories are
+// enumerated and both observed executable basenames are tried in each,
+// rather than guessing at layouts nobody has measured.
+function playwrightHeadlessShellCandidates() {
+  const versionsRoot = join(homedir(), "Library/Caches/ms-playwright");
+  if (!existsSync(versionsRoot)) return [];
+  const versions = readdirSync(versionsRoot)
+    .filter((name) => name.startsWith("chromium_headless_shell-"))
+    .sort()
+    .reverse();
+  return versions.flatMap((version) => {
+    const versionRoot = join(versionsRoot, version);
+    let platforms;
+    try {
+      platforms = readdirSync(versionRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      return [];
+    }
+    return platforms.flatMap((platform) => [
+      join(versionRoot, platform, "chrome-headless-shell"),
+      join(versionRoot, platform, "headless_shell"),
+    ]);
+  });
+}
 const chrome = [
   process.env.CHROME_BIN,
-  "/Users/rizumita/Library/Caches/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-mac-arm64/chrome-headless-shell",
+  ...playwrightHeadlessShellCandidates(),
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "/usr/bin/google-chrome",
   "/usr/bin/google-chrome-stable",

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -99,7 +99,7 @@ const candidates = [
 // Documents the Worker has no verb for, and therefore cannot be compared
 // against the native CLI. Each entry records the document type and the
 // *measured* reason the exclusion holds, so the next reader does not re-derive
-// it. `workerSignature` below turns each entry into a self-retiring one: the
+// it. `exclusionProbes` below turns each entry into a self-retiring one: the
 // harness probes the Worker for every excluded document and fails loudly when
 // the Worker's behaviour no longer matches the recorded premise, i.e. when the
 // exclusion has become unnecessary (#568). This is a *capability* exclusion,

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -10,7 +10,6 @@ import { dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import "./build.mjs";
-import { cases } from "./web/cases.mjs";
 import { assertNormalizerContract, differences, normalizeEnvelope } from "./parity.mjs";
 import { workerMessageError } from "./web/worker-protocol.mjs";
 

--- a/rust/fsl-wasm/web/cases.mjs
+++ b/rust/fsl-wasm/web/cases.mjs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Browser smoke cases shared between the Worker client probe (client.mjs)
-// and the native parity gate (test-browser.mjs). Each case carries the exact
-// verify options both probes must use so the parity comparison stays honest.
+// Worker smoke cases for client.mjs, the only consumer: each case is checked
+// in the browser against its own `expected` verdict (and `expect` shape),
+// not against native. A native comparison loop keyed on these cases existed
+// once (`nativeVerdict`, removed in d30f456 / issue 287) but test-browser.mjs
+// no longer imports this module -- the corpus parity run it does instead
+// (415 real specs/examples documents, each through native and the Worker) is
+// strictly stronger than these 9 inline sources, so that comparison is not
+// worth restoring (issue 585). Do not reintroduce an import of `cases` there
+// on the assumption these are meant to be parity-checked; they are not.
 export const cases = [
   {
     id: "verified",


### PR DESCRIPTION
## Problem

Four defects, all in the browser parity harness, found while working on the first.

**#577 — 28 refinement parity exclusions were stale.** `#574` removed the native↔Worker
divergence that justified them, so they suppressed nothing while removing 56 comparison
cases from the corpus.

**#583 — the harness embedded a developer's absolute path.** The only committed line in the
repository containing an absolute home path, which `AGENTS.md` forbids.

**#584 — `cdp()` could never settle.** No timeout, and no socket `close`/`error` handler
rejecting outstanding requests, so a dropped or half-open CDP connection hung Node forever.
The `for (attempt < 360)` loop is not a bound when a single `await` inside it never returns.

**#585 — `web/cases.mjs` documented a check that no longer existed.** The native comparison
keyed on the smoke cases was removed in `d30f456`; the unused `import { cases }` and the
comment promising "the parity comparison stays honest" both survived it.

## Contract change

`parityCases` 359 → **415**, `exclusionProbes` 32 → **4** (1 agent + 3 causal). No verdict,
location, assurance, or exit-code difference is allowlisted anywhere — this remains a
capability exclusion, and **retiring the 28 introduced zero new divergence**, which is the
result the issue demanded and the reason it could be retired at all.

`cdp()` now fails loudly instead of hanging. That is a behavior change for the gate: a stall
that previously produced an unbounded hang now produces a named error in 30s.

## The invariant that made this fixable, and now enforces itself

The #568 probe tests only the **Worker** side (`result !== "error"`). Measuring every
document explains exactly when that is sufficient:

| | native `result` |
|---|---|
| the 28 retired | **`error`** (all 28) |
| the 4 surviving | **non-`error`** — `ok` (agent), `causal_model_checked` (causal ×3) |

If native is non-`error`, agreement forces the Worker non-`error`, which the existing probe
already catches — no envelope comparison needed. If native is `error`, two sides erroring are
indistinguishable from agreement, and the probe stays green forever. That is precisely why it
went blind on exactly those 28.

So this adds a per-exclusion assertion that **native answers non-`error`** — the premise that
makes the cheap probe sound. Full envelope comparison was evaluated and rejected: the causal
envelope has no `versions` block, so `validateEnvelope` throws before any comparison, which is
a normalizer rejection rather than a verdict. The assertion runs in the candidate loop, not
beside the Worker probe, because it depends on nothing but native — a sub-second failure
instead of a ~6-minute one.

To be precise about what guards what: the named `retiredRefinementCase` anchor
(`specs/cart_refines.fsl`, following the `duplicateWriteCase` idiom) catches the document
leaving the corpus. A **re-exclusion** is caught by the native non-`error` assertion, which
fires on the first refinement document. These are different failure modes with different
anchors.

## Test evidence

Full gate on the merge-target tree (`3accb42`, rebased onto `40d1a4e`):

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0
{ "nativeParity": true, "parityCases": 415, "exclusionProbes": 4 }
```

**#577 negative control** — operator unchanged, one surviving exclusion's native check pointed
at `examples/causal/evidence/incident-log-mapping.fsl` (measured native exit=2/result=error):
exactly **one** entry failed by name, the other three silent, in <1s. Inverting the operator
instead was rejected as an ablation: it fires on all four regardless of where the value came
from, so it cannot distinguish a check that reads native's result from one that reads
something else.

**#584 negative controls** — three configurations, each producing a different named error,
0 orphaned processes in every case:

| configuration | result |
|---|---|
| both changes, forced close with request outstanding | `CDP socket closed with requests outstanding`, immediate |
| close/error handlers removed, same injection | `CDP method "Runtime.evaluate" timed out after 30000ms`, 32s |
| `cdpTimeoutMs = 1` | `CDP method "Runtime.enable" timed out after 1ms` |

Each change is independently load-bearing: the handlers cover the socket-closed path, the
timeout covers the no-response path where no close event ever fires. On `main` both paths hang
forever. Zero orphans in every run is the direct evidence for the causal claim in #584 — making
the hang loud is what lets the existing `finally` run.

**#583** — `git grep -n "/Users/" -- .` returns zero hits, and `CHROME_BIN` is unset in the
environment these gates ran in, so every green run above exercised the Playwright discovery
path. Both binary layouts are needed and both were measured on one machine:
`chromium_headless_shell-1187/chrome-mac/headless_shell` and
`chromium_headless_shell-1208/chrome-headless-shell-mac-arm64/chrome-headless-shell` — different
directory *and* binary names, which is why the version, platform directory, and binary name are
all discovered rather than spelled out.

## One intermittent failure, filed rather than hidden

One `check-native-integration.sh` run failed with the new CDP timeout. Investigated rather
than retried: instrumenting the polling loop measured a healthy maximum `Runtime.evaluate`
latency of **21ms over 100 attempts** — roughly 1400× margin against the 30s timeout — so the
timeout value is not the cause and raising it would only hide the event. Three consecutive
re-runs on the identical tree passed (501s / 511s / 518s, 415 cases, 0 orphans each).

It is an intermittent stall that **predates this branch**: before #584 it appeared as an
infinite hang plus an orphaned `chrome-headless-shell` (measured earlier this session at
PPID=1, 4h13m old, with 7 leaked profile directories). #584 made it bounded and visible.
Filed as #587 with the measurements, including what is *not* known — which side stalls — and a
fix sketch that adds diagnostics rather than a retry, since a retry would mask a genuine hang.

Closes #577
Closes #583
Closes #584
Closes #585