### PR TITLE
test(fslc): put the refine corpus parity check into CI, in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `rust/fslc/tests/refine_corpus_parity.rs`: a native port of
+  `tools/check_rust_refinement_parity.py`'s 6 corpus refinement-mapping
+  regressions (`specs/cart_refines.fsl`, `specs/seat_refines.fsl`,
+  `examples/gallery/errors/refinement_failed_map.fsl`,
+  `examples/gallery/adversarial/refine_mapping_boundary_map.fsl`, and 2
+  `examples/refinement_liveness/*_progress_refines.fsl` files). The Python
+  script checked both the `fslc refine` stdout envelope and the process
+  exit code, but was never called from any CI workflow or
+  `tools/check-native-integration.sh`, so the native `refine` path's corpus
+  coverage ran nowhere — a structural gap that let #466, #483, #493, #494,
+  and #512 escape as false greens on this path (issue #593). The new test
+  is picked up automatically by `cargo test --workspace`, which both
+  `tools/check-native-integration.sh` and CI already run.
 - `rust/fslc/tests/corpus_check_sweep.rs::check_result_and_exit_status_never_contradict`:
   an oracle-free Verdict Conservation Law check (issue #537 C2) over every
   `.fsl` file under `specs/` + `examples/`. It holds no per-file expectation;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   that exited 0 would previously pass unnoticed.
 
 ### Fixed
+- `rust/fslc/tests/corpus_check_sweep.rs`'s module doc claimed (per issue
+  #483) that "the gallery fixtures and `examples/refinement_liveness/*`"
+  are refined by a test; only 6 of the 28 `refinement`-dialect corpus files
+  are, and that exercise was never wired into CI. Reworded to name the 6
+  covered files and their owning test, `refine_corpus_parity.rs` (issue
+  #593; same "comment claims a contract the implementation does not back"
+  shape as #585).
 - A CDP timeout in the browser parity gate now reports the call ordinal, the
   socket's `readyState`, how many other requests were outstanding, and Chrome's
   own stderr, instead of only the method and the elapsed budget. The stall it

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -15,10 +15,16 @@
 //! `fslc check` always reports `semantics`/"spec has no state block" for one
 //! regardless of whether the mapping itself is sound. Whether a given
 //! mapping is actually exercised by `fslc refine` is a separate, narrower
-//! claim this sweep does not make (of the 28 such files, issue #483 found
-//! only the gallery fixtures and `examples/refinement_liveness/*` are
-//! refined by any test; the `agentic_rag`/`multi_agent_system` mappings are
-//! refined by nothing — see #483, not re-asserted as closed here).
+//! claim this sweep does not make. Of the 28 such files, only 6 are
+//! exercised by any native test — `refine_corpus_parity.rs` (issue #593):
+//! `specs/cart_refines.fsl`, `specs/seat_refines.fsl`,
+//! `examples/gallery/errors/refinement_failed_map.fsl`,
+//! `examples/gallery/adversarial/refine_mapping_boundary_map.fsl`, and 2 of
+//! the 5 `examples/refinement_liveness/*_refines.fsl` files (the
+//! `*_progress_refines` pair; the other 3 and the remaining 22 mappings
+//! across `agentic_rag`, `multi_agent_system`, `refinement_chain`, and
+//! elsewhere are refined by nothing — see #593, tracked separately from
+//! this sweep).
 //! `examples/gallery/injected/` (its own primary/blind detector matrix in
 //! `injection_detector_matrix.rs`) is a genuine verified-elsewhere category,
 //! not a silent skip.

--- a/rust/fslc/tests/refine_corpus_parity.rs
+++ b/rust/fslc/tests/refine_corpus_parity.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Native port of `tools/check_rust_refinement_parity.py` (issue #593).
+//!
+//! The Python script exercised the same 6 corpus refinement mappings and
+//! checked both the stdout JSON envelope and the process exit code against
+//! the Python reference implementation, but it was never wired into any CI
+//! workflow or `tools/check-native-integration.sh` -- `grep -rn
+//! "check_rust_refinement_parity" .github/ tools/` has zero hits. Of the 28
+//! `refinement`-dialect files in the corpus (`corpus_check_sweep.rs`
+//! excludes all of them from its `check` sweep because a mapping file has
+//! no `state` block), these are the only 6 ever exercised by any test, and
+//! that exercise ran nowhere. This test closes that hole natively: it
+//! compares each case's `result` field (and, for `refinement_failed` cases,
+//! its `kind`) plus the exit code against a fixed expectation, so a broken
+//! mapping fails a named test instead of silently rotting. It does not
+//! attempt AGENTS.md-forbidden Python parity (the required product gate
+//! must not execute Python); it pins the native envelope directly.
+//!
+//! This is a minimal-scope fix (issue #593 fix sketch B), not the broader
+//! C: it does not extend coverage to the remaining 22 refinement mappings
+//! in the corpus (`specs/bank_refines.fsl`, `examples/agentic_rag/*`,
+//! `examples/multi_agent_system/*`, `examples/refinement_chain/*`, and
+//! others) -- that needs the manifest issue #537 C4 describes
+//! (impl/abs/mapping/depth/expected-result/kind) and is tracked separately.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+/// One corpus refinement mapping this test exercises, mirroring a row of
+/// `CASES` in `tools/check_rust_refinement_parity.py`.
+struct Case {
+    implementation: &'static str,
+    abstraction: &'static str,
+    mapping: &'static str,
+    depth: u32,
+    /// Expected `result` field.
+    expected_result: &'static str,
+    /// Expected `kind` field for a `refinement_failed` result; `None` when
+    /// `expected_result` is `"refines"`.
+    expected_kind: Option<&'static str>,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        implementation: "specs/cart_impl.fsl",
+        abstraction: "specs/cart_v1.fsl",
+        mapping: "specs/cart_refines.fsl",
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+    },
+    Case {
+        implementation: "specs/seat_booking_impl.fsl",
+        abstraction: "specs/seat_booking.fsl",
+        mapping: "specs/seat_refines.fsl",
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+    },
+    Case {
+        implementation: "examples/gallery/errors/refinement_failed_impl.fsl",
+        abstraction: "examples/gallery/errors/refinement_failed_abs.fsl",
+        mapping: "examples/gallery/errors/refinement_failed_map.fsl",
+        depth: 4,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_requires_failed"),
+    },
+    Case {
+        implementation: "examples/gallery/adversarial/refine_mapping_boundary_impl.fsl",
+        abstraction: "examples/gallery/adversarial/refine_mapping_boundary_abs.fsl",
+        mapping: "examples/gallery/adversarial/refine_mapping_boundary_map.fsl",
+        depth: 2,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_state_mismatch"),
+    },
+    Case {
+        implementation: "examples/refinement_liveness/design_drops_liveness.fsl",
+        abstraction: "examples/refinement_liveness/policy.fsl",
+        mapping: "examples/refinement_liveness/design_drops_liveness_progress_refines.fsl",
+        depth: 8,
+        expected_result: "refinement_failed",
+        expected_kind: Some("progress_lost"),
+    },
+    Case {
+        implementation: "examples/refinement_liveness/design_keeps_liveness.fsl",
+        abstraction: "examples/refinement_liveness/policy.fsl",
+        mapping: "examples/refinement_liveness/design_keeps_liveness_progress_refines.fsl",
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+    },
+];
+
+fn root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run_refine(case: &Case) -> (Value, i32) {
+    let root = root();
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "refine",
+            case.implementation,
+            case.abstraction,
+            case.mapping,
+            "--depth",
+            &case.depth.to_string(),
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc refine {} {} {}`: {error}; stderr={}",
+            case.implementation,
+            case.abstraction,
+            case.mapping,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc refine {} {} {}` terminated by signal, no exit code",
+            case.implementation, case.abstraction, case.mapping
+        )
+    });
+    (value, status)
+}
+
+/// `tools/check_rust_refinement_parity.py::_expected_status`: `error` exits
+/// 2, `refinement_failed` exits 1, everything else (`refines`) exits 0.
+fn expected_status(result: &str) -> i32 {
+    match result {
+        "error" => 2,
+        "refinement_failed" => 1,
+        _ => 0,
+    }
+}
+
+/// Each of the 6 corpus refinement mappings `tools/check_rust_refinement_parity.py`
+/// covered must keep reporting its expected `result`/`kind` and exit code
+/// under native `fslc refine`. A mapping edit that breaks the correspondence
+/// must fail its named case here, not go unnoticed the way #466, #483,
+/// #493, #494, and #512 did.
+#[test]
+fn native_refine_matches_expected_result_and_exit_for_the_corpus_mapping_regressions() {
+    let mut failures = Vec::new();
+
+    for case in CASES {
+        let (output, status) = run_refine(case);
+        let result = output["result"].as_str().unwrap_or_else(|| {
+            panic!(
+                "{}: `fslc refine` envelope has no string `result` field: {output}",
+                case.mapping
+            )
+        });
+
+        if result != case.expected_result {
+            failures.push(format!(
+                "{}: expected result={:?}, got result={result:?} ({output})",
+                case.mapping, case.expected_result
+            ));
+            continue;
+        }
+
+        if let Some(expected_kind) = case.expected_kind {
+            let kind = output["kind"].as_str();
+            if kind != Some(expected_kind) {
+                failures.push(format!(
+                    "{}: expected kind={expected_kind:?}, got kind={kind:?} ({output})",
+                    case.mapping
+                ));
+            }
+        }
+
+        let expected_exit = expected_status(case.expected_result);
+        if status != expected_exit {
+            failures.push(format!(
+                "{}: result={result:?} expects exit={expected_exit}, got exit={status}",
+                case.mapping
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}


### PR DESCRIPTION
## Problem

`refine` had **effectively zero corpus verification in CI.**

Of the 28 refinement mappings in the corpus, only 6 were ever run through native
`fslc refine` — and the script that runs them is **invoked from nowhere**:

```
$ grep -rn "check_rust_refinement_parity" .github/ tools/
(no hits)
$ grep -rln "check_rust_refinement_parity" . --exclude-dir=.git --exclude-dir=target
docs/RUST-PORTING.md        ← a manual step, and only that
```

The irony is that the script's *contents* are good — it compares both the stdout JSON
envelope and the exit code, which is the strictness #537 C4 asks for and which most of the
repo's checks do not have. It simply never runs.

`refine` produced **five separate false greens this release cycle** (#466 #483 #493 #494
#512). That its corpus verification was running nowhere is a structural explanation for
why those escaped rather than a coincidence.

## Contract change

None. This adds a test and corrects a comment; no product behavior moves.

## What this does

`rust/fslc/tests/refine_corpus_parity.rs` ports the six cases into a native Rust test that
runs in `cargo test`, keeping the property that made the original worth having: **both the
stdout envelope and the process exit code are asserted**, not one or the other.

| | |
|---|---|
| `specs/cart_refines.fsl` | `refines` |
| `specs/seat_refines.fsl` | `refines` |
| `examples/gallery/errors/refinement_failed_map.fsl` | `refinement_failed` |
| `examples/gallery/adversarial/refine_mapping_boundary_map.fsl` | boundary case |
| `examples/refinement_liveness/design_drops_liveness_progress_refines.fsl` | progress lost |
| `examples/refinement_liveness/design_keeps_liveness_progress_refines.fsl` | progress kept |

Scope is deliberately the **minimum correction**. Extending to all 28 needs C4's
impl/abs/mapping/depth/expected-result manifest and belongs to Phase 1. Wiring the Python
script into CI was rejected outright: `AGENTS.md` requires the complete product gate to not
execute Python.

## A stale comment corrected alongside

`corpus_check_sweep.rs`'s own docstring claimed, citing #483, that "the gallery fixtures and
`examples/refinement_liveness/*`" are refined by a test. **Not verifiable in the native
suite** — none of those paths appeared anywhere under `rust/fslc/tests/`. The real coverage
was the six cases above, through a script CI never ran.

It now names the six files and their owning test explicitly, and says plainly that the other
22 mappings are refined by nothing. Same shape as #585: a comment asserting a contract the
implementation does not back.

## Test evidence

Full gate on the merge-target tree (`6094883`):

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0   NATIVE_EXIT=0
{ "parityCases": 415, "exclusionProbes": 4 }
```

### Negative control

Six cases passing proves the test runs, not that it detects anything — #577 is this repo's
own demonstration of that distinction. So the mapping was broken on purpose: drop the
`- reserved[i]` term from `specs/cart_refines.fsl`'s state map, making the abstraction no
longer hold.

```
ABLATED_EXIT=101
specs/cart_refines.fsl: expected result="refines", got result="refinement_failed"
  kind: stutter_changed_abs
  reserve(i=0) should leave the abstraction unchanged; it moved stock[0] from 1 to 2
```

It fails with the concrete counterexample, not just a mismatched string. Restored
afterwards: baseline green again in 3.98s.

Refs #593