### PR TITLE
fix(fslc)!: give the CLI one success/failure class definition (#537 C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `rust/fslc/src/outcome.rs`: one definition of the success and failure
+  classes over the CLI's `result` vocabulary (issue #537 C2,
+  `docs/DESIGN-rust-component-internals.md` "Outcome classification"). The
+  crate previously had none — each command arm compared `result` against
+  literals at its own return point, so the class was re-derived, and
+  re-forgotten, once per family. `outcome_class` takes the whole envelope
+  rather than the `result` string because five values carry their verdict in
+  a sibling field (`approval check`'s `status`, `fmt --check`'s `changed`,
+  `lint`'s `finding_count`, `diff`'s `violations` and `gate.passed`) — the
+  same reason `docs/LANGUAGE.md`'s exit-code table excludes
+  `approval_check`/`approval_diff`. Unknown values classify as `Failure`,
+  following `mutate_exit_status`'s `_ => 3`: a result nobody registered now
+  fails loudly instead of exiting 0, which is how #554 arose. Cacheability
+  stays a separate predicate (`verify_cache_admits`), because `violated` is
+  failure-class *and* cacheable.
+- `rust/fslc/tests/issue_600_db_check_folds_kernel_verdict.rs` and
+  `rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl`: the
+  rejecting control for #600 below, plus a guard test that fails loudly if
+  the fixture stops producing an inconclusive kernel — otherwise the control
+  would start passing vacuously.
 - `rust/fslc/tests/refine_corpus_parity.rs`: a native port of
   `tools/check_rust_refinement_parity.py`'s 6 corpus refinement-mapping
   regressions (`specs/cart_refines.fsl`, `specs/seat_refines.fsl`,
@@ -38,6 +58,49 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   exit-code class (0 vs non-zero) to agree for every corpus file.
 
 ### Fixed
+- `fslc db check` reported `result:"verified_under_assumptions"` alongside a
+  non-zero exit whenever its nested kernel `verify` came back
+  `unknown_cti`/`reachable_failed`/`unknown_budget` (issue #600).
+  `run_db_check` folded only `violated` into the top-level verdict, so the
+  exit code was right and the envelope contradicted it — the half of the
+  Verdict Conservation Law a gate reading the JSON sees. Its
+  `run_domain_check` sibling has folded every non-passing kernel verdict
+  since #515; `db` now matches it, and its status guard admits both
+  definitive codes (`status != 0 && status != 1`) instead of testing `== 2`,
+  which had let a `kind:"internal"` kernel envelope be absorbed as a
+  `dbsystem` verdict.
+- `wrap_specialized` (the `ai`/`domain`/`db`/`agent` aggregation, 15 call
+  sites) ended its status match in `_ => 0`, so every specialized-dialect
+  result nobody had added to its failure list exited 0 (issue #601) — the
+  shape #554 arose from, and the opposite default to `outcome_class`'s
+  `_ => Failure` in the same crate. `check_ai` forwards its nested kernel's `result` verbatim when
+  it has no finding of its own, so an inconclusive kernel verdict reached
+  that arm. It now derives the status from `outcome_class`. A differential
+  sweep of the pre- and post-change binaries over `examples/` + `specs/`
+  found no corpus input that reaches it, so this omission is latent, unlike
+  its `db check` sibling above. Unlike #594 and #600, which are each a single
+  missing value, this was the mechanism that loses them: with the default on
+  the success side, any failure value added to any specialized dialect exits
+  0 from the moment someone forgets to register it.
+- `fslc sweep`'s minimal-counterexample selection carried a hand-written
+  failure list that had silently lost `unknown_budget` (issue #594), so a
+  grid whose only failing scope reported it would collapse into
+  `sweep_passed`/exit 0. It now defers to `outcome_class`. The omission was
+  latent rather than a live false green: `sweep` restricts `--engine` to
+  `bmc|induction`, `unknown_budget` is produced only by the explicit engine,
+  `--engine auto` falls back to BMC before it escapes, and the verify-cache
+  key includes the engine — so the control for this one is at the classifier
+  (`outcome.rs`), not end-to-end.
+- `rust/fslc/tests/corpus_check_sweep.rs` no longer carries
+  `CHECK_SUCCESS_RESULTS`, its own two-value copy of the success class
+  (issue #596). `check_result_and_exit_status_never_contradict` now calls
+  `fslc_rust::outcome::outcome_class`, so the law is stated against
+  production code instead of against a list in the test — the stale-check
+  shape #577 retired 28 instances of. `chain_layer_passes`,
+  `verify_cache_store`, and `mutate_exit_status` were migrated to the same
+  definition; `chain` and `analyze` batch now each state their
+  empty-workset choice (reject vs allow) as a named local, with the
+  asymmetry recorded rather than removed.
 - `rust/fslc/tests/corpus_check_sweep.rs`'s module doc claimed (per issue
   #483) that "the gallery fixtures and `examples/refinement_liveness/*`"
   are refined by a test; only 6 of the 28 `refinement`-dialect corpus files

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -727,6 +727,67 @@ control for each newly centralized branch rather than treating green positive ou
 Re-evaluate the decision if #441 touches family producers, cannot preserve a stream contract without
 a third delivery concern, or a real production follow-up contradicts the expected edit reduction.
 
+#### Outcome classification (#537 C2)
+
+The Verdict Conservation Law — a failure-class `result` must not exit zero, and a success-class
+`result` must not exit non-zero — needs one definition of those two classes. The crate has 43
+distinct `result` values and no such definition. #596 recorded the consequence from inside: its
+corpus sweep had to carry `CHECK_SUCCESS_RESULTS` in test code because `check`'s arms each set
+their exit code at their own return point, so there was no production enumeration to defer to. A
+conservation check whose class definition lives in the test is the stale-check shape #577 retired
+28 instances of.
+
+`rust/fslc/src/outcome.rs` owns that definition, as a `native-cli` bin module beside `verification.rs`:
+
+```text
+enum OutcomeClass { Success, Failure }
+fn outcome_class(output: &Value) -> OutcomeClass
+```
+
+Three properties are load-bearing:
+
+- **It takes the envelope, not the result string.** `approval check` derives its exit from
+  `status == "signature-invalid"` (`main.rs:11134`), not from `result:"approval_check"`, which is
+  the same value for `approved`, `drifted`, and `signature-invalid`. A `&str` signature cannot
+  express that family and would force a second classifier beside the first — the defect being
+  removed.
+- **It is flat, not per-family.** Classification asks only for the class, and the class does not
+  collide even where meaning does: `"generated"` names different artifacts in `ledger`, `testgen`,
+  and `document`, and is success-class in all three. Six or seven family classifiers would be six or
+  seven places to forget a new value, which is the present defect at smaller scale.
+- **Unknown values classify as `Failure`,** following `mutate_exit_status`'s `_ => 3`. A new result
+  value that nobody registered then fails loudly at its first corpus run instead of exiting zero.
+  This is the direction #554 established: falling through to zero is how that defect arose.
+
+Cacheability is a separate predicate and does not collapse into the classifier. `verify_cache_store`
+admits `violated`, `reachable_failed`, `unknown_cti`, and `unknown_budget` — failure-class results
+that are nonetheless settled verdicts worth storing. It moves next to `outcome_class` so the
+vocabulary has one home, and stays a distinct function so a new value forces an explicit decision in
+both.
+
+Producer signatures do not change. `(Value, i32)` producers keep their contract; what changes is
+that the last line computing `.1` calls the shared classifier instead of comparing literals locally.
+#599 already demonstrated this shape in production by extending `mutate_exit_status` to `ledger`
+without touching a signature. C2 stays rejected and none of its re-evaluation triggers above is
+tripped: no family producer changes, no third delivery concern appears, and the edit count falls.
+
+The nine raw-success sites currently split four ways: five guard on `result` and exit `result.1`,
+two exit `result.1` with no guard (`main.rs:1231`, `1241`), one guards and exits a hard-coded zero
+(`2981`), and one does neither (`3183`, `domain expand`). `3183` is not a live defect — every error
+path in `run_domain_expand` returns before setting `kernel_source`, so the extraction guard implies
+success — but it depends on an unstated invariant, and raw delivery replaces the JSON envelope that
+would otherwise carry the failure. All nine gain the classifier guard. For the three sites that lack
+one, the implementation must measure whether a failure path can reach the extraction rather than
+assert it cannot; if one can, that site is a defect to fix with a rejecting control, not an
+invariant to record.
+
+`empty_allowed` is made explicit, not uniform. #537 C2 asks that a command treating an empty workset
+as success say so in its contract; it does not ask that `chain` (which rejects an empty manifest with
+exit 2) and `analyze` batch (which reports `analyzed` for zero files) agree. They address different
+inputs — a fixed pipeline versus a directory glob — and no accepted decision calls the asymmetry a
+defect. Each aggregation records its choice as a stated constant reproducing today's behavior. If
+`analyze` batch's zero-file success is itself wrong, that is a separate issue with its own evidence.
+
 ### `fsl-wasm`
 
 - `Request`/`Options` own decoded input, `MemoryResolver` owns per-call in-memory files, and each

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -737,12 +737,22 @@ their exit code at their own return point, so there was no production enumeratio
 conservation check whose class definition lives in the test is the stale-check shape #577 retired
 28 instances of.
 
-`rust/fslc/src/outcome.rs` owns that definition, as a `native-cli` bin module beside `verification.rs`:
+`rust/fslc/src/outcome.rs` owns that definition, as a `lib.rs` module rather than a bin module
+beside `verification.rs`, and without a feature gate:
 
 ```text
 enum OutcomeClass { Success, Failure }
 fn outcome_class(output: &Value) -> OutcomeClass
 ```
+
+The lib placement is forced by the requirement it exists to serve. `approval`, `causal`,
+`code_audit`, and `verification` are bin modules declared in `main.rs`, reachable only from the
+inline `#[cfg(test)] mod exit_status_tests`. `corpus_check_sweep.rs` is an integration test that
+runs the binary over the corpus, so a bin module would leave it unable to call the classifier and
+force it to keep its own copy of the success set — the exact stale-check shape the classifier
+removes. Nothing about the classifier needs `native-cli`: it reads `serde_json::Value` and returns
+an enum, touching none of that feature's optional dependencies. It sits beside
+`verification_output.rs`, which already constructs most of the vocabulary it classifies.
 
 Three properties are load-bearing:
 

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -737,8 +737,8 @@ their exit code at their own return point, so there was no production enumeratio
 conservation check whose class definition lives in the test is the stale-check shape #577 retired
 28 instances of.
 
-`rust/fslc/src/outcome.rs` owns that definition, as a `lib.rs` module rather than a bin module
-beside `verification.rs`, and without a feature gate:
+`rust/fslc/src/outcome.rs` owns that definition, declared from `lib.rs` under
+`#[cfg(feature = "native-cli")]` rather than as a bin module beside `verification.rs`:
 
 ```text
 enum OutcomeClass { Success, Failure }
@@ -750,9 +750,14 @@ The lib placement is forced by the requirement it exists to serve. `approval`, `
 inline `#[cfg(test)] mod exit_status_tests`. `corpus_check_sweep.rs` is an integration test that
 runs the binary over the corpus, so a bin module would leave it unable to call the classifier and
 force it to keep its own copy of the success set — the exact stale-check shape the classifier
-removes. Nothing about the classifier needs `native-cli`: it reads `serde_json::Value` and returns
-an enum, touching none of that feature's optional dependencies. It sits beside
-`verification_output.rs`, which already constructs most of the vocabulary it classifies.
+removes. It sits beside `verification_output.rs`, which already constructs most of the vocabulary
+it classifies.
+
+The feature gate is about surface, not dependencies: the classifier reads `serde_json::Value` and
+returns an enum, needing none of `native-cli`'s optional crates. `fsl-lsp` and `fsl-wasm` both take
+`fslc-rust = { default-features = false }`, so gating keeps the classifier out of their public
+surface entirely while the integration tests, which run with default features, still reach it.
+Promote it out of the gate when a Worker or LSP consumer actually appears.
 
 Three properties are load-bearing:
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -924,6 +924,14 @@ refinement_failed / sweep_failed / observed_mismatch、
 空の台帳行として描画してはならない — `docs/DESIGN-ledger.md`)でもフェイルクローズド
 に適用されます。
 
+`approval_check` と `approval_diff` がこの表に無いのは、exit code が `result` の
+関数ではないからです。`fslc approval check` はどの結果でも同じ `approval_check` を
+返し、判定は `status` が担います: `approved` と `drifted` が `0`、
+`signature-invalid` が `1`。drift が 0 で終わるのは、`diff` の findings と同じく
+分析出力だからです(§12)。理由と、`fslc document check` の `document_drifted` が
+異なる扱いになる理由は `docs/DESIGN-approval.md` にあります。exit code ではなく
+`status` でゲートしてください。
+
 ### 結果の種類
 
 | result | 意味 | 次の一手 |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -952,6 +952,14 @@ section, zero recognized sections, or an unparseable `depth`/`refine_depth` —
 replay error is not implementation-log evidence and must not be rendered as
 an empty ledger row — `docs/DESIGN-ledger.md`).
 
+`approval_check` and `approval_diff` are absent from this table because their
+exit code is not a function of `result`. `fslc approval check` reports the same
+`approval_check` for every outcome and carries the verdict in `status`: `0` for
+`approved` and for `drifted`, `1` for `signature-invalid`. Drift exits 0 because
+it is analysis output, as `diff` findings are (§12); `docs/DESIGN-approval.md`
+records why, and why `fslc document check`'s `document_drifted` differs. Gate on
+`status`, not on the exit code.
+
 ### Kinds of result
 
 | result | Meaning | Next move |

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -9,6 +9,14 @@ pub mod coverage;
 pub mod frontend_output;
 pub mod migration;
 pub mod origin_coverage;
+// The one definition of the success/failure classes (issue #537 C2). It is
+// declared on the library side rather than as a `main.rs` bin module so the
+// corpus conservation sweep under `tests/` can defer to it instead of carrying
+// its own copy of the vocabulary -- integration tests link the library, not
+// the binary. `fsl-lsp` and `fsl-wasm` both depend on this crate with
+// `default-features = false`, so the gate leaves their surface unchanged.
+#[cfg(feature = "native-cli")]
+pub mod outcome;
 pub mod replay_trace;
 pub mod source_diagnostic;
 pub mod spec_load;

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -13,6 +13,7 @@ use fsl_core::{
     ParamDef, TraceStep, TypeDef, TypeRef, insert_requirement_metadata, model_warnings,
     requirement_metadata,
 };
+use fslc_rust::outcome::{OutcomeClass, outcome_class};
 use fslc_rust::spec_load::{
     SemanticDiagnostic, SpecLoadError, kernel_load_error, surface_parse_failure,
 };
@@ -1226,11 +1227,15 @@ fn command() -> Result<(Value, i32), String> {
                 "typestate" => run_typestate(&path),
                 _ => unreachable!(),
             };
-            if readable && let Some(text) = result.0.get("readable").and_then(Value::as_str) {
+            if readable
+                && raw_delivery_allowed(&result)
+                && let Some(text) = result.0.get("readable").and_then(Value::as_str)
+            {
                 println!("{text}");
                 std::process::exit(result.1);
             }
             if typescript_only
+                && raw_delivery_allowed(&result)
                 && let Some(entities) = result.0.get("entities").and_then(Value::as_array)
             {
                 for entity in entities {
@@ -1337,6 +1342,7 @@ fn command() -> Result<(Value, i32), String> {
                 _ => unreachable!(),
             };
             if output.is_none()
+                && raw_delivery_allowed(&result)
                 && result.0.get("result").and_then(Value::as_str) == Some("generated")
                 && let Some(content) = result.0.get("content").and_then(Value::as_str)
             {
@@ -1401,6 +1407,7 @@ fn command() -> Result<(Value, i32), String> {
                 )
             };
             if output_format != "json"
+                && raw_delivery_allowed(&result)
                 && result.0.get("result").and_then(Value::as_str) == Some("analyzed")
                 && let Some(content) = result.0.get("content").and_then(Value::as_str)
             {
@@ -1990,6 +1997,7 @@ fn document_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i3
                 output.as_deref(),
             );
             if output.is_none()
+                && raw_delivery_allowed(&result)
                 && result.0.get("result").and_then(Value::as_str) == Some("generated")
                 && let Some(content) = result.0.get("content").and_then(Value::as_str)
             {
@@ -2030,6 +2038,7 @@ fn document_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i3
             }
             let result = run_document_claims(&path, output.as_deref());
             if output.is_none()
+                && raw_delivery_allowed(&result)
                 && result.0.get("result").and_then(Value::as_str) == Some("generated")
                 && let Some(content) = result.0.get("content").and_then(Value::as_str)
             {
@@ -2974,6 +2983,11 @@ fn db_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32), St
             }
             let result = run_db_import(&path, &name, &format, output.as_deref());
             if output.is_none()
+                && raw_delivery_allowed(&result)
+                // Kept alongside the class guard, not replaced by it:
+                // `imported_with_warnings` is also success-class, and it
+                // deliberately keeps the JSON envelope so the warnings reach
+                // the caller.
                 && result.0.get("result").and_then(Value::as_str) == Some("imported")
                 && let Some(source) = result.0.get("dbsystem_source").and_then(Value::as_str)
             {
@@ -3177,6 +3191,7 @@ fn domain_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32)
             let output = parse_optional_output(&mut args)?;
             let result = run_domain_expand(&path, output.as_deref());
             if output.is_none()
+                && raw_delivery_allowed(&result)
                 && let Some(source) = result.0.get("kernel_source").and_then(Value::as_str)
             {
                 print!("{source}");
@@ -3271,6 +3286,7 @@ fn domain_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i32)
             let result =
                 run_domain_testgen(&path, depth, &target, &deadlock, strict, output.as_deref());
             if output.is_none()
+                && raw_delivery_allowed(&result)
                 && result.0.get("result").and_then(Value::as_str) == Some("generated")
                 && let Some(content) = result.0.get("content").and_then(Value::as_str)
             {
@@ -3490,17 +3506,16 @@ fn run_sweep(
                     "summary": summary,
                     "verification": verification,
                 });
+                // Issue #594: this was a hand-written failure list that had
+                // silently lost `unknown_budget`, so a grid whose only failing
+                // scope reported it collapsed into `sweep_passed`/exit 0.
+                // Deferring to the shared classifier removes the whole class
+                // of omission -- a new result value cannot be forgotten here
+                // without also being forgotten in `outcome.rs`, where it falls
+                // to the failure class anyway.
                 if minimal.is_none()
-                    && entry["summary"]["result"].as_str().is_some_and(|result| {
-                        matches!(
-                            result,
-                            "violated"
-                                | "reachable_failed"
-                                | "unknown_cti"
-                                | "nonconformant"
-                                | "refinement_failed"
-                        )
-                    })
+                    && !outcome_class(&entry["summary"]).is_success()
+                    && entry["summary"]["result"].is_string()
                 {
                     minimal = Some(entry.clone());
                 }
@@ -3598,23 +3613,12 @@ fn chain_layer_passes(detail: &Value, status: i32) -> bool {
     {
         return false;
     }
-    detail
-        .get("result")
-        .and_then(Value::as_str)
-        .is_some_and(|result| {
-            matches!(
-                result,
-                "ok" | "verified"
-                    | "proved"
-                    | "refines"
-                    | "conformant"
-                    | "generated"
-                    | "scenarios"
-                    | "typestate"
-                    | "mutated"
-                    | "explained"
-            )
-        })
+    // The second guard behind `status != 0`: a layer producer that returned 0
+    // alongside a failure-class `result` must still not pass. This used to be
+    // a hand-maintained success allowlist; it now defers to the one shared
+    // definition (issue #537 C2) so a new layer result cannot be forgotten
+    // here.
+    outcome_class(detail).is_success()
 }
 
 fn skipped_chain_entry(
@@ -3711,7 +3715,14 @@ fn run_project_chain(path: &Path, keep_going: bool) -> (Value, i32) {
     if sections.contains_key("impl") {
         steps.push(("impl".to_owned(), "impl".to_owned()));
     }
-    if steps.is_empty() {
+    // Issue #537 C2: each aggregation states whether an empty workset counts
+    // as success. `chain` rejects one -- its input is a fixed pipeline, and a
+    // manifest that declares no layer is a malformed manifest, not a run with
+    // nothing to do. `analyze` batch deliberately answers the opposite way for
+    // its directory glob; the asymmetry is intentional and neither behavior
+    // changes here.
+    let chain_empty_allowed = false;
+    if steps.is_empty() && !chain_empty_allowed {
         let mut output = error_output(
             "parse",
             "project manifest declares no [business], [requirements], [design], or [impl] section",
@@ -5913,11 +5924,23 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     } else {
         let (kernel, kernel_status) =
             run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
-        if kernel_status == 2 {
+        // Issue #600, matching the `run_domain_check` sibling below: only a
+        // definitive kernel verdict (status 0 = verified/proved, status 1 =
+        // violated/reachable_failed/unknown_cti/unknown_budget) has a `result`
+        // that can safely be folded into the top-level verdict. Any other
+        // status (2 = spec error, 3 = internal error) must return the kernel
+        // envelope verbatim rather than be misread downstream; testing only
+        // `== 2` let an internal error be absorbed as a `dbsystem` verdict.
+        if kernel_status != 0 && kernel_status != 1 {
             return (kernel, kernel_status);
         }
+        // ... and every non-passing kernel verdict folds through, not just
+        // `violated`. Reporting `verified_under_assumptions` over a kernel
+        // that came back `unknown_cti`/`reachable_failed`/`unknown_budget`
+        // made the envelope contradict its own exit code.
+        let kernel_passed = outcome_class(&kernel).is_success();
         if let Value::Object(kernel) = kernel {
-            if kernel.get("result").and_then(Value::as_str) == Some("violated") {
+            if !kernel_passed {
                 result.insert("result".to_owned(), json!("violated"));
             }
             let projection = [
@@ -6062,35 +6085,62 @@ fn stable_kernel_projection(kernel: Value) -> Value {
     )
 }
 
+/// Whether a producer's output may be delivered as raw bytes instead of its
+/// JSON envelope (issue #537 C2, Verdict Conservation Law).
+///
+/// Raw delivery *replaces* the envelope that would otherwise carry a failure's
+/// `kind`/`message`/`loc`, so every raw-output path must first confirm the
+/// producer succeeded. This is an **additional** conjunct and never a
+/// replacement for the structural field guard a site already has: `db import`
+/// prints raw source only for `result:"imported"` and keeps the JSON envelope
+/// for `imported_with_warnings`, which is also success-class.
+///
+/// Three of the nine raw-output sites previously had no guard at all
+/// (`--readable`, `--ts`, `domain expand`). Measured rather than assumed: no
+/// failure path can currently reach any of those extractions, because the
+/// extracted field is inserted at exactly one place in each producer, after
+/// every error return -- `"readable"` in `run_explain`, `"entities"` in
+/// `fsl_tools::analyze_typestate`, `"kernel_source"` in `run_domain_expand`.
+/// The guard therefore records an invariant that was until now unstated. It is
+/// not idle: `fsl-tools/src/domain.rs` builds a `result:"violated"` envelope
+/// that also carries `kernel_source`, so the invariant is one routing change
+/// away from breaking.
+fn raw_delivery_allowed(result: &(Value, i32)) -> bool {
+    outcome_class(&result.0).is_success()
+}
+
 fn wrap_specialized(result: Value) -> (Value, i32) {
     let Value::Object(mut result) = result else {
         return (error_output("internal", "invalid specialized result"), 3);
     };
     result.retain(|_, value| !value.is_null());
-    let status = match result.get("result").and_then(Value::as_str) {
-        Some(
-            "violated"
-            | "replay_nonconformant"
-            | "nonconformant"
-            | "statistically_unsupported"
-            | "observed_mismatch"
-            // fsl-ai statistical gate statuses (issue #510): a result that
-            // gates before producing a Wilson interval -- no dataset/schema
-            // evidence, an untrusted evaluator, too few samples, or an
-            // unsupported requirement shape -- is not a passing evaluation
-            // and must not exit 0 alongside `statistically_supported`.
-            | "dataset_invalid"
-            | "evaluator_untrusted"
-            | "slice_missing"
-            | "insufficient_samples"
-            | "inconclusive",
-        ) => 1,
-        Some("error") => 2,
-        _ => 0,
+    // Issue #601. This used to carry its own failure list ending in `_ => 0`,
+    // so every specialized-dialect result nobody had thought to add exited 0
+    // -- the shape #554 arose from, and the opposite default to
+    // `outcome_class`'s `_ => Failure` in the same crate. `check_ai` forwards
+    // its nested kernel's `result` verbatim when it has no finding of its own
+    // (`fsl-tools/src/ai.rs`), so an inconclusive kernel verdict
+    // (`unknown_cti`, `reachable_failed`, `unknown_budget`) reached this
+    // fallthrough and reported success for a verification that had not passed.
+    // `run_domain_check` folds the same way for the `domain` dialect (#515);
+    // this is its missing sibling.
+    //
+    // Deliberately *not* `_ => 1`: every success-class value flowing through
+    // here (`expanded`, `analyzed`, `causal_analyzed`,
+    // `verified_under_assumptions`, `agent_analyzed`, `ai_project_analyzed`,
+    // `compared`, `compat_profile_generated`, ...) must keep exiting 0, which
+    // is what registering them in `outcome_class` guarantees. A value missing
+    // from that registry fails loudly in the corpus sweep rather than here.
+    let mut envelope = envelope();
+    envelope.extend(result);
+    let output = Value::Object(envelope);
+    let status = match outcome_class(&output) {
+        OutcomeClass::Success => 0,
+        // An `error` envelope keeps the spec-error code the dialects use.
+        OutcomeClass::Failure if output.get("result").and_then(Value::as_str) == Some("error") => 2,
+        OutcomeClass::Failure => 1,
     };
-    let mut output = envelope();
-    output.extend(result);
-    (Value::Object(output), status)
+    (output, status)
 }
 
 fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Value, i32) {
@@ -13224,7 +13274,17 @@ fn run_analyze_batch(
             }));
         }
     }
-    let failed = !errors.is_empty();
+    // Issue #537 C2: the counterpart of `chain`'s `CHAIN_EMPTY_ALLOWED`. Batch
+    // analyze's input is a directory glob, so "no matching file" is a run with
+    // nothing to do rather than a malformed request, and zero files report
+    // `analyzed`/exit 0. Whether that is the right answer is a separate
+    // question with its own evidence; recording the choice does not change it.
+    let batch_empty_allowed = true;
+    let failed = if entries.is_empty() {
+        !batch_empty_allowed
+    } else {
+        !errors.is_empty()
+    };
     let mut output = envelope();
     output.insert(
         "result".to_owned(),
@@ -15748,34 +15808,14 @@ fn model_error_output(error: &fsl_core::ModelError) -> Value {
 }
 
 /// `docs/LANGUAGE.md`'s exit-code table applied to an envelope `mutate`
-/// returns, as a *total* match over the result vocabulary a mutation run can
-/// carry.
+/// returns.
 ///
-/// `mutate` re-emits its baseline `verify` envelope verbatim when the baseline
-/// does not verify, so the baseline's `result` -- not merely the fact that it
-/// is "not verified" -- decides the exit code. Deriving the status from
-/// `result == "error"` alone let every other non-success value fall through to
-/// 0, so `violated` exited 0 (issue #554): a mutation score is meaningless
-/// over a spec that already fails, and a gate reading only the exit code saw a
-/// pass. `scenarios` and `testgen` re-emit the same baseline envelope and
-/// already exit 1.
-///
-/// `error_status` is the classified spec-error code the caller already holds
-/// (2 for parse/type/semantics/io, or whatever the baseline reported), so an
-/// error envelope is never re-classified here.
+/// The success/failure classification this used to restate now lives once, in
+/// `fslc_rust::outcome` (issue #537 C2); what remains here is the name this
+/// command's call sites already use. See [`fslc_rust::outcome::exit_status`]
+/// for the #554 rationale.
 fn mutate_exit_status(output: &Value, error_status: i32) -> i32 {
-    match output.get("result").and_then(Value::as_str) {
-        // Exit-code table row 0.
-        Some("mutated" | "verified" | "proved") => 0,
-        // Row 1. A baseline `verify` cannot produce that row's remaining
-        // members (`nonconformant`, `refinement_failed`, `sweep_failed`,
-        // `observed_mismatch`); those belong to other commands.
-        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
-        Some("error") => error_status,
-        // An unmapped result is an internal inconsistency, never a silent
-        // success -- falling through to 0 is exactly how #554 arose.
-        _ => 3,
-    }
+    fslc_rust::outcome::exit_status(output, error_status)
 }
 
 /// Pair a `mutate` error envelope with the exit code the table gives it, so no
@@ -15818,6 +15858,78 @@ fn block_on_native<F: Future>(future: F) -> F::Output {
 #[cfg(test)]
 mod exit_status_tests {
     use super::*;
+
+    /// Rejecting control for the `wrap_specialized` fallthrough (issue #601).
+    /// The specialized-dialect aggregation used to end in `_ => 0`, so
+    /// any result value nobody had added to its failure list exited 0.
+    /// `check_ai` forwards its nested kernel's `result` verbatim when it has
+    /// no finding of its own (`fsl-tools/src/ai.rs`), which is how an
+    /// inconclusive kernel verdict reached that arm.
+    ///
+    /// Asserted at the aggregation rather than end-to-end: a differential
+    /// sweep of both binaries over `examples/` + `specs/` found no corpus
+    /// input that reaches it, because every `ai_component` in the corpus
+    /// lowers to a kernel that verifies under both engines `ai check` accepts
+    /// (it rejects `--engine explicit`, and `lower_ai_component` emits no
+    /// `reachable` property). The omission was latent; its `db check` sibling
+    /// (#600) was not, and carries an end-to-end control.
+    #[test]
+    fn wrap_specialized_never_exits_zero_for_an_unregistered_or_failing_result() {
+        for result in [
+            "unknown_cti",
+            "reachable_failed",
+            "unknown_budget",
+            "a_value_nobody_registered",
+        ] {
+            let (_, status) = wrap_specialized(json!({"result": result}));
+            assert_ne!(
+                status, 0,
+                "wrap_specialized must not exit 0 for result={result:?}"
+            );
+        }
+        // The two mappings it did get right must not regress.
+        assert_eq!(wrap_specialized(json!({"result": "violated"})).1, 1);
+        assert_eq!(wrap_specialized(json!({"result": "error"})).1, 2);
+        assert_eq!(
+            wrap_specialized(json!({"result": "verified_under_assumptions"})).1,
+            0
+        );
+        assert_eq!(wrap_specialized(json!({"result": "expanded"})).1, 0);
+    }
+
+    /// The raw-delivery guard the nine `std::process::exit` sites now share.
+    ///
+    /// No failure path can currently reach any of those extractions -- the
+    /// extracted field is inserted at exactly one place in each producer,
+    /// after every error return -- so this cannot be a live end-to-end
+    /// control. What it does pin is the cross-path hazard that motivates the
+    /// guard: `fsl-tools/src/domain.rs` builds a `result:"violated"` envelope
+    /// that *also* carries `kernel_source`, the very field `domain expand`
+    /// extracts. Today that envelope reaches a sibling subcommand arm with no
+    /// raw extraction. If a future routing change sends it to one, this guard
+    /// is what stops the raw bytes from replacing the failure envelope.
+    #[test]
+    fn raw_delivery_rejects_a_failure_envelope_that_carries_the_extracted_field() {
+        let violated_with_kernel_source = (
+            json!({"result": "violated", "kernel_source": "spec X { }"}),
+            1,
+        );
+        assert!(!raw_delivery_allowed(&violated_with_kernel_source));
+
+        let expanded = (
+            json!({"result": "expanded", "kernel_source": "spec X { }"}),
+            0,
+        );
+        assert!(raw_delivery_allowed(&expanded));
+
+        // `db import` keeps both guards: the class guard admits
+        // `imported_with_warnings`, and the structural guard beside it is what
+        // still routes that case to the JSON envelope.
+        assert!(raw_delivery_allowed(&(
+            json!({"result": "imported_with_warnings"}),
+            0
+        )));
+    }
 
     /// Negative control for #465: before the fix, `apply_vacuity_mode`
     /// selected findings with `kind.starts_with("vacuous_")`, which matches

--- a/rust/fslc/src/outcome.rs
+++ b/rust/fslc/src/outcome.rs
@@ -1,0 +1,488 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! One definition of the success and failure classes over the CLI's `result`
+//! vocabulary (issue #537 C2, `docs/DESIGN-rust-component-internals.md`
+//! "Outcome classification").
+//!
+//! The Verdict Conservation Law is that a failure-class `result` must not exit
+//! zero and a success-class `result` must not exit non-zero. Before this
+//! module the crate had no such definition: each command arm compared `result`
+//! against literals at its own return point, so the class was re-derived — and
+//! re-forgotten — once per family. #596 recorded the consequence from inside
+//! the test suite, which had to carry its own `CHECK_SUCCESS_RESULTS` list
+//! because there was no production enumeration to defer to; a conservation
+//! check whose class definition lives in the test is the stale-check shape
+//! #577 retired 28 instances of.
+//!
+//! Three properties are load-bearing and must survive future edits:
+//!
+//! - **It takes the envelope, not the result string.** Five values cannot be
+//!   classified from `result` alone — they carry their verdict in a sibling
+//!   field (`approval check`'s `status`, `fmt --check`'s `changed`, `lint`'s
+//!   `finding_count`, `diff`'s `violations` and `gate.passed`). A `&str`
+//!   signature would force a second classifier beside this one, which is the
+//!   defect being removed. `docs/LANGUAGE.md`'s exit-code table says the same
+//!   thing from the outside: `approval_check`/`approval_diff` are absent from
+//!   it "because their exit code is not a function of `result`".
+//! - **It is flat, not per-family.** The class does not collide even where
+//!   meaning does: `"generated"` names different artifacts in `ledger`,
+//!   `testgen`, and `document`, and is success-class in all three. Six or
+//!   seven family classifiers would be six or seven places to forget a new
+//!   value.
+//! - **Unknown values classify as [`OutcomeClass::Failure`].** A result value
+//!   nobody registered fails loudly at its first corpus run instead of exiting
+//!   zero. Falling through to zero is how #554 arose. **Never add a
+//!   `_ => OutcomeClass::Success` arm.**
+//!
+//! Cacheability is a separate predicate ([`verify_cache_admits`]) and does not
+//! collapse into the classifier — see its own comment.
+
+use serde_json::Value;
+
+/// The two classes the Verdict Conservation Law is stated over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutcomeClass {
+    /// Exit zero is permitted.
+    Success,
+    /// Exit zero is forbidden.
+    Failure,
+}
+
+impl OutcomeClass {
+    /// Whether this class permits a zero exit status.
+    #[must_use]
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::Success)
+    }
+}
+
+/// Classify a CLI output envelope.
+///
+/// The class is the one the producing site's exit code already implies, so
+/// migrating a call site to this function preserves behavior; the places where
+/// it does not are the fixes tracked by #594 (`sweep`'s failure list omitted
+/// `unknown_budget`), #600 (`db check` folded only `violated`), and #601
+/// (`wrap_specialized`'s `_ => 0` fallthrough).
+///
+/// The failure arm deliberately enumerates its values even though the `_` arm
+/// would classify them identically: the enumeration *is* the registry, and a
+/// value that vanishes from it (or is misspelled into it) must be visible here
+/// rather than absorbed by the catch-all. Merging the two, as
+/// `clippy::match_same_arms` suggests, would delete the registry and leave only
+/// the safety net.
+#[must_use]
+#[allow(clippy::match_same_arms)]
+pub fn outcome_class(output: &Value) -> OutcomeClass {
+    let Some(result) = output.get("result").and_then(Value::as_str) else {
+        // No `result` field at all is not a passing verdict. `chain` layer
+        // entries and the raw `fmt` source path are the only outputs without
+        // one, and neither is classified here.
+        return OutcomeClass::Failure;
+    };
+    match result {
+        // ---- Values whose verdict lives in a sibling field ---------------
+        //
+        // These are why this function takes `&Value`. Each mirrors the exit
+        // code its producing site computes today.
+
+        // `main.rs` `run_approval_check`: `i32::from(status ==
+        // "signature-invalid")`. `result` is `"approval_check"` for
+        // `approved`, `drifted`, and `signature-invalid` alike; only the
+        // last exits non-zero. Approval *drift* deliberately exits 0 (#598).
+        "approval_check" => {
+            class_of(output.get("status").and_then(Value::as_str) != Some("signature-invalid"))
+        }
+        // `main.rs` `run_fmt_check`: `i32::from(any_changed)`.
+        "format_check" => class_of(output.get("changed") != Some(&Value::Bool(true))),
+        // `main.rs` `run_lint`: `i32::from(finding_count > 0)`.
+        "lint" => class_of(
+            output
+                .get("finding_count")
+                .and_then(Value::as_u64)
+                .is_none_or(|count| count == 0),
+        ),
+        // `main.rs` `run_diff`: `i32::from(!violations.is_empty())`.
+        "semantic_diff" => class_of(
+            output
+                .get("violations")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty),
+        ),
+        // `main.rs` `run_diff_git` batch: the same gate, aggregated. The
+        // envelope publishes the decision as `gate.passed`.
+        "semantic_diff_batch" => class_of(
+            output
+                .get("gate")
+                .and_then(|gate| gate.get("passed"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        ),
+
+        // ---- Success class ----------------------------------------------
+        //
+        // Every value below exits 0 at its producing site.
+
+        // Core verification and checking verdicts.
+        "ok"
+        | "verified"
+        | "proved"
+        | "refines"
+        | "conformant"
+        // Bounded sweep grid over a clean spec.
+        | "sweep_passed"
+        // Derived artifacts: `ledger`, `testgen`, `html`, `document`,
+        // `domain generate`, `db import`, `approval record`.
+        | "generated"
+        | "created"
+        | "imported"
+        | "imported_with_warnings"
+        // Analyses and projections that either succeed or error out.
+        | "analyzed"
+        | "expanded"
+        | "explained"
+        | "kernel"
+        | "typestate"
+        | "scenarios"
+        | "mutated"
+        | "migrated"
+        | "compared"
+        | "compat_profile_generated"
+        // Conformance projections and replay evidence.
+        | "conformance"
+        | "conformance_coverage"
+        | "testgen_trace"
+        | "conformance_checked"
+        | "document_conformant"
+        | "observed_conformant"
+        | "replay_conformant"
+        // `ai drift`'s success result, deliberately distinct from `db
+        // observe`'s `observed_conformant` (#509, `main.rs` `run_ai_drift`).
+        | "observed_supported"
+        // Specialized dialects: a clean verdict under the declared
+        // assumptions (`fsl-tools` `ai.rs`, `domain.rs`, `db.rs`, `agent.rs`).
+        | "verified_under_assumptions"
+        | "agent_analyzed"
+        | "ai_project_analyzed"
+        // Causal dialect (`fsl-tools/src/causal_analysis.rs`, `causal.rs`).
+        | "causal_analyzed"
+        | "causal_model_checked"
+        | "causal_diffed"
+        | "causal_ledger"
+        | "causal_expectations_checked"
+        | "causal_expectations_observed"
+        // `fsl-ai` statistical evaluation that met its requirement.
+        | "statistically_supported"
+        // A `chain` layer the manifest did not request. Its own entry
+        // declares `exit_code: 0` (`main.rs` `skipped_layer_entry`).
+        | "skipped" => OutcomeClass::Success,
+
+        // ---- Failure class ----------------------------------------------
+        //
+        // Listed explicitly rather than left to the `_` arm so that a typo in
+        // one of these names surfaces as an unregistered value rather than
+        // silently landing in the same class by accident.
+
+        // Spec/usage/internal errors. The *code* (2 vs 3) is chosen by the
+        // caller; the class is the same.
+        "error"
+        // Kernel verification verdicts that are not a pass.
+        | "violated"
+        | "reachable_failed"
+        | "unknown_cti"
+        | "unknown_budget"
+        // Refinement, conformance, and sweep failures.
+        | "refinement_failed"
+        | "nonconformant"
+        | "impl_violated"
+        | "sweep_failed"
+        // Dialect-level failures.
+        | "observed_mismatch"
+        | "replay_nonconformant"
+        | "document_drifted"
+        | "migration_refused"
+        // `approval diff` only ever publishes this `result` on its
+        // signature-invalid path (`main.rs` `run_approval_diff`); a valid
+        // signature returns the underlying `semantic_diff` envelope instead.
+        | "approval_diff"
+        // `fsl-ai` statistical gate statuses (#510): a result that gates
+        // before producing a Wilson interval is not a passing evaluation.
+        | "statistically_unsupported"
+        | "dataset_invalid"
+        | "evaluator_untrusted"
+        | "slice_missing"
+        | "insufficient_samples"
+        | "inconclusive"
+        // A refinement mapping the auto-mapper could not decide.
+        | "unknown" => OutcomeClass::Failure,
+
+        // An unregistered value is an internal inconsistency, never a silent
+        // success. Falling through to zero is exactly how #554 arose, and a
+        // poisoned verify-cache entry must not be readable as a pass either.
+        _ => OutcomeClass::Failure,
+    }
+}
+
+fn class_of(success: bool) -> OutcomeClass {
+    if success {
+        OutcomeClass::Success
+    } else {
+        OutcomeClass::Failure
+    }
+}
+
+/// Whether a `verify` envelope is a settled verdict worth writing to the
+/// on-disk verification cache.
+///
+/// **This is not [`outcome_class`] and must not be folded into it.**
+/// Cacheability asks "is this verdict settled enough to replay", not "did it
+/// pass": `violated`, `reachable_failed`, `unknown_cti`, and `unknown_budget`
+/// are all failure-class *and* cacheable. The two predicates live in the same
+/// file so the vocabulary has one home, and stay distinct so that a new result
+/// value forces an explicit decision in both.
+#[must_use]
+pub fn verify_cache_admits(output: &Value) -> bool {
+    matches!(
+        output.get("result").and_then(Value::as_str),
+        Some(
+            "verified"
+                | "proved"
+                | "violated"
+                | "reachable_failed"
+                | "unknown_cti"
+                | "unknown_budget"
+        )
+    )
+}
+
+/// `docs/LANGUAGE.md`'s exit-code table applied to an envelope, as a total
+/// function over [`outcome_class`].
+///
+/// Classification decides whether exit zero is *allowed*; it does not by
+/// itself pick the code. `error_status` is the classified spec-error code the
+/// caller already holds (2 for parse/type/semantics/io, 3 for internal), so an
+/// error envelope is never re-classified here.
+///
+/// `mutate` re-emits its baseline `verify` envelope verbatim when the baseline
+/// does not verify, so the baseline's `result` -- not merely the fact that it
+/// is "not verified" -- decides the exit code. Deriving the status from
+/// `result == "error"` alone let every other non-success value fall through to
+/// 0, so `violated` exited 0 (issue #554): a mutation score is meaningless
+/// over a spec that already fails, and a gate reading only the exit code saw a
+/// pass. `scenarios` and `testgen` re-emit the same baseline envelope and
+/// already exit 1.
+#[must_use]
+pub fn exit_status(output: &Value, error_status: i32) -> i32 {
+    // Row 0 of the table is exactly the success class; that is the part this
+    // function no longer restates.
+    if outcome_class(output).is_success() {
+        return 0;
+    }
+    match output.get("result").and_then(Value::as_str) {
+        Some("error") => error_status,
+        // Row 1, restricted to the members a baseline `verify` envelope can
+        // actually carry. The row's remaining members (`nonconformant`,
+        // `refinement_failed`, `sweep_failed`, `observed_mismatch`) belong to
+        // other commands and cannot appear here.
+        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
+        // A failure-class value outside this command's vocabulary, or one
+        // nobody registered at all, is an internal inconsistency -- never a
+        // silent success.
+        _ => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{OutcomeClass, outcome_class, verify_cache_admits};
+
+    /// Negative control for the `_` arm: a value nobody registered must not
+    /// be readable as a pass. This is the property #554 violated.
+    #[test]
+    fn an_unregistered_result_is_failure_class() {
+        assert_eq!(
+            outcome_class(&json!({"result": "a_value_nobody_registered"})),
+            OutcomeClass::Failure
+        );
+        assert_eq!(
+            outcome_class(&json!({"result": "verified_typo"})),
+            OutcomeClass::Failure
+        );
+        // An envelope with no `result` field at all is likewise not a pass.
+        assert_eq!(outcome_class(&json!({})), OutcomeClass::Failure);
+        assert_eq!(outcome_class(&json!({"result": 7})), OutcomeClass::Failure);
+    }
+
+    /// `verification.rs`'s cache-poisoning fixture value. A poisoned cache
+    /// entry must never be read back as a success.
+    #[test]
+    fn the_cache_poison_fixture_is_failure_class() {
+        assert_eq!(
+            outcome_class(&json!({"result": "bogus"})),
+            OutcomeClass::Failure
+        );
+    }
+
+    /// The `&Value` signature exists for these: `result` alone cannot
+    /// classify them.
+    #[test]
+    fn sibling_field_verdicts_follow_their_producing_site() {
+        // `run_approval_check`: only `signature-invalid` exits non-zero.
+        // Drift deliberately exits 0 (#598).
+        for (status, expected) in [
+            ("approved", OutcomeClass::Success),
+            ("drifted", OutcomeClass::Success),
+            ("signature-invalid", OutcomeClass::Failure),
+        ] {
+            assert_eq!(
+                outcome_class(&json!({"result": "approval_check", "status": status})),
+                expected,
+                "approval_check status={status}"
+            );
+        }
+
+        // `fmt --check`: `i32::from(any_changed)`.
+        assert_eq!(
+            outcome_class(&json!({"result": "format_check", "changed": false})),
+            OutcomeClass::Success
+        );
+        assert_eq!(
+            outcome_class(&json!({"result": "format_check", "changed": true})),
+            OutcomeClass::Failure
+        );
+
+        // `lint`: `i32::from(finding_count > 0)`.
+        assert_eq!(
+            outcome_class(&json!({"result": "lint", "finding_count": 0})),
+            OutcomeClass::Success
+        );
+        assert_eq!(
+            outcome_class(&json!({"result": "lint", "finding_count": 3})),
+            OutcomeClass::Failure
+        );
+
+        // `diff`: `i32::from(!violations.is_empty())`.
+        assert_eq!(
+            outcome_class(&json!({"result": "semantic_diff", "violations": []})),
+            OutcomeClass::Success
+        );
+        assert_eq!(
+            outcome_class(&json!({"result": "semantic_diff", "violations": ["R1"]})),
+            OutcomeClass::Failure
+        );
+
+        // Batch `diff` publishes the same decision as `gate.passed`.
+        assert_eq!(
+            outcome_class(&json!({
+                "result": "semantic_diff_batch",
+                "gate": {"violations": [], "passed": true}
+            })),
+            OutcomeClass::Success
+        );
+        assert_eq!(
+            outcome_class(&json!({
+                "result": "semantic_diff_batch",
+                "gate": {"violations": ["R1"], "passed": false}
+            })),
+            OutcomeClass::Failure
+        );
+        // A batch envelope missing the gate is not a pass.
+        assert_eq!(
+            outcome_class(&json!({"result": "semantic_diff_batch"})),
+            OutcomeClass::Failure
+        );
+    }
+
+    /// #594: `sweep`'s hand-written failure list omitted `unknown_budget`, so
+    /// a grid whose only failing scope reported it collapsed into
+    /// `sweep_passed`/exit 0. The classifier cannot have that omission
+    /// because the value is registered here.
+    ///
+    /// This is asserted at the classifier rather than end-to-end because the
+    /// CLI cannot currently reach it: `fslc sweep` restricts `--engine` to
+    /// `bmc|induction` at its parse site in `main.rs`, `unknown_budget` is
+    /// produced only by the explicit engine
+    /// (`verification_output.rs` `render_explicit_budget`), the `auto` engine
+    /// falls back to BMC before it escapes (`verification.rs`
+    /// `auto_fallback_to_bmc`), and the verify-cache key includes the engine
+    /// so a BMC sweep cannot read an explicit entry. The omission was latent,
+    /// not a live false green.
+    #[test]
+    fn every_non_passing_kernel_verdict_is_failure_class() {
+        for result in [
+            "violated",
+            "reachable_failed",
+            "unknown_cti",
+            "unknown_budget",
+        ] {
+            assert_eq!(
+                outcome_class(&json!({"result": result})),
+                OutcomeClass::Failure,
+                "{result} must not be readable as a pass"
+            );
+        }
+        for result in ["verified", "proved"] {
+            assert_eq!(
+                outcome_class(&json!({"result": result})),
+                OutcomeClass::Success,
+                "{result} must not be readable as a failure"
+            );
+        }
+    }
+
+    /// Cacheability is not success. If these two ever collapse into one
+    /// predicate, this test fails.
+    #[test]
+    fn cacheability_is_not_the_success_class() {
+        let violated = json!({"result": "violated"});
+        assert!(
+            verify_cache_admits(&violated),
+            "a violation is a settled verdict and stays cacheable"
+        );
+        assert_eq!(
+            outcome_class(&violated),
+            OutcomeClass::Failure,
+            "and is still failure-class"
+        );
+
+        // An error is neither cacheable nor a pass.
+        let error = json!({"result": "error", "kind": "parse"});
+        assert!(!verify_cache_admits(&error));
+        assert_eq!(outcome_class(&error), OutcomeClass::Failure);
+
+        // A success-class result outside `verify`'s vocabulary is not
+        // cacheable either.
+        let generated = json!({"result": "generated"});
+        assert!(!verify_cache_admits(&generated));
+        assert_eq!(outcome_class(&generated), OutcomeClass::Success);
+    }
+
+    /// The exit-code derivation is separate from the classification: the
+    /// class says whether zero is allowed, `error_status` chooses which
+    /// non-zero code an error envelope carries.
+    #[test]
+    fn exit_status_preserves_the_mutate_table() {
+        use super::exit_status;
+
+        for result in ["mutated", "verified", "proved"] {
+            assert_eq!(exit_status(&json!({"result": result}), 2), 0);
+        }
+        for result in [
+            "violated",
+            "reachable_failed",
+            "unknown_cti",
+            "unknown_budget",
+        ] {
+            assert_eq!(exit_status(&json!({"result": result}), 2), 1);
+        }
+        assert_eq!(exit_status(&json!({"result": "error"}), 2), 2);
+        assert_eq!(exit_status(&json!({"result": "error"}), 3), 3);
+        // An unmapped result is an internal inconsistency, never a silent
+        // success -- and keeps the table's distinct code for it.
+        assert_eq!(exit_status(&json!({"result": "who_knows"}), 2), 3);
+        // A registered failure outside a verify baseline's vocabulary is the
+        // same kind of inconsistency when it reaches `mutate`.
+        assert_eq!(exit_status(&json!({"result": "nonconformant"}), 2), 3);
+    }
+}

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1589,17 +1589,12 @@ fn verify_cache_store(key: &str, xdepth: &str, output: &Value) {
     if !valid_cache_key(key) || !valid_cache_key(xdepth) {
         return;
     }
-    if !matches!(
-        output.get("result").and_then(Value::as_str),
-        Some(
-            "verified"
-                | "proved"
-                | "violated"
-                | "reachable_failed"
-                | "unknown_cti"
-                | "unknown_budget"
-        )
-    ) {
+    // Cacheability, not success: `violated` and the three inconclusive
+    // verdicts are failure-class and still worth storing. The predicate lives
+    // beside `outcome_class` in `fslc_rust::outcome` so the vocabulary has one
+    // home, and stays a distinct function so that a new result value forces an
+    // explicit decision in both (issue #537 C2).
+    if !fslc_rust::outcome::verify_cache_admits(output) {
         return;
     }
     let Some(path) = verify_cache_path(key) else {

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -36,7 +36,8 @@
 //! status agree with the result class" is a closed law that every corpus
 //! file -- including deliberately-failing fixtures and the
 //! `refinement`/`examples/gallery/injected/` categories excluded above --
-//! must satisfy.
+//! must satisfy. Its class definition is production code
+//! (`fslc_rust::outcome::outcome_class`), not a list in this file.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -227,30 +228,21 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
-/// `result` values `fslc check` emits that belong to the success class
-/// (exit status must be 0).
-///
-/// `check`'s own family arms (`run_check_with_tags`, `agent_check_output`,
-/// `run_causal_check` in `rust/fslc/src/main.rs`/`causal.rs`) each set their
-/// exit code directly at the return site rather than deriving it from
-/// `result` through one shared function -- unlike, say, `mutate_exit_status`
-/// in `main.rs`, there is no existing single production-code enumeration of
-/// `check`'s result vocabulary this test could defer to instead. This is
-/// therefore deliberately an allowlist, not a denylist: issue #537 C2
-/// requires that aggregation "never default an unknown variant to
-/// success", so a `check` result value that is not (yet) listed here falls
-/// through to the failure class below and the test fails loudly instead of
-/// silently accepting a new false-green shape.
-const CHECK_SUCCESS_RESULTS: &[&str] = &[
-    "ok",                   // rust/fslc/src/main.rs: run_check_with_tags, agent_check_output
-    "causal_model_checked", // rust/fsl-tools/src/causal_analysis.rs
-];
-
 /// Verdict Conservation Law for `fslc check` (issue #537 C2), checked
 /// without any per-file oracle: a success-class `result` must exit 0, and
-/// every other `result` -- including a value not yet in
-/// `CHECK_SUCCESS_RESULTS` -- must exit non-zero. The envelope itself must
+/// every failure-class `result` must exit non-zero. The envelope itself must
 /// also be a JSON object carrying a string `result` field.
+///
+/// The class definition is `fslc_rust::outcome::outcome_class`, in production
+/// code. This test used to carry its own `CHECK_SUCCESS_RESULTS` allowlist,
+/// because `check`'s family arms each set their exit code at their own return
+/// point and there was no production enumeration to defer to. That is the
+/// shape #577 retired 28 instances of: a conservation check whose class
+/// definition lives in the test can only ever agree with itself, and the
+/// production code it is supposed to constrain is free to drift. The
+/// allowlist is gone. An unregistered value now falls to the failure class in
+/// `outcome.rs` -- never here -- so a new false-green shape fails loudly at
+/// the definition instead of being quietly re-declared in a test fixture.
 #[test]
 fn check_result_and_exit_status_never_contradict() {
     let root = root();
@@ -286,15 +278,16 @@ fn check_result_and_exit_status_never_contradict() {
         };
 
         observed_results.insert(result.to_owned());
-        let is_success = CHECK_SUCCESS_RESULTS.contains(&result);
+        let is_success = fslc_rust::outcome::outcome_class(&envelope).is_success();
         if is_success && exit != 0 {
             failures.push(format!(
                 "{rel}: result={result:?} is success-class but exit={exit} (false red)"
             ));
         } else if !is_success && exit == 0 {
             failures.push(format!(
-                "{rel}: result={result:?} is not a registered success-class result but \
-                 exit=0 (false green)"
+                "{rel}: result={result:?} is failure-class per \
+                 `fslc_rust::outcome::outcome_class` but exit=0 (false green). If this is a \
+                 new success-class result, register it there -- not here"
             ));
         }
     }

--- a/rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl
+++ b/rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #600 negative control. The `dbsystem` compatibility rules below all hold, so
+// `check_db` reports no finding of its own and sets
+// `result:"verified_under_assumptions"`. The lowered kernel, however, is not
+// inductive: under `--engine induction` it comes back `unknown_cti`, exit 1.
+//
+// `run_db_check` used to fold only a `violated` kernel into the top-level
+// verdict, so this file produced `{"result":"verified_under_assumptions"}` with
+// exit 1 -- an envelope contradicting its own exit code. Its `domain check`
+// sibling has folded every non-passing kernel verdict since #515.
+dbsystem DbInconclusiveKernel {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+      column full_name: Text present backfilled nullable;
+      column first_name: Text absent;
+      column last_name: Text absent;
+    }
+  }
+
+  migration split_full_name from 0 to 1 {
+    split users.full_name into users.first_name, users.last_name;
+  }
+
+  artifact server_v2 {
+    reads users.id, users.first_name, users.last_name;
+  }
+
+  environment prod {
+    schema 0..1;
+    active server_v2 when schema 1..1;
+  }
+
+  // Deliberately does not select `preservation_transforms_annotated`: the
+  // unannotated `split` above is what makes the lowered kernel non-inductive,
+  // and this control needs the dbsystem layer itself to stay finding-free so
+  // the kernel verdict is the only thing left to fold.
+  check compatibility {
+    rule all_active_reads_exist;
+    rule all_active_writes_exist;
+  }
+}

--- a/rust/fslc/tests/issue_600_db_check_folds_kernel_verdict.rs
+++ b/rust/fslc/tests/issue_600_db_check_folds_kernel_verdict.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Negative control for #600: `fslc db check` must fold *every* non-passing
+//! nested kernel verdict into its top-level `result`, not only `violated`.
+//!
+//! `run_db_check` set `result:"verified_under_assumptions"` whenever the
+//! `dbsystem` compatibility rules produced no finding, then ran the kernel
+//! `verify` and rewrote the top level only for `violated`. A kernel that came
+//! back `unknown_cti`, `reachable_failed`, or `unknown_budget` therefore
+//! produced an envelope reporting success alongside exit 1 -- the exit code
+//! was right and the JSON lied about it, which is the half of the Verdict
+//! Conservation Law that a gate reading the envelope (rather than the exit
+//! code) sees.
+//!
+//! The `run_domain_check` sibling has folded the same way since #515, and its
+//! status guard admits both definitive codes (`status != 0 && status != 1`)
+//! rather than testing `== 2`. `db` now matches it on both counts.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn fixture() -> String {
+    "rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl".to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {args:?}`: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output
+        .status
+        .code()
+        .unwrap_or_else(|| panic!("`fslc {args:?}` terminated by signal, no exit code"));
+    (value, status)
+}
+
+/// The fixture has to keep producing an inconclusive kernel for this control
+/// to mean anything. If a verifier improvement makes it `proved`, this test
+/// fails loudly rather than passing vacuously.
+#[test]
+fn the_fixture_still_produces_an_inconclusive_kernel() {
+    let path = fixture();
+    let (verification, status) = run(&[
+        "verify",
+        &path,
+        "--engine",
+        "induction",
+        "--deadlock",
+        "ignore",
+    ]);
+    assert_eq!(
+        verification["result"], "unknown_cti",
+        "fixture must still be non-inductive for #600's control to exercise \
+         the fold; got {verification}"
+    );
+    assert_eq!(status, 1);
+}
+
+#[test]
+fn db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict() {
+    let path = fixture();
+    let (output, status) = run(&["db", "check", &path, "--engine", "induction"]);
+
+    // The dbsystem layer itself is clean: this is purely the kernel verdict
+    // folding through. Without that, the assertion below would be testing the
+    // ordinary `violated` path that already worked.
+    assert_eq!(
+        output["findings"].as_array().map(Vec::len),
+        Some(0),
+        "fixture must stay finding-free at the dbsystem layer; got {output}"
+    );
+    assert_eq!(
+        output["kernel"]["result"], "unknown_cti",
+        "the nested kernel verdict must still be reported; got {output}"
+    );
+
+    assert_ne!(
+        output["result"], "verified_under_assumptions",
+        "an inconclusive kernel must not be reported as success (#600); got {output}"
+    );
+    assert_eq!(output["result"], "violated");
+    assert_ne!(status, 0);
+}
+
+/// The other half of #600: the status guard. `run_domain_check` returns the
+/// kernel envelope verbatim for any status that is neither 0 nor 1;
+/// `run_db_check` tested `== 2` and so would have absorbed a `kind:"internal"`
+/// (status 3) kernel envelope as a `dbsystem` verdict. A parse error (status
+/// 2) must still come back verbatim, which is what this pins.
+#[test]
+fn db_check_returns_a_spec_error_envelope_verbatim() {
+    let (output, status) = run(&["db", "check", "rust/fslc/tests/fixtures/does_not_exist.fsl"]);
+    assert_eq!(output["result"], "error", "got {output}");
+    assert_eq!(status, 2);
+    assert_ne!(
+        output["result"], "verified_under_assumptions",
+        "a spec error must never be absorbed into a dbsystem verdict"
+    );
+}


### PR DESCRIPTION
## Problem

`fslc` reports one verdict two ways: the JSON `result` string and the process exit
code. Different consumers read different ones — agents and CI read the envelope,
shell pipelines read the exit code — so when the two disagree, the disagreement is
invisible to whoever reads only one.

The crate had **43 distinct `result` values and no definition of which ones are a
pass**. Every command arm compared `result` against string literals at its own
return point, so the class was re-derived, and re-forgotten, once per family.

#596 recorded the consequence from inside the test suite: it had to carry its own
`CHECK_SUCCESS_RESULTS` list because there was no production enumeration to defer
to. That is the shape #577 retired 28 instances of — a conservation check whose
class definition lives in the test can only ever agree with itself.

## Contract change

`rust/fslc/src/outcome.rs` now owns the definition. Three properties are
load-bearing, and each is recorded in `docs/DESIGN-rust-component-internals.md`:

- **It takes the envelope, not the `result` string.** Five values carry their
  verdict in a sibling field: `approval check`'s `status`, `fmt --check`'s
  `changed`, `lint`'s `finding_count`, `diff`'s `violations`, and the batch
  gate's `gate.passed`. A `&str` signature cannot express any of them.
- **It is flat, not per-family.** The class does not collide even where meaning
  does — `"generated"` names different artifacts in `ledger`, `testgen`, and
  `document`, and is success-class in all three.
- **Unknown values classify as `Failure`,** following `mutate_exit_status`'s
  `_ => 3`. Falling through to zero is exactly how #554 arose.

Cacheability stays a separate predicate: `violated` is failure-class *and* a
settled verdict worth caching.

## Defects fixed, all in the same direction

A failure-class result can no longer exit 0.

| Issue | Site | Shape |
|---|---|---|
| #601 | `wrap_specialized`, 15 call sites | ended in `_ => 0` — the **opposite default** to `outcome_class` in the same crate. Not a missing value but the mechanism that loses them |
| #600 | `run_db_check` | folded only `violated`, returned verbatim only on `kernel_status == 2`, so an inconclusive kernel gave `verified_under_assumptions` **alongside exit 1** |
| #594 | `run_sweep` | failure list had lost `unknown_budget` |

#600's `run_domain_check` sibling has folded correctly since #515; the asymmetry
was the evidence.

Migrated to the shared definition: `mutate_exit_status`, `chain_layer_passes`,
`verify_cache_store`, and the sweep selection. All nine raw-output sites gain an
`outcome_class` guard as an **additional** conjunct, never replacing the
structural field guard — `db import` still routes `imported_with_warnings` to its
JSON envelope.

`chain` and `analyze` batch each now state their empty-workset choice. The
asymmetry is recorded, not removed: #537 C2 asks for explicitness, not uniformity,
and no accepted decision calls the difference a defect.

## Evidence

**#600 is reachable, with an end-to-end rejecting control.** Reproduction needs
two conditions at once — zero dbsystem findings (else `check_db` returns
`violated` first) and a non-inductive kernel — and no corpus spec has both. The
fixture supplies both. On the pre-change binary:

```
$ fslc db check rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl --engine induction
top result = verified_under_assumptions
kernel     = unknown_cti
EXIT       = 1
```

`db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict` fails on that
binary and passes after. `the_fixture_still_produces_an_inconclusive_kernel`
keeps the control from going vacuous if the fixture ever starts proving.

**#601 and #594 are latent.** A differential sweep of the pre- and post-change
binaries over every affected command across `examples/` + `specs/` found **zero
`(result, exit)` differences**, so their controls sit at the aggregation and the
classifier respectively, each with the measured reason it cannot be end-to-end
(`ai` lowering emits no `Reachable` and rejects `--engine explicit`; `sweep`
restricts `--engine` to `bmc|induction`).

**The safety net caught one value during the migration.** `observed_supported`
(`ai drift`'s success value, reached through a conditional the static extraction
missed) went unregistered, fell to `_ => Failure`, and a test failed loudly
instead of a new false green landing quietly. `_ => Failure` is not a theoretical
precaution here — it earned its place inside this PR.

**The three previously unguarded raw-output sites** (`--readable`, `--ts`,
`domain expand`) were measured, not assumed: each extracted field is inserted at
exactly one place in its producer, after every error return. The guards state
that invariant. It is not idle — `fsl-tools/src/domain.rs` builds a
`result:"violated"` envelope that also carries `kernel_source`, so the invariant
is one routing change from breaking.

## Gates

| Check | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo test --workspace --locked` | 0 — **1187 passed**, 0 failed |
| `./tools/check-native-integration.sh` | 0 — browser parity 415 cases, `nativeParity: true` |

## Out of scope

`fsl-tools/src/ledger.rs`'s `evidence_verdict` is a third enumeration, but it is
`Option<bool>` — `None` means "an evidence source with no verdict", a third state
that collapsing into two classes would change. Left untouched and reported
separately.

Closes #600, #601, #594. Advances #537 C2.