### PR TITLE
docs(approval): say why drift exits 0, and put it in the exit-code table

### DIFF
--- a/docs/DESIGN-approval.md
+++ b/docs/DESIGN-approval.md
@@ -101,7 +101,15 @@ fslc ledger specs/order.fsl --approval order.approval.json \
 The direct result is `approval_check` with `status:"approved"` or
 `status:"drifted"`. A signed record can instead report
 `status:"signature-invalid"`, which exits 1 and never grants approval. Drift
-remains an analysis result and exits 0. A malformed,
+remains an analysis result and exits 0, for the same reason `diff` findings do
+(`docs/LANGUAGE.md` §12): drift is the expected state during development — you
+approved at one commit and kept working — and the command's job is to report
+what changed and hand you `fslc approval diff`, not to fail a build. The ledger
+renders it `⚠` accordingly, distinct from the `❌` it gives
+`signature-invalid`. This differs deliberately from `fslc document check`,
+whose `document_drifted` exits 1: there, drift means a document contradicts the
+spec it documents, which is a state to correct, not a normal step in the loop.
+Gate on drift by reading `status` from the JSON, not the exit code. A malformed,
 unsupported, wrong-spec, or locally unavailable Git-baseline record is an error
 and exits 2. A signed record without its matching trust key is also a
 configuration error and exits 2. Unknown sidecar fields are rejected so schema

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -756,7 +756,9 @@ fslc document check <file.fsl> <document.md> [--glossary glossary.json] [--evide
 fslc approval create <file.fsl> --kind ledger|html|scenarios|requirements_document --artifact <reviewed> --approver <name>
                [--signing-key private.pem] [--glossary glossary.json] [--evidence evidence.json]... [-o record.json]
                                                   # requirements_document records a v3/v4 revision with a claim_set_digest (§13)
-fslc approval check  <file.fsl> --record <record.json> [--trust-key public.pem] # approved | drifted | signature-invalid
+fslc approval check  <file.fsl> --record <record.json> [--trust-key public.pem]
+                                                  # approved (exit 0) | drifted (exit 0、分析結果)
+                                                  # | signature-invalid (exit 1); DESIGN-approval.md 参照
 fslc approval diff   <file.fsl> --record <record.json> [--depth K] [--trust-key public.pem]
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check <file.fsl> [--depth K] [--engine bmc|induction] # Functional DDD / effect findings

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -778,7 +778,9 @@ fslc document check <file.fsl> <document.md> [--glossary glossary.json] [--evide
 fslc approval create <file.fsl> --kind ledger|html|scenarios|requirements_document --artifact <reviewed> --approver <name>
                [--signing-key private.pem] [--glossary glossary.json] [--evidence evidence.json]... [-o record.json]
                                                   # requirements_document records a v3/v4 revision with a claim_set_digest (§13)
-fslc approval check  <file.fsl> --record <record.json> [--trust-key public.pem] # approved | drifted | signature-invalid
+fslc approval check  <file.fsl> --record <record.json> [--trust-key public.pem]
+                                                  # approved (exit 0) | drifted (exit 0, analysis output)
+                                                  # | signature-invalid (exit 1); see DESIGN-approval.md
 fslc approval diff   <file.fsl> --record <record.json> [--depth K] [--trust-key public.pem]
 fslc typestate <file.fsl> [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check <file.fsl> [--depth K] [--engine bmc|induction] # Functional DDD / effect findings


### PR DESCRIPTION
## Problem

`fslc approval check` reports three statuses. `docs/LANGUAGE.md`'s command table listed all
three and **no exit code for any of them**:

```
fslc approval check <file.fsl> --record <record.json> [--trust-key public.pem]
  # approved | drifted | signature-invalid
```

The behaviour was written down in exactly one place — a sentence in
`docs/DESIGN-approval.md` giving the conclusion with no reason:

> Drift remains an analysis result and exits 0.

That combination is enough to make a careful reader conclude the implementation is wrong.
**It did.** #595 was filed against this exact behaviour, claiming a false green, on the
reasoning that three statuses map to one exit branch so two must have been overlooked. The
implementation was correct and had matched an accepted decision from #211/#283 the whole
time. The issue is now corrected and reclassified.

I filed it. The failure was not carelessness about the code — it was that the contract's
*rationale* lived nowhere, so "documented decision" and "implementation oversight" were
indistinguishable from the outside.

## Contract change

**None.** No behaviour moves. This records behaviour that already exists, in the places a
reader would look for it.

## What changes

- **`docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md`** — the command table now carries the exit
  code for each of the three statuses, and points at `DESIGN-approval.md`. Both files keep
  18 `## ` sections, per the alignment `tools/build_site_reference.py` enforces.
- **`docs/DESIGN-approval.md`** — the rule now travels with its reason:
  - drift is the *expected* state during development (you approve at one commit and keep
    working), so the command reports what changed and hands you `fslc approval diff` rather
    than failing a build — the same reasoning `docs/LANGUAGE.md` §12 already gives for
    `diff` findings being analysis output that exit 0;
  - the ledger already renders drift `⚠`, distinct from `signature-invalid`'s `❌`
    (`rust/fsl-tools/src/ledger.rs:765-788`) — that distinction was visible in the code and
    stated nowhere;
  - the asymmetry with `fslc document check`, whose `document_drifted` exits 1, is
    deliberate and now says why: there, drift means a document contradicts the spec it
    documents, which is a state to correct rather than a normal step in the loop;
  - callers who *do* want to gate on drift are pointed at `status` in the JSON.

## Why this is worth a PR on its own

This is the #537 thesis applied to itself. A contract that matches its implementation is
still a liability if the *reason* is absent: the next reader cannot tell a decision from an
oversight, and the honest response to an apparent false green is to file it. Recording the
rationale is what stops the next person — or the next agent — from re-litigating a settled
decision, or worse, "fixing" it.

Refs #595