### PR TITLE
docs(skills): state that the inline `implements` seam does not reach the exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   definition; `chain` and `analyze` batch now each state their
   empty-workset choice (reject vs allow) as a named local, with the
   asymmetry recorded rather than removed.
+- The agent skills now state that a requirements spec's inline
+  `implements Abs from "business.fsl"` seam is the one exception to the
+  exit-code contract: `check`/`verify` run the refinement to the business
+  layer but report the verdict only in the `implements` field, so a
+  `refinement_failed` / `impl_violated` seam still returns `result: "ok"` /
+  `"verified"` and exit 0, while the same failure is exit 1 through
+  standalone `fslc refine` and through `fslc chain`. `skills/fsl/SKILL.md`
+  previously stated the exit contract with no exception, and its diagnostic
+  table keyed the row on `implements.result: violated` — a value the verdict
+  vocabulary never produces (`refines` / `refinement_failed` /
+  `impl_violated`), so an agent searching the JSON for `violated` would miss
+  a broken seam entirely. `skills/fsl-delivery`'s Requirements stage gate and
+  both skills' "green `implements`" claim-discipline lines now say to assert
+  `implements.result == "refines"` rather than relying on the exit code. Only
+  `docs/DESIGN-design-family.md` ("treat `implements.result != refines` as
+  failure even when the top-level process exits zero") had carried this, and
+  it never reached the skills or `docs/LANGUAGE.md`.
 - `rust/fslc/tests/corpus_check_sweep.rs`'s module doc claimed (per issue
   #483) that "the gallery fixtures and `examples/refinement_liveness/*`"
   are refined by a test; only 6 of the 28 `refinement`-dialect corpus files

--- a/skills/fsl-delivery/SKILL.md
+++ b/skills/fsl-delivery/SKILL.md
@@ -86,7 +86,7 @@ rules in this skill.
 | Stage | Deliverable | Required checks |
 |---|---|---|
 | Business | `business` spec with policies, KPIs, goals | check, verify, induction |
-| Requirements | `requirements` spec with REQ IDs, acceptance, forbidden, NFRs | check, verify, induction, scenarios; implements/refines business when present |
+| Requirements | `requirements` spec with REQ IDs, acceptance, forbidden, NFRs | check, verify, induction, scenarios; when `implements` is present, assert `implements.result == "refines"` in the JSON (or gate with `fslc chain`) — a failed business seam still exits 0 |
 | Design | kernel `spec` plus mapping to requirements | check, verify, induction, refine |
 | Implementation | Adapter or event log connected to real behavior | testgen pytest or replay; do not claim conformance before this |
 | Review/change | proposal spec or before/after contract | verify each side, refine against frozen contract, optional mutate/vacuity |
@@ -109,7 +109,8 @@ For high-risk contracts, add the more expensive checks:
   the stated interpretation.
 - A green requirements layer means the requirements model is internally
   consistent; if `implements` is green, it also preserves the business contract's
-  checked safety obligations.
+  checked safety obligations. "Green" here means `implements.result == "refines"`
+  in the JSON — not exit 0, which stays 0 even when the seam fails.
 - A green design layer means the design model is internally consistent.
 - A green `refine` means lower-layer observable behavior conforms to the upper
   contract for checked safety behavior.

--- a/skills/fsl-requirements/SKILL.md
+++ b/skills/fsl-requirements/SKILL.md
@@ -139,7 +139,11 @@ skill produced.
 - Do not add retries, storage rules, asynchronous jobs, queues, screen internals,
   or API shape unless the source explicitly requires them.
 - A green `implements` result means the requirements contract conforms to the
-  agreed business layer. It does not prove any design or implementation.
+  agreed business layer. It does not prove any design or implementation. Green
+  means `implements.result == "refines"` in the result JSON: the seam's verdict
+  is not folded into the top-level `result` or the exit code, so a
+  `refinement_failed` / `impl_violated` seam still exits 0 on `check`/`verify`.
+  Assert the field, or gate with `fslc chain`.
 - When a counterexample suggests a repair, decide whether it is a missing
   requirement, a wrong interpretation, or an intentional exception before changing
   guards or invariants.

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -163,6 +163,15 @@ Output is always a single JSON document on stdout. exit: 0=success
 (violated/reachable_failed/unknown_cti/nonconformant), 2=spec error
 (parse/type/semantics/io), 3=internal error.
 
+**The one exception is the inline `implements` seam.** A requirements spec with
+`implements Abs from "business.fsl" { ... }` has its refinement to the upper
+layer checked during `check`/`verify`, but that verdict is reported *only* in the
+`implements` field — it is not folded into the top-level `result` or the exit
+code. A broken business seam still returns `result: "ok"` / `"verified"` and
+exit 0. Gate it explicitly on `implements.result == "refines"` (the only passing
+value; the failing ones are `refinement_failed` and `impl_violated`), or run
+`fslc chain`, which applies that gate for you and does exit 1.
+
 ## Before writing a spec: source fidelity and the formalization memo
 
 FSL is a specification language, not a requirements generator. Encode only facts
@@ -392,7 +401,9 @@ authoring through the role skills.)
    - requirements → business: put `implements BusinessName from "business.fsl" { }`
      in the requirements spec; `verify` then also runs the refine and reports it under
      the `implements` field of the result JSON (an empty body auto-generates identity
-     refinement when names match).
+     refinement when names match). This seam is the exception to the exit-code
+     contract: assert `implements.result == "refines"` yourself — a failed seam
+     still exits 0.
    - design → requirements: a mapping file + `fslc refine design.fsl requirements.fsl
      mapping.fsl`.
    - when an upper response must survive the seam, add
