### PR TITLE
fix(tests): apply fault-operator patches with git apply, not system patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `MODEL-`/`ASSUME-`prefixed id for modeling intent, and process `covers` for the
   business/requirements dialects. Native only; the frozen Python reference keeps
   its wording, and no parity gate, test, or snapshot compares this string.
+- `tools/run-fault-operators.sh` applies operator patches with `git apply`
+  instead of the system `patch`. The matrix's first CI run failed (#613):
+  BSD `patch` on macOS accepted the no-op control's end-of-file hunk while
+  GNU `patch` on `ubuntu-latest` rejected the identical hunk against
+  identical bytes, so the calibration was green locally and red on the
+  runner. A harness whose verdict depends on where it runs calibrates
+  nothing; `git apply` is one implementation wherever git is.
 - The agent skills now state that typed link as the only canonical form.
   `skills/fsl/SKILL.md` had a worked example writing
   `invariant OnePerUser "ASSUME-1: ..."`, `skills/fsl-design/SKILL.md` — the

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -219,6 +219,17 @@ Rebuild cost puts this in the product gate (`tools/check-native-integration.sh`)
 not the per-pull-request gate. Operators patch `rust/fslc` where possible, so
 the rebuild is that crate plus a relink rather than the workspace.
 
+Patches are applied with `git apply`, never the system `patch`. The first CI run
+of this matrix failed (#613) because BSD `patch` on macOS accepted the no-op
+control's hunk — which ends at end-of-file — while GNU `patch` on
+`ubuntu-latest` rejected the identical hunk against identical bytes. The matrix
+was green on the author's machine and red on the runner, so for a moment its
+verdicts were a property of the machine rather than of the fault. That is the
+same class as the scratch-fidelity defect above and the reason both controls
+exist: a calibration harness whose result depends on where it runs calibrates
+nothing. `git apply` is one implementation wherever git is, applies zero fuzz by
+default, and tolerates the prose preamble each patch file carries.
+
 The harness is `tools/run-fault-operators.sh`, reached as the
 `fault-operators` phase of `tools/check-native-integration.sh` and included in
 its `all` — deliberately not in its `rust` phase, which `.github/workflows/ci.yml`

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -103,11 +103,21 @@ sync_scratch() {
   [ -e "$scratch/.git" ] || git -C "$scratch" init --quiet
 }
 
-# Applies one patch to the scratch checkout. Exact context only (`-F 0`): a
-# seam that moved must be refused, not absorbed by fuzz.
+# Applies one patch to the scratch checkout. Exact context only: a seam that
+# moved must be refused, not absorbed by fuzz.
+#
+# `git apply` rather than `patch`, because this harness's verdicts must be a
+# property of the fault and not of the machine. BSD `patch` (macOS) accepted the
+# no-op control against a hunk ending at end-of-file; GNU `patch` (ubuntu-latest)
+# rejected the identical hunk against the identical bytes, so the matrix went
+# green locally and red on its first CI run. `git apply` is one implementation
+# everywhere git is, applies zero fuzz by default, and tolerates the prose
+# preamble each patch file carries. The scratch already has a repository of its
+# own -- `sync_scratch` gives it one so `portable_cli_source_path` cannot walk
+# out into the enclosing tree -- so `git -C` has a work tree to apply into.
 apply_patch() {
   local file="$1" log="$2" status=0
-  patch -d "$scratch" -p1 -N -t -F 0 <"$file" >"$log" 2>&1 || status=$?
+  git -C "$scratch" apply --whitespace=nowarn "$file" >"$log" 2>&1 || status=$?
   return "$status"
 }
 


### PR DESCRIPTION
Fixes the post-merge product gate failure #613 — the operator matrix's **first**
CI run.

## What happened

```
control stale-seam: refused, as required (0s)
patching file rust/fslc/src/outcome.rs
Hunk #1 FAILED at 219.
1 out of 1 hunk FAILED -- saving rejects to file rust/fslc/src/outcome.rs.rej
fault-operators: operator patch '.../controls/no-op.patch' no longer applies.
```

The no-op control's hunk ends at end-of-file (`}` is the last line of
`outcome.rs`). **BSD `patch` on macOS accepts it; GNU `patch` on `ubuntu-latest`
rejects it — same patch, same bytes.** Green on the author's machine, red on the
runner.

## Why this is the harness's own failure class

The matrix exists to answer "would we notice if the verifier started lying?" For
one run, its verdicts were **a property of the machine rather than of the fault**.

That is the same class as the scratch-fidelity defect fixed during #611, where
paths gained a prefix because the scratch had no repository root of its own. A
calibration harness whose result depends on where it runs calibrates nothing.

**The no-op control did its job.** It is what failed, loudly, instead of three
operators reporting "calibrated" over a tree the runner would have patched
differently. Without it the run could have reported success while the operators
measured nothing — which is precisely why the design note requires it.

## Fix

`git apply` instead of `patch`:

- one implementation wherever git is, so the platform variable is removed **by
  construction** rather than by patching around a version difference;
- zero fuzz by default, which is what `-F 0` was asking for;
- tolerates the prose preamble each patch file carries;
- the scratch already has a repository of its own, so `git -C` has a work tree.

## Verification

| patch | required | `git apply --check` |
|---|---|---|
| `controls/no-op.patch` | applies | exit 0 |
| `controls/stale-seam.patch` | **refused** | **exit 1** |
| `unknown-result-to-success.patch` | applies | exit 0 |
| `failure-verdict-exits-zero.patch` | applies | exit 0 |
| `db-check-drops-kernel-verdict.patch` | applies | exit 0 |

The stale-seam row is the one that matters: a tool that applied *everything*
would silently destroy the "a moved seam fails loudly" property while making the
gate green.

End to end on this branch:

```
control stale-seam: refused, as required (1s)
control no-op: all 3 operators' detectors green (91s)
operator unknown-result-to-success: primary=failed blind=ok (4s)
operator failure-verdict-exits-zero: primary=failed blind=ok (6s)
operator db-check-drops-kernel-verdict: primary=failed blind=ok (6s)
fault-operators: 3 operators calibrated (108s total)
HARNESS_EXIT=0
```

## What is not verified

GNU `patch` was never reproduced locally — this machine has only BSD `patch`, and
installing GNU `patch` would prove the diagnosis, not the fix. The fix removes
the variable instead of accommodating it. **The real confirmation is the next
post-merge run**, which is the same run that just caught this one.

Closes #613. Advances #537 C5.