### PR TITLE
feat(tests): calibrate implementation fault operators (#537 C5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,30 @@ jobs:
         working-directory: rust
         run: cargo test --locked -p fsl-solver-z3 -p fsl-verifier -p fslc-rust
 
+  # Implementation fault operators (#537 C5,
+  # `docs/DESIGN-conformance-harness.md`). Post-merge only: the harness patches
+  # a scratch checkout and rebuilds `fslc` there once per operator, and the
+  # design puts that rebuild cost outside the phase every pull request runs.
+  # It is still required evidence — `product gate` below fails when this job
+  # does, because a detector matrix that never runs is worse than one that
+  # skips: it rots into decoration while reading green.
+  fault-operators:
+    name: fault operators
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Calibrate implementation fault operators
+        run: ./tools/check-native-integration.sh fault-operators
+
   product-gate:
     name: product gate
     if: >-
@@ -153,6 +177,7 @@ jobs:
       - wasm
       - rust-native-z3
       - production-native-z3-linux
+      - fault-operators
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -162,7 +187,9 @@ jobs:
           WASM: ${{ needs.wasm.result }}
           NATIVE_Z3: ${{ needs.rust-native-z3.result }}
           PRODUCTION_NATIVE_Z3_LINUX: ${{ needs.production-native-z3-linux.result }}
+          FAULT_OPERATORS: ${{ needs.fault-operators.result }}
           BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
         shell: bash
         run: |
           failures=0
@@ -174,7 +201,14 @@ jobs:
           if [ "$BASE_REF" = "production" ] && [ "$PRODUCTION_NATIVE_Z3_LINUX" != "success" ]; then
             failures=1
           fi
+          # `fault-operators` is post-merge only, so it is legitimately skipped
+          # on pull requests and required everywhere else. Keyed on the same
+          # condition the job carries, so a job that silently stopped running
+          # cannot pass as "skipped on purpose".
+          if [ "$EVENT_NAME" != "pull_request" ] && [ "$FAULT_OPERATORS" != "success" ]; then
+            failures=1
+          fi
           if [ "$failures" -ne 0 ]; then
-            echo "product gate failed: rust=$RUST_WORKSPACE wasm=$WASM native-z3=$NATIVE_Z3 production-linux=$PRODUCTION_NATIVE_Z3_LINUX" >&2
+            echo "product gate failed: rust=$RUST_WORKSPACE wasm=$WASM native-z3=$NATIVE_Z3 production-linux=$PRODUCTION_NATIVE_Z3_LINUX fault-operators=$FAULT_OPERATORS" >&2
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,29 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   fails loudly instead of exiting 0, which is how #554 arose. Cacheability
   stays a separate predicate (`verify_cache_admits`), because `violated` is
   failure-class *and* cacheable.
+- `rust/fslc/tests/fault_operators/` and `tools/run-fault-operators.sh`:
+  implementation fault operators (issue #537 C5,
+  `docs/DESIGN-conformance-harness.md`). `injection_detector_matrix.rs`
+  calibrates detectors against defective *specs*; this answers the other
+  question — would the test suite notice if the *verifier* started lying?
+  Every escaped defect in the 2026-07 batch was of that kind (#601's
+  `_ => 0`, #600's `violated`-only fold, #496's dropped explicit input), and
+  none of them lives in a `.fsl` file. Each operator is a **patch file, not
+  code**: the harness copies the working tree to a scratch checkout, applies
+  one minimal diff, rebuilds `fslc` there, and requires that operator's
+  primary detector to fail while its blind detector still passes. No
+  fault-injection hook exists in the shipped binary, under a feature flag or
+  otherwise — a switch that makes a verifier lie about verdicts must not exist
+  in the codebase whose purpose is to prevent exactly that. Two controls make
+  the matrix readable rather than decorative: a no-op patch must leave every
+  named detector green, and a stale-seam patch must be *refused*, which keeps
+  "a patch that no longer applies is a loud failure, never a skip" verified
+  instead of merely intended. Wired into `tools/check-native-integration.sh`
+  as its own `fault-operators` phase, part of `all` and deliberately not part
+  of `rust`, which every pull request runs. Adding an operator is a patch file
+  plus one row in `operators.txt` — data, no harness code, and `CONTRIBUTING.md`
+  now asks for one whenever a fixed escaped defect's class can recur at a
+  sibling seam.
 - `rust/fslc/tests/issue_600_db_check_folds_kernel_verdict.rs` and
   `rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl`: the
   rejecting control for #600 below, plus a guard test that fails loudly if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   "a patch that no longer applies is a loud failure, never a skip" verified
   instead of merely intended. Wired into `tools/check-native-integration.sh`
   as its own `fault-operators` phase, part of `all` and deliberately not part
-  of `rust`, which every pull request runs. Adding an operator is a patch file
-  plus one row in `operators.txt` — data, no harness code, and `CONTRIBUTING.md`
-  now asks for one whenever a fixed escaped defect's class can recur at a
-  sibling seam.
+  of `rust`, which every pull request runs. CI runs it as its own post-merge
+  `fault operators` job, required by the `product gate` aggregator: a matrix
+  that never runs is worse than one that skips, because it rots into decoration
+  while reporting green. Adding an operator is a patch file plus one row in
+  `operators.txt` — data, no harness code, and `CONTRIBUTING.md` now asks for
+  one whenever a fixed escaped defect's class can recur at a sibling seam.
+  One blind detector is the public Kernel v2 golden contract, whose
+  `spec.source.file` is repository-relative; naming it makes the no-op control
+  prove the scratch checkout is a *faithful* copy, not merely a compiling one.
+  It caught the first such infidelity immediately: `portable_cli_source_path`
+  finds the repository root by walking ancestors for a `.git`, and a scratch
+  tree without one escaped upward into the enclosing worktree, prefixing every
+  such path with `rust/target/fault-operators/checkout/`. The harness now gives
+  the scratch tree a repository root of its own.
 - `rust/fslc/tests/issue_600_db_check_folds_kernel_verdict.rs` and
   `rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl`: the
   rejecting control for #600 below, plus a guard test that fails loudly if

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,11 @@ inventory and explicitly optional Python surfaces.
   explicit compatibility reason and focused regression evidence.
 - **Generated artifacts:** never hand-edit compatibility snapshots or generated site output. Use the
   owning generator and review the diff.
+- **A fixed escaped defect:** when its defect class can recur at a sibling seam, add an operator to
+  `rust/fslc/tests/fault_operators/` — a patch file plus one row in `operators.txt` naming the primary
+  detector that must fail under it and a blind detector that must not. `tools/run-fault-operators.sh`
+  then proves not only that the defect is gone but that the suite would notice its return. Run it with
+  `./tools/check-native-integration.sh fault-operators`.
 
 Use repository-relative paths in committed text and examples. New source files require the Apache-2.0
 SPDX header used by neighboring files. Rust must remain formatted, Clippy-clean, and free of unsafe code.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -85,11 +85,22 @@ parallel:
 - the complete Rust-native integration phase from `tools/check-native-integration.sh rust`
   (`rust workspace`);
 - the production WASM/browser phase from `tools/check-native-integration.sh wasm` (`WASM`);
-- focused native-Z3 tests on macOS and Windows (`native Z3 4.16`).
+- focused native-Z3 tests on macOS and Windows (`native Z3 4.16`);
+- the implementation fault operators from `tools/check-native-integration.sh fault-operators`
+  (`fault operators`).
 
 **The first two carry no event condition and therefore also run on every pull request**, which is
 what makes the Linux evidence pre-merge. Only `native Z3 4.16` and the aggregate `product gate`
 context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into `main`.
+
+`fault operators` is the one job that never runs on a pull request, under any variable: it patches a
+scratch checkout and rebuilds `fslc` there once per operator, and
+[`DESIGN-conformance-harness.md`](DESIGN-conformance-harness.md) puts that rebuild cost outside the
+per-pull-request phase. It is still required evidence everywhere else. The aggregator keys its
+requirement on the same `github.event_name != 'pull_request'` condition the job carries, so a
+`fault operators` job that stopped running for any other reason fails the gate instead of reading as
+a deliberate skip — a detector matrix that never runs is worse than one that skips, because it rots
+into decoration while reporting green.
 
 Scheduled and manual runs use the same evidence. Pull requests into `production` also run the
 complete product gate and emit the Linux native-Z3 compatibility context expected by the production

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -253,11 +253,22 @@ inconsistencies, not spec properties. The guard is defensive depth against a
 verifier fault, not a reachable behavior, so no fixture can calibrate it and an
 operator for it would only ever report "primary did not fail". An operator whose
 fault is unobservable is not a missing detector; it is a fault that does not
-exist yet. Recorded as #610 instead, in the shape #594 and #601 use.
+exist yet. No issue tracks it: an issue asserts there is work to do, and there
+is none — the guard is correct, defensive, and consistent with its
+`run_domain_check` sibling. This paragraph is the record.
 
 This is the distinction the harness has to keep making. "No test covers this
 line" and "no input can reach this line" look identical from a coverage report
 and are opposite conclusions.
+
+Tell them apart the way this one was told apart, before writing either an
+operator or the test you think is missing: patch the seam to its defective form
+and run the *whole* `fslc` suite, not the one test you expect to own it. A single
+test staying green says only that this test does not cover the seam. The whole
+suite staying green — with the pre-existing failures subtracted, since a suite
+that is already red proves nothing either way — says no input reaches it, and
+the honest output is a recorded measurement rather than a new operator or a
+fixture nobody can build.
 
 ## Coupled changes
 

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -253,7 +253,7 @@ inconsistencies, not spec properties. The guard is defensive depth against a
 verifier fault, not a reachable behavior, so no fixture can calibrate it and an
 operator for it would only ever report "primary did not fail". An operator whose
 fault is unobservable is not a missing detector; it is a fault that does not
-exist yet. Recorded as an issue instead, in the shape #594 and #601 use.
+exist yet. Recorded as #610 instead, in the shape #594 and #601 use.
 
 This is the distinction the harness has to keep making. "No test covers this
 line" and "no input can reach this line" look identical from a coverage report

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -222,7 +222,10 @@ the rebuild is that crate plus a relink rather than the workspace.
 The harness is `tools/run-fault-operators.sh`, reached as the
 `fault-operators` phase of `tools/check-native-integration.sh` and included in
 its `all` — deliberately not in its `rust` phase, which `.github/workflows/ci.yml`
-runs on every pull request. Operators are rows in
+runs on every pull request. CI runs it as its own post-merge `fault operators`
+job, required by the `product gate` aggregator (`docs/DESIGN-ci.md` "Product
+gate contract"): a matrix that never runs is worse than one that skips, so
+"not on pull requests" must not become "nowhere". Operators are rows in
 `rust/fslc/tests/fault_operators/operators.txt`, each naming a patch file, a
 primary detector, and a blind detector; the two controls are
 `controls/no-op.patch` and `controls/stale-seam.patch`. Adding an operator is a
@@ -238,13 +241,23 @@ status-guard half (`!= 0 && != 1`) folds a status-1 kernel identically to
 `issue_600_db_check_folds_kernel_verdict` actually detects. Both are the kind of
 mis-attribution a matrix that never runs its own negative side would have kept.
 
-That second measurement also names an uncovered seam: reverting `run_db_check`'s
-status guard to `== 2` leaves all three tests in
-`issue_600_db_check_folds_kernel_verdict.rs` green, because the file's only
-verbatim-return case (`db_check_returns_a_spec_error_envelope_verbatim`) returns
-at `parse_surface_document` and never reaches the guard. A `kind:"internal"`
-(status 3) kernel envelope absorbed as a `dbsystem` verdict would therefore go
-unnoticed. That is a fourth operator waiting on a detector to calibrate.
+#600's status guard is deliberately **not** a fourth operator, and the reason is
+itself a measurement. Reverting `run_db_check`'s guard to `== 2` and running the
+whole `fslc` suite fails nothing: the two guards differ only for a kernel status
+outside {0,1,2}, and inside `run_db_check` no `.fsl` input can produce one.
+`check_db` calls `validate_db` first, so every input `run_verify` would reject
+with status 2 is already rejected before the kernel runs; `run_verify`'s
+remaining non-{0,1} exits are status 3 from `Z3Solver::new`, from
+`replay_bmc_witnesses`, and from `render_explicit_output` — internal
+inconsistencies, not spec properties. The guard is defensive depth against a
+verifier fault, not a reachable behavior, so no fixture can calibrate it and an
+operator for it would only ever report "primary did not fail". An operator whose
+fault is unobservable is not a missing detector; it is a fault that does not
+exist yet. Recorded as an issue instead, in the shape #594 and #601 use.
+
+This is the distinction the harness has to keep making. "No test covers this
+line" and "no input can reach this line" look identical from a coverage report
+and are opposite conclusions.
 
 ## Coupled changes
 

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -253,9 +253,19 @@ inconsistencies, not spec properties. The guard is defensive depth against a
 verifier fault, not a reachable behavior, so no fixture can calibrate it and an
 operator for it would only ever report "primary did not fail". An operator whose
 fault is unobservable is not a missing detector; it is a fault that does not
-exist yet. No issue tracks it: an issue asserts there is work to do, and there
-is none — the guard is correct, defensive, and consistent with its
-`run_domain_check` sibling. This paragraph is the record.
+exist yet. The unreachability itself needs no issue: an issue asserts there is
+work to do, and for that there is none — the guard is correct, defensive, and
+consistent with its `run_domain_check` sibling. This paragraph is the record.
+
+What #610 does track is a different obligation the measurement surfaced:
+`run_db_check` and `run_domain_check` carry the *same* predicate in two places,
+and #600 exists because someone maintained one of them and not the other. That
+duplication is real work whatever the branch's reachability, and it belongs with
+the rest of the outcome vocabulary in `rust/fslc/src/outcome.rs`. Its
+justification is the duplication and the third site that will otherwise repeat
+#600 — not that extracting it would make a fourth operator possible. Building
+test machinery for a fault that cannot occur is the mistake this paragraph
+exists to prevent.
 
 This is the distinction the harness has to keep making. "No test covers this
 line" and "no input can reach this line" look identical from a coverage report

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -219,6 +219,33 @@ Rebuild cost puts this in the product gate (`tools/check-native-integration.sh`)
 not the per-pull-request gate. Operators patch `rust/fslc` where possible, so
 the rebuild is that crate plus a relink rather than the workspace.
 
+The harness is `tools/run-fault-operators.sh`, reached as the
+`fault-operators` phase of `tools/check-native-integration.sh` and included in
+its `all` — deliberately not in its `rust` phase, which `.github/workflows/ci.yml`
+runs on every pull request. Operators are rows in
+`rust/fslc/tests/fault_operators/operators.txt`, each naming a patch file, a
+primary detector, and a blind detector; the two controls are
+`controls/no-op.patch` and `controls/stale-seam.patch`. Adding an operator is a
+patch file and a table row, both data.
+
+Detector naming is measured, not asserted. The first calibration moved two of
+the three intended primaries after the harness showed the named test could not
+fail under the fault: `exit_status`'s failure row is reachable only through
+`mutate_exit_status`, so `corpus_check_sweep`'s conservation law never sees it
+(`issue_554_mutate_exit_status::a_violated_baseline_exits_one` does), and #600's
+status-guard half (`!= 0 && != 1`) folds a status-1 kernel identically to
+`== 2`, so only its verdict-fold half is what
+`issue_600_db_check_folds_kernel_verdict` actually detects. Both are the kind of
+mis-attribution a matrix that never runs its own negative side would have kept.
+
+That second measurement also names an uncovered seam: reverting `run_db_check`'s
+status guard to `== 2` leaves all three tests in
+`issue_600_db_check_folds_kernel_verdict.rs` green, because the file's only
+verbatim-return case (`db_check_returns_a_spec_error_envelope_verbatim`) returns
+at `parse_surface_document` and never reaches the guard. A `kind:"internal"`
+(status 3) kernel envelope absorbed as a `dbsystem` verdict would therefore go
+unnoticed. That is a fourth operator waiting on a detector to calibrate.
+
 ## Coupled changes
 
 `CONTRIBUTING.md` "Adding a language feature" gains: register any new dialect's
@@ -226,9 +253,10 @@ construct and example corpus in `tests/dialect_registry.py` (and any new example
 directory is claimed automatically by the scan — the harness fails until its
 construct is registered).
 
-A fixed escaped defect gains an entry in `rust/fslc/tests/fault_operators/` when
-its defect class can recur at a sibling seam, so the regression test proves not
-only that the defect is gone but that the suite would notice its return.
+`CONTRIBUTING.md` "Guidelines for changes" gains: a fixed escaped defect gains
+an entry in `rust/fslc/tests/fault_operators/` when its defect class can recur
+at a sibling seam, so the regression test proves not only that the defect is
+gone but that the suite would notice its return.
 
 ## Non-goals
 

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -257,7 +257,7 @@ exist yet. The unreachability itself needs no issue: an issue asserts there is
 work to do, and for that there is none — the guard is correct, defensive, and
 consistent with its `run_domain_check` sibling. This paragraph is the record.
 
-What #610 does track is a different obligation the measurement surfaced:
+The measurement did surface a separate obligation, tracked as #612:
 `run_db_check` and `run_domain_check` carry the *same* predicate in two places,
 and #600 exists because someone maintained one of them and not the other. That
 duplication is real work whatever the branch's reachability, and it belongs with

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -176,12 +176,59 @@ inputs.
   `fslc ai`/`db import`/domain replay) are out of scope by extension — the scan
   is `*.fsl` only.
 
+## Implementation fault operators (#537 C5)
+
+`injection_detector_matrix.rs` calibrates detectors against defective *specs*:
+`examples/gallery/injected/*.fsl` are hand-authored, and each names the detector
+that must catch it and one that must stay blind. It answers "can this detector
+see a bad spec?"
+
+C5 asks a different question — "would our test suite notice if the *verifier*
+started lying?" — and needs a different mechanism, because the defect lives in
+Rust, not in a `.fsl` file. Every escaped defect in the 2026-07 batch was of this
+kind: `wrap_specialized`'s `_ => 0` (#601), `run_db_check` folding only
+`violated` (#600), `analyze batch` dropping explicit non-`.fsl` input (#496).
+
+The operators are **patches, not code**. `rust/fslc/tests/fault_operators/` holds
+one minimal diff per operator; the harness applies it to a scratch checkout,
+rebuilds there, runs the test named as that operator's primary detector, and
+**requires that test to fail**. Then it reverts. Nothing is injected at runtime.
+
+No fault-injection hook may exist in the shipped binary, under a feature flag or
+otherwise. For a verifier that is the worst artifact imaginable: a switch that
+makes the product lie about verdicts, in the same codebase whose purpose is to
+prevent exactly that. The mechanism that proves we detect false greens must not
+itself be able to cause one. This is not a cost trade-off, and no build
+convenience overrides it.
+
+Each operator declares a primary detector and a blind detector, reusing
+`injection_detector_matrix.rs`'s discipline: the primary must fail under the
+patch, and the blind must still pass — an operator that breaks everything proves
+nothing about the detector it claims to calibrate.
+
+The harness needs its own negative control. A no-op patch must leave every named
+detector passing; if it does not, the harness reports failure whatever the
+operator does, and every cell in it is meaningless.
+
+A patch that no longer applies is a **loud failure, not a skip**. It means the
+seam it targeted moved, and someone must confirm the fault is still possible
+there and re-target the patch. Silently skipping a stale operator is how a
+detector matrix rots into decoration.
+
+Rebuild cost puts this in the product gate (`tools/check-native-integration.sh`),
+not the per-pull-request gate. Operators patch `rust/fslc` where possible, so
+the rebuild is that crate plus a relink rather than the workspace.
+
 ## Coupled changes
 
 `CONTRIBUTING.md` "Adding a language feature" gains: register any new dialect's
 construct and example corpus in `tests/dialect_registry.py` (and any new example
 directory is claimed automatically by the scan — the harness fails until its
 construct is registered).
+
+A fixed escaped defect gains an entry in `rust/fslc/tests/fault_operators/` when
+its defect class can recur at a sibling seam, so the regression test proves not
+only that the defect is gone but that the suite would notice its return.
 
 ## Non-goals
 

--- a/rust/fslc/tests/fault_operators/controls/no-op.patch
+++ b/rust/fslc/tests/fault_operators/controls/no-op.patch
@@ -1,0 +1,15 @@
+The harness's negative control. It applies, it forces the same `fslc` rebuild
+every operator forces, and it changes no behavior -- so every detector named
+in `operators.txt` must stay green under it. Without this control a harness
+that fails for its own reasons would read as "the operator worked", and every
+cell in the matrix would be meaningless.
+
+--- a/rust/fslc/src/outcome.rs
++++ b/rust/fslc/src/outcome.rs
+@@ -219,5 +219,6 @@
+         // success. Falling through to zero is exactly how #554 arose, and a
+         // poisoned verify-cache entry must not be readable as a pass either.
+         _ => OutcomeClass::Failure,
++        // Fault-operator no-op control: this comment is the whole patch.
+     }
+ }

--- a/rust/fslc/tests/fault_operators/controls/stale-seam.patch
+++ b/rust/fslc/tests/fault_operators/controls/stale-seam.patch
@@ -1,0 +1,15 @@
+A patch that targets a seam which does not exist and never will. The harness
+requires it to be *refused*, which is how the "a stale operator fails loudly,
+it does not skip" property stays verified rather than merely intended. If this
+patch ever applies, the harness has lost the ability to tell a moved seam from
+a live one and every operator below it is decoration.
+
+--- a/rust/fslc/src/outcome.rs
++++ b/rust/fslc/src/outcome.rs
+@@ -1,5 +1,5 @@
+ // A seam this repository has never contained, so that no future edit to
+ // outcome.rs can make this hunk apply by accident.
+-fn a_fault_seam_that_moved_long_ago() -> OutcomeClass {
++fn a_fault_seam_that_moved_long_ago() -> OutcomeClass { unreachable!() }
+     OutcomeClass::Failure
+ }

--- a/rust/fslc/tests/fault_operators/db-check-drops-kernel-verdict.patch
+++ b/rust/fslc/tests/fault_operators/db-check-drops-kernel-verdict.patch
@@ -1,0 +1,16 @@
+Restores the #600 defect: `db check` folds only a `violated` kernel into its
+top-level verdict, so a kernel that came back `unknown_cti` /
+`reachable_failed` / `unknown_budget` is reported as
+`verified_under_assumptions` beside exit 1 -- the envelope contradicts its own
+exit code, and a gate reading the JSON sees a pass.
+
+--- a/rust/fslc/src/main.rs
++++ b/rust/fslc/src/main.rs
+@@ -5943,6 +5943,6 @@
+         // `violated`. Reporting `verified_under_assumptions` over a kernel
+         // that came back `unknown_cti`/`reachable_failed`/`unknown_budget`
+         // made the envelope contradict its own exit code.
+-        let kernel_passed = outcome_class(&kernel).is_success();
++        let kernel_passed = kernel.get("result").and_then(Value::as_str) != Some("violated");
+         if let Value::Object(kernel) = kernel {
+             if !kernel_passed {

--- a/rust/fslc/tests/fault_operators/failure-verdict-exits-zero.patch
+++ b/rust/fslc/tests/fault_operators/failure-verdict-exits-zero.patch
@@ -1,0 +1,16 @@
+Sends row 1 of `docs/LANGUAGE.md`'s exit-code table to zero: a `mutate` whose
+baseline `verify` came back `violated`/`reachable_failed`/`unknown_cti`/
+`unknown_budget` exits 0 while its envelope still reports the failure. A gate
+reading only the exit code sees a pass. This is #554 itself.
+
+--- a/rust/fslc/src/outcome.rs
++++ b/rust/fslc/src/outcome.rs
+@@ -283,7 +283,7 @@
+         // actually carry. The row's remaining members (`nonconformant`,
+         // `refinement_failed`, `sweep_failed`, `observed_mismatch`) belong to
+         // other commands and cannot appear here.
+-        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
++        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 0,
+         // A failure-class value outside this command's vocabulary, or one
+         // nobody registered at all, is an internal inconsistency -- never a
+         // silent success.

--- a/rust/fslc/tests/fault_operators/operators.txt
+++ b/rust/fslc/tests/fault_operators/operators.txt
@@ -17,9 +17,18 @@
 # syntax/diagnostic test the fault has no business reaching. Targets are cargo
 # test-target selectors within `-p fslc-rust` (`--lib`, `--test <name>`).
 #
+# One blind detector is deliberately a golden-contract test
+# (`native_cli_kernel_v2_output_matches_the_origin_golden_contract`). It is
+# blind to all three faults, and it is also the most location-sensitive test in
+# the crate: its golden embeds a repository-relative `spec.source.file`. Naming
+# it here makes the no-op control prove that the scratch checkout is a faithful
+# copy of the working tree, not merely that it compiles -- an infidelity there
+# would make every verdict in this matrix a property of the harness rather than
+# of the fault.
+#
 # A patch that no longer applies is a loud failure, never a skip. It means the
 # seam moved; confirm the fault is still possible there and re-target the diff.
 
 unknown-result-to-success   | unknown-result-to-success.patch   | --lib                                          | outcome::tests::an_unregistered_result_is_failure_class      | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location
 failure-verdict-exits-zero  | failure-verdict-exits-zero.patch  | --test issue_554_mutate_exit_status            | a_violated_baseline_exits_one                                | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location
-db-check-drops-kernel-verdict | db-check-drops-kernel-verdict.patch | --test issue_600_db_check_folds_kernel_verdict | db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location
+db-check-drops-kernel-verdict | db-check-drops-kernel-verdict.patch | --test issue_600_db_check_folds_kernel_verdict | db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict | --test kernel_contract | native_cli_kernel_v2_output_matches_the_origin_golden_contract

--- a/rust/fslc/tests/fault_operators/operators.txt
+++ b/rust/fslc/tests/fault_operators/operators.txt
@@ -1,0 +1,25 @@
+# Implementation fault operators (#537 C5).
+# Read `docs/DESIGN-conformance-harness.md` "Implementation fault operators"
+# before adding a row. Run with `tools/run-fault-operators.sh`.
+#
+# Adding an operator is two data edits and no code:
+#   1. write `<name>.patch` in this directory -- a unified diff against the
+#      repository root, minimal, reproducing one escaped defect class;
+#   2. add one row below.
+#
+# Columns, `|`-separated (surrounding whitespace is trimmed):
+#
+#   operator | patch file | primary target | primary test | blind target | blind test
+#
+# The *primary* detector must FAIL under the patch: it is the test that owns
+# the property the fault violates. The *blind* detector must still PASS: an
+# operator that breaks everything calibrates nothing, so each row names a
+# syntax/diagnostic test the fault has no business reaching. Targets are cargo
+# test-target selectors within `-p fslc-rust` (`--lib`, `--test <name>`).
+#
+# A patch that no longer applies is a loud failure, never a skip. It means the
+# seam moved; confirm the fault is still possible there and re-target the diff.
+
+unknown-result-to-success   | unknown-result-to-success.patch   | --lib                                          | outcome::tests::an_unregistered_result_is_failure_class      | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location
+failure-verdict-exits-zero  | failure-verdict-exits-zero.patch  | --test issue_554_mutate_exit_status            | a_violated_baseline_exits_one                                | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location
+db-check-drops-kernel-verdict | db-check-drops-kernel-verdict.patch | --test issue_600_db_check_folds_kernel_verdict | db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict | --test issue_484_parse_diagnostic_matrix | every_spec_reading_command_reports_a_syntax_error_as_parse_with_a_location

--- a/rust/fslc/tests/fault_operators/unknown-result-to-success.patch
+++ b/rust/fslc/tests/fault_operators/unknown-result-to-success.patch
@@ -1,0 +1,15 @@
+Reinstates the `_ => OutcomeClass::Success` fallthrough `outcome.rs` forbids
+in its module comment. Every unregistered `result` value -- a typo, a value a
+new command forgot to register, a poisoned verify-cache entry -- becomes a
+pass. This is the shape of #554.
+
+--- a/rust/fslc/src/outcome.rs
++++ b/rust/fslc/src/outcome.rs
+@@ -218,6 +218,6 @@
+         // An unregistered value is an internal inconsistency, never a silent
+         // success. Falling through to zero is exactly how #554 arose, and a
+         // poisoned verify-cache entry must not be readable as a pass either.
+-        _ => OutcomeClass::Failure,
++        _ => OutcomeClass::Success,
+     }
+ }

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -32,6 +32,15 @@ check_boundaries() {
   assert_dependency_absent fsl-wasm 'fsl-solver-z3 v' 'fsl-wasm must not depend on the native Z3 backend'
 }
 
+# Implementation fault operators (#537 C5): would the suite notice if the
+# verifier started lying? Deliberately kept out of `check_rust` — it patches a
+# scratch checkout and rebuilds `fslc` there once per operator, and
+# `docs/DESIGN-conformance-harness.md` puts that rebuild cost in the product
+# gate rather than in the phase every pull request runs.
+check_fault_operators() {
+  ./tools/run-fault-operators.sh
+}
+
 check_wasm() {
   npm --prefix rust/spikes/z3js-worker ci
   npm --prefix rust/spikes/z3js-worker run probe
@@ -51,12 +60,16 @@ case "${1:-all}" in
   boundaries)
     check_boundaries
     ;;
+  fault-operators)
+    check_fault_operators
+    ;;
   all)
     check_rust
     check_wasm
