### PR TITLE
docs(language): put the inline `implements` exit-code exception in LANGUAGE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `implements.result == "refines"` rather than relying on the exit code. Only
   `docs/DESIGN-design-family.md` ("treat `implements.result != refines` as
   failure even when the top-level process exits zero") had carried this, and
-  it never reached the skills or `docs/LANGUAGE.md`.
+  it never reached the skills or `docs/LANGUAGE.md`. `docs/LANGUAGE.md` and
+  `docs/LANGUAGE.ja.md` now state it too, beside the `implements` description
+  and naming it the one exception to their exit-code table: the skills derive
+  from the language contract, so recording it only in the skills would leave
+  the canonical source still claiming the contract holds without exception.
 - `rust/fslc/tests/corpus_check_sweep.rs`'s module doc claimed (per issue
   #483) that "the gallery fixtures and `examples/refinement_liveness/*`"
   are refined by a test; only 6 of the 28 `refinement`-dialect corpus files

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1904,7 +1904,16 @@ verify {
   宣言的な射影です。ghost のカウンターや自動の `_kpi_*` invariant を作ることは
   ありません。
 - `implements` があると、`fslc verify` は**上位レイヤーへの refine も同時に実行**
-  し、結果は `implements: {abs, result}` を運びます。空のボディ
+  し、結果は `implements: {abs, result}` を運びます。値は
+  `refines` / `refinement_failed` / `impl_violated` のいずれかです。**この判定は
+  このフィールドにしか現れません。トップレベルの `result` にも exit code にも
+  畳み込まれない**ため、seam が壊れていても `result:"ok"`/`"verified"` と exit 0 を
+  返します — 上の exit code 表の唯一の例外であり、`implements` が表に無い理由です。
+  `implements.result == "refines"` でゲートするか、`fslc chain` を使ってください
+  (chain はまさにこのゲートをレイヤーに適用し exit 1 します。
+  `docs/DESIGN-design-family.md` がオーケストレータ向けに同じ規則を述べています)。
+  スタンドアロンの `fslc refine` は `refinement_failed` で exit 1 します。
+  黙るのはインラインの seam だけです。空のボディ
   (`implements X from "..." { }`)は、process/action/stage の名前が一致するとき、
   恒等の refinement を自動生成します。`implements { }` ブロックの内側には、状態の
   `map` エントリ、`maps auto`、`preserve progress`、そして — #73 以降 —

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1959,7 +1959,16 @@ verify {
   business and requirements. It does not create a ghost counter or an automatic
   `_kpi_*` invariant.
 - With `implements`, `fslc verify` **also runs the refine to the upper layer
-  simultaneously**, and the result carries `implements: {abs, result}`. An empty
+  simultaneously**, and the result carries `implements: {abs, result}`, whose
+  values are `refines` / `refinement_failed` / `impl_violated`. **That verdict is
+  reported only in this field. It is not folded into the top-level `result` or
+  the exit code**, so a broken seam still returns `result:"ok"`/`"verified"` and
+  exit 0 — the one exception to the exit-code table above, and the reason
+  `implements` has no row in it. Gate on `implements.result == "refines"`, or run
+  `fslc chain`, which applies exactly that gate to the layer and exits 1
+  (`docs/DESIGN-design-family.md` states the same rule for orchestrators).
+  Standalone `fslc refine` does exit 1 on `refinement_failed`; only the inline
+  seam is silent. An empty
   body (`implements X from "..." { }`) auto-generates identity refinement when
   process/action/stage names match. Inside the `implements { }` block you write
   state `map` entries, `maps auto`, `preserve progress`, and — since #73 —


### PR DESCRIPTION
Follow-up to #604.

## Problem

#604 established that the inline `implements` seam's verdict never reaches the
top-level `result` or the exit code, and recorded it in three skill files. Its
own changelog entry says:

> Only `docs/DESIGN-design-family.md` had carried this, and it never reached the
> skills or **`docs/LANGUAGE.md`**.

It then updated only the skills. `docs/LANGUAGE.md:1961` still describes
`implements` without mentioning the exit code, so the canonical contract
presents its exit-code table as holding without exception while the derived
skill documents carry the correction.

`AGENTS.md` puts `docs/LANGUAGE.md` above the skills in the evidence order, and
its coupling rule moves `skills/fsl/reference.md` together with
`docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md`. #604 moved `reference.md` alone.

## Change

Both language files now state, beside the `implements` description:

- the verdict is reported **only** in the `implements` field;
- its values are `refines` / `refinement_failed` / `impl_violated`;
- a broken seam still returns `result:"ok"`/`"verified"` and exit 0 — the one
  exception to the exit-code table above;
- gate on `implements.result == "refines"`, or run `fslc chain`;
- **standalone `fslc refine` does exit 1 on `refinement_failed`; only the inline
  seam is silent.**

That last point is the disambiguation a reader most needs: `refinement_failed`
already appears in the table's exit-1 row, so without it the natural reading is
that the inline seam exits 1 too.

## Verification

`fslc chain` really does apply the gate the text now recommends —
`chain_layer_passes` in `rust/fslc/src/main.rs` reads
`implements` → `result` and fails the layer when it is not `refines`. The advice
points at something that works rather than at an assumed behaviour.

Section counts stay 18/18, so `tools/build_site_reference.py`'s 1:1 alignment
check is satisfied. (It cannot run locally here — `ModuleNotFoundError: markdown`
— unrelated to this change; CI has the dependency.)

Documentation only. No code, schema, or exit-code behaviour changes.