### PR TITLE
test(refine): bind every corpus refinement mapping to native refine (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 ### Added
+- `rust/fslc/tests/refine_corpus_parity.rs`: a command-owned manifest binding
+  every corpus refinement mapping to native `fslc refine` (issue #593, #537 C4,
+  `docs/DESIGN-conformance-harness.md` "Refinement mapping manifest"). 22 of the
+  28 mappings had never been executed by any test, and the script covering the
+  other 6 (`tools/check_rust_refinement_parity.py`) was invoked by no workflow and
+  no `tools/check-native-integration.sh` lane. `corpus_check_sweep.rs` cannot
+  close this: a mapping has no `state` block, so `fslc check` answers
+  `semantics`/"spec has no state block" for one whether or not the mapping is
+  sound — a green corpus said nothing about `refine`. The roster is walked from
+  `specs/` + `examples/` rather than listed, so an unregistered mapping fails
+  instead of silently joining the 22, and a registered path that no longer exists
+  fails as a stale entry; a hard-coded list is the shape #577 retired 28 stale
+  instances of. Each of the 26 live rows carries `declared_by`, the `path:line` of
+  the README row or fixture header that **declares** its verdict, and compares
+  `result`, `kind`, **and** the process exit code. Expectations are transcribed
+  from those declarations, never from observed output: pinning a measurement would
+  make a future defect look like the contract, which is exactly the state
+  `examples/layers/return_impl_refines.fsl` is in. Where a mapping declares its
+  own expectation in the gallery `expected-command`/`expected-result`/
+  `expected-kind` header convention, the row is checked against it rather than
+  trusted, `--depth` included — that caught a row running at depth 4 against a
+  header declaring `--depth 3`. 22 of the 26 rows additionally anchor their
+  `declared_by` to the cited file, and the harness requires that file to still
+  contain a line stating the row's verdict, so a citation cannot outlive the
+  declaration it names. That keeps each declaration single-owner:
+  `governance_semantic_mapping.fsl` is declared by the broken implementation it
+  maps, and the citation is checked there rather than copied onto the mapping as
+  a second header to keep in sync. The two exclusions are self-retiring in the #568
+  sense: the harness re-measures each recorded premise and fails, naming the row
+  that must replace it, once the premise stops holding.
+- `specs/bank.fsl` and `specs/seat_booking.fsl`: the `fslc refine` command line
+  each header already implied. Both headers asserted that the paired
+  implementation "refines this" but documented no way to run it, so the manifest
+  row above had no depth to inherit. This promotes an existing assertion to a
+  runnable claim; it introduces no new expectation and deliberately uses prose
+  rather than the `expected-command:` key, which `tests/test_corpus_snapshot.py`
+  and `tools/check_rust_cli_snapshot.py` consume.
 - `rust/fslc/src/outcome.rs`: one definition of the success and failure
   classes over the CLI's `result` vocabulary (issue #537 C2,
   `docs/DESIGN-rust-component-internals.md` "Outcome classification"). The

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -176,6 +176,84 @@ inputs.
   `fslc ai`/`db import`/domain replay) are out of scope by extension — the scan
   is `*.fsl` only.
 