@@ -457,7 +468,7 @@ existing result/kind fields:
 | `refinement_failed` / `abs_requires_failed` | A detailed-layer transition breaks an upper-layer guard (e.g. a shortcut skipping approval) | Read `impl_action` and `impl_trace`. Add a guard to the detailed layer, or review the interpretation of the correspondence (`maps` / mapping) |
 | `refinement_failed` / `abs_state_mismatch` / `stutter_changed_abs` / `map_out_of_bounds` | Mapping inconsistency (an update has no correspondence / a stutter nonetheless changes upper-layer state / a mapped value is out of the type's range) | Compare the `mismatch` path with `abs_before/after`. Fix the mapping expression or the action correspondence |
 | `refinement_failed` / `progress_lost` | A `preserve progress` mapping pulled an upper `leadsTo` into the lower layer and found a lasso/stall | Read `progress_failure`, `impl_trace`, `pending_since`, `loop_start`/`stutter`, and the `progress.actions`. Add/restore lower-layer `fair action` on the progress action, add a lower-layer ranked `leadsTo`, or revise the progress mapping |
-| `implements.result: violated` within verify | The requirements layer deviates from the upper (business) layer | The contents of `implements.violation` have the same shape as refinement_failed. Same procedure as above + check the `requirement` on the requirements side |
+| `implements.result: refinement_failed` / `impl_violated` within check/verify | The requirements layer deviates from the upper (business) layer (`impl_violated` = the requirements spec breaks its own bounds/invariants, so no refinement verdict was reached) | **The top-level `result` is still `ok`/`verified` and the exit code is still 0 — read this field, never the exit code.** The contents of `implements.violation` have the same shape as refinement_failed. Same procedure as above + check the `requirement` on the requirements side |
 | `error` / `acceptance` | Replay of an acceptance criterion failed | The ID and step of the failed AC are returned. Decide whether the procedure's precondition (state) or the expect is correct, and fix accordingly |
 | `error` / `forbidden` | An operation sequence that should be rejected was accepted (under-constraint; the kind that a safety invariant stays silent about) | `accepted_trace` is the accepting path. The requires enabling the last operation is too loose → add a guard or review the spec |
 | `error` / `forbidden_setup` | A precondition (non-final) step of the forbidden is not enabled (invalid trace) | Review the setup procedure. The non-final steps are there to reach that point and are not treated as success |

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1793,7 +1793,16 @@ verify {
   with both origin kinds and locations). An inline `action` item cannot target
   a `branches`-split action by its pre-split name — reference the generated
   `name__b<N>` alias. Auto-mapped process transitions are statically
-  actor-checked; an actor mismatch is a check-time type error.
+  actor-checked; an actor mismatch is a check-time type error. The seam's
+  verdict is reported as `implements: {abs, result}` with `result` one of
+  `refines` / `refinement_failed` / `impl_violated` (the last one meaning the
+  requirements spec breaks its own bounds/invariants, so no refinement verdict
+  was reached), plus `violation` on the two failing values. It is **not** folded
+  into the top-level `result` or the exit code — unlike standalone `fslc refine`,
+  where `refinement_failed` is exit 1 — so a broken seam returns
+  `result: "ok"` / `"verified"` and exit 0. Gate on
+  `implements.result == "refines"`, or use `fslc chain`, which applies exactly
+  that gate to the layer and exits 1.
 - `acceptance` is replay-checked at check time with the concrete Monitor (failure is
   `kind: "acceptance"`). It supports the readable stage form
   `expect <Entity> <id> in <Stage>` alongside `expect <expr>`, is output to


### PR DESCRIPTION
## Problem

A requirements spec's inline `implements Abs from "business.fsl" { ... }` seam — the business↔requirements refinement — is checked during `check`/`verify`, but its verdict is only decorated into the `implements` field of the envelope (`rust/fslc/src/verification.rs:2110-2142`). It is never folded into the top-level `result` or the process exit code.

So a requirements spec that no longer refines its business layer **exits 0**:

```
$ fslc check tests/fixtures/chain/requirements_broken_implements.fsl
{ "result": "ok", ..., "implements": {"abs":"ChainBusiness","result":"refinement_failed",
                                      "violation":{"kind":"abs_state_mismatch"}} }
exit=0
```

The same failure is exit 1 through standalone `fslc refine`, and exit 1 through `fslc chain` — the latter only because `chain_layer_passes` carries its own compensating `implements.result != "refines"` guard (`rust/fslc/src/main.rs:3592-3600`).

The trap was recorded in exactly one place, `docs/DESIGN-design-family.md:89` ("treat `implements.result != refines` as failure even when the top-level process exits zero") — an internal prototype-protocol document. It never reached the skills the agents actually read:

- `skills/fsl/SKILL.md:160-163` states the global exit contract (`0=success … 1=property not satisfied`) with **no exception**, so an agent gating a requirements layer on `fslc verify`'s exit code passes a broken seam green.
- `skills/fsl/SKILL.md:460`'s diagnostic table keyed its row on `implements.result: violated` — a value the verdict vocabulary **never produces** (`refines` / `refinement_failed` / `impl_violated`, `rust/fslc/src/verification_output.rs:256-273`), so searching the JSON for `violated` misses the seam too.
- `skills/fsl-delivery/SKILL.md:89`'s Requirements stage gate reads as "running verify covers the seam"; its and `skills/fsl-requirements`'s "a green `implements`" claim-discipline lines never define what green means operationally.

## Contract change

None — documentation only, no behavior touched. The skills now state the exception, name the real verdict vocabulary, and say to assert `implements.result == "refines"` (or gate with `fslc chain`) instead of relying on the exit code.

Files: `skills/fsl/SKILL.md`, `skills/fsl/reference.md`, `skills/fsl-delivery/SKILL.md`, `skills/fsl-requirements/SKILL.md`, `CHANGELOG.md`.

## Test evidence

Measured on this branch's working tree (v4.0.0, debug `fslc`):

| Command | Result | Exit |
|---|---|---|
| `fslc check tests/fixtures/chain/requirements_broken_implements.fsl` | `ok` + `implements.result: refinement_failed` | 0 |
| `fslc verify` same file `--depth 8` | `verified` + same nested verdict | 0 |
| `fslc chain tests/fixtures/chain/fsl-project-broken-implements.toml` | `violated`, layer `requirements` failed | 1 |
| `fslc chain tests/fixtures/chain/fsl-project.toml` | `verified` | 0 |
| `fslc refine examples/gallery/errors/refinement_failed_{impl,abs,map}.fsl --depth 4` | `refinement_failed` | 1 |

Doc-contract tests that read `skills/fsl/reference.md` still pass:

```
cargo test -p fslc-rust --test causal_docs_contract --test mutation_docs_contract --locked
  → 2 passed / 3 passed
```

## Follow-up not in this PR

`docs/LANGUAGE.md` §`implements` (line ~1953) documents that verify "also runs the refine … and the result carries `implements: {abs, result}`" but likewise never states the exit-code consequence, while the `fslc refine` section right above it does (`Violation: refinement_failed (exit 1)`). Aligning the canonical manual — or making `check`/`verify` exit 1 on a failed seam, which is a breaking change — is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
