### PR TITLE
test(fslc,verifier): federate the C3 Semantic Assurance Matrix skeleton (#537, #646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `rust/fslc/tests/assurance_matrix.rs` introduces the federated Semantic
+  Assurance Matrix skeleton (issue #537 C3 slice 1,
+  `docs/DESIGN-assurance-matrix.md`): axis modules under `tests/assurance/`
+  own their rows (read from existing single-owner registries, never copied)
+  and declared columns; every `(row, column)` cell carries a
+  machine-rechecked citation (path + anchor, re-read from the working tree
+  each run); blank required cells and stale/fabricated citations fail CI;
+  negative controls prove both checks can actually fail. Slice 1 axes:
+  `outcome_kind` (7 Monitor kinds × Monitor/CLI), `violation_kind` (12
+  engine kinds × BMC/induction, #646), and `properties` (5 KernelModel
+  property kinds × BMC/explicit/induction/replay).
 - `fsl-verifier`'s free-form `Violation.kind` strings (`BmcViolation`/
   `InductionCti`/`RankFailure`) are now single-owned in
   `rust/fsl-verifier/src/violation_kind.rs` instead of scattered string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `fsl-verifier`'s free-form `Violation.kind` strings (`BmcViolation`/
+  `InductionCti`/`RankFailure`) are now single-owned in
+  `rust/fsl-verifier/src/violation_kind.rs` instead of scattered string
+  literals (#646). Reading the emission sites directly (not transcribing
+  issue #646's own citation list) found 12 live values, not the 9 the issue
+  named — `pending_not_preserved`, `non_decreasing_helpful_action`, and
+  `non_helpful_action_increases_measure` had no exercising fixture anywhere
+  in the corpus before this change. No emitted JSON `violation_kind` value
+  changes by a single byte. Part of #537 C3 slice 1
+  (`docs/DESIGN-assurance-matrix.md`).
 - The kernel AST projection no longer re-serializes every subtree, and is named
   for what it is: `python_ast` is now `kernel_ast_v1` (#622). `json!` calls
   `serde_json::to_value` on each interpolated operand, and the operands were

--- a/docs/DESIGN-assurance-matrix.md
+++ b/docs/DESIGN-assurance-matrix.md
@@ -1,0 +1,314 @@
+# FSL — C3 Semantic Assurance Matrix (issue #537 C3, issue #646)
+
+## Goal
+
+`fslc` has two existing, narrow feature-coverage registries: the Public Kernel
+`coverage.rs` matrix (`OUTCOME_FEATURE_KEYS` and friends, issue #223) and the
+RCIR no-silent-omission registry. Issue #537's C3 asks for the same discipline
+generalized across every semantic/product surface: rows are semantic
+features, columns are verification/rendering surfaces, and every cell is one
+of `exercised` / `rejecting-control` / `unsupported-fail-closed` /
+`not-applicable` (with a reason), never blank. This document is the accepted
+design for slice 1: the mechanism (`Claim`/`Citation`/aggregator/negative
+controls) plus two fully-registered axes (`outcome_kind`, `violation_kind`)
+and one axis pending citation completion (`properties`).
+
+This is not the assurance-*class* vocabulary in
+[`DESIGN-assurance-classes.md`](DESIGN-assurance-classes.md) (`proved` /
+`bounded` / `replay-observed` / `statistical` / `not_run`, a per-requirement
+strength label rendered to end users in `fslc ledger`/`fslc html`). This
+document's `Claim` vocabulary answers a different, CI-internal question: does
+a real, currently-passing test in this repository actually demonstrate that
+semantic feature X is exercised (or correctly rejected, or fail-closed
+unsupported, or structurally inapplicable) on surface Y? It never appears in
+product output.
+
+## Relationship to #479 and #537's other contracts
+
+#537 is the umbrella issue; C3 is one of its seven contracts (C1 false-green,
+C2 verdict conservation, C3 this matrix, C4 corpus ownership, C5 fault
+calibration, C6 typed generative agreement, C7 native self-conformance). C4
+(corpus/refinement-mapping ownership, `tests/refine_corpus_parity.rs`) is
+this design's direct precedent for the citation-anchor discipline: a
+`Citation` here is structurally the same idea as C4's `Declaration` —
+`path` + `anchor` text, re-verified against the working tree on every run,
+never a cached table.
+
+## Physical form
+
+No new crate, no central hand-written table.
+
+- `rust/fslc/tests/assurance_matrix.rs` — the aggregator. Declares every axis
+  module via `#[path = "assurance/<name>.rs"]`, collects each axis's `Axis`
+  value, and enforces two properties across all of them: every declared
+  `(row, column)` cell has a `Claim`
+  (`every_declared_cell_across_every_axis_has_a_claim`), and every claimed
+  cell's citation rechecks against the current working tree
+  (`every_claim_citation_rechecks_against_the_working_tree`). A
+  `negative_controls` module demonstrates both checks actually fail: a
+  fabricated/missing-file citation fails `Citation::recheck`, and an
+  unclaimed required cell fails `Axis::check_complete` — proving the checkers
+  are not vacuously `Ok`, with a matching positive control proving they are
+  not vacuously `Err` either.
+- `rust/fslc/tests/assurance/claim.rs` — the shared `Citation`/`Claim`/`Axis`
+  types and their `recheck`/`check_complete`/`check_citations` methods.
+- `rust/fslc/tests/assurance/outcome_kind.rs`,
+  `rust/fslc/tests/assurance/violation_kind.rs`,
+  `rust/fslc/tests/assurance/properties.rs` — one module per semantic-surface
+  axis. Each module owns its own `axis()` constructor and any small targeted
+  test it needed to write because no existing test cleanly covered a cell.
+
+## Cell vocabulary
+
+```rust
+pub enum Claim {
+    Exercised { by: Citation },
+    RejectingControl { by: Citation },
+    UnsupportedFailClosed { by: Citation },
+    NotApplicable { reason: &'static str, basis: Citation },
+}
+```
+
+Every variant carries exactly one `Citation { path, anchor }`. `recheck()`
+re-reads `path` from the working tree and asserts some line contains
+`anchor` — never a line number (an unrelated edit above the citation must
+not fail it, but deleting or renaming the anchored declaration must). This
+mirrors `refine_corpus_parity.rs`'s `Declaration`/`declared_by` discipline
+exactly, including its residual trust boundary: the citation proves the
+*existence* of a real test at that anchor, not that the test's assertions
+are correct — assertion correctness is `cargo test`'s job, run as one of
+this feature's required gates, not the aggregator's.
+
+"Required" is scoped per axis: each axis module declares its own `rows` and
+`columns`; the aggregator only requires a `Claim` for `(row, column)` pairs
+within that axis's own declared scope. A cell outside an axis's declared
+columns is not part of that axis's matrix at all — it is not silently
+skipped, it was never declared required. Narrowing an axis's declared
+columns after this document is accepted needs a reason recorded here (see
+"Slice 1 boundary" below for the two boundaries this slice already made).
+
+## Axis: `outcome_kind`
+
+7 rows, referenced directly from
+`rust/fslc/src/coverage.rs::OUTCOME_FEATURE_KEYS` (never copied — the axis
+module reads the constant, so the two can never drift). Declared columns:
+`Monitor`, `CLI`.
+
+| Kind | Monitor | CLI |
+|---|---|---|
+| `ok`, `requires_failed`, `partial_op`, `type_bound`, `invariant`, `trans`, `ensures` | `Exercised` — `conformance_coverage.rs::every_outcome_kind_the_corpus_emits_is_registered_and_exercised` | `Exercised` — `assurance/outcome_kind.rs::cli_conformance_command_emits_every_registered_outcome_kind` |
+
+The `Monitor` column cites the existing bidirectional coverage test
+verbatim: it already regenerates conformance vectors from the fixed fixture
+manifest and asserts every registered kind is both emitted and present at
+`level: "exercised"` in the coverage matrix — read in full before citing,
+confirmed to do exactly this (not merely mention the word "outcome").
+
+The `CLI` column has no existing test that decomposes by kind (the closest,
+`kernel_contract.rs`'s golden-diff test for `fslc conformance`, asserts
+whole-JSON equality, not a per-kind breakdown), so this axis owns one small
+targeted test, `cli_conformance_command_emits_every_registered_outcome_kind`:
+it runs the real `fslc conformance` subcommand as a subprocess against the
+same fixture manifest `coverage.rs` scans and asserts every registered kind
+appears in the CLI's own stdout JSON.
+
+## Axis: `violation_kind` (issue #646)
+
+### The vocabulary issue #646 under-reported
+
+Issue #646 cites 9 `Violation.kind` values across 4 emission-site groups.
+Reading `rust/fsl-verifier/src/induction.rs::prove_ranked_leadstos` in full
+(not transcribing the issue text) found **12** live values, not 9: the
+`RankFailure.kind` selection at what is now `induction.rs`'s dynamic
+`let kind = if ... else { ... }` chain (reached only when a `helpful` clause
+is declared) produces three values the issue's citation list omits entirely
+— `pending_not_preserved`, `non_decreasing_helpful_action`, and
+`non_helpful_action_increases_measure` — none of which had any exercising
+fixture anywhere in the corpus before this slice. This is exactly the defect
+class #537 C3 exists to make structurally impossible to miss again: the
+registry below is the full, source-verified 12-value set, not the issue's
+transcription of it.
+
+### Registry
+
+Single-owner constants in `rust/fsl-verifier/src/violation_kind.rs`
+(`pub const ALL: &[&str]`), referenced (not copied) by the axis module.
+Every one of the following emission sites now references a constant instead
+of a bare string literal, with **zero byte-level change to any emitted JSON
+`violation_kind` value** (proven by running the full existing `fsl-verifier`
+and `fslc` verification test suites, including every golden-JSON-diff test,
+unchanged before/after):
+
+| Constant | Value | Emission site(s) |
+|---|---|---|
+| `LEADS_TO` | `leadsTo` | `bmc.rs::leadsto_violation`; `fslc`'s `verification_output.rs::render_leadsto_failure` (duplicate literal, now routed through the same constant) |
+| `INVARIANT` | `invariant` | `induction.rs`'s `InductionCti` construction in the k-induction base/step loop |
+| `TRANS` | `trans` | `induction.rs`'s `InductionCti` construction in the `k == 1` transition-property special case |
+| `UNBOUNDED_BELOW` | `unbounded_below` | `induction.rs::prove_ranked_leadstos`, the unconditional pre-check |
+| `PROGRESS_ACTION_NOT_FAIR` | `progress_action_not_fair` | `induction.rs::prove_ranked_leadstos`, the `helpful_fairness` check |
+| `HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY` | `helpful_action_enabledness_not_sticky` | `induction.rs::prove_ranked_leadstos`, the `helpful_sticky` check |
+| `HELPFUL_ACTION_NOT_ENABLED` | `helpful_action_not_enabled` | `induction.rs::prove_ranked_leadstos`, the `no_deadlock` (helpful variant) check |
+| `NON_DECREASING_ACTION` | `non_decreasing_action` | `induction.rs::prove_ranked_leadstos`, the no-`helpful`-declared branch, and the dynamic `kind` chain's `else` fallback |
+| `PENDING_NOT_PRESERVED` | `pending_not_preserved` | `induction.rs::prove_ranked_leadstos`, the dynamic `kind` chain (`helpful`-declared branch) |
+| `NON_DECREASING_HELPFUL_ACTION` | `non_decreasing_helpful_action` | same dynamic `kind` chain |
+| `NON_HELPFUL_ACTION_INCREASES_MEASURE` | `non_helpful_action_increases_measure` | same dynamic `kind` chain |
+| `DEADLOCK` | `deadlock` | not a `Violation`-shaped struct field — `fslc`'s `verification_output.rs::render_deadlock_failure` renders it directly from `BmcResult::deadlock_trace`; the CLI's duplicate literal in `render_leadsto_failure`'s sibling path was also routed through the constant |
+
+Declared columns: `BMC`, `induction` — the two fsl-verifier engines capable
+of populating one of these fields.
+
+| Kind | BMC | induction |
+|---|---|---|
+| `leadsTo` | `Exercised` | `NotApplicable` (Slice 1 boundary) |
+| `invariant` | `NotApplicable` (Slice 1 boundary) | `Exercised` |
+| `trans` | `NotApplicable` (Slice 1 boundary) | `Exercised` |
+| `unbounded_below` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `progress_action_not_fair` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `helpful_action_enabledness_not_sticky` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `helpful_action_not_enabled` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `non_decreasing_action` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `pending_not_preserved` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `non_decreasing_helpful_action` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `non_helpful_action_increases_measure` | `NotApplicable` (induction-only ranking) | `Exercised` |
+| `deadlock` | `Exercised` | `NotApplicable` (induction never calls the BMC deadlock probe) |
+
+Every `Exercised` cell cites a real, individually-read test:
+`leadsTo`/`deadlock` cite `issue_260_leadsto_stagnation.rs`'s
+`violation_kind`-asserting tests; `invariant`/`trans` cite
+`induction_suggestions.rs`'s tests (confirmed via each test's assertion on
+the `--engine induction`-only fields `suggested_invariants`/`"trans"` that
+`render_induction_cti` only inserts for that exact `cti.kind`, not merely a
+test that happens to run the induction engine); the four ranked-liveness
+kinds already exercised elsewhere cite `leadsto_helpful_ranking.rs`
+(`progress_action_not_fair`, `helpful_action_enabledness_not_sticky`,
+`helpful_action_not_enabled`, `non_helpful_action_increases_measure`); the
+four with no prior fixture cite the new
+`rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs`
+(`unbounded_below`, `non_decreasing_action`, `pending_not_preserved`,
+`non_decreasing_helpful_action`) — each fixture confirmed by running it
+through the real solver and reading the resulting `RankFailure.kind`, not
+derived on paper.
+
+### Independent bidirectional check
+
+`assurance/violation_kind.rs::every_violation_kind_the_probe_corpus_emits_is_exactly_the_registered_set`
+mirrors `conformance_coverage.rs`'s own bidirectional discipline: it runs one
+small, self-contained spec per registered value directly through
+`fsl_verifier`'s public API (its own probe corpus, independent of every
+other test's fixtures) and asserts the observed `kind` set equals
+`violation_kind::ALL` exactly — catching a kind that stops firing (dead
+registry entry) as loudly as a kind that fires but was never registered (the
+#646 defect class this whole axis exists to close).
+
+### Slice 1 boundary
+
+Two file-scope decisions bound this slice, both cited by axis `NotApplicable`
+cells via this section (`### Slice 1 boundary`, cited by anchor text) rather
+than a source-code citation, because they are design decisions, not
+observable source facts:
+
+1. `bmc.rs`'s own `make_violation` call sites for the plain (non-induction)
+   BMC engine's `"invariant"`/`"trans"`/`"ensures"` property violations are
+   **not** routed through `violation_kind`. Issue #646's own citation list
+   never named these sites; they mirror `fsl_runtime::Monitor`'s already-
+   registered `outcome.kind` spelling (`coverage.rs::OUTCOME_FEATURE_KEYS`
+   already has `invariant`/`trans`/`ensures` rows), so unifying them is that
+   registry's concern, not a gap in this one. Revisiting this is in-scope
+   for a future slice if the two registries are ever meant to merge.
+2. `fslc`'s `main.rs:14741` (the `refine` command's progress-check
+   rendering, also a `"leadsTo"` literal reading a `BmcViolation`-shaped
+   value) and `verification.rs:537` (`"leadsTo_rank"`, a fixed envelope-shape
+   tag with no corresponding `RankFailure.kind` value — the granular ranked
+   kind renders separately, in the `rank_failure` JSON field) are outside
+   this slice's file scope (`bmc.rs`/`induction.rs`/`verification_output.rs`
+   only, per the accepted brief). `main.rs:14741` duplicates an
+   already-registered value and is a reasonable target for the same
+   constant in a later slice; `verification.rs:537` is a different
+   vocabulary entirely (JSON envelope shape tags, not `Violation.kind`) and
+   is out of scope for this axis regardless of slice.
+
+## Axis: `properties`
+
+Rows are the kernel schema's `properties.required` list — `invariants`,
+`transitions`, `reachables`, `leads_to`, `terminal`
+(`schemas/fslc/kernel/kernel.v1.schema.json`). A `KernelModel` struct field
+cannot be caught by a compile error here, so the axis uses the same
+schema-anchored sync discipline as `SEMANTICS_FEATURE_KEYS`:
+`kernel_schema_property_groups_match_the_axis_rows` asserts the axis's row
+list equals the schema's `required` set, and a new property group must land
+in that schema to become a public-kernel contract surface at all. Declared
+columns: `BMC`, `explicit`, `induction`, `replay`.
+
+The `replay` column rests on a source-verified structural fact: every
+native verify run replays *every* symbolic witness (violation trace,
+leadsTo violation trace, each reachable witness trace, deadlock trace)
+through the solver-independent Monitor before rendering
+(`verification_output.rs::replay_bmc_witnesses`, exit 3 on failure, called
+on both the BMC seam and the explicit renderer). A cited test asserting
+exit 0/1 on a witnessed/violated verdict is therefore genuine replay
+evidence: a Monitor rejection would have produced exit 3 and failed the
+cited assertion.
+
+| Group | BMC | explicit | induction | replay |
+|---|---|---|---|---|
+| `invariants` | `Exercised` — `expression_agreement.rs::bounded_verification_rejects_initial_violation_without_action_instances` | `Exercised` — `fsl-runtime/tests/explicit_engine.rs::explicit_engine_totalizes_property_context_zero_division` | `Exercised` — `induction_suggestions.rs::suggests_a_scalar_bound_without_changing_the_verdict` | `Exercised` — `explicit_engine.rs::explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec` (replays every violation trace, `replayed > 0` asserted) |
+| `transitions` | `Exercised` — targeted probe (below) | `Exercised` — same probe | `Exercised` — `induction_suggestions.rs::trans_ctis_never_receive_invariant_suggestions` | `Exercised` — same probe (exit 1, not 3) |
+| `reachables` | `Exercised` — `explicit_engine.rs::explicit_reachable_witness_step_matches_bmc` | `Exercised` — same test | `UnsupportedFailClosed` — targeted probe (below) | `Exercised` — same test (witness replay gates the exit) |
+| `leads_to` | `Exercised` — `issue_260_leadsto_stagnation.rs::leadsto_deadlock_stagnation_is_detected_beyond_the_deadlock_step_for_plain_kernel_spec` | `UnsupportedFailClosed` — `explicit_engine.rs::explicit_cli_exit_codes_cover_bounded_proved_violated_budget_and_semantics` (exit 2, "does not support leadsTo") | `Exercised` — `induction_suggestions.rs::ranked_leadsto_failures_never_receive_suggestions` | `Exercised` — `replay_trace_contract.rs::overdue_bounded_response_is_liveness_nonconformance_after_safety` |
+| `terminal` | `Exercised` — targeted probe (below) | `Exercised` — `fsl-runtime/tests/explicit_engine.rs::explicit_bfs_proves_at_state_space_closure` | `NotApplicable` — terminal's only kernel semantic is deadlock-report exclusion and the induction engine has no deadlock probe (basis: `coverage.rs`'s `terminal_deadlock` row description) | `Exercised` — `fsl-runtime/tests/monitor_regression.rs::action_cover_trace_uses_the_enabling_bool_value_and_may_end_at_terminal` |
+
+Three cells had no existing owner anywhere in the corpus and got targeted
+probes in `assurance/properties.rs`, each empirically confirmed against the
+real binary before its expectation was written down:
+
+- `bmc_and_explicit_report_and_replay_a_trans_property_violation` — no
+  pre-existing test asserted an end-to-end verify run reporting
+  `violation_kind: "trans"` on either engine
+  (`fixtures/assurance_trans_violation.fsl`).
+- `induction_rejects_a_reachable_property_fail_closed` — `--engine
+  induction --property <reachable>` must be a usage error naming the
+  reason, not a silent skip or vacuous proof.
+- `terminal_excludes_the_final_state_from_bmc_deadlock_reporting` — with
+  its negative control: the identical machine minus `terminal`
+  (`fixtures/assurance_terminal_once_missing.fsl`) must deadlock under
+  `--deadlock error`, proving the green verdict on the `terminal` fixture
+  is the exclusion at work, not a deadlock probe that never fires.
+
+## Negative controls
+
+`assurance_matrix.rs::negative_controls` demonstrates, without touching any
+real axis:
+
+- `a_citation_with_a_fabricated_anchor_fails_recheck` /
+  `a_citation_to_a_nonexistent_file_fails_recheck` — `Citation::recheck`
+  actually rejects a broken citation.
+- `an_unclaimed_required_cell_fails_the_completeness_check` —
+  `Axis::check_complete` actually rejects a blank required cell.
+- `a_fully_claimed_toy_axis_passes_both_checks` — the positive control:
+  proves the two checks above are not vacuously `Err` either.
+
+## Anti-Goodhart
+
+Per issue #537's own guardrail: cell/row count is not a success metric.
+The two measurements that matter are "required-blank-cell count stays 0"
+(enforced every run by `every_declared_cell_across_every_axis_has_a_claim`)
+and "does adding a new registry entry force a matching axis update" — for
+`outcome_kind`/`violation_kind` this holds because rows are read from the
+single-owner constant, not copied, so a new registered kind with no cell
+fails `check_complete` immediately; for a genuinely new `KernelModel`
+property group, the anchor is the kernel schema's `properties.required`
+list plus `kernel_schema_property_groups_match_the_axis_rows` (see the
+`properties` axis section above).
+
+## Slice 2 / slice 3 plan
+
+- **Slice 2** (`expr` axis): `fsl_syntax::Expr`'s 22 variants +
+  `AggregateKind`'s 4, connecting to C6's typed generative/metamorphic
+  agreement sweep once that lands.
+- **Slice 3**: `types` axis (`TypeRef`'s 9 variants, `TypeDef`'s 3),
+  `dialects` axis (`dispatch.rs`'s `DIALECT_KEYWORDS`, single-sourced from
+  the `frontends!` macro). Also: extend the specs-only BMC/explicit
+  agreement sweep (`explicit_engine.rs`'s largest existing cell,
+  `explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec`) to cover
+  `examples/`, and add an `induction` column to that sweep once a
+  representative induction-provable subset of the corpus is identified.

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -636,6 +636,9 @@ bmc -> refinement progress
   model state remains behind `&mut S: SmtSolver`.
 - `value`, `eval`, and `transition` are the shared symbolic semantic kernel. `agreement` observes
   that kernel and does not become a production execution dependency on `fsl-runtime`.
