### PR TITLE
refactor(fslc): give the kernel-verdict fold rule one owner (#612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   form. The mapping's #616 exclusion went stale on the fix and is replaced by a
   live manifest row, which is the self-retirement working on a real repair
   rather than a rehearsed one.
+- `run_db_check` and `run_domain_check` now share one
+  `outcome::is_definitive_kernel_verdict` instead of each carrying the rule
+  that only a kernel status of 0 or 1 may be folded into a dialect verdict
+  (#612). #600 existed because they did not: `run_domain_check` had folded
+  correctly since #515 while `run_db_check` tested only `== 2`, so an internal
+  error was absorbed as a `dbsystem` verdict. Behaviour is unchanged; the point
+  is that a third dialect check cannot now be written without the rule.
 ### Added
 - `rust/fslc/tests/refine_corpus_parity.rs`: a command-owned manifest binding
   every corpus refinement mapping to native `fslc refine` (issue #593, #537 C4,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5929,14 +5929,9 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     } else {
         let (kernel, kernel_status) =
             run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
-        // Issue #600, matching the `run_domain_check` sibling below: only a
-        // definitive kernel verdict (status 0 = verified/proved, status 1 =
-        // violated/reachable_failed/unknown_cti/unknown_budget) has a `result`
-        // that can safely be folded into the top-level verdict. Any other
-        // status (2 = spec error, 3 = internal error) must return the kernel
-        // envelope verbatim rather than be misread downstream; testing only
-        // `== 2` let an internal error be absorbed as a `dbsystem` verdict.
-        if kernel_status != 0 && kernel_status != 1 {
+        // Issue #600. The rule and its rationale live with the rest of the
+        // outcome vocabulary; `run_domain_check` calls the same predicate.
+        if !fslc_rust::outcome::is_definitive_kernel_verdict(kernel_status) {
             return (kernel, kernel_status);
         }
         // ... and every non-passing kernel verdict folds through, not just
@@ -6795,12 +6790,9 @@ fn run_domain_check(
         }
     };
     let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
-    // Only a definitive kernel verdict (status 0 = verified/proved, status 1 =
-    // violated/reachable_failed/unknown_cti/unknown_budget) has a `result`
-    // that `check_domain` can safely fold into the top-level verdict. Any
-    // other status (2 = spec error, 3 = internal error, ...) must return the
-    // kernel envelope verbatim rather than let it be misread downstream.
-    if status != 0 && status != 1 {
+    // Issue #515. The rule and its rationale live with the rest of the outcome
+    // vocabulary; `run_db_check` calls the same predicate.
+    if !fslc_rust::outcome::is_definitive_kernel_verdict(status) {
         return apply_domain_edition((kernel, status), path, path, edition);
     }
     let result = match fsl_tools::check_domain(&domain, &stable_kernel_projection(kernel)) {

--- a/rust/fslc/src/outcome.rs
+++ b/rust/fslc/src/outcome.rs
@@ -254,6 +254,28 @@ pub fn verify_cache_admits(output: &Value) -> bool {
     )
 }
 
+/// Whether a kernel `verify` reached a verdict a dialect check may fold into
+/// its own.
+///
+/// Status 0 is `verified`/`proved` and status 1 is
+/// `violated`/`reachable_failed`/`unknown_cti`/`unknown_budget`: both are
+/// answers about the spec, so a dialect layer may combine them with its own
+/// findings. Anything else — 2 for a spec error, 3 for an internal
+/// inconsistency — is an answer about the *run*, and the kernel envelope must
+/// be returned verbatim rather than absorbed into a `dbsystem` or `domain`
+/// verdict that would then contradict its own exit code.
+///
+/// This lives here because `run_db_check` and `run_domain_check` both need it
+/// and #600 exists because they did not share it: `run_domain_check` had folded
+/// correctly since #515, `run_db_check` tested only `== 2`, and an internal
+/// error read as a `dbsystem` verdict. The rule is one sentence, so the risk
+/// was never that it is hard — it is that a third dialect check will be written
+/// and its author will not know to look at the other two (#612).
+#[must_use]
+pub fn is_definitive_kernel_verdict(status: i32) -> bool {
+    status == 0 || status == 1
+}
+
 /// `docs/LANGUAGE.md`'s exit-code table applied to an envelope, as a total
 /// function over [`outcome_class`].
 ///
@@ -295,7 +317,35 @@ pub fn exit_status(output: &Value, error_status: i32) -> i32 {
 mod tests {
     use serde_json::json;
 
-    use super::{OutcomeClass, outcome_class, verify_cache_admits};
+    use super::{OutcomeClass, is_definitive_kernel_verdict, outcome_class, verify_cache_admits};
+
+    /// The rule `run_db_check` and `run_domain_check` share, pinned where it
+    /// now lives. Both once carried it separately and one of them carried it
+    /// wrong (#600, #612).
+    ///
+    /// Status 3 is the case that matters and the one no `.fsl` input can
+    /// currently produce inside `run_db_check` — `check_db` calls `validate_db`
+    /// first, so everything `run_verify` would reject with status 2 is rejected
+    /// before the kernel runs, and the remaining status-3 exits are internal
+    /// inconsistencies (#610). An end-to-end control is therefore impossible;
+    /// this is where the rule can still be asserted directly, which is a
+    /// by-product of the extraction rather than its reason.
+    #[test]
+    fn only_a_spec_verdict_may_be_folded_into_a_dialect_verdict() {
+        assert!(is_definitive_kernel_verdict(0), "verified/proved");
+        assert!(
+            is_definitive_kernel_verdict(1),
+            "violated/reachable_failed/unknown_*"
+        );
+        assert!(
+            !is_definitive_kernel_verdict(2),
+            "spec error is about the run"
+        );
+        assert!(
+            !is_definitive_kernel_verdict(3),
+            "internal error is about the run"
+        );
+    }
 
     /// Negative control for the `_` arm: a value nobody registered must not
     /// be readable as a pass. This is the property #554 violated.


### PR DESCRIPTION
## Problem

Two call sites each carried the same rule:

```rust
// run_db_check
if kernel_status != 0 && kernel_status != 1 { return (kernel, kernel_status); }
// run_domain_check
if status != 0 && status != 1 { return apply_domain_edition((kernel, status), ...); }
```

Status 0 and 1 are answers **about the spec** — `verified`/`proved`, or
`violated`/`reachable_failed`/`unknown_*` — so a dialect layer may combine them
with its own findings. Status 2 and 3 are answers **about the run**, and folding
one produces a `dbsystem` or `domain` verdict that contradicts its own exit code.

**#600 exists because the two sites carried it separately.** `run_domain_check`
had folded correctly since #515. `run_db_check` tested only `== 2`, so an
internal error was absorbed. The rule is one sentence — the risk was never that
it is hard, it is that a third dialect check gets written and its author does
not know to look at the other two.

`CLAUDE.md` requires extraction when the same logic appears in two or more
places.

## Change

One `outcome::is_definitive_kernel_verdict`, beside the rest of the outcome
vocabulary (#603 established that module as its single address, and "what counts
as a definitive kernel verdict" is that vocabulary).

**Behaviour is unchanged.** Both sites tested the same two statuses before and
after; this moves where the rule is written, not what it says.

## Why the unit test is a by-product, not the reason

#610 measured that **no `.fsl` input can reach the status-3 branch** inside
`run_db_check`: `check_db` calls `validate_db` first, so everything `run_verify`
would reject with status 2 is rejected before the kernel runs, and the remaining
status-3 exits are internal inconsistencies. That is why no end-to-end control
exists for it, and why it is not a #537 C5 fault operator — an operator whose
fault is unobservable would report `primary did not fail` forever.

Extracting the predicate gives the rule somewhere it can still be asserted
directly, and this PR asserts it. But **building test machinery for a fault that
cannot occur would have been the wrong reason to move production code**, so the
justification stays the duplication and the third site.

## Gates

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `./tools/check-native-integration.sh rust` | 0 — 0 FAILED, 0 panics |

`issue_600_db_check_folds_kernel_verdict` and the new
`only_a_spec_verdict_may_be_folded_into_a_dialect_verdict` both pass. Exit codes
captured without a pipe.

Closes #612.