+## Refinement mapping manifest (#537 C4, issue #593)
+
+The corpus sweeps above are `check`-shaped, and `check` is structurally blind to a
+refinement mapping: a mapping file has no `state` block, so `fslc check` answers
+`semantics`/"spec has no state block" for one whether or not the mapping is sound.
+A green corpus therefore said nothing about `fslc refine`. Until this manifest only
+6 of the 28 corpus mappings had ever been run through `refine`, by a script
+(`tools/check_rust_refinement_parity.py`) that no workflow and no
+`tools/check-native-integration.sh` lane invoked. The other 22 were executed by
+nothing.
+
+`rust/fslc/tests/refine_corpus_parity.rs` owns the mapping corpus the way
+`tests/dialect_registry.py` owns the dialect corpus, on three rules:
+
+- **The roster is derived, never listed.** The test walks `specs/` + `examples/`
+  for `refinement`-dialect files and requires each to hold a manifest row or an
+  exclusion. Adding a mapping fails the test until it is registered, and a
+  registered path that no longer exists fails as a stale entry. A hard-coded list
+  is the shape #577 retired 28 stale instances of.
+- **Expectations are transcribed from declarations, not from output.** Each row
+  carries `declared_by`, the `path:line` of the README row, documented command
+  comment, or fixture header that states the expected verdict. Recording what the
+  binary prints would pin a defect as the contract the moment one exists — which
+  is exactly the state `examples/layers/return_impl_refines.fsl` is in
+  (issue #615). Where no declaration exists, the correct move is to write one, not
+  to transcribe a measurement. `depth` is deliberately *not* part of that contract:
+  it bounds the search rather than declaring the verdict, so it is taken from the
+  documented command line where one exists.
+- **Both channels, every row.** `result`, `kind`, and the process exit code are all
+  compared (#537 C4). An envelope that disagrees with its exit status is how #554
+  and #600 escaped.
+- **The citation is checked, not trusted.** Where a mapping declares its own
+  expectation in the gallery `expected-command`/`expected-result`/`expected-kind`
+  header convention, the row must agree with it — including the `--depth` inside
+  `expected-command`. Otherwise `declared_by` is prose that can drift from the file
+  it names, which is the same "the citation looked fine" failure the manifest
+  exists to prevent. It caught one on introduction: the `refinement_failed_map.fsl`
+  row ran at depth 4 against a header declaring `--depth 3`.
+
+  22 of the 26 rows additionally carry a `declaration` anchor, and the harness
+  requires the cited file to still contain a line stating this row's verdict.
+  That is what keeps each declaration single-owner. `governance_semantic_mapping`
+  is declared by the broken *implementation* it maps
+  (`governance_semantic_after.fsl:2`, `// expected-result: error`) — the file that
+  owns the error — so the citation is verified where the declaration already
+  lives rather than copied onto the mapping as a second `expected-result` header
+  to keep in sync. The anchor is a text match, not a line number: an edit above
+  the declaration must not fail the test, but deleting it or changing its verdict
+  must. The 4 unanchored rows (the `agentic_rag` and `multi_agent_system` positive
+  pairs) are declared by multi-line statements of the mapping's *purpose* rather
+  than a verdict on one line; they are the manifest's residual trust.
+
+Depth is the one field the corpus is allowed to leave open, and where it is
+declared the declaration wins. 24 of the 26 rows run at the depth their README
+command line or fixture header states. The two that do not —
+`specs/bank_refines.fsl` and `specs/seat_refines.fsl` — had no documented command
+at all; each now carries one in its abstraction's header (`specs/bank.fsl:2-3`,
+`specs/seat_booking.fsl:2-4`), promoting the `refines` those headers already
+asserted into a runnable claim. Their depth 6 is the manifest's own and says so in
+the row: it subsumes the depth-4 `refines` that `tests/test_refine_oracle.py`
+asserted, since a counterexample within 4 steps is also within 6.
+
+Exclusions are self-retiring in the #568 sense: each records the *measured* fact
+that blocks a live row, and the harness re-measures it. `Blocked` re-runs `refine`
+and fails when the recorded failure stops reproducing; `UndeclaredImplOperand`
+fails when the corpus starts declaring the operand the mapping names. Both failure
+messages name the row that must replace the exclusion. Two entries exist:
+`examples/layers/return_impl_refines.fsl` (issue #615 — the README declares
+`refines`, `da003eb` tightened `typecheck.rs` without migrating the corpus to the
+`convert`/`abstract` requirement) and
+`examples/causal/evidence/incident-log-mapping.fsl` (not a `refine` input at all:
+its `impl` operand is a production observation log consumed by
+`fslc causal observe-expectations --mapping`, owned by `causal_cli.rs`).
+
+Cost: ~2m15s wall, the rows being run on a worker pool. Two `agentic_rag` rows are
+~100s and ~126s on their own in a debug build, so the sweep is bounded by its
+slowest row rather than by their sum.
+
 ## Implementation fault operators (#537 C5)
 
 `injection_detector_matrix.rs` calibrates detectors against defective *specs*:
@@ -309,5 +387,8 @@ gone but that the suite would notice its return.
   the harness (they keep their deeper declared-depth cases; overlap ≈ 1 min).
 - Verifying declared verdicts (`expected-result: proved` etc.) — that stays in
   `test_gallery.py`; the harness checks evaluator *agreement*, not spec intent.
-- Refinement-checking the mapping files (covered by `test_refine*.py`).
+- Refinement-checking the mapping files (owned by the manifest in
+  `rust/fslc/tests/refine_corpus_parity.rs`, above — not by this `check` sweep,
+  and no longer by the frozen `tests/test_refine*.py`, which the required product
+  gate does not execute).
 - Making Monitor accept no-action specs or project-level fsl-ai files.

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -15,16 +15,11 @@
 //! `fslc check` always reports `semantics`/"spec has no state block" for one
 //! regardless of whether the mapping itself is sound. Whether a given
 //! mapping is actually exercised by `fslc refine` is a separate, narrower
-//! claim this sweep does not make. Of the 28 such files, only 6 are
-//! exercised by any native test — `refine_corpus_parity.rs` (issue #593):
-//! `specs/cart_refines.fsl`, `specs/seat_refines.fsl`,
-//! `examples/gallery/errors/refinement_failed_map.fsl`,
-//! `examples/gallery/adversarial/refine_mapping_boundary_map.fsl`, and 2 of
-//! the 5 `examples/refinement_liveness/*_refines.fsl` files (the
-//! `*_progress_refines` pair; the other 3 and the remaining 22 mappings
-//! across `agentic_rag`, `multi_agent_system`, `refinement_chain`, and
-//! elsewhere are refined by nothing — see #593, tracked separately from
-//! this sweep).
+//! claim this sweep does not make. That claim is owned by
+//! `refine_corpus_parity.rs`, whose manifest binds every one of these files
+//! to a `refine` run or to a self-retiring exclusion (issue #593, #537 C4),
+//! and which walks the same corpus rather than listing paths, so a mapping
+//! added here cannot escape both tests at once.
 //! `examples/gallery/injected/` (its own primary/blind detector matrix in
 //! `injection_detector_matrix.rs`) is a genuine verified-elsewhere category,
 //! not a silent skip.
@@ -185,7 +180,7 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
 
         let source = std::fs::read_to_string(path).expect("read corpus source");
         if top_level_keyword(&source) == Some("refinement") {
-            continue; // no `state` block to `check`; `fslc refine` coverage tracked by #483, not asserted here
+            continue; // no `state` block to `check`; `refine` coverage is owned by refine_corpus_parity.rs
         }
 
         if governance_exclusions.contains(rel.as_str()) {

--- a/rust/fslc/tests/refine_corpus_parity.rs
+++ b/rust/fslc/tests/refine_corpus_parity.rs
@@ -1,47 +1,99 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
-//! Native port of `tools/check_rust_refinement_parity.py` (issue #593).
+//! Command-owned manifest binding every corpus refinement mapping to native
+//! `fslc refine` (issue #593, issue #537 C4).
 //!
-//! The Python script exercised the same 6 corpus refinement mappings and
-//! checked both the stdout JSON envelope and the process exit code against
-//! the Python reference implementation, but it was never wired into any CI
-//! workflow or `tools/check-native-integration.sh` -- `grep -rn
-//! "check_rust_refinement_parity" .github/ tools/` has zero hits. Of the 28
-//! `refinement`-dialect files in the corpus (`corpus_check_sweep.rs`
-//! excludes all of them from its `check` sweep because a mapping file has
-//! no `state` block), these are the only 6 ever exercised by any test, and
-//! that exercise ran nowhere. This test closes that hole natively: it
-//! compares each case's `result` field (and, for `refinement_failed` cases,
-//! its `kind`) plus the exit code against a fixed expectation, so a broken
-//! mapping fails a named test instead of silently rotting. It does not
-//! attempt AGENTS.md-forbidden Python parity (the required product gate
-//! must not execute Python); it pins the native envelope directly.
+//! `corpus_check_sweep.rs` excludes every `refinement`-dialect file from its
+//! `check` sweep for a structural reason: a mapping file has no `state`
+//! block, so `fslc check` always answers `semantics`/"spec has no state
+//! block" for one whether or not the mapping itself is sound. **A green
+//! `check` therefore says nothing at all about `refine`.** Until this
+//! manifest, only 6 of the 28 corpus mappings were run through `fslc refine`
+//! by any test, and the script that covered those 6
+//! (`tools/check_rust_refinement_parity.py`) was wired into no CI workflow
+//! and no `tools/check-native-integration.sh` lane. The remaining 22 had
+//! never been executed by anything.
 //!
-//! This is a minimal-scope fix (issue #593 fix sketch B), not the broader
-//! C: it does not extend coverage to the remaining 22 refinement mappings
-//! in the corpus (`specs/bank_refines.fsl`, `examples/agentic_rag/*`,
-//! `examples/multi_agent_system/*`, `examples/refinement_chain/*`, and
-//! others) -- that needs the manifest issue #537 C4 describes
-//! (impl/abs/mapping/depth/expected-result/kind) and is tracked separately.
+//! Three properties, in the order they matter:
+//!
+//! 1. `every_corpus_refinement_mapping_is_registered` walks `specs/` and
+//!    `examples/` and requires every `refinement`-dialect file to appear
+//!    either in `CASES` or in `EXCLUSIONS`. The roster is derived from the
+//!    corpus, never hard-coded, so adding a mapping fails this test until it
+//!    is registered. A hard-coded list is precisely the shape #577 retired
+//!    28 stale instances of.
+//! 2. `native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping`
+//!    runs each live row and compares `result`, `kind`, **and** the process
+//!    exit code (#537 C4 requires both; a JSON envelope that disagrees with
+//!    the exit status is how #554 and #600 escaped).
+//! 3. `every_exclusion_premise_still_holds` re-measures each exclusion's
+//!    recorded premise and fails when it no longer holds — the self-retiring
+//!    shape #568 introduced for the Worker parity corpus. An exclusion here
+//!    cannot outlive its reason.
+//!
+//! **Every `expected_result`/`expected_kind` is transcribed from a
+//! repository declaration, cited in `declared_by`, never from observed
+//! output.** Recording what the binary happens to print would pin a defect
+//! as the contract the moment one exists — which is exactly the state
+//! `examples/layers/return_impl_refines.fsl` is in below. `depth` is not
+//! part of that contract: it is taken from the documented command line where
+//! one exists and otherwise chosen to exercise the mapping, because depth
+//! bounds the search rather than declaring the expected verdict.
 
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::Value;
 
-/// One corpus refinement mapping this test exercises, mirroring a row of
-/// `CASES` in `tools/check_rust_refinement_parity.py`.
+/// One live manifest row: a corpus refinement mapping, the implementation
+/// and abstraction it is declared to be run against, and the verdict the
+/// repository declares for that run.
 struct Case {
+    /// Implementation operand, as a repo-relative **file path**. Resolving
+    /// it from the mapping's `impl <Name>` declaration instead is not
+    /// reliable: `governance_semantic_mapping.fsl`'s `impl After` and
+    /// `incident-log-mapping.fsl`'s `impl IncidentProductionLog` do not name
+    /// files, and one of them names no `.fsl` declaration at all.
     implementation: &'static str,
     abstraction: &'static str,
     mapping: &'static str,
     depth: u32,
-    /// Expected `result` field.
+    /// Expected `result` field, transcribed from `declared_by`.
     expected_result: &'static str,
-    /// Expected `kind` field for a `refinement_failed` result; `None` when
-    /// `expected_result` is `"refines"`.
+    /// Expected `kind` field, transcribed from `declared_by`. `None` when
+    /// the repository declares the result but not the failure class.
     expected_kind: Option<&'static str>,
+    /// `path:line` of the repository text that declares the expectation. The
+    /// citation is the point of the manifest: a row whose expectation cannot
+    /// be traced to a declaration is an observation, and pinning an
+    /// observation makes a future defect look like the contract.
+    declared_by: &'static str,
+    /// Machine-checkable anchor for `declared_by`, checked by
+    /// `manifest_rows_agree_with_the_expectations_their_mapping_files_declare`.
+    ///
+    /// `None` for the four rows whose declaration is a multi-line statement
+    /// of the mapping's *purpose* rather than a verdict on one line (the
+    /// `agentic_rag` and `multi_agent_system` positive pairs). Those keep the
+    /// prose citation only, and are the manifest's residual trust.
+    declaration: Option<Declaration>,
+}
+
+/// Where a row's `declared_by` citation points, in a form the harness can
+/// re-check: the declaring file, plus text identifying the declaring line.
+///
+/// The check is "some line of `path` contains both `anchor` and this row's
+/// `expected_result`" — deliberately not a line number. An unrelated edit
+/// above the declaration must not fail this test, but deleting the
+/// declaration, or changing the verdict it states, must. That keeps the
+/// declaration single-owner: the citation is verified where the declaration
+/// already lives instead of being copied next to the row.
+struct Declaration {
+    path: &'static str,
+    anchor: &'static str,
 }
 
 const CASES: &[Case] = &[
@@ -49,53 +101,453 @@ const CASES: &[Case] = &[
         implementation: "specs/cart_impl.fsl",
         abstraction: "specs/cart_v1.fsl",
         mapping: "specs/cart_refines.fsl",
-        depth: 6,
+        declaration: Some(Declaration {
+            path: "docs/LANGUAGE.md",
+            anchor: "Success: `result:",
+        }),
+        depth: 8,
         expected_result: "refines",
         expected_kind: None,
+        declared_by: "docs/LANGUAGE.md:1378-1381 (command line, then \
+                      `Success: result: \"refines\" (exit 0)`)",
     },
     Case {
         implementation: "specs/seat_booking_impl.fsl",
         abstraction: "specs/seat_booking.fsl",
         mapping: "specs/seat_refines.fsl",
+        declaration: Some(Declaration {
+            path: "specs/seat_booking.fsl",
+            anchor: "seat_refines.fsl",
+        }),
         depth: 6,
         expected_result: "refines",
         expected_kind: None,
+        declared_by: "specs/seat_booking.fsl:2-4 (`The two-phase implementation \
+                      (seat_booking_impl.fsl) refines this`, followed by the command \
+                      line). The depth is the manifest's, not the corpus's: nothing \
+                      documented one before this row, and `tests/test_refine_oracle.py` \
+                      asserted `refines` at depth 4. Depth 6 subsumes that claim -- a \
+                      counterexample within 4 steps is also within 6",
+    },
+    Case {
+        implementation: "specs/bank_impl.fsl",
+        abstraction: "specs/bank.fsl",
+        mapping: "specs/bank_refines.fsl",
+        declaration: Some(Declaration {
+            path: "specs/bank.fsl",
+            anchor: "bank_refines.fsl",
+        }),
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "specs/bank.fsl:2-3 (`The detailed two-ledger implementation \
+                      (bank_impl.fsl) refines this`, followed by the command line). \
+                      Depth as for seat_refines above: undocumented before this row, and \
+                      6 subsumes the depth-4 `refines` claim in \
+                      tests/test_refine_oracle.py",
     },
     Case {
         implementation: "examples/gallery/errors/refinement_failed_impl.fsl",
         abstraction: "examples/gallery/errors/refinement_failed_abs.fsl",
         mapping: "examples/gallery/errors/refinement_failed_map.fsl",
-        depth: 4,
+        declaration: Some(Declaration {
+            path: "examples/gallery/errors/refinement_failed_map.fsl",
+            anchor: "expected-result",
+        }),
+        depth: 3,
         expected_result: "refinement_failed",
         expected_kind: Some("abs_requires_failed"),
+        declared_by: "examples/gallery/errors/refinement_failed_map.fsl:1-3 \
+                      (`expected-command`/`expected-result`/`expected-kind`, including \
+                      `--depth 3`), corroborated by examples/gallery/README.md:43. This \
+                      row's depth was 4 until the header was consulted; the file's own \
+                      declaration wins",
     },
     Case {
         implementation: "examples/gallery/adversarial/refine_mapping_boundary_impl.fsl",
         abstraction: "examples/gallery/adversarial/refine_mapping_boundary_abs.fsl",
         mapping: "examples/gallery/adversarial/refine_mapping_boundary_map.fsl",
+        declaration: Some(Declaration {
+            path: "examples/gallery/adversarial/refine_mapping_boundary_map.fsl",
+            anchor: "expected-result",
+        }),
         depth: 2,
         expected_result: "refinement_failed",
         expected_kind: Some("abs_state_mismatch"),
+        declared_by: "examples/gallery/adversarial/refine_mapping_boundary_map.fsl:1-3 \
+                      (`expected-command`/`expected-result`/`expected-kind`, including \
+                      `--depth 2`), corroborated by examples/gallery/README.md:56-60 \
+                      (regression example of the full-unfolding deadlock -> vacuous \
+                      `refines` bug)",
+    },
+    Case {
+        // The mapping `governance_semantic_dependency.fsl` names in its
+        // `checked_by refinement`. The implementation operand is the
+        // adversarial fixture whose undefined type *is* the fixture's
+        // purpose, so `refine` erroring here is the declared behaviour, not
+        // a defect: an error result on a deliberately broken input is the
+        // only outcome that would let the governance preservation report the
+        // dependency as semantically invalid.
+        implementation: "examples/gallery/adversarial/governance_semantic_after.fsl",
+        abstraction: "examples/gallery/adversarial/governance_semantic_before.fsl",
+        mapping: "examples/gallery/adversarial/governance_semantic_mapping.fsl",
+        declaration: Some(Declaration {
+            path: "examples/gallery/adversarial/governance_semantic_after.fsl",
+            anchor: "expected-result",
+        }),
+        depth: 6,
+        expected_result: "error",
+        expected_kind: Some("type"),
+        declared_by: "examples/gallery/adversarial/governance_semantic_after.fsl:2 \
+                      (`// expected-result: error`) with the failure class named in \
+                      corpus_check_sweep.rs GOVERNANCE_FIXTURE_EXCLUSIONS (`its own \
+                      undefined-type failure is the fixture's purpose`)",
+    },
+    Case {
+        implementation: "examples/refinement_liveness/design_drops_liveness.fsl",
+        abstraction: "examples/refinement_liveness/policy.fsl",
+        mapping: "examples/refinement_liveness/design_drops_liveness_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_liveness/README.md",
+            anchor: "design_drops_liveness_refines.fsl",
+        }),
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        // Reading `refines` here as a false green inverts the example. The
+        // README's headline finding is that this mapping *passes*: safety
+        // propagates across refinement and liveness does not, so a design
+        // that drops `fair` still refines. The failing counterpart is the
+        // `_progress_refines` row below, which opts in to progress
+        // preservation.
+        declared_by: "examples/refinement_liveness/README.md:33 (`# refines`) and :54 \
+                      (`design_drops_liveness` returns `refines` (safety OK))",
+    },
+    Case {
+        implementation: "examples/refinement_liveness/design_keeps_liveness.fsl",
+        abstraction: "examples/refinement_liveness/policy.fsl",
+        mapping: "examples/refinement_liveness/design_keeps_liveness_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_liveness/README.md",
+            anchor: "design_keeps_liveness_refines.fsl",
+        }),
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/refinement_liveness/README.md:38 (`# refines`)",
     },
     Case {
         implementation: "examples/refinement_liveness/design_drops_liveness.fsl",
         abstraction: "examples/refinement_liveness/policy.fsl",
         mapping: "examples/refinement_liveness/design_drops_liveness_progress_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_liveness/README.md",
+            anchor: "design_drops_liveness_progress_refines.fsl",
+        }),
         depth: 8,
         expected_result: "refinement_failed",
         expected_kind: Some("progress_lost"),
