### PR TITLE
fix(strict-tags): point the untagged hint at the canonical requirement tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,29 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   exit-code class (0 vs non-zero) to agree for every corpus file.
 
 ### Fixed
+- `--strict-tags`' `untagged` hint proposed the non-canonical form. It read
+  `add a declaration tag such as "REQ-1: original requirement"; use "MODEL: ..."
+  or "ASSUME-1: ..."` — the `"ID: text"` string slot that
+  `docs/DESIGN-id-policy.md` classifies as migration input and that `fslc lint`
+  reports as `legacy_string_metadata` with a machine-applicable
+  `@requirement(...)` replacement. The diagnostic that fires at the exact moment
+  an author is choosing a tag was therefore teaching the form the next gate
+  rejects, which no amount of documentation elsewhere can outweigh. The hint now
+  names `@requirement("REQ-SCOPE-001", "original requirement")`, the
+  `MODEL-`/`ASSUME-`prefixed id for modeling intent, and process `covers` for the
+  business/requirements dialects. Native only; the frozen Python reference keeps
+  its wording, and no parity gate, test, or snapshot compares this string.
+- The agent skills now state that typed link as the only canonical form.
+  `skills/fsl/SKILL.md` had a worked example writing
+  `invariant OnePerUser "ASSUME-1: ..."`, `skills/fsl-design/SKILL.md` — the
+  design layer's own skill, where a design declaration links back to a
+  requirement ID the requirements spec owns — said nothing about requirement
+  links at all, and `@requirement` appeared nowhere outside the on-demand
+  `reference.md`. The skills' tagging gate was `--strict-tags` alone, which only
+  asks whether a tag exists: it counts a legacy string as tagged. `fslc lint`,
+  the command that actually rejects the non-canonical form, was named in no
+  skill; it is now part of the gate in `fsl/SKILL.md`, `fsl-design`,
+  `fsl-requirements`, and `fsl-delivery`.
 - `fslc db check` reported `result:"verified_under_assumptions"` alongside a
   non-zero exit whenever its nested kernel `verify` came back
   `unknown_cti`/`reachable_failed`/`unknown_budget` (issue #600).

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5640,7 +5640,12 @@ fn strict_tag_warnings(
     requirements: Option<&Path>,
 ) -> Result<Vec<Value>, String> {
     let mut warnings = Vec::new();
-    let hint = "add a declaration tag such as \"REQ-1: original requirement\"; use \"MODEL: ...\" or \"ASSUME-1: ...\" when this is modeling intent";
+    // The hint names the canonical link form from `docs/DESIGN-id-policy.md`.
+    // It used to propose the `"REQ-1: original requirement"` string slot, which
+    // that policy classifies as non-canonical migration input and `fslc lint`
+    // reports as `legacy_string_metadata` — so the repair this diagnostic asked
+    // for was the one the next gate rejects.
+    let hint = "tag the declaration with a typed annotation such as @requirement(\"REQ-SCOPE-001\", \"original requirement\"); use a MODEL-/ASSUME-prefixed id for modeling intent, or process `covers` in the business/requirements dialects. The legacy \"REQ-1: text\" string slot is non-canonical (fslc lint reports it as legacy_string_metadata)";
     for (element, name, span, annotations) in model
         .actions
         .iter()

--- a/rust/fslc/tests/fixtures/untagged_hint_canonical.fsl
+++ b/rust/fslc/tests/fixtures/untagged_hint_canonical.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The repair the `untagged` hint asks for, written out: the typed annotation
+// from `docs/DESIGN-id-policy.md`, including the MODEL-prefixed id the hint
+// offers for modeling intent. Both gates must accept this file.
+spec UntaggedHintCanonical {
+  state { n: 0..3 }
+  init { n = 0 }
+
+  @requirement("MODEL-COUNTER-001", "the counter is modeled as a bounded integer")
+  invariant Bounded { n <= 3 }
+
+  @requirement("REQ-COUNTER-001", "the counter can advance")
+  action bump() {
+    requires n < 3
+    n = n + 1
+  }
+}

--- a/rust/fslc/tests/fixtures/untagged_hint_legacy.fsl
+++ b/rust/fslc/tests/fixtures/untagged_hint_legacy.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The repair the hint used to ask for: the `"ID: text"` string slot.
+// `--strict-tags` accepts it as tagged; `fslc lint` rejects it as
+// `legacy_string_metadata`. This file is the negative control that keeps the
+// hint from drifting back to a form the next gate refuses.
+spec UntaggedHintLegacy {
+  state { n: 0..3 }
+  init { n = 0 }
+
+  invariant Bounded "REQ-COUNTER-001: the counter never leaves its bound" { n <= 3 }
+
+  action bump() "REQ-COUNTER-002: the counter can advance" {
+    requires n < 3
+    n = n + 1
+  }
+}

--- a/rust/fslc/tests/fixtures/untagged_hint_untagged.fsl
+++ b/rust/fslc/tests/fixtures/untagged_hint_untagged.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Every declaration is untagged, so `check --strict-tags` emits one `untagged`
+// warning per declaration and the hint under test rides on each of them.
+spec UntaggedHintSubject {
+  state { n: 0..3 }
+  init { n = 0 }
+
+  invariant Bounded { n <= 3 }
+
+  action bump() {
+    requires n < 3
+    n = n + 1
+  }
+}

--- a/rust/fslc/tests/untagged_hint_names_canonical_tag.rs
+++ b/rust/fslc/tests/untagged_hint_names_canonical_tag.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! `--strict-tags`' `untagged` hint must name the canonical requirement link.
+//!
+//! The hint fires at the exact moment an author is choosing a tag, so it is
+//! the most load-bearing sentence FSL emits about ID form. It used to propose
+//! `add a declaration tag such as "REQ-1: original requirement"; use
+//! "MODEL: ..." or "ASSUME-1: ..."` — the `"ID: text"` string slot that
+//! `docs/DESIGN-id-policy.md` classifies as non-canonical migration input and
+//! that `fslc lint` rejects as `legacy_string_metadata`. Following the
+//! diagnostic produced a spec the next gate refuses.
+//!
+//! Nothing tested the hint's text, so the two gates could disagree
+//! indefinitely. These tests pin the contract from both sides: the hint names
+//! the typed annotation, that annotation clears `--strict-tags` *and* `lint`,
+//! and the legacy form it used to propose is the negative control — accepted
+//! by `--strict-tags`, rejected by `lint`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+/// The retired proposal. Named here so a revert cannot pass silently.
+const LEGACY_PROPOSAL: &str = "REQ-1: original requirement";
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn fixture(name: &str) -> String {
+    format!("rust/fslc/tests/fixtures/untagged_hint_{name}.fsl")
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {args:?}`: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit code"))
+}
+
+fn untagged_warnings(envelope: &Value) -> Vec<Value> {
+    envelope["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .filter(|warning| warning["kind"] == "untagged")
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn untagged_hint_proposes_the_typed_annotation_and_not_the_string_slot() {
+    let (envelope, status) = run(&["check", &fixture("untagged"), "--strict-tags"]);
+    assert_eq!(envelope["result"], "ok");
+    assert_eq!(status, 0);
+
+    let warnings = untagged_warnings(&envelope);
+    assert_eq!(warnings.len(), 2, "one per declaration: {warnings:?}");
+    for warning in &warnings {
+        let hint = warning["hint"].as_str().expect("hint string");
+        assert!(
+            hint.contains(r#"@requirement("REQ-SCOPE-001""#),
+            "hint must name the canonical annotation: {hint}"
+        );
+        assert!(
+            hint.contains("MODEL-/ASSUME-prefixed id"),
+            "hint must keep the modeling-intent roles in canonical form: {hint}"
+        );
+        assert!(
+            !hint.contains(LEGACY_PROPOSAL),
+            "hint must not propose the non-canonical string slot: {hint}"
+        );
+    }
+}
+
+#[test]
+fn the_hinted_repair_clears_both_tagging_gates() {
+    let (envelope, status) = run(&["check", &fixture("canonical"), "--strict-tags"]);
+    assert_eq!(status, 0);
+    assert!(
+        untagged_warnings(&envelope).is_empty(),
+        "typed annotations must count as tagged: {envelope:?}"
+    );
+
+    let (lint, lint_status) = run(&["lint", &fixture("canonical")]);
+    assert_eq!(lint["finding_count"], 0, "{lint:?}");
+    assert_eq!(lint_status, 0);
+}
+
+#[test]
+fn the_previously_hinted_form_is_accepted_by_strict_tags_and_rejected_by_lint() {
+    // The asymmetry that let the old hint survive: `--strict-tags` only asks
+    // whether a tag exists, so it cannot be the gate that catches ID form.
+    let (envelope, status) = run(&["check", &fixture("legacy"), "--strict-tags"]);
+    assert_eq!(status, 0);
+    assert!(
+        untagged_warnings(&envelope).is_empty(),
+        "strict-tags counts the legacy string as tagged: {envelope:?}"
+    );
+
+    let (lint, lint_status) = run(&["lint", &fixture("legacy")]);
+    assert_eq!(lint_status, 1);
+    let findings = lint["files"][0]["findings"]
+        .as_array()
+        .expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["code"] == "legacy_string_metadata"),
+        "{findings:?}"
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["canonical_replacement"]
+                .as_str()
+                .is_some_and(|replacement| replacement.starts_with("@requirement("))),
+        "lint's replacement is the form the hint now names: {findings:?}"
+    );
+}

--- a/skills/fsl-delivery/SKILL.md
+++ b/skills/fsl-delivery/SKILL.md
@@ -95,6 +95,10 @@ For every layer, also run:
 
 - `fslc verify <file> --strict-tags` (traceability — untagged declarations and
   unreferenced requirement IDs)
+- `fslc lint <file>` (ID form — exits 1 on a non-canonical `"REQ-1: text"`
+  string tag, which `--strict-tags` accepts silently, and on an ID outside the
+  active policy. The canonical link is `@requirement("REQ-SCOPE-001", "text")`,
+  or process `covers` in the business/requirements dialects)
 - `fslc explain <file> --readable` (renders the spec as a readable digest; this is
   the spec's documentation, not a separate report)
 

--- a/skills/fsl-design/SKILL.md
+++ b/skills/fsl-design/SKILL.md
@@ -44,19 +44,30 @@ for a contract decision.
 2. Write the design spec as kernel FSL. It may include internal states, queues,
    outboxes, two-phase operations, retries, and decomposition that are absent from
    requirements, as long as they map back to the upper contract.
-3. Verify the design itself with `fslc check`, `fslc verify`, and usually
-   `fslc verify --engine induction`.
-4. Write the mapping file:
+3. Link every design declaration back to the requirement it serves with the
+   canonical typed annotation, on the line before the declaration:
+   `@requirement("REQ-CHECKOUT-001", "one-sentence intent")` before
+   `invariant PaidLedger { ... }` / `action submit(...) { ... }`. The
+   requirements spec owns the ID (`requirement REQ-CHECKOUT-001`); the design
+   spec only links to it. Use a `MODEL-`/`ASSUME-`prefixed id for a design
+   choice the requirements do not state. **Never use the `"REQ-1: text"` string
+   slot** — `docs/DESIGN-id-policy.md` classifies it as non-canonical migration
+   input and `fslc lint` reports it as `legacy_string_metadata`.
+4. Verify the design itself with `fslc check`, `fslc verify`, and usually
+   `fslc verify --engine induction`. Run `fslc lint <file>` as the tagging
+   gate: it exits 1 on any non-canonical ID form, which `--strict-tags` accepts
+   silently.
+5. Write the mapping file:
    - `map abs_var = expr` or `map abs_var[x: T] = expr`
    - `action impl_action(...) -> abs_action(...)` for visible effects
    - `action impl_action(...) -> stutter` only when the action is confirmed not to
      change abstract observable state
    - `preserve progress { respond AbsLeadsTo by impl_action, ... }` when an
      upper `leadsTo` must be checked through the mapping at refine time
-5. Run `fslc refine design.fsl requirements.fsl mapping.fsl`. Repair by deciding
+6. Run `fslc refine design.fsl requirements.fsl mapping.fsl`. Repair by deciding
    whether the design is wrong, the mapping is wrong, or the upper contract needs
    human revision.
-6. If implementation anchoring is required, run `fslc testgen` and wire the
+7. If implementation anchoring is required, run `fslc testgen` and wire the
    Adapter, or use `fslc replay` against execution logs.
 
 ## Guardrails

--- a/skills/fsl-requirements/SKILL.md
+++ b/skills/fsl-requirements/SKILL.md
@@ -25,9 +25,14 @@ thin spec) and **inventing** a rule the source never stated. Hold both ends:
   transition / invariant / acceptance / forbidden, or is recorded in the memo as
   out-of-scope or needs-decision. The step-1 coverage map forces the hard
   requirements in instead of stopping at the happy path.
-- **Ground the spec.** Every declaration carries provenance — `covers REQ-n "..."`
-  to source text, or a `MODEL:` / `ASSUME-n:` tag for an explicit modeling choice.
-  An untagged declaration is an ungrounded guess, not a style nit.
+- **Ground the spec.** Every declaration carries provenance — process
+  `covers REQ-CHECKOUT-001 "..."` to source text, or the typed annotation
+  `@requirement("REQ-CHECKOUT-001", "...")` on a declaration that links to an ID
+  a `requirement` block owns, with a `MODEL-`/`ASSUME-`prefixed id for an
+  explicit modeling choice. Those two are the canonical forms
+  (`docs/DESIGN-id-policy.md`); the `"REQ-1: text"` string slot is non-canonical
+  migration input, so never write it. An untagged declaration is an ungrounded
+  guess, not a style nit.
 - **Do not invent to reach green.** If `check`/`verify` needs a guard, bound,
   state, actor, deadline, or exception the source does not state, that is a step-1
   question for the human — not a default you may pick to reach `verified`.
@@ -72,11 +77,14 @@ skill produced.
    - upper business contract, if any, and candidate `implements` mapping
    - assumptions and questions that affect behavior
 2. Preserve source fidelity. Requirement IDs and verbatim text belong in
-   `covers REQ-n "..."` on process transitions, or in
-   `requirement REQ-n "..."` for kernel-wrapper declarations, so diagnostics and
-   scenarios trace back to the PM document. Tag any declaration that is not a
-   direct source requirement `MODEL:` or `ASSUME-n:` so the strict-tags gate can
-   tell intended modeling from fabrication.
+   `covers REQ-CHECKOUT-001 "..."` on process transitions, or in a
+   `requirement REQ-CHECKOUT-001 "..."` block that owns the ID for kernel-wrapper
+   declarations, so diagnostics and scenarios trace back to the PM document. Any
+   other declaration links to an owned ID with the typed annotation
+   `@requirement("REQ-CHECKOUT-001", "...")` — and one carrying a
+   `MODEL-`/`ASSUME-`prefixed id when it is not a direct source requirement, so
+   the strict-tags gate can tell intended modeling from fabrication. Do not use
+   the non-canonical `"REQ-1: text"` string slot.
 3. Encode only externally observable product behavior. State names should describe
    product/system states, not engineering mechanisms.
 4. Use the process+data profile first for a single-entity lifecycle:
@@ -120,6 +128,10 @@ skill produced.
 9. Run `fslc check --strict-tags` as the faithfulness gate — not done until it
    reports zero `untagged` and zero `unreferenced_requirement` (add
    `--requirements <ids>` from the memo to also catch fully omitted requirements).
+   `--strict-tags` counts a legacy `"REQ-1: text"` string as tagged, so also run
+   `fslc lint <file>`: it exits 1 with `legacy_string_metadata` and a
+   machine-applicable `@requirement(...)` replacement for every non-canonical
+   form, and with `non_canonical_id` for an ID outside the active policy.
    Then `fslc verify`, and for stable requirements
    `fslc verify --engine induction`. Run `fslc scenarios` to hand development the
    acceptance/forbidden skeletons.

--- a/skills/fsl/SKILL.md
+++ b/skills/fsl/SKILL.md
@@ -229,8 +229,10 @@ confirmed assumptions in the `.fsl` itself as comments / tags**:
 
 - Global assumptions → a ledger block at the top of the spec:
   `// ASSUME-1: stock is reserved by only one user at a time`
-- An assumption justifying a specific guard / invariant → tag that declaration:
-  `invariant OnePerUser "ASSUME-1: only one user reserves at a time" { ... }`
+- An assumption justifying a specific guard / invariant → tag that declaration
+  with the canonical typed annotation:
+  `@requirement("ASSUME-STOCK-001", "only one user reserves at a time")` on the
+  line before `invariant OnePerUser { ... }`
 
 This way assumptions travel with the spec, are visible in PRs, and a future
 `--strict-tags` check can distinguish "intended assumptions (tagged)" from
@@ -304,6 +306,15 @@ the formalization memo.**
    (and `--requirements ids.txt` if needed). Only when the result is
    ok/verified/proved do untagged declarations and unreferenced requirement IDs
    become warnings.
+   **The one canonical way to link a declaration to a requirement ID** is the
+   typed annotation on the line before it —
+   `@requirement("REQ-SCOPE-001", "one-sentence intent")` — with process
+   `covers REQ-SCOPE-001 "..."` as the equivalent dialect sugar, and a
+   `MODEL-`/`ASSUME-`prefixed id for modeling intent rather than a source
+   requirement. The `invariant X "REQ-1: text" { ... }` string slot is
+   non-canonical migration input (`docs/DESIGN-id-policy.md`); `--strict-tags`
+   still counts it as tagged, so add `fslc lint file.fsl`, which exits 1 with
+   `legacy_string_metadata` plus a machine-applicable replacement.
 2. `fslc verify file.fsl --depth 8` → see the table below for what each result means
    To ask a bounded operational what-if from a complete `Monitor.state` JSON,
    use `fslc verify file.fsl --from-state state.json --depth 8`; this replaces

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1329,8 +1329,11 @@ substituted default — only an *absent* `depth`/`refine_depth` key defaults.
   ok/verified/proved success results. The targets are untagged
   action/invariant/trans/reachable/leadsTo, and IDs declared via
   `--requirements ids.txt` or a `requirement` block in the requirements dialect but
-  never referenced. A declaration with a tag such as `MODEL: ...` / `ASSUME-n: ...`
-  does not become a warning.
+  never referenced. A declaration linked by `@requirement("MODEL-SCOPE-001", ...)`
+  / `@requirement("ASSUME-SCOPE-001", ...)` does not become a warning. This gate
+  only asks whether a tag exists, not whether it is canonical: a legacy
+  `"REQ-1: text"` string counts as tagged here, and `fslc lint` is what reports
+  it (`legacy_string_metadata`, exit 1, machine-applicable), so run both.
 - `typestate`: determines how far a state machine (a struct field with enum values,
   scoped by field name **and** owning struct type so two structs with a same-named
   field stay independent machines / a state variable / an `Option<_>` slot) can be


### PR DESCRIPTION
## Problem

Agents authoring FSL keep writing the non-canonical requirement tag — `invariant X "REQ-1: text" { ... }` — instead of the canonical typed annotation. The cause is not (only) missing documentation: **fslc itself recommends the wrong form, at the exact moment the author is choosing one.**

`fslc check spec.fsl --strict-tags` on an untagged declaration returns:

```json
{"kind":"untagged","element":"action","name":"bump",
 "hint":"add a declaration tag such as \"REQ-1: original requirement\";
         use \"MODEL: ...\" or \"ASSUME-1: ...\" when this is modeling intent"}
```

That `"ID: text"` string slot is exactly what `docs/DESIGN-id-policy.md` (Accepted) classifies as non-canonical migration input, and what `fslc lint` rejects:

```
legacy_string_metadata / "legacy string metadata is deprecated; use a typed annotation"
canonical_replacement: @requirement("REQ-COUNTER-001", "…")   machine_applicable: true   exit 1
```

So the repair one gate asks for is the one the next gate refuses. Nothing kept them consistent: `--strict-tags` only asks *whether a tag exists* (a legacy string counts as tagged), and no test read the hint's text.

The skills carried the same defect from the other end:

- `skills/fsl/SKILL.md` had a worked example writing `invariant OnePerUser "ASSUME-1: only one user reserves at a time" { ... }`.
- `skills/fsl-design/SKILL.md` — the design layer's own skill, where a declaration links back to a REQ id the requirements spec owns — said **nothing** about requirement links at all.
- `@requirement` appeared nowhere outside the on-demand `skills/fsl/reference.md`.
- `fslc lint`, the only command that rejects the non-canonical form, was named in **no** skill.

Corpus reinforcement, for context: `@requirement` appears in 4 `.fsl` files (all `examples/annotations/` feature demos); the legacy string appears in 8 (`examples/nfr/`, `examples/agentic_rag/`, `examples/named_predicate.fsl`, …).

## Contract change

The `untagged` hint's text. It now names `@requirement("REQ-SCOPE-001", "original requirement")`, the `MODEL-`/`ASSUME-`prefixed id for modeling intent, and process `covers` for the business/requirements dialects. Verdicts, `kind`, `loc`, exit codes, and which declarations warn are unchanged.

Native only. The frozen Python reference (`src/fslc/model.py:1454`) keeps its wording — no parity gate, test, or snapshot compares this string, so no compatibility decision requires both to move.

Skills: `fsl/SKILL.md`, `fsl/reference.md`, `fsl-design`, `fsl-requirements`, `fsl-delivery` now state the typed annotation as the only canonical link, and add `fslc lint` to the tagging gate alongside `--strict-tags`.

## Test evidence

New: `rust/fslc/tests/untagged_hint_names_canonical_tag.rs` (3 tests) with 3 fixtures.

| Test | Asserts |
|---|---|
| `untagged_hint_proposes_the_typed_annotation_and_not_the_string_slot` | every hint contains `@requirement("REQ-SCOPE-001"` and the `MODEL-/ASSUME-` role, and does **not** contain the retired `REQ-1: original requirement` proposal |
| `the_hinted_repair_clears_both_tagging_gates` | writing what the hint asks for → 0 `untagged` warnings **and** `lint` `finding_count: 0` / exit 0 |
| `the_previously_hinted_form_is_accepted_by_strict_tags_and_rejected_by_lint` | negative control: legacy form → `--strict-tags` sees no `untagged`, `lint` exits 1 with `legacy_string_metadata` and an `@requirement(`-prefixed `canonical_replacement` |

Mutation check (the test detects drift, it does not merely pass): restoring the old hint string makes `untagged_hint_proposes_the_typed_annotation_and_not_the_string_slot` fail and nothing else — 2 passed, 1 failed. Hint restored afterwards.

Gates:

```
cargo test -p fslc-rust --locked            → all green (exit 0)
cargo fmt --all -- --check                  → clean
cargo clippy -p fslc-rust --all-targets -- -D warnings → clean
```

## Not in this PR

The 8 corpus `.fsl` files still using the legacy string. `fslc lint`'s fix is machine-applicable (`fslc migrate --edition next` converts it), but that is a separate, larger diff — and it is what an agent reads for imitation, so it is worth doing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