+    check_fault_operators
     ;;
   *)
-    echo "usage: $0 [all|rust|wasm|boundaries]" >&2
+    echo "usage: $0 [all|rust|wasm|boundaries|fault-operators]" >&2
     exit 2
     ;;
 esac

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Implementation fault operators (#537 C5). See
+# `docs/DESIGN-conformance-harness.md` "Implementation fault operators".
+#
+# `injection_detector_matrix.rs` asks "can this detector see a bad spec?".
+# This harness asks the other question: would the test suite notice if the
+# *verifier* started lying? The defect lives in Rust, not in a `.fsl` file, so
+# each operator is a **patch file, not code**. Nothing is injected at runtime
+# and no fault-injection hook exists in the shipped binary, under a feature
+# flag or otherwise: a switch that makes a verifier lie about verdicts must not
+# exist in the codebase whose purpose is to prevent exactly that.
+#
+# For each operator the harness copies the working tree to a scratch checkout,
+# applies the patch, rebuilds `fslc` there, and requires the operator's primary
+# detector to fail while its blind detector still passes.
+#
+# Three properties are load-bearing:
+#
+#   1. The no-op control runs first and must leave *every* named detector
+#      green. Without it a harness failing for its own reasons would read as
+#      "the operator worked" and every cell below would be meaningless.
+#   2. The blind detector is measured, not assumed. An operator that breaks
+#      everything proves nothing about the detector it claims to calibrate.
+#   3. A patch that no longer applies is a loud failure, never a skip. The
+#      stale-seam control proves the harness still refuses one.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+operators_dir="$root/rust/fslc/tests/fault_operators"
+table="$operators_dir/operators.txt"
+# Inside `rust/target/`, which is git-ignored and excluded from the copy below,
+# so the scratch tree never dirties the working tree and survives between runs
+# (an unchanged file keeps its mtime, so only the patched crate rebuilds).
+work="$root/rust/target/fault-operators"
+scratch="$work/checkout"
+logs="$work/logs"
+export CARGO_TARGET_DIR="$work/target"
+
+fail() {
+  echo "fault-operators: $*" >&2
+  exit 1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  printf '%s' "${value%"${value##*[![:space:]]}"}"
+}
+
+names=()
+patch_files=()
+primary_targets=()
+primary_tests=()
+blind_targets=()
+blind_tests=()
+
+read_table() {
+  local name patch_file primary_target primary_test blind_target blind_test extra
+  while IFS='|' read -r name patch_file primary_target primary_test blind_target blind_test extra; do
+    name="$(trim "${name:-}")"
+    [ -n "$name" ] || continue
+    case "$name" in \#*) continue ;; esac
+    [ -z "$(trim "${extra:-}")" ] || fail "$table: row '$name' has more than six columns"
+    patch_file="$(trim "${patch_file:-}")"
+    [ -n "$patch_file" ] || fail "$table: row '$name' names no patch file"
+    [ -f "$operators_dir/$patch_file" ] || fail "$table: row '$name' names a missing patch file '$patch_file'"
+    names+=("$name")
+    patch_files+=("$operators_dir/$patch_file")
+    primary_targets+=("$(trim "${primary_target:-}")")
+    primary_tests+=("$(trim "${primary_test:-}")")
+    blind_targets+=("$(trim "${blind_target:-}")")
+    blind_tests+=("$(trim "${blind_test:-}")")
+  done <"$table"
+  [ "${#names[@]}" -gt 0 ] || fail "$table declares no operators"
+
+  # An operator whose row was dropped but whose patch file stayed behind is a
+  # silently skipped operator, which is the failure mode this harness exists to
+  # prevent. Controls live in `controls/` and are named directly below.
+  local file
+  for file in "$operators_dir"/*.patch; do
+    grep -q "|[[:space:]]*$(basename "$file")[[:space:]]*|" "$table" ||
+      fail "$file is not referenced by any row in $table. Either add its row or
+  delete the patch -- an operator that runs nowhere is not an operator."
+  done
+}
+
+sync_scratch() {
+  mkdir -p "$scratch" "$logs"
+  rsync -a --delete \
+    --exclude=target/ --exclude=.git --exclude=node_modules/ \
+    "$root/" "$scratch/"
+}
+
+# Applies one patch to the scratch checkout. Exact context only (`-F 0`): a
+# seam that moved must be refused, not absorbed by fuzz.
+apply_patch() {
+  local file="$1" log="$2" status=0
+  patch -d "$scratch" -p1 -N -t -F 0 <"$file" >"$log" 2>&1 || status=$?
+  return "$status"
+}
+
+apply_operator_patch() {
+  local file="$1" log="$2"
+  if ! apply_patch "$file" "$log"; then
+    cat "$log" >&2
+    fail "operator patch '$file' no longer applies. The seam it targets moved:
+  confirm the fault is still possible there and re-target the patch. Do not
+  delete the operator to make this green, and do not skip it -- a silently
+  skipped operator is how a detector matrix rots into decoration."
+  fi
+}
+
+# Runs one named detector in the scratch checkout and reports "ok" or "failed"
+# in $detector_result. A detector that does not run at all is a loud failure,
+# never a pass: a renamed or deleted test must not read as green, and a
+# compile error must not be mistaken for the operator taking effect.
+detector_result=""
+run_detector() {
+  local target="$1" name="$2" log="$3" status=0
+  # `$target` is a cargo test-target selector ("--lib", "--test <name>") and
+  # is deliberately word-split.
+  # shellcheck disable=SC2086
+  if ! (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked --no-run) >"$log.build" 2>&1; then
+    tail -40 "$log.build" >&2
+    fail "the patched checkout does not compile (target: $target). Full log: $log.build"
+  fi
+  # shellcheck disable=SC2086
+  (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked -- --exact "$name") >"$log" 2>&1 || status=$?
+  if ! grep -q -- "^test ${name} \.\.\. " "$log"; then
+    tail -20 "$log" >&2
+    fail "detector '$name' did not run under \`cargo test -p fslc-rust $target\`.
+  It was renamed, deleted, or its target moved. A detector that cannot run
+  must never read as a pass. Full log: $log"
+  fi
+  if [ "$status" -eq 0 ]; then
+    detector_result="ok"
+  else
+    detector_result="failed"
+  fi
+}
+
+# The harness's own negative control: the stale-seam patch must be refused.
+# Needs no build, so it runs first and costs nothing.
+check_stale_seam_control() {
+  local started=$SECONDS
+  sync_scratch
+  if apply_patch "$operators_dir/controls/stale-seam.patch" "$logs/stale-seam.log"; then
+    fail "the stale-seam control patch applied cleanly. The harness can no
+  longer tell a moved seam from a live one, so no operator below it is
+  trustworthy."
+  fi
+  echo "control stale-seam: refused, as required ($((SECONDS - started))s)"
+}
+
+# Every named detector must be green under a patch that changes no behavior.
+check_no_op_control() {
+  local started=$SECONDS index
+  sync_scratch
+  apply_operator_patch "$operators_dir/controls/no-op.patch" "$logs/no-op.apply.log"
+  for index in "${!names[@]}"; do
+    run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
+      "$logs/no-op.${names[$index]}.primary.log"
+    [ "$detector_result" = "ok" ] || fail "no-op control: primary detector
+  '${primary_tests[$index]}' (operator ${names[$index]}) failed without any
+  fault applied. Every cell in this matrix is meaningless until it passes.
+  Full log: $logs/no-op.${names[$index]}.primary.log"
+    run_detector "${blind_targets[$index]}" "${blind_tests[$index]}" \
+      "$logs/no-op.${names[$index]}.blind.log"
+    [ "$detector_result" = "ok" ] || fail "no-op control: blind detector
+  '${blind_tests[$index]}' (operator ${names[$index]}) failed without any fault
+  applied. Full log: $logs/no-op.${names[$index]}.blind.log"
+  done
+  echo "control no-op: all ${#names[@]} operators' detectors green ($((SECONDS - started))s)"
+}
+
+failures=()
+
+run_operator() {
+  local index="$1" name="${names[$1]}" started=$SECONDS
+  sync_scratch
+  apply_operator_patch "${patch_files[$index]}" "$logs/$name.apply.log"
+
+  run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
+    "$logs/$name.primary.log"
+  local primary="$detector_result"
+  run_detector "${blind_targets[$index]}" "${blind_tests[$index]}" \
+    "$logs/$name.blind.log"
+  local blind="$detector_result"
+
+  if [ "$primary" != "failed" ]; then
+    failures+=("$name: primary detector '${primary_tests[$index]}' still passed
+  under the fault. The suite would not notice this defect returning. Either the
+  detector no longer covers the seam, or the patch no longer reaches it.
+  Full log: $logs/$name.primary.log")
+  fi
+  if [ "$blind" != "ok" ]; then
+    failures+=("$name: blind detector '${blind_tests[$index]}' also failed. An
+  operator that breaks everything calibrates nothing -- narrow the patch.
+  Full log: $logs/$name.blind.log")
+  fi
+  printf 'operator %s: primary=%s blind=%s (%ss)\n' \
+    "$name" "$primary" "$blind" "$((SECONDS - started))"
+}
+
+read_table
+check_stale_seam_control
+check_no_op_control
+
+for index in "${!names[@]}"; do
+  run_operator "$index"
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  printf 'fault-operators: %s\n' "${failures[@]}" >&2
+  exit 1
+fi
+
+echo "fault-operators: ${#names[@]} operators calibrated (${SECONDS}s total)"

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -92,6 +92,15 @@ sync_scratch() {
   rsync -a --delete \
     --exclude=target/ --exclude=.git --exclude=node_modules/ \
     "$root/" "$scratch/"
+  # The scratch tree must be its own repository root. `portable_cli_source_path`
+  # (`rust/fslc/src/main.rs`) resolves a public Kernel v2 `spec.source.file` by
+  # walking ancestors for a `.git`, and the scratch lives *inside* `rust/target/`
+  # of the real tree -- so without a marker of its own that walk escapes upward
+  # and every such path gains a `rust/target/fault-operators/checkout/` prefix.
+  # An infidelity like that makes a detector's verdict a property of the harness
+  # rather than of the fault. `rsync --delete` leaves excluded paths alone, so
+  # this survives the next sync.
+  [ -e "$scratch/.git" ] || git -C "$scratch" init --quiet
 }
 
 # Applies one patch to the scratch checkout. Exact context only (`-F 0`): a


### PR DESCRIPTION
## Problem

`injection_detector_matrix.rs` calibrates detectors against defective **specs**
and answers "can this detector see a bad `.fsl`?". It cannot ask the question
#537 C5 is about — *would our test suite notice if the verifier itself started
lying?* — because every escaped defect in the 2026-07 batch lived in Rust, not in
a spec: `wrap_specialized`'s `_ => 0` (#601), `run_db_check` folding only
`violated` (#600), `analyze batch` dropping explicit non-`.fsl` input (#496).

A green regression test proves the defect is gone. It does not prove the suite
would notice its return.

## Mechanism

Operators are **patches, not code**. `rust/fslc/tests/fault_operators/` holds one
minimal diff per operator; the harness applies it to a scratch checkout,
rebuilds, runs the operator's primary detector, requires that test to **fail**,
then reverts.

**No fault-injection hook exists in the shipped binary, feature-gated or
otherwise.** For a verifier, a switch that makes it lie about verdicts — inside
the codebase built to prevent exactly that — is the worst artifact this project
could ship. The mechanism proving we detect false greens must not be able to
cause one.

Adding an operator is two data edits and no code: a `.patch` file and one row in
`operators.txt`.

## Calibration

| operator | primary detector (must fail) |
|---|---|
| `unknown-result-to-success` | `outcome::tests::an_unregistered_result_is_failure_class` |
| `failure-verdict-exits-zero` | `issue_554_mutate_exit_status::a_violated_baseline_exits_one` |
| `db-check-drops-kernel-verdict` | `issue_600_db_check_folds_kernel_verdict::db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict` |

Each declares a blind detector that must still **pass** — an operator that breaks
everything calibrates nothing. The third row means the #600 fix cannot silently
regress: the test that owns it is proven to fail when it does.

```
control stale-seam: refused, as required (0s)
control no-op: all 3 operators' detectors green (13s)
operator unknown-result-to-success: primary=failed blind=ok (5s)
operator failure-verdict-exits-zero: primary=failed blind=ok (6s)
operator db-check-drops-kernel-verdict: primary=failed blind=ok (6s)
fault-operators: 3 operators calibrated (30s total)
```

## Four ways it fails loudly

A matrix that skips is decoration. Each demonstrated, each exit 1:

| broken how | outcome |
|---|---|
| seam moved, patch no longer applies | refuses, names the seam, tells you to re-target — never delete or skip |
| detector renamed or deleted | refuses. **`cargo test <missing name>` prints `running 0 tests` / `test result: ok` and exits 0** — a harness trusting the name reads green, so the harness greps for `^test <name> ... ` instead |
| `.patch` referenced by no row | refuses |
| scratch checkout not faithful | no-op control fails |

## A fidelity defect the discipline caught

Adding the public Kernel v2 golden contract as a blind detector exposed a real
harness bug: `portable_cli_source_path` walks ancestors for `.git`, the scratch
tree had none and sat under the real tree's `rust/target/`, so the walk escaped
upward and every such path gained a `rust/target/fault-operators/checkout/`
prefix. **Detector verdicts were partly a property of the harness rather than of
the fault** — the exact way a calibration matrix lies.

The scratch now gets a repository root of its own, and the no-op control pins it:
remove the fix and the control fails loudly instead of the matrix reporting three
calibrated operators over a subtly wrong tree.

This is why blind detectors are mandatory rather than nice to have. Measuring
only the primary would never have surfaced it.

## Why there is no fourth operator

#600's status guard was investigated as a candidate. Reverting it to `== 2` and
running the **whole** `fslc` suite fails nothing: `check_db` calls `validate_db`
first, so every input `run_verify` would reject with status 2 is rejected before
the kernel runs, and the remaining status-3 exits are internal inconsistencies.
No `.fsl` input reaches the branch.

> An operator whose fault is unobservable is not a missing detector; it is a
> fault that does not exist yet. "No test covers this line" and "no input can
> reach this line" look identical from a coverage report and are opposite
> conclusions.

The note records the procedure for telling them apart, since it is the reusable
half. #610 tracks the separate obligation the measurement surfaced — the same
predicate duplicated across `run_db_check` and `run_domain_check`, which is what
let #600 happen — deliberately left out of this PR so a production refactor does
not ride along with the harness.

## CI

A `fault operators` job gated on `github.event_name != 'pull_request'` (rebuild
cost stays out of the per-PR phase, per the design note), added to the `product
gate` aggregator's `needs`. The aggregator keys its requirement on the same
condition the job carries, so a job that stops running for any *other* reason
fails the gate rather than reading as a deliberate skip. Five-case dry run
covers that, including "push to main, silently skipped → fail".

**Not yet observed in CI**: post-merge only, so this PR's own run skips it and
the first real execution is the initial push to main, cold.

## Gates (run independently of the implementer's report)

Re-run on the current tree at `1daf8d5`, after the rebase onto `main` and after
every documentation commit — an earlier run predated both, and 'the rebase only
brought in a docs change so it is fine' is the reasoning this PR exists to
distrust.

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `./tools/check-native-integration.sh rust` | 0 — 0 FAILED, 0 panics |
| `./tools/check-native-integration.sh fault-operators` | 0 |

Exit codes captured without a pipe: `cmd | tail; echo $?` reports `tail`'s
status, not the command's, and a harness whose job is to assert that a test
*failed* cannot afford to read the wrong one.

Advances #537 C5.