+- `violation_kind` is a dependency-free leaf, sibling to `value`/`trace`: single-owned
+  `BmcViolation`/`InductionCti`/`RankFailure.kind` string constants that both `bmc` and `induction`
+  reference instead of duplicating literals (issue #646, `docs/DESIGN-assurance-matrix.md`).
 - `induction` currently imports `leadsto_bindings`, `leadsto_condition`, and `project_trace` from
   `bmc`. A candidate target moves those helpers to neutral `liveness` and `trace` owners before
   extending either engine.

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -18,6 +18,7 @@ use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, concrete_value, i64_index, logical_equal,
     symbolic_state,
 };
+use crate::violation_kind;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BmcViolation {
@@ -656,7 +657,7 @@ async fn leadsto_violation<S: SmtSolver>(
     let mut details = details;
     details.bindings = binding.concrete.clone();
     Ok(BmcViolation {
-        kind: "leadsTo".to_owned(),
+        kind: violation_kind::LEADS_TO.to_owned(),
         name: property.name.clone(),
         step: upto,
         last_action,

--- a/rust/fsl-verifier/src/induction.rs
+++ b/rust/fsl-verifier/src/induction.rs
@@ -13,6 +13,7 @@ use crate::transition::{ActionInstance, action_instances, transition_constraint}
 use crate::value::{
     Bindings, SymbolicState, bool_term, bounds, i64_index, int_term, symbolic_state_with_suffix,
 };
+use crate::violation_kind;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InductionCti {
@@ -217,7 +218,7 @@ pub async fn prove_induction<S: SmtSolver>(
                 SatResult::Sat => {
                     let trace = project_trace(solver, model, &states, &choices, &instances, k)?;
                     last_cti = Some(InductionCti {
-                        kind: "invariant".to_owned(),
+                        kind: violation_kind::INVARIANT.to_owned(),
                         name: property.name(model),
                         k,
                         trace,
@@ -253,7 +254,7 @@ pub async fn prove_induction<S: SmtSolver>(
                         return Ok(InductionResult {
                             k_used,
                             cti: Some(InductionCti {
-                                kind: "trans".to_owned(),
+                                kind: violation_kind::TRANS.to_owned(),
                                 name: transition.name.clone(),
                                 k: 1,
                                 trace,
@@ -486,7 +487,7 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                             name: property.name.clone(),
                             bindings: binding.concrete,
                             measure: measure_expr.clone(),
-                            kind: "unbounded_below".to_owned(),
+                            kind: violation_kind::UNBOUNDED_BELOW.to_owned(),
                             measure_value: Some(measure_value),
                             measure_before: None,
                             measure_after: None,
@@ -535,7 +536,7 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                     name: property.name.clone(),
                                     bindings: binding.concrete,
                                     measure: measure_expr.clone(),
-                                    kind: "progress_action_not_fair".to_owned(),
+                                    kind: violation_kind::PROGRESS_ACTION_NOT_FAIR.to_owned(),
                                     measure_value: Some(measure_value),
                                     measure_before: None,
                                     measure_after: None,
@@ -644,7 +645,8 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                     name: property.name.clone(),
                                     bindings: binding.concrete,
                                     measure: measure_expr.clone(),
-                                    kind: "helpful_action_enabledness_not_sticky".to_owned(),
+                                    kind: violation_kind::HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY
+                                        .to_owned(),
                                     measure_value: None,
                                     measure_before: None,
                                     measure_after: None,
@@ -707,7 +709,7 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                 name: property.name.clone(),
                                 bindings: binding.concrete,
                                 measure: measure_expr.clone(),
-                                kind: "helpful_action_not_enabled".to_owned(),
+                                kind: violation_kind::HELPFUL_ACTION_NOT_ENABLED.to_owned(),
                                 measure_value: Some(measure_value),
                                 measure_before: None,
                                 measure_after: None,
@@ -757,7 +759,7 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                                     name: property.name.clone(),
                                     bindings: binding.concrete,
                                     measure: measure_expr.clone(),
-                                    kind: "non_decreasing_action".to_owned(),
+                                    kind: violation_kind::NON_DECREASING_ACTION.to_owned(),
                                     measure_value: None,
                                     measure_before: Some(before),
                                     measure_after: Some(after),
@@ -805,24 +807,24 @@ pub async fn prove_ranked_leadstos<S: SmtSolver>(
                             let q_next_holds = model_bool(solver, &q1)?;
                             let p_next_holds = model_bool(solver, &p1)?;
                             let kind = if !q_next_holds && !p_next_holds {
-                                "pending_not_preserved"
+                                violation_kind::PENDING_NOT_PRESERVED
                             } else if is_helpful && after >= before {
-                                "non_decreasing_helpful_action"
+                                violation_kind::NON_DECREASING_HELPFUL_ACTION
                             } else if !is_helpful && after > before {
-                                "non_helpful_action_increases_measure"
+                                violation_kind::NON_HELPFUL_ACTION_INCREASES_MEASURE
                             } else {
-                                "non_decreasing_action"
+                                violation_kind::NON_DECREASING_ACTION
                             };
                             let message = match kind {
-                                "pending_not_preserved" => format!(
+                                violation_kind::PENDING_NOT_PRESERVED => format!(
                                     "enabled action '{}' can make leadsTo '{}' no longer pending without making Q true",
                                     instance.action, property.name
                                 ),
-                                "non_decreasing_helpful_action" => format!(
+                                violation_kind::NON_DECREASING_HELPFUL_ACTION => format!(
                                     "helpful action '{}' can leave leadsTo '{}' pending without strictly decreasing the measure",
                                     instance.action, property.name
                                 ),
-                                "non_helpful_action_increases_measure" => format!(
+                                violation_kind::NON_HELPFUL_ACTION_INCREASES_MEASURE => format!(
                                     "non-helpful action '{}' can increase the measure while leadsTo '{}' is still pending, which could outpace the helpful action's guaranteed decrease",
                                     instance.action, property.name
                                 ),

--- a/rust/fsl-verifier/src/lib.rs
+++ b/rust/fsl-verifier/src/lib.rs
@@ -13,6 +13,7 @@ mod trace;
 mod transition;
 mod vacuity;
 mod value;
+pub mod violation_kind;
 
 use std::error::Error;
 use std::fmt;

--- a/rust/fsl-verifier/src/violation_kind.rs
+++ b/rust/fsl-verifier/src/violation_kind.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Single-owner vocabulary for the free-form `kind` strings the symbolic
+//! engines (BMC, k-induction, ranked-`leadsTo` liveness) put into
+//! `BmcViolation`/`InductionCti`/`RankFailure`, plus the `"deadlock"`
+//! literal `fslc` renders for a BMC deadlock trace (issue #646).
+//!
+//! This is the sibling registry to `fsl_runtime::Monitor`'s `outcome.kind`
+//! (`rust/fslc/src/coverage.rs::OUTCOME_FEATURE_KEYS`): before this module,
+//! every emission site was a bare string literal with no registry, no
+//! bidirectional check, and no per-value exercising evidence. A typo'd or
+//! new engine-internal kind shipped silently.
+//!
+//! Every emission site in `bmc.rs`/`induction.rs` and in `fslc`'s
+//! `verification_output.rs` (the two `violation_kind: "leadsTo"`/`"deadlock"`
+//! literals that duplicate an already-registered value) references one of
+//! these constants instead of a bare string literal, so a typo or a new kind
+//! is a compile error at the reference, not a silently unregistered value.
+//! `rust/fslc/tests/assurance/violation_kind.rs` asserts the corpus-observed
+//! set equals [`ALL`] exactly, mirroring `conformance_coverage.rs`'s
+//! `every_outcome_kind_the_corpus_emits_is_registered_and_exercised`.
+//!
+//! **Scope boundary (Slice 1):** `bmc.rs`'s own `make_violation` call sites
+//! for `"invariant"`/`"trans"`/`"ensures"` (the plain, non-induction BMC
+//! engine's property violations) are deliberately *not* routed through this
+//! module. Issue #646 and `docs/DESIGN-assurance-matrix.md` scope this
+//! registry to the induction/liveness kinds plus the two hardcoded ones
+//! (`leadsTo`, `deadlock`); the plain-BMC values mirror
+//! `fsl_runtime::Monitor`'s own registered `outcome.kind` spelling
+//! (`OUTCOME_FEATURE_KEYS` already has `invariant`/`trans`/`ensures`) and are
+//! that registry's concern, not this one's. `fslc`'s `main.rs:14741`
+//! (`refine`'s progress-check rendering, also `"leadsTo"`) and
+//! `verification.rs:537` (`"leadsTo_rank"`, a fixed envelope-shape tag with
+//! no corresponding `RankFailure.kind` value) are likewise out of Slice 1's
+//! file scope; see `docs/DESIGN-assurance-matrix.md`'s "Slice 1 boundary"
+//! section for the reasoned basis these axis N/A cells cite.
+
+/// A bounded BMC search found a state where the `leadsTo` trigger (`P` holds,
+/// `Q` false) has been pending past the search depth. `BmcViolation.kind`,
+/// `bmc.rs`.
+pub const LEADS_TO: &str = "leadsTo";
+
+/// A k-induction step found a state sequence that satisfies every invariant
+/// at step `k - 1` but violates one at step `k`. `InductionCti.kind`,
+/// `induction.rs`.
+pub const INVARIANT: &str = "invariant";
+
+/// A k-induction step found a state sequence that satisfies every invariant
+/// but violates a `transition` property. `InductionCti.kind`, `induction.rs`.
+pub const TRANS: &str = "trans";
+
+/// A `leadsTo`'s `decreases` measure can be negative in some state where the
+/// trigger is pending, so it cannot serve as a ranking function.
+/// `RankFailure.kind`, `induction.rs`.
+pub const UNBOUNDED_BELOW: &str = "unbounded_below";
+
+/// A `leadsTo`'s `helpful` action instance is not declared `fair`, so
+/// `helpful` alone cannot obligate it to eventually fire. `RankFailure.kind`,
+/// `induction.rs`.
+pub const PROGRESS_ACTION_NOT_FAIR: &str = "progress_action_not_fair";
+
+/// With two or more matching `helpful` instances, one can become enabled
+/// while pending and then disabled again without firing, so its `fair`
+/// obligation is never triggered. `RankFailure.kind`, `induction.rs`.
+pub const HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY: &str = "helpful_action_enabledness_not_sticky";
+
+/// A `leadsTo` obligation can be pending while no matching `helpful` action
+/// instance is enabled, so none of them is ever obligated to fire.
+/// `RankFailure.kind`, `induction.rs`.
+pub const HELPFUL_ACTION_NOT_ENABLED: &str = "helpful_action_not_enabled";
+
+/// No `helpful` clause is declared, and some enabled action can leave the
+/// obligation pending without strictly decreasing the measure.
+/// `RankFailure.kind`, `induction.rs`.
+pub const NON_DECREASING_ACTION: &str = "non_decreasing_action";
+
+/// A `helpful` clause is declared, and a non-`helpful` action can move the
+/// state to where neither `P` nor `Q` holds -- outside the region the
+/// ranking proof reasons about. `RankFailure.kind`, `induction.rs`.
+pub const PENDING_NOT_PRESERVED: &str = "pending_not_preserved";
+
+/// A `helpful` clause is declared, and the matching `helpful` action instance
+/// itself can fire while pending without strictly decreasing the measure.
+/// `RankFailure.kind`, `induction.rs`.
+pub const NON_DECREASING_HELPFUL_ACTION: &str = "non_decreasing_helpful_action";
+
+/// A `helpful` clause is declared, and a non-`helpful` action can increase
+/// the measure while the obligation is pending, which could outpace the
+/// `helpful` action's guaranteed decrease. `RankFailure.kind`, `induction.rs`.
+pub const NON_HELPFUL_ACTION_INCREASES_MEASURE: &str = "non_helpful_action_increases_measure";
+
+/// A bounded search found a state with zero enabled actions (outside any
+/// declared `terminal` condition). Not a `Violation`-shaped struct field --
+/// `fslc`'s `verification_output.rs` renders this directly from
+/// `BmcResult::deadlock_trace`.
+pub const DEADLOCK: &str = "deadlock";
+
+/// Every value the constants above declare, in a stable order. Exhaustive by
+/// construction only in the sense that this module is the single owner --
+/// nothing enforces at compile time that every `pub const` above also
+/// appears here, so `rust/fslc/tests/assurance/violation_kind.rs` asserts the
+/// two stay in sync (a corpus-observed kind missing from `ALL` fails loudly,
+/// the same discipline `OUTCOME_FEATURE_KEYS` uses for `outcome.kind`).
+pub const ALL: &[&str] = &[
+    LEADS_TO,
+    INVARIANT,
+    TRANS,
+    UNBOUNDED_BELOW,
+    PROGRESS_ACTION_NOT_FAIR,
+    HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY,
+    HELPFUL_ACTION_NOT_ENABLED,
+    NON_DECREASING_ACTION,
+    PENDING_NOT_PRESERVED,
+    NON_DECREASING_HELPFUL_ACTION,
+    NON_HELPFUL_ACTION_INCREASES_MEASURE,
+    DEADLOCK,
+];

--- a/rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs
+++ b/rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Exercising evidence for the four `RankFailure.kind` values that no other
+//! checked-in test reaches (issue #646, `rust/fsl-verifier/src/violation_kind.rs`).
+//!
+//! `tests/leadsto_helpful_ranking.rs` already exercises `progress_action_not_fair`,
+//! `helpful_action_enabledness_not_sticky`, `helpful_action_not_enabled`, and
+//! `non_helpful_action_increases_measure`. Reading `prove_ranked_leadstos`
+//! directly (not the #646 issue text, which under-reported this vocabulary)
+//! found four more reachable `kind` values with no exercising fixture
+//! anywhere in the corpus: `unbounded_below`, `non_decreasing_action`,
+//! `pending_not_preserved`, `non_decreasing_helpful_action`. Each fixture
+//! here was confirmed by running it through the real solver and inspecting
+//! the resulting `RankFailure.kind`, not derived on paper.
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn ranked(source: &str) -> fsl_verifier::RankedLeadstoResult {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    let model = build_model(kernel).expect("build model");
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    block_on(fsl_verifier::prove_ranked_leadstos(&model, &mut solver))
+        .expect("prove_ranked_leadstos")
+}
+
+/// `x` is an unbounded `Int` measure: a free state satisfying `P` (`done ==
+/// false`) can still have `x < 0`, so the unconditional pre-check at the top
+/// of `prove_ranked_leadstos` (which asks nothing about reachability, only
+/// whether `pending && measure < 0` is satisfiable at all) fires first.
+const UNBOUNDED_BELOW_SRC: &str = r"
+spec RankUnboundedBelow {
+  state { x: Int, done: Bool }
+  init { x = 0  done = false }
+  action step() {
+    requires done == false
+    x = x - 1
+  }
+  action finish() {
+    requires x < -3
+    done = true
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+    decreases x
+  }
+}
+";
+
+/// No `helpful` clause is declared, so every action -- not only a `helpful`
+/// one -- must keep `P` true and strictly decrease the measure, or make `Q`
+/// true, whenever it fires while pending. `stall` does neither.
+const NON_DECREASING_SRC: &str = r"
+spec RankNonDecreasing {
+  type Level = 0..5
+  state { level: Level, done: Bool }
+  init { level = 5  done = false }
+  action wiggle() {
+    requires level > 0
+    level = level - 1
+  }
+  action stall() {
+    requires done == false
+    level = level
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+    decreases level
+  }
+}
+";
+
+/// `derail` is a non-`helpful` action that can move the state to `phase ==
+/// 5`, where neither `P` (`phase == 0`) nor `Q` (`phase == 2`) holds -- the
+/// `pending_not_preserved` branch, distinct from every other rank-failure
+/// kind, which all keep `p1` true.
+const PENDING_NOT_PRESERVED_SRC: &str = r"
+spec RankPendingNotPreserved {
+  type Phase = 0..5
+  state { phase: Phase }
+  init { phase = 0 }
+  fair action advance() {
+    requires phase == 0
+    phase = 2
+  }
+  action derail() {
+    requires phase == 0
+    phase = 5
+  }
+  leadsTo Finishes {
+    phase == 0 ~> phase == 2
+    helpful advance()
+    decreases (2 - phase)
+  }
+}
+";
+
+/// `stallHelpful` is the sole `helpful` action, `fair`, and always enabled
+/// while pending, but its firing leaves the measure unchanged and `P` still
+/// true -- `non_decreasing_helpful_action`, distinct from
+/// `non_helpful_action_increases_measure` (a *non*-helpful action) and from
+/// `non_decreasing_action` (no `helpful` declared at all).
+const NON_DECREASING_HELPFUL_SRC: &str = r"
+spec RankNonDecreasingHelpful {
+  type Credit = 0..5
+  state { progressed: Bool, credit: Credit }
+  init { progressed = false  credit = 3 }
+  fair action stallHelpful() {
+    requires progressed == false
+    credit = credit
+  }
+  leadsTo Finishes {
+    progressed == false ~> progressed == true
+    helpful stallHelpful()
+    decreases credit
+  }
+}
+";
+
+#[test]
+fn unbounded_measure_is_reported_as_unbounded_below() {
+    let result = ranked(UNBOUNDED_BELOW_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "unbounded_below");
+}
+
+#[test]
+fn a_non_helpful_stall_with_no_helpful_declared_is_non_decreasing_action() {
+    let result = ranked(NON_DECREASING_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "non_decreasing_action");
+    assert_eq!(failure.action.as_deref(), Some("stall"));
+}
+
+#[test]
+fn a_non_helpful_action_leaving_both_p_and_q_false_is_pending_not_preserved() {
+    let result = ranked(PENDING_NOT_PRESERVED_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "pending_not_preserved");
+    assert_eq!(failure.action.as_deref(), Some("derail"));
+}
+
+#[test]
+fn a_helpful_action_that_stalls_the_measure_is_non_decreasing_helpful_action() {
+    let result = ranked(NON_DECREASING_HELPFUL_SRC);
+    let failure = result
+        .failure
+        .unwrap_or_else(|| panic!("expected a rank failure, got {:?}", result.proofs));
+    assert_eq!(failure.kind, "non_decreasing_helpful_action");
+    assert_eq!(failure.action.as_deref(), Some("stallHelpful"));
+}

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -12,7 +12,7 @@ use fsl_core::{
     state_json, trace_json,
 };
 use fsl_solver::VerificationStatistics;
-use fsl_verifier::{BmcResult, BmcViolation, VacuityFinding};
+use fsl_verifier::{BmcResult, BmcViolation, VacuityFinding, violation_kind};
 use serde_json::{Map, Value, json};
 
 /// Deadlock reporting policy shared by native and browser verification.
@@ -1425,7 +1425,7 @@ fn render_deadlock_failure(
 ) -> (Value, i32) {
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("violated"));
-    output.insert("violation_kind".to_owned(), json!("deadlock"));
+    output.insert("violation_kind".to_owned(), json!(violation_kind::DEADLOCK));
     output.insert("invariant".to_owned(), json!("deadlock"));
     output.insert("violated_at_step".to_owned(), json!(step));
     if let Some(trace) = &result.deadlock_trace {
@@ -1461,7 +1461,7 @@ fn render_leadsto_failure(
         .find(|property| property.name == violation.name);
     output.insert("spec".to_owned(), json!(model.name));
     output.insert("result".to_owned(), json!("violated"));
-    output.insert("violation_kind".to_owned(), json!("leadsTo"));
+    output.insert("violation_kind".to_owned(), json!(violation_kind::LEADS_TO));
     let name = origin_aware_property_name(&mut output, model, "leadsTo", &violation.name);
     output.insert("invariant".to_owned(), json!(name));
     output

--- a/rust/fslc/tests/assurance/claim.rs
+++ b/rust/fslc/tests/assurance/claim.rs
@@ -129,27 +129,52 @@ pub struct Axis {
 
 impl Axis {
     /// Every `(row, column)` pair over this axis's declared rows/columns
-    /// must have a `Claim`. A blank cell is a hard failure, never a silent
-    /// N/A -- N/A is itself a `Claim` variant that must cite its basis.
+    /// must have a `Claim` (a blank cell is a hard failure, never a silent
+    /// N/A -- N/A is itself a `Claim` variant that must cite its basis), and
+    /// conversely `cells` must not carry a key outside `rows`x`columns` --
+    /// a row or column removed/renamed from the axis's declared scope must
+    /// take its cells with it, or the stale cell is dead, unverified
+    /// registry state hiding behind a scope that no longer claims it. This
+    /// is the same both-directions discipline as the corpus/refinement
+    /// manifests (`refine_corpus_parity.rs`'s registered-vs-declared check,
+    /// `coverage.rs`'s unrecognized-outcome-kind rejection): unregistered
+    /// fails, and stale-registered fails too.
     ///
     /// # Errors
     ///
-    /// Returns `Err` naming every missing cell.
+    /// Returns `Err` naming every missing cell and every stale cell.
     pub fn check_complete(&self) -> Result<(), String> {
+        let rows = self
+            .rows
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
+        let columns = self
+            .columns
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
         let missing = self
             .rows
             .iter()
             .flat_map(|row| self.columns.iter().map(move |column| (*row, *column)))
             .filter(|key| !self.cells.contains_key(key))
-            .map(|(row, column)| format!("{}::{row}x{column}", self.name))
-            .collect::<Vec<_>>();
-        if missing.is_empty() {
+            .map(|(row, column)| format!("{}::{row}x{column} (missing)", self.name));
+        let stale = self
+            .cells
+            .keys()
+            .filter(|&&(row, column)| !rows.contains(row) || !columns.contains(column))
+            .map(|(row, column)| {
+                format!(
+                    "{}::{row}x{column} (stale, outside declared rows/columns)",
+                    self.name
+                )
+            });
+        let errors = missing.chain(stale).collect::<Vec<_>>();
+        if errors.is_empty() {
             Ok(())
         } else {
-            Err(format!(
-                "required cells with no Claim: {}",
-                missing.join(", ")
-            ))
+            Err(format!("cell errors: {}", errors.join(", ")))
         }
     }
 

--- a/rust/fslc/tests/assurance/claim.rs
+++ b/rust/fslc/tests/assurance/claim.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Core `Claim`/`Citation`/`Axis` types for the C3 Semantic Assurance Matrix
+//! (issue #537 C3, `docs/DESIGN-assurance-matrix.md`).
+//!
+//! A `Citation` is a machine-rechecked pointer: `path` + `anchor`, where
+//! `anchor` must appear on some line of `path`. `recheck()` re-reads the
+//! file from the working tree every time it runs -- nothing here is a cached
+//! table, mirroring `tests/refine_corpus_parity.rs`'s
+//! `declaration.recheck()` discipline (`#537 C4`, `#616`). A `Claim` names
+//! one of four evidence classes for a single `(row, column)` cell and always
+//! carries exactly one `Citation`. `Axis::check_complete` is the "no blank
+//! required cells" enforcement; `Axis::check_citations` is the "no
+//! fabricated citation" enforcement. Both return `Err` naming every failure
+//! instead of stopping at the first one, matching
+//! `coverage.rs::coverage_matrix`'s discipline.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Repository root, derived from `CARGO_MANIFEST_DIR` (`rust/fslc`) rather
+/// than a hardcoded absolute path, matching
+/// `tests/conformance_coverage.rs::workspace_root`.
+pub fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+/// A machine-rechecked pointer to a declaration: a repository-relative
+/// `path` and an `anchor` substring that some line of that file must
+/// contain. Never a line number -- an unrelated edit above the anchor must
+/// not fail `recheck()`, but deleting or renaming the anchored declaration
+/// must (same shape as `tests/refine_corpus_parity.rs::Declaration`).
+#[derive(Clone, Copy, Debug)]
+pub struct Citation {
+    pub path: &'static str,
+    pub anchor: &'static str,
+}
+
+impl Citation {
+    /// Re-read `path` from the working tree and confirm some line contains
+    /// `anchor`. Never trusts a prior run's result.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when `path` cannot be read, or when no line of it
+    /// contains `anchor`.
+    pub fn recheck(&self) -> Result<(), String> {
+        let full = workspace_root().join(self.path);
+        let content = std::fs::read_to_string(&full)
+            .map_err(|error| format!("{}: cannot read citation target: {error}", self.path))?;
+        if content.lines().any(|line| line.contains(self.anchor)) {
+            Ok(())
+        } else {
+            Err(format!(
+                "{}: anchor `{}` not found on any line (citation is stale or fabricated)",
+                self.path, self.anchor
+            ))
+        }
+    }
+}
+
+/// One assurance-matrix cell's evidence class, matching
+/// `docs/DESIGN-assurance-matrix.md`'s cell vocabulary. Every variant
+/// carries exactly one [`Citation`] -- there is no variant without one,
+/// so a cell can never be "claimed" without something to recheck.
+///
+/// `RejectingControl` and `UnsupportedFailClosed` are unused by every
+/// Slice 1 axis (`outcome_kind`, `violation_kind`, `properties`): none of
+/// their cells are honestly a rejecting-control or fail-closed-unsupported
+/// case rather than `Exercised`/`NotApplicable`, and forcing one to avoid a
+/// dead-code warning would misclassify a real cell. Both variants are part
+/// of the accepted `docs/DESIGN-assurance-matrix.md` cell vocabulary for
+/// later slices (e.g. an `expr`/`types` axis construct a given engine
+/// explicitly refuses).
+#[allow(dead_code)]
+pub enum Claim {
+    /// A real, currently-passing test demonstrates the row is actually
+    /// produced/checked on this column's surface.
+    Exercised { by: Citation },
+    /// A real, currently-passing test demonstrates this column's surface
+    /// correctly *rejects* a contract-violating case for this row.
+    RejectingControl { by: Citation },
+    /// This column's surface does not support the row at all, and rejects
+    /// it closed (an explicit error/refusal, not silent success).
+    UnsupportedFailClosed { by: Citation },
+    /// This `(row, column)` combination is structurally out of scope for a
+    /// reason recorded in `reason`, with `basis` citing where that
+    /// structural fact is codified (source or design doc).
+    NotApplicable {
+        reason: &'static str,
+        basis: Citation,
+    },
+}
+
+impl Claim {
+    #[must_use]
+    pub fn citation(&self) -> &Citation {
+        match self {
+            Self::Exercised { by }
+            | Self::RejectingControl { by }
+            | Self::UnsupportedFailClosed { by } => by,
+            Self::NotApplicable { basis, .. } => basis,
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns `Err` when this claim's citation fails [`Citation::recheck`].
+    pub fn recheck(&self) -> Result<(), String> {
+        self.citation().recheck()
+    }
+}
+
+/// One semantic-surface axis of the assurance matrix: a set of rows, a set
+/// of *declared* columns (the axis's own required scope -- see
+/// `docs/DESIGN-assurance-matrix.md`'s "required" definition), and the
+/// `Claim` for every `(row, column)` pair the axis declares as required.
+pub struct Axis {
+    pub name: &'static str,
+    pub rows: Vec<&'static str>,
+    pub columns: Vec<&'static str>,
+    pub cells: BTreeMap<(&'static str, &'static str), Claim>,
+}
+
+impl Axis {
+    /// Every `(row, column)` pair over this axis's declared rows/columns
+    /// must have a `Claim`. A blank cell is a hard failure, never a silent
+    /// N/A -- N/A is itself a `Claim` variant that must cite its basis.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` naming every missing cell.
+    pub fn check_complete(&self) -> Result<(), String> {
+        let missing = self
+            .rows
+            .iter()
+            .flat_map(|row| self.columns.iter().map(move |column| (*row, *column)))
+            .filter(|key| !self.cells.contains_key(key))
+            .map(|(row, column)| format!("{}::{row}x{column}", self.name))
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "required cells with no Claim: {}",
+                missing.join(", ")
+            ))
+        }
+    }
+
+    /// Every claimed cell's citation must recheck against the current
+    /// working tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` naming every cell whose citation failed to recheck.
+    pub fn check_citations(&self) -> Result<(), String> {
+        let errors = self
+            .cells
+            .iter()
+            .filter_map(|((row, column), claim)| {
+                claim
+                    .recheck()
+                    .err()
+                    .map(|error| format!("{}::{row}x{column}: {error}", self.name))
+            })
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("\n"))
+        }
+    }
+}

--- a/rust/fslc/tests/assurance/outcome_kind.rs
+++ b/rust/fslc/tests/assurance/outcome_kind.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `outcome_kind` axis: the 7 `fsl_runtime::Monitor` `outcome.kind` values
+//! (issue #537 C3 slice 1). Rows are *referenced*, not re-owned: this module
+//! reads `fslc_rust::coverage::OUTCOME_FEATURE_KEYS` directly rather than
+//! copying its 7-entry list, so the two can never drift.
+//!
+//! Declared columns: `Monitor` (the concrete Monitor/BFS surface that
+//! produces `outcome.kind`, already registered and corpus-observed by
+//! `tests/conformance_coverage.rs`) and `CLI` (the `fslc conformance`
+//! command, which serializes the same field over the process boundary --
+//! exercised here directly, since no existing test decomposes the CLI's
+//! golden-diff test by kind).
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::claim::{Axis, Citation, Claim, workspace_root};
+
+/// Every `OUTCOME_FEATURE_KEYS` kind has real evidence on both declared
+/// columns: `Monitor` from the existing bidirectional coverage test, `CLI`
+/// from [`cli_conformance_command_emits_every_registered_outcome_kind`]
+/// below (no existing test decomposes the CLI's golden-diff assertion by
+/// kind, so this axis owns a small targeted one, per the brief's "write a
+/// small targeted test when no cell can be cited" rule).
+#[must_use]
+pub fn axis() -> Axis {
+    let rows = fslc_rust::coverage::OUTCOME_FEATURE_KEYS
+        .iter()
+        .map(|&(kind, _)| kind)
+        .collect::<Vec<_>>();
+    let columns = vec!["Monitor", "CLI"];
+    let mut cells = std::collections::BTreeMap::new();
+    for &row in &rows {
+        cells.insert(
+            (row, "Monitor"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/fslc/tests/conformance_coverage.rs",
+                    anchor: "fn every_outcome_kind_the_corpus_emits_is_registered_and_exercised()",
+                },
+            },
+        );
+        cells.insert(
+            (row, "CLI"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/fslc/tests/assurance/outcome_kind.rs",
+                    anchor: "fn cli_conformance_command_emits_every_registered_outcome_kind()",
+                },
+            },
+        );
+    }
+    Axis {
+        name: "outcome_kind",
+        rows,
+        columns,
+        cells,
+    }
+}
+
+/// Runs the real `fslc conformance` subcommand (not the library-level
+/// `conformance_vectors` call `conformance_coverage.rs` uses) against the
+/// same fixed fixture manifest `coverage.rs` scans, and confirms every
+/// `OUTCOME_FEATURE_KEYS` kind appears in the CLI's own stdout JSON. This is
+/// the axis's `CLI`-column exercising evidence.
+#[test]
+fn cli_conformance_command_emits_every_registered_outcome_kind() {
+    let mut observed = BTreeSet::new();
+    for (file, depth) in [("kernel_contract.fsl", 2), ("conformance_failures.fsl", 1)] {
+        let path = workspace_root().join("rust/fslc/tests/fixtures").join(file);
+        let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+            .args([
+                "conformance",
+                path.to_str().expect("UTF-8 path"),
+                "--depth",
+                &depth.to_string(),
+            ])
+            .current_dir(workspace_root())
+            .output()
+            .expect("run native CLI");
+        assert!(
+            output.status.success(),
+            "fslc conformance {file} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).expect("conformance JSON");
+        for vector in value["vectors"].as_array().expect("vectors") {
+            if let Some(kind) = vector["outcome"]["kind"].as_str() {
+                observed.insert(kind.to_owned());
+            }
+        }
+    }
+
+    for &(kind, _) in fslc_rust::coverage::OUTCOME_FEATURE_KEYS {
+        assert!(
+            observed.contains(kind),
+            "CLI `fslc conformance` never emitted outcome.kind == \"{kind}\" for the fixed fixture manifest; observed={observed:?}"
+        );
+    }
+}

--- a/rust/fslc/tests/assurance/properties.rs
+++ b/rust/fslc/tests/assurance/properties.rs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `properties` axis: the five `KernelModel` property groups (issue #537 C3
+//! slice 1). Rows are the kernel schema's own `properties.required` list
+//! (`invariants`, `transitions`, `reachables`, `leads_to`, `terminal`) --
+//! `kernel_schema_property_groups_match_the_axis_rows` asserts the local
+//! list equals the schema's, the same schema-anchored sync discipline
+//! `conformance_coverage.rs` uses for `SEMANTICS_FEATURE_KEYS` (a new
+//! property group must land in the public-kernel schema to exist as a
+//! contract surface, and landing there without an axis row fails that
+//! test).
+//!
+//! Declared columns: `BMC`, `explicit`, `induction`, `replay`.
+//!
+//! The `replay` column leans on a structural fact of the verification
+//! pipeline, verified in source before any cell cited it: every native
+//! verify run replays *every* symbolic witness -- violation trace, leadsTo
+//! violation trace, each reachable witness trace, deadlock trace -- through
+//! the solver-independent Monitor before rendering
+//! (`verification_output.rs::replay_bmc_witnesses`, called at
+//! `verification.rs`'s BMC seam with exit 3 on failure, and for the
+//! explicit engine inside `verification_output.rs`'s explicit renderer). A
+//! test that asserts exit 0/1 on a witnessed or violated verdict therefore
+//! *is* replay evidence for that row: had the Monitor rejected the trace,
+//! the exit would have been 3 and the cited assertion would have failed.
+//!
+//! Every citation below was confirmed by reading the cited test's function
+//! body (or running the probe here), never transcribed from a filename.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::claim::{Axis, Citation, Claim, workspace_root};
+
+/// The five kernel property groups, spelled exactly as the kernel schema's
+/// `properties.required` spells them. Kept in sync with
+/// `schemas/fslc/kernel/kernel.v1.schema.json` by
+/// [`kernel_schema_property_groups_match_the_axis_rows`].
+const ROWS: &[&str] = &[
+    "invariants",
+    "transitions",
+    "reachables",
+    "leads_to",
+    "terminal",
+];
+
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn axis() -> Axis {
+    let columns = vec!["BMC", "explicit", "induction", "replay"];
+    let mut cells = std::collections::BTreeMap::new();
+
+    cells.insert(
+        ("invariants", "BMC"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fsl-verifier/tests/expression_agreement.rs",
+                anchor: "fn bounded_verification_rejects_initial_violation_without_action_instances()",
+            },
+        },
+    );
+    cells.insert(
+        ("invariants", "explicit"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fsl-runtime/tests/explicit_engine.rs",
+                anchor: "fn explicit_engine_totalizes_property_context_zero_division()",
+            },
+        },
+    );
+    cells.insert(
+        ("invariants", "induction"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/induction_suggestions.rs",
+                anchor: "fn suggests_a_scalar_bound_without_changing_the_verdict()",
+            },
+        },
+    );
+    // The corpus sweep replays every explicit-engine violation trace through
+    // `fsl_runtime::replay_trace` directly (`replayed > 0` is asserted), and
+    // the corpus's violated top-level specs violate invariants (cart_buggy).
+    cells.insert(
+        ("invariants", "replay"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/explicit_engine.rs",
+                anchor: "fn explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec()",
+            },
+        },
+    );
+
+    let trans_probe = Citation {
+        path: "rust/fslc/tests/assurance/properties.rs",
+        anchor: "fn bmc_and_explicit_report_and_replay_a_trans_property_violation()",
+    };
+    cells.insert(("transitions", "BMC"), Claim::Exercised { by: trans_probe });
+    cells.insert(
+        ("transitions", "explicit"),
+        Claim::Exercised { by: trans_probe },
+    );
+    cells.insert(
+        ("transitions", "induction"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/induction_suggestions.rs",
+                anchor: "fn trans_ctis_never_receive_invariant_suggestions()",
+            },
+        },
+    );
+    // Exit 1 (not 3) from the probe proves the Monitor replayed the trans
+    // violation trace: `replay_bmc_witnesses` gates rendering.
+    cells.insert(
+        ("transitions", "replay"),
+        Claim::Exercised { by: trans_probe },
+    );
+
+    let reachable_witness = Citation {
+        path: "rust/fslc/tests/explicit_engine.rs",
+        anchor: "fn explicit_reachable_witness_step_matches_bmc()",
+    };
+    cells.insert(
+        ("reachables", "BMC"),
+        Claim::Exercised {
+            by: reachable_witness,
+        },
+    );
+    cells.insert(
+        ("reachables", "explicit"),
+        Claim::Exercised {
+            by: reachable_witness,
+        },
+    );
+    cells.insert(
+        ("reachables", "induction"),
+        Claim::UnsupportedFailClosed {
+            by: Citation {
+                path: "rust/fslc/tests/assurance/properties.rs",
+                anchor: "fn induction_rejects_a_reachable_property_fail_closed()",
+            },
+        },
+    );
+    // Exit 0 on both engines proves every reachable witness trace replayed
+    // (`for witness in result.reachables.values().flatten()` in
+    // `replay_bmc_witnesses`).
+    cells.insert(
+        ("reachables", "replay"),
+        Claim::Exercised {
+            by: reachable_witness,
+        },
+    );
+
+    cells.insert(
+        ("leads_to", "BMC"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/issue_260_leadsto_stagnation.rs",
+                anchor: "fn leadsto_deadlock_stagnation_is_detected_beyond_the_deadlock_step_for_plain_kernel_spec()",
+            },
+        },
+    );
+    cells.insert(
+        ("leads_to", "explicit"),
+        Claim::UnsupportedFailClosed {
+            by: Citation {
+                path: "rust/fslc/tests/explicit_engine.rs",
+                anchor: "fn explicit_cli_exit_codes_cover_bounded_proved_violated_budget_and_semantics()",
+            },
+        },
+    );
+    cells.insert(
+        ("leads_to", "induction"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/induction_suggestions.rs",
+                anchor: "fn ranked_leadsto_failures_never_receive_suggestions()",
+            },
+        },
+    );
+    cells.insert(
+        ("leads_to", "replay"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/replay_trace_contract.rs",
+                anchor: "fn overdue_bounded_response_is_liveness_nonconformance_after_safety()",
+            },
+        },
+    );
+
+    cells.insert(
+        ("terminal", "BMC"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/assurance/properties.rs",
+                anchor: "fn terminal_excludes_the_final_state_from_bmc_deadlock_reporting()",
+            },
+        },
+    );
+    cells.insert(
+        ("terminal", "explicit"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fsl-runtime/tests/explicit_engine.rs",
+                anchor: "fn explicit_bfs_proves_at_state_space_closure()",
+            },
+        },
+    );
+    cells.insert(
+        ("terminal", "induction"),
+        Claim::NotApplicable {
+            reason: "terminal's only kernel semantic is excluding matching states from deadlock reporting; the induction engine proves invariants/transitions over arbitrary states and has no deadlock probe (no bounded search), so terminal has nothing to act on there",
+            basis: Citation {
+                path: "rust/fslc/src/coverage.rs",
+                anchor: "excluding matching states from deadlock reporting",
+            },
+        },
+    );
+    cells.insert(
+        ("terminal", "replay"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fsl-runtime/tests/monitor_regression.rs",
+                anchor: "fn action_cover_trace_uses_the_enabling_bool_value_and_may_end_at_terminal()",
+            },
+        },
+    );
+
+    Axis {
+        name: "properties",
+        rows: ROWS.to_vec(),
+        columns,
+        cells,
+    }
+}
+
+fn run_verify(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {}`: {error}; stderr={}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+/// The axis's row list must equal the kernel schema's `properties.required`
+/// exactly -- the schema is where a new property group must land to become
+/// part of the public Kernel contract, so this is the registration a new
+/// group cannot skip (mirroring
+/// `conformance_coverage.rs::semantics_schema_keys_are_all_registered_as_feature_rows`).
+#[test]
+fn kernel_schema_property_groups_match_the_axis_rows() {
+    let schema: Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            workspace_root().join("schemas/fslc/kernel/kernel.v1.schema.json"),
+        )
+        .expect("read Kernel schema"),
+    )
+    .expect("Kernel schema JSON");
+    let required = schema["properties"]["properties"]["required"]
+        .as_array()
+        .expect("properties.required")
+        .iter()
+        .map(|value| value.as_str().expect("string key").to_owned())
+        .collect::<BTreeSet<_>>();
+    let rows = ROWS
+        .iter()
+        .map(|&row| row.to_owned())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        required, rows,
+        "every kernel.v1.schema.json property group must be a properties-axis row \
+         (update ROWS in rust/fslc/tests/assurance/properties.rs)"
+    );
+}
+
+/// Targeted probe for the `transitions` row's `BMC`, `explicit`, and
+/// `replay` cells: no pre-existing test asserted an end-to-end verify run
+/// reporting `violation_kind: "trans"` on either engine. Exit 1 (violated),
+/// not 3 (internal), additionally proves the Monitor replayed the trans
+/// counterexample trace, because `replay_bmc_witnesses` runs before
+/// rendering on both engine paths and fails closed to exit 3.
+#[test]
+fn bmc_and_explicit_report_and_replay_a_trans_property_violation() {
+    let fixture = "rust/fslc/tests/fixtures/assurance_trans_violation.fsl";
+
+    let (bmc, status) = run_verify(&[
+        "verify",
+        fixture,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{bmc}");
+    assert_eq!(bmc["result"], "violated");
+    assert_eq!(bmc["violation_kind"], "trans");
+    assert_eq!(bmc["trans"], "NeverDecrease");
+
+    let (explicit, status) = run_verify(&[
+        "verify",
+        fixture,
+        "--engine",
+        "explicit",
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{explicit}");
+    assert_eq!(explicit["result"], "violated");
+    assert_eq!(explicit["violation_kind"], "trans");
+    assert_eq!(explicit["engine"], "explicit");
+}
+
+/// Targeted probe for the `reachables` row's `induction` cell: the
+/// induction engine cannot prove reachability and must reject the property
+/// selection closed (a usage error naming the reason), not silently skip or
+/// vacuously prove it.
+#[test]
+fn induction_rejects_a_reachable_property_fail_closed() {
+    let (output, status) = run_verify(&[
+        "verify",
+        "rust/fslc/tests/fixtures/explicit_reachable_witnessed.fsl",
+        "--engine",
+        "induction",
+        "--property",
+        "HitTwo",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 2, "{output}");
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "usage");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("which the induction engine cannot prove")),
+        "{output}"
+    );
+}
+
+/// Targeted probe for the `terminal` row's `BMC` cell, with its negative
+/// control: the identical machine minus the `terminal` declaration must
+/// deadlock under `--deadlock error`, proving the green verdict on the
+/// `terminal` fixture is the exclusion at work, not a deadlock probe that
+/// never fires.
+#[test]
+fn terminal_excludes_the_final_state_from_bmc_deadlock_reporting() {
+    let (with_terminal, status) = run_verify(&[
+        "verify",
+        "rust/fslc/tests/fixtures/assurance_terminal_once.fsl",
+        "--depth",
+        "4",
+        "--deadlock",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 0, "{with_terminal}");
+    assert_eq!(with_terminal["result"], "verified");
+
+    let (without_terminal, status) = run_verify(&[
+        "verify",
+        "rust/fslc/tests/fixtures/assurance_terminal_once_missing.fsl",
+        "--depth",
+        "4",
+        "--deadlock",
+        "error",
+        "--no-cache",
+    ]);
+    assert_eq!(status, 1, "{without_terminal}");
+    assert_eq!(without_terminal["result"], "violated");
+    assert_eq!(without_terminal["violation_kind"], "deadlock");
+}

--- a/rust/fslc/tests/assurance/violation_kind.rs
+++ b/rust/fslc/tests/assurance/violation_kind.rs
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `violation_kind` axis: the 12-value `fsl_verifier::violation_kind::ALL`
+//! vocabulary (issue #646, #537 C3 slice 1). Rows are *referenced* from
+//! `fsl_verifier::violation_kind::ALL`, not re-owned.
+//!
+//! Declared columns: `BMC`, `induction` -- the two fsl-verifier engines that
+//! can populate a `BmcViolation`/`InductionCti`/`RankFailure.kind` field (or,
+//! for `deadlock`, the BMC-only deadlock probe). Every cell is filled:
+//! `leadsTo`/`deadlock` are BMC-only, `invariant`/`trans`/the 8 ranked-leadsTo
+//! kinds are induction-only, so exactly half of this 12x2 matrix is
+//! `NotApplicable` by construction -- each with a citation to where that
+//! structural fact is codified (see this module's `SLICE1_BOUNDARY` and
+//! `INDUCTION_ONLY_RANKING` bases, and `docs/DESIGN-assurance-matrix.md`'s
+//! "Slice 1 boundary" section, which records the reasoned scope decision
+//! this axis's N/A cells rest on).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+use fsl_verifier::violation_kind as vk;
+
+use crate::claim::{Axis, Citation, Claim};
+
+/// Basis for every `NotApplicable` cell whose structural fact is "this
+/// engine never emits this kind because of a Slice 1 file-scope boundary
+/// documented in the design doc" (the plain-BMC `invariant`/`trans`
+/// literals, and the bounded `leadsTo` kind's absence from the induction
+/// engine).
+const SLICE1_BOUNDARY: Citation = Citation {
+    path: "docs/DESIGN-assurance-matrix.md",
+    anchor: "### Slice 1 boundary",
+};
+
+/// Basis for every `NotApplicable` cell whose structural fact is "the
+/// induction engine is the sole caller of `prove_ranked_leadstos`, and the
+/// bounded BMC engine never attempts a ranking proof" -- cites the CLI's own
+/// engine dispatch, which routes `--engine induction` exclusively through
+/// `run_induction_filtered`/`prove_induction`/`prove_ranked_leadstos`.
+const INDUCTION_ONLY_RANKING: Citation = Citation {
+    path: "rust/fslc/src/verification.rs",
+    anchor: "Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {",
+};
+
+/// Basis for the `deadlock` row's `induction` N/A cell: the induction engine
+/// dispatch never calls `verify_bounded` (the sole caller of the BMC
+/// deadlock probe), so it structurally cannot emit `deadlock`. Same citation
+/// as [`INDUCTION_ONLY_RANKING`] -- the dispatch table is the single fact
+/// both N/A reasons rest on.
+const INDUCTION_NEVER_CALLS_BMC: Citation = INDUCTION_ONLY_RANKING;
+
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn axis() -> Axis {
+    let rows = vk::ALL.to_vec();
+    let columns = vec!["BMC", "induction"];
+    let mut cells: BTreeMap<(&'static str, &'static str), Claim> = BTreeMap::new();
+
+    cells.insert(
+        (vk::LEADS_TO, "BMC"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/issue_260_leadsto_stagnation.rs",
+                anchor: "fn leadsto_deadlock_stagnation_is_detected_beyond_the_deadlock_step()",
+            },
+        },
+    );
+    cells.insert(
+        (vk::LEADS_TO, "induction"),
+        Claim::NotApplicable {
+            reason: "the induction engine's leadsTo obligations surface through the 8 ranked-proof kinds (unbounded_below, ...), never the bounded `leadsTo` kind, which only the BMC engine's bounded search (bmc.rs::leadsto_violation) emits",
+            basis: SLICE1_BOUNDARY,
+        },
+    );
+
+    cells.insert(
+        (vk::INVARIANT, "induction"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/induction_suggestions.rs",
+                anchor: "fn suggests_a_scalar_bound_without_changing_the_verdict()",
+            },
+        },
+    );
+    cells.insert(
+        (vk::INVARIANT, "BMC"),
+        Claim::NotApplicable {
+            reason: "the plain (non-induction) BMC engine's invariant violations are emitted by a separate, out-of-Slice-1-scope site (bmc.rs's make_violation, which mirrors fsl_runtime::Monitor's own registered outcome.kind spelling and is that registry's concern, not this one's)",
+            basis: SLICE1_BOUNDARY,
+        },
+    );
+
+    cells.insert(
+        (vk::TRANS, "induction"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/induction_suggestions.rs",
+                anchor: "fn trans_ctis_never_receive_invariant_suggestions()",
+            },
+        },
+    );
+    cells.insert(
+        (vk::TRANS, "BMC"),
+        Claim::NotApplicable {
+            reason: "same boundary as `invariant`: the plain BMC engine's transition violations are a separate, out-of-Slice-1-scope emission site",
+            basis: SLICE1_BOUNDARY,
+        },
+    );
+
+    let ranked = [
+        (
+            vk::UNBOUNDED_BELOW,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs",
+                anchor: "fn unbounded_measure_is_reported_as_unbounded_below()",
+            },
+        ),
+        (
+            vk::PROGRESS_ACTION_NOT_FAIR,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_helpful_ranking.rs",
+                anchor: "fn helpful_does_not_create_fairness()",
+            },
+        ),
+        (
+            vk::HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_helpful_ranking.rs",
+                anchor: "fn multiple_helpful_actions_with_flickering_enabledness_is_not_falsely_proved()",
+            },
+        ),
+        (
+            vk::HELPFUL_ACTION_NOT_ENABLED,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_helpful_ranking.rs",
+                anchor: "fn blocked_helpful_action_is_reported()",
+            },
+        ),
+        (
+            vk::NON_DECREASING_ACTION,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs",
+                anchor: "fn a_non_helpful_stall_with_no_helpful_declared_is_non_decreasing_action()",
+            },
+        ),
+        (
+            vk::PENDING_NOT_PRESERVED,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs",
+                anchor: "fn a_non_helpful_action_leaving_both_p_and_q_false_is_pending_not_preserved()",
+            },
+        ),
+        (
+            vk::NON_DECREASING_HELPFUL_ACTION,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs",
+                anchor: "fn a_helpful_action_that_stalls_the_measure_is_non_decreasing_helpful_action()",
+            },
+        ),
+        (
+            vk::NON_HELPFUL_ACTION_INCREASES_MEASURE,
+            Citation {
+                path: "rust/fsl-verifier/tests/leadsto_helpful_ranking.rs",
+                anchor: "fn non_helpful_action_pumping_the_measure_is_not_falsely_proved()",
+            },
+        ),
+    ];
+    for (kind, citation) in ranked {
+        cells.insert((kind, "induction"), Claim::Exercised { by: citation });
+        cells.insert(
+            (kind, "BMC"),
+            Claim::NotApplicable {
+                reason: "ranked/inductive leadsTo liveness proof (prove_ranked_leadstos) is induction-engine-only; the bounded BMC engine never attempts a ranking proof",
+                basis: INDUCTION_ONLY_RANKING,
+            },
+        );
+    }
+
+    cells.insert(
+        (vk::DEADLOCK, "BMC"),
+        Claim::Exercised {
+            by: Citation {
+                path: "rust/fslc/tests/issue_260_leadsto_stagnation.rs",
+                anchor: "fn deadlock_error_still_wins_over_leadsto_beyond_the_deadlock_step()",
+            },
+        },
+    );
+    cells.insert(
+        (vk::DEADLOCK, "induction"),
+        Claim::NotApplicable {
+            reason: "the induction engine's CLI dispatch never calls verify_bounded (the sole caller of the BMC deadlock probe); --engine induction routes exclusively through prove_induction/prove_ranked_leadstos, neither of which examines enabled-action counts",
+            basis: INDUCTION_NEVER_CALLS_BMC,
+        },
+    );
+
+    Axis {
+        name: "violation_kind",
+        rows,
+        columns,
+        cells,
+    }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn model(source: &str) -> fsl_core::KernelModel {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(std::env::temp_dir())).expect("parse");
+    build_model(kernel).expect("build model")
+}
+
+const LEADS_TO_SRC: &str = r"
+spec AssuranceProbeLeadsTo {
+  state { done: Bool }
+  init { done = false }
+  action idle() {
+    done = false
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+  }
+}
+";
+
+const DEADLOCK_SRC: &str = r"
+spec AssuranceProbeDeadlock {
+  type Level = 0..3
+  state { level: Level }
+  init { level = 0 }
+  action inc() {
+    requires level < 3
+    level = level + 1
+  }
+}
+";
+
+const INVARIANT_CTI_SRC: &str = r"
+spec AssuranceProbeInvariantCti {
+  type Level = 0..5
+  state { level: Level }
+  init { level = 0 }
+  action inc() {
+    requires level < 5
+    level = level + 1
+  }
+  invariant NeverAtMax { level < 5 }
+}
+";
+
+const TRANS_CTI_SRC: &str = r"
+spec AssuranceProbeTransCti {
+  state { x: Int }
+  init { x = 0 }
+  action inc() {
+    x = x + 1
+  }
+  action dec() {
+    x = x - 1
+  }
+  trans NeverDecrease { x >= old(x) }
+}
+";
+
+const UNBOUNDED_BELOW_SRC: &str = r"
+spec AssuranceProbeUnboundedBelow {
+  state { x: Int, done: Bool }
+  init { x = 0  done = false }
+  action step() {
+    requires done == false
+    x = x - 1
+  }
+  action finish() {
+    requires x < -3
+    done = true
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+    decreases x
+  }
+}
+";
+
+const PROGRESS_ACTION_NOT_FAIR_SRC: &str = r"
+spec AssuranceProbeNonfairHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state { level: Map<Case, Level> }
+  init { forall c: Case { level[c] = 2 } }
+  action step(c: Case) {
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  action idle(c: Case) {
+    level[c] = level[c]
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+";
+
+const HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY_SRC: &str = r"
+spec AssuranceProbeFlickeringHelpful {
+  type Phase = 0..9
+  type Credit = 0..1
+  state { phase: Phase, done: Bool, credit: Credit }
+  init { phase = 0  done = false  credit = 1 }
+  fair action helpEven() {
+    requires phase % 2 == 0
+    requires done == false
+    done = true
+    credit = 0
+  }
+  fair action helpOdd() {
+    requires phase % 2 == 1
+    requires done == false
+    done = true
+    credit = 0
+  }
+  action rotate() {
+    requires done == false
+    phase = (phase + 1) % 10
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+    helpful helpEven()
+    helpful helpOdd()
+    decreases credit
+  }
+}
+";
+
+const HELPFUL_ACTION_NOT_ENABLED_SRC: &str = r"
+spec AssuranceProbeBlockedHelpful {
+  type Case = 0..1
+  type Level = 0..2
+  state {
+    level: Map<Case, Level>,
+    gate: Map<Case, Bool>
+  }
+  init {
+    forall c: Case {
+      level[c] = 2
+      gate[c] = false
+    }
+  }
+  fair action step(c: Case) {
+    requires gate[c]
+    requires level[c] > 0
+    level[c] = level[c] - 1
+  }
+  invariant NonNeg { forall c: Case { level[c] >= 0 } }
+  leadsTo Responds {
+    forall c: Case { level[c] > 0 ~> level[c] == 0 }
+    helpful step(c)
+    decreases level[c]
+  }
+}
+";
+
+const NON_DECREASING_SRC: &str = r"
+spec AssuranceProbeNonDecreasing {
+  type Level = 0..5
+  state { level: Level, done: Bool }
+  init { level = 5  done = false }
+  action wiggle() {
+    requires level > 0
+    level = level - 1
+  }
+  action stall() {
+    requires done == false
+    level = level
+  }
+  leadsTo Finishes {
+    done == false ~> done == true
+    decreases level
+  }
+}
+";
+
+const PENDING_NOT_PRESERVED_SRC: &str = r"
+spec AssuranceProbePendingNotPreserved {
+  type Phase = 0..5
+  state { phase: Phase }
+  init { phase = 0 }
+  fair action advance() {
+    requires phase == 0
+    phase = 2
+  }
+  action derail() {
+    requires phase == 0
+    phase = 5
+  }
+  leadsTo Finishes {
+    phase == 0 ~> phase == 2
+    helpful advance()
+    decreases (2 - phase)
+  }
+}
+";
+
+const NON_DECREASING_HELPFUL_SRC: &str = r"
+spec AssuranceProbeNonDecreasingHelpful {
+  type Credit = 0..5
+  state { progressed: Bool, credit: Credit }
+  init { progressed = false  credit = 3 }
+  fair action stallHelpful() {
+    requires progressed == false
+    credit = credit
+  }
+  leadsTo Finishes {
+    progressed == false ~> progressed == true
+    helpful stallHelpful()
+    decreases credit
+  }
+}
+";
+
+const NON_HELPFUL_ACTION_INCREASES_MEASURE_SRC: &str = r"
+spec AssuranceProbePumpedMeasure {
+  state { x: Int }
+  init { x = 5 }
+  fair action work() {
+    requires x > 0
+    x = x - 1
+  }
+  action pump() {
+    requires x > 0
+    x = x + 2
+  }
+  invariant NonNeg { x >= 0 }
+  leadsTo Finishes {
+    x > 0 ~> x == 0
+    helpful work()
+    decreases x
+  }
+}
+";
+
+/// Independent bidirectional check (issue #646, mirroring
+/// `conformance_coverage.rs`'s `every_outcome_kind_the_corpus_emits_is_registered_and_exercised`):
+/// runs one small, self-contained spec per registered `violation_kind` value
+/// directly through `fsl_verifier`'s public API (not through any other
+/// test's fixtures, so this check is independent of them), collects every
+/// `kind` actually produced, and asserts the observed set equals
+/// `violation_kind::ALL` exactly -- catching both a kind that stops firing
+/// (dead registry entry) and a kind that fires but was never registered
+/// (the #646 defect class).
+#[test]
+fn every_violation_kind_the_probe_corpus_emits_is_exactly_the_registered_set() {
+    let mut observed = BTreeSet::new();
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let leadsto = block_on(fsl_verifier::verify_bounded(
+        &model(LEADS_TO_SRC),
+        &mut solver,
+        3,
+    ))
+    .expect("bmc leadsTo probe");
+    observed.insert(
+        leadsto
+            .leadsto_violation
+            .expect("expected a leadsTo violation")
+            .kind,
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let deadlock = block_on(fsl_verifier::verify_bounded(
+        &model(DEADLOCK_SRC),
+        &mut solver,
+        4,
+    ))
+    .expect("bmc deadlock probe");
+    assert!(
+        deadlock.deadlock_step.is_some(),
+        "expected a deadlock within depth 4"
+    );
+    observed.insert(vk::DEADLOCK.to_owned());
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let invariant = block_on(fsl_verifier::prove_induction(
+        &model(INVARIANT_CTI_SRC),
+        &mut solver,
+        1,
+    ))
+    .expect("induction invariant probe");
+    observed.insert(invariant.cti.expect("expected an invariant CTI").kind);
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let trans = block_on(fsl_verifier::prove_induction(
+        &model(TRANS_CTI_SRC),
+        &mut solver,
+        1,
+    ))
+    .expect("induction trans probe");
+    observed.insert(trans.cti.expect("expected a trans CTI").kind);
+
+    for source in [
+        UNBOUNDED_BELOW_SRC,
+        PROGRESS_ACTION_NOT_FAIR_SRC,
+        HELPFUL_ACTION_ENABLEDNESS_NOT_STICKY_SRC,
+        HELPFUL_ACTION_NOT_ENABLED_SRC,
+        NON_DECREASING_SRC,
+        PENDING_NOT_PRESERVED_SRC,
+        NON_DECREASING_HELPFUL_SRC,
+        NON_HELPFUL_ACTION_INCREASES_MEASURE_SRC,
+    ] {
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        let ranked = block_on(fsl_verifier::prove_ranked_leadstos(
+            &model(source),
+            &mut solver,
+        ))
+        .expect("prove_ranked_leadstos probe");
+        observed.insert(ranked.failure.expect("expected a rank failure").kind);
+    }
+
+    let registered = vk::ALL
+        .iter()
+        .map(|&kind| kind.to_owned())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        observed, registered,
+        "the probe corpus's observed violation_kind values must equal fsl_verifier::violation_kind::ALL exactly \
+         (add a matching const/probe for a value only on one side, per issue #646)"
+    );
+}

--- a/rust/fslc/tests/assurance_matrix.rs
+++ b/rust/fslc/tests/assurance_matrix.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! C3 Semantic Assurance Matrix aggregator (issue #537 C3 slice 1,
+//! `docs/DESIGN-assurance-matrix.md`).
+//!
+//! No central hand-written table: each semantic-surface module under
+//! `tests/assurance/` owns its own rows (derived from an existing registry
+//! or enum, never copied) and declared columns, and builds a `Claim` --
+//! `Exercised`, `RejectingControl`, `UnsupportedFailClosed`, or
+//! `NotApplicable` -- for every `(row, column)` cell in that scope. This
+//! file only aggregates and enforces completeness across all axes.
+//!
+//! Two independent failure modes are enforced, matching issue #537's
+//! acceptance criteria ("required Semantic Assurance Matrix blank cells =
+//! 0" and every claim's citation must be real, not fabricated):
+//!
+//! 1. [`every_declared_cell_across_every_axis_has_a_claim`] -- no blank
+//!    required cell.
+//! 2. [`every_claim_citation_rechecks_against_the_working_tree`] -- no
+//!    fabricated or stale citation.
+//!
+//! [`negative_controls`] demonstrates both checks actually fail on a
+//! corrupted citation and an unclaimed cell -- without this, a checker that
+//! always returns `Ok` would pass the two tests above vacuously.
+
+#[path = "assurance/claim.rs"]
+mod claim;
+#[path = "assurance/outcome_kind.rs"]
+mod outcome_kind;
+#[path = "assurance/properties.rs"]
+mod properties;
+#[path = "assurance/violation_kind.rs"]
+mod violation_kind;
+
+use claim::Axis;
+
+fn axes() -> Vec<Axis> {
+    vec![
+        outcome_kind::axis(),
+        violation_kind::axis(),
+        properties::axis(),
+    ]
+}
+
+#[test]
+fn every_declared_cell_across_every_axis_has_a_claim() {
+    let errors = axes()
+        .iter()
+        .filter_map(|axis| axis.check_complete().err())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "assurance matrix has blank required cells:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn every_claim_citation_rechecks_against_the_working_tree() {
+    let errors = axes()
+        .iter()
+        .filter_map(|axis| axis.check_citations().err())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "assurance matrix has claims with stale or fabricated citations:\n{}",
+        errors.join("\n")
+    );
+}
+
+mod negative_controls {
+    use std::collections::BTreeMap;
+
+    use crate::claim::{Axis, Citation, Claim};
+
+    /// A citation whose anchor text does not appear anywhere in the target
+    /// file must fail `recheck()`. Without this, a checker that always
+    /// returns `Ok` would pass
+    /// `every_claim_citation_rechecks_against_the_working_tree` vacuously.
+    #[test]
+    fn a_citation_with_a_fabricated_anchor_fails_recheck() {
+        let broken = Citation {
+            path: "rust/Cargo.toml",
+            anchor: "this-anchor-text-does-not-exist-in-the-manifest-6f2a1c",
+        };
+        assert!(
+            broken.recheck().is_err(),
+            "a fabricated anchor must fail recheck"
+        );
+    }
+
+    /// A citation pointing at a nonexistent file must fail `recheck()`.
+    #[test]
+    fn a_citation_to_a_nonexistent_file_fails_recheck() {
+        let broken = Citation {
+            path: "rust/fslc/tests/assurance/this-file-does-not-exist.rs",
+            anchor: "anything",
+        };
+        assert!(
+            broken.recheck().is_err(),
+            "a citation to a missing file must fail recheck"
+        );
+    }
+
+    /// A required `(row, column)` cell with no `Claim` at all must fail
+    /// `Axis::check_complete`. Without this, a checker that always returns
+    /// `Ok` would pass `every_declared_cell_across_every_axis_has_a_claim`
+    /// vacuously.
+    #[test]
+    fn an_unclaimed_required_cell_fails_the_completeness_check() {
+        let mut cells = BTreeMap::new();
+        cells.insert(
+            ("row-a", "col-1"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/Cargo.toml",
+                    anchor: "[workspace]",
+                },
+            },
+        );
+        // "row-a" x "col-2" is deliberately left unclaimed.
+        let toy = Axis {
+            name: "negative_control_toy_axis",
+            rows: vec!["row-a"],
+            columns: vec!["col-1", "col-2"],
+            cells,
+        };
+        assert!(
+            toy.check_complete().is_err(),
+            "an axis with an unclaimed required cell must fail check_complete"
+        );
+    }
+
+    /// A fully-claimed toy axis with real citations must pass both checks --
+    /// the positive control for the two negative controls above, proving the
+    /// checkers are not simply always-`Err`.
+    #[test]
+    fn a_fully_claimed_toy_axis_passes_both_checks() {
+        let mut cells = BTreeMap::new();
+        cells.insert(
+            ("row-a", "col-1"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/Cargo.toml",
+                    anchor: "[workspace]",
+                },
+            },
+        );
+        let toy = Axis {
+            name: "positive_control_toy_axis",
+            rows: vec!["row-a"],
+            columns: vec!["col-1"],
+            cells,
+        };
+        assert!(toy.check_complete().is_ok());
+        assert!(toy.check_citations().is_ok());
+    }
+}

--- a/rust/fslc/tests/assurance_matrix.rs
+++ b/rust/fslc/tests/assurance_matrix.rs
@@ -132,6 +132,46 @@ mod negative_controls {
         );
     }
 
+    /// A cell keyed by a row that was removed/renamed from the axis's
+    /// declared `rows` must fail `Axis::check_complete` too -- the reverse
+    /// direction from [`an_unclaimed_required_cell_fails_the_completeness_check`].
+    /// Without this, narrowing `rows`/`columns` after building `cells` would
+    /// leave a stale, unverified `Claim` sitting outside the axis's own
+    /// declared scope with nothing to catch it.
+    #[test]
+    fn a_cell_keyed_by_an_undeclared_row_fails_the_completeness_check() {
+        let mut cells = BTreeMap::new();
+        cells.insert(
+            ("row-a", "col-1"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/Cargo.toml",
+                    anchor: "[workspace]",
+                },
+            },
+        );
+        // "row-stale" was removed from `rows` below but its cell was not.
+        cells.insert(
+            ("row-stale", "col-1"),
+            Claim::Exercised {
+                by: Citation {
+                    path: "rust/Cargo.toml",
+                    anchor: "[workspace]",
+                },
+            },
+        );
+        let toy = Axis {
+            name: "negative_control_toy_axis_stale_row",
+            rows: vec!["row-a"],
+            columns: vec!["col-1"],
+            cells,
+        };
+        assert!(
+            toy.check_complete().is_err(),
+            "an axis with a cell keyed by an undeclared row must fail check_complete"
+        );
+    }
+
     /// A fully-claimed toy axis with real citations must pass both checks --
     /// the positive control for the two negative controls above, proving the
     /// checkers are not simply always-`Err`.

--- a/rust/fslc/tests/fixtures/assurance_terminal_once.fsl
+++ b/rust/fslc/tests/fixtures/assurance_terminal_once.fsl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Assurance-matrix probe (issue #537 C3): after `finish()` fires, no action
+// is enabled; the `terminal` declaration excludes that state from deadlock
+// reporting. The sibling fixture assurance_terminal_once_missing.fsl is the
+// same machine without `terminal` -- the negative control that must report
+// a deadlock. See rust/fslc/tests/assurance/properties.rs.
+
+spec AssuranceTerminalOnce {
+  state { done: Bool }
+  init { done = false }
+
+  action finish() {
+    requires not done
+    done = true
+  }
+
+  terminal { done }
+}

--- a/rust/fslc/tests/fixtures/assurance_terminal_once_missing.fsl
+++ b/rust/fslc/tests/fixtures/assurance_terminal_once_missing.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Negative control for assurance_terminal_once.fsl (issue #537 C3): the
+// same machine without the `terminal` declaration must report a deadlock
+// under --deadlock error, proving the sibling's green verdict is the
+// terminal exclusion at work and not deadlock-detection failure.
+
+spec AssuranceTerminalOnceMissing {
+  state { done: Bool }
+  init { done = false }
+
+  action finish() {
+    requires not done
+    done = true
+  }
+}

--- a/rust/fslc/tests/fixtures/assurance_trans_violation.fsl
+++ b/rust/fslc/tests/fixtures/assurance_trans_violation.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Assurance-matrix probe (issue #537 C3): `dec` violates the `trans`
+// property at its first firing, on every engine that checks transition
+// properties. See rust/fslc/tests/assurance/properties.rs.
+
+spec AssuranceTransViolation {
+  type Count = 0..2
+  state { x: Count }
+  init { x = 1 }
+
+  action dec() {
+    requires x > 0
+    x = x - 1
+  }
+
+  trans NeverDecrease { x >= old(x) }
+}


### PR DESCRIPTION
# Problem

#537 C3 requires a Semantic Assurance Matrix: rows = semantic features, columns = evaluation surfaces, every required cell claimed as exercised / rejecting-control / unsupported-fail-closed / not-applicable-with-reason, with blank cells and reasonless exclusions failing CI — federated from per-owner registries, no hand-written central table.

Additionally, #646: the induction/liveness `Violation.kind` vocabulary was registered nowhere — free-form string literals at ~12 emission sites, the unregistered sibling of the Monitor's `outcome.kind` (which has `OUTCOME_FEATURE_KEYS` + a bidirectional corpus check). Implementation re-count found the vocabulary is **12 values, not the 9 the issue listed**: `prove_ranked_leadstos` selects 3 more (`pending_not_preserved`, `non_decreasing_helpful_action`, `non_helpful_action_increases_measure`) via a dynamic `if` chain invisible to `kind: "…"` grep — none of them exercised by any fixture until now.

# Contract change

- **`rust/fsl-verifier/src/violation_kind.rs` (new)**: single-owner consts for the 12 induction/liveness kinds + `deadlock`. Emission sites in `bmc.rs`, `induction.rs`, and `fslc/src/verification_output.rs` now reference the consts. **No emitted string changes by a single byte** — proven by the full fsl-verifier suite, fslc golden-JSON tests, and the whole workspace gate passing without diff.
- **`rust/fslc/tests/assurance_matrix.rs` + `tests/assurance/` (new)**: the C3 skeleton. `Claim` (4 variants, each carrying a machine-rechecked `Citation` — path + anchor, re-read from the working tree every run) + `Axis` with bidirectional completeness (blank required cell fails; stale cell outside declared rows×columns fails). Three federated axes:
  - `outcome_kind` — 7 rows (referencing `OUTCOME_FEATURE_KEYS`, not copied) × {Monitor, CLI}; all 14 cells Exercised (CLI column gets a new targeted probe running real `fslc conformance`).
  - `violation_kind` — 12 rows (referencing `violation_kind::ALL`) × {BMC, induction}; 24 cells, zero reasonless entries. Independent bidirectional check runs a minimal spec per kind through the real solver and asserts the observed set equals `ALL` exactly. The 4 previously-unexercised kinds got real fixtures (`rust/fsl-verifier/tests/leadsto_rank_kind_vocabulary.rs`).
  - `properties` — 5 rows (kept equal to the kernel schema's `properties.required` by a sync test) × {BMC, explicit, induction, replay}; 20 cells: Exercised 16, UnsupportedFailClosed 2, NotApplicable 1 (reason + basis), with 3 new targeted probes where no existing test covered a cell.
- Negative controls: corrupted citation, missing citation target, unclaimed cell, stale cell, plus a positive control.
- `docs/DESIGN-assurance-matrix.md` (new): accepted design, cell inventory, Slice 1 boundary (which emission sites stay outside the registry and why), slice 2/3 plan (expr / types / dialect axes).

# Test evidence

All exit codes measured directly, no pipes:

- `cargo fmt --all -- --check` 0; `cargo clippy --workspace --all-targets --locked -- -D warnings` 0
- `cargo test -p fsl-verifier --locked` 0 (includes 4 new solver-verified kind fixtures)
- `cargo test -p fslc-rust --test assurance_matrix --locked` 0 (13/13, incl. 5 controls); `--test conformance_coverage` 0 (golden JSON unchanged — emission strings immobile)
- `./tools/check-native-integration.sh rust` 0; `wasm` 0 (415 parity cases; first run hit the known intermittent CDP stall #587, retry green)
- `tools/run-fault-operators.sh` 0 (4 operators primary=failed/blind=ok, both controls correct)

Linked issues: #537 (C3 slice 1), #646 (fixed, vocabulary corrected to 12 on the issue record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
