### PR TITLE
chore(release): v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-27
+
 ### Changed
 - Pull requests into `main` now run the complete Linux product evidence — `rust workspace`
   and `WASM` — instead of deferring it to after the merge. Only the cross-platform
@@ -3701,7 +3703,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/ymm-oss/fsl/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/ymm-oss/fsl/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/ymm-oss/fsl/compare/v2.7.0...v3.0.0
 [2.7.0]: https://github.com/ymm-oss/fsl/compare/v2.6.3...v2.7.0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -66,19 +66,42 @@ It also rejects a dynamic dependency on `libz3`.
    Do not hand-edit `rust/Cargo.lock`. Do not bump `pyproject.toml` for a native
    GitHub Release; the Python package is a frozen, unpublished compatibility
    reference.
-5. Move all current `[Unreleased]` entries under
+5. Bump the VS Code extension to the same version, so the release unit stays
+   atomic. Let npm write both files rather than hand-editing the lockfile:
+
+   ```bash
+   ( cd editors/vscode && npm version X.Y.Z --no-git-tag-version )
+   ```
+
+   `native_release_unit_is_atomic_pinned_and_platform_closed` asserts
+   `editors/vscode/package.json`'s version equals the workspace version, so
+   skipping this fails the product gate rather than shipping a mismatched
+   extension.
+6. Regenerate the domain characterization baseline, which embeds the CLI
+   version in every recorded envelope:
+
+   ```bash
+   UPDATE_DOMAIN_CHARACTERIZATION=1 \
+     cargo test --manifest-path rust/Cargo.toml -p fslc-rust \
+     --test domain_expression_characterization --locked
+   ```
+
+   Review the diff and require it to contain version strings only. A generated
+   snapshot is regenerated, never hand-edited; any other change in that diff is
+   a contract change that does not belong in a release commit.
+7. Move all current `[Unreleased]` entries under
    `## [X.Y.Z] - YYYY-MM-DD`, leaving an empty `## [Unreleased]`. Update the
    link references so `[Unreleased]` compares `vX.Y.Z...HEAD` and `[X.Y.Z]`
    compares the previous tag with `vX.Y.Z`.
-6. Confirm the complete `X.Y.Z` changelog section is non-empty and suitable for
+8. Confirm the complete `X.Y.Z` changelog section is non-empty and suitable for
    the GitHub Release body.
-7. Run the complete product gate:
+9. Run the complete product gate:
 
    ```bash
    ./tools/check-native-integration.sh
    ```
 
-8. Commit `chore(release): vX.Y.Z`, open a pull request to `main`, and merge it
+10. Commit `chore(release): vX.Y.Z`, open a pull request to `main`, and merge it
    only after required checks pass. Record the exact merged `main` SHA as the
    release candidate.
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -364,14 +364,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0"
+version = "4.0.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7857,11 +7857,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8013,11 +8013,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8038,11 +8038,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8094,11 +8094,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8119,11 +8119,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8158,11 +8158,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8189,11 +8189,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8218,11 +8218,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8248,11 +8248,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8276,11 +8276,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8306,11 +8306,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8334,11 +8334,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8364,11 +8364,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8392,11 +8392,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8423,11 +8423,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8452,11 +8452,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8483,11 +8483,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8512,11 +8512,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8542,11 +8542,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",
@@ -8570,11 +8570,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "3.1.0"
+              "version": "4.0.0"
             },
             "solver": {
               "name": "z3",


### PR DESCRIPTION
## Problem

Prepare the release commit for **4.0.0** on `main`, per `docs/RELEASE.md` section 1.

## Why 4.0.0 and not a patch

152 commits since `v3.1.0`, including **14 breaking changes**. Every one of them
*tightens* a verdict rather than adding a feature:

```
fix(explicit)!:  reject contradictory init instead of proving it
fix(sweep)!:     stop swallowing spec errors as sweep_passed
fix(chain)!:     fail closed on manifest errors instead of silent verified/exit 0
fix(refine)!:    report impl self-violation instead of refines
fix(runtime)!:   Monitor now rejects nondeterministic init
fix(core)!:      reject reserved words as declaration names
... 8 more
```

A pipeline pinning `fslc` will see previously green runs turn red **without changing a
line of specification**. That is the release's headline, not a footnote: those runs were
green because the tool was reporting things as verified that it had not verified.

## Contract change

`[workspace.package].version` 3.1.0 → 4.0.0, `editors/vscode` to match, the
`[Unreleased]` changelog section moved under `## [4.0.0] - 2026-07-27` with link
references updated. `pyproject.toml` is deliberately **not** bumped — the Python package
is a frozen, unpublished compatibility reference.

## Two procedure defects found and fixed

Following `docs/RELEASE.md` section 1 **as written** produces a commit that fails the
product gate twice. Both steps were performed for v3.1.0 (`e1dfdcb` touched the same six
files) but were never written down, so every release had to rediscover them from a red gate.

| Gate that failed | Cause | Documented? |
|---|---|---|
| `domain_expression_characterization` | `baseline.v1.json` embeds `"version": "3.1.0"` in all 40 recorded envelopes | no |
| `native_release_unit_is_atomic_pinned_and_platform_closed` | `editors/vscode/package.json` still 3.1.0 | no |

The second is the release-unit atomicity contract doing its job — it caught a version the
bump had missed. Neither was resolved by editing an expectation to go green: the snapshot
was **regenerated** with `UPDATE_DOMAIN_CHARACTERIZATION=1` and its diff verified to
contain version strings and nothing else, and the extension version was actually corrected.

`docs/RELEASE.md` now carries both steps, including that the generated snapshot is
regenerated rather than hand-edited and that any non-version change in that diff is a
contract change which does not belong in a release commit.

## Test evidence

On this tree:

```
cargo check --manifest-path rust/Cargo.toml --workspace           exit 0
cargo check --manifest-path rust/Cargo.toml --workspace --locked  exit 0
fslc --version                                                    fslc 4.0.0
./tools/check-native-integration.sh                               exit 0
  { "nativeParity": true, "parityCases": 415, "exclusionProbes": 4 }
```

`rust/Cargo.lock` was regenerated by Cargo, not hand-edited; its diff is 11 workspace
crate version lines and no dependency resolution change. The baseline diff is 40 version
strings.

Independently of the gate, the candidate was exercised through the **release binary** as a
user invokes it: 211 corpus documents through `check` with zero verdict/exit conservation
violations, 161 specs verified on both the symbolic and explicit engines with no
soundness-relevant disagreement, all 27 CLI verbs, the 19 metadata-carrying gallery
fixtures matched on exact result/kind/exit, and the whole test suite re-run in the
**release profile** that actually ships (1173 passed, 0 failed).