### PR TITLE
fix(fslc): give every platform the same stack, not the OS default (#617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `fslc` now runs on an explicitly sized 8 MiB stack on every platform
+  instead of whatever the OS gives the main thread (#617). Windows gives
+  1 MiB where Linux and macOS give 8, and `fslc refine` needed more than 1
+  on `examples/agentic_rag` and `examples/multi_agent_system`: the same
+  command on the same bytes answered `refines` on Linux and aborted with
+  `has overflowed its stack` on Windows, returning neither a JSON envelope
+  nor an exit code. Those two mappings are among the 22 that #593 counted as
+  never executed, so #616's manifest ran them for the first time and the
+  crash surfaced on its first post-merge Windows run. The recursion is still
+  unbounded — it grows with the spec's structure, not with `--depth` — which
+  is #620; this makes the platforms agree, it does not add a limit.
 - `examples/layers/return_impl_refines.fsl` now declares an `enum abstraction`
   instead of a bare-member if-chain, so the command `examples/layers/README.md`
   documents answers `refines` again rather than `error`/`kind:"type"` (#615).

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -298,7 +298,42 @@ fn parse_optional_output(
     }
 }
 
+/// The stack every `fslc` run gets, on every platform.
+///
+/// 8 MiB is the Linux and macOS default for a process's main thread. Windows
+/// gives 1 MiB, and `fslc refine` needs more than that on
+/// `examples/agentic_rag` and `examples/multi_agent_system`: the same command
+/// on the same bytes returned `refines` on Linux and aborted with
+/// `has overflowed its stack` on Windows (issue #617). A verifier whose answer
+/// depends on which machine ran it is the failure this repository spends most
+/// of its effort on, and platform-dependent *crashing* is that failure in its
+/// crudest form.
+///
+/// This makes the platforms agree at the Unix value. It does not make the
+/// recursion bounded: `refine`'s depth grows with the spec's structure rather
+/// than with `--depth` (measured — it aborts at `--depth 2` exactly as at 4,
+/// while `specs/cart_*` survives at `--depth 8`), so a large enough spec will
+/// exhaust any fixed stack. That is issue #620, and it wants a depth guard
+/// that reports `kind:"internal"` instead of aborting.
+const STACK_SIZE: usize = 8 * 1024 * 1024;
+
 fn main() {
+    // `run` on an explicitly sized thread rather than the process's main
+    // thread, whose size the OS picks.
+    let worker = std::thread::Builder::new()
+        .stack_size(STACK_SIZE)
+        .name("fslc".to_owned())
+        .spawn(run)
+        .expect("spawn the fslc worker thread");
+    if worker.join().is_err() {
+        // The panic message has already been printed by the default hook.
+        // Exit as a panicking `main` would, so a crash is never mistaken for
+        // a verdict.
+        std::process::exit(101);
+    }
+}
+
+fn run() {
     if print_cli_metadata() {
         return;
     }

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -16,6 +16,7 @@ assert_dependency_absent() {
 }
 
 check_rust() {
+  check_stack_parity
   cargo fmt --manifest-path rust/Cargo.toml --all -- --check
   cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
   cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --lib --locked
@@ -41,6 +42,48 @@ check_fault_operators() {
   ./tools/run-fault-operators.sh
 }
 
+# Negative control for issue #617: `fslc` must not depend on the operating
+# system's choice of main-thread stack.
+#
+# Windows gives 1 MiB where Linux and macOS give 8, and `fslc refine` needed
+# more than 1 on `examples/agentic_rag`: it answered `refines` on Linux and
+# aborted with `has overflowed its stack` on Windows, from the same bytes. The
+# fix gives every platform 8 MiB explicitly; this asserts it, on the platforms
+# that can ask for a smaller one.
+#
+# `ulimit -s 1024` makes a Unix runner reproduce the Windows condition, so the
+# regression is caught here rather than only post-merge on the Windows matrix
+# — which is where it actually escaped to, unnoticed for three merges. Depth 2
+# is deliberate: the abort does not depend on `--depth` (it happened at 2 and
+# at 4 alike), so the cheap run is as good a control as the expensive one.
+check_stack_parity() {
+  if ! (ulimit -s 1024) 2>/dev/null; then
+    echo "check-native-integration: cannot lower the stack limit here; \
+issue #617's control needs a shell that can (Linux/macOS). Not skipping \
+silently: run this phase on a platform that can, or the control is absent." >&2
+    return 1
+  fi
+  cargo build --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc --locked
+  local out
+  out=$(
+    ulimit -s 1024
+    ./rust/target/debug/fslc refine \
+      examples/agentic_rag/agentic_rag_design.fsl \
+      examples/agentic_rag/agentic_rag_requirements.fsl \
+      examples/agentic_rag/agentic_rag_design_refines_requirements.fsl \
+      --depth 2 2>&1
+  )
+  local status=$?
+  if [ "$status" -ne 0 ] || printf '%s' "$out" | grep -q "overflowed its stack"; then
+    printf '%s\n' "$out" >&2
+    echo "check-native-integration: \`fslc refine\` did not survive a 1 MiB \
+stack (exit $status). That is the Windows default, so this is issue #617 \
+returning: the CLI is back on whatever stack the OS picked." >&2
+    return 1
+  fi
+  echo "stack parity: refine survives a 1 MiB (Windows-sized) stack"
+}
+
 check_wasm() {
   npm --prefix rust/spikes/z3js-worker ci
   npm --prefix rust/spikes/z3js-worker run probe
@@ -63,13 +106,16 @@ case "${1:-all}" in
   fault-operators)
     check_fault_operators
     ;;
+  stack-parity)
+    check_stack_parity
+    ;;
   all)
     check_rust
     check_wasm
     check_fault_operators
     ;;
   *)
-    echo "usage: $0 [all|rust|wasm|boundaries|fault-operators]" >&2
+    echo "usage: $0 [all|rust|wasm|boundaries|fault-operators|stack-parity]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Problem

`fslc refine` answered `refines` on Linux and **aborted on Windows, from the same
bytes**:

```
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

Windows gives a process's main thread 1 MiB; Linux and macOS give 8. The abort
returns **neither a JSON envelope nor an exit code**, which is why
`refine_corpus_parity` reported it as `invalid JSON`.

`main` has been red on Windows since `b1d17c5` — three merges. #616 did not
break it: **#616 revealed it.** Both affected mappings are among the 22 that #593
counted as never executed, so the manifest ran them for the first time and the
crash surfaced on its first post-merge Windows run. Per-PR CI is Linux-only.

**This is the failure this repository spends most of its effort on, in its
crudest form: an answer that depends on which machine produced it.**

## Measured, not assumed

`ulimit -s 1024` makes macOS reproduce the Windows condition, so the scope
question was answerable locally rather than by dispatching CI:

| command | agentic_rag / multi_agent | specs/cart_* |
|---|---|---|
| `check` | ok | ok |
| `verify --depth 4` | ok | — |
| **`refine`** | **abort** | ok, even at `--depth 8` |
| `scenarios` | ok | — |
| `mutate` | ok | — |

Two things follow. Only refinement reaches the depth — so a fix aimed solely at
`refine` would have been defensible. And **`--depth` is not the parameter**: it
aborts at 2 exactly as at 4, while a small spec survives 8. The recursion tracks
the spec's structure.

## Fix

```rust
const STACK_SIZE: usize = 8 * 1024 * 1024;   // the Unix default, everywhere
```

`main` spawns `run` on a thread with that stack and joins it, exiting 101 if it
panicked so a crash is still never mistaken for a verdict.

**8 MiB is not a new budget** — it is what Linux and macOS already gave. The
change is that the number is now the program's choice rather than the operating
system's.

## What this does not fix

It raises the ceiling without adding a bound. A large enough spec exhausts 8 MiB
on **every** platform, and then aborts identically everywhere.

Filed as **#620**, with the honest limitation stated there: no such spec has
actually been constructed. "A big enough spec would crash" is currently an
inference, not a measurement, and #610 is the standing reminder that "no test
covers this" and "no input reaches this" are opposite conclusions that look
alike.

## Control

`./tools/check-native-integration.sh stack-parity` re-runs the repro under a
1 MiB limit and fails if `fslc` aborts:

```
stack parity: refine survives a 1 MiB (Windows-sized) stack
```

**Verified to fail against the pre-fix binary** (exit 134) — the control detects
the defect it claims to.

Wired into the per-pull-request `rust` phase, not post-merge. This escaped *to*
the Windows matrix and sat there for three merges; running the control only
where the escape landed would preserve the path. Depth 2 keeps it at ~2s. Where
the stack limit cannot be lowered the phase **fails loudly rather than
skipping**.

## Gates

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `./tools/check-native-integration.sh rust` | 0 — 0 FAILED, 0 panics, stack parity ok |

Exit codes captured without a pipe.

Closes #617.