### PR TITLE
test(fslc): corpus-wide Verdict Conservation Law check for `check` (#537 C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+### Added
+- `rust/fslc/tests/corpus_check_sweep.rs::check_result_and_exit_status_never_contradict`:
+  an oracle-free Verdict Conservation Law check (issue #537 C2) over every
+  `.fsl` file under `specs/` + `examples/`. It holds no per-file expectation;
+  it only requires that a success-class `fslc check` result exit 0, that
+  every other (including any future, unlisted) result exit non-zero, and
+  that the stdout envelope is a JSON object carrying a string `result`
+  field. `corpus_check_sweep.rs`'s existing sweep only ever inspected the
+  JSON body, never the process exit status, so a `result:"error"` envelope
+  that exited 0 would previously pass unnoticed.
+
 ### Fixed
 - A CDP timeout in the browser parity gate now reports the call ordinal, the
   socket's `readyState`, how many other requests were outstanding, and Chrome's

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -22,6 +22,15 @@
 //! `examples/gallery/injected/` (its own primary/blind detector matrix in
 //! `injection_detector_matrix.rs`) is a genuine verified-elsewhere category,
 //! not a silent skip.
+//!
+//! `check_result_and_exit_status_never_contradict` below is a second,
+//! independent property over the same corpus sweep (issue #537 C2, Verdict
+//! Conservation Law). It holds no per-file oracle and needs none of the
+//! exclusions above: unlike "does this file check clean", "does the exit
+//! status agree with the result class" is a closed law that every corpus
+//! file -- including deliberately-failing fixtures and the
+//! `refinement`/`examples/gallery/injected/` categories excluded above --
+//! must satisfy.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -113,19 +122,31 @@ fn headers(source: &str) -> std::collections::BTreeMap<String, String> {
     out
 }
 
-fn run_check(path: &Path) -> Value {
+/// Runs `fslc check` on `path` and returns the parsed stdout envelope
+/// together with the process exit status, so a single sweep of the corpus
+/// can serve both the per-file oracle below and the oracle-free
+/// `result`/exit conservation law in
+/// `check_result_and_exit_status_never_contradict`.
+fn run_check(path: &Path) -> (Value, i32) {
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args(["check", path.to_str().expect("utf8 path")])
         .current_dir(root())
         .output()
         .expect("run native CLI");
-    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(
             "invalid JSON for `fslc check {}`: {error}; stderr={}",
             path.display(),
             String::from_utf8_lossy(&output.stderr)
         )
-    })
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc check {}` terminated by signal, no exit code",
+            path.display()
+        )
+    });
+    (value, status)
 }
 
 #[test]
@@ -164,7 +185,7 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
             continue;
         }
 
-        let result = run_check(path);
+        let (result, _exit) = run_check(path);
 
         let file_headers = headers(&source);
         // `expected-command`/`expected-result` may target a *stricter* verb
@@ -198,4 +219,88 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
     }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// `result` values `fslc check` emits that belong to the success class
+/// (exit status must be 0).
+///
+/// `check`'s own family arms (`run_check_with_tags`, `agent_check_output`,
+/// `run_causal_check` in `rust/fslc/src/main.rs`/`causal.rs`) each set their
+/// exit code directly at the return site rather than deriving it from
+/// `result` through one shared function -- unlike, say, `mutate_exit_status`
+/// in `main.rs`, there is no existing single production-code enumeration of
+/// `check`'s result vocabulary this test could defer to instead. This is
+/// therefore deliberately an allowlist, not a denylist: issue #537 C2
+/// requires that aggregation "never default an unknown variant to
+/// success", so a `check` result value that is not (yet) listed here falls
+/// through to the failure class below and the test fails loudly instead of
+/// silently accepting a new false-green shape.
+const CHECK_SUCCESS_RESULTS: &[&str] = &[
+    "ok",                   // rust/fslc/src/main.rs: run_check_with_tags, agent_check_output
+    "causal_model_checked", // rust/fsl-tools/src/causal_analysis.rs
+];
+
+/// Verdict Conservation Law for `fslc check` (issue #537 C2), checked
+/// without any per-file oracle: a success-class `result` must exit 0, and
+/// every other `result` -- including a value not yet in
+/// `CHECK_SUCCESS_RESULTS` -- must exit non-zero. The envelope itself must
+/// also be a JSON object carrying a string `result` field.
+#[test]
+fn check_result_and_exit_status_never_contradict() {
+    let root = root();
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 150,
+        "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let mut failures = Vec::new();
+    let mut observed_results = BTreeSet::new();
+
+    for path in &files {
+        let rel = repo_relative(&root, path);
+        let (envelope, exit) = run_check(path);
+
+        let Some(object) = envelope.as_object() else {
+            failures.push(format!(
+                "{rel}: `fslc check` stdout is not a JSON object: {envelope}"
+            ));
+            continue;
+        };
+        let Some(result) = object.get("result").and_then(Value::as_str) else {
+            failures.push(format!(
+                "{rel}: `fslc check` envelope has no string `result` field: {envelope}"
+            ));
+            continue;
+        };
+
+        observed_results.insert(result.to_owned());
+        let is_success = CHECK_SUCCESS_RESULTS.contains(&result);
+        if is_success && exit != 0 {
+            failures.push(format!(
+                "{rel}: result={result:?} is success-class but exit={exit} (false red)"
+            ));
+        } else if !is_success && exit == 0 {
+            failures.push(format!(
+                "{rel}: result={result:?} is not a registered success-class result but \
+                 exit=0 (false green)"
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+    // Not a conservation check: a corpus that happened to contain zero
+    // check-failing files would make the `!is_success && exit == 0` arm
+    // above vacuously true for every file, so this law's negative side
+    // would never actually fire. Confirm the corpus still exercises it.
+    assert!(
+        observed_results.contains("error"),
+        "expected at least one corpus file to produce result=\"error\"; \
+         got {observed_results:?} -- the failure-class arm of this law is untested"
+    );
 }


### PR DESCRIPTION
## Problem

`corpus_check_sweep.rs`'s existing sweep inspects the JSON body of every corpus document's
`fslc check` envelope and **never looks at the process exit status**. A `result:"error"`
envelope that exited 0 passes it unnoticed.

That is #537's C1/C2 class exactly, and this release cycle shipped **9+ instances of it**
(#554 #517 #542 #496 #515 #500 #522 #484 #497) — each found and fixed individually, with
nothing added that would catch the tenth.

## What this adds

One oracle-free law over all 211 `.fsl` files under `specs/` + `examples/`:

- a success-class `result` must exit 0 (else: false red)
- **every other `result`, including any future value not yet listed, must exit non-zero**
  (else: false green)
- the envelope must be a JSON object carrying a string `result`

**It holds no per-file expectation.** That is the point: it applies to every document
without knowing what any of them is supposed to do, so it needed none of C4's corpus
ownership manifest to become useful. It is a *detector*, not a description — a
classification table records the past; this fires on the next one.

## An allowlist here is deliberate, and it documents why

`CHECK_SUCCESS_RESULTS` is an allowlist (`ok`, `causal_model_checked`), not a denylist, so
an unrecognized result **falls into the failure class and the test fails loudly** rather
than silently accepting a new false-green shape — C2's "never default an unknown variant
to success".

The test's own comment records something worth reading before Phase 1 starts:

> `check`'s own family arms (`run_check_with_tags`, `agent_check_output`, `run_causal_check`)
> each set their exit code directly at the return site rather than deriving it from `result`
> through one shared function — unlike, say, `mutate_exit_status` in `main.rs`, **there is no
> existing single production-code enumeration of `check`'s result vocabulary this test could
> defer to instead.**

The implementer went looking for a production-side source of truth to defer to, found none,
and said so. That is #441's problem observed from inside an attempt to build on top of it;
it is why #441 has been recorded as C2's prerequisite rather than an independent refactor.

## Test evidence

Full gate on the merge-target tree (`46fdead`, rebased onto `e7f7314`):

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0   NATIVE_EXIT=0
{ "parityCases": 415, "exclusionProbes": 4 }
```

### Negative control — two independent injections, same result

A test that passes over a corpus already satisfying the law proves nothing; **211/211
currently conform, so this test is green whether or not it is connected to anything.**
It was therefore ablated twice, at different layers:

| injection point | result |
|---|---|
| **production dispatch** — force `check` to exit 0 for every outcome | `exit=101`, **50 files named individually** |
| **harness** — coerce only failure-class exits to 0 over the real envelopes | `FAILED`, **the same 50 files** |

And the finding that matters most: under the same injected fault, the **pre-existing**
`every_corpus_spec_checks_ok_or_declares_its_error` **stayed green**. It reads only the JSON
body, so it cannot see this class of defect at all. That is the direct measurement of the
hole this test fills, rather than an argument that one exists.

Restored afterwards: `git diff HEAD --stat` empty, test green in 14s.

### Cost

+0.67s (9.70s → 10.37s for the file), because it reuses the existing 211-process cycle
rather than adding one.

## What this does not do

Covers `check` only. Two conservation violations in *other* commands are already filed and
measured — **#592** (`ledger` exits 0 while embedding a `violated` verification) and
**#595** (`approval check` reports `status:"drifted"` in JSON and still exits 0) — and this
harness does not reach them yet. The success-class definition generalizes directly, but
corpus enumeration and command invocation do not: `ledger` takes an artifact, `approval
check` takes `--record`. Extending to those two is the next step, and doing it *before*
fixing them makes this gate the negative control for those fixes.

Refs #537