### PR TITLE
fix(ledger)!: propagate the verify baseline's verdict to the exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   field. `corpus_check_sweep.rs`'s existing sweep only ever inspected the
   JSON body, never the process exit status, so a `result:"error"` envelope
   that exited 0 would previously pass unnoticed.
+- `rust/fslc/tests/corpus_check_sweep.rs::ledger_exit_status_agrees_with_its_verify_baseline`:
+  extends the same Verdict Conservation Law (issue #537 C2) to `fslc ledger`.
+  Unlike `check`, `ledger`'s JSON envelope always reports
+  `result:"generated"` regardless of the verification baseline it embeds, so
+  there is no `result`-string vocabulary to allowlist; instead this runs
+  `fslc verify` at matching `--depth`/`--deadlock ignore`/`--engine bmc`
+  arguments as an independent process and requires the two commands'
+  exit-code class (0 vs non-zero) to agree for every corpus file.
 
 ### Fixed
 - `rust/fslc/tests/corpus_check_sweep.rs`'s module doc claimed (per issue
@@ -37,6 +45,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   covered files and their owning test, `refine_corpus_parity.rs` (issue
   #593; same "comment claims a contract the implementation does not back"
   shape as #585).
+- `fslc ledger` now exits non-zero when the verification baseline it embeds
+  is not itself success-class (`violated`, `reachable_failed`,
+  `unknown_cti`, `unknown_budget`, or `error`), instead of unconditionally
+  reporting `result:"generated"`/exit 0 regardless of the child verdict
+  (issue #592). The rendered ledger content is unaffected -- a violated spec
+  still produces a full audit ledger with the violation embedded -- only the
+  process exit code changes, reusing `mutate_exit_status`'s existing
+  `docs/LANGUAGE.md` exit-code mapping rather than adding a second one. This
+  only changes `fslc ledger`'s own direct exit code; `approval create`/
+  `check`'s internal reuse of the same rendering (`generate_unapproved_ledger_report`,
+  which exists purely to reproduce a target for a digest comparison) is
+  unaffected, since a verdict mismatch there is legitimate drift evidence,
+  not a hard error.
 - A CDP timeout in the browser parity gate now reports the call ordinal, the
   socket's `readyState`, how many other requests were outstanding, and Chrome's
   own stderr, instead of only the method and the elapsed budget. The stall it

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -11173,11 +11173,20 @@ struct LedgerReportRequest<'a> {
 struct PreparedLedgerReport {
     model: KernelModel,
     verification: Value,
+    verification_status: i32,
     replay: Option<Value>,
     evidence: Vec<(String, Value)>,
     scenarios: Value,
 }
 
+/// The direct `fslc ledger` entry point. Unlike
+/// `generate_unapproved_ledger_report` (which `approval_artifact` also calls
+/// to reproduce a target's canonical rendering purely for a digest
+/// comparison -- a verdict mismatch there is legitimate drift evidence for
+/// `approval check`/`create`, not a hard error), this is the command a user
+/// or CI gate actually runs and reads the exit code of, so it must not hide
+/// a violated/unknown verification baseline behind the unconditional exit 0
+/// `generated_content_result` gives every generated artifact (issue #592).
 fn run_ledger_report(
     request: &LedgerReportRequest<'_>,
     approval_paths: &[PathBuf],
@@ -11195,7 +11204,20 @@ fn run_ledger_report(
             Err(error) => return (error, 2),
         }
     };
-    render_ledger_report(request, &prepared, approvals.as_ref())
+    let (result, status) = render_ledger_report(request, &prepared, approvals.as_ref());
+    if status != 0 {
+        // An `io` failure writing `-o` (the only non-zero
+        // `generated_content_result` can itself report) outranks the
+        // verification verdict.
+        return (result, status);
+    }
+    // `docs/LANGUAGE.md`'s exit-code table applied to the same `verify`
+    // baseline `mutate` already shares through `mutate_exit_status`:
+    // `prepared.verification` carries the identical `result` vocabulary
+    // (`verified`/`proved`/`violated`/`unknown_cti`/`unknown_budget`/`error`)
+    // because both call the same `run_verify`. Reusing the mapping here
+    // instead of writing a second one is the fix issue #592 asked for.
+    (result, mutate_exit_status(&prepared.verification, prepared.verification_status))
 }
 
 fn generate_unapproved_ledger_report(request: &LedgerReportRequest<'_>) -> (Value, i32) {
@@ -11211,7 +11233,7 @@ fn prepare_ledger_report(request: &LedgerReportRequest<'_>) -> Result<PreparedLe
         Ok(model) => model,
         Err(error) => return Err(spec_load_error_output(&error)),
     };
-    let (verification, _) = run_verify(
+    let (verification, verification_status) = run_verify(
         request.path,
         request.depth,
         request.deadlock_mode,
@@ -11257,6 +11279,7 @@ fn prepare_ledger_report(request: &LedgerReportRequest<'_>) -> Result<PreparedLe
     Ok(PreparedLedgerReport {
         model,
         verification,
+        verification_status,
         replay,
         evidence,
         scenarios,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -11217,7 +11217,10 @@ fn run_ledger_report(
     // (`verified`/`proved`/`violated`/`unknown_cti`/`unknown_budget`/`error`)
     // because both call the same `run_verify`. Reusing the mapping here
     // instead of writing a second one is the fix issue #592 asked for.
-    (result, mutate_exit_status(&prepared.verification, prepared.verification_status))
+    (
+        result,
+        mutate_exit_status(&prepared.verification, prepared.verification_status),
+    )
 }
 
 fn generate_unapproved_ledger_report(request: &LedgerReportRequest<'_>) -> (Value, i32) {

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -310,3 +310,76 @@ fn check_result_and_exit_status_never_contradict() {
          got {observed_results:?} -- the failure-class arm of this law is untested"
     );
 }
+
+/// Runs `fslc` with `args` and returns only its exit status -- `ledger`
+/// prints rendered Markdown (not JSON) to stdout when `-o` is omitted, so
+/// unlike `run_check` there is no envelope here to parse.
+fn run_exit_status(args: &[&str]) -> i32 {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    output.status.code().unwrap_or_else(|| {
+        panic!("`fslc {args:?}` terminated by signal, no exit code")
+    })
+}
+
+/// Verdict Conservation Law for `fslc ledger` (issue #592), checked without
+/// any per-file oracle -- structurally different from
+/// `check_result_and_exit_status_never_contradict` above because it cannot
+/// be: `ledger`'s JSON envelope reports `result:"generated"` unconditionally,
+/// whether the verification baseline it embeds is clean or violated, so
+/// there is no top-level `result` string whose vocabulary a
+/// `CHECK_SUCCESS_RESULTS`-style allowlist could key off. `ledger` renders
+/// that baseline by calling `run_verify` with the same
+/// `--depth`/`--deadlock ignore`/`--engine bmc` `ledger` itself defaults to
+/// (`prepare_ledger_report` in `rust/fslc/src/main.rs`), so this law instead
+/// runs `fslc verify` at matching arguments as an independent process and
+/// requires the two commands' exit-code *class* (0 success vs non-zero
+/// failure) to agree for every corpus file: a `ledger` that exits 0 over a
+/// spec its own `verify` pass found violated is hiding that verdict.
+#[test]
+fn ledger_exit_status_agrees_with_its_verify_baseline() {
+    let root = root();
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 150,
+        "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let mut failures = Vec::new();
+    let mut saw_failure_class = false;
+
+    for path in &files {
+        let rel = repo_relative(&root, path);
+        let path_str = path.to_str().expect("utf8 path");
+        let verify_exit = run_exit_status(&[
+            "verify", path_str, "--depth", "2", "--deadlock", "ignore", "--engine", "bmc",
+        ]);
+        let ledger_exit = run_exit_status(&["ledger", path_str, "--depth", "2"]);
+
+        if verify_exit != 0 {
+            saw_failure_class = true;
+        }
+        if (verify_exit == 0) != (ledger_exit == 0) {
+            failures.push(format!(
+                "{rel}: verify exit={verify_exit} but ledger exit={ledger_exit} at the same \
+                 depth/deadlock/engine -- ledger must not hide a verify verdict (issue #592)"
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+    // Not a conservation check: see the identical rationale above.
+    assert!(
+        saw_failure_class,
+        "expected at least one corpus file to fail `fslc verify` at depth 2; \
+         the failure-class arm of this law is untested"
+    );
+}

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -320,9 +320,10 @@ fn run_exit_status(args: &[&str]) -> i32 {
         .current_dir(root())
         .output()
         .expect("run native CLI");
-    output.status.code().unwrap_or_else(|| {
-        panic!("`fslc {args:?}` terminated by signal, no exit code")
-    })
+    output
+        .status
+        .code()
+        .unwrap_or_else(|| panic!("`fslc {args:?}` terminated by signal, no exit code"))
 }
 
 /// Verdict Conservation Law for `fslc ledger` (issue #592), checked without
@@ -360,7 +361,14 @@ fn ledger_exit_status_agrees_with_its_verify_baseline() {
         let rel = repo_relative(&root, path);
         let path_str = path.to_str().expect("utf8 path");
         let verify_exit = run_exit_status(&[
-            "verify", path_str, "--depth", "2", "--deadlock", "ignore", "--engine", "bmc",
+            "verify",
+            path_str,
+            "--depth",
+            "2",
+            "--deadlock",
+            "ignore",
+            "--engine",
+            "bmc",
         ]);
         let ledger_exit = run_exit_status(&["ledger", path_str, "--depth", "2"]);
 

--- a/rust/fslc/tests/issue_189_undecided.rs
+++ b/rust/fslc/tests/issue_189_undecided.rs
@@ -42,8 +42,16 @@ fn undecided_declarations_surface_in_reports_and_acknowledge_without_suppression
     let spec = spec.to_str().expect("UTF-8 fixture path");
 
     let ledger = run(&["ledger", spec]);
-    assert!(
-        ledger.status.success(),
+    // This fixture's own verification baseline is `violated` (`fslc verify`
+    // exits 1 on it), so `ledger` exits 1 too since issue 592: the report is
+    // still rendered in full -- every content assertion below still holds --
+    // but the exit code no longer claims the audit found nothing. `verify`,
+    // `testgen`, and `scenarios` all exit 1 on this same fixture; `ledger`
+    // exiting 0 was the odd one out. Pinned rather than dropped so the
+    // conservation property stays asserted here, not just its absence.
+    assert_eq!(
+        ledger.status.code(),
+        Some(1),
         "{}",
         String::from_utf8_lossy(&ledger.stderr)
     );

--- a/rust/fslc/tests/issue_190_approval.rs
+++ b/rust/fslc/tests/issue_190_approval.rs
@@ -452,6 +452,12 @@ fn approval_record_reports_approved_then_drifted_and_drives_semantic_diff() {
         .replace(" \"REQ-190: an approved review remains approved\"", "");
     std::fs::write(root.join("spec.fsl"), without_requirement_ids)
         .expect("remove requirement IDs from current spec");
+    // `.replace("approved = true", "approved = false")` above also matched
+    // the substring inside `ever_approved = true`, so `approve()` no longer
+    // sets either flag: `ever_approved` never becomes true and
+    // `ApprovalPersists` holds vacuously (`verify` still reports
+    // `"verified"`, with a `vacuous_implication` warning). This `ledger` run
+    // is therefore unaffected by issue #592's fix and stays exit 0.
     successful(
         &root,
         &[
@@ -649,6 +655,9 @@ fn signed_v2_records_require_a_matching_trust_anchor_and_fail_closed() {
         original.replace("approved = true", "approved = false"),
     )
     .expect("write semantic change");
+    // Same substring-overlap quirk as `removed-requirement.md` above
+    // (`ApprovalPersists` still holds vacuously), so this `ledger` run is
+    // unaffected by issue #592's fix and stays exit 0.
     successful(
         &root,
         &[

--- a/rust/fslc/tests/ledger_impl_log_cli.rs
+++ b/rust/fslc/tests/ledger_impl_log_cli.rs
@@ -11,6 +11,15 @@
 //! `*_still_generates` tests guard that legitimate replay evidence
 //! (conformant and nonconformant, as opposed to a replay error) is not
 //! collaterally broken by making the command fail-closed.
+//!
+//! `replay_trace.fsl`'s `partial(i: Id)` action is deliberately left
+//! unguarded at `i == 0` -- `replay_trace_contract.rs` replays it there on
+//! purpose to exercise the concrete Monitor's `partial_op` violation kind.
+//! The same unguarded division makes `fslc verify` legitimately classify
+//! this spec `result:"error"`/exit 2 (`kind:"semantics"`, "division by
+//! zero"), which issue #592 now correctly propagates to `fslc ledger`'s own
+//! exit code even though the ledger content still renders in full. That is
+//! why the `*_still_generates` tests below assert exit 2, not exit 0.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -161,8 +170,12 @@ fn ledger_impl_log_conformant_trace_still_generates() {
     let out = dir.join("ledger.md");
     let output = ledger_with_impl_log(&fixture("replay_trace.valid.v1.json"), &out);
 
-    assert!(
-        output.status.success(),
+    // Exit 2, not 0: `replay_trace.fsl` itself carries a genuine `verify`
+    // error (see the module doc), and issue #592 makes `ledger` report that
+    // rather than hide it -- but the ledger content still generates in full.
+    assert_eq!(
+        output.status.code(),
+        Some(2),
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
@@ -179,8 +192,12 @@ fn ledger_impl_log_nonconformant_trace_still_generates() {
     let out = dir.join("ledger.md");
     let output = ledger_with_impl_log(&fixture("replay_trace.state-mismatch.v1.json"), &out);
 
-    assert!(
-        output.status.success(),
+    // Same exit 2 as the conformant case above, for the same reason (the
+    // spec's own `verify` baseline errors, independent of the impl-log
+    // trace's conformance) -- the nonconformant row still renders.
+    assert_eq!(
+        output.status.code(),
+        Some(2),
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );


### PR DESCRIPTION
## Problem

`fslc ledger` exits 0 on a spec whose verification is `violated`. The audit ledger renders
in full, violation embedded — and the exit code says the audit found nothing.

```
$ fslc verify   examples/gallery/errors/violated_invariant_counter.fsl --depth 2   → exit 1
$ fslc ledger   examples/gallery/errors/violated_invariant_counter.fsl --depth 2   → exit 0
$ fslc testgen  examples/gallery/errors/violated_invariant_counter.fsl --depth 2   → exit 1
```

`testgen` returning 1 on the identical input is what settles this as an oversight rather
than a decision: `generated_content_result` gives every generated artifact an unconditional
exit 0, and `testgen` happens to have a separate path that propagates its child's status
first. `ledger` does not.

For an *audit ledger* specifically, the exit code hiding "the audit found a violation" is
the failure mode the artifact exists to prevent. A CI gate running `fslc ledger` always
passes.

## Contract change

**Breaking.** `fslc ledger` now exits non-zero when the verification baseline it embeds is
not success-class. Ledger *content* is unchanged — a violated spec still renders a complete
ledger with the violation in it. Only the exit code moves.

The mapping is not new: it reuses `mutate_exit_status`, which already implements
`docs/LANGUAGE.md`'s exit-code table over the identical `result` vocabulary, since both
commands embed the same `run_verify` envelope. Writing a second mapping was the thing to
avoid — that is how the two lists in #594 came to disagree.

**`approval create`/`check` are deliberately unaffected.** They call the same rendering
through `generate_unapproved_ledger_report` purely to reproduce a target for a digest
comparison; a verdict mismatch there is legitimate drift evidence, not a hard error. The fix
is scoped to the entry point a user or CI gate actually reads the exit code of.

## Test evidence

Full gate on the merge-target tree (`0de0bfc`, rebased onto `922a02e`):

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0   NATIVE_EXIT=0
{ "parityCases": 415, "exclusionProbes": 4 }
```

### Negative controls — both directions

| case | before | after |
|---|---|---|
| `ledger` on a **violated** spec | exit 0 | **exit 1** |
| `ledger` on a **healthy** spec | exit 0 | **exit 0** |

The second row is the one that matters for review: without it this would be
indistinguishable from "make it always fail". The siblings now agree — `verify`, `testgen`,
and `scenarios` all exit 1 on the same input.

### One existing test was pinning the defect

`issue_189_undecided.rs` asserted `ledger.status.success()` on `tests/fixtures/undecided.fsl`.
Before changing it, the fixture was measured rather than assumed:

```
verify    → exit 1 (result: violated)
testgen   → exit 1
scenarios → exit 1
ledger    → exit 1   (after this fix)
```

The fixture's own verification baseline is `violated`; `ledger`'s exit 0 was the outlier.
The assertion is **pinned to `Some(1)`, not deleted** — dropping it would remove the only
statement about exit status at that call site. Every content assertion in that test is
untouched and still passes; what it is actually about — undecided declarations surfacing
without suppression — does not depend on the exit code.

## Noted, not changed

`html` and `explain` also exit 0 on the same violated fixture. `explain` is documented that
way (`docs/DESIGN-explain.md:11`: `result:"explained"`, exit 0) and is correct. `html` has
no stated rule either way, so it is left alone here and recorded as input to #537 C2's
outcome algebra, which has to draw the report-only/gate line explicitly.

Closes #592