+        declared_by: "examples/refinement_liveness/README.md:43 \
+                      (`# refinement_failed / progress_lost`)",
     },
     Case {
         implementation: "examples/refinement_liveness/design_keeps_liveness.fsl",
         abstraction: "examples/refinement_liveness/policy.fsl",
         mapping: "examples/refinement_liveness/design_keeps_liveness_progress_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_liveness/README.md",
+            anchor: "design_keeps_liveness_progress_refines.fsl",
+        }),
         depth: 8,
         expected_result: "refines",
         expected_kind: None,
+        declared_by: "examples/refinement_liveness/README.md:45 (`# refines + progress`)",
+    },
+    Case {
+        implementation: "examples/refinement_liveness/design_bypasses_control.fsl",
+        abstraction: "examples/refinement_liveness/policy.fsl",
+        mapping: "examples/refinement_liveness/design_bypasses_control_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_liveness/README.md",
+            anchor: "design_bypasses_control_refines.fsl",
+        }),
+        depth: 8,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_requires_failed"),
+        declared_by: "examples/refinement_liveness/README.md:49 \
+                      (`# refinement_failed / abs_requires_failed`)",
+    },
+    Case {
+        implementation: "examples/ui_spike/return_ui.fsl",
+        abstraction: "examples/ui_spike/return_req_min.fsl",
+        mapping: "examples/ui_spike/ui_refines_req.fsl",
+        declaration: Some(Declaration {
+            path: "examples/ui_spike/README.md",
+            anchor: "ui_refines_req.fsl",
+        }),
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/ui_spike/README.md:12 (`**refines**`) and :17-18 \
+                      (command line with `# refines`)",
+    },
+    Case {
+        implementation: "examples/consulting/tobe_expense.fsl",
+        abstraction: "examples/consulting/asis_expense.fsl",
+        mapping: "examples/consulting/tobe_refines_asis.fsl",
+        declaration: Some(Declaration {
+            path: "examples/consulting/README.md",
+            anchor: "\"result\":",
+        }),
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/consulting/README.md:45-49 \
+                      (`# -> {\"result\": \"refines\", ...} = the controls are preserved`)",
+    },
+    Case {
+        implementation: "examples/e2e/3_design.fsl",
+        abstraction: "examples/e2e/2_requirements.fsl",
+        mapping: "examples/e2e/3_refines_2.fsl",
+        declaration: Some(Declaration {
+            path: "examples/e2e/README.md",
+            anchor: "confirm that the design layer",
+        }),
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/e2e/README.md:46-47 (`confirm that the design layer \
+                      refines the requirements layer`)",
+    },
+    Case {
+        implementation: "examples/refinement_chain/bot.fsl",
+        abstraction: "examples/refinement_chain/mid.fsl",
+        mapping: "examples/refinement_chain/bot_refines_mid.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_chain/README.md",
+            anchor: "bot_refines_mid.fsl",
+        }),
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/refinement_chain/README.md:30 (`# refines`)",
+    },
+    Case {
+        implementation: "examples/refinement_chain/mid.fsl",
+        abstraction: "examples/refinement_chain/top.fsl",
+        mapping: "examples/refinement_chain/mid_refines_top.fsl",
+        declaration: Some(Declaration {
+            path: "examples/refinement_chain/README.md",
+            anchor: "mid_refines_top.fsl",
+        }),
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/refinement_chain/README.md:31 (`# refines`)",
+    },
+    Case {
+        implementation: "examples/nfr/sla_worker_design.fsl",
+        abstraction: "examples/nfr/sla_worker.fsl",
+        mapping: "examples/nfr/sla_worker_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/nfr/README.md",
+            anchor: "sla_worker_refines.fsl",
+        }),
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/nfr/README.md:30-31 (`# => refines`)",
+    },
+    Case {
+        implementation: "examples/validation/order_refund_windowed.fsl",
+        abstraction: "examples/validation/order_refund.fsl",
+        mapping: "examples/validation/order_refund_windowed_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/validation/README.md",
+            anchor: "order_refund_windowed_refines.fsl",
+        }),
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/validation/README.md:12 (`**refines**` -- a time limit can \
+                      be added without breaking the contract) and :40 (`# refines`)",
+    },
+    Case {
+        implementation: "examples/validation/order_refund_instant.fsl",
+        abstraction: "examples/validation/order_refund.fsl",
+        mapping: "examples/validation/order_refund_instant_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/validation/README.md",
+            anchor: "order_refund_instant_refines.fsl",
+        }),
+        depth: 8,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_requires_failed"),
+        declared_by: "examples/validation/README.md:14 \
+                      (`**refinement_failed / abs_requires_failed**`) and :43",
+    },
+    Case {
+        implementation: "examples/agentic_rag/agentic_rag_requirements.fsl",
+        abstraction: "examples/agentic_rag/agentic_rag_business.fsl",
+        mapping: "examples/agentic_rag/agentic_rag_requirements_refines_business.fsl",
+        declaration: None,
+        depth: 7,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/agentic_rag/README.md:106-110 (the command's stated purpose \
+                      is to confirm the requirements layer does not deviate from the \
+                      business layer) and negative/README.md:3, which declares \
+                      `negative/` -- not this directory -- the home of designs that must fail",
+    },
+    Case {
+        implementation: "examples/agentic_rag/agentic_rag_design.fsl",
+        abstraction: "examples/agentic_rag/agentic_rag_requirements.fsl",
+        mapping: "examples/agentic_rag/agentic_rag_design_refines_requirements.fsl",
+        declaration: None,
+        depth: 6,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/agentic_rag/README.md:112-116 (the command's stated purpose \
+                      is to confirm the design layer does not deviate from the \
+                      requirements layer) and negative/README.md:3",
+    },
+    Case {
+        implementation: "examples/agentic_rag/negative/guard_bypass_design.fsl",
+        abstraction: "examples/agentic_rag/agentic_rag_requirements.fsl",
+        mapping: "examples/agentic_rag/negative/guard_bypass_refines_requirements.fsl",
+        declaration: Some(Declaration {
+            path: "examples/agentic_rag/negative/README.md",
+            anchor: "guard_bypass_refines_requirements.fsl",
+        }),
+        depth: 6,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_requires_failed"),
+        declared_by: "examples/agentic_rag/negative/README.md:10 \
+                      (Expected: `refinement_failed`, `abs_requires_failed`)",
+    },
+    Case {
+        implementation: "examples/agentic_rag/negative/tool_approval_bypass_design.fsl",
+        abstraction: "examples/agentic_rag/agentic_rag_requirements.fsl",
+        mapping: "examples/agentic_rag/negative/tool_approval_bypass_refines_requirements.fsl",
+        declaration: Some(Declaration {
+            path: "examples/agentic_rag/negative/README.md",
+            anchor: "tool_approval_bypass_refines_requirements.fsl",
+        }),
+        depth: 6,
+        expected_result: "refinement_failed",
+        expected_kind: Some("abs_requires_failed"),
+        declared_by: "examples/agentic_rag/negative/README.md:11 \
+                      (Expected: `refinement_failed`, `abs_requires_failed`)",
+    },
+    Case {
+        implementation: "examples/agentic_rag/negative/liveness_drop_design.fsl",
+        abstraction: "examples/agentic_rag/negative/liveness_requirements.fsl",
+        mapping: "examples/agentic_rag/negative/liveness_drop_refines_requirements.fsl",
+        declaration: Some(Declaration {
+            path: "examples/agentic_rag/negative/README.md",
+            anchor: "liveness_drop_refines_requirements.fsl",
+        }),
+        depth: 4,
+        expected_result: "refinement_failed",
+        expected_kind: Some("progress_lost"),
+        declared_by: "examples/agentic_rag/negative/README.md:12 \
+                      (Expected: `refinement_failed`, `progress_lost`, `leadsTo`)",
+    },
+    Case {
+        implementation: "examples/multi_agent_system/multi_agent_requirements.fsl",
+        abstraction: "examples/multi_agent_system/multi_agent_business.fsl",
+        mapping: "examples/multi_agent_system/multi_agent_requirements_refines_business.fsl",
+        declaration: None,
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/multi_agent_system/multi_agent_requirements_refines_business.fsl:1-7 \
+                      (the mapping's declared role is to confirm the detail does not create \
+                      a business shortcut) and README.md:79-82",
+    },
+    Case {
+        implementation: "examples/multi_agent_system/multi_agent_design.fsl",
+        abstraction: "examples/multi_agent_system/multi_agent_requirements.fsl",
+        mapping: "examples/multi_agent_system/multi_agent_design_refines_requirements.fsl",
+        declaration: None,
+        depth: 8,
+        expected_result: "refines",
+        expected_kind: None,
+        declared_by: "examples/multi_agent_system/multi_agent_design_refines_requirements.fsl:1-7 \
+                      (the mapping's declared role is to fold the design's queues into the \
+                      requirements' externally visible state without dropping progress) and \
+                      README.md:84-87",
     },
 ];
 
-fn root() -> std::path::PathBuf {
+/// The measured fact that keeps an exclusion honest. Re-checked by
+/// `every_exclusion_premise_still_holds`, so an exclusion cannot outlive its
+/// reason: when the premise stops holding the test fails and names the row
+/// that must replace it.
+enum Premise {
+    /// A defect blocks the declared expectation. `refine` currently answers
+    /// `result`/`kind` for this triple; the day it stops, the exclusion is
+    /// stale and the declared row must go live.
+    Blocked {
+        implementation: &'static str,
+        abstraction: &'static str,
+        depth: u32,
+        result: &'static str,
+        kind: &'static str,
+    },
+    /// The mapping is not a `fslc refine` input at all: its `impl` operand
+    /// names an artifact that no corpus declaration defines, so there is no
+    /// implementation spec to pair it with. The day such a declaration
+    /// appears, the exclusion is stale.
+    UndeclaredImplOperand { operand: &'static str },
+}
+
+struct Exclusion {
+    mapping: &'static str,
+    /// Why this mapping has no live row, and what has to change for it to
+    /// get one.
+    reason: &'static str,
+    premise: Premise,
+}
+
+const EXCLUSIONS: &[Exclusion] = &[
+    Exclusion {
+        mapping: "examples/layers/return_impl_refines.fsl",
+        reason: "issue #615: examples/layers/README.md:10 declares `refines` and :15-16 \
+                 gives the exact command, but native `fslc refine` answers \
+                 `error`/`kind:\"type\"` (exit 2) -- `ambiguous enum member 'New' belongs \
+                 to [DSt, SSt]`. `da003eb fix(refine): reject ambiguous enum members` \
+                 tightened rust/fsl-core/src/typecheck.rs without migrating the corpus to \
+                 the new `convert`/`abstract` requirement. The expectation is NOT recorded \
+                 as `error`: doing so would pin the regression as the contract. When #615 \
+                 is fixed this exclusion goes stale, and the row that replaces it is \
+                 depth 5, expected_result \"refines\", declared_by \
+                 examples/layers/README.md:10",
+        premise: Premise::Blocked {
+            implementation: "examples/layers/return_impl.fsl",
+            abstraction: "examples/layers/return_system.fsl",
+            depth: 5,
+            result: "error",
+            kind: "type",
+        },
+    },
+    Exclusion {
+        mapping: "examples/causal/evidence/incident-log-mapping.fsl",
+        reason: "not a `fslc refine` input. Its `impl IncidentProductionLog` names a \
+                 production observation log (examples/causal/evidence/\
+                 incident-observation-log.jsonl), not a spec, so no implementation \
+                 `.fsl` exists to pair with the abstraction. The command that consumes \
+                 this file is `fslc causal observe-expectations --mapping` (issue #360), \
+                 owned by rust/fslc/tests/causal_cli.rs (OBS_MAPPING, 6 call sites). \
+                 This is a capability exclusion, not a tolerated difference: no verdict, \
+                 location, or exit code is allowlisted for it anywhere",
+        premise: Premise::UndeclaredImplOperand {
+            operand: "IncidentProductionLog",
+        },
+    },
+];
+
+fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(Path::parent)
@@ -103,59 +555,333 @@ fn root() -> std::path::PathBuf {
         .to_owned()
 }
 
-fn run_refine(case: &Case) -> (Value, i32) {
+fn collect_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read corpus directory") {
+        let path = entry.expect("read corpus entry").path();
+        if path.is_dir() {
+            collect_fsl_files(&path, out);
+        } else if path.extension().is_some_and(|extension| extension == "fsl") {
+            out.push(path);
+        }
+    }
+}
+
+fn repo_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .expect("path under workspace root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// The file's top-level dialect keyword: the first token on the first
+/// non-blank, non-`//`-comment line. Same rule `corpus_check_sweep.rs` uses
+/// to identify (and structurally skip) the very files this manifest owns.
+fn top_level_keyword(source: &str) -> Option<&str> {
+    source
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with("//"))
+        .and_then(|line| line.split_whitespace().next())
+}
+
+/// Every `refinement`-dialect file under `specs/` + `examples/`, repo-relative.
+fn corpus_refinement_mappings(root: &Path) -> BTreeSet<String> {
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files
+        .into_iter()
+        .filter(|path| {
+            let source = std::fs::read_to_string(path).expect("read corpus source");
+            top_level_keyword(&source) == Some("refinement")
+        })
+        .map(|path| repo_relative(root, &path))
+        .collect()
+}
+
+/// Does any corpus `.fsl` declare `name` at top level? A top-level
+/// declaration is unindented and has the declared name as its second token
+/// (`spec Foo {`, `design Foo {`, ...).
+fn corpus_declares(root: &Path, name: &str) -> bool {
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files.iter().any(|path| {
+        let source = std::fs::read_to_string(path).expect("read corpus source");
+        source.lines().any(|line| {
+            if line.starts_with(char::is_whitespace) || line.trim_start().starts_with("//") {
+                return false;
+            }
+            let mut tokens = line.split_whitespace();
+            tokens.next().is_some() && tokens.next() == Some(name)
+        })
+    })
+}
+
+/// The `// key: value` header comments the
+/// `examples/gallery/{errors,adversarial}` fixtures use to declare their own
+/// expected command, result, and failure kind. Same convention
+/// `corpus_check_sweep.rs::headers` reads for `check`-targeted fixtures.
+fn headers(source: &str) -> BTreeMap<String, String> {
+    source
+        .lines()
+        .take(10)
+        .filter_map(|line| line.trim().strip_prefix("//"))
+        .filter_map(|body| body.trim().split_once(':'))
+        .map(|(key, value)| (key.trim().to_owned(), value.trim().to_owned()))
+        .collect()
+}
+
+/// Where a mapping declares its own expectation in the gallery header
+/// convention, that declaration is the authority and the manifest row must
+/// agree with it -- including the `--depth` inside `expected-command`.
+///
+/// Without this check `declared_by` is a prose claim that can drift from the
+/// file it cites, which is the same "the citation looked fine" failure the
+/// manifest exists to prevent. It caught one immediately: the
+/// `refinement_failed_map.fsl` row carried `depth: 4` while the fixture's own
+/// header declares `--depth 3`.
+#[test]
+fn manifest_rows_agree_with_the_expectations_their_mapping_files_declare() {
     let root = root();
+    let mut failures = Vec::new();
+
+    for case in CASES {
+        // The cited declaration must still be there, and must still state
+        // this row's verdict. Checking the citation is what lets the
+        // declaration stay in exactly one place: `governance_semantic_mapping`
+        // is declared by the broken *implementation* it maps
+        // (`governance_semantic_after.fsl`), which is the file that owns the
+        // error, and copying an `expected-result` header onto the mapping
+        // would create a second copy to keep in sync.
+        if let Some(declaration) = &case.declaration {
+            let declaring = std::fs::read_to_string(root.join(declaration.path))
+                .expect("read declaration source");
+            let states_verdict = declaring.lines().any(|line| {
+                line.contains(declaration.anchor) && line.contains(case.expected_result)
+            });
+            if !states_verdict {
+                failures.push(format!(
+                    "{}: no line of {} carries both {:?} and {:?}. The cited declaration is \
+                     gone or no longer states this verdict, so `declared_by` is stale: \
+                     {}",
+                    case.mapping,
+                    declaration.path,
+                    declaration.anchor,
+                    case.expected_result,
+                    case.declared_by
+                ));
+            }
+        }
+
+        let source = std::fs::read_to_string(root.join(case.mapping)).expect("read mapping");
+        let declared = headers(&source);
+
+        if let Some(result) = declared.get("expected-result")
+            && result != case.expected_result
+        {
+            failures.push(format!(
+                "{}: header declares expected-result={result:?} but the row says {:?}",
+                case.mapping, case.expected_result
+            ));
+        }
+        if let Some(kind) = declared.get("expected-kind")
+            && Some(kind.as_str()) != case.expected_kind
+        {
+            failures.push(format!(
+                "{}: header declares expected-kind={kind:?} but the row says {:?}",
+                case.mapping, case.expected_kind
+            ));
+        }
+        let Some(command) = declared.get("expected-command") else {
+            continue;
+        };
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+        if tokens.first() != Some(&"refine") {
+            failures.push(format!(
+                "{}: header declares a non-`refine` expected-command {command:?}; this \
+                 manifest only owns `refine` expectations",
+                case.mapping
+            ));
+            continue;
+        }
+        if let Some(depth) = tokens
+            .iter()
+            .position(|token| *token == "--depth")
+            .and_then(|index| tokens.get(index + 1))
+            .and_then(|value| value.parse::<u32>().ok())
+            && depth != case.depth
+        {
+            failures.push(format!(
+                "{}: header declares `--depth {depth}` but the row runs at depth {}. The \
+                 file's own declaration wins; change the row.",
+                case.mapping, case.depth
+            ));
+        }
+        // The command's operands are bare file names relative to the fixture
+        // directory; compare them against the row's path basenames.
+        let basename = |path: &str| path.rsplit('/').next().unwrap_or(path).to_owned();
+        for (position, expected) in [(1, case.implementation), (2, case.abstraction)] {
+            if let Some(declared_operand) = tokens.get(position)
+                && basename(declared_operand) != basename(expected)
+            {
+                failures.push(format!(
+                    "{}: header's expected-command operand {position} is \
+                     {declared_operand:?} but the row uses {expected:?}",
+                    case.mapping
+                ));
+            }
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+fn run_refine(implementation: &str, abstraction: &str, mapping: &str, depth: u32) -> (Value, i32) {
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args([
             "refine",
-            case.implementation,
-            case.abstraction,
-            case.mapping,
+            implementation,
+            abstraction,
+            mapping,
             "--depth",
-            &case.depth.to_string(),
+            &depth.to_string(),
         ])
-        .current_dir(&root)
+        .current_dir(root())
         .output()
         .expect("run native CLI");
     let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(
-            "invalid JSON for `fslc refine {} {} {}`: {error}; stderr={}",
-            case.implementation,
-            case.abstraction,
-            case.mapping,
+            "invalid JSON for `fslc refine {implementation} {abstraction} {mapping}`: \
+             {error}; stderr={}",
             String::from_utf8_lossy(&output.stderr)
         )
     });
     let status = output.status.code().unwrap_or_else(|| {
-        panic!(
-            "`fslc refine {} {} {}` terminated by signal, no exit code",
-            case.implementation, case.abstraction, case.mapping
-        )
+        panic!("`fslc refine {implementation} {abstraction} {mapping}` terminated by signal")
     });
     (value, status)
 }
 
-/// `tools/check_rust_refinement_parity.py::_expected_status`: `error` exits
-/// 2, `refinement_failed` exits 1, everything else (`refines`) exits 0.
+/// The exit code the CLI contract binds to a `refine` result
+/// (`docs/LANGUAGE.md:1381` and `:1394`): `refines` exits 0, `refinement_failed`
+/// exits 1, a static `error` exits 2, and `violated` — the impl-self-
+/// violation verdict `refine` reaches before it consults the abstraction
+/// (#466) — is failure-class, so it exits 1.
+///
+/// An unregistered result panics rather than falling through to 0. A `_ => 0`
+/// arm here would give any future `refine` verdict a passing exit
+/// expectation by default, which is the exact shape of #601's `_ => 0` and
+/// #554's missing arm: the manifest would keep reporting green for a verdict
+/// nobody classified. `fslc_rust::outcome::outcome_class` takes the same
+/// position for the same reason.
 fn expected_status(result: &str) -> i32 {
     match result {
+        "refines" => 0,
+        "refinement_failed" | "violated" => 1,
         "error" => 2,
-        "refinement_failed" => 1,
-        _ => 0,
+        other => panic!(
+            "unregistered `fslc refine` result {other:?}: add its exit code to \
+             expected_status. Do not let a new verdict default to 0."
+        ),
     }
 }
 
-/// Each of the 6 corpus refinement mappings `tools/check_rust_refinement_parity.py`
-/// covered must keep reporting its expected `result`/`kind` and exit code
-/// under native `fslc refine`. A mapping edit that breaks the correspondence
-/// must fail its named case here, not go unnoticed the way #466, #483,
-/// #493, #494, and #512 did.
-#[test]
-fn native_refine_matches_expected_result_and_exit_for_the_corpus_mapping_regressions() {
-    let mut failures = Vec::new();
+/// Runs `job` over `0..count` on a small worker pool and collects the
+/// failure strings. Two `agentic_rag` rows take ~100s and ~126s each in a
+/// debug build and dominate the sweep; running the rows concurrently keeps
+/// the manifest's CI cost near the single slowest row rather than the sum.
+fn for_each_parallel(count: usize, job: impl Fn(usize) -> Option<String> + Sync) -> Vec<String> {
+    let next = AtomicUsize::new(0);
+    let failures = Mutex::new(Vec::new());
+    let workers = std::thread::available_parallelism()
+        .map_or(4, std::num::NonZero::get)
+        .min(count.max(1));
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    if index >= count {
+                        break;
+                    }
+                    if let Some(failure) = job(index) {
+                        failures.lock().expect("failure list").push(failure);
+                    }
+                }
+            });
+        }
+    });
+    let mut failures = failures.into_inner().expect("failure list");
+    failures.sort();
+    failures
+}
 
