### PR TITLE
fix(syntax)!: build the kernel AST without re-serializing every subtree (#622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- The kernel AST projection no longer re-serializes every subtree, and is named
+  for what it is: `python_ast` is now `kernel_ast_v1` (#622). `json!` calls
+  `serde_json::to_value` on each interpolated operand, and the operands were
+  already-built `Value` children, so every level deep-copied the subtree below
+  it — O(depth) stack and O(n²) time per level, spent *inside*
+  `recursion::guard` rather than around it, which is why #620's guard could not
+  see it. Nodes are now built with `Value::Array(vec![...])`. The name was
+  history, not contract: the tagged-array shape came from the frozen Python
+  reference, but the shape is now the input to `fsl-kernel-ast-v1+sha256`, which
+  **two** digests hash (`approval::spec_digest`,
+  `document_digest::spec_digest_from_kernel`). Deleting or reshaping it would
+  drift every approval record already in a user's repository; renaming the
+  function changes nothing a user can observe.
+- `PredicateExpander::expand_expr` and `public_kernel::expr_json` are now
+  guarded too, bringing the #620 table to ten cycles (#622). Neither was
+  reachable by the #620 witness, whose depth lived in a refinement mapping; a
+  second generator that puts the same depth inside an `invariant` — the shape
+  the digests actually project — aborted both immediately. `expr_json` is the
+  more interesting of the two: it called the already-guarded `infer_type` once
+  per level, so the guard ran every level, and the crash still landed in
+  `stacker::_grow` itself, because the check happens on entry and this frame is
+  large enough that the stack could fall from above the red zone to below what
+  growing it costs. A guard on a called function is not a guard on the calling
+  cycle. `fslc check`, `document claims`, and `kernel` now complete on a
+  2000-deep invariant.
+- Byte-identity was proven by differential sweep, not self-consistency: the
+  pre-change and post-change binaries were run over all 211 corpus specs under
+  `document claims`, `analyze`, and `testgen`, comparing stdout byte for byte —
+  633 comparisons, 0 mismatches. The sweep's own control came first and mattered:
+  run against itself the old binary disagreed with itself on 14 files, because
+  `testgen` stamps wall-clock `elapsed_s`/`check_elapsed_s` into its envelope.
+  Those two keys are blanked; nothing else is normalized.
+
 - `tools/run-fault-operators.sh` no longer measures a *previous* run's fault.
   The scratch checkout shares one `CARGO_TARGET_DIR` across steps, and `rsync -a`
   restores the reverted sources with the worktree's mtimes -- which can be older
@@ -36,7 +69,7 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   shows whichever site ran out first, so guarding one exposed the next, six
   rounds over. Eight cycles across three crates are now guarded —
   `SyntaxParser::expression`, `SyntaxExpr::into_kernel`,
-  `SyntaxExpr::render_source`, `Expr::python_ast` (`fsl-syntax`),
+  `SyntaxExpr::render_source`, `Expr::kernel_ast_v1` (`fsl-syntax`),
   `elaborate_enum_conversions`, `infer_type`, `validate_expression`
   (`fsl-core`), and `eval` (`fsl-verifier`) — behind one
   `fsl_syntax::recursion::guard` that owns the red zone and segment size, so a
@@ -48,7 +81,7 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   that previously aborted at 160, and `check`/`fmt` return their ordinary
   envelopes on the same file.
 
-  The invariant is **not** fully met, and #622 tracks the rest. `Expr::python_ast`
+  The invariant is **not** fully met, and #622 tracks the rest. `Expr::kernel_ast_v1`
   builds its result with `json!`, which calls `serde_json::to_value` on each
   already-built child and re-serializes the whole subtree — O(depth) stack per
   level, inside the guard rather than around it. `fslc analyze` still aborts

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -126,9 +126,9 @@ contained action/property target exactly the way the block's own
 extend the trace case's own `Requirement{id,text}` relation
 (`dialect.rs::trace_case_annotations`).
 
-`python_ast()` never projects the new `annotations` field (destructured with
+`kernel_ast_v1()` never projects the new `annotations` field (destructured with
 `..` in every projection match arm) — the frozen Python oracle has no
-annotation concept, `fslc::approval::spec_digest` hashes `python_ast`, and
+annotation concept, `fslc::approval::spec_digest` hashes `kernel_ast_v1`, and
 Public Kernel v1/v2 stay closed contracts. A file that uses `@...` on a
 nested declaration is therefore unparseable by the frozen Python reference by
 construction (confirmed native-only via `tests/dialect_registry.py`'s
@@ -219,13 +219,13 @@ by more than one surface declaration" pattern issue #241 established for
   `lower_domain_surface` never reads `domain.projections`, and
   `lower_ai_component` is a catalog-sentinel stub with no per-declaration
   content). Their annotations are preserved on the frontend AST and reachable
-  through `python_ast()`/direct AST inspection, with no `AnnotationRegistry`
+  through `kernel_ast_v1()`/direct AST inspection, with no `AnnotationRegistry`
   binding to reach — there is no Kernel target for one to attach to.
 
 `ai_component`'s `AiAuthority` restructuring: `may_suggest`/`may_execute`/
 `requires_human_approval`/`forbidden` change from `Vec<String>` to
 `Vec<AiAuthorityRule>`, where `AiAuthorityRule { name, annotations, loc }`.
-`AiAuthority::python_ast()` reconstructs the original plain `Vec<String>` JSON
+`AiAuthority::kernel_ast_v1()` reconstructs the original plain `Vec<String>` JSON
 shape (`rule.name` only) so the public JSON projection is unchanged; the
 typed carrier is additive. Every Rust call site that used to compare a
 `&String` name directly (`rust/fslc/src/main.rs`'s specialized-document
@@ -235,12 +235,12 @@ to compare `rule.name` instead.
 `dbsystem`'s existing `DbMigration`/`DbMigrationOp` already declare a field
 named `annotations: Vec<String>` — a pre-#281, unrelated legacy mechanism
 (the `destructive`/`irreversible`/`rollbackable`/`lossy`/`lossless` migration
-keyword flags, still projected into `python_ast()` under the same JSON key).
+keyword flags, still projected into `kernel_ast_v1()` under the same JSON key).
 The new typed carrier could not reuse that name, so `DbMigration` gained a
 second, distinctly named field: `decl_annotations: Annotations`. Compatibility
 rules changed shape instead of gaining a same-named field:
 `DbCheck.rules: Vec<String>` became `Vec<DbCheckRule>`, where
-`DbCheckRule { name, annotations, span }`; `DbCheck::python_ast()`
+`DbCheckRule { name, annotations, span }`; `DbCheck::kernel_ast_v1()`
 reconstructs the original plain `Vec<String>` rule-name list.
 
 Issue #410 supersedes the temporary text-transport detail from #281.
@@ -262,7 +262,7 @@ artifact/environment entry, and column declarations that caused it.
 
 `tools/check_rust_surface_parity.py`'s `SUPPORTED_SPECIALIZED_FRONTENDS`
 already includes `ai-component`/`db`/`domain`; since no new field was
-projected into any of these three dialects' `python_ast()`, corpus parity is
+projected into any of these three dialects' `kernel_ast_v1()`, corpus parity is
 unaffected by construction (the tool is not CI-wired — see the Python
 compatibility gate note in the repository's CLAUDE.md — but was still run
 manually against the corpus to confirm).
@@ -285,7 +285,7 @@ manually against the corpus to confirm).
 ## Rationale convention for tooling and AI consumption
 
 Editorial convention, not a new checked behavior: a `//` comment is lexer
-trivia and never reaches `KernelModel`, `python_ast()`, the JSON result
+trivia and never reaches `KernelModel`, `kernel_ast_v1()`, the JSON result
 envelope, the LSP index, or the audit ledger (confirmed by
 `comments_are_trivia_and_locations_are_one_based` in
 `rust/fsl-syntax/src/lexer.rs`). A fact a downstream tool or an AI agent must

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -169,7 +169,7 @@ happened to exhaust the stack first, so guarding it does not fix the file, it re
 Implementing the fix took six rounds of guard-rebuild-recrash before the witness completed. Neither
 earlier count was a bad measurement; both were single measurements read as a census.
 
-Eight cycles are guarded, in three crates. **Six are crash-witnessed; two are not**, and the table
+Ten cycles are guarded, in three crates. **Eight are crash-witnessed; two are not**, and the table
 says which, because a reader who cannot tell them apart cannot tell this apart from the preventive
 spraying the design forbids:
 
@@ -178,11 +178,23 @@ spraying the design forbids:
 | `fsl-syntax` | `syntax_expr.rs` `SyntaxParser::expression` | #620, N=160, frame `ident_atom` | every spec-reading command |
 | `fsl-syntax` | `syntax_expr.rs` `SyntaxExpr::into_kernel` | `check` N=200 after guarding the parser | every spec-reading command |
 | `fsl-syntax` | `syntax_expr.rs` `SyntaxExpr::render_source` | **not crash-witnessed**; survives N=2000 | `fmt`, diagnostics |
-| `fsl-syntax` | `ast.rs` `Expr::python_ast` | `analyze` N=400 | `analyze`, both digests, document claims |
+| `fsl-syntax` | `ast.rs` `Expr::kernel_ast_v1` | `analyze` N=400 | `analyze`, both digests, document claims |
 | `fsl-core` | `refinement.rs` `elaborate_enum_conversions` | `refine` N=200 | `refine` |
 | `fsl-core` | `typecheck.rs` `infer_type` | **not crash-witnessed**; survives N=1000 | every checked command |
 | `fsl-core` | `typecheck.rs` `validate_expression` | `refine` N=400 | every checked command |
+| `fsl-core` | `lib.rs` `PredicateExpander::expand_expr` | `check` on a 400-deep *invariant* (#622) | every checked command |
+| `fsl-core` | `public_kernel.rs` `expr_json` | `document claims` on the same spec (#622) | Kernel v2, document claims, digests |
 | `fsl-verifier` | `eval.rs` `eval` | #620 sample, `agentic_rag` at 1 MiB | `verify`, `refine` |
+
+The last two were found by changing the *witness*, not the code, and they are the clearest evidence
+for this section's thesis. #620's witness put its depth in a refinement mapping, so no amount of
+re-running it could reach predicate expansion or the Kernel v2 projection. Writing a second
+generator that puts the same depth inside an `invariant` — the shape the digests actually project —
+exposed both immediately. `expr_json` also shows that a guard on a *called* function is not a
+substitute for a guard on the *calling* cycle: it invoked the already-guarded `infer_type` once per
+level, so the guard ran every level, yet the innermost crash frame was `stacker::_grow` itself. The
+check happens on entry, and this frame is large enough that the stack could fall from above the red
+zone to below what growing the stack needs.
 
 The two unwitnessed guards are kept, not because deep recursion there is hypothetical — both are
 genuinely unbounded over the same user-controlled tree — but because each is dominated by a guarded
@@ -216,24 +228,37 @@ Three boundaries hold the mechanism in place:
   `unguarded-recursion` #537 C5 fault operator patches `guard` back into a direct call to prove the
   deep-spec test still detects its absence.
 - A guard around a *third-party* recursion moves the threshold without removing the unboundedness,
-  so it is not a substitute for removing the recursion. One such site is open and tracked as
-  **#622**: `Expr::python_ast` builds its result with `json!`, which calls `serde_json::to_value` on
-  each already-built child and therefore re-serializes the whole subtree — O(depth) stack and O(n²)
-  time *per level*, inside our guard rather than around it. The fix is to build `Value::Array`
-  directly, not to widen the red zone.
+  so it is not a substitute for removing the recursion. `Expr::kernel_ast_v1` used to build its
+  result with `json!`, which calls `serde_json::to_value` on each already-built child and therefore
+  re-serialized the whole subtree — O(depth) stack and O(n²) time *per level*, spent inside our
+  guard rather than around it, which is why the guard could not see it. #622 removed the recursion
+  by building `Value::Array` directly rather than widening the red zone.
 
-**The invariant at the top of this section is therefore not yet met.** It holds for the parse,
-lowering, typecheck, refinement, and evaluation paths; it does not hold wherever `python_ast` is
-projected, and that is wider than the command the witness happened to expose. `analyze` aborts on a
-400-stage witness, and the same projection feeds `fslc::approval::spec_digest`,
-`fsl_tools::document_digest::spec_digest_from_kernel`, the requirements document's claim
-projection, and testgen's `expect` — so an approval or document digest over a spec with a deep
-enough invariant is the same class. The witness reached only `analyze` because its deep expression
-lives in a refinement mapping rather than in a spec, which is a property of the witness, not of the
-defect. Treating "analyze only" as the scope would repeat the #617 and #620 errors a third time.
-Because that projection is digest input, its repair must prove byte-identical output against the
-existing digest tests and corpus snapshots, which is why it is a separate reviewable change (#622)
-rather than part of this one.
+**The invariant holds across the measured surface, and the measurement is stated so it can be
+falsified.** Two witness shapes — depth in a refinement mapping, depth in an `invariant` — were run
+at N up to 2000 through `check`, `lint`, `fmt`, `kernel`, `analyze`, `typestate`, `conformance`,
+`refine`, and `document claims`. None aborts; each returns its ordinary envelope and exit code.
+`explain`, `html`, `testgen`, and `scenarios` are excluded from that claim on purpose: they time out
+on these witnesses under bounded verification, identically before and after, which is solver cost
+rather than stack, and a timeout is not evidence either way.
+
+That is a statement about shapes that have been tried, not a proof over all specs. The honest
+falsifier is the one that has now worked three times: **write a witness with a different shape.**
+#617's corpus said "only `refine`", #620's debugger said "two sites", and #620's mapping-shaped
+witness said "analyze only" — each was a property of the instrument. A spec shape that reaches a
+cycle none of these witnesses reach would extend the table again, and adding the guard is part of
+adding that shape.
+
+Because the projection is digest input for two separate digests
+(`fslc::approval::spec_digest`, `fsl_tools::document_digest::spec_digest_from_kernel`), #622's
+repair was held to byte-identical output, proven by differential sweep between the pre- and
+post-change binaries over the whole corpus rather than by self-consistency inside one binary.
+
+One consumer-side limit is worth recording because it is not ours to fix and will surprise someone:
+`serde_json`'s *deserializer* has a 128-deep nesting limit, so a Rust consumer reading a
+200-deep projection back with `serde_json::from_slice` fails with "recursion limit exceeded" even
+though `fslc` emitted the envelope correctly. The regression test asserts on the exit code and the
+envelope's first byte for exactly this reason.
 
 This section records current ownership and possible target directions. Any
 source movement described as a target, trigger, or experiment is a candidate,

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1824,7 +1824,7 @@ migration/互換性ルールのアノテーションが、損失のあるレガ�
 #### 13.1.2 ツール・AI 消費のための根拠(rationale)
 
 `//` コメントは字句解析上の trivia(`rust/fsl-syntax/src/lexer.rs`)であり、
-AST にも `KernelModel` にも `python_ast()` にも JSON の result envelope にも
+AST にも `KernelModel` にも `kernel_ast_v1()` にも JSON の result envelope にも
 LSP のインデックスにも監査台帳にも到達しません。補助不変条件が k-induction の
 CTI を閉じるために存在する、あるいは実装のガードが抽象側より意図的に強い、と
 いった、下流のツールや AI エージェントが失ってはならない事実は、散文だけに

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1876,7 +1876,7 @@ construction.
 #### 13.1.2 Rationale for tooling and AI consumption
 
 A `//` comment is lexer trivia (`rust/fsl-syntax/src/lexer.rs`): it never
-reaches the AST, `KernelModel`, `python_ast()`, the JSON result envelope, the
+reaches the AST, `KernelModel`, `kernel_ast_v1()`, the JSON result envelope, the
 LSP index, or the audit ledger. A fact a downstream tool or an AI agent must
 not lose — that an auxiliary invariant exists to close a k-induction CTI, or
 that an implementation guard is deliberately stronger than its abstract

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -588,7 +588,20 @@ scalar | <code>Option&lt;scalar&gt;</code> | struct (scalar / <code>Option&lt;sc
   it contains no symmetric identity type. This is intended for models such as
   <code>Map&lt;TaskId, Status&gt;</code> where no task identity is special.</li>
 </ul></div></details>
-<details id="3-expressions"><summary>3. Expressions<span class="tree-blurb"> — Expression grammar — operators, quantifiers, calls.</span></summary><div class="tree-body"><p>Named predicates factor repeated or business-significant expressions:</p>
+<details id="3-expressions"><summary>3. Expressions<span class="tree-blurb"> — Expression grammar — operators, quantifiers, calls.</span></summary><div class="tree-body"><p><code>true</code>, <code>false</code>, and <code>none</code> are <strong>reserved</strong>: they always resolve to the literal,
+so they cannot name a declaration anywhere — specification, const, <code>def</code> and its
+parameters, type, enum and its members, struct and its fields, state variable,
+action and its parameters, property, or a quantifier/aggregate binder or <code>is
+some(x)</code> pattern binding. A declaration with one of those names would be
+unreadable from every expression, and the misreading is silent: before this was
+checked, <code>state { true: Bool }</code> with <code>invariant AlwaysHolds { true }</code> returned
+<code>proved</code> while <code>init { true = false }</code> assigned a variable nothing could read.
+No other word is reserved. <code>count</code>, <code>sum</code>, <code>stage</code>, <code>in</code>, <code>is</code>, <code>where</code>, <code>old</code>,
+<code>abs</code>, <code>and</code>, and <code>or</code> are contextual and remain valid names; <code>some</code>, <code>Set</code>,
+<code>Seq</code>, <code>unique</code>, <code>exactlyOne</code>, <code>forall</code>, and <code>exists</code> are only recognized before
+further syntax, so misusing one as a name is a parse error rather than a silent
+literal.</p>
+<p>Named predicates factor repeated or business-significant expressions:</p>
 <pre><code class="language-fsl">def eligible(c: Claim) = submitted[c] and amount[c] &lt;= AUTO_LIMIT
 invariant OnlyEligible { forall c: Claim { approved[c] =&gt; eligible(c) } }
 </code></pre>
@@ -601,7 +614,18 @@ variable capture instead of inventing internal binder names. See
 <ul>
 <li>Arithmetic: <code>+ - * / %</code>, unary <code>-</code>, <code>min(a, b)</code> / <code>max(a, b)</code> / <code>abs(a)</code>
   (since <code>a//b</code> would turn everything after <code>//</code> into a comment, write division
-  as <code>a / b</code> with whitespace)</li>
+  as <code>a / b</code> with whitespace). <code>/</code> and <code>%</code> are Euclidean for <code>b != 0</code>
+  (<code>a == b * (a / b) + (a % b)</code> and <code>0 &lt;= a % b &lt; |b|</code>, so <code>-7 / 2 == -4</code> and
+  <code>-7 % 2 == 1</code>). Division by zero is <strong>totally defined</strong>: <code>a / 0 == 0</code> and
+  <code>a % 0 == 0</code> always evaluate, so an invariant/trans/reachable/leadsTo/refinement
+  state-map expression that reads <code>a / 0</code> never fails to evaluate. Inside an
+  action's <code>requires</code>/body/<code>ensures</code>, an unguarded <code>/</code>/<code>%</code> whose divisor can
+  reach zero is still reported as <code>partial_op</code> (see §6) even though the value
+  is defined — guard it with <code>y != 0 =&gt; P(x / y)</code> or <code>requires y != 0</code>. A
+  refinement action-correspondence <em>argument</em> expression (§10,
+  <code>impl_action(a) -&gt; abs_action(a / c)</code>) is action context, not a property-context
+  mapping expression, since it constructs an abstract action call: it gets the
+  same <code>partial_op</code> treatment, surfaced as <code>kind: "map_partial_op"</code>.</li>
 <li>Comparison: <code>== != &lt; &lt;= &gt; &gt;=</code></li>
 <li>Logical: <code>and or not =&gt;</code></li>
 <li>Conditional: <code>if condition then when_true else when_false</code>. The condition is
@@ -641,7 +665,13 @@ variable capture instead of inventing internal binder names. See
 <li>Relation: <code>r.contains(a, b)</code>, <code>r.add(a, b)</code>, <code>r.remove(a, b)</code>,
   <code>reachable(r, a, b)</code>, <code>acyclic(r)</code>, <code>functional(r)</code>, <code>injective(r)</code>,
   <code>domain(r)</code>, <code>range(r)</code>. <code>reachable</code> and <code>acyclic</code> require a self-relation
-  (<code>relation T -&gt; T</code>); endpoint type/arity errors include repair hints.</li>
+  (<code>relation T -&gt; T</code>); endpoint type/arity errors include repair hints.
+  <code>reachable(r, a, a)</code> is <strong>not</strong> reflexive by construction: it is true only
+  if a real path of one or more edges leads from <code>a</code> back to <code>a</code> (so an empty
+  or acyclic relation gives <code>reachable(r, a, a) == false</code> for every <code>a</code>). A
+  reflexive reading would make <code>not reachable(r, a, a)</code> unsatisfiable by
+  construction for any inhabited domain, draining the predicate of meaning;
+  use <code>acyclic(r)</code> to state "no self-loops or cycles anywhere in <code>r</code>".</li>
 <li>Inside ensures / trans only: read the pre-transition state with <code>old(expr)</code></li>
 <li>Inside a leadsTo block only: <code>P ~&gt; Q</code> (response property. not part of the operator hierarchy of general expressions);
   optional <code>within K</code> before Q for a bounded deadline, and optional
@@ -717,7 +747,7 @@ variable.</p></div></details>
 <td><code>violated</code> / <code>type_bound</code> / <code>_bounds_&lt;var&gt;</code></td>
 </tr>
 <tr>
-<td>Partial operations</td>
+<td>Partial operations (action context: <code>requires</code>/body/<code>ensures</code> only, see §3)</td>
 <td>At the time of <code>pop()</code>/<code>head()</code>/<code>at(i)</code>, the sequence is non-empty and the index is in range, and the divisor of <code>/</code> <code>%</code> is non-zero</td>
 <td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code></td>
 </tr>
@@ -825,7 +855,9 @@ fslc document check &lt;file.fsl&gt; &lt;document.md&gt; [--glossary glossary.js
 fslc approval create &lt;file.fsl&gt; --kind ledger|html|scenarios|requirements_document --artifact &lt;reviewed&gt; --approver &lt;name&gt;
                [--signing-key private.pem] [--glossary glossary.json] [--evidence evidence.json]... [-o record.json]
                                                   # requirements_document records a v3/v4 revision with a claim_set_digest (§13)
-fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt; [--trust-key public.pem] # approved | drifted | signature-invalid
+fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt; [--trust-key public.pem]
+                                                  # approved (exit 0) | drifted (exit 0, analysis output)
+                                                  # | signature-invalid (exit 1); see DESIGN-approval.md
 fslc approval diff   &lt;file.fsl&gt; --record &lt;record.json&gt; [--depth K] [--trust-key public.pem]
 fslc typestate &lt;file.fsl&gt; [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
@@ -884,8 +916,13 @@ See <code>DESIGN-from-state.md</code>.</p>
 <code>leadsTo P ~&gt; Q</code>, a <code>respond_&lt;Name&gt;[_&lt;binding&gt;]</code> scenario. Each scenario has
 <code>kind: "leadsTo"</code>, <code>pending_at</code>, <code>satisfied_at</code>, <code>bindings</code>, <code>steps</code>,
 <code>initial_state</code>, and <code>expected_states</code>, representing the shortest trace from P
-holding to Q holding within depth K. Bindings for which P never holds are not
-turned into scenarios and appear in <code>warnings</code>.</p>
+holding to Q holding within depth K. A quantified property is tracked
+per binding, not per property name: one binding's response scenario never
+suppresses the completeness warning for a sibling binding with none. A
+binding for which P never holds within depth K gets its own warning worded
+"antecedent never holds within depth K"; a binding for which P held but no
+response ever closed gets "has no response scenario within depth K" — the
+two are never conflated.</p>
 <p><code>verify --property Name</code> resolves across invariant, <code>trans</code>, <code>leadsTo</code>, and
 <code>reachable</code> declarations and checks only the named property kind in isolation.
 <code>--exclude-property Name</code> is repeatable and acts as the cross-kind inverse:
@@ -913,7 +950,11 @@ verification. It evaluates a deterministic grid of <code>--instances NAME=lo..hi
 verification result under <code>sweep.results</code>, and returns the first failing scope
 under <code>sweep.minimal_counterexample</code>. For <code>--values</code>, the sweep fixes the lower
 bound and expands the upper bound (<code>lo..lo</code>, <code>lo..lo+1</code>, ..., <code>lo..hi</code>). A
-passing sweep means "no counterexample in this grid", not an unbounded proof.</p>
+passing sweep means "no counterexample in this grid", not an unbounded proof.
+A spec <code>error</code> (parse / type / semantics / io / vacuous / …) from any scope in
+the grid is not a counterexample: <code>sweep</code> returns that underlying error
+envelope verbatim (<code>result</code>, <code>kind</code>, <code>message</code>, <code>loc</code>, exit code unchanged)
+instead of folding it into <code>sweep_passed</code>/<code>sweep_failed</code>.</p>
 <p><code>diff</code> compares state-machine meaning instead of source text. It runs bounded
 refinement in both directions: NEW→OLD failure is <code>behavior_added</code>, while
 OLD→NEW failure is <code>behavior_removed</code>. It separately checks implication between
@@ -967,7 +1008,19 @@ imported / imported_with_warnings,
 refinement_failed / sweep_failed / observed_mismatch,
 <code>2</code> = spec error (parse / type / semantics / io / vacuous / acceptance / forbidden /
 <code>--vacuity error</code>), <code>3</code> = internal error. <code>observed_*</code> is <code>fslc db observe</code>'s
-result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc db import</code>'s.</p>
+result; <code>imported</code>/<code>imported_with_warnings</code> is <code>fslc db import</code>'s. The same
+<code>2</code> mapping is fail-closed for <code>chain</code>'s project-manifest reader (unrecognized
+section, zero recognized sections, or an unparseable <code>depth</code>/<code>refine_depth</code> —
+<code>docs/DESIGN-layers.md</code> §7) and for <code>ledger --impl-log</code>'s replay input (a
+replay error is not implementation-log evidence and must not be rendered as
+an empty ledger row — <code>docs/DESIGN-ledger.md</code>).</p>
+<p><code>approval_check</code> and <code>approval_diff</code> are absent from this table because their
+exit code is not a function of <code>result</code>. <code>fslc approval check</code> reports the same
+<code>approval_check</code> for every outcome and carries the verdict in <code>status</code>: <code>0</code> for
+<code>approved</code> and for <code>drifted</code>, <code>1</code> for <code>signature-invalid</code>. Drift exits 0 because
+it is analysis output, as <code>diff</code> findings are (§12); <code>docs/DESIGN-approval.md</code>
+records why, and why <code>fslc document check</code>'s <code>document_drifted</code> differs. Gate on
+<code>status</code>, not on the exit code.</p>
 <h3 id="kinds-of-result">Kinds of result</h3>
 <table>
 <thead>
@@ -1292,7 +1345,15 @@ not depart from the behavior of abs (see <code>DESIGN-refinement.md</code>).</p>
   variables with no explicit <code>map</code>, it synthesizes <code>map x = x</code>; for same-named
   compatible actions with no explicit correspondence, it synthesizes
   <code>action f(params...) -&gt; f(params...)</code>. Explicit entries override the defaults.
-  Incompatible same-name candidates are reported as <code>kind: "type"</code> errors.</li>
+  Action parameters are matched <strong>by name, never by position</strong>: each abstract
+  parameter binds to the impl parameter sharing its exact name (so a pure
+  reorder still auto-maps), in the abstract action's parameter order. Auto
+  never guesses — a same-name action pair with a different arity, a surplus
+  impl parameter, a renamed parameter, or any abstract parameter with no
+  same-named impl counterpart is a located <code>kind: "type"</code> error; write an
+  explicit <code>action ... -&gt; ...</code> correspondence for that pair instead.
+  Incompatible same-name state candidates are likewise reported as
+  <code>kind: "type"</code> errors.</li>
 <li><code>action &lt;impl&gt;(&lt;formal params&gt;) -&gt; &lt;abs&gt;(&lt;expr&gt;) | stutter</code> — required for every impl action.
   Formal params may be bare names or <code>name: Type</code> annotations matching the impl action declaration.
   <code>stutter</code> is an internal step in which the abstract state does not change.</li>
@@ -1354,9 +1415,45 @@ design_exists[convert(column_key, c)]</code> with <code>column_key Column -&gt; 
 </code></pre>
 <p>Success: <code>result: "refines"</code> (exit 0). Violation: <code>refinement_failed</code> (exit 1)
 with <code>kind</code> (<code>abs_requires_failed</code> / <code>abs_state_mismatch</code> / <code>stutter_changed_abs</code> /
-<code>map_out_of_bounds</code>), <code>impl_trace</code>, and the post-mapping <code>abs_before</code> /
-<code>abs_after_*</code>. A static error (a missing map, an unknown action, etc.) is
-<code>kind: "type"</code> (exit 2).</p>
+<code>map_out_of_bounds</code> / <code>map_partial_op</code>), <code>impl_trace</code>, and the post-mapping
+<code>abs_before</code> / <code>abs_after_*</code>. A static error (a missing map, an unknown action,
+etc.) is <code>kind: "type"</code> (exit 2). <code>map_partial_op</code> is an action-correspondence
+argument expression (<code>impl_action(a) -&gt; abs_action(a / c)</code>) dividing by an impl
+state variable that can be zero — action context (§3/§6's <code>partial_op</code> rule),
+not the "no check" property context a refinement <em>state</em> map gets.</p>
+<p>Before any correspondence is checked, <code>refine</code> first verifies that the impl
+spec is internally consistent on its own — does not violate its own type
+bounds or invariants — within <code>--depth</code>. A refinement mapping cannot make a
+broken impl meaningful, so this is checked independently of the abstraction
+and the mapping: <code>result: "violated"</code> (exit 1) with <code>violation_kind</code> and a
+<code>note</code> explaining this is a property of the refinement <em>input</em>, not a
+fidelity failure. It is never reported <code>refines</code>, and never folded into
+<code>refinement_failed</code> (whose <code>kind</code>s above describe a mismatch <em>between</em> impl
+and abs, not a defect in the impl alone). <code>fslc diff</code> surfaces the same
+condition as an <code>impl_violated</code> finding and fails its gate unconditionally
+(not subject to <code>--forbid</code>), since a self-violating side makes the
+comparison itself untrustworthy.</p>
+<p>A state variable <code>init</code> never assigns on any path (an <code>init if</code> reading an
+unassigned <code>Bool</code>, for example) is a genuinely free initial value across its
+full type domain, not a value silently defaulted — <code>refine</code> checks it that
+way on both the impl and abs side. The self-consistency precondition above
+and the init correspondence it feeds both reason over <strong>every</strong> concrete
+initial valuation <code>init</code> permits, not one arbitrarily chosen default: an
+impl-side initial valuation must not violate the impl's own semantics, and
+its mapped state must be a member of the abs's own set of valid initial
+valuations, for every such valuation on both sides. A same-named state
+variable init leaves unassigned on <em>some</em> but not all paths (e.g. only
+inside an <code>if</code> with no <code>else</code>) is not enumerated this way and keeps the
+prior single-valuation behavior.</p>
+<p>This closed two opposite defects and is a <strong>breaking change</strong> to <code>refine</code>'s
+verdicts for a mapping where either side's <code>init</code> leaves a state variable
+fully unassigned: a refinement that previously reported <code>refines</code> because
+only the impl's default initial branch was ever checked may now report
+<code>refinement_failed</code> (an initial-correspondence violation on another impl
+branch was missed before); a refinement that previously reported
+<code>refinement_failed</code> solely because the abs's default initial branch did not
+equal the mapped impl state may now report <code>refines</code> (the impl state
+matches a different, still-valid, abs initial branch).</p>
 <p>Give impl and abs <strong>distinct enum/struct type names</strong>, even when a state
 variable pair is mapped 1:1. Type metadata is merged by name for refinement
 checking; a same-named enum (or struct) declared with a different member
@@ -1798,7 +1895,7 @@ it, so specs that use it are outside the Python-parity corpus by
 construction.</p>
 <h4 id="1312-rationale-for-tooling-and-ai-consumption">13.1.2 Rationale for tooling and AI consumption</h4>
 <p>A <code>//</code> comment is lexer trivia (<code>rust/fsl-syntax/src/lexer.rs</code>): it never
-reaches the AST, <code>KernelModel</code>, <code>python_ast()</code>, the JSON result envelope, the
+reaches the AST, <code>KernelModel</code>, <code>kernel_ast_v1()</code>, the JSON result envelope, the
 LSP index, or the audit ledger. A fact a downstream tool or an AI agent must
 not lose — that an auxiliary invariant exists to close a k-induction CTI, or
 that an implementation guard is deliberately stronger than its abstract
@@ -1879,7 +1976,16 @@ verify {
   business and requirements. It does not create a ghost counter or an automatic
   <code>_kpi_*</code> invariant.</li>
 <li>With <code>implements</code>, <code>fslc verify</code> <strong>also runs the refine to the upper layer
-  simultaneously</strong>, and the result carries <code>implements: {abs, result}</code>. An empty
+  simultaneously</strong>, and the result carries <code>implements: {abs, result}</code>, whose
+  values are <code>refines</code> / <code>refinement_failed</code> / <code>impl_violated</code>. <strong>That verdict is
+  reported only in this field. It is not folded into the top-level <code>result</code> or
+  the exit code</strong>, so a broken seam still returns <code>result:"ok"</code>/<code>"verified"</code> and
+  exit 0 — the one exception to the exit-code table above, and the reason
+  <code>implements</code> has no row in it. Gate on <code>implements.result == "refines"</code>, or run
+  <code>fslc chain</code>, which applies exactly that gate to the layer and exits 1
+  (<code>docs/DESIGN-design-family.md</code> states the same rule for orchestrators).
+  Standalone <code>fslc refine</code> does exit 1 on <code>refinement_failed</code>; only the inline
+  seam is silent. An empty
   body (<code>implements X from "..." { }</code>) auto-generates identity refinement when
   process/action/stage names match. Inside the <code>implements { }</code> block you write
   state <code>map</code> entries, <code>maps auto</code>, <code>preserve progress</code>, and — since #73 —
@@ -2178,7 +2284,10 @@ probability, and full production-data completeness are outside the formal model.
 <p>If <code>check compatibility</code> is omitted, default rules cover read/write lifecycle,
 destructive annotations, preservation-transform annotations, and API/offline
 compatibility. <code>data_preserved</code> and <code>rollback_equivalent</code> are opt-in bounded
-checks and report <code>DB-ASSUME-BOUNDED-ROW-MODEL</code>.</p>
+checks and report <code>DB-ASSUME-BOUNDED-ROW-MODEL</code>. A <code>rule</code> name outside the
+closed vocabulary above, or an <code>environment schema lo..hi</code> that the declared,
+strictly sequential migration plan never reaches, fails validation with exit 2
+instead of silently checking nothing.</p>
 <p>Feature flags are finite environment dimensions. <code>fslc db check</code> enumerates the
 declared variants with schema snapshots and reports
 <code>DB-ASSUME-FINITE-FLAG-STATE</code>; this is a rollout/kill-switch compatibility
@@ -2213,6 +2322,11 @@ candidates. Runtime observation returns <code>observed_mismatch</code> with
 <code>formal_result: "not_run"</code>; absence from logs is not proof of unused behavior.
 Use ordinary <code>fslc verify</code> when you want to inspect the generated kernel
 counterexample directly.</p>
+<p><code>fslc db observe</code> validates the observation envelope/events against
+<code>schemas/fslc/db/observation.v0.schema.json</code> (typed required fields, a closed
+<code>capability</code> vocabulary, exit 2 on a malformed record) before evaluating them,
+and matches each event's optional <code>flags</code> snapshot against artifact windows the
+same way <code>fslc db check</code> does.</p>
 <p>Generic <code>requires</code> / <code>provides</code> capabilities let AI model/prompt/retriever/tool
 schema and output schema profiles share the same compatibility check as
 DB/API/mobile/server artifacts. A <code>requires tool.RefundPaymentV2</code> declaration is
@@ -2334,14 +2448,30 @@ graph analysis, not kernel proof. <code>fslc ai replay</code> accepts JSONL or
 </ul>
 <p>Project-level fsl-ai evidence declarations can combine <code>ai_component</code>,
 <code>dataset</code>, <code>evaluator</code>, <code>failure_mode</code>, <code>statistical_property</code>,
-<code>ai_migration</code>, and <code>observed_property</code>. <code>fslc ai check</code> parses these files and
-returns <code>ai_project_analyzed</code>; <code>fslc ai eval</code> checks Bernoulli/proportion
-metrics from precomputed JSONL with Wilson intervals; <code>fslc ai regress</code> checks
-aggregate <code>no_regression</code> metric drop/increase clauses; <code>fslc ai compare</code>
-reports metric deltas without a threshold claim; <code>fslc ai drift</code> checks runtime
-telemetry thresholds and drift; and <code>fslc ai compat</code> emits a finite
-<code>dbsystem artifact</code> capability profile. All of these use
-<code>formal_result:"not_run"</code>.</p>
+<code>ai_migration</code>, and <code>observed_property</code>. <code>fslc ai check</code> parses these files with
+the same parser the evidence commands run and returns <code>ai_project_analyzed</code>;
+<code>fslc ai eval</code> checks the selected
+<code>statistical_property</code>'s declared <code>slice</code>/<code>min_samples</code>/<code>ci_lower</code>/<code>ci_upper</code>
+requirements against precomputed JSONL (<code>--records</code>, or the declared
+<code>dataset</code>'s <code>source</code> file) with Wilson intervals; <code>fslc ai regress</code> checks the
+selected <code>ai_migration</code>'s declared aggregate <code>no_regression</code> metric
+drop/increase clauses; <code>fslc ai compare</code> reports metric deltas without a
+threshold claim; <code>fslc ai drift</code> checks the selected <code>observed_property</code>'s
+declared <code>observed</code>/<code>drift</code> requirements over runtime telemetry
+(<code>observed_supported</code> / <code>observed_mismatch</code>); and <code>fslc ai compat</code> emits a
+finite <code>dbsystem artifact</code> capability profile for one <code>ai_component</code> or every
+<code>ai_component</code> a project declares, rejecting non-AI input and an AI project
+with no <code>ai_component</code> at all (exit 2). All of these use
+<code>formal_result:"not_run"</code>. A <code>require</code> clause matching none of the known
+evidence-clause grammars (<code>min_samples</code>, <code>ci_lower</code>, <code>ci_upper</code>, a point
+estimate, <code>observed</code>, <code>drift</code>) is a spec error (exit 2) at <code>check</code> time, in
+both <code>fslc ai check</code> and the <code>fslc check</code> dispatch: the check stage must not
+report an analyzed project that <code>eval</code>/<code>drift</code> cannot execute. An unknown
+<code>--property</code>/<code>--migration</code> selection is
+a check-time error (exit 2); a selected <code>statistical_property</code>'s gate status
+(<code>dataset_invalid</code>, <code>evaluator_untrusted</code>, <code>slice_missing</code>,
+<code>insufficient_samples</code>, <code>inconclusive</code>, or <code>statistically_unsupported</code>) exits
+1, matching <code>statistically_supported</code>'s exit 0 as the only success case.</p>
 <p>Recursive <code>agent</code> shape:</p>
 <pre><code class="language-fsl">agent SupportOrchestrator {
   context [CustomerTicket, ApprovedSupportDocs];
@@ -2486,7 +2616,11 @@ DESIGN-*.md).</p>
   action enables/conflict edges; <code>--projection impact_graph --focus NODE</code> emits
   the upstream/downstream slice around a TSG node. It accepts multiple files or
   directories in batch mode;
-  directories are expanded recursively for <code>*.fsl</code> and sorted deterministically.
+  directories are expanded recursively for <code>*.fsl</code> and sorted deterministically —
+  an explicitly named file is always kept regardless of extension (a <code>.toml</code>
+  project manifest routes the same way it does in single-file mode; anything
+  else that cannot be analyzed is a real error in <code>files[]</code>/<code>errors[]</code>, never
+  a silent drop).
   Standalone refinement mappings can be viewed with <code>--projection
   refinement_graph</code>; this is an unresolved structural view because the command
   has no impl/abs model paths. Project manifests can be viewed with <code>--projection
@@ -2533,10 +2667,16 @@ lookup, recommended practices) is in the AI-agent skills under <code>skills/</co
 the shared language reference in <code>skills/fsl/SKILL.md</code>. A maintained worked example
 is under <a href="https://github.com/ymm-oss/fsl/tree/main/examples/validation"><code>examples/validation/</code></a>.</p></div></details>
 <details id="16-promotion-judgment-to-ghost-types-typestate"><summary>16. Promotion judgment to ghost types (typestate)<span class="tree-blurb"> — Deciding when a state machine promotes to a ghost type / typestate.</span></summary><div class="tree-body"><p><code>fslc typestate &lt;file.fsl&gt; [--ts]</code> decides how soundly the state machine of a
-design spec (enum-valued struct fields / state variables / <code>Option&lt;_&gt;</code> slots)
-can be mapped to the host language's typestate (ghost types). It classifies each
+design spec (enum-valued struct fields, scoped by field name <strong>and</strong> owning
+struct type so two structs with a same-named field remain independent
+machines / state variables / <code>Option&lt;_&gt;</code> slots) can be mapped to the host
+language's typestate (ghost types). It classifies each
 <code>(entity, action)</code> as <code>derivable</code> (the from-state is the entity's own local
-guard) / <code>branching</code> (data-dependent inside an <code>if</code>) / <code>relational</code> (no local
+guard — a compound guard's from-state is what the <strong>whole</strong> formula implies:
+<code>or</code> is a union of what each disjunct implies, but only when every disjunct
+constrains the entity; a disjunct silent about the entity, e.g. an unrelated
+flag, drops the guard entirely rather than narrowing it) /
+<code>branching</code> (data-dependent inside an <code>if</code>) / <code>relational</code> (no local
 guard, and the precondition lives in an external structure — cannot be expressed
 in the type and remains as a runtime/verification obligation). An entity's
 <code>applicability</code> is <code>full</code> only when all transitions are derivable/branching.

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -576,7 +576,18 @@ induction、Public Kernel v1 は、等価な <code>init</code> ブロックと�
   ときだけ使われます。これは、どのタスクの同一性も特別ではない
   <code>Map&lt;TaskId, Status&gt;</code> のようなモデルを意図しています。</li>
 </ul></div></details>
-<details id="3-expressions"><summary>3. 式<span class="tree-blurb"> — 式の文法 — 演算子、量化子、関数呼び出しなど。</span></summary><div class="tree-body"><p>名前付き述語は、繰り返される式や業務上重要な式をくくり出します:</p>
+<details id="3-expressions"><summary>3. 式<span class="tree-blurb"> — 式の文法 — 演算子、量化子、関数呼び出しなど。</span></summary><div class="tree-body"><p><code>true</code> / <code>false</code> / <code>none</code> は<strong>予約語</strong>である。式中では常にリテラルに解決されるため、
+宣言名として使えない —— 仕様名、const、<code>def</code> とその引数、型、enum とそのメンバー、
+struct とそのフィールド、状態変数、アクションとその引数、プロパティ、
+量化子/集約の束縛変数、<code>is some(x)</code> のパターン束縛のいずれにおいてもである。
+これらの名前を持つ宣言はどの式からも読めなくなり、しかもその読み違えは沈黙する。
+検査が入る前は、<code>state { true: Bool }</code> と <code>invariant AlwaysHolds { true }</code> は
+<code>proved</code> を返し、<code>init { true = false }</code> は何からも読めない変数への代入になっていた。
+予約語はこの 3 語のみである。<code>count</code>、<code>sum</code>、<code>stage</code>、<code>in</code>、<code>is</code>、<code>where</code>、<code>old</code>、
+<code>abs</code>、<code>and</code>、<code>or</code> は文脈依存であり、名前として引き続き有効である。<code>some</code>、<code>Set</code>、
+<code>Seq</code>、<code>unique</code>、<code>exactlyOne</code>、<code>forall</code>、<code>exists</code> は後続の構文がある場合にのみ
+認識されるため、名前として誤用してもリテラルへの沈黙した解決ではなくパースエラーになる。</p>
+<p>名前付き述語は、繰り返される式や業務上重要な式をくくり出します:</p>
 <pre><code class="language-fsl">def eligible(c: Claim) = submitted[c] and amount[c] &lt;= AUTO_LIMIT
 invariant OnlyEligible { forall c: Claim { approved[c] =&gt; eligible(c) } }
 </code></pre>
@@ -588,7 +599,18 @@ invariant OnlyEligible { forall c: Claim { approved[c] =&gt; eligible(c) } }
 <ul>
 <li>算術: <code>+ - * / %</code>、単項 <code>-</code>、<code>min(a, b)</code> / <code>max(a, b)</code> / <code>abs(a)</code>
   (<code>a//b</code> は <code>//</code> 以降がすべてコメントになってしまうので、除算は空白を入れて
-  <code>a / b</code> と書きます)</li>
+  <code>a / b</code> と書きます)。<code>/</code> と <code>%</code> は <code>b != 0</code> のとき Euclidean(ユークリッド)
+  剰余系に従います(<code>a == b * (a / b) + (a % b)</code> かつ <code>0 &lt;= a % b &lt; |b|</code>。
+  よって <code>-7 / 2 == -4</code>、<code>-7 % 2 == 1</code>)。ゼロ除算は<strong>全域的に定義</strong>されており、
+  <code>a / 0 == 0</code> と <code>a % 0 == 0</code> は常に評価できます — invariant/trans/reachable/
+  leadsTo/refinement の state map 式で <code>a / 0</code> を読んでも評価が失敗することは
+  ありません。action の <code>requires</code>/本体/<code>ensures</code> 内では、ゼロになりうる除数への
+  未ガードの <code>/</code>/<code>%</code> は値自体が定義されていても <code>partial_op</code>(§6 参照)として
+  報告されます — <code>y != 0 =&gt; P(x / y)</code> や <code>requires y != 0</code> でガードしてください。
+  refinement の action 対応の<strong>引数</strong>式(§10、<code>impl_action(a) -&gt; abs_action(a / c)</code>)
+  は、抽象 action 呼び出しを構成するものなので property 文脈の mapping 式ではなく
+  action 文脈であり、同じ <code>partial_op</code> 扱いを受けて <code>kind: "map_partial_op"</code> として
+  報告されます。</li>
 <li>比較: <code>== != &lt; &lt;= &gt; &gt;=</code></li>
 <li>論理: <code>and or not =&gt;</code></li>
 <li>条件: <code>if condition then when_true else when_false</code>。条件は <code>Bool</code> で、両方の
@@ -627,7 +649,12 @@ invariant OnlyEligible { forall c: Claim { approved[c] =&gt; eligible(c) } }
   <code>reachable(r, a, b)</code>、<code>acyclic(r)</code>、<code>functional(r)</code>、<code>injective(r)</code>、
   <code>domain(r)</code>、<code>range(r)</code>。<code>reachable</code> と <code>acyclic</code> は自己関係
   (<code>relation T -&gt; T</code>)を要求します。端点の型/アリティのエラーは修復ヒントを
-  含みます。</li>
+  含みます。<code>reachable(r, a, a)</code> は構造上<strong>反射的ではありません</strong>——<code>a</code> から
+  <code>a</code> に戻る、1本以上の辺からなる本物のパスがある場合にのみ真です(空の関係
+  や非巡回の関係では、すべての <code>a</code> について <code>reachable(r, a, a) == false</code>)。
+  反射的な読みだと、任意の非空ドメインで <code>not reachable(r, a, a)</code> が構造上
+  充足不能になり、述語から意味が失われます。「<code>r</code> のどこにも自己ループや
+  サイクルがない」を述べるには <code>acyclic(r)</code> を使ってください。</li>
 <li>ensures / trans の内側のみ: <code>old(expr)</code> で遷移前の状態を読む</li>
 <li>leadsTo ブロックの内側のみ: <code>P ~&gt; Q</code>(応答プロパティ。一般式の演算子階層の一部ではありません)。
   Q の前に有界の締め切り <code>within K</code> を、応答本体の後に induction のランキング用の
@@ -699,7 +726,7 @@ until  Name { P until Q }    // unless safety plus a leadsTo P ~&gt; Q progress 
 <td><code>violated</code> / <code>type_bound</code> / <code>_bounds_&lt;var&gt;</code></td>
 </tr>
 <tr>
-<td>部分演算</td>
+<td>部分演算(action 文脈限定: <code>requires</code>/本体/<code>ensures</code> のみ、§3 参照)</td>
 <td><code>pop()</code>/<code>head()</code>/<code>at(i)</code> の時点で列が非空かつインデックスが範囲内であり、<code>/</code> <code>%</code> の除数が非ゼロ</td>
 <td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code></td>
 </tr>
@@ -807,7 +834,9 @@ fslc document check &lt;file.fsl&gt; &lt;document.md&gt; [--glossary glossary.js
 fslc approval create &lt;file.fsl&gt; --kind ledger|html|scenarios|requirements_document --artifact &lt;reviewed&gt; --approver &lt;name&gt;
                [--signing-key private.pem] [--glossary glossary.json] [--evidence evidence.json]... [-o record.json]
                                                   # requirements_document records a v3/v4 revision with a claim_set_digest (§13)
-fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt; [--trust-key public.pem] # approved | drifted | signature-invalid
+fslc approval check  &lt;file.fsl&gt; --record &lt;record.json&gt; [--trust-key public.pem]
+                                                  # approved (exit 0) | drifted (exit 0、分析結果)
+                                                  # | signature-invalid (exit 1); DESIGN-approval.md 参照
 fslc approval diff   &lt;file.fsl&gt; --record &lt;record.json&gt; [--depth K] [--trust-key public.pem]
 fslc typestate &lt;file.fsl&gt; [--ts]                 # decide applicability of state machine → ghost type (§16)
 fslc domain check &lt;file.fsl&gt; [--depth K] [--engine bmc|induction] # Functional DDD / effect findings
@@ -865,8 +894,12 @@ Public Kernel v2 はオプトインで、
 ついて <code>respond_&lt;Name&gt;[_&lt;binding&gt;]</code> シナリオを出力します。各シナリオは
 <code>kind: "leadsTo"</code>、<code>pending_at</code>、<code>satisfied_at</code>、<code>bindings</code>、<code>steps</code>、
 <code>initial_state</code>、<code>expected_states</code> を持ち、P の成立から深さ K 以内での Q の成立
-までの最短トレースを表します。P が決して成立しないバインディングはシナリオに
-ならず、<code>warnings</code> に現れます。</p>
+までの最短トレースを表します。数量化された性質は性質名単位ではなくバインディ
+ング単位で追跡されます: あるバインディングの応答シナリオが見つかっても、応答
+のない別のバインディングの完全性警告を隠しません。P が深さ K 以内で一度も成立
+しないバインディングは「antecedent never holds within depth K」という専用の
+警告になり、P は成立したが応答が一度も閉じなかったバインディングは
+「has no response scenario within depth K」になります。両者は混同されません。</p>
 <p><code>verify --property Name</code> は invariant、<code>trans</code>、<code>leadsTo</code>、<code>reachable</code> の宣言を
 横断して解決し、指名されたプロパティ種別だけを単独で検査します。
 <code>--exclude-property Name</code> は繰り返し指定でき、種別を横断する逆操作として機能します:
@@ -893,7 +926,11 @@ Public Kernel v2 はオプトインで、
 したスコープを <code>sweep.minimal_counterexample</code> として返します。<code>--values</code> に
 ついては、sweep は下限を固定して上限を拡大します(<code>lo..lo</code>, <code>lo..lo+1</code>, ...,
 <code>lo..hi</code>)。sweep の合格は「このグリッドに反例がない」ことを意味し、非有界の証明
-ではありません。</p>
+ではありません。グリッド中のいずれかのスコープが spec <code>error</code>(parse / type /
+semantics / io / vacuous / …)を返した場合、それは反例ではありません。<code>sweep</code> は
+その基盤のエラー envelope をそのまま返します(<code>result</code>、<code>kind</code>、<code>message</code>、
+<code>loc</code>、exit code は変更しません)。<code>sweep_passed</code>/<code>sweep_failed</code> に畳み込むこと
+はありません。</p>
 <p><code>diff</code> は、ソーステキストではなく状態機械の意味を比較します。有界の refinement を
 両方向に実行します: NEW→OLD の失敗は <code>behavior_added</code>、OLD→NEW の失敗は
 <code>behavior_removed</code> です。ユーザー invariant の連言の間の含意を別途検査し
@@ -944,7 +981,19 @@ imported / imported_with_warnings、
 refinement_failed / sweep_failed / observed_mismatch、
 <code>2</code> = spec エラー(parse / type / semantics / io / vacuous / acceptance / forbidden /
 <code>--vacuity error</code>)、<code>3</code> = 内部エラー。<code>observed_*</code> は <code>fslc db observe</code> の結果、
-<code>imported</code>/<code>imported_with_warnings</code> は <code>fslc db import</code> の結果です。</p>
+<code>imported</code>/<code>imported_with_warnings</code> は <code>fslc db import</code> の結果です。同じ <code>2</code> の
+対応付けは <code>chain</code> のプロジェクトマニフェストリーダー(未知のセクション、認識できる
+セクションが0個、パース不能な <code>depth</code>/<code>refine_depth</code> — <code>docs/DESIGN-layers.md</code> §7)
+と、<code>ledger --impl-log</code> の replay 入力(replay エラーは実装ログの証跡ではなく、
+空の台帳行として描画してはならない — <code>docs/DESIGN-ledger.md</code>)でもフェイルクローズド
+に適用されます。</p>
+<p><code>approval_check</code> と <code>approval_diff</code> がこの表に無いのは、exit code が <code>result</code> の
+関数ではないからです。<code>fslc approval check</code> はどの結果でも同じ <code>approval_check</code> を
+返し、判定は <code>status</code> が担います: <code>approved</code> と <code>drifted</code> が <code>0</code>、
+<code>signature-invalid</code> が <code>1</code>。drift が 0 で終わるのは、<code>diff</code> の findings と同じく
+分析出力だからです(§12)。理由と、<code>fslc document check</code> の <code>document_drifted</code> が
+異なる扱いになる理由は <code>docs/DESIGN-approval.md</code> にあります。exit code ではなく
+<code>status</code> でゲートしてください。</p>
 <h3 id="_1">結果の種類</h3>
 <table>
 <thead>
@@ -1264,7 +1313,15 @@ abs の振る舞いから逸脱していないことを <strong><code>fslc refin
 <li><code>maps auto</code> — 省略可能な恒等デフォルト。明示の <code>map</code> のない同名で互換な状態変数
   には <code>map x = x</code> を合成し、明示の対応のない同名で互換な action には
   <code>action f(params...) -&gt; f(params...)</code> を合成します。明示のエントリはデフォルトを
-  上書きします。互換でない同名の候補は <code>kind: "type"</code> エラーとして報告されます。</li>
+  上書きします。action のパラメータは<strong>位置ではなく名前</strong>で対応付けられます:
+  各抽象パラメータは、abstract action 自身のパラメータ順で、まったく同じ名前を持つ
+  impl パラメータに束縛されます(そのため、純粋な並べ替えは引き続き auto-map
+  されます)。auto は決して推測しません — 同名の action ペアでもアリティが異なる、
+  impl 側に余剰パラメータがある、パラメータ名が変わっている、あるいは同名の impl
+  パラメータを持たない抽象パラメータがある場合(issue #494)は、位置付きの
+  <code>kind: "type"</code> エラーになります。そのペアには明示の <code>action ... -&gt; ...</code>
+  対応を書いてください。互換でない同名の状態候補も同様に <code>kind: "type"</code> エラー
+  として報告されます。</li>
 <li><code>action &lt;impl&gt;(&lt;formal params&gt;) -&gt; &lt;abs&gt;(&lt;expr&gt;) | stutter</code> — すべての impl
   action に必須です。形式パラメータは裸の名前でも、impl の action 宣言に一致する
   <code>name: Type</code> の注釈でもかまいません。
@@ -1324,9 +1381,42 @@ binder を逆方向に変換します。例えば <code>column_key Column -&gt; 
 </code></pre>
 <p>成功: <code>result: "refines"</code>(exit 0)。違反: <code>refinement_failed</code>(exit 1)で、
 <code>kind</code>(<code>abs_requires_failed</code> / <code>abs_state_mismatch</code> / <code>stutter_changed_abs</code> /
-<code>map_out_of_bounds</code>)、<code>impl_trace</code>、マッピング後の <code>abs_before</code> /
-<code>abs_after_*</code> を伴います。静的なエラー(マップの欠落、未知の action など)は
-<code>kind: "type"</code>(exit 2)です。</p>
+<code>map_out_of_bounds</code> / <code>map_partial_op</code>)、<code>impl_trace</code>、マッピング後の
+<code>abs_before</code> / <code>abs_after_*</code> を伴います。静的なエラー(マップの欠落、未知の
+action など)は <code>kind: "type"</code>(exit 2)です。<code>map_partial_op</code> は、action 対応の
+引数式(<code>impl_action(a) -&gt; abs_action(a / c)</code>)がゼロになりうる impl の state
+変数で除算しているケースです — action 文脈であり、refinement の state map が
+受ける「チェックなし」の property 文脈ではありません(§3 のゼロ除算規則)。</p>
+<p><code>refine</code> はどの対応関係も検査する前に、まず impl spec が <code>--depth</code> の範囲内で
+それ自身の型境界や不変条件を破っていないか(内部的に一貫しているか)を検証しま
+す。壊れた impl を refinement mapping で意味のあるものにすることはできないため、
+これは abstraction や mapping とは独立に検査されます: <code>result: "violated"</code>
+(exit 1)に <code>violation_kind</code> と、これが fidelity の失敗ではなく refinement
+<em>入力</em>自体の性質であることを説明する <code>note</code> を伴います。<code>refines</code> として報告さ
+れることはなく、<code>refinement_failed</code>(上記の <code>kind</code> 群は impl と abs の<strong>間</strong>の
+不一致を表すものであり、impl 単独の欠陥ではありません)に畳み込まれることもあり
+ません。<code>fslc diff</code> は同じ条件を <code>impl_violated</code> の finding として表面化させ、
+gate を無条件に(<code>--forbid</code> の対象ではなく)失敗させます。自己矛盾した側がある
+比較そのものが信頼できないためです。</p>
+<p><code>init</code> がどの経路でも一度も代入しない状態変数(例えば、代入されていない <code>Bool</code>
+を読む <code>init if</code>)は、黙ってデフォルト値になるのではなく、その型の全域にわたって
+本当に自由な初期値です — <code>refine</code> は impl 側でも abs 側でもこの通りに検査します。
+上記の自己一貫性の precondition と、それが供給する init 対応関係は、いずれも
+<code>init</code> が許すあらゆる具体的初期値評価を検査します。一つだけ任意に選ばれた
+デフォルトではありません: impl 側のあらゆる初期値評価は impl 自身の意味論に
+違反してはならず、そのマップ後の状態は、両側のそうしたあらゆる初期値評価について、
+abs 自身の有効な初期値評価の集合のメンバーでなければなりません。同名の状態変数が
+一部の経路(例えば <code>else</code> のない <code>if</code> の内側だけ)で代入されない場合は、この
+列挙の対象にはならず、以前どおり単一の値としての振る舞いを維持します。</p>
+<p>これは 2 つの逆向きの欠陥を解消するものであり、いずれかの側の <code>init</code> が状態変数を
+どの経路でも代入しない mapping について、<code>refine</code> の判定に対する<strong>破壊的変更</strong>
+です: 以前は impl のデフォルトの初期分岐だけが検査されていたために <code>refines</code> と
+報告されていた refinement が、(以前は見落とされていた別の impl 分岐での
+init 対応関係の違反により)<code>refinement_failed</code> を報告するようになる場合があります。
+また、以前は abs のデフォルトの初期分岐がマップ後の impl 状態と一致しないという
+理由だけで <code>refinement_failed</code> と報告されていた refinement が、(impl の状態が
+別の、なお有効な abs の初期分岐と一致するため)<code>refines</code> を報告するようになる
+場合があります。</p>
 <p>状態変数のペアが 1:1 でマップされる場合でも、impl と abs には<strong>別々の enum/struct
 型名</strong>を与えてください。型メタデータは refinement 検査のために名前でマージされ
 ます。両側で異なるメンバーリスト(またはフィールド集合)を持って宣言された同名の
@@ -1754,7 +1844,7 @@ migration/互換性ルールのアノテーションが、損失のあるレガ�
 ので、これを使う spec は構成上 Python パリティコーパスの外にあります。</p>
 <h4 id="1312-ai-rationale">13.1.2 ツール・AI 消費のための根拠(rationale)</h4>
 <p><code>//</code> コメントは字句解析上の trivia(<code>rust/fsl-syntax/src/lexer.rs</code>)であり、
-AST にも <code>KernelModel</code> にも <code>python_ast()</code> にも JSON の result envelope にも
+AST にも <code>KernelModel</code> にも <code>kernel_ast_v1()</code> にも JSON の result envelope にも
 LSP のインデックスにも監査台帳にも到達しません。補助不変条件が k-induction の
 CTI を閉じるために存在する、あるいは実装のガードが抽象側より意図的に強い、と
 いった、下流のツールや AI エージェントが失ってはならない事実は、散文だけに
@@ -1832,7 +1922,16 @@ verify {
   宣言的な射影です。ghost のカウンターや自動の <code>_kpi_*</code> invariant を作ることは
   ありません。</li>
 <li><code>implements</code> があると、<code>fslc verify</code> は<strong>上位レイヤーへの refine も同時に実行</strong>
-  し、結果は <code>implements: {abs, result}</code> を運びます。空のボディ
+  し、結果は <code>implements: {abs, result}</code> を運びます。値は
+  <code>refines</code> / <code>refinement_failed</code> / <code>impl_violated</code> のいずれかです。<strong>この判定は
+  このフィールドにしか現れません。トップレベルの <code>result</code> にも exit code にも
+  畳み込まれない</strong>ため、seam が壊れていても <code>result:"ok"</code>/<code>"verified"</code> と exit 0 を
+  返します — 上の exit code 表の唯一の例外であり、<code>implements</code> が表に無い理由です。
+  <code>implements.result == "refines"</code> でゲートするか、<code>fslc chain</code> を使ってください
+  (chain はまさにこのゲートをレイヤーに適用し exit 1 します。
+  <code>docs/DESIGN-design-family.md</code> がオーケストレータ向けに同じ規則を述べています)。
+  スタンドアロンの <code>fslc refine</code> は <code>refinement_failed</code> で exit 1 します。
+  黙るのはインラインの seam だけです。空のボディ
   (<code>implements X from "..." { }</code>)は、process/action/stage の名前が一致するとき、
   恒等の refinement を自動生成します。<code>implements { }</code> ブロックの内側には、状態の
   <code>map</code> エントリ、<code>maps auto</code>、<code>preserve progress</code>、そして — #73 以降 —
@@ -2133,7 +2232,9 @@ requirement NFR-1 &quot;complete within 4 ticks of acceptance&quot; {
 ライフサイクル、destructive のアノテーション、preservation-transform の
 アノテーション、API/オフラインの互換性をカバーします。<code>data_preserved</code> と
 <code>rollback_equivalent</code> はオプトインの有界検査で、<code>DB-ASSUME-BOUNDED-ROW-MODEL</code> を
-報告します。</p>
+報告します。上記の閉じた語彙にない <code>rule</code> 名や、宣言された厳密に順序付けられた
+マイグレーション計画では到達しない <code>environment schema lo..hi</code> は、何も検査せず
+に静かに通るのではなく、検証で exit 2 になります。</p>
 <p>フィーチャーフラグは有限の環境次元です。<code>fslc db check</code> は、宣言されたバリアント
 を schema のスナップショットとともに列挙し、
 <code>DB-ASSUME-FINITE-FLAG-STATE</code> を報告します。これはロールアウト/キルスイッチの
@@ -2169,6 +2270,11 @@ migration/schema の要素、最小の競合集合、修復候補を含む <code
 ログからの不在は、未使用の振る舞いの証明ではありません。
 生成されたカーネルの反例を直接調べたいときは、通常の <code>fslc verify</code> を使って
 ください。</p>
+<p><code>fslc db observe</code> は、観測イベントを評価する前に、観測エンベロープ/イベントを
+<code>schemas/fslc/db/observation.v0.schema.json</code> に対して検証します(型付きの必須
+フィールド、閉じた <code>capability</code> 語彙、不正なレコードでは exit 2)。各イベントの
+任意の <code>flags</code> スナップショットは、<code>fslc db check</code> と同じ方法でアーティファクト
+のウィンドウと照合されます。</p>
 <p>汎用の <code>requires</code> / <code>provides</code> ケイパビリティにより、AI モデル/プロンプト/
 リトリーバー/ツールスキーマと出力スキーマのプロファイルが、DB/API/モバイル/
 サーバーのアーティファクトと同じ互換性検査を共有します。
@@ -2291,14 +2397,31 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 <p>プロジェクトレベルの fsl-ai エビデンス宣言は、<code>ai_component</code>、
 <code>dataset</code>、<code>evaluator</code>、<code>failure_mode</code>、<code>statistical_property</code>、
 <code>ai_migration</code>、<code>observed_property</code> を組み合わせられます。<code>fslc ai check</code> は
-これらのファイルをパースして <code>ai_project_analyzed</code> を返します。<code>fslc ai eval</code> は
-Wilson 区間つきで、事前計算された JSONL から Bernoulli/比率のメトリクスを検査
-します。<code>fslc ai regress</code> は集約の <code>no_regression</code> のメトリクス低下/増加の節を
-検査します。<code>fslc ai compare</code> は閾値の主張なしにメトリクスの差分を報告します。
-<code>fslc ai drift</code> はランタイムのテレメトリの閾値とドリフトを検査します。そして
-<code>fslc ai compat</code> は有限の
-<code>dbsystem artifact</code> ケイパビリティプロファイルを出力します。これらはすべて
-<code>formal_result:"not_run"</code> を使います。</p>
+これらのファイルをエビデンス系コマンドと同じパーサでパースして
+<code>ai_project_analyzed</code> を返します。<code>fslc ai eval</code> は
+選択された <code>statistical_property</code> が宣言する <code>slice</code>/<code>min_samples</code>/
+<code>ci_lower</code>/<code>ci_upper</code> の要件を、事前計算された JSONL（<code>--records</code>、または
+宣言された <code>dataset</code> の <code>source</code> ファイル）に対して Wilson 区間つきで検査
+します。<code>fslc ai regress</code> は選択された <code>ai_migration</code> が宣言する集約の
+<code>no_regression</code> メトリクス低下/増加の節を検査します。<code>fslc ai compare</code> は
+閾値の主張なしにメトリクスの差分を報告します。<code>fslc ai drift</code> は選択された
+<code>observed_property</code> が宣言する <code>observed</code>/<code>drift</code> の要件をランタイムの
+テレメトリに対して検査します（<code>observed_supported</code> / <code>observed_mismatch</code>）。
+そして <code>fslc ai compat</code> は、1 つの <code>ai_component</code>、またはプロジェクトが
+宣言するすべての <code>ai_component</code> について有限の <code>dbsystem artifact</code>
+ケイパビリティプロファイルを出力し、AI ではない入力や <code>ai_component</code> を
+1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
+<code>formal_result:"not_run"</code> を使います。既知のエビデンス節文法
+（<code>min_samples</code>、<code>ci_lower</code>、<code>ci_upper</code>、点推定、<code>observed</code>、<code>drift</code>）の
+いずれにも一致しない <code>require</code> 節は、<code>fslc ai check</code> と <code>fslc check</code> の
+どちらでもチェック時の spec エラー（exit 2）であり、解析済みプロジェクト
+とはしません。<code>eval</code>/<code>drift</code> が実行できないものを check が受理しては
+なりません。未知の <code>--property</code>/<code>--migration</code> の
+選択はチェック時エラー（exit 2）です。選択された <code>statistical_property</code> の
+ゲート状態（<code>dataset_invalid</code>、<code>evaluator_untrusted</code>、<code>slice_missing</code>、
+<code>insufficient_samples</code>、<code>inconclusive</code>、<code>statistically_unsupported</code>）は
+exit 1 となり、唯一の成功ケースである <code>statistically_supported</code> の exit 0
+と対比されます。</p>
 <p>再帰的な <code>agent</code> の形:</p>
 <pre><code class="language-fsl">agent SupportOrchestrator {
   context [CustomerTicket, ApprovedSupportDocs];
@@ -2442,7 +2565,11 @@ DESIGN-*.md があります)。</p>
   エッジを公開します。<code>--projection impact_graph --focus NODE</code> は、TSG のノードの
   周りの上流/下流のスライスを出力します。バッチモードで複数のファイルや
   ディレクトリを受け付けます。
-  ディレクトリは <code>*.fsl</code> について再帰的に展開され、決定的にソートされます。
+  ディレクトリは <code>*.fsl</code> について再帰的に展開され、決定的にソートされます —
+  明示的に指定されたファイルは拡張子によらず常に保持されます（<code>.toml</code> の
+  プロジェクトマニフェストは単一ファイルモードと同じ経路で処理され、それ以外の
+  解析できないファイルは <code>files[]</code>/<code>errors[]</code> 上の実際のエラーとなり、
+  無言で捨てられることはありません）。
   スタンドアロンの refinement マッピングは <code>--projection
   refinement_graph</code> で見られます。このコマンドは impl/abs のモデルのパスを持たない
   ため、これは未解決の構造ビューです。プロジェクトのマニフェストは <code>--projection
@@ -2492,10 +2619,17 @@ DESIGN-*.md があります)。</p>
 <code>skills/fsl/SKILL.md</code> にあります。保守される実例は
 <a href="https://github.com/ymm-oss/fsl/tree/main/examples/validation"><code>examples/validation/</code></a> にあります。</p></div></details>
 <details id="16-promotion-judgment-to-ghost-types-typestate"><summary>16. ghost 型への昇格判定(typestate)<span class="tree-blurb"> — 状態機械を ghost 型 / typestate へ昇格させる判断。</span></summary><div class="tree-body"><p><code>fslc typestate &lt;file.fsl&gt; [--ts]</code> は、設計 spec の状態機械(enum 値の struct
-フィールド / 状態変数 / <code>Option&lt;_&gt;</code> スロット)を、ホスト言語の typestate
+フィールド — フィールド名と所有する struct の型の両方でスコープされ、同名の
+フィールドを持つ別々の struct は独立した機械のまま扱われます / 状態変数 /
+<code>Option&lt;_&gt;</code> スロット)を、ホスト言語の typestate
 (ghost 型)へどれだけ健全にマップできるかを判定します。各
 <code>(entity, action)</code> を、<code>derivable</code>(from の状態がエンティティ自身のローカルな
-ガード)/ <code>branching</code>(<code>if</code> の内側でデータ依存)/ <code>relational</code>(ローカルな
+ガード — 複合ガードの from 状態は式<strong>全体</strong>が含意するものです。<code>or</code> は各選言項
+が含意する状態の<strong>和集合</strong>ですが、それはすべての選言項がエンティティを制約
+している場合に限ります。ある選言項がエンティティについて何も述べていない
+(例: 無関係なフラグ)場合、ガード全体を絞り込むのではなく、そのガード自体を
+落とします)/
+<code>branching</code>(<code>if</code> の内側でデータ依存)/ <code>relational</code>(ローカルな
 ガードがなく、事前条件が外部の構造に住む — 型では表現できず、ランタイム/検証の
 義務として残る)に分類します。エンティティの
 <code>applicability</code> が <code>full</code> になるのは、すべての遷移が derivable/branching のとき

--- a/examples/annotations/annotated_ai_component.fsl
+++ b/examples/annotations/annotated_ai_component.fsl
@@ -8,7 +8,7 @@
 // individual rule lines. See docs/DESIGN-annotations.md's "domain/db/ai
 // nested declaration syntax" section for the `AiAuthority`/`AiHardCheck`
 // restructuring into `AiAuthorityRule`/`AiCheckRule { name, annotations,
-// loc }` and the unchanged `python_ast()` JSON shape.
+// loc }` and the unchanged `kernel_ast_v1()` JSON shape.
 //
 // Native-only: the frozen Python reference does not parse `@...`
 // before an ai_component nested declaration, so this file is excluded

--- a/rust/fsl-core/src/bin/fsl-parse-kernel.rs
+++ b/rust/fsl-core/src/bin/fsl-parse-kernel.rs
@@ -24,7 +24,7 @@ fn main() {
     match fsl_core::parse_kernel_source(&source, &resolver) {
         Ok(spec) => println!(
             "{}",
-            serde_json::to_string(&spec.python_ast()).expect("serialize kernel AST")
+            serde_json::to_string(&spec.kernel_ast_v1()).expect("serialize kernel AST")
         ),
         Err(error) => {
             eprintln!("{error}");

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -212,8 +212,8 @@ pub fn build_surface_model(spec: SurfaceSpec) -> Result<KernelModel, ModelError>
 
 impl KernelSpec {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
-        self.spec.python_ast()
+    pub fn kernel_ast_v1(&self) -> Value {
+        self.spec.kernel_ast_v1()
     }
 
     #[must_use]
@@ -1052,8 +1052,22 @@ impl PredicateExpander {
         })
     }
 
-    #[allow(clippy::too_many_lines)]
+    /// Cycle entry for `def` predicate expansion, and where `recursion::guard`
+    /// belongs: every arm below recurses back through here, and the binder
+    /// expansion above re-enters it too.
+    ///
+    /// Measured: `check` and `document claims` on a 400-deep `if` chain written
+    /// inside an *invariant*, with this function as the innermost frame at
+    /// ~22 KiB per level. The #620 witness never reached it because that
+    /// witness put its depth in a refinement mapping, which is not expanded
+    /// here -- the ninth site of the same class, found by changing the witness
+    /// rather than the code (#622).
     fn expand_expr(&self, expr: Expr, stack: &mut Vec<String>) -> Result<Expr, CoreError> {
+        recursion::guard(|| self.expand_expr_inner(expr, stack))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn expand_expr_inner(&self, expr: Expr, stack: &mut Vec<String>) -> Result<Expr, CoreError> {
         if let Expr::Call { name, args, span } = expr {
             let Some(definition) = self.definitions.get(&name) else {
                 return Err(core_error(format!("undefined predicate '{name}'"), span)

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -19,6 +19,7 @@ use crate::typecheck::{
     validate_public_expression,
 };
 
+use crate::recursion;
 use crate::{
     ActionGuard, KernelModel, KernelSpec, OriginChain, OriginSite, ParamDef, TypeDef, TypeRef,
     action_target, property_target, state_target, type_target,
@@ -235,8 +236,31 @@ fn binder_json(
     Ok(output)
 }
 
+/// Cycle entry for the public Kernel expression projection, and where
+/// `recursion::guard` belongs: all 46 recursive call sites below re-enter here.
+///
+/// Measured: `document claims` on a 400-deep `if` chain inside an invariant.
+/// Guarding `infer_type` alone was not enough and the reason is worth keeping:
+/// this walk called it once per level, so the guard *did* run every level, but
+/// the check happens on entry and this frame is large. Between two checks the
+/// stack could fall from above the red zone to below what `stacker::_grow`
+/// itself needs, so the innermost frame was `_grow` rather than a projection
+/// function -- growth failing for want of stack to grow with. Guarding the
+/// cycle that actually consumes the stack fixes it at the source (#622).
 #[allow(clippy::too_many_lines)]
 fn expr_json(
+    expr: &Expr,
+    env: &TypeEnv,
+    model: &KernelModel,
+    path: &str,
+    span: Span,
+    expected: Option<&TypeRef>,
+) -> Result<Value, PublicKernelError> {
+    recursion::guard(|| expr_json_inner(expr, env, model, path, span, expected))
+}
+
+#[allow(clippy::too_many_lines)]
+fn expr_json_inner(
     expr: &Expr,
     env: &TypeEnv,
     model: &KernelModel,

--- a/rust/fsl-syntax/src/ai.rs
+++ b/rust/fsl-syntax/src/ai.rs
@@ -23,7 +23,7 @@ impl From<Span> for AiLoc {
 }
 
 impl AiLoc {
-    fn python_ast(self) -> Value {
+    fn kernel_ast_v1(self) -> Value {
         json!({"line":self.line,"column":self.column})
     }
 }
@@ -96,25 +96,25 @@ pub struct AiComponent {
 
 impl AiComponent {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"AiComponent","name":self.name,"model":self.model,"prompt":self.prompt,
             "retriever":self.retriever,"temperature":self.temperature,
             "input_schema":self.input_schema,"output_schema":self.output_schema,
-            "tools":self.tools.iter().map(AiTool::python_ast).collect::<Vec<_>>(),
-            "authority":self.authority.python_ast(),
-            "fallback":self.fallback.iter().map(AiFallback::python_ast).collect::<Vec<_>>(),
-            "check":self.check.python_ast(),"loc":self.loc.python_ast(),
+            "tools":self.tools.iter().map(AiTool::kernel_ast_v1).collect::<Vec<_>>(),
+            "authority":self.authority.kernel_ast_v1(),
+            "fallback":self.fallback.iter().map(AiFallback::kernel_ast_v1).collect::<Vec<_>>(),
+            "check":self.check.kernel_ast_v1(),"loc":self.loc.kernel_ast_v1(),
         })
     }
 }
 
 impl AiTool {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"AiTool","name":self.name,"schema":self.schema,
             "irreversible":self.irreversible,"preconditions":self.preconditions,
-            "effect":self.effect,"loc":self.loc.map(AiLoc::python_ast),
+            "effect":self.effect,"loc":self.loc.map(AiLoc::kernel_ast_v1),
         })
     }
 }
@@ -126,12 +126,12 @@ impl AiAuthorityRule {
 }
 
 impl AiAuthority {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"AiAuthority","may_suggest":AiAuthorityRule::names(&self.may_suggest),
             "may_execute":AiAuthorityRule::names(&self.may_execute),
             "requires_human_approval":AiAuthorityRule::names(&self.requires_human_approval),
-            "forbidden":AiAuthorityRule::names(&self.forbidden),"loc":self.loc.map(AiLoc::python_ast),
+            "forbidden":AiAuthorityRule::names(&self.forbidden),"loc":self.loc.map(AiLoc::kernel_ast_v1),
         })
     }
 }
@@ -183,17 +183,17 @@ pub struct AiAgentContract {
 }
 
 impl AiFallback {
-    fn python_ast(&self) -> Value {
-        json!({"$type":"AiFallback","reason":self.reason,"target":self.target,"loc":self.loc.python_ast()})
+    fn kernel_ast_v1(&self) -> Value {
+        json!({"$type":"AiFallback","reason":self.reason,"target":self.target,"loc":self.loc.kernel_ast_v1()})
     }
 }
 
 impl AiHardCheck {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"AiHardCheck",
             "rules":self.rules.iter().map(|rule| rule.name.as_str()).collect::<Vec<_>>(),
-            "loc":self.loc.map(AiLoc::python_ast),
+            "loc":self.loc.map(AiLoc::kernel_ast_v1),
         })
     }
 }

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -50,7 +50,7 @@ pub struct ConditionalSpans {
 
 impl QualifiedName {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         self.namespace.as_ref().map_or_else(
             || Value::String(self.name.clone()),
             |namespace| {
@@ -174,7 +174,7 @@ pub enum Expr {
 
 impl Pattern {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::None => Value::Array(vec![Value::from("pat_none")]),
             Self::Some(name) => {
@@ -186,7 +186,7 @@ impl Pattern {
 
 impl Binder {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Typed {
                 name,
@@ -195,8 +195,8 @@ impl Binder {
             } => Value::Array(vec![
                 Value::from("binder_typed"),
                 Value::from(name.as_str()),
-                type_name.python_ast(),
-                optional(where_expr.as_deref().map(Expr::python_ast)),
+                type_name.kernel_ast_v1(),
+                optional(where_expr.as_deref().map(Expr::kernel_ast_v1)),
             ]),
             Self::Range {
                 name,
@@ -208,17 +208,17 @@ impl Binder {
                     Value::Array(vec![
                         Value::from("binder_range"),
                         Value::from(name.as_str()),
-                        lo.python_ast(),
-                        hi.python_ast(),
+                        lo.kernel_ast_v1(),
+                        hi.kernel_ast_v1(),
                     ])
                 },
                 |where_expr| {
                     Value::Array(vec![
                         Value::from("binder_range"),
                         Value::from(name.as_str()),
-                        lo.python_ast(),
-                        hi.python_ast(),
-                        where_expr.python_ast(),
+                        lo.kernel_ast_v1(),
+                        hi.kernel_ast_v1(),
+                        where_expr.kernel_ast_v1(),
                     ])
                 },
             ),
@@ -229,8 +229,8 @@ impl Binder {
             } => Value::Array(vec![
                 Value::from("binder_collection"),
                 Value::from(name.as_str()),
-                collection.python_ast(),
-                optional(where_expr.as_deref().map(Expr::python_ast)),
+                collection.kernel_ast_v1(),
+                optional(where_expr.as_deref().map(Expr::kernel_ast_v1)),
             ]),
         }
     }
@@ -251,17 +251,17 @@ impl Expr {
     /// `analyze`-only problem. The witness only reaches it via `analyze`
     /// because the deep expression lives in the mapping file, not in a spec.
     #[must_use]
-    pub fn python_ast(&self) -> Value {
-        recursion::guard(|| self.python_ast_inner())
+    pub fn kernel_ast_v1(&self) -> Value {
+        recursion::guard(|| self.kernel_ast_v1_inner())
     }
 
     #[allow(clippy::too_many_lines)]
-    fn python_ast_inner(&self) -> Value {
+    fn kernel_ast_v1_inner(&self) -> Value {
         match self {
             Self::Num(value) => Value::Array(vec![Value::from("num"), Value::from(*value)]),
             Self::Bool(value) => Value::Array(vec![Value::from("bool"), Value::from(*value)]),
             Self::None => Value::Array(vec![Value::from("none")]),
-            Self::Some(expr) => Value::Array(vec![Value::from("some"), expr.python_ast()]),
+            Self::Some(expr) => Value::Array(vec![Value::from("some"), expr.kernel_ast_v1()]),
             Self::Set(items) => {
                 Value::Array(vec![Value::from("set_lit"), Value::Array(ast_list(items))])
             }
@@ -271,7 +271,7 @@ impl Expr {
             Self::Struct { name, fields } => {
                 let object = fields
                     .iter()
-                    .map(|(key, value)| (key.clone(), value.python_ast()))
+                    .map(|(key, value)| (key.clone(), value.kernel_ast_v1()))
                     .collect::<serde_json::Map<_, _>>();
                 Value::Array(vec![
                     Value::from("struct_lit"),
@@ -293,12 +293,12 @@ impl Expr {
             ]),
             Self::Index(base, index) => Value::Array(vec![
                 Value::from("index"),
-                base.python_ast(),
-                index.python_ast(),
+                base.kernel_ast_v1(),
+                index.kernel_ast_v1(),
             ]),
             Self::Field(base, name) => Value::Array(vec![
                 Value::from("field"),
-                base.python_ast(),
+                base.kernel_ast_v1(),
                 Value::from(name.as_str()),
             ]),
             Self::Method {
@@ -307,18 +307,18 @@ impl Expr {
                 args,
             } => Value::Array(vec![
                 Value::from("method"),
-                receiver.python_ast(),
+                receiver.kernel_ast_v1(),
                 Value::from(name.as_str()),
                 Value::Array(ast_list(args)),
             ]),
             Self::Binary { op, left, right } => Value::Array(vec![
                 Value::from("bin"),
                 Value::from(op.as_str()),
-                left.python_ast(),
-                right.python_ast(),
+                left.kernel_ast_v1(),
+                right.kernel_ast_v1(),
             ]),
-            Self::Neg(expr) => Value::Array(vec![Value::from("neg"), expr.python_ast()]),
-            Self::Not(expr) => Value::Array(vec![Value::from("not"), expr.python_ast()]),
+            Self::Neg(expr) => Value::Array(vec![Value::from("neg"), expr.kernel_ast_v1()]),
+            Self::Not(expr) => Value::Array(vec![Value::from("not"), expr.kernel_ast_v1()]),
             Self::Conditional {
                 condition,
                 then_expr,
@@ -326,14 +326,14 @@ impl Expr {
                 ..
             } => Value::Array(vec![
                 Value::from("ite"),
-                condition.python_ast(),
-                then_expr.python_ast(),
-                else_expr.python_ast(),
+                condition.kernel_ast_v1(),
+                then_expr.kernel_ast_v1(),
+                else_expr.kernel_ast_v1(),
             ]),
             Self::Is { expr, pattern } => Value::Array(vec![
                 Value::from("is"),
-                expr.python_ast(),
-                pattern.python_ast(),
+                expr.kernel_ast_v1(),
+                pattern.kernel_ast_v1(),
             ]),
             Self::Quantified {
                 quantifier,
@@ -341,8 +341,8 @@ impl Expr {
                 body,
             } => Value::Array(vec![
                 Value::from(quantifier.as_str()),
-                binder.python_ast(),
-                body.python_ast(),
+                binder.kernel_ast_v1(),
+                body.kernel_ast_v1(),
             ]),
             Self::Aggregate {
                 kind,
@@ -360,8 +360,8 @@ impl Expr {
                 ) => Value::Array(vec![
                     Value::from("count"),
                     Value::from(name.as_str()),
-                    type_name.python_ast(),
-                    condition.python_ast(),
+                    type_name.kernel_ast_v1(),
+                    condition.kernel_ast_v1(),
                 ]),
                 (
                     AggregateKind::Sum,
@@ -374,15 +374,15 @@ impl Expr {
                 ) => Value::Array(vec![
                     Value::from("sum"),
                     Value::from(name.as_str()),
-                    type_name.python_ast(),
-                    body.python_ast(),
-                    optional(where_expr.as_deref().map(Expr::python_ast)),
+                    type_name.kernel_ast_v1(),
+                    body.kernel_ast_v1(),
+                    optional(where_expr.as_deref().map(Expr::kernel_ast_v1)),
                 ]),
                 (AggregateKind::Unique, binder, None) => {
-                    Value::Array(vec![Value::from("unique"), binder.python_ast()])
+                    Value::Array(vec![Value::from("unique"), binder.kernel_ast_v1()])
                 }
                 (AggregateKind::ExactlyOne, binder, None) => {
-                    Value::Array(vec![Value::from("exactly_one"), binder.python_ast()])
+                    Value::Array(vec![Value::from("exactly_one"), binder.kernel_ast_v1()])
                 }
                 _ => Value::Array(vec![
                     Value::from("aggregate"),
@@ -392,8 +392,8 @@ impl Expr {
                         AggregateKind::Unique => "unique",
                         AggregateKind::ExactlyOne => "exactly_one",
                     }),
-                    binder.python_ast(),
-                    optional(value.as_deref().map(Expr::python_ast)),
+                    binder.kernel_ast_v1(),
+                    optional(value.as_deref().map(Expr::kernel_ast_v1)),
                 ]),
             },
             Self::Stage {
@@ -405,7 +405,7 @@ impl Expr {
                 || {
                     Value::Array(vec![
                         Value::from("stage"),
-                        entity.python_ast(),
+                        entity.kernel_ast_v1(),
                         span.python_loc(),
                     ])
                 },
@@ -413,7 +413,7 @@ impl Expr {
                     Value::Array(vec![
                         Value::from("qualified_stage"),
                         Value::from(process.to_string()),
-                        entity.python_ast(),
+                        entity.kernel_ast_v1(),
                         span.python_loc(),
                     ])
                 },
@@ -423,16 +423,23 @@ impl Expr {
                 expr,
                 span: _,
             } => match name.as_str() {
-                "old" | "abs" => Value::Array(vec![Value::from(name.as_str()), expr.python_ast()]),
-                "rel_acyclic" | "rel_functional" | "rel_injective" | "rel_domain" | "rel_range" => {
-                    Value::Array(vec![Value::from(name.as_str()), expr.python_ast()])
+                // Two families -- the value/temporal `old`/`abs` and the
+                // relation predicates -- project identically, as `[name, arg]`.
+                // They were separate arms with the same body until the longer
+                // method name made rustfmt render both as blocks and
+                // `clippy::match_same_arms` saw the duplication it had been
+                // hiding. The list stays exhaustive so an unvalidated name
+                // still reaches `unreachable!` rather than a silent projection.
+                "old" | "abs" | "rel_acyclic" | "rel_functional" | "rel_injective"
+                | "rel_domain" | "rel_range" => {
+                    Value::Array(vec![Value::from(name.as_str()), expr.kernel_ast_v1()])
                 }
                 _ => unreachable!("validated named unary expression"),
             },
             Self::BinaryNamed { name, left, right } => Value::Array(vec![
                 Value::from(name.as_str()),
-                left.python_ast(),
-                right.python_ast(),
+                left.kernel_ast_v1(),
+                right.kernel_ast_v1(),
             ]),
             Self::TernaryNamed {
                 name,
@@ -441,16 +448,16 @@ impl Expr {
                 third,
             } => Value::Array(vec![
                 Value::from(name.as_str()),
-                first.python_ast(),
-                second.python_ast(),
-                third.python_ast(),
+                first.kernel_ast_v1(),
+                second.kernel_ast_v1(),
+                third.kernel_ast_v1(),
             ]),
         }
     }
 }
 
 fn ast_list(items: &[Expr]) -> Vec<Value> {
-    items.iter().map(Expr::python_ast).collect()
+    items.iter().map(Expr::kernel_ast_v1).collect()
 }
 
 /// A missing optional child projects as JSON `null`.

--- a/rust/fsl-syntax/src/ast.rs
+++ b/rust/fsl-syntax/src/ast.rs
@@ -53,7 +53,13 @@ impl QualifiedName {
     pub fn python_ast(&self) -> Value {
         self.namespace.as_ref().map_or_else(
             || Value::String(self.name.clone()),
-            |namespace| json!(["qname", namespace, self.name]),
+            |namespace| {
+                Value::Array(vec![
+                    Value::from("qname"),
+                    Value::from(namespace.as_str()),
+                    Value::from(self.name.as_str()),
+                ])
+            },
         )
     }
 }
@@ -170,8 +176,10 @@ impl Pattern {
     #[must_use]
     pub fn python_ast(&self) -> Value {
         match self {
-            Self::None => json!(["pat_none"]),
-            Self::Some(name) => json!(["pat_some", name]),
+            Self::None => Value::Array(vec![Value::from("pat_none")]),
+            Self::Some(name) => {
+                Value::Array(vec![Value::from("pat_some"), Value::from(name.as_str())])
+            }
         }
     }
 }
@@ -184,11 +192,11 @@ impl Binder {
                 name,
                 type_name,
                 where_expr,
-            } => json!([
-                "binder_typed",
-                name,
+            } => Value::Array(vec![
+                Value::from("binder_typed"),
+                Value::from(name.as_str()),
                 type_name.python_ast(),
-                where_expr.as_deref().map(Expr::python_ast)
+                optional(where_expr.as_deref().map(Expr::python_ast)),
             ]),
             Self::Range {
                 name,
@@ -196,14 +204,21 @@ impl Binder {
                 hi,
                 where_expr,
             } => where_expr.as_deref().map_or_else(
-                || json!(["binder_range", name, lo.python_ast(), hi.python_ast()]),
-                |where_expr| {
-                    json!([
-                        "binder_range",
-                        name,
+                || {
+                    Value::Array(vec![
+                        Value::from("binder_range"),
+                        Value::from(name.as_str()),
                         lo.python_ast(),
                         hi.python_ast(),
-                        where_expr.python_ast()
+                    ])
+                },
+                |where_expr| {
+                    Value::Array(vec![
+                        Value::from("binder_range"),
+                        Value::from(name.as_str()),
+                        lo.python_ast(),
+                        hi.python_ast(),
+                        where_expr.python_ast(),
                     ])
                 },
             ),
@@ -211,11 +226,11 @@ impl Binder {
                 name,
                 collection,
                 where_expr,
-            } => json!([
-                "binder_collection",
-                name,
+            } => Value::Array(vec![
+                Value::from("binder_collection"),
+                Value::from(name.as_str()),
                 collection.python_ast(),
-                where_expr.as_deref().map(Expr::python_ast)
+                optional(where_expr.as_deref().map(Expr::python_ast)),
             ]),
         }
     }
@@ -243,57 +258,92 @@ impl Expr {
     #[allow(clippy::too_many_lines)]
     fn python_ast_inner(&self) -> Value {
         match self {
-            Self::Num(value) => json!(["num", value]),
-            Self::Bool(value) => json!(["bool", value]),
-            Self::None => json!(["none"]),
-            Self::Some(expr) => json!(["some", expr.python_ast()]),
-            Self::Set(items) => json!(["set_lit", ast_list(items)]),
-            Self::Seq(items) => json!(["seq_lit", ast_list(items)]),
+            Self::Num(value) => Value::Array(vec![Value::from("num"), Value::from(*value)]),
+            Self::Bool(value) => Value::Array(vec![Value::from("bool"), Value::from(*value)]),
+            Self::None => Value::Array(vec![Value::from("none")]),
+            Self::Some(expr) => Value::Array(vec![Value::from("some"), expr.python_ast()]),
+            Self::Set(items) => {
+                Value::Array(vec![Value::from("set_lit"), Value::Array(ast_list(items))])
+            }
+            Self::Seq(items) => {
+                Value::Array(vec![Value::from("seq_lit"), Value::Array(ast_list(items))])
+            }
             Self::Struct { name, fields } => {
                 let object = fields
                     .iter()
                     .map(|(key, value)| (key.clone(), value.python_ast()))
                     .collect::<serde_json::Map<_, _>>();
-                json!(["struct_lit", name, object])
+                Value::Array(vec![
+                    Value::from("struct_lit"),
+                    Value::from(name.as_str()),
+                    Value::Object(object),
+                ])
             }
-            Self::Var(name) => json!(["var", name]),
-            Self::EnumMember { type_name, member } => {
-                json!(["enum_member", type_name, member])
-            }
-            Self::Call { name, args, span } => {
-                json!(["call", name, ast_list(args), span.python_loc()])
-            }
-            Self::Index(base, index) => json!(["index", base.python_ast(), index.python_ast()]),
-            Self::Field(base, name) => json!(["field", base.python_ast(), name]),
+            Self::Var(name) => Value::Array(vec![Value::from("var"), Value::from(name.as_str())]),
+            Self::EnumMember { type_name, member } => Value::Array(vec![
+                Value::from("enum_member"),
+                Value::from(type_name.as_str()),
+                Value::from(member.as_str()),
+            ]),
+            Self::Call { name, args, span } => Value::Array(vec![
+                Value::from("call"),
+                Value::from(name.as_str()),
+                Value::Array(ast_list(args)),
+                span.python_loc(),
+            ]),
+            Self::Index(base, index) => Value::Array(vec![
+                Value::from("index"),
+                base.python_ast(),
+                index.python_ast(),
+            ]),
+            Self::Field(base, name) => Value::Array(vec![
+                Value::from("field"),
+                base.python_ast(),
+                Value::from(name.as_str()),
+            ]),
             Self::Method {
                 receiver,
                 name,
                 args,
-            } => json!(["method", receiver.python_ast(), name, ast_list(args)]),
-            Self::Binary { op, left, right } => {
-                json!(["bin", op, left.python_ast(), right.python_ast()])
-            }
-            Self::Neg(expr) => json!(["neg", expr.python_ast()]),
-            Self::Not(expr) => json!(["not", expr.python_ast()]),
+            } => Value::Array(vec![
+                Value::from("method"),
+                receiver.python_ast(),
+                Value::from(name.as_str()),
+                Value::Array(ast_list(args)),
+            ]),
+            Self::Binary { op, left, right } => Value::Array(vec![
+                Value::from("bin"),
+                Value::from(op.as_str()),
+                left.python_ast(),
+                right.python_ast(),
+            ]),
+            Self::Neg(expr) => Value::Array(vec![Value::from("neg"), expr.python_ast()]),
+            Self::Not(expr) => Value::Array(vec![Value::from("not"), expr.python_ast()]),
             Self::Conditional {
                 condition,
                 then_expr,
                 else_expr,
                 ..
-            } => json!([
-                "ite",
+            } => Value::Array(vec![
+                Value::from("ite"),
                 condition.python_ast(),
                 then_expr.python_ast(),
-                else_expr.python_ast()
+                else_expr.python_ast(),
             ]),
-            Self::Is { expr, pattern } => {
-                json!(["is", expr.python_ast(), pattern.python_ast()])
-            }
+            Self::Is { expr, pattern } => Value::Array(vec![
+                Value::from("is"),
+                expr.python_ast(),
+                pattern.python_ast(),
+            ]),
             Self::Quantified {
                 quantifier,
                 binder,
                 body,
-            } => json!([quantifier, binder.python_ast(), body.python_ast()]),
+            } => Value::Array(vec![
+                Value::from(quantifier.as_str()),
+                binder.python_ast(),
+                body.python_ast(),
+            ]),
             Self::Aggregate {
                 kind,
                 binder,
@@ -307,11 +357,11 @@ impl Expr {
                         where_expr: Some(condition),
                     },
                     None,
-                ) => json!([
-                    "count",
-                    name,
+                ) => Value::Array(vec![
+                    Value::from("count"),
+                    Value::from(name.as_str()),
                     type_name.python_ast(),
-                    condition.python_ast()
+                    condition.python_ast(),
                 ]),
                 (
                     AggregateKind::Sum,
@@ -321,27 +371,29 @@ impl Expr {
                         where_expr,
                     },
                     Some(body),
-                ) => json!([
-                    "sum",
-                    name,
+                ) => Value::Array(vec![
+                    Value::from("sum"),
+                    Value::from(name.as_str()),
                     type_name.python_ast(),
                     body.python_ast(),
-                    where_expr.as_deref().map(Expr::python_ast)
+                    optional(where_expr.as_deref().map(Expr::python_ast)),
                 ]),
-                (AggregateKind::Unique, binder, None) => json!(["unique", binder.python_ast()]),
-                (AggregateKind::ExactlyOne, binder, None) => {
-                    json!(["exactly_one", binder.python_ast()])
+                (AggregateKind::Unique, binder, None) => {
+                    Value::Array(vec![Value::from("unique"), binder.python_ast()])
                 }
-                _ => json!([
-                    "aggregate",
-                    match kind {
+                (AggregateKind::ExactlyOne, binder, None) => {
+                    Value::Array(vec![Value::from("exactly_one"), binder.python_ast()])
+                }
+                _ => Value::Array(vec![
+                    Value::from("aggregate"),
+                    Value::from(match kind {
                         AggregateKind::Count => "count",
                         AggregateKind::Sum => "sum",
                         AggregateKind::Unique => "unique",
                         AggregateKind::ExactlyOne => "exactly_one",
-                    },
+                    }),
                     binder.python_ast(),
-                    value.as_deref().map(Expr::python_ast)
+                    optional(value.as_deref().map(Expr::python_ast)),
                 ]),
             },
             Self::Stage {
@@ -350,13 +402,19 @@ impl Expr {
                 span,
                 ..
             } => process.as_ref().map_or_else(
-                || json!(["stage", entity.python_ast(), span.python_loc()]),
-                |process| {
-                    json!([
-                        "qualified_stage",
-                        process.to_string(),
+                || {
+                    Value::Array(vec![
+                        Value::from("stage"),
                         entity.python_ast(),
-                        span.python_loc()
+                        span.python_loc(),
+                    ])
+                },
+                |process| {
+                    Value::Array(vec![
+                        Value::from("qualified_stage"),
+                        Value::from(process.to_string()),
+                        entity.python_ast(),
+                        span.python_loc(),
                     ])
                 },
             ),
@@ -365,25 +423,27 @@ impl Expr {
                 expr,
                 span: _,
             } => match name.as_str() {
-                "old" | "abs" => json!([name, expr.python_ast()]),
+                "old" | "abs" => Value::Array(vec![Value::from(name.as_str()), expr.python_ast()]),
                 "rel_acyclic" | "rel_functional" | "rel_injective" | "rel_domain" | "rel_range" => {
-                    json!([name, expr.python_ast()])
+                    Value::Array(vec![Value::from(name.as_str()), expr.python_ast()])
                 }
                 _ => unreachable!("validated named unary expression"),
             },
-            Self::BinaryNamed { name, left, right } => {
-                json!([name, left.python_ast(), right.python_ast()])
-            }
+            Self::BinaryNamed { name, left, right } => Value::Array(vec![
+                Value::from(name.as_str()),
+                left.python_ast(),
+                right.python_ast(),
+            ]),
             Self::TernaryNamed {
                 name,
                 first,
                 second,
                 third,
-            } => json!([
-                name,
+            } => Value::Array(vec![
+                Value::from(name.as_str()),
                 first.python_ast(),
                 second.python_ast(),
-                third.python_ast()
+                third.python_ast(),
             ]),
         }
     }
@@ -391,6 +451,15 @@ impl Expr {
 
 fn ast_list(items: &[Expr]) -> Vec<Value> {
     items.iter().map(Expr::python_ast).collect()
+}
+
+/// A missing optional child projects as JSON `null`.
+///
+/// `json!` produced this from an interpolated `Option<Value>`; direct
+/// construction has to say it, and saying it in one place keeps the four
+/// optional-child sites from drifting apart.
+fn optional(child: Option<Value>) -> Value {
+    child.unwrap_or(Value::Null)
 }
 
 #[cfg(test)]

--- a/rust/fsl-syntax/src/bin/fsl-parse-expr.rs
+++ b/rust/fsl-syntax/src/bin/fsl-parse-expr.rs
@@ -14,7 +14,7 @@ fn main() {
     match fsl_syntax::parse_expr(&source) {
         Ok(expr) => println!(
             "{}",
-            serde_json::to_string(&expr.python_ast()).expect("serialize AST")
+            serde_json::to_string(&expr.kernel_ast_v1()).expect("serialize AST")
         ),
         Err(error) => {
             eprintln!("{error}");

--- a/rust/fsl-syntax/src/bin/fsl-parse-surface.rs
+++ b/rust/fsl-syntax/src/bin/fsl-parse-surface.rs
@@ -18,7 +18,7 @@ fn main() {
     match fsl_syntax::parse_surface_document(&source) {
         Ok(document) => println!(
             "{}",
-            serde_json::to_string(&document.python_ast()).expect("serialize AST")
+            serde_json::to_string(&document.kernel_ast_v1()).expect("serialize AST")
         ),
         Err(error) => {
             eprintln!("{error}");

--- a/rust/fsl-syntax/src/db.rs
+++ b/rust/fsl-syntax/src/db.rs
@@ -124,42 +124,42 @@ pub struct DbSystem {
 
 impl DbSystem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbSystem",
             "name": self.name,
-            "database": self.database.python_ast(),
-            "migrations": self.migrations.iter().map(DbMigration::python_ast).collect::<Vec<_>>(),
-            "artifacts": self.artifacts.iter().map(DbArtifact::python_ast).collect::<Vec<_>>(),
-            "environments": self.environments.iter().map(DbEnvironment::python_ast).collect::<Vec<_>>(),
-            "check": self.check.python_ast(),
+            "database": self.database.kernel_ast_v1(),
+            "migrations": self.migrations.iter().map(DbMigration::kernel_ast_v1).collect::<Vec<_>>(),
+            "artifacts": self.artifacts.iter().map(DbArtifact::kernel_ast_v1).collect::<Vec<_>>(),
+            "environments": self.environments.iter().map(DbEnvironment::kernel_ast_v1).collect::<Vec<_>>(),
+            "check": self.check.kernel_ast_v1(),
             "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbDatabase {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbDatabase", "name": self.name, "initial_schema": self.initial_schema,
-            "tables": self.tables.iter().map(DbTable::python_ast).collect::<Vec<_>>(),
+            "tables": self.tables.iter().map(DbTable::kernel_ast_v1).collect::<Vec<_>>(),
             "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbTable {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbTable", "name": self.name,
-            "columns": self.columns.iter().map(DbColumn::python_ast).collect::<Vec<_>>(),
+            "columns": self.columns.iter().map(DbColumn::kernel_ast_v1).collect::<Vec<_>>(),
             "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbColumn {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbColumn", "table": self.table, "name": self.name,
             "db_type": self.db_type, "present": self.present, "backfilled": self.backfilled,
@@ -169,18 +169,18 @@ impl DbColumn {
 }
 
 impl DbMigration {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbMigration", "name": self.name, "from_schema": self.from_schema,
             "to_schema": self.to_schema,
-            "ops": self.ops.iter().map(DbMigrationOp::python_ast).collect::<Vec<_>>(),
+            "ops": self.ops.iter().map(DbMigrationOp::kernel_ast_v1).collect::<Vec<_>>(),
             "annotations": self.annotations, "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbMigrationOp {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbMigrationOp", "op": self.op, "column": self.column,
             "nullability": self.nullability, "columns": self.columns,
@@ -190,7 +190,7 @@ impl DbMigrationOp {
 }
 
 impl DbArtifact {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         let capability = |name: &str| self.capabilities.get(name).cloned().unwrap_or_default();
         let offline_ttls = self
             .offline_ttls
@@ -210,7 +210,7 @@ impl DbArtifact {
 }
 
 impl DbFlag {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbFlag", "name": self.name, "variants": self.variants,
             "default": self.default, "loc": self.span.python_loc(),
@@ -219,7 +219,7 @@ impl DbFlag {
 }
 
 impl DbFlagCondition {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbFlagCondition", "flag": self.flag, "variant": self.variant,
             "loc": self.span.python_loc(),
@@ -228,29 +228,29 @@ impl DbFlagCondition {
 }
 
 impl DbEnvironmentArtifact {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbEnvironmentArtifact", "role": self.role, "artifact": self.artifact,
             "schema_window": self.schema_window,
-            "flag_conditions": self.flag_conditions.iter().map(DbFlagCondition::python_ast).collect::<Vec<_>>(),
+            "flag_conditions": self.flag_conditions.iter().map(DbFlagCondition::kernel_ast_v1).collect::<Vec<_>>(),
             "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbEnvironment {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbEnvironment", "name": self.name, "schema_window": self.schema_window,
-            "artifacts": self.artifacts.iter().map(DbEnvironmentArtifact::python_ast).collect::<Vec<_>>(),
-            "flags": self.flags.iter().map(DbFlag::python_ast).collect::<Vec<_>>(),
+            "artifacts": self.artifacts.iter().map(DbEnvironmentArtifact::kernel_ast_v1).collect::<Vec<_>>(),
+            "flags": self.flags.iter().map(DbFlag::kernel_ast_v1).collect::<Vec<_>>(),
             "loc": self.span.python_loc(),
         })
     }
 }
 
 impl DbCheck {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type": "DbCheck",
             "rules": self.rules.iter().map(|rule| rule.name.as_str()).collect::<Vec<_>>(),

--- a/rust/fsl-syntax/src/domain.rs
+++ b/rust/fsl-syntax/src/domain.rs
@@ -262,117 +262,117 @@ macro_rules! ast_list {
 
 impl DomainSpec {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainSpec", "name":self.name,
             "implementation_profile":self.implementation_profile,
-            "types":ast_list!(self.types, python_ast),
-            "aggregates":ast_list!(self.aggregates, python_ast),
-            "effects":ast_list!(self.effects, python_ast),
-            "awaits":ast_list!(self.awaits, python_ast),
-            "sagas":ast_list!(self.sagas, python_ast),
-            "projections":ast_list!(self.projections, python_ast), "loc":self.loc,
+            "types":ast_list!(self.types, kernel_ast_v1),
+            "aggregates":ast_list!(self.aggregates, kernel_ast_v1),
+            "effects":ast_list!(self.effects, kernel_ast_v1),
+            "awaits":ast_list!(self.awaits, kernel_ast_v1),
+            "sagas":ast_list!(self.sagas, kernel_ast_v1),
+            "projections":ast_list!(self.projections, kernel_ast_v1), "loc":self.loc,
         })
     }
 }
 
 impl DomainField {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainField","name":self.name.text,"type_name":self.type_name.render_source(),"default":render_optional_expr(self.default.as_ref()),"loc":self.loc})
     }
 }
 
 impl DomainInvariant {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainInvariant","name":self.name.text,"expr":self.expr.render_source(),"loc":self.loc})
     }
 }
 
 impl DomainType {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainType","name":self.name,"kind":self.kind,"members":self.members,
-            "lo":render_optional_expr(self.lo.as_ref()),"hi":render_optional_expr(self.hi.as_ref()),"fields":ast_list!(self.fields, python_ast),
-            "invariants":ast_list!(self.invariants, python_ast),"loc":self.loc,
+            "lo":render_optional_expr(self.lo.as_ref()),"hi":render_optional_expr(self.hi.as_ref()),"fields":ast_list!(self.fields, kernel_ast_v1),
+            "invariants":ast_list!(self.invariants, kernel_ast_v1),"loc":self.loc,
         })
     }
 }
 
 impl DomainCommand {
-    fn python_ast(&self) -> Value {
-        json!({"$type":"DomainCommand","name":self.name,"inputs":ast_list!(self.inputs, python_ast),"loc":self.loc})
+    fn kernel_ast_v1(&self) -> Value {
+        json!({"$type":"DomainCommand","name":self.name,"inputs":ast_list!(self.inputs, kernel_ast_v1),"loc":self.loc})
     }
 }
 
 impl DomainEvent {
-    fn python_ast(&self) -> Value {
-        json!({"$type":"DomainEvent","name":self.name,"fields":ast_list!(self.fields, python_ast),"loc":self.loc})
+    fn kernel_ast_v1(&self) -> Value {
+        json!({"$type":"DomainEvent","name":self.name,"fields":ast_list!(self.fields, kernel_ast_v1),"loc":self.loc})
     }
 }
 
 impl DomainError {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainError","name":self.name,"loc":self.loc})
     }
 }
 
 impl DomainReject {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainReject","error":self.error,"condition":self.condition.render_source(),"loc":self.loc})
     }
 }
 
 impl DomainDecide {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainDecide","command":self.command,"requires":render_exprs(&self.requires),
-            "rejects":ast_list!(self.rejects, python_ast),"emits":self.emits,"loc":self.loc,
+            "rejects":ast_list!(self.rejects, kernel_ast_v1),"emits":self.emits,"loc":self.loc,
         })
     }
 }
 
 impl DomainAssignment {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainAssignment","target":self.target.render_source(),"expr":self.value.render_source(),"loc":self.loc})
     }
 }
 
 impl DomainEvolve {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainEvolve","event":self.event,"requires":render_exprs(&self.requires),
-            "assignments":ast_list!(self.assignments, python_ast),"loc":self.loc,
+            "assignments":ast_list!(self.assignments, kernel_ast_v1),"loc":self.loc,
         })
     }
 }
 
 impl DomainProjection {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainProjection","name":self.name,"source":self.source,"fields":self.fields,"loc":self.loc})
     }
 }
 
 impl DomainStalePolicy {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainStalePolicy","event":self.event,"condition":self.condition.render_source(),"emits":self.emits,"loc":self.loc})
     }
 }
 
 impl DomainAggregate {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainAggregate","name":self.name,"id_type":self.id_type,
-            "state":ast_list!(self.state, python_ast),"commands":ast_list!(self.commands, python_ast),
-            "events":ast_list!(self.events, python_ast),"errors":ast_list!(self.errors, python_ast),
-            "decides":ast_list!(self.decides, python_ast),"evolves":ast_list!(self.evolves, python_ast),
-            "invariants":ast_list!(self.invariants, python_ast),
-            "stale_policies":ast_list!(self.stale_policies, python_ast),"loc":self.loc,
+            "state":ast_list!(self.state, kernel_ast_v1),"commands":ast_list!(self.commands, kernel_ast_v1),
+            "events":ast_list!(self.events, kernel_ast_v1),"errors":ast_list!(self.errors, kernel_ast_v1),
+            "decides":ast_list!(self.decides, kernel_ast_v1),"evolves":ast_list!(self.evolves, kernel_ast_v1),
+            "invariants":ast_list!(self.invariants, kernel_ast_v1),
+            "stale_policies":ast_list!(self.stale_policies, kernel_ast_v1),"loc":self.loc,
         })
     }
 }
 
 impl DomainRetry {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainRetry","max_attempts":self.max_attempts,"backoff":self.backoff,"loc":self.loc})
     }
 }
@@ -453,14 +453,14 @@ impl DomainEffect {
         events
     }
 
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainEffect","name":self.name,"async_effect":self.async_effect,
             "reliable":self.reliable,"irreversible":self.irreversible,
             "idempotency_key":render_optional_expr(self.idempotency_key.as_ref()),"correlation_id":render_optional_expr(self.correlation_id.as_ref()),
             "handles":self.handles,"outcomes":self.outcomes,"request_event":self.request_event,
             "success_event":self.success_event,"failure_event":self.failure_event,
-            "timeout_event":self.timeout_event,"retry":self.retry.python_ast(),
+            "timeout_event":self.timeout_event,"retry":self.retry.kernel_ast_v1(),
             "timeout_after":self.timeout_after,"compensation_events":self.compensation_events,
             "outbox":self.outbox,"inbox":self.inbox,"loc":self.loc,
         })
@@ -468,13 +468,13 @@ impl DomainEffect {
 }
 
 impl DomainAwait {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({"$type":"DomainAwait","name":self.name,"mode":self.mode,"events":self.events,"branches":self.branches,"loc":self.loc})
     }
 }
 
 impl DomainSagaStep {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainSagaStep","name":self.name,"async_step":self.async_step,
             "requires":render_exprs(&self.requires),"emits":self.emits,"awaits_mode":self.awaits_mode,
@@ -485,7 +485,7 @@ impl DomainSagaStep {
 }
 
 impl DomainSagaCompensation {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainSagaCompensation","trigger_event":self.trigger_event,
             "after_event":self.after_event,"emits":self.emits,"loc":self.loc,
@@ -494,12 +494,12 @@ impl DomainSagaCompensation {
 }
 
 impl DomainSaga {
-    fn python_ast(&self) -> Value {
+    fn kernel_ast_v1(&self) -> Value {
         json!({
             "$type":"DomainSaga","name":self.name,"starts_on":self.starts_on,
-            "steps":ast_list!(self.steps, python_ast),
-            "compensations":ast_list!(self.compensations, python_ast),
-            "invariants":ast_list!(self.invariants, python_ast),
+            "steps":ast_list!(self.steps, kernel_ast_v1),
+            "compensations":ast_list!(self.compensations, kernel_ast_v1),
+            "invariants":ast_list!(self.invariants, kernel_ast_v1),
             "outboxes":self.outboxes,"inboxes":self.inboxes,"loc":self.loc,
         })
     }

--- a/rust/fsl-syntax/src/lib.rs
+++ b/rust/fsl-syntax/src/lib.rs
@@ -4,7 +4,7 @@
 //! Syntax layer for the Rust fslc port.
 //!
 //! Phase 0 starts with the expression grammar because it is shared by every
-//! declaration dialect.  The public `python_ast` projection deliberately emits
+//! declaration dialect.  The public `kernel_ast_v1` projection deliberately emits
 //! the tuple/list JSON shape of the Python reference implementation, allowing
 //! differential tests without making that legacy representation the Rust AST.
 

--- a/rust/fsl-syntax/src/parser.rs
+++ b/rust/fsl-syntax/src/parser.rs
@@ -2238,7 +2238,7 @@ mod tests {
     use super::*;
 
     fn ast(source: &str) -> serde_json::Value {
-        parse_expr(source).unwrap().python_ast()
+        parse_expr(source).unwrap().kernel_ast_v1()
     }
 
     #[test]
@@ -2344,7 +2344,7 @@ mod tests {
 }
 verify { values Id = 0..2 }
 "#;
-        let ast = parse_surface_spec(source).unwrap().python_ast();
+        let ast = parse_surface_spec(source).unwrap().kernel_ast_v1();
         assert_eq!(ast[0], "spec");
         assert_eq!(ast[1], "Demo");
         assert_eq!(

--- a/rust/fsl-syntax/src/surface.rs
+++ b/rust/fsl-syntax/src/surface.rs
@@ -724,25 +724,25 @@ impl MetaTag {
     }
 
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!({"id": self.id, "text": self.text})
     }
 }
 
 impl TypeExpr {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Int => json!(["int"]),
             Self::Bool => json!(["bool"]),
-            Self::Range(lo, hi) => json!(["range", lo.python_ast(), hi.python_ast()]),
-            Self::Map(key, value) => json!(["map", key.python_ast(), value.python_ast()]),
+            Self::Range(lo, hi) => json!(["range", lo.kernel_ast_v1(), hi.kernel_ast_v1()]),
+            Self::Map(key, value) => json!(["map", key.kernel_ast_v1(), value.kernel_ast_v1()]),
             Self::Relation(source, target) => {
-                json!(["relation", source.python_ast(), target.python_ast()])
+                json!(["relation", source.kernel_ast_v1(), target.kernel_ast_v1()])
             }
-            Self::Set(element) => json!(["set", element.python_ast()]),
-            Self::Seq(element, cap) => json!(["seq", element.python_ast(), cap.python_ast()]),
-            Self::Option(inner) => json!(["option", inner.python_ast()]),
+            Self::Set(element) => json!(["set", element.kernel_ast_v1()]),
+            Self::Seq(element, cap) => json!(["seq", element.kernel_ast_v1(), cap.kernel_ast_v1()]),
+            Self::Option(inner) => json!(["option", inner.kernel_ast_v1()]),
             Self::Name(name) => json!(["name", name]),
         }
     }
@@ -750,13 +750,13 @@ impl TypeExpr {
 
 impl Param {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Typed(name, type_name) => {
-                json!(["param_typed", name, type_name.python_ast()])
+                json!(["param_typed", name, type_name.kernel_ast_v1()])
             }
             Self::Range(name, lo, hi) => {
-                json!(["param_range", name, lo.python_ast(), hi.python_ast()])
+                json!(["param_range", name, lo.kernel_ast_v1(), hi.kernel_ast_v1()])
             }
         }
     }
@@ -764,14 +764,14 @@ impl Param {
 
 impl LValue {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Var(name) => json!(["var", name]),
-            Self::Index(name, index) => json!(["index", name, index.python_ast()]),
+            Self::Index(name, index) => json!(["index", name, index.kernel_ast_v1()]),
             Self::Field(base, field) => match base.as_ref() {
                 Self::Var(name) => json!(["field_lv", ["var", name], field]),
                 Self::Index(name, index) => {
-                    json!(["field_lv", ["index", name, index.python_ast()], field])
+                    json!(["field_lv", ["index", name, index.kernel_ast_v1()], field])
                 }
                 Self::Field(_, _) => unreachable!("grammar permits one lvalue field suffix"),
             },
@@ -781,7 +781,7 @@ impl LValue {
 
 impl Statement {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Assign {
                 target,
@@ -789,8 +789,8 @@ impl Statement {
                 span,
             } => json!([
                 "assign",
-                target.python_ast(),
-                value.python_ast(),
+                target.kernel_ast_v1(),
+                value.kernel_ast_v1(),
                 span.python_loc()
             ]),
             Self::If {
@@ -800,7 +800,7 @@ impl Statement {
                 span,
             } => json!([
                 "if",
-                condition.python_ast(),
+                condition.kernel_ast_v1(),
                 statements_ast(then_statements),
                 statements_ast(else_statements),
                 span.python_loc()
@@ -811,7 +811,7 @@ impl Statement {
                 span,
             } => json!([
                 "forall_stmt",
-                binder.python_ast(),
+                binder.kernel_ast_v1(),
                 statements_ast(statements),
                 span.python_loc()
             ]),
@@ -821,25 +821,25 @@ impl Statement {
 
 impl ActionItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Requires(expr, span) => {
-                json!(["requires", expr.python_ast(), span.python_loc()])
+                json!(["requires", expr.kernel_ast_v1(), span.python_loc()])
             }
             Self::Ensures(expr, span) => {
-                json!(["ensures", expr.python_ast(), span.python_loc()])
+                json!(["ensures", expr.kernel_ast_v1(), span.python_loc()])
             }
             Self::Let(name, expr, span) => {
-                json!(["let", name, expr.python_ast(), span.python_loc()])
+                json!(["let", name, expr.kernel_ast_v1(), span.python_loc()])
             }
-            Self::Statement(statement) => statement.python_ast(),
+            Self::Statement(statement) => statement.kernel_ast_v1(),
         }
     }
 }
 
 impl VerifyItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Instances(name, value, span) => {
                 json!(["verify_instances", name, value, span.python_loc()])
@@ -847,8 +847,8 @@ impl VerifyItem {
             Self::Values(name, lo, hi, span) => json!([
                 "verify_values",
                 name,
-                lo.python_ast(),
-                hi.python_ast(),
+                lo.kernel_ast_v1(),
+                hi.kernel_ast_v1(),
                 span.python_loc()
             ]),
         }
@@ -858,9 +858,9 @@ impl VerifyItem {
 impl SpecItem {
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Const { name, value } => json!(["const", name, value.python_ast()]),
+            Self::Const { name, value } => json!(["const", name, value.kernel_ast_v1()]),
             Self::Def {
                 name,
                 params,
@@ -871,9 +871,9 @@ impl SpecItem {
                 name,
                 params
                     .iter()
-                    .map(|(name, ty)| json!(["def_param", name, ty.python_ast()]))
+                    .map(|(name, ty)| json!(["def_param", name, ty.kernel_ast_v1()]))
                     .collect::<Vec<_>>(),
-                value.python_ast(),
+                value.kernel_ast_v1(),
                 span.python_loc()
             ]),
             Self::Type {
@@ -882,7 +882,12 @@ impl SpecItem {
                 hi,
                 symmetric,
             } => {
-                let mut values = vec![json!("type"), json!(name), lo.python_ast(), hi.python_ast()];
+                let mut values = vec![
+                    json!("type"),
+                    json!(name),
+                    lo.kernel_ast_v1(),
+                    hi.kernel_ast_v1(),
+                ];
                 if *symmetric {
                     values.push(json!({"symmetric": true}));
                 }
@@ -903,7 +908,7 @@ impl SpecItem {
             Self::Struct { name, fields, .. } => {
                 let fields = fields
                     .iter()
-                    .map(|(name, ty)| (name.clone(), ty.python_ast()))
+                    .map(|(name, ty)| (name.clone(), ty.kernel_ast_v1()))
                     .collect::<Map<_, _>>();
                 json!(["struct", name, fields])
             }
@@ -915,9 +920,9 @@ impl SpecItem {
                     .iter()
                     .map(|field| {
                         let mut declaration =
-                            vec![json!("decl"), json!(field.name), field.ty.python_ast()];
+                            vec![json!("decl"), json!(field.name), field.ty.kernel_ast_v1()];
                         if let Some(initializer) = &field.initializer {
-                            declaration.push(initializer.python_ast());
+                            declaration.push(initializer.kernel_ast_v1());
                             declaration.push(json!(field.initializer_span.map(Span::python_loc)));
                         }
                         Value::Array(declaration)
@@ -929,7 +934,7 @@ impl SpecItem {
             } => {
                 let mut values = vec![json!("init"), Value::Array(statements_ast(statements))];
                 if let Some(meta) = meta {
-                    values.push(meta.python_ast());
+                    values.push(meta.kernel_ast_v1());
                 }
                 Value::Array(values)
             }
@@ -946,11 +951,16 @@ impl SpecItem {
                 let mut values = vec![
                     json!("action"),
                     json!(name),
-                    json!(params.iter().map(Param::python_ast).collect::<Vec<_>>()),
-                    json!(items.iter().map(ActionItem::python_ast).collect::<Vec<_>>()),
+                    json!(params.iter().map(Param::kernel_ast_v1).collect::<Vec<_>>()),
+                    json!(
+                        items
+                            .iter()
+                            .map(ActionItem::kernel_ast_v1)
+                            .collect::<Vec<_>>()
+                    ),
                     span.python_loc(),
                     json!(fair),
-                    json!(meta.as_ref().map(MetaTag::python_ast)),
+                    json!(meta.as_ref().map(MetaTag::kernel_ast_v1)),
                 ];
                 if *sync {
                     values.push(json!(true));
@@ -979,7 +989,7 @@ impl SpecItem {
                 ..
             } => property_ast("reachable", name, expr, *span, meta.as_ref()),
             Self::Terminal { expr, span } => {
-                json!(["terminal", expr.python_ast(), span.python_loc()])
+                json!(["terminal", expr.kernel_ast_v1(), span.python_loc()])
             }
             Self::Until {
                 name,
@@ -991,10 +1001,10 @@ impl SpecItem {
             } => json!([
                 "until",
                 name,
-                before.python_ast(),
-                after.python_ast(),
+                before.kernel_ast_v1(),
+                after.kernel_ast_v1(),
                 span.python_loc(),
-                meta.as_ref().map(MetaTag::python_ast)
+                meta.as_ref().map(MetaTag::kernel_ast_v1)
             ]),
             Self::Unless {
                 name,
@@ -1006,10 +1016,10 @@ impl SpecItem {
             } => json!([
                 "unless",
                 name,
-                before.python_ast(),
-                after.python_ast(),
+                before.kernel_ast_v1(),
+                after.kernel_ast_v1(),
                 span.python_loc(),
-                meta.as_ref().map(MetaTag::python_ast)
+                meta.as_ref().map(MetaTag::kernel_ast_v1)
             ]),
             Self::LeadsTo {
                 name,
@@ -1025,25 +1035,31 @@ impl SpecItem {
             } => json!([
                 "leadsto",
                 name,
-                binders.iter().map(Binder::python_ast).collect::<Vec<_>>(),
-                before.python_ast(),
-                after.python_ast(),
+                binders
+                    .iter()
+                    .map(Binder::kernel_ast_v1)
+                    .collect::<Vec<_>>(),
+                before.kernel_ast_v1(),
+                after.kernel_ast_v1(),
                 span.python_loc(),
-                meta.as_ref().map(MetaTag::python_ast),
-                decreases.as_ref().map(|expr| expr.python_ast()),
-                within.as_ref().map(|expr| expr.python_ast()),
+                meta.as_ref().map(MetaTag::kernel_ast_v1),
+                decreases.as_ref().map(|expr| expr.kernel_ast_v1()),
+                within.as_ref().map(|expr| expr.kernel_ast_v1()),
                 helpful
                     .iter()
                     .map(|entry| json!({
                         "action": entry.action,
-                        "args": entry.args.iter().map(Expr::python_ast).collect::<Vec<_>>(),
+                        "args": entry.args.iter().map(Expr::kernel_ast_v1).collect::<Vec<_>>(),
                         "loc": entry.span.python_loc()
                     }))
                     .collect::<Vec<_>>()
             ]),
             Self::VerifyBounds { items, span } => json!([
                 "verify_bounds",
-                items.iter().map(VerifyItem::python_ast).collect::<Vec<_>>(),
+                items
+                    .iter()
+                    .map(VerifyItem::kernel_ast_v1)
+                    .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
         }
@@ -1052,36 +1068,36 @@ impl SpecItem {
 
 impl SurfaceSpec {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         let mut items = Vec::new();
         if let Some(meta) = &self.meta {
-            items.push(json!(["__spec_meta", meta.python_ast()]));
+            items.push(json!(["__spec_meta", meta.kernel_ast_v1()]));
         }
-        items.extend(self.items.iter().map(SpecItem::python_ast));
+        items.extend(self.items.iter().map(SpecItem::kernel_ast_v1));
         json!(["spec", self.name, items])
     }
 }
 
 impl RefinementParam {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "refinement_param",
             self.name,
-            self.ty.as_ref().map(TypeExpr::python_ast)
+            self.ty.as_ref().map(TypeExpr::kernel_ast_v1)
         ])
     }
 }
 
 impl ActionTarget {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Stutter => json!(["stutter"]),
             Self::Action(name, args) => json!([
                 "action",
                 name,
-                args.iter().map(Expr::python_ast).collect::<Vec<_>>()
+                args.iter().map(Expr::kernel_ast_v1).collect::<Vec<_>>()
             ]),
         }
     }
@@ -1089,7 +1105,7 @@ impl ActionTarget {
 
 impl RefinementItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Impl(name) => json!(["impl", name]),
             Self::Abs(name) => json!(["abs", name]),
@@ -1136,8 +1152,8 @@ impl RefinementItem {
             } => json!([
                 "map",
                 name,
-                binder.as_ref().map(Binder::python_ast),
-                expr.python_ast(),
+                binder.as_ref().map(Binder::kernel_ast_v1),
+                expr.kernel_ast_v1(),
                 span.python_loc()
             ]),
             Self::Action {
@@ -1151,9 +1167,9 @@ impl RefinementItem {
                 name,
                 params
                     .iter()
-                    .map(RefinementParam::python_ast)
+                    .map(RefinementParam::kernel_ast_v1)
                     .collect::<Vec<_>>(),
-                target.python_ast(),
+                target.kernel_ast_v1(),
                 span.python_loc()
             ]),
             Self::PreserveProgress { responses, span } => json!([
@@ -1172,13 +1188,13 @@ impl RefinementItem {
 
 impl SurfaceRefinement {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "refinement",
             self.name,
             self.items
                 .iter()
-                .map(RefinementItem::python_ast)
+                .map(RefinementItem::kernel_ast_v1)
                 .collect::<Vec<_>>()
         ])
     }
@@ -1186,24 +1202,24 @@ impl SurfaceRefinement {
 
 impl ProcessField {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "proc_field",
             self.name,
-            self.type_name.python_ast(),
-            self.initial.as_ref().map(Expr::python_ast)
+            self.type_name.kernel_ast_v1(),
+            self.initial.as_ref().map(Expr::kernel_ast_v1)
         ])
     }
 }
 
 impl ProcessFields {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "proc_fields",
             self.fields
                 .iter()
-                .map(ProcessField::python_ast)
+                .map(ProcessField::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.span.python_loc()
         ])
@@ -1212,7 +1228,7 @@ impl ProcessFields {
 
 impl ProcessItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Stages(names, span) => json!(["biz_stages", names, span.python_loc()]),
             Self::Initial(name, span) => json!(["biz_initial", name, span.python_loc()]),
@@ -1225,14 +1241,14 @@ impl ProcessItem {
                 if has_extra {
                     extra.insert(
                         "inputs".to_owned(),
-                        Value::Array(transition.inputs.iter().map(Param::python_ast).collect()),
+                        Value::Array(transition.inputs.iter().map(Param::kernel_ast_v1).collect()),
                     );
                     extra.insert(
                         "guard".to_owned(),
                         transition
                             .guard
                             .as_ref()
-                            .map_or(Value::Null, Expr::python_ast),
+                            .map_or(Value::Null, Expr::kernel_ast_v1),
                     );
                     extra.insert(
                         "sets".to_owned(),
@@ -1240,7 +1256,9 @@ impl ProcessItem {
                             transition
                                 .assignments
                                 .iter()
-                                .map(|(name, expr)| json!(["proc_assign", name, expr.python_ast()]))
+                                .map(|(name, expr)| {
+                                    json!(["proc_assign", name, expr.kernel_ast_v1()])
+                                })
                                 .collect(),
                         ),
                     );
@@ -1268,7 +1286,7 @@ impl ProcessItem {
 
 impl ControlAttribute {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Owner(name) => json!(["control_owner", name]),
             Self::Severity(name) => json!(["control_severity", name]),
@@ -1279,9 +1297,9 @@ impl ControlAttribute {
 
 impl BusinessPolicyBody {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Invariant(expr) => json!(["biz_policy_invariant", expr.python_ast()]),
+            Self::Invariant(expr) => json!(["biz_policy_invariant", expr.kernel_ast_v1()]),
             Self::Responds {
                 binders,
                 before,
@@ -1289,10 +1307,13 @@ impl BusinessPolicyBody {
                 within,
             } => json!([
                 "biz_policy_responds",
-                binders.iter().map(Binder::python_ast).collect::<Vec<_>>(),
-                before.python_ast(),
-                after.python_ast(),
-                within.as_deref().map(Expr::python_ast)
+                binders
+                    .iter()
+                    .map(Binder::kernel_ast_v1)
+                    .collect::<Vec<_>>(),
+                before.kernel_ast_v1(),
+                after.kernel_ast_v1(),
+                within.as_deref().map(Expr::kernel_ast_v1)
             ]),
             Self::Eventually {
                 case_name,
@@ -1315,9 +1336,9 @@ impl BusinessPolicyBody {
 
 impl BusinessGoalBody {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Expr(expr) => json!(["biz_goal_expr", expr.python_ast()]),
+            Self::Expr(expr) => json!(["biz_goal_expr", expr.kernel_ast_v1()]),
             Self::SomeStage { case_name, stage } => {
                 json!(["biz_goal_some_stage", case_name, stage])
             }
@@ -1330,7 +1351,7 @@ impl BusinessGoalBody {
 
 impl BusinessItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Actor(names, span) => json!(["biz_actor", names, span.python_loc()]),
             Self::Entity(name, span) => json!(["entity", name, span.python_loc()]),
@@ -1342,10 +1363,10 @@ impl BusinessItem {
             } => json!([
                 "biz_process",
                 name.to_string(),
-                fields.as_ref().map(ProcessFields::python_ast),
+                fields.as_ref().map(ProcessFields::kernel_ast_v1),
                 items
                     .iter()
-                    .map(ProcessItem::python_ast)
+                    .map(ProcessItem::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1366,7 +1387,7 @@ impl BusinessItem {
                 text,
                 attributes
                     .iter()
-                    .map(ControlAttribute::python_ast)
+                    .map(ControlAttribute::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1381,7 +1402,7 @@ impl BusinessItem {
                 "biz_policy",
                 id,
                 text,
-                body.python_ast(),
+                body.kernel_ast_v1(),
                 span.python_loc(),
                 satisfies
             ]),
@@ -1396,13 +1417,16 @@ impl BusinessItem {
                 "biz_goal",
                 id,
                 text,
-                body.python_ast(),
+                body.kernel_ast_v1(),
                 span.python_loc(),
                 satisfies
             ]),
             Self::VerifyBounds { items, span } => json!([
                 "verify_bounds",
-                items.iter().map(VerifyItem::python_ast).collect::<Vec<_>>(),
+                items
+                    .iter()
+                    .map(VerifyItem::kernel_ast_v1)
+                    .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
         }
@@ -1411,13 +1435,13 @@ impl BusinessItem {
 
 impl SurfaceBusiness {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "business",
             self.name,
             self.items
                 .iter()
-                .map(BusinessItem::python_ast)
+                .map(BusinessItem::kernel_ast_v1)
                 .collect::<Vec<_>>()
         ])
     }
@@ -1425,7 +1449,7 @@ impl SurfaceBusiness {
 
 impl GovernanceArtifactRef {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Policy(id, span) => json!(["policy", id, span.python_loc()]),
             Self::Goal(id, span) => json!(["goal", id, span.python_loc()]),
@@ -1435,7 +1459,7 @@ impl GovernanceArtifactRef {
 
 impl GovernanceDelegateItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Require(id, span) => json!(["gov_require", id, span.python_loc()]),
             Self::Satisfaction {
@@ -1447,7 +1471,7 @@ impl GovernanceDelegateItem {
                 control_id,
                 artifacts
                     .iter()
-                    .map(GovernanceArtifactRef::python_ast)
+                    .map(GovernanceArtifactRef::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1457,7 +1481,7 @@ impl GovernanceDelegateItem {
 
 impl PreservationItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Before {
                 spec_name,
@@ -1481,7 +1505,7 @@ impl PreservationItem {
 
 impl GovernanceItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Authority {
                 authority,
@@ -1499,7 +1523,7 @@ impl GovernanceItem {
                 text,
                 attributes
                     .iter()
-                    .map(ControlAttribute::python_ast)
+                    .map(ControlAttribute::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1514,7 +1538,7 @@ impl GovernanceItem {
                 path,
                 items
                     .iter()
-                    .map(GovernanceDelegateItem::python_ast)
+                    .map(GovernanceDelegateItem::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1523,7 +1547,7 @@ impl GovernanceItem {
                 name,
                 items
                     .iter()
-                    .map(PreservationItem::python_ast)
+                    .map(PreservationItem::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1533,13 +1557,13 @@ impl GovernanceItem {
 
 impl SurfaceGovernance {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "governance",
             self.name,
             self.items
                 .iter()
-                .map(GovernanceItem::python_ast)
+                .map(GovernanceItem::kernel_ast_v1)
                 .collect::<Vec<_>>()
         ])
     }
@@ -1547,19 +1571,19 @@ impl SurfaceGovernance {
 
 impl MapsClause {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
-        json!(["maps", self.target.python_ast(), self.span.python_loc()])
+    pub fn kernel_ast_v1(&self) -> Value {
+        json!(["maps", self.target.kernel_ast_v1(), self.span.python_loc()])
     }
 }
 
 impl RequirementBranch {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "branch",
-            self.condition.python_ast(),
+            self.condition.kernel_ast_v1(),
             statements_ast(&self.statements),
-            self.maps.python_ast(),
+            self.maps.kernel_ast_v1(),
             self.span.python_loc()
         ])
     }
@@ -1567,14 +1591,14 @@ impl RequirementBranch {
 
 impl RequirementActionItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Action(item) => item.python_ast(),
+            Self::Action(item) => item.kernel_ast_v1(),
             Self::Branches { branches, span } => json!([
                 "branches",
                 branches
                     .iter()
-                    .map(RequirementBranch::python_ast)
+                    .map(RequirementBranch::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1584,34 +1608,34 @@ impl RequirementActionItem {
 
 impl RequirementAction {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "req_action",
             self.name,
             self.params
                 .iter()
-                .map(Param::python_ast)
+                .map(Param::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.items
                 .iter()
-                .map(RequirementActionItem::python_ast)
+                .map(RequirementActionItem::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.span.python_loc(),
             self.fair,
-            self.meta.as_ref().map(MetaTag::python_ast),
-            self.maps.as_ref().map(MapsClause::python_ast)
+            self.meta.as_ref().map(MetaTag::kernel_ast_v1),
+            self.maps.as_ref().map(MapsClause::kernel_ast_v1)
         ])
     }
 }
 
 impl RequirementBlockItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Action(action) => action.python_ast(),
-            Self::Property(item) => item.python_ast(),
+            Self::Action(action) => action.kernel_ast_v1(),
+            Self::Property(item) => item.kernel_ast_v1(),
             Self::Deadline { name, bound, span } => {
-                json!(["deadline", name, bound.python_ast(), span.python_loc()])
+                json!(["deadline", name, bound.kernel_ast_v1(), span.python_loc()])
             }
         }
     }
@@ -1619,11 +1643,14 @@ impl RequirementBlockItem {
 
 impl AcceptanceStep {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "acceptance_step",
             self.name,
-            self.args.iter().map(Expr::python_ast).collect::<Vec<_>>(),
+            self.args
+                .iter()
+                .map(Expr::kernel_ast_v1)
+                .collect::<Vec<_>>(),
             self.span.python_loc()
         ])
     }
@@ -1631,10 +1658,10 @@ impl AcceptanceStep {
 
 impl AcceptanceExpectation {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Expr(expr, span) => {
-                json!(["acceptance_expect", expr.python_ast(), span.python_loc()])
+                json!(["acceptance_expect", expr.kernel_ast_v1(), span.python_loc()])
             }
             Self::Stage {
                 entity,
@@ -1654,7 +1681,7 @@ impl AcceptanceExpectation {
 
 impl TimeItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Urgent(names, span) => json!(["time_urgent", names, span.python_loc()]),
             Self::Age {
@@ -1665,8 +1692,8 @@ impl TimeItem {
             } => json!([
                 "time_age",
                 name,
-                binder.as_ref().map(Binder::python_ast),
-                condition.python_ast(),
+                binder.as_ref().map(Binder::kernel_ast_v1),
+                condition.kernel_ast_v1(),
                 span.python_loc()
             ]),
         }
@@ -1675,7 +1702,7 @@ impl TimeItem {
 
 impl RequirementsItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Implements {
                 name,
@@ -1688,7 +1715,7 @@ impl RequirementsItem {
                 path,
                 items
                     .iter()
-                    .map(RefinementItem::python_ast)
+                    .map(RefinementItem::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1704,7 +1731,7 @@ impl RequirementsItem {
                 text,
                 items
                     .iter()
-                    .map(RequirementBlockItem::python_ast)
+                    .map(RequirementBlockItem::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
@@ -1721,9 +1748,9 @@ impl RequirementsItem {
                 text,
                 steps
                     .iter()
-                    .map(AcceptanceStep::python_ast)
+                    .map(AcceptanceStep::kernel_ast_v1)
                     .collect::<Vec<_>>(),
-                expectation.python_ast(),
+                expectation.kernel_ast_v1(),
                 span.python_loc()
             ]),
             Self::Forbidden {
@@ -1738,31 +1765,34 @@ impl RequirementsItem {
                 text,
                 steps
                     .iter()
-                    .map(AcceptanceStep::python_ast)
+                    .map(AcceptanceStep::kernel_ast_v1)
                     .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
-            Self::Process(item) | Self::Kpi(item) => item.python_ast(),
-            Self::Action(action) => action.python_ast(),
+            Self::Process(item) | Self::Kpi(item) => item.kernel_ast_v1(),
+            Self::Action(action) => action.kernel_ast_v1(),
             Self::Time { items, span } => json!([
                 "time",
-                items.iter().map(TimeItem::python_ast).collect::<Vec<_>>(),
+                items
+                    .iter()
+                    .map(TimeItem::kernel_ast_v1)
+                    .collect::<Vec<_>>(),
                 span.python_loc()
             ]),
-            Self::Common(item) => item.python_ast(),
+            Self::Common(item) => item.kernel_ast_v1(),
         }
     }
 }
 
 impl SurfaceRequirements {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "requirements",
             self.name,
             self.items
                 .iter()
-                .map(RequirementsItem::python_ast)
+                .map(RequirementsItem::kernel_ast_v1)
                 .collect::<Vec<_>>()
         ])
     }
@@ -1770,44 +1800,47 @@ impl SurfaceRequirements {
 
 impl SyncRef {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "sync_ref",
             self.alias,
             self.action,
-            self.args.iter().map(Expr::python_ast).collect::<Vec<_>>()
+            self.args
+                .iter()
+                .map(Expr::kernel_ast_v1)
+                .collect::<Vec<_>>()
         ])
     }
 }
 
 impl SyncAction {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "sync_action",
             self.name,
             self.params
                 .iter()
-                .map(Param::python_ast)
+                .map(Param::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.refs
                 .iter()
-                .map(SyncRef::python_ast)
+                .map(SyncRef::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.items
                 .iter()
-                .map(ActionItem::python_ast)
+                .map(ActionItem::kernel_ast_v1)
                 .collect::<Vec<_>>(),
             self.span.python_loc(),
             self.fair,
-            self.meta.as_ref().map(MetaTag::python_ast)
+            self.meta.as_ref().map(MetaTag::kernel_ast_v1)
         ])
     }
 }
 
 impl ComposeItem {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
             Self::Use {
                 spec_name,
@@ -1820,21 +1853,21 @@ impl ComposeItem {
                 action,
                 span,
             } => json!(["internal", alias, action, span.python_loc()]),
-            Self::SyncAction(action) => action.python_ast(),
-            Self::Common(item) => item.python_ast(),
+            Self::SyncAction(action) => action.kernel_ast_v1(),
+            Self::Common(item) => item.kernel_ast_v1(),
         }
     }
 }
 
 impl SurfaceCompose {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         json!([
             "compose",
             self.name,
             self.items
                 .iter()
-                .map(ComposeItem::python_ast)
+                .map(ComposeItem::kernel_ast_v1)
                 .collect::<Vec<_>>()
         ])
     }
@@ -1842,17 +1875,17 @@ impl SurfaceCompose {
 
 impl SurfaceDocument {
     #[must_use]
-    pub fn python_ast(&self) -> Value {
+    pub fn kernel_ast_v1(&self) -> Value {
         match self {
-            Self::Spec(spec) => spec.python_ast(),
-            Self::Refinement(refinement) => refinement.python_ast(),
-            Self::Business(business) => business.python_ast(),
-            Self::Governance(governance) => governance.python_ast(),
-            Self::Requirements(requirements) => requirements.python_ast(),
-            Self::Compose(compose) => compose.python_ast(),
-            Self::Db(system) => system.python_ast(),
-            Self::Domain(domain) => domain.python_ast(),
-            Self::AiComponent(component) => component.python_ast(),
+            Self::Spec(spec) => spec.kernel_ast_v1(),
+            Self::Refinement(refinement) => refinement.kernel_ast_v1(),
+            Self::Business(business) => business.kernel_ast_v1(),
+            Self::Governance(governance) => governance.kernel_ast_v1(),
+            Self::Requirements(requirements) => requirements.kernel_ast_v1(),
+            Self::Compose(compose) => compose.kernel_ast_v1(),
+            Self::Db(system) => system.kernel_ast_v1(),
+            Self::Domain(domain) => domain.kernel_ast_v1(),
+            Self::AiComponent(component) => component.kernel_ast_v1(),
             Self::Agent(agent) => json!({
                 "$type": "Agent", "name": agent.name, "loc": agent.span.python_loc(),
             }),
@@ -1861,15 +1894,15 @@ impl SurfaceDocument {
 }
 
 fn statements_ast(statements: &[Statement]) -> Vec<Value> {
-    statements.iter().map(Statement::python_ast).collect()
+    statements.iter().map(Statement::kernel_ast_v1).collect()
 }
 
 fn property_ast(kind: &str, name: &str, expr: &Expr, span: Span, meta: Option<&MetaTag>) -> Value {
     json!([
         kind,
         name,
-        expr.python_ast(),
+        expr.kernel_ast_v1(),
         span.python_loc(),
-        meta.map(MetaTag::python_ast)
+        meta.map(MetaTag::kernel_ast_v1)
     ])
 }

--- a/rust/fsl-syntax/tests/dialect_declaration_annotations.rs
+++ b/rust/fsl-syntax/tests/dialect_declaration_annotations.rs
@@ -89,7 +89,7 @@ fn stray_annotation_before_closing_brace_in_aggregate_is_a_target_error() {
 }
 
 #[test]
-fn ai_authority_rules_accept_annotations_and_expose_plain_name_python_ast() {
+fn ai_authority_rules_accept_annotations_and_expose_plain_name_kernel_ast_v1() {
     let component = parse_ai_component(
         r#"
 ai_component Assistant {
@@ -114,7 +114,7 @@ ai_component Assistant {
         1
     );
     assert_eq!(component.authority.may_execute[0].name, "Execute");
-    let ast = component.python_ast();
+    let ast = component.kernel_ast_v1();
     assert_eq!(
         ast["authority"]["may_suggest"],
         serde_json::json!(["Search"])
@@ -240,7 +240,7 @@ ai_component Assistant {
             .source_order()
             .is_empty()
     );
-    let ast = component.python_ast();
+    let ast = component.kernel_ast_v1();
     assert_eq!(
         ast["check"]["rules"],
         serde_json::json!(["tool_authority", "tool_schema_declared"])

--- a/rust/fsl-tools/src/analysis.rs
+++ b/rust/fsl-tools/src/analysis.rs
@@ -1006,7 +1006,7 @@ impl<'a> Builder<'a> {
                     "label".to_owned(),
                     json!(format!("{} requires {index}", display(name))),
                 );
-                value.insert("expr".to_owned(), requirement.python_ast());
+                value.insert("expr".to_owned(), requirement.kernel_ast_v1());
                 value.insert("action".to_owned(), json!(action_id));
                 self.add_node(value, false);
                 self.add_edge(edge(&action_id, "has_guard", &id));
@@ -1029,7 +1029,7 @@ impl<'a> Builder<'a> {
                     "label".to_owned(),
                     json!(format!("{} effect {index}", display(name))),
                 );
-                value.insert("expr".to_owned(), expr.python_ast());
+                value.insert("expr".to_owned(), expr.kernel_ast_v1());
                 value.insert("action".to_owned(), json!(action_id));
                 value.insert("target".to_owned(), json!(root));
                 self.add_node(value, false);
@@ -1051,7 +1051,7 @@ impl<'a> Builder<'a> {
                     "label".to_owned(),
                     json!(format!("{} ensures {index}", display(name))),
                 );
-                value.insert("expr".to_owned(), ensures.python_ast());
+                value.insert("expr".to_owned(), ensures.kernel_ast_v1());
                 value.insert("action".to_owned(), json!(action_id));
                 self.add_node(value, false);
                 self.add_edge(edge(&action_id, "has_ensures", &id));
@@ -1074,7 +1074,7 @@ impl<'a> Builder<'a> {
                     Some(property.name.clone()),
                     Some(property.span.python_loc()),
                 );
-                value.insert("expr".to_owned(), property.expr.python_ast());
+                value.insert("expr".to_owned(), property.expr.kernel_ast_v1());
                 add_requirement_metadata(&mut value, &property.annotations, property.meta.as_ref());
                 self.add_node(value, true);
                 let reads = expr_reads(&property.expr, &self.state);
@@ -1090,14 +1090,14 @@ impl<'a> Builder<'a> {
                 Some(property.name.clone()),
                 Some(property.span.python_loc()),
             );
-            value.insert("P".to_owned(), property.before.python_ast());
-            value.insert("Q".to_owned(), property.after.python_ast());
+            value.insert("P".to_owned(), property.before.kernel_ast_v1());
+            value.insert("Q".to_owned(), property.after.kernel_ast_v1());
             add_requirement_metadata(&mut value, &property.annotations, property.meta.as_ref());
             if let Some(within) = property.within {
                 value.insert("within".to_owned(), json!(within));
             }
             if let Some(decreases) = &property.decreases {
-                value.insert("decreases".to_owned(), decreases.python_ast());
+                value.insert("decreases".to_owned(), decreases.kernel_ast_v1());
             }
             self.add_node(value, true);
             let mut reads = expr_reads(&property.before, &self.state);

--- a/rust/fsl-tools/src/document_digest.rs
+++ b/rust/fsl-tools/src/document_digest.rs
@@ -114,7 +114,7 @@ pub fn framed_text_digest(algorithm: &str, text: &str) -> String {
 ///
 /// Returns an error string when the normalized kernel AST is empty.
 pub fn spec_digest_from_kernel(kernel: &KernelSpec) -> Result<String, String> {
-    let ast = normalized_kernel_ast(&kernel.python_ast())
+    let ast = normalized_kernel_ast(&kernel.kernel_ast_v1())
         .ok_or_else(|| "normalized kernel AST is empty".to_owned())?;
     Ok(framed_digest(SPEC_DIGEST_ALGORITHM, &ast))
 }

--- a/rust/fsl-tools/src/document_project.rs
+++ b/rust/fsl-tools/src/document_project.rs
@@ -415,22 +415,22 @@ fn push_action_claim(
         .iter()
         .map(|guard| match guard {
             ActionGuard::Requires(expr) => {
-                json!({"role": "requires", "name": null, "ast": normalize(expr.python_ast())})
+                json!({"role": "requires", "name": null, "ast": normalize(expr.kernel_ast_v1())})
             }
             ActionGuard::Let(name, expr) => {
-                json!({"role": "let", "name": name, "ast": normalize(expr.python_ast())})
+                json!({"role": "let", "name": name, "ast": normalize(expr.kernel_ast_v1())})
             }
         })
         .collect();
     let statements: Vec<Value> = action
         .statements
         .iter()
-        .map(|statement| normalize(statement.python_ast()))
+        .map(|statement| normalize(statement.kernel_ast_v1()))
         .collect();
     let postconditions: Vec<Value> = action
         .ensures
         .iter()
-        .map(|expr| normalize(expr.python_ast()))
+        .map(|expr| normalize(expr.kernel_ast_v1()))
         .collect();
     let fairness = if action.fair { "weak" } else { "none" };
 
@@ -555,7 +555,7 @@ fn push_terminal_claim(
     let links = model.requirements_for(&target);
     let kind_ids = kind_ids_from(model.annotations_for(&target));
     let requirement_ids = record_links(&links, &kind_ids, &claim_id, source_path, agg);
-    let condition = normalize(expr.python_ast());
+    let condition = normalize(expr.kernel_ast_v1());
 
     let core = json!({
         "id": claim_id,
@@ -628,7 +628,7 @@ fn push_trace_claims(
             .map(|step| {
                 json!({
                     "action": step.name,
-                    "args": step.args.iter().map(|arg| normalize(arg.python_ast())).collect::<Vec<_>>(),
+                    "args": step.args.iter().map(|arg| normalize(arg.kernel_ast_v1())).collect::<Vec<_>>(),
                 })
             })
             .collect();
@@ -637,7 +637,7 @@ fn push_trace_claims(
             .as_ref()
             .map(|expectation| match expectation {
                 RequirementsTraceExpectation::Expr(expr) => {
-                    json!({"kind": "expr", "ast": normalize(expr.python_ast())})
+                    json!({"kind": "expr", "ast": normalize(expr.kernel_ast_v1())})
                 }
                 RequirementsTraceExpectation::Stage {
                     entity,
@@ -856,7 +856,7 @@ fn project_requirement_claims_with_trace(
             "invariant",
             &property.name,
             property.span,
-            property.expr.python_ast(),
+            property.expr.kernel_ast_v1(),
             claim_kind,
             model,
             source_path,
@@ -870,7 +870,7 @@ fn project_requirement_claims_with_trace(
             "trans",
             &property.name,
             property.span,
-            property.expr.python_ast(),
+            property.expr.kernel_ast_v1(),
             ClaimKind::TransitionRule,
             model,
             source_path,
@@ -884,7 +884,7 @@ fn project_requirement_claims_with_trace(
             "reachable",
             &property.name,
             property.span,
-            property.expr.python_ast(),
+            property.expr.kernel_ast_v1(),
             ClaimKind::ReachabilityGoal,
             model,
             source_path,
@@ -904,14 +904,14 @@ fn project_requirement_claims_with_trace(
         let binders: Vec<Value> = property
             .binders
             .iter()
-            .map(|binder| normalize(binder.python_ast()))
+            .map(|binder| normalize(binder.kernel_ast_v1()))
             .collect();
-        let before = normalize(property.before.python_ast());
-        let after = normalize(property.after.python_ast());
+        let before = normalize(property.before.kernel_ast_v1());
+        let after = normalize(property.after.kernel_ast_v1());
         let decreases = property
             .decreases
             .as_ref()
-            .map(|expr| normalize(expr.python_ast()));
+            .map(|expr| normalize(expr.kernel_ast_v1()));
         let progress = json!({
             "binders": binders,
             "before": &before,

--- a/rust/fsl-tools/src/refinement_analysis.rs
+++ b/rust/fsl-tools/src/refinement_analysis.rs
@@ -54,7 +54,7 @@ fn expression_vars(expr: &Expr) -> BTreeSet<String> {
         }
     }
     let mut names = BTreeSet::new();
-    visit(&expr.python_ast(), &mut names);
+    visit(&expr.kernel_ast_v1(), &mut names);
     names
 }
 
@@ -164,7 +164,7 @@ pub fn analyze_refinement(refinement: &SurfaceRefinement) -> Value {
                     if let Some(binder) = binder {
                         object.insert("binder".to_owned(), json!(binder));
                     }
-                    object.insert("expr".to_owned(), expr.python_ast());
+                    object.insert("expr".to_owned(), expr.kernel_ast_v1());
                 }
                 insert_node(&mut nodes, value);
                 insert_edge(&mut edges, edge(&ref_id, "declares", &id));

--- a/rust/fslc/src/approval.rs
+++ b/rust/fslc/src/approval.rs
@@ -463,13 +463,13 @@ fn normalize_number_key(source: &str, quote: &str, key: &str, replacement: &str)
 ///
 /// Comments, whitespace, source paths, and line movement do not invalidate an
 /// approval. Imported/composed specifications are covered because the resolver
-/// expands them before `python_ast` is projected.
+/// expands them before `kernel_ast_v1` is projected.
 pub fn spec_digest(path: &Path) -> Result<String, String> {
     let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
     let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
     let kernel =
         fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| error.to_string())?;
-    let ast = normalized_ast(&kernel.python_ast())
+    let ast = normalized_ast(&kernel.kernel_ast_v1())
         .ok_or_else(|| "normalized kernel AST is empty".to_owned())?;
     let encoded = serde_json::to_vec(&ast).map_err(|error| error.to_string())?;
     let mut framed = SPEC_DIGEST_ALGORITHM.as_bytes().to_vec();

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -11490,7 +11490,7 @@ fn tagged_property(kind: &str, property: &fsl_core::PropertyDef) -> Option<Value
         "tags":tags,
         "loc":property.span.python_loc(),
         "formal_definition":{"expression":fslc_rust::expr_text(&property.expr)},
-        "formal_identifiers":expression_identifiers(&property.expr.python_ast()),
+        "formal_identifiers":expression_identifiers(&property.expr.kernel_ast_v1()),
     }))
 }
 
@@ -11504,10 +11504,10 @@ fn tag_review_output(model: &KernelModel) -> Value {
         };
         let mut identifiers = std::collections::BTreeSet::new();
         for expr in action.requires.iter().chain(&action.ensures) {
-            identifiers.extend(expression_identifiers(&expr.python_ast()));
+            identifiers.extend(expression_identifiers(&expr.kernel_ast_v1()));
         }
         for statement in &action.statements {
-            identifiers.extend(expression_identifiers(&statement.python_ast()));
+            identifiers.extend(expression_identifiers(&statement.kernel_ast_v1()));
         }
         identifiers.extend(action.params.iter().map(|param| param.name().to_owned()));
         let mut effects = Vec::new();
@@ -11551,10 +11551,10 @@ fn tag_review_output(model: &KernelModel) -> Value {
         let Some(tag) = tags.first().cloned() else {
             continue;
         };
-        let mut identifiers = expression_identifiers(&property.before.python_ast());
-        identifiers.extend(expression_identifiers(&property.after.python_ast()));
+        let mut identifiers = expression_identifiers(&property.before.kernel_ast_v1());
+        identifiers.extend(expression_identifiers(&property.after.kernel_ast_v1()));
         if let Some(decreases) = &property.decreases {
-            identifiers.extend(expression_identifiers(&decreases.python_ast()));
+            identifiers.extend(expression_identifiers(&decreases.kernel_ast_v1()));
         }
         let mut formal = Map::new();
         formal.insert(
@@ -11843,15 +11843,15 @@ fn ai_progressless_findings(model: &KernelModel, tsg: &Value) -> Vec<Value> {
         });
         if !attached {
             attached = model.leadstos.iter().any(|property| {
-                let mut reads = expression_identifiers(&property.before.python_ast());
-                reads.extend(expression_identifiers(&property.after.python_ast()));
+                let mut reads = expression_identifiers(&property.before.kernel_ast_v1());
+                reads.extend(expression_identifiers(&property.after.kernel_ast_v1()));
                 reads
                     .iter()
                     .any(|state| cycle_states.contains(&format!("state:{state}")))
             });
         }
         if !attached && let Some(terminal) = &model.terminal {
-            attached = expression_identifiers(&terminal.python_ast())
+            attached = expression_identifiers(&terminal.kernel_ast_v1())
                 .iter()
                 .any(|state| cycle_states.contains(&format!("state:{state}")));
         }
@@ -12750,7 +12750,7 @@ fn project_traceability_output(path: &Path) -> Result<Value, SpecLoadError> {
                             &format!("{target}:state:{name}"),
                         ),
                     );
-                    let mut reads = expression_identifiers(&expr.python_ast());
+                    let mut reads = expression_identifiers(&expr.kernel_ast_v1());
                     reads.retain(|read| impl_states.contains(read));
                     if let Some(binder) = binder {
                         let binder = match binder {

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -629,7 +629,7 @@ pub fn validate_requirement_trace_source(
         if value != FslValue::Bool(true) {
             let mut output = requirement_failure_base(envelope, "acceptance", case);
             output.insert("failed_step".to_owned(), json!(case.steps.len()));
-            output.insert("expect".to_owned(), expression.python_ast());
+            output.insert("expect".to_owned(), expression.kernel_ast_v1());
             output.insert("state".to_owned(), state_json(&monitor.state));
             output.insert(
                 "loc".to_owned(),

--- a/rust/fslc/tests/deep_nesting.rs
+++ b/rust/fslc/tests/deep_nesting.rs
@@ -268,6 +268,97 @@ fn fmt_formats_a_deeply_nested_mapping_instead_of_overflowing_the_stack() {
     );
 }
 
+/// `analyze` reaches `Expr::kernel_ast_v1`, which is where #622 lived: the
+/// projection built each node with `json!`, and `json!` re-serialized every
+/// already-built child subtree, spending O(depth) stack *inside*
+/// `recursion::guard` rather than around it. This aborted (exit 138) until the
+/// projection switched to `Value::Array`.
+#[test]
+fn analyze_projects_a_deeply_nested_mapping_instead_of_overflowing_the_stack() {
+    let directory = scratch_dir("analyze");
+    let trio = refinement_trio(&directory, WITNESS_STAGES);
+
+    let output = run(&["analyze", trio.mapping.to_str().expect("map path")]);
+    let status = exit_code("analyze", &output);
+
+    assert_eq!(
+        status,
+        0,
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Deliberately not parsed. `serde_json`'s *deserializer* has its own
+    // 128-deep nesting limit, so `from_slice` on a 200-deep tagged array fails
+    // with "recursion limit exceeded" even though `fslc` produced the envelope
+    // correctly. That is a property of this test's reader, not of the output,
+    // and asserting on the exit code plus non-empty stdout tests what this file
+    // is about -- that the process finished at all.
+    assert!(
+        output.stdout.starts_with(b"{"),
+        "`analyze` produced no JSON envelope for a {WITNESS_STAGES}-stage witness"
+    );
+}
+
+/// The same projection, reached the way the *digests* reach it.
+///
+/// This is the lane the #620 witness could not open. Its depth lives in a
+/// refinement mapping, so it reached the projection only through `analyze` --
+/// a property of the witness, not of the defect. Both spec digests
+/// (`fslc::approval::spec_digest`,
+/// `fsl_tools::document_digest::spec_digest_from_kernel`) project a *spec*, so
+/// proving anything about them needs the depth inside one. Written as a
+/// separate generator rather than by deepening the trio, because the two
+/// shapes reach different cycles: this one found
+/// `PredicateExpander::expand_expr` and `public_kernel::expr_json` still
+/// unguarded after #620 shipped.
+#[test]
+fn a_deeply_nested_invariant_reaches_the_digest_projection_without_aborting() {
+    let directory = scratch_dir("invariant");
+    let spec = deep_invariant_spec(&directory, WITNESS_STAGES);
+    // Repository-relative on purpose: Public Kernel v2 refuses an absolute
+    // `spec.source.file` ("must be repository-relative or a portable URI"), and
+    // `document claims` carries that identity. The scratch directory lives
+    // under `rust/target/`, so a relative path always exists.
+    let relative = spec
+        .strip_prefix(root())
+        .expect("scratch path is inside the repository");
+    let path = relative.to_str().expect("spec path");
+
+    for command in [
+        vec!["check", path],
+        vec!["document", "claims", path],
+        vec!["kernel", path],
+    ] {
+        let label = command.join(" ");
+        let output = run(&command);
+        let status = exit_code(&label, &output);
+        assert_eq!(
+            status,
+            0,
+            "`fslc {label}` on a {WITNESS_STAGES}-deep invariant; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+/// Writes a spec whose *invariant* carries a right-nested `if` chain of length
+/// `n`, so the depth is inside the spec rather than in a mapping.
+fn deep_invariant_spec(directory: &Path, n: usize) -> PathBuf {
+    assert!(n >= 2, "a chain needs at least two arms");
+    let mut chain = String::from("0");
+    for k in (0..n).rev() {
+        chain = format!("if x == {k} then {k}\n      else {chain}");
+    }
+    let spec = format!(
+        "spec DeepInvariant{n} {{\n  state {{ x: Int, seen: Int }}\n  init {{ x = 0  seen = 0 }}\n  \
+         action bump() {{\n    requires x < {n}\n    x = x + 1\n    seen = seen + 1\n  }}\n  \
+         invariant DeepChain {{\n    ({chain}) >= 0\n  }}\n}}\n"
+    );
+    let path = directory.join(format!("deep_invariant_{n}.fsl"));
+    std::fs::write(&path, spec).expect("write deep invariant spec");
+    path
+}
+
 /// The generator has to keep producing a *deep* file for any of the above to
 /// mean anything.
 ///
@@ -285,5 +376,13 @@ fn the_generated_witness_is_still_deeper_than_the_unguarded_crash_threshold() {
         nesting,
         2 * WITNESS_STAGES - 1,
         "the mapping's if-chain is the deep structure under test"
+    );
+
+    let spec = std::fs::read_to_string(deep_invariant_spec(&directory, WITNESS_STAGES))
+        .expect("read deep invariant spec");
+    assert_eq!(
+        spec.matches("if x ==").count(),
+        WITNESS_STAGES,
+        "the invariant's if-chain is the deep structure under test"
     );
 }

--- a/rust/fslc/tests/domain_expression_characterization.rs
+++ b/rust/fslc/tests/domain_expression_characterization.rs
@@ -214,10 +214,10 @@ fn semantic_model(model: &KernelModel) -> Value {
             json!({
                 "name":action.name,
                 "parameters":action.params.iter().map(param_json).collect::<Vec<_>>(),
-                "requires":action.requires.iter().map(|expr|erase_locations(expr.python_ast())).collect::<Vec<_>>(),
-                "lets":action.lets.iter().map(|(name,expr)|json!([name,erase_locations(expr.python_ast())])).collect::<Vec<_>>(),
-                "updates":action.statements.iter().map(|statement|erase_locations(statement.python_ast())).collect::<Vec<_>>(),
-                "ensures":action.ensures.iter().map(|expr|erase_locations(expr.python_ast())).collect::<Vec<_>>(),
+                "requires":action.requires.iter().map(|expr|erase_locations(expr.kernel_ast_v1())).collect::<Vec<_>>(),
+                "lets":action.lets.iter().map(|(name,expr)|json!([name,erase_locations(expr.kernel_ast_v1())])).collect::<Vec<_>>(),
+                "updates":action.statements.iter().map(|statement|erase_locations(statement.kernel_ast_v1())).collect::<Vec<_>>(),
+                "ensures":action.ensures.iter().map(|expr|erase_locations(expr.kernel_ast_v1())).collect::<Vec<_>>(),
                 "fair":action.fair
             })
         })
@@ -227,7 +227,7 @@ fn semantic_model(model: &KernelModel) -> Value {
         .invariants
         .iter()
         .map(|property| {
-            json!({"name":property.name,"expression":erase_locations(property.expr.python_ast())})
+            json!({"name":property.name,"expression":erase_locations(property.expr.kernel_ast_v1())})
         })
         .collect::<Vec<_>>();
     invariants.sort_by(|left, right| left["name"].as_str().cmp(&right["name"].as_str()));
@@ -238,7 +238,7 @@ fn semantic_model(model: &KernelModel) -> Value {
         "initial_state":value_map(&initial.state),
         "actions":actions,
         "invariants":invariants,
-        "terminal":model.terminal.as_ref().map(|expr|erase_locations(expr.python_ast()))
+        "terminal":model.terminal.as_ref().map(|expr|erase_locations(expr.kernel_ast_v1()))
     })
 }
 


### PR DESCRIPTION
## Problem

`Expr::python_ast` assembled its projection with `json!` interpolation, and
`json!` re-serializes each completed subtree via `serde_json::to_value` — so one
guarded call consumed O(depth) stack *inside* the #620 red zone, which no zone
size covers, plus O(n²) time. `fslc analyze` aborted at N=400 on the #620
witness after every other command had been fixed.

The projection cannot be deleted and its bytes cannot move: it is the input to
**`fsl-kernel-ast-v1+sha256`**, the digest algorithm behind both `fslc approval`
records and document digests. Every existing approval record in every user
repository hashes exactly these bytes (measured and recorded on #622, with the
delete option considered and rejected there).

## Changes

1. **`json!` interpolation → direct `Value::Array` construction** — same value
   tree, children moved instead of re-serialized. Removes the O(depth)-per-level
   stack and the O(n²) time at once.
2. **Rename `python_ast` → `kernel_ast_v1`** — the name said "Python support";
   the function is the native digest contract's serialization, version-named to
   match the algorithm it feeds. `git grep python_ast` is zero outside released
   changelog history. Function names are not the contract; the bytes are, and
   the sweep below is the proof they did not move.
3. **Two more recursion guards (8 → 10)** — acceptance required sweeping *every*
   command with a new witness shape (depth in an invariant, not a mapping)
   before declaring the §4.4 invariant met. That sweep aborted `check` in
   `PredicateExpander::expand_expr` and `document claims` in
   `public_kernel::expr_json` at N=400 — sites the #620 witness could never
   reach. The second carries a lesson now recorded in §4.4: **a guarded callee
   does not protect its caller's cycle.** `expr_json` called the guarded
   `infer_type` every level and still died — in `stacker::_grow` itself, because
   the caller's frames drained the zone between the callee's checks.
4. **Site regeneration, split out** (`8cdf256`): renaming reached
   `docs/LANGUAGE.md` prose, so `docs/intro/*.html` had to be regenerated — and
   regenerating from *unchanged* HEAD sources already produced a 327-line diff.
   The committed site has been stale since at least #570/#605 and nothing checks
   it (#630). The drift lands in its own commit so this PR's contract-stability
   diff stays legible.

## Proof the contract did not move

A differential sweep: the pre-change binary (`01a21a8`, today's main) and the
post-change binary run `document claims`, `analyze`, and `testgen` over all
**211** corpus files; stdout compared byte-for-byte. **633 comparisons, zero
mismatches, zero timeouts** — run twice independently (implementer, then
reviewer with separately built and symbol-checked binaries).

**The determinism control is what makes that green mean something.** Run first
as before-vs-*before*, the sweep found **14 files unequal to themselves**:
`testgen` stamps `elapsed_s`/`check_elapsed_s` wall-clock times. Those two keys
alone are normalized — nothing else — and the control was re-run to zero before
the real comparison. Without it, 633 green comparisons would have been
measuring the clock.

Existing digest tests and the corpus snapshot pass without regeneration.

## Witness results

| | before | after |
|---|---|---|
| `analyze`, N=400 | abort (exit 138) | exit 0 |
| `analyze`, N=1000 | abort | exit 0, 1.43s |
| `analyze`, N=200 | 0.33s | 0.16s |
| `check` / `document claims` / `kernel`, N=2000 (new witness shape) | `check`/`claims` abort | complete |

`deep_nesting.rs` gains the `analyze` row and a digest-path negative control
(deep invariant); all assertions still require `status.code()` to be `Some`.

One recorded limitation (§4.4): `serde_json`'s *deserializer* refuses >128
nesting levels, so a downstream consumer parsing `fslc`'s (correct) output of a
very deep spec needs its own recursion config. `explain`/`html`/`testgen`/
`scenarios` time out on the witness for BMC cost, before and after alike, and
are explicitly excluded from the no-abort claim — a timeout is evidence of
neither.

## Gates (reviewer-run, independent of the implementer's)

| check | exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `./tools/check-native-integration.sh rust` | 0 |
| `./tools/check-native-integration.sh fault-operators` | 0 — 4 operators calibrated |
| `./tools/check-native-integration.sh wasm` | 0 — `nativeParity: true` |
| digest sweep, control then real | 0 — 633+633 comparisons, 0 mismatches |

Split verified by tree hash: the three-commit history and the original
single-pass history resolve to the identical tree (`526d257`). Exit codes
captured without a pipe.

Closes #622.