### PR TITLE
fix(examples): migrate the layers mapping to enum abstraction (#615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `examples/layers/return_impl_refines.fsl` now declares an `enum abstraction`
+  instead of a bare-member if-chain, so the command `examples/layers/README.md`
+  documents answers `refines` again rather than `error`/`kind:"type"` (#615).
+  `da003eb` began rejecting members that name a position in more than one enum,
+  which is correct -- `New`, `AutoApproved`, `MgrQueue`, `MgrApproved`, and
+  `MgrRejected` each belong to both `DSt` and `SSt`, so the chain read as an
+  identity while the compiler had to guess. The corpus was never migrated to
+  the `convert`/`abstract` requirement that change introduced. `DSt`'s
+  `PaySubmitted` and `PayConfirmed` both collapse to `SSt`'s `Paid`, making this
+  many-to-one and `enum abstraction` rather than `enum conversion` the right
+  form. The mapping's #616 exclusion went stale on the fix and is replaced by a
+  live manifest row, which is the self-retirement working on a real repair
+  rather than a rehearsed one.
 ### Added
 - `rust/fslc/tests/refine_corpus_parity.rs`: a command-owned manifest binding
   every corpus refinement mapping to native `fslc refine` (issue #593, #537 C4,

--- a/examples/layers/return_impl_refines.fsl
+++ b/examples/layers/return_impl_refines.fsl
@@ -2,13 +2,24 @@ refinement ImplRefinesRequirements {
   impl ReturnImpl
   abs  ReturnSystemReq
 
+  // Design's two payment steps collapse to the requirement layer's single Paid,
+  // so this is many-to-one and needs `enum abstraction`, not `enum conversion`.
+  // Written out rather than left as a bare-member if-chain because `New`,
+  // `AutoApproved`, `MgrQueue`, `MgrApproved`, and `MgrRejected` each name a
+  // member of both DSt and SSt: the chain read as if it were the identity while
+  // the compiler had to guess which enum each bare name meant.
+  enum abstraction case_state DSt -> SSt {
+    New          -> New
+    AutoApproved -> AutoApproved
+    MgrQueue     -> MgrQueue
+    MgrApproved  -> MgrApproved
+    MgrRejected  -> MgrRejected
+    PaySubmitted -> Paid
+    PayConfirmed -> Paid
+  }
+
   map sys[c: CaseId] = RCase {
-    st: if d[c].st == New then New
-        else if d[c].st == AutoApproved then AutoApproved
-        else if d[c].st == MgrQueue then MgrQueue
-        else if d[c].st == MgrApproved then MgrApproved
-        else if d[c].st == MgrRejected then MgrRejected
-        else Paid,
+    st: abstract(case_state, d[c].st),
     amount: d[c].amount
   }
   map paid_count = paid

--- a/rust/fslc/tests/refine_corpus_parity.rs
+++ b/rust/fslc/tests/refine_corpus_parity.rs
@@ -35,8 +35,11 @@
 //! **Every `expected_result`/`expected_kind` is transcribed from a
 //! repository declaration, cited in `declared_by`, never from observed
 //! output.** Recording what the binary happens to print would pin a defect
-//! as the contract the moment one exists — which is exactly the state
-//! `examples/layers/return_impl_refines.fsl` is in below. `depth` is not
+//! as the contract the moment one exists. `examples/layers/return_impl_refines.fsl`
+//! was that case: it is a live row now, but it entered this manifest as an
+//! exclusion whose recorded premise was the defect (#615), not an
+//! `expected_result: "error"` that would have made the regression the
+//! contract. `depth` is not
 //! part of that contract: it is taken from the documented command line where
 //! one exists and otherwise chosen to exercise the mapping, because depth
 //! bounds the search rather than declaring the expected verdict.
@@ -292,6 +295,26 @@ const CASES: &[Case] = &[
                       (command line with `# refines`)",
     },
     Case {
+        implementation: "examples/layers/return_impl.fsl",
+        abstraction: "examples/layers/return_system.fsl",
+        mapping: "examples/layers/return_impl_refines.fsl",
+        declaration: Some(Declaration {
+            path: "examples/layers/README.md",
+            anchor: "return_impl_refines.fsl",
+        }),
+        depth: 5,
+        expected_result: "refines",
+        expected_kind: None,
+        // Was an exclusion until issue #615: the mapping used a bare-member
+        // if-chain over names `DSt` and `SSt` both declare, and `da003eb`
+        // rightly began rejecting that ambiguity. The exclusion went stale the
+        // moment the mapping was migrated to `enum abstraction`, and this row
+        // is what its failure message said to write.
+        declared_by: "examples/layers/README.md:10 \
+                      (`| `return_impl_refines.fsl` | design -> requirements mapping | refines |`), \
+                      command at :15-16",
+    },
+    Case {
         implementation: "examples/consulting/tobe_expense.fsl",
         abstraction: "examples/consulting/asis_expense.fsl",
         mapping: "examples/consulting/tobe_refines_asis.fsl",
@@ -484,17 +507,15 @@ const CASES: &[Case] = &[
 /// `every_exclusion_premise_still_holds`, so an exclusion cannot outlive its
 /// reason: when the premise stops holding the test fails and names the row
 /// that must replace it.
+/// There was a second variant, `Blocked`, for an exclusion a defect stands in
+/// the way of: it recorded the `result`/`kind` `refine` answered while broken,
+/// so the exclusion went stale the day that changed. Issue #615 was its only
+/// instance, and fixing #615 retired it exactly that way — the premise failed,
+/// named the row to write, and the row went live. The variant is gone rather
+/// than kept unused: no mapping is currently blocked by a defect, and a type
+/// that says otherwise would be describing a state the corpus is not in. Bring
+/// it back with its first user, whose shape this paragraph records.
 enum Premise {
-    /// A defect blocks the declared expectation. `refine` currently answers
-    /// `result`/`kind` for this triple; the day it stops, the exclusion is
-    /// stale and the declared row must go live.
-    Blocked {
-        implementation: &'static str,
-        abstraction: &'static str,
-        depth: u32,
-        result: &'static str,
-        kind: &'static str,
-    },
     /// The mapping is not a `fslc refine` input at all: its `impl` operand
     /// names an artifact that no corpus declaration defines, so there is no
     /// implementation spec to pair it with. The day such a declaration
@@ -510,30 +531,9 @@ struct Exclusion {
     premise: Premise,
 }
 
-const EXCLUSIONS: &[Exclusion] = &[
-    Exclusion {
-        mapping: "examples/layers/return_impl_refines.fsl",
-        reason: "issue #615: examples/layers/README.md:10 declares `refines` and :15-16 \
-                 gives the exact command, but native `fslc refine` answers \
-                 `error`/`kind:\"type\"` (exit 2) -- `ambiguous enum member 'New' belongs \
-                 to [DSt, SSt]`. `da003eb fix(refine): reject ambiguous enum members` \
-                 tightened rust/fsl-core/src/typecheck.rs without migrating the corpus to \
-                 the new `convert`/`abstract` requirement. The expectation is NOT recorded \
-                 as `error`: doing so would pin the regression as the contract. When #615 \
-                 is fixed this exclusion goes stale, and the row that replaces it is \
-                 depth 5, expected_result \"refines\", declared_by \
-                 examples/layers/README.md:10",
-        premise: Premise::Blocked {
-            implementation: "examples/layers/return_impl.fsl",
-            abstraction: "examples/layers/return_system.fsl",
-            depth: 5,
-            result: "error",
-            kind: "type",
-        },
-    },
-    Exclusion {
-        mapping: "examples/causal/evidence/incident-log-mapping.fsl",
-        reason: "not a `fslc refine` input. Its `impl IncidentProductionLog` names a \
+const EXCLUSIONS: &[Exclusion] = &[Exclusion {
+    mapping: "examples/causal/evidence/incident-log-mapping.fsl",
+    reason: "not a `fslc refine` input. Its `impl IncidentProductionLog` names a \
                  production observation log (examples/causal/evidence/\
                  incident-observation-log.jsonl), not a spec, so no implementation \
                  `.fsl` exists to pair with the abstraction. The command that consumes \
@@ -541,11 +541,10 @@ const EXCLUSIONS: &[Exclusion] = &[
                  owned by rust/fslc/tests/causal_cli.rs (OBS_MAPPING, 6 call sites). \
                  This is a capability exclusion, not a tolerated difference: no verdict, \
                  location, or exit code is allowlisted for it anywhere",
-        premise: Premise::UndeclaredImplOperand {
-            operand: "IncidentProductionLog",
-        },
+    premise: Premise::UndeclaredImplOperand {
+        operand: "IncidentProductionLog",
     },
-];
+}];
 
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -919,36 +918,19 @@ fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mappi
 
 /// An exclusion may not outlive its reason. Each entry records the fact that
 /// blocks a live row; this re-measures it and fails when it no longer holds,
-/// so fixing #615 — or adding the missing declaration — forces the excluded
-/// mapping into the manifest instead of leaving a permanent hole (#568).
+/// so adding the missing declaration forces the excluded mapping into the
+/// manifest instead of leaving a permanent hole (#568).
+///
+/// This has already fired once for real. Fixing #615 made that exclusion's
+/// premise false, and the failure named the row to write — depth, expected
+/// result, and citation — so the repair and the coverage landed together
+/// rather than the fix quietly outrunning the manifest.
 #[test]
 fn every_exclusion_premise_still_holds() {
     let root = root();
     let failures = for_each_parallel(EXCLUSIONS.len(), |index| {
         let exclusion = &EXCLUSIONS[index];
         match &exclusion.premise {
-            Premise::Blocked {
-                implementation,
-                abstraction,
-                depth,
-                result,
-                kind,
-            } => {
-                let (output, _status) =
-                    run_refine(implementation, abstraction, exclusion.mapping, *depth);
-                if output["result"].as_str() == Some(result)
-                    && output["kind"].as_str() == Some(kind)
-                {
-                    return None;
-                }
-                Some(format!(
-                    "{}: the exclusion is STALE. `fslc refine {implementation} {abstraction} \
-                     {} --depth {depth}` no longer answers result={result:?}/kind={kind:?}; \
-                     it now answers {output}. Delete the exclusion and add the live \
-                     manifest row. Recorded reason: {}",
-                    exclusion.mapping, exclusion.mapping, exclusion.reason
-                ))
-            }
             Premise::UndeclaredImplOperand { operand } => {
                 if !corpus_declares(&root, operand) {
                     return None;


### PR DESCRIPTION
## Problem

`examples/layers/README.md:10` declares:

| File | Result |
|---|---|
| `return_impl_refines.fsl` | design → requirements mapping | **refines** |

and gives the exact command at :15-16. **That command answered
`error`/`kind:"type"`** — `ambiguous enum member 'New' belongs to [DSt, SSt]`.

## Diagnosis

`da003eb fix(refine): reject ambiguous enum members` was **right**. `New`,
`AutoApproved`, `MgrQueue`, `MgrApproved`, and `MgrRejected` each name a member
of *both* `DSt` and `SSt`, so the mapping's bare-member if-chain read as an
identity while the compiler had to guess which enum each name meant.

What that commit did not do is migrate the corpus to the `convert`/`abstract`
requirement it introduced. Nothing noticed because this mapping was one of the
**22 that no test ran** until #616.

## Fix

`DSt`'s `PaySubmitted` and `PayConfirmed` both collapse to `SSt`'s `Paid`, so the
boundary is many-to-one — `enum abstraction`, not `enum conversion`:

```fsl
enum abstraction case_state DSt -> SSt {
  New          -> New
  ...
  PaySubmitted -> Paid
  PayConfirmed -> Paid
}
map sys[c: CaseId] = RCase { st: abstract(case_state, d[c].st), ... }
```

Source-total, as the form requires. The documented command now answers `refines`
at the documented depth 5.

## The exclusion retired itself, on a real repair

This is the part worth reading. #616 landed this mapping as an **exclusion**
whose recorded premise was the defect — deliberately *not* an
`expected_result: "error"`, which would have pinned the regression as the
contract. Fixing the mapping made the premise false, and the test failed with:

```
examples/layers/return_impl_refines.fsl: the exclusion is STALE.
`fslc refine ... --depth 5` no longer answers result="error"/kind="type";
it now answers ... "result":"refines" ...
Delete the exclusion and add the live manifest row.
... the row that replaces it is depth 5, expected_result "refines",
declared_by examples/layers/README.md:10
```

**The failure named the row to write.** This PR writes exactly that row. The
repair and its coverage land together instead of the fix quietly outrunning the
manifest — which is what happened to `da003eb` and is why #615 existed.

#616 claimed all three self-retirement properties were demonstrated. Two were
demonstrated by breaking something on purpose; this one was not rehearsed.

## `Premise::Blocked` goes with it

#615 was the variant's only instance, so removing the exclusion left it with no
constructor and `clippy` said so. Keeping it behind an `allow` would describe a
state the corpus is not in — **no mapping is currently blocked by a defect**, and
that is worth letting the type say. Its shape is recorded in prose where the
variant was, for whoever needs the next one.

Two stale doc statements are corrected with it: the module comment said this
mapping *is* in the defective state, and the test comment cited #615 as a future
trigger.

## Gates

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `./tools/check-native-integration.sh rust` | 0 — 0 FAILED, 0 panics |

`refine_corpus_parity` is 4/4 green with 27 live rows and 1 exclusion.
Exit codes captured without a pipe.

Closes #615.