-    for case in CASES {
-        let (output, status) = run_refine(case);
+/// Every `refinement`-dialect file in the corpus must carry a live manifest
+/// row or a reasoned exclusion. The roster is walked from `specs/` +
+/// `examples/`, so a mapping added without registration fails here instead
+/// of joining the 22 that were exercised by nothing until #593. The reverse
+/// direction is checked too: a registered path that no longer exists is a
+/// stale entry, not a silent pass.
+#[test]
+fn every_corpus_refinement_mapping_is_registered() {
+    let root = root();
+    let corpus = corpus_refinement_mappings(&root);
+    assert!(
+        corpus.len() >= 28,
+        "corpus scan floor: found only {} refinement mappings under specs/+examples/, \
+         expected at least the 28 that existed at #593 (the directory walk may be broken)",
+        corpus.len()
+    );
+
+    let registered: BTreeSet<&str> = CASES
+        .iter()
+        .map(|case| case.mapping)
+        .chain(EXCLUSIONS.iter().map(|exclusion| exclusion.mapping))
+        .collect();
+    assert_eq!(
+        registered.len(),
+        CASES.len() + EXCLUSIONS.len(),
+        "a mapping is registered twice; each must have exactly one row or one exclusion"
+    );
+
+    let mut failures = Vec::new();
+    for mapping in &corpus {
+        if !registered.contains(mapping.as_str()) {
+            failures.push(format!(
+                "{mapping}: refinement mapping is in the corpus but in neither CASES nor \
+                 EXCLUSIONS. Add a row citing the repository text that declares its \
+                 expected `fslc refine` result (never the observed output), or add an \
+                 exclusion with a reason and a re-checkable premise."
+            ));
+        }
+    }
+    for mapping in &registered {
+        if !corpus.contains(*mapping) {
+            failures.push(format!(
+                "{mapping}: registered here but is not a corpus refinement mapping \
+                 (deleted, moved, or no longer `refinement`-dialect). Remove the stale entry."
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Each live row must reproduce the `result`, the `kind`, **and** the exit
+/// code its `declared_by` citation states (#537 C4: stdout JSON and process
+/// status, both). A mapping or a semantics change that breaks the declared
+/// correspondence fails here by name, the way #466, #483, #493, #494, and
+/// #512 did not.
+#[test]
+fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping() {
+    let failures = for_each_parallel(CASES.len(), |index| {
+        let case = &CASES[index];
+        let (output, status) = run_refine(
+            case.implementation,
+            case.abstraction,
+            case.mapping,
+            case.depth,
+        );
         let result = output["result"].as_str().unwrap_or_else(|| {
             panic!(
                 "{}: `fslc refine` envelope has no string `result` field: {output}",
@@ -164,31 +890,78 @@ fn native_refine_matches_expected_result_and_exit_for_the_corpus_mapping_regress
         });
 
         if result != case.expected_result {
-            failures.push(format!(
-                "{}: expected result={:?}, got result={result:?} ({output})",
-                case.mapping, case.expected_result
+            return Some(format!(
+                "{}: declared result={:?} ({}), got result={result:?} ({output})",
+                case.mapping, case.expected_result, case.declared_by
             ));
-            continue;
         }
-
         if let Some(expected_kind) = case.expected_kind {
             let kind = output["kind"].as_str();
             if kind != Some(expected_kind) {
-                failures.push(format!(
-                    "{}: expected kind={expected_kind:?}, got kind={kind:?} ({output})",
-                    case.mapping
+                return Some(format!(
+                    "{}: declared kind={expected_kind:?} ({}), got kind={kind:?} ({output})",
+                    case.mapping, case.declared_by
                 ));
             }
         }
-
         let expected_exit = expected_status(case.expected_result);
         if status != expected_exit {
-            failures.push(format!(
-                "{}: result={result:?} expects exit={expected_exit}, got exit={status}",
+            return Some(format!(
+                "{}: result={result:?} binds exit={expected_exit}, got exit={status}",
                 case.mapping
             ));
         }
-    }
+        None
+    });
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// An exclusion may not outlive its reason. Each entry records the fact that
+/// blocks a live row; this re-measures it and fails when it no longer holds,
+/// so fixing #615 — or adding the missing declaration — forces the excluded
+/// mapping into the manifest instead of leaving a permanent hole (#568).
+#[test]
+fn every_exclusion_premise_still_holds() {
+    let root = root();
+    let failures = for_each_parallel(EXCLUSIONS.len(), |index| {
+        let exclusion = &EXCLUSIONS[index];
+        match &exclusion.premise {
+            Premise::Blocked {
+                implementation,
+                abstraction,
+                depth,
+                result,
+                kind,
+            } => {
+                let (output, _status) =
+                    run_refine(implementation, abstraction, exclusion.mapping, *depth);
+                if output["result"].as_str() == Some(result)
+                    && output["kind"].as_str() == Some(kind)
+                {
+                    return None;
+                }
+                Some(format!(
+                    "{}: the exclusion is STALE. `fslc refine {implementation} {abstraction} \
+                     {} --depth {depth}` no longer answers result={result:?}/kind={kind:?}; \
+                     it now answers {output}. Delete the exclusion and add the live \
+                     manifest row. Recorded reason: {}",
+                    exclusion.mapping, exclusion.mapping, exclusion.reason
+                ))
+            }
+            Premise::UndeclaredImplOperand { operand } => {
+                if !corpus_declares(&root, operand) {
+                    return None;
+                }
+                Some(format!(
+                    "{}: the exclusion is STALE. The corpus now declares {operand:?}, so this \
+                     mapping has an implementation operand and can take a live manifest row. \
+                     Recorded reason: {}",
+                    exclusion.mapping, exclusion.reason
+                ))
+            }
+        }
+    });
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/specs/bank.fsl
+++ b/specs/bank.fsl
@@ -1,5 +1,6 @@
 // Abstract bank account: an immediately-consistent balance.
-// The detailed two-ledger implementation (bank_impl.fsl) refines this.
+// The detailed two-ledger implementation (bank_impl.fsl) refines this:
+//   fslc refine specs/bank_impl.fsl specs/bank.fsl specs/bank_refines.fsl --depth 6   # refines
 spec BankAccount {
   type Amount = 0..3
 

--- a/specs/seat_booking.fsl
+++ b/specs/seat_booking.fsl
@@ -1,6 +1,7 @@
 // Abstract seat booking: a seat is either free (none) or owned by a user.
 // The two-phase implementation (seat_booking_impl.fsl) refines this via a
 // State-dependent conditional mapping exercises refinement expression lowering.
+//   fslc refine specs/seat_booking_impl.fsl specs/seat_booking.fsl specs/seat_refines.fsl --depth 6   # refines
 spec SeatBooking {
   type SeatId = 0..2
   type UserId = 0..1


### PR DESCRIPTION
## Problem

Of the corpus's **28 refinement mappings, 6 were exercised by any native test**.
The other 22 had never been run through `fslc refine` at all.

`corpus_check_sweep` sweeps `check` over every `.fsl`, and those mappings pass —
but **a mapping file is not a state machine, so `check` passing says nothing
about whether `refine` passes.** That gap is what #537 C4 means by binding each
artifact to the command that actually evaluates it.

## What the sweep found before a manifest row existed

**#615 — a documented example is broken.** `examples/layers/README.md` states
`return_impl_refines.fsl` → **refines**, and gives the command. Running that exact
command returns `error` / `kind:"type"` / exit 2. `da003eb` tightened
`typecheck.rs` to reject ambiguous enum members and **touched no `.fsl` corpus
file**; nobody noticed because this mapping is not in CI. Classified by
measurement as corpus non-migration, not product over-rejection: applying the
migration the error message names yields `refines` / exit 0.

**Three different depths for the same artifact.** `cart_refines` is `--depth 8` in
`README.md`/`docs/LANGUAGE.md`, `6` in the native parity test, `4` in the Python
one. A test passing at a depth the documentation does not claim has not verified
the documentation's claim, so the manifest uses the documented depth — **24 of 26
rows** — and states the reason wherever it deviates.

## Structure

The manifest is 26 rows and 2 self-retiring exclusions. Three properties make it
a manifest rather than a longer list:

| check | why it exists |
|---|---|
| **an unregistered mapping fails** | the corpus is walked, not listed — a hardcoded list is the stale shape #577 retired 28 instances of |
| **a stale exclusion fails** | #615's exclusion goes stale the moment #615 is fixed, forcing the row live |
| **a stale citation fails** | `declared_by` as prose can drift from what it cites and nobody would know |

All three are demonstrated, each failing loudly.

`corpus_check_sweep.rs` hands `refine` ownership over explicitly. Both tests walk
the same corpus, so **a mapping added to the repository cannot escape both at
once.**

## Expectations come from declarations, never from observation

Recording what the tool currently prints would freeze whatever is wrong — which
is exactly what #615 is. Every row cites where its expectation is declared: a
README row, a `// expected-result:` header, or a spec header naming its
implementation.

This mattered concretely. An early probe flagged
`design_drops_liveness_refines.fsl` as a false green because its name contains
`drops`; the file's own header says *"With this mapping refine **passes** (=
safety is satisfied), but the upper-layer liveness does not propagate."*
Inference was wrong, the corpus was right. Two further probe conclusions — that
`order_refund_instant_refines.fsl` had no declared expectation, and that
`ui_refines_req.fsl` could not be run — were also wrong, both from guessing
instead of reading. Hence impl/abs are explicit paths in every row.

## The citation check caught its author, on day one

Adding the "row agrees with the declaration it cites" test immediately failed:
`refinement_failed_map`'s row said `--depth 4` while the mapping's own
`// expected-command:` header says `--depth 3` — a deviation introduced in the
same change that added the check. Same shape as #611's `_ => Failure` catching an
unregistered `observed_supported` on its first run. **A mechanism being correct in
principle and a mechanism working are different claims, and only the second one
can be shown.**

## What is not covered

**4 of 26 rows carry no machine-checked citation.** Their declarations are
multi-line prose describing the mapping's role, with no single line carrying a
verdict; anchoring them would produce a match that means nothing. The design note
names them as the manifest's residual trust rather than implying full coverage.

`examples/causal/evidence/incident-log-mapping.fsl` is excluded because it is
**not a `refine` target**: its `impl` names a production observation log, and the
command that evaluates it is `fslc causal observe-expectations --mapping`. That
is C4's answer working correctly — the artifact is owned by a different command,
not missing from this one.

## Cost, and why per-PR

**137s** for the whole manifest, dominated by two `agentic_rag` rows (~126s and
~100s in a debug build) that together exceed the other 24. Rows run on a worker
pool, so adding rows does not scale linearly.

Per-PR rather than post-merge: corpus and mappings are touched routinely in pull
requests, and #615 is precisely a change that tightened the type checker and
merged without migrating the corpus. Registration and citation checks are
sub-second on their own, so even a future decision to move the `refine` runs
post-merge would keep those two per-PR.

## Gates (run independently of the implementer's report)

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `./tools/check-native-integration.sh rust` | 0 — 0 FAILED, 0 panics |
| `./tools/check-native-integration.sh fault-operators` | 0 |

Exit codes captured without a pipe.

Closes #593. Advances #537 C4.