### PR TITLE
fix(wasm): report what a CDP timeout knows, not just that it timed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Fixed
+- A CDP timeout in the browser parity gate now reports the call ordinal, the
+  socket's `readyState`, how many other requests were outstanding, and Chrome's
+  own stderr, instead of only the method and the elapsed budget. The stall it
+  catches is intermittent — one failure in five full local runs, none in CI —
+  and is not reproducible on demand, so the single message an occurrence prints
+  is all the evidence there will ever be, and the previous message could not
+  separate "Chrome never became usable" from "the page stopped answering
+  mid-poll". Call id 1 is `Runtime.enable`, so an id-1 timeout indicts startup
+  while a later id indicts the page; an `OPEN` socket means nobody answered
+  while `CLOSING`/`CLOSED` means the transport went away and the close handler
+  lost the race. No retry was added: retrying an unexplained stall would
+  suppress the event this exists to capture, and a genuine hang would return as
+  a slow pass rather than a failure (#587).
+
 ## [4.0.0] - 2026-07-27
 
 ### Changed

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -361,6 +361,24 @@ const cdpTimeoutMs = 30_000;
 // below turn that hang into a loud, named failure, which lets the
 // surrounding `finally` still run and clean up the child process and
 // profile directory.
+// A CDP timeout is rare and not reproducible on demand (#587: one failure in
+// five full local runs, none in CI), so the single message it prints is all
+// the evidence anyone gets. Report what separates the candidate causes rather
+// than only that time ran out:
+//
+//   - `call id` is the ordinal. id 1 is `Runtime.enable`, so a timeout there
+//     means the connection never became usable, while a later id means the
+//     page stopped answering mid-poll. That is the difference between
+//     suspecting Chrome startup and suspecting the page's main thread.
+//   - `socket` separates a transport still OPEN -- nobody is answering -- from
+//     one already CLOSING/CLOSED, where the close handler lost the race.
+//   - Chrome's stderr is already accumulated but is otherwise printed only on
+//     a startup failure. A crash or renderer message in it names the cause.
+//
+// Deliberately no retry: retrying an unexplained stall would hide the event
+// this diagnostic exists to capture, and a real hang would return as a slow
+// pass instead of a failure.
+const READY_STATE = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
 function cdp(socket, method, params = {}) {
   const id = nextId;
   nextId += 1;
@@ -368,7 +386,14 @@ function cdp(socket, method, params = {}) {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       pending.delete(id);
-      reject(new Error(`CDP method "${method}" timed out after ${cdpTimeoutMs}ms`));
+      const state = READY_STATE[socket.readyState] ?? `unknown(${socket.readyState})`;
+      const chromeStderr = stderr.trim();
+      reject(new Error(
+        `CDP method "${method}" timed out after ${cdpTimeoutMs}ms `
+        + `(call id ${id}, socket ${state}, ${pending.size} other request(s) outstanding); `
+        + `see issue 587. Chrome stderr: `
+        + `${chromeStderr === "" ? "<empty>" : `\n${chromeStderr}`}`,
+      ));
     }, cdpTimeoutMs);
     pending.set(id, {
       resolve: (value) => { clearTimeout(timeout); resolve(value); },


### PR DESCRIPTION
## Problem

The browser parity gate stalls intermittently — **one failure in five full local runs,
none in CI** — and is not reproducible on demand. The single message a timeout prints is
therefore the only evidence any occurrence will ever leave, and it was:

```
CDP method "Runtime.enable" timed out after 30000ms
```

That cannot separate *Chrome never became usable* from *the page stopped answering
mid-poll*, and those want opposite investigations.

## Contract change

None. The timeout, its budget, and every verdict are unchanged. Only the failure message
grows.

## What it reports now, and why each field

```
CDP method "Runtime.enable" timed out after 1ms
  (call id 1, socket OPEN, 0 other request(s) outstanding); see issue 587.
  Chrome stderr:
DevTools listening on ws://127.0.0.1:54239/devtools/browser/4455c19e-…
[0727/044754] ERROR:ui/display/mac/cv_display_link_mac.mm:168 CVDisplayLinkCreateWithCGDisplay failed. CVReturn: -6670
```

- **call id** — id 1 is `Runtime.enable`, so an id-1 timeout indicts startup while a later
  id indicts the page. This is the field that picks the investigation.
- **socket state** — `OPEN` means nobody answered; `CLOSING`/`CLOSED` means the transport
  went away and the close handler lost the race.
- **outstanding count** — distinguishes one stuck call from a wholesale stall.
- **Chrome's stderr** — already accumulated, but previously printed only on a startup
  failure. The `CVDisplayLink` line above would have been invisible.

## Deliberately no retry

Retrying an unexplained stall would suppress the very event this exists to capture, and a
genuine hang would come back as a slow pass instead of a failure. #587 records this as a
requirement, not an oversight.

## Test evidence

The negative control #587 asks for: force a stall, confirm all three facts actually reach
the output. Ablated with `cdpTimeoutMs = 1`:

```
ABLATION_EXIT=1
→ call id, socket state, outstanding count, and Chrome stderr all present
```

Reading the code and concluding it *should* print them is what let #574's staleness
survive for weeks, so this was measured by running it.

Full gate on the merge-target tree:

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0   NATIVE_EXIT=0
{ "parityCases": 415, "exclusionProbes": 4 }
```

Zero orphaned `chrome-headless-shell` processes after the ablation run — the failure stays
loud and self-cleaning, which is the property #584 established.

## What this does not do

It does not fix the stall. The cause is still unknown, and #587 stays open recording
exactly what is *not* known. This makes the next occurrence diagnosable instead of
guessing now.

Refs #587