### PR TITLE
test(fslc): own the declared gallery fixture and evidence-only corpus (#537 C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `corpus_expectation_manifest.rs` and `evidence_corpus_manifest.rs` give every
+  declared `examples/gallery/{valid,errors,adversarial}` fixture and every
+  `causal`/`agent`/`ai_component` evidence-only document exactly one native
+  owner (issue #645, #537 C4 residual). 12 of ~38 declared gallery fixtures had
+  never been run by any native test — `tests/test_gallery.py` was the only
+  oracle, and it is frozen-Python, outside `tools/check-native-
+  integration.sh` — and nothing walked the corpus for an unregistered
+  `causal`/`fsl-ai` document. All reproduce their declared `result`/`kind`/exit
+  natively; no defect surfaced. `corpus_check_sweep.rs`'s
+  `every_corpus_spec_checks_ok_or_declares_its_error` no longer duplicates the
+  `check`-targeted half of that claim, now owned by the new manifest instead.
+  A shared `rust/fslc/tests/support/mod.rs` replaces the corpus-walk helpers
+  `corpus_check_sweep.rs` and `refine_corpus_parity.rs` each carried their own
+  copy of.
 - `rust/fslc/tests/assurance_matrix.rs` introduces the federated Semantic
   Assurance Matrix skeleton (issue #537 C3 slice 1,
   `docs/DESIGN-assurance-matrix.md`): axis modules under `tests/assurance/`

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -254,6 +254,73 @@ Cost: ~2m15s wall, the rows being run on a worker pool. Two `agentic_rag` rows a
 ~100s and ~126s on their own in a debug build, so the sweep is bounded by its
 slowest row rather than by their sum.
 
+## Corpus expectation ownership (#537 C4)
+
+C4 requires every `specs/`+`examples/` artifact bound to the command that
+actually evaluates it. Slice 1 (above) closed the refinement-mapping column;
+issue #645 closes the two categories a comment in `corpus_check_sweep.rs` used
+to document as an open gap. Each corpus category now has exactly one owning
+test:
+
+| Category | Owning test |
+|---|---|
+| kernel/dialect spec, bare `check` | `corpus_check_sweep.rs::every_corpus_spec_checks_ok_or_declares_its_error` |
+| `check`/`verify`/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
+| `ledger` vs its `verify` baseline | `corpus_check_sweep.rs::ledger_exit_status_agrees_with_its_verify_baseline` |
+| refinement mapping | `refine_corpus_parity.rs` (this section, above) |
+| declared `examples/gallery/{valid,errors,adversarial}` fixture | `corpus_expectation_manifest.rs` |
+| `examples/gallery/injected/` (calibrated detectors) | `injection_detector_matrix.rs` |
+| evidence-only document (`causal`, `agent`/`ai_component`/ai project) | `evidence_corpus_manifest.rs` |
+| Worker column (native/Worker parity) | `rust/fsl-wasm/test-browser.mjs` (already C4-complete; see below) |
+
+`corpus_expectation_manifest.rs` reads `examples/gallery/{valid,errors,
+adversarial}`'s `expected-command`/`expected-result`/`expected-kind` header
+convention and runs each declared command verbatim, comparing `result`,
+`kind`, and the exit code the production `fslc_rust::outcome` module binds to
+that result — the same three-channel discipline the refinement manifest uses,
+reused here rather than re-derived. It found that 12 of the corpus's ~38
+declared fixtures (three of which need a non-default flag —
+`--vacuity error` / `--deadlock error` — to reproduce their own declared
+verdict at all) had never been run by any native test; `tests/test_gallery.py`
+was the only oracle, and it is frozen-Python, so `tools/check-native-
+integration.sh` never executed it. All 38 reproduce their declaration
+natively; no exclusion was needed. Every file in the three directories that
+carries no header (a refine-mapping operand, or a governance fixture already
+owned by `corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS`) is a
+self-retiring `StructuralExclusion`, re-checked against the file that actually
+owns it.
+
+`evidence_corpus_manifest.rs` classifies the corpus the same way
+`fslc ai check`'s own dispatch does — `fsl_syntax::is_causal_source`,
+`fslc_rust::frontend_output::is_ai_project`, `fsl_syntax::dialect_keyword` —
+rather than re-deriving a fourth string sniff, and requires every classified
+document to carry a manifest row or a reasoned exclusion in both directions.
+The corpus holds exactly 6 live evidence-only documents today (3 `causal`
+sidecars, 3 `fsl-ai` documents split `agent`/plain `ai_component`/project) and
+one exclusion (`examples/annotations/annotated_ai_component.fsl`, an issue
+#281 annotation-syntax sample whose own doc comment declares plain `check`,
+not `ai check`).
+
+`corpus_check_sweep.rs`'s `every_corpus_spec_checks_ok_or_declares_its_error`
+no longer asserts that a `check`-targeted declared-error fixture actually
+fails under `check` — that positive assertion moved to
+`corpus_expectation_manifest.rs`, which runs the exact declared command
+(including non-`check` ones) rather than a hard-coded `command == "check"`
+comparison. The sweep keeps its complementary half: a file declaring no error
+anywhere must not fail `check` unexpectedly.
+
+**Worker column, already satisfied.** `rust/fsl-wasm/test-browser.mjs` walks
+all corpus `.fsl` files and compares native/Worker `check`/`verify` envelopes
+for every one of them except a self-retiring `agent`/`causal` exclusion set
+(the Worker has no verb for either document type at all). No change was
+needed for C4's Worker column.
+
+**Residual.** `span` location fidelity has no header-declared expectation
+anywhere in the corpus (no fixture states "the location must be exactly
+`L:C`"), so nothing in this ownership map cross-checks it. That is a real gap,
+not a silent one: C4's span column is future slice work, not claimed done
+here.
+
 ## Implementation fault operators (#537 C5)
 
 `injection_detector_matrix.rs` calibrates detectors against defective *specs*:

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -6,23 +6,36 @@
 //! can rot silently forever — this is exactly how the 18 files issue #485
 //! repaired (a `requirement` annotation text conflict) went undetected on
 //! `main`. This test closes that hole: every `.fsl` file must either
-//! succeed under `fslc check`, declare `// expected-result: error` for a
-//! header-less (or explicitly `check`-targeted) invocation — the
-//! `examples/gallery/{errors,adversarial}` convention — or be on the
-//! explicit, reasoned exclusion below. `refinement`-dialect files are
-//! excluded structurally, not because coverage is known to exist elsewhere:
-//! a mapping file has no `state` block to build a checked model from, so
-//! `fslc check` always reports `semantics`/"spec has no state block" for one
-//! regardless of whether the mapping itself is sound. Whether a given
-//! mapping is actually exercised by `fslc refine` is a separate, narrower
-//! claim this sweep does not make. That claim is owned by
-//! `refine_corpus_parity.rs`, whose manifest binds every one of these files
-//! to a `refine` run or to a self-retiring exclusion (issue #593, #537 C4),
-//! and which walks the same corpus rather than listing paths, so a mapping
-//! added here cannot escape both tests at once.
-//! `examples/gallery/injected/` (its own primary/blind detector matrix in
-//! `injection_detector_matrix.rs`) is a genuine verified-elsewhere category,
-//! not a silent skip.
+//! succeed under `fslc check`, declare `// expected-result: error` somewhere
+//! in its header, or be on the explicit, reasoned exclusion below.
+//! `refinement`-dialect files are excluded structurally, not because
+//! coverage is known to exist elsewhere: a mapping file has no `state` block
+//! to build a checked model from, so `fslc check` always reports
+//! `semantics`/"spec has no state block" for one regardless of whether the
+//! mapping itself is sound. Whether a given mapping is actually exercised by
+//! `fslc refine` is a separate, narrower claim this sweep does not make.
+//! That claim is owned by `refine_corpus_parity.rs`, whose manifest binds
+//! every one of these files to a `refine` run or to a self-retiring
+//! exclusion (issue #593, #537 C4), and which walks the same corpus rather
+//! than listing paths, so a mapping added here cannot escape both tests at
+//! once. `examples/gallery/injected/` (its own primary/blind detector matrix
+//! in `injection_detector_matrix.rs`) is a genuine verified-elsewhere
+//! category, not a silent skip.
+//!
+//! This sweep used to also assert the *positive* half of the
+//! `examples/gallery/{errors,adversarial}` header convention: that a file
+//! declaring `expected-result: error` **for `check` specifically** actually
+//! fails under `check`. That assertion now belongs to
+//! `corpus_expectation_manifest.rs`, which runs every header's declared
+//! command verbatim (not just `check`) and compares `result`/`kind`/exit
+//! against the declaration (issue #645, #537 C4 residual). This file keeps
+//! exactly two properties, deliberately narrower than a per-file oracle:
+//! (i) a file that declares no error anywhere must not fail `check`
+//! unexpectedly, and (ii) the Verdict Conservation Law below. Splitting the
+//! two prevents a gap, not a hole: `corpus_expectation_manifest.rs`'s roster
+//! is derived from the same header convention this sweep reads, so a
+//! `check`-targeted declared fixture cannot lose its owner by falling
+//! between the two files.
 //!
 //! `check_result_and_exit_status_never_contradict` below is a second,
 //! independent property over the same corpus sweep (issue #537 C2, Verdict
@@ -35,10 +48,14 @@
 //! (`fslc_rust::outcome::outcome_class`), not a list in this file.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use serde_json::Value;
+
+#[path = "support/mod.rs"]
+mod support;
+use support::{corpus_files, repo_relative, root, top_level_keyword};
 
 /// Repo-relative path (forward slashes) -> reason a bare
 /// check-must-pass-or-declare-error rule does not apply. Each reason names
@@ -71,59 +88,6 @@ const GOVERNANCE_FIXTURE_EXCLUSIONS: &[(&str, &str)] = &[
     ),
 ];
 
-fn root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .expect("workspace root")
-        .to_owned()
-}
-
-fn collect_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    for entry in std::fs::read_dir(dir).expect("read corpus directory") {
-        let path = entry.expect("read corpus entry").path();
-        if path.is_dir() {
-            collect_fsl_files(&path, out);
-        } else if path.extension().is_some_and(|extension| extension == "fsl") {
-            out.push(path);
-        }
-    }
-}
-
-fn repo_relative(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .expect("path under workspace root")
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-/// The file's top-level dialect keyword (`spec`, `requirements`,
-/// `refinement`, `governance`, ...): the first token on the first
-/// non-blank, non-`//`-comment line.
-fn top_level_keyword(source: &str) -> Option<&str> {
-    source
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty() && !line.starts_with("//"))
-        .and_then(|line| line.split_whitespace().next())
-}
-
-/// Parse the `// key: value` header comments in the first 10 lines, the
-/// `expected-command`/`expected-result` convention
-/// `examples/gallery/{valid,errors,adversarial}` use.
-fn headers(source: &str) -> std::collections::BTreeMap<String, String> {
-    let mut out = std::collections::BTreeMap::new();
-    for line in source.lines().take(10) {
-        let Some(body) = line.trim().strip_prefix("//") else {
-            continue;
-        };
-        if let Some((key, value)) = body.trim().split_once(':') {
-            out.insert(key.trim().to_owned(), value.trim().to_owned());
-        }
-    }
-    out
-}
-
 /// Runs `fslc check` on `path` and returns the parsed stdout envelope
 /// together with the process exit status, so a single sweep of the corpus
 /// can serve both the per-file oracle below and the oracle-free
@@ -154,10 +118,7 @@ fn run_check(path: &Path) -> (Value, i32) {
 #[test]
 fn every_corpus_spec_checks_ok_or_declares_its_error() {
     let root = root();
-    let mut files = Vec::new();
-    collect_fsl_files(&root.join("specs"), &mut files);
-    collect_fsl_files(&root.join("examples"), &mut files);
-    files.sort();
+    let files = corpus_files(&root);
     assert!(
         files.len() > 150,
         "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
@@ -189,29 +150,18 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
 
         let (result, _exit) = run_check(path);
 
-        let file_headers = headers(&source);
-        // `expected-command`/`expected-result` may target a *stricter* verb
-        // than `check` (`verify`, `refine`): a declared error there does not
-        // guarantee `check` itself fails (e.g. vacuity only surfaces under
-        // `verify --vacuity error`), so it only pins the "must fail" edge
-        // when the header targets `check` specifically. Any declared error
-        // (for any command) also makes a `check`-time failure unsurprising
-        // — a semantics-class defect (e.g. double assignment) often
-        // surfaces at both. Only a *completely undeclared* `check` failure
-        // is the structural hole this test exists to catch.
-        let declares_error = file_headers
+        // Whether a *declared* `check`-targeted error actually reproduces is
+        // `corpus_expectation_manifest.rs`'s claim, not this sweep's: it runs
+        // every header's `expected-command` verbatim and compares
+        // `result`/`kind`/exit against the declaration. This sweep keeps only
+        // the complementary half -- a file that declares no error anywhere
+        // must not fail `check` unexpectedly -- which needs no oracle beyond
+        // "does the header say `expected-result: error`".
+        let declares_error = support::headers(&source)
             .get("expected-result")
             .is_some_and(|r| r == "error");
-        let targets_check = file_headers
-            .get("expected-command")
-            .is_none_or(|command| command == "check" || command.starts_with("check "));
-
         let is_error = result["result"] == "error";
-        if targets_check && declares_error && !is_error {
-            failures.push(format!(
-                "{rel}: declares `expected-result: error` for `check` but got {result}"
-            ));
-        } else if !declares_error && is_error {
+        if !declares_error && is_error {
             failures.push(format!(
                 "{rel}: `fslc check` unexpectedly failed and the file does not declare \
                  `expected-result: error` anywhere (add the header, register a reasoned \
@@ -241,10 +191,7 @@ fn every_corpus_spec_checks_ok_or_declares_its_error() {
 #[test]
 fn check_result_and_exit_status_never_contradict() {
     let root = root();
-    let mut files = Vec::new();
-    collect_fsl_files(&root.join("specs"), &mut files);
-    collect_fsl_files(&root.join("examples"), &mut files);
-    files.sort();
+    let files = corpus_files(&root);
     assert!(
         files.len() > 150,
         "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
@@ -331,10 +278,7 @@ fn run_exit_status(args: &[&str]) -> i32 {
 #[test]
 fn ledger_exit_status_agrees_with_its_verify_baseline() {
     let root = root();
-    let mut files = Vec::new();
-    collect_fsl_files(&root.join("specs"), &mut files);
-    collect_fsl_files(&root.join("examples"), &mut files);
-    files.sort();
+    let files = corpus_files(&root);
     assert!(
         files.len() > 150,
         "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \

--- a/rust/fslc/tests/corpus_expectation_manifest.rs
+++ b/rust/fslc/tests/corpus_expectation_manifest.rs
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Command-owned runner for every corpus fixture that declares its own
+//! `expected-command`/`expected-result`/`expected-kind` header (issue #645,
+//! #537 C4 residual).
+//!
+//! `examples/gallery/{valid,errors,adversarial}` carries ~38 of these
+//! headers, and `tests/test_gallery.py` is the only oracle that has ever run
+//! them: it is frozen-Python, and `tools/check-native-integration.sh` does
+//! not execute Python, so no required native gate ran any of them. 12 of the
+//! 38 had never been executed by *any* native test at all -- three of those
+//! (`vacuous_contradictory_init`, `vacuous_implication_warning`,
+//! `violated_deadlock_terminal`) declare verdicts that only reproduce under a
+//! non-default flag (`--vacuity error` / `--deadlock error`), so nothing
+//! native had ever exercised the flag that makes the fixture's own claim
+//! true.
+//!
+//! This runner walks `specs/` + `examples/` (never a hard-coded list, the
+//! shape #577 retired 28 stale instances of) and reads each header directly
+//! at test time rather than transcribing it into a static manifest: the
+//! header comment **is** the declaration here, unlike
+//! `refine_corpus_parity.rs`'s refinement mappings, most of which are
+//! declared in a README rather than the mapping file itself. Reading the
+//! header at test time means there is nothing to keep in sync -- the
+//! roster's declared command and this runner's executed command are, by
+//! construction, the same string.
+//!
+//! Two commands are structurally out of scope and left to their existing
+//! owners:
+//!
+//! - A header whose `expected-command` starts with `refine` is
+//!   `refine_corpus_parity.rs`'s row (`refinement_failed_map.fsl`,
+//!   `refine_mapping_boundary_map.fsl`); running it again here would give it
+//!   two owners.
+//! - `examples/gallery/injected/` keeps its own primary/blind detector
+//!   matrix in `injection_detector_matrix.rs`. `every_injected_fixture_declares_its_detector_premise`
+//!   below only re-checks the self-retiring premise that lets this runner
+//!   skip the directory: every file there names its own `inject`/
+//!   `expect-detector` header.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde_json::Value;
+
+#[path = "support/mod.rs"]
+mod support;
+use support::{corpus_files, headers, repo_relative, root};
+
+/// A file under `examples/gallery/{valid,errors,adversarial}` that carries no
+/// `expected-command`/`expected-result` header of its own, and why: each is
+/// an operand or companion of another file's declared expectation, or is
+/// already owned by a different registry. `every_structural_exclusion_premise_still_holds`
+/// re-measures `cited_in` for every entry, so an exclusion cannot outlive its
+/// reason (#568) -- the day a citing registry drops the path, this test fails
+/// and names the row that must gain its own header or a new reason.
+struct StructuralExclusion {
+    path: &'static str,
+    reason: &'static str,
+    /// A repo-relative file whose source must still contain the literal
+    /// string `path`. Re-checked, not trusted.
+    cited_in: &'static str,
+}
+
+const STRUCTURAL_EXCLUSIONS: &[StructuralExclusion] = &[
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/governance_semantic_after.fsl",
+        reason: "governance fixture whose own undefined-type failure is the fixture's purpose; \
+                 corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS already owns it \
+                 (validated indirectly by cli_regression.rs), and refine_corpus_parity.rs \
+                 registers it as the `impl` operand of governance_semantic_mapping.fsl",
+        cited_in: "rust/fslc/tests/corpus_check_sweep.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/governance_semantic_before.fsl",
+        reason: "carries no gallery header; it is the `abs` operand of \
+                 governance_semantic_mapping.fsl, registered in refine_corpus_parity.rs's \
+                 CASES (its bare `fslc check` obligation is still owned by corpus_check_sweep.rs, \
+                 which does not exclude it)",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/governance_semantic_dependency.fsl",
+        reason: "governance-dialect file validated indirectly by cli_regression.rs, per \
+                 corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS",
+        cited_in: "rust/fslc/tests/corpus_check_sweep.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/governance_semantic_mapping.fsl",
+        reason: "refinement-dialect mapping; its expectation is owned by refine_corpus_parity.rs's \
+                 manifest (CASES entry keyed on this path), not the gallery header convention",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/refine_mapping_boundary_abs.fsl",
+        reason: "refine operand (`// expected-helper: used by refine_mapping_boundary_map.fsl`); \
+                 registered as the `abstraction` operand in refine_corpus_parity.rs's CASES",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/adversarial/refine_mapping_boundary_impl.fsl",
+        reason: "refine operand (`// expected-helper: used by refine_mapping_boundary_map.fsl`); \
+                 registered as the `implementation` operand in refine_corpus_parity.rs's CASES",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/errors/governance_malformed_business.fsl",
+        reason: "malformed `business` fixture; corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS \
+                 already owns it",
+        cited_in: "rust/fslc/tests/corpus_check_sweep.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/errors/governance_malformed_dependency.fsl",
+        reason: "governance-dialect file; corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS \
+                 already owns it",
+        cited_in: "rust/fslc/tests/corpus_check_sweep.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/errors/governance_missing_before.fsl",
+        reason: "governance-dialect file; corpus_check_sweep.rs::GOVERNANCE_FIXTURE_EXCLUSIONS \
+                 already owns it",
+        cited_in: "rust/fslc/tests/corpus_check_sweep.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/errors/refinement_failed_abs.fsl",
+        reason: "refine operand (`// expected-helper: used by refinement_failed_map.fsl`); \
+                 registered as the `abstraction` operand in refine_corpus_parity.rs's CASES",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+    StructuralExclusion {
+        path: "examples/gallery/errors/refinement_failed_impl.fsl",
+        reason: "refine operand (`// expected-helper: used by refinement_failed_map.fsl`); \
+                 registered as the `implementation` operand in refine_corpus_parity.rs's CASES",
+        cited_in: "rust/fslc/tests/refine_corpus_parity.rs",
+    },
+];
+
+/// One roster row read from a corpus header. `expected_kind` is `None` when
+/// the file declares no `expected-kind` (the success rows: `proved`/`verified`).
+struct RosterEntry {
+    path: String,
+    command: String,
+    expected_result: String,
+    expected_kind: Option<String>,
+}
+
+/// Results this manifest's roster must never see. Each carries its verdict in
+/// a sibling JSON field rather than `result` (`fslc_rust::outcome::outcome_class`'s
+/// doc comment), so a bare `expected-result: <value>` header could not state
+/// their outcome even if one appeared. The gallery convention has never used
+/// them; this list documents that as a checked fact instead of an assumption
+/// (issue #645 step 5).
+const SIBLING_FIELD_RESULTS: &[&str] = &[
+    "approval_check",
+    "format_check",
+    "lint",
+    "semantic_diff",
+    "semantic_diff_batch",
+];
+
+/// Walk `specs/` + `examples/` and read every `expected-command` header
+/// directly, splitting the roster in three: fixtures this runner owns and
+/// executes, refine-targeted fixtures deferred to `refine_corpus_parity.rs`,
+/// and the set of `examples/gallery/{valid,errors,adversarial}` paths seen
+/// (for the structural-coverage check below).
+fn read_roster(root: &Path) -> (Vec<RosterEntry>, Vec<String>) {
+    let mut owned = Vec::new();
+    let mut deferred_to_refine = Vec::new();
+
+    for path in corpus_files(root) {
+        let rel = repo_relative(root, &path);
+        let source = std::fs::read_to_string(&path).expect("read corpus source");
+        let file_headers = headers(&source);
+        let Some(command) = file_headers.get("expected-command") else {
+            continue;
+        };
+        if command == "refine" || command.starts_with("refine ") {
+            deferred_to_refine.push(rel);
+            continue;
+        }
+        // `examples/named_predicate.fsl` is the one file outside the gallery
+        // convention: it declares `// expected: verified` rather than
+        // `// expected-result: verified`. That is still a declaration, just
+        // under a different key, so it is read rather than treated as
+        // missing -- the alternative is editing the file's own header to
+        // match this runner's naming, which the no-.fsl-rewrite rule
+        // forbids.
+        let expected_result = file_headers
+            .get("expected-result")
+            .or_else(|| file_headers.get("expected"))
+            .unwrap_or_else(|| {
+                panic!("{rel}: has `expected-command` but no `expected-result`/`expected` header")
+            })
+            .clone();
+        assert!(
+            !SIBLING_FIELD_RESULTS.contains(&expected_result.as_str()),
+            "{rel}: declares expected-result={expected_result:?}, a sibling-field verdict \
+             (fslc_rust::outcome::outcome_class); this runner only compares the top-level \
+             `result` string and cannot express that contract -- write a dedicated test instead \
+             of a header",
+        );
+        owned.push(RosterEntry {
+            path: rel,
+            command: command.clone(),
+            expected_result,
+            expected_kind: file_headers.get("expected-kind").cloned(),
+        });
+    }
+
+    (owned, deferred_to_refine)
+}
+
+/// Repo-relative paths under `examples/gallery/{valid,errors,adversarial}`.
+fn gallery_declared_fixture_paths(root: &Path) -> Vec<String> {
+    corpus_files(root)
+        .into_iter()
+        .map(|path| repo_relative(root, &path))
+        .filter(|rel| {
+            rel.starts_with("examples/gallery/valid/")
+                || rel.starts_with("examples/gallery/errors/")
+                || rel.starts_with("examples/gallery/adversarial/")
+        })
+        .collect()
+}
+
+/// Every `examples/gallery/{valid,errors,adversarial}` file must carry its
+/// own `expected-command`/`expected-result` header or a reasoned, re-checked
+/// exclusion: an unregistered corpus fixture must fail loudly, not sit
+/// unexercised the way 12 of the 38 declared fixtures did before this runner.
+#[test]
+fn every_declared_gallery_fixture_is_registered_or_structurally_excluded() {
+    let root = root();
+    let declared = gallery_declared_fixture_paths(&root);
+    assert!(
+        declared.len() >= 45,
+        "corpus scan floor: found only {} files under \
+         examples/gallery/{{valid,errors,adversarial}}, expected 45+ (the directory walk may be \
+         broken)",
+        declared.len()
+    );
+
+    let (owned, deferred_to_refine) = read_roster(&root);
+    let has_header: std::collections::BTreeSet<&str> = owned
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .chain(deferred_to_refine.iter().map(String::as_str))
+        .collect();
+    let excluded: std::collections::BTreeSet<&str> =
+        STRUCTURAL_EXCLUSIONS.iter().map(|e| e.path).collect();
+
+    let mut failures = Vec::new();
+    for path in &declared {
+        if !has_header.contains(path.as_str()) && !excluded.contains(path.as_str()) {
+            failures.push(format!(
+                "{path}: no `expected-command`/`expected-result` header and no \
+                 StructuralExclusion entry in corpus_expectation_manifest.rs. Add the header \
+                 (the gallery convention), or register a reasoned, re-checkable exclusion."
+            ));
+        }
+    }
+    for exclusion in STRUCTURAL_EXCLUSIONS {
+        if !declared.contains(&exclusion.path.to_owned()) {
+            failures.push(format!(
+                "{}: registered as a StructuralExclusion but is no longer a gallery file \
+                 (deleted, moved, or gained a header and duplicated its own exclusion). Remove \
+                 the stale entry.",
+                exclusion.path
+            ));
+        }
+        if has_header.contains(exclusion.path) {
+            failures.push(format!(
+                "{}: registered as a StructuralExclusion but also carries a header now -- \
+                 remove the exclusion, the file has claimed its own row.",
+                exclusion.path
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Re-measures every `StructuralExclusion`'s premise: the citing file must
+/// still contain the excluded path verbatim. A citing registry that drops the
+/// path (a rename, a retired governance exclusion, a mapping removed from
+/// `refine_corpus_parity.rs`) leaves the excluded gallery file with no owner
+/// at all, and this is what catches that (#568 self-retiring shape).
+#[test]
+fn every_structural_exclusion_premise_still_holds() {
+    let root = root();
+    let mut failures = Vec::new();
+    for exclusion in STRUCTURAL_EXCLUSIONS {
+        let citing = std::fs::read_to_string(root.join(exclusion.cited_in))
+            .unwrap_or_else(|error| panic!("read {}: {error}", exclusion.cited_in));
+        if !citing.contains(exclusion.path) {
+            failures.push(format!(
+                "{}: STALE. {} no longer mentions this path, so the reason \
+                 (\"{}\") no longer has anything backing it. Give this file its own header, or \
+                 re-cite wherever it is now owned.",
+                exclusion.path, exclusion.cited_in, exclusion.reason
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Re-measures the premise `read_roster`'s `refine`-deferral rests on: every
+/// path it hands to `refine_corpus_parity.rs` must still appear, verbatim, in
+/// that file's source. Without this, the deferral is an unchecked assumption
+/// with no counterpart to `StructuralExclusion`'s `cited_in` re-measurement:
+/// if `refine_corpus_parity.rs` ever dropped `refinement_failed_map.fsl` or
+/// `refine_mapping_boundary_map.fsl` from its `CASES`/`EXCLUSIONS` (a rename,
+/// a merge conflict, a future edit), that file's `expected-command: refine`
+/// header would go silently unexecuted by every native test -- deferred here,
+/// dropped there, owned nowhere.
+#[test]
+fn every_refine_deferred_fixture_is_still_named_in_refine_corpus_parity() {
+    let root = root();
+    let (_owned, deferred_to_refine) = read_roster(&root);
+    assert!(
+        !deferred_to_refine.is_empty(),
+        "expected at least one `expected-command: refine` header deferred to \
+         refine_corpus_parity.rs (refinement_failed_map.fsl, refine_mapping_boundary_map.fsl); \
+         found none -- the deferral path itself may be broken"
+    );
+
+    let citing = std::fs::read_to_string(root.join("rust/fslc/tests/refine_corpus_parity.rs"))
+        .expect("read rust/fslc/tests/refine_corpus_parity.rs");
+    let mut failures = Vec::new();
+    for path in &deferred_to_refine {
+        if !citing.contains(path.as_str()) {
+            failures.push(format!(
+                "{path}: declares `expected-command: refine`, deferred to \
+                 refine_corpus_parity.rs, but that file's source no longer contains this path. \
+                 It has no owner any more -- add it back to refine_corpus_parity.rs's \
+                 CASES/EXCLUSIONS, or give it a non-refine header and let \
+                 corpus_expectation_manifest.rs execute it directly."
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Every file under `examples/gallery/injected/` must declare its own
+/// `inject:`/`expect-detector:` header -- the premise that lets this runner
+/// (and `corpus_check_sweep.rs`) skip the directory in favor of
+/// `injection_detector_matrix.rs`'s primary/blind matrix. A file that lands
+/// there without either header would be silently unexercised by everything.
+#[test]
+fn every_injected_fixture_declares_its_detector_premise() {
+    let root = root();
+    let mut files = Vec::new();
+    support::collect_fsl_files(&root.join("examples/gallery/injected"), &mut files);
+    assert!(
+        files.len() >= 14,
+        "corpus scan floor: found only {} files under examples/gallery/injected/, expected 14+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let mut failures = Vec::new();
+    for path in &files {
+        let rel = repo_relative(&root, path);
+        let source = std::fs::read_to_string(path).expect("read corpus source");
+        let file_headers = headers(&source);
+        if !file_headers.contains_key("inject") && !file_headers.contains_key("expect-detector") {
+            failures.push(format!(
+                "{rel}: declares neither `// inject:` nor `// expect-detector:`; register it in \
+                 injection_detector_matrix.rs (or give it a gallery header and move it out of \
+                 examples/gallery/injected/)."
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+fn run_fslc(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {}`: {error}; stderr={}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc {}` terminated by signal, no exit code",
+            args.join(" ")
+        )
+    });
+    (value, status)
+}
+
+/// The declared command line, with the fixture's own absolute path inserted
+/// right after the verb -- the same slot `tests/test_gallery.py::_argv` uses.
+fn command_args(command: &str, abs_path: &Path) -> Vec<String> {
+    let mut tokens = command.split_whitespace();
+    let verb = tokens
+        .next()
+        .unwrap_or_else(|| panic!("empty expected-command"));
+    let mut args = vec![
+        verb.to_owned(),
+        abs_path.to_str().expect("utf8 path").to_owned(),
+    ];
+    args.extend(tokens.map(str::to_owned));
+    args
+}
+
+/// The failure-class `kind` a JSON envelope carries for `entry`'s declared
+/// verdict, or `None` for a success-class verdict (no kind to compare).
+///
+/// The field name is not uniform: `result: "error"` envelopes (`check`, and
+/// `verify` for a static or vacuity error) carry `kind`; `result: "violated"`
+/// envelopes carry `violation_kind` instead. This mirrors
+/// `tests/test_gallery.py::_actual_kind` (`out.get("kind") or
+/// out.get("violation_kind")`), the frozen reference's own resolution of the
+/// same two-field vocabulary -- read here, not re-derived from observed
+/// output, per the no-observation-transcription rule.
+fn actual_kind(envelope: &Value) -> Option<&str> {
+    envelope
+        .get("kind")
+        .and_then(Value::as_str)
+        .or_else(|| envelope.get("violation_kind").and_then(Value::as_str))
+}
+
+/// Compares one roster entry's declaration against an observed envelope and
+/// exit status. Returns `Some(failure message)` on any mismatch, `None` on
+/// full agreement. Extracted from the execution loop so both the real run
+/// and the negative control below share one comparator -- the property this
+/// manifest exists to prove is that *this function* can tell a correct
+/// declaration from a wrong one, not merely that today's fixtures happen to
+/// pass.
+fn compare_case(
+    path: &str,
+    expected_result: &str,
+    expected_kind: Option<&str>,
+    envelope: &Value,
+    exit_status: i32,
+) -> Option<String> {
+    let result = envelope
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{path}: envelope has no string `result` field: {envelope}"));
+    if result != expected_result {
+        return Some(format!(
+            "{path}: declared expected-result={expected_result:?}, got result={result:?} \
+             ({envelope})"
+        ));
+    }
+    if let Some(expected_kind) = expected_kind {
+        let kind = actual_kind(envelope);
+        if kind != Some(expected_kind) {
+            return Some(format!(
+                "{path}: declared expected-kind={expected_kind:?}, got kind={kind:?} \
+                 ({envelope})"
+            ));
+        }
+    }
+    // Every gallery `error` result is a spec-level error (parse / type /
+    // name / semantics / vacuous / vacuous_implication / acceptance /
+    // forbidden), never an internal one, so `error_status` is always 2 --
+    // `docs/LANGUAGE.md`'s exit-code table's own boundary between the two.
+    let expected_exit =
+        fslc_rust::outcome::exit_status(&serde_json::json!({"result": expected_result}), 2);
+    if exit_status != expected_exit {
+        return Some(format!(
+            "{path}: result={result:?} binds exit={expected_exit} \
+             (fslc_rust::outcome::exit_status), got exit={exit_status}"
+        ));
+    }
+    None
+}
+
+/// Runs each roster row's declared command line verbatim and compares
+/// `result`, the declared `kind` (when the header states one), and the exit
+/// code the production outcome module binds to that result (#537 C4: all
+/// three, never just the JSON envelope). Rows run concurrently: several of
+/// these fixtures invoke `--engine induction`, which is the slower engine.
+#[test]
+fn native_matches_the_declared_expectation_for_every_registered_fixture() {
+    let root = root();
+    let (owned, _deferred_to_refine) = read_roster(&root);
+    assert!(
+        owned.len() >= 30,
+        "corpus scan floor: found only {} roster rows (expected-command headers minus refine-\
+         targeted ones), expected 30+ (the directory walk, or the header parse, may be broken)",
+        owned.len()
+    );
+
+    let failures = for_each_parallel(owned.len(), |index| {
+        let entry = &owned[index];
+        let abs_path = root.join(&entry.path);
+        let args = command_args(&entry.command, &abs_path);
+        let (envelope, exit_status) = run_fslc(&args);
+        compare_case(
+            &entry.path,
+            &entry.expected_result,
+            entry.expected_kind.as_deref(),
+            &envelope,
+            exit_status,
+        )
+    });
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Negative control (AGENTS.md; issue #645 step 7): proves `compare_case` can
+/// actually detect a wrong expectation, not merely that today's fixtures
+/// happen to agree with it. A comparator that always returns `None` would
+/// make the test above pass for any corpus, declared or not.
+#[test]
+fn compare_case_reports_a_wrong_expectation_as_a_mismatch() {
+    let observed = serde_json::json!({"result": "violated", "violation_kind": "invariant"});
+
+    let wrong_result = compare_case("specs/does_not_matter.fsl", "proved", None, &observed, 1);
+    assert!(
+        wrong_result.is_some(),
+        "declared `proved` vs observed `violated` must be reported as a mismatch"
+    );
+
+    let wrong_kind = compare_case(
+        "specs/does_not_matter.fsl",
+        "violated",
+        Some("type_bound"),
+        &observed,
+        1,
+    );
+    assert!(
+        wrong_kind.is_some(),
+        "declared kind `type_bound` vs observed `invariant` must be reported as a mismatch"
+    );
+
+    let wrong_exit = compare_case(
+        "specs/does_not_matter.fsl",
+        "violated",
+        Some("invariant"),
+        &observed,
+        0,
+    );
+    assert!(
+        wrong_exit.is_some(),
+        "declared `violated` (exit 1) vs observed exit 0 must be reported as a mismatch"
+    );
+
+    let right = compare_case(
+        "specs/does_not_matter.fsl",
+        "violated",
+        Some("invariant"),
+        &observed,
+        1,
+    );
+    assert!(
+        right.is_none(),
+        "a correct expectation must not be reported as a mismatch: {right:?}"
+    );
+}
+
+/// Runs `job` over `0..count` on a small worker pool and collects the failure
+/// strings, matching `refine_corpus_parity.rs`'s parallel harness: several
+/// rows here run `--engine induction`, and running them concurrently keeps
+/// this manifest's wall-clock cost near the slowest row rather than the sum.
+fn for_each_parallel(count: usize, job: impl Fn(usize) -> Option<String> + Sync) -> Vec<String> {
+    let next = AtomicUsize::new(0);
+    let failures = Mutex::new(Vec::new());
+    let workers = std::thread::available_parallelism()
+        .map_or(4, std::num::NonZero::get)
+        .min(count.max(1));
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    if index >= count {
+                        break;
+                    }
+                    if let Some(failure) = job(index) {
+                        failures.lock().expect("failure list").push(failure);
+                    }
+                }
+            });
+        }
+    });
+    let mut failures = failures.into_inner().expect("failure list");
+    failures.sort();
+    failures
+}

--- a/rust/fslc/tests/evidence_corpus_manifest.rs
+++ b/rust/fslc/tests/evidence_corpus_manifest.rs
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Command-owned manifest for the corpus's evidence-only documents: `causal`
+//! sidecars and the `fsl-ai` agent/component/project surface (issue #645,
+//! #537 C4 residual).
+//!
+//! These documents are not `check`-shaped: `causal` bypasses dialect
+//! dispatch entirely (`docs/DESIGN-causal.md`), and `agent`/`ai_component`
+//! evaluate under `fslc ai check`, not `fslc check`, for their declared
+//! result. Before this manifest, nothing walked the corpus and failed on an
+//! unregistered evidence-only document -- only fixed-path issue tests
+//! (`causal_cli.rs`, `issue_468_recursive_agent.rs`,
+//! `issue_509_ai_declared_policy_execution.rs`, `issue_542_...rs`,
+//! `issue_562_...rs`, `issue_563_...rs`) exercised the 6 files that exist
+//! today, by name. A new `examples/causal/*.fsl` or `examples/ai/*.fsl` file
+//! would be checked only by `corpus_check_sweep.rs`'s bare `check` -- which
+//! proves the file parses, never that its actual evaluating command
+//! (`fslc causal check`, `fslc ai check`) was ever run.
+//!
+//! # Classification is native, not string-sniffed
+//!
+//! `rust/fsl-wasm`'s Worker-parity harness (`test-browser.mjs`) already
+//! classifies this exact corpus the same way `fslc ai check`'s own dispatch
+//! does, reusing native functions rather than re-deriving the sniff:
+//! `fsl_syntax::is_causal_source` (causal bypasses dialect dispatch, so the
+//! FRONTENDS-restricted `dialect_keyword` cannot see it -- `is_causal_source`
+//! is the pre-dispatch sniff `causal.rs`'s own doc comment names for exactly
+//! this purpose) and `fsl_syntax::dialect_keyword` for the registered
+//! `agent`/`ai_component` frontends. `fslc_rust::frontend_output::is_ai_project`
+//! is the same predicate `run_ai_check` (`rust/fslc/src/main.rs`) itself
+//! calls first to route to `run_ai_project_check` instead of the plain
+//! component/agent path. `classify` below is that same three-function
+//! decision tree, not a fourth reimplementation of it.
+//!
+//! # Roster
+//!
+//! `causal` (3): `examples/causal/{incident_response,marketing_funnel,
+//! subscription_retention}.fsl`. `funnel.fsl`, `incident_system.fsl`, and
+//! `subscription_business.fsl` are `spec`-dialect design/business companions
+//! the causal files `uses ... from` -- ordinary specs, already owned by
+//! `corpus_check_sweep.rs`, not causal documents themselves.
+//!
+//! `agent`/`ai_component`/`ai project` (3): `examples/ai/
+//! recursive_support_agent.fsl` (`agent`), `examples/ai/
+//! refund_agent_tool_safety.fsl` (plain `ai_component`), `examples/ai/
+//! support_answer_quality.fsl` (`ai_component` carrying `dataset`/
+//! `evaluator`/`statistical_property` blocks, i.e. an fsl-ai project
+//! declaration). `examples/annotations/annotated_ai_component.fsl` is a
+//! fourth `ai_component` file in the corpus, but its own doc comment
+//! declares `fslc check`, not `fslc ai check`, as its evaluating command
+//! (issue #281's annotation-syntax sample); it is a registered
+//! `EvidenceExclusion` below, not a seventh roster row.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+#[path = "support/mod.rs"]
+mod support;
+use support::{corpus_files, repo_relative, root};
+
+/// What `classify` answers for one corpus document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Construct {
+    Causal,
+    AiAgent,
+    /// A plain `ai_component` file (the hard-contract path, `verified_under_assumptions`).
+    AiComponent,
+    /// An `ai_component` file whose `is_ai_project` predicate is true (the
+    /// `dataset`/`evaluator`/... project path, `ai_project_analyzed`).
+    AiProject,
+}
+
+/// The native classification `fslc ai check`'s own dispatch uses, applied
+/// read-only for roster purposes (issue #645 step 1: "native, not a string
+/// sniff reinvented").
+fn classify(source: &str) -> Option<Construct> {
+    if fsl_syntax::is_causal_source(source) {
+        return Some(Construct::Causal);
+    }
+    if fslc_rust::frontend_output::is_ai_project(source) {
+        return Some(Construct::AiProject);
+    }
+    match fsl_syntax::dialect_keyword(source) {
+        Ok("agent") => Some(Construct::AiAgent),
+        Ok("ai_component") => Some(Construct::AiComponent),
+        _ => None,
+    }
+}
+
+/// Where a row's `declared_by` citation points, re-checked by
+/// `manifest_rows_agree_with_their_citations`: some line of `path` must
+/// still contain `anchor`. Unlike `refine_corpus_parity.rs`'s same-named
+/// type, the check here is whole-file, not same-line -- these are prose
+/// citations from README/design-doc paragraphs, and the command line and the
+/// stated result routinely wrap across two lines of Markdown.
+struct Declaration {
+    path: &'static str,
+    anchor: &'static str,
+}
+
+/// One live manifest row.
+struct Row {
+    path: &'static str,
+    construct: Construct,
+    /// The command tokens before the file's own path argument, e.g.
+    /// `["causal", "check"]` or `["ai", "check"]`.
+    command: &'static [&'static str],
+    expected_result: &'static str,
+    declared_by: &'static str,
+    declaration: Declaration,
+}
+
+const ROWS: &[Row] = &[
+    Row {
+        path: "examples/causal/incident_response.fsl",
+        construct: Construct::Causal,
+        command: &["causal", "check"],
+        expected_result: "causal_model_checked",
+        declared_by: "docs/LANGUAGE.md:2726-2730 (`causal <Name> { ... }` is evaluated by \
+                      `fslc causal check model.fsl`) and docs/DESIGN-causal.md:475 (the \
+                      command's success envelope: `\"result\": \"causal_model_checked\"`)",
+        declaration: Declaration {
+            path: "docs/DESIGN-causal.md",
+            anchor: "\"result\": \"causal_model_checked\"",
+        },
+    },
+    Row {
+        path: "examples/causal/marketing_funnel.fsl",
+        construct: Construct::Causal,
+        command: &["causal", "check"],
+        expected_result: "causal_model_checked",
+        declared_by: "docs/LANGUAGE.md:2726-2730 and docs/DESIGN-causal.md:475, as for \
+                      incident_response.fsl above -- one command contract, three fixtures",
+        declaration: Declaration {
+            path: "docs/DESIGN-causal.md",
+            anchor: "\"result\": \"causal_model_checked\"",
+        },
+    },
+    Row {
+        path: "examples/causal/subscription_retention.fsl",
+        construct: Construct::Causal,
+        command: &["causal", "check"],
+        expected_result: "causal_model_checked",
+        declared_by: "docs/LANGUAGE.md:2726-2730 and docs/DESIGN-causal.md:475, as above",
+        declaration: Declaration {
+            path: "docs/DESIGN-causal.md",
+            anchor: "\"result\": \"causal_model_checked\"",
+        },
+    },
+    Row {
+        path: "examples/ai/recursive_support_agent.fsl",
+        construct: Construct::AiAgent,
+        command: &["ai", "check"],
+        expected_result: "agent_analyzed",
+        declared_by: "examples/ai/README.md:11 (`fslc ai check \
+                      examples/ai/recursive_support_agent.fsl`) and :33-34 (`fslc ai check` \
+                      returns `agent_analyzed`, deterministic `agent_ir`, ...)",
+        declaration: Declaration {
+            path: "examples/ai/README.md",
+            anchor: "agent_analyzed",
+        },
+    },
+    Row {
+        path: "examples/ai/refund_agent_tool_safety.fsl",
+        construct: Construct::AiComponent,
+        command: &["ai", "check"],
+        expected_result: "verified_under_assumptions",
+        declared_by: "examples/ai/README.md:10 (`fslc ai check \
+                      examples/ai/refund_agent_tool_safety.fsl`) and :28-30 (`fslc ai check` \
+                      lowers the hard-contract authority model ... and returns \
+                      `verified_under_assumptions` when the finite hard-contract expansion \
+                      verifies)",
+        declaration: Declaration {
+            path: "examples/ai/README.md",
+            anchor: "verified_under_assumptions",
+        },
+    },
+    Row {
+        path: "examples/ai/support_answer_quality.fsl",
+        construct: Construct::AiProject,
+        command: &["ai", "check"],
+        expected_result: "ai_project_analyzed",
+        declared_by: "docs/LANGUAGE.md:2459-2462 (`fslc ai check` parses a project-level \
+                      fsl-ai evidence declaration -- combining `ai_component`, `dataset`, \
+                      `evaluator`, `failure_mode`, `statistical_property`, `ai_migration`, \
+                      `observed_property` -- with the same parser the evidence commands run, \
+                      and returns `ai_project_analyzed`) and examples/ai/README.md:43 \
+                      (`support_answer_quality.fsl` declares `dataset`, `evaluator`, ... \
+                      blocks, i.e. is that shape)",
+        declaration: Declaration {
+            path: "docs/LANGUAGE.md",
+            anchor: "ai_project_analyzed",
+        },
+    },
+];
+
+/// A classified document that carries no manifest row, and the re-checked
+/// fact that keeps its exclusion honest. Mirrors
+/// `corpus_expectation_manifest.rs::StructuralExclusion`.
+struct EvidenceExclusion {
+    path: &'static str,
+    reason: &'static str,
+    /// Substring that must still appear verbatim in `path`'s own source: the
+    /// file's own doc comment states its evaluating command.
+    premise_needle: &'static str,
+}
+
+const EXCLUSIONS: &[EvidenceExclusion] = &[EvidenceExclusion {
+    path: "examples/annotations/annotated_ai_component.fsl",
+    reason: "issue #281 annotation-syntax sample (nested `@requirement(...)` on ai_component \
+             declarations), not fsl-ai evidence; its own doc comment declares `fslc check`, not \
+             `fslc ai check`, and rust/fsl-tools/tests/document.rs already exercises it. Bare \
+             `check` already owns it via corpus_check_sweep.rs's >150-file sweep",
+    premise_needle: "fslc check examples/annotations/annotated_ai_component.fsl",
+}];
+
+/// Every `causal`/`agent`/`ai_component`(project-or-not) document under
+/// `specs/` + `examples/` must carry a manifest row or a reasoned exclusion,
+/// in both directions: an unclassified-but-registered path is stale, an
+/// unregistered classified path is the gap this manifest exists to close.
+#[test]
+fn every_evidence_only_document_is_registered() {
+    let root = root();
+    let mut found: Vec<(String, Construct)> = Vec::new();
+    for path in corpus_files(&root) {
+        let source = std::fs::read_to_string(&path).expect("read corpus source");
+        if let Some(construct) = classify(&source) {
+            found.push((repo_relative(&root, &path), construct));
+        }
+    }
+    let found_count = found.len();
+    assert_eq!(
+        found_count, 7,
+        "expected exactly 7 evidence-only documents in the corpus today (3 causal + 3 fsl-ai \
+         rows + 1 annotation-sample exclusion), found {found_count}: {found:?}. If this is an \
+         intentional new document, register a Row or an EvidenceExclusion; if it is a \
+         regression in `classify`, fix that instead",
+    );
+
+    let registered: std::collections::BTreeMap<&str, Construct> = ROWS
+        .iter()
+        .map(|row| (row.path, row.construct))
+        .chain(
+            EXCLUSIONS
+                .iter()
+                .map(|exclusion| (exclusion.path, Construct::AiComponent)),
+        )
+        .collect();
+    assert_eq!(
+        registered.len(),
+        ROWS.len() + EXCLUSIONS.len(),
+        "a path is registered twice across ROWS and EXCLUSIONS"
+    );
+
+    let mut failures = Vec::new();
+    for (path, construct) in &found {
+        match registered.get(path.as_str()) {
+            None => failures.push(format!(
+                "{path}: classified as {construct:?} but registered in neither ROWS nor \
+                 EXCLUSIONS in evidence_corpus_manifest.rs. Add a row citing the primary \
+                 declaration of its evaluating command, or a reasoned exclusion."
+            )),
+            Some(registered_construct) if registered_construct != construct => {
+                failures.push(format!(
+                    "{path}: classified as {construct:?} but registered as \
+                     {registered_construct:?}. `classify`'s decision changed; update the row."
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    let found_paths: std::collections::BTreeSet<&str> =
+        found.iter().map(|(path, _)| path.as_str()).collect();
+    for path in registered.keys() {
+        if !found_paths.contains(path) {
+            failures.push(format!(
+                "{path}: registered here but `classify` no longer recognizes it as \
+                 causal/agent/ai_component (deleted, moved, or changed shape). Remove the stale \
+                 entry."
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Re-checks every `EvidenceExclusion`'s premise: the excluded file's own
+/// source must still contain the command it claims to declare. Self-retiring
+/// (#568) -- the day `annotated_ai_component.fsl` starts declaring
+/// `fslc ai check` instead, this fails and the file must join `ROWS`.
+#[test]
+fn every_evidence_exclusion_premise_still_holds() {
+    let root = root();
+    let mut failures = Vec::new();
+    for exclusion in EXCLUSIONS {
+        let source = std::fs::read_to_string(root.join(exclusion.path))
+            .unwrap_or_else(|error| panic!("read {}: {error}", exclusion.path));
+        if !source.contains(exclusion.premise_needle) {
+            failures.push(format!(
+                "{}: STALE. The file no longer contains {:?}, so the reason ({}) no longer has \
+                 anything backing it.",
+                exclusion.path, exclusion.premise_needle, exclusion.reason
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Every row's `declared_by` citation must still be true: some line of the
+/// cited file must still contain the row's `declaration.anchor`. Checked
+/// whole-file (not same-line, unlike `refine_corpus_parity.rs`'s
+/// `Declaration`) because these are prose citations, and every anchor here
+/// already includes the row's own `expected_result` string, so a match also
+/// confirms the file still states that verdict.
+#[test]
+fn manifest_rows_agree_with_their_citations() {
+    let root = root();
+    let mut failures = Vec::new();
+    for row in ROWS {
+        let citing = std::fs::read_to_string(root.join(row.declaration.path))
+            .unwrap_or_else(|error| panic!("read {}: {error}", row.declaration.path));
+        if !citing.contains(row.declaration.anchor) {
+            failures.push(format!(
+                "{}: no line of {} contains {:?} any more. `declared_by` is stale: {}",
+                row.path, row.declaration.path, row.declaration.anchor, row.declared_by
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+fn run_fslc(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {}`: {error}; stderr={}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc {}` terminated by signal, no exit code",
+            args.join(" ")
+        )
+    });
+    (value, status)
+}
+
+/// Compares one row's declaration against an observed envelope and exit
+/// status; extracted so the real run and the negative control below share
+/// one comparator (same rationale as
+/// `corpus_expectation_manifest.rs::compare_case`).
+fn compare_row(
+    path: &str,
+    expected_result: &str,
+    envelope: &Value,
+    exit_status: i32,
+) -> Option<String> {
+    let result = envelope
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{path}: envelope has no string `result` field: {envelope}"));
+    if result != expected_result {
+        return Some(format!(
+            "{path}: declared expected-result={expected_result:?}, got result={result:?} \
+             ({envelope})"
+        ));
+    }
+    let expected_exit =
+        fslc_rust::outcome::exit_status(&serde_json::json!({"result": expected_result}), 2);
+    if exit_status != expected_exit {
+        return Some(format!(
+            "{path}: result={result:?} binds exit={expected_exit} \
+             (fslc_rust::outcome::exit_status), got exit={exit_status}"
+        ));
+    }
+    None
+}
+
+/// Runs every row's declared command and compares `result` and exit status
+/// (#537 C4: both channels). All 6 declared results are success-class in
+/// `fslc_rust::outcome::outcome_class`, so exit 0 in every row; the
+/// comparator still derives it from production code rather than asserting
+/// `0` directly, the same discipline `corpus_expectation_manifest.rs` uses.
+#[test]
+fn native_matches_the_declared_expectation_for_every_registered_row() {
+    let root = root();
+    let mut failures = Vec::new();
+    for row in ROWS {
+        let abs_path = root.join(row.path).to_str().expect("utf8 path").to_owned();
+        let args: Vec<String> = row
+            .command
+            .iter()
+            .map(|token| (*token).to_owned())
+            .chain(std::iter::once(abs_path))
+            .collect();
+        let (envelope, exit_status) = run_fslc(&args);
+        if let Some(failure) = compare_row(row.path, row.expected_result, &envelope, exit_status) {
+            failures.push(failure);
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// Negative control (AGENTS.md; issue #645 step 6): proves `compare_row` can
+/// detect a wrong expectation, matching
+/// `corpus_expectation_manifest.rs::compare_case_reports_a_wrong_expectation_as_a_mismatch`.
+#[test]
+fn compare_row_reports_a_wrong_expectation_as_a_mismatch() {
+    let observed = serde_json::json!({"result": "causal_model_checked"});
+
+    let wrong_result = compare_row(
+        "examples/causal/does_not_matter.fsl",
+        "agent_analyzed",
+        &observed,
+        0,
+    );
+    assert!(
+        wrong_result.is_some(),
+        "declared `agent_analyzed` vs observed `causal_model_checked` must be reported"
+    );
+
+    let wrong_exit = compare_row(
+        "examples/causal/does_not_matter.fsl",
+        "causal_model_checked",
+        &observed,
+        1,
+    );
+    assert!(
+        wrong_exit.is_some(),
+        "declared `causal_model_checked` (exit 0) vs observed exit 1 must be reported"
+    );
+
+    let right = compare_row(
+        "examples/causal/does_not_matter.fsl",
+        "causal_model_checked",
+        &observed,
+        0,
+    );
+    assert!(
+        right.is_none(),
+        "a correct expectation must not be reported as a mismatch: {right:?}"
+    );
+}
+
+/// `classify`'s own negative control: a corpus document from a dialect none
+/// of the four evidence-only paths recognize must classify as `None`, not
+/// silently join one of the buckets. Uses a real corpus file
+/// (`specs/cart_v1.fsl`, an ordinary kernel spec) rather than a synthetic
+/// string, so the control exercises the same `fsl_syntax`/`fslc_rust`
+/// functions the real classification does.
+#[test]
+fn classify_does_not_misclassify_an_ordinary_spec() {
+    let root = root();
+    let source =
+        std::fs::read_to_string(root.join("specs/cart_v1.fsl")).expect("read specs/cart_v1.fsl");
+    assert_eq!(
+        classify(&source),
+        None,
+        "an ordinary kernel spec must not classify as an evidence-only construct"
+    );
+}

--- a/rust/fslc/tests/refine_corpus_parity.rs
+++ b/rust/fslc/tests/refine_corpus_parity.rs
@@ -44,13 +44,17 @@
 //! one exists and otherwise chosen to exercise the mapping, because depth
 //! bounds the search rather than declaring the expected verdict.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::collections::BTreeSet;
+use std::path::Path;
 use std::process::Command;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::Value;
+
+#[path = "support/mod.rs"]
+mod support;
+use support::{corpus_files, headers, repo_relative, root, top_level_keyword};
 
 /// One live manifest row: a corpus refinement mapping, the implementation
 /// and abstraction it is declared to be run against, and the verdict the
@@ -546,49 +550,9 @@ const EXCLUSIONS: &[Exclusion] = &[Exclusion {
     },
 }];
 
-fn root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .expect("workspace root")
-        .to_owned()
-}
-
-fn collect_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    for entry in std::fs::read_dir(dir).expect("read corpus directory") {
-        let path = entry.expect("read corpus entry").path();
-        if path.is_dir() {
-            collect_fsl_files(&path, out);
-        } else if path.extension().is_some_and(|extension| extension == "fsl") {
-            out.push(path);
-        }
-    }
-}
-
-fn repo_relative(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .expect("path under workspace root")
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-/// The file's top-level dialect keyword: the first token on the first
-/// non-blank, non-`//`-comment line. Same rule `corpus_check_sweep.rs` uses
-/// to identify (and structurally skip) the very files this manifest owns.
-fn top_level_keyword(source: &str) -> Option<&str> {
-    source
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty() && !line.starts_with("//"))
-        .and_then(|line| line.split_whitespace().next())
-}
-
 /// Every `refinement`-dialect file under `specs/` + `examples/`, repo-relative.
 fn corpus_refinement_mappings(root: &Path) -> BTreeSet<String> {
-    let mut files = Vec::new();
-    collect_fsl_files(&root.join("specs"), &mut files);
-    collect_fsl_files(&root.join("examples"), &mut files);
-    files
+    corpus_files(root)
         .into_iter()
         .filter(|path| {
             let source = std::fs::read_to_string(path).expect("read corpus source");
@@ -602,10 +566,7 @@ fn corpus_refinement_mappings(root: &Path) -> BTreeSet<String> {
 /// declaration is unindented and has the declared name as its second token
 /// (`spec Foo {`, `design Foo {`, ...).
 fn corpus_declares(root: &Path, name: &str) -> bool {
-    let mut files = Vec::new();
-    collect_fsl_files(&root.join("specs"), &mut files);
-    collect_fsl_files(&root.join("examples"), &mut files);
-    files.iter().any(|path| {
+    corpus_files(root).iter().any(|path| {
         let source = std::fs::read_to_string(path).expect("read corpus source");
         source.lines().any(|line| {
             if line.starts_with(char::is_whitespace) || line.trim_start().starts_with("//") {
@@ -615,20 +576,6 @@ fn corpus_declares(root: &Path, name: &str) -> bool {
             tokens.next().is_some() && tokens.next() == Some(name)
         })
     })
-}
-
-/// The `// key: value` header comments the
-/// `examples/gallery/{errors,adversarial}` fixtures use to declare their own
-/// expected command, result, and failure kind. Same convention
-/// `corpus_check_sweep.rs::headers` reads for `check`-targeted fixtures.
-fn headers(source: &str) -> BTreeMap<String, String> {
-    source
-        .lines()
-        .take(10)
-        .filter_map(|line| line.trim().strip_prefix("//"))
-        .filter_map(|body| body.trim().split_once(':'))
-        .map(|(key, value)| (key.trim().to_owned(), value.trim().to_owned()))
-        .collect()
 }
 
 /// Where a mapping declares its own expectation in the gallery header

--- a/rust/fslc/tests/support/mod.rs
+++ b/rust/fslc/tests/support/mod.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Corpus-walk helpers shared by every `specs/`+`examples/` corpus test
+//! (issue #645, #537 C4). Before this module, `corpus_check_sweep.rs` and
+//! `refine_corpus_parity.rs` each carried an identical copy of `root`,
+//! `collect_fsl_files`, `repo_relative`, `headers`, and `top_level_keyword`;
+//! adding `corpus_expectation_manifest.rs` and `evidence_corpus_manifest.rs`
+//! as two more copies is exactly the "same logic in 2+ places" duplication
+//! the project's implementation policy forbids. One copy here, reused by
+//! all four.
+//!
+//! Placed at `tests/support/mod.rs` (not `tests/support.rs`) so Cargo does
+//! not compile it as its own top-level integration-test binary; each
+//! consumer pulls it in with `mod support;`. Every item is `pub` because a
+//! given consumer only needs a subset, and `#[allow(dead_code)]` is applied
+//! per item because each integration test is compiled as its own binary
+//! crate, where an unused `pub` item still triggers the lint.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Workspace root, resolved from `CARGO_MANIFEST_DIR` (`rust/fslc`) two
+/// levels up.
+#[allow(dead_code)]
+pub fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+/// Recursively collect every `.fsl` file under `dir`.
+#[allow(dead_code)]
+pub fn collect_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read corpus directory") {
+        let path = entry.expect("read corpus entry").path();
+        if path.is_dir() {
+            collect_fsl_files(&path, out);
+        } else if path.extension().is_some_and(|extension| extension == "fsl") {
+            out.push(path);
+        }
+    }
+}
+
+/// Every `.fsl` file under `specs/` + `examples/`, repo-relative, sorted.
+#[allow(dead_code)]
+pub fn corpus_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_fsl_files(&root.join("specs"), &mut files);
+    collect_fsl_files(&root.join("examples"), &mut files);
+    files.sort();
+    files
+}
+
+/// `path`, relative to `root`, with forward slashes on every platform.
+#[allow(dead_code)]
+pub fn repo_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .expect("path under workspace root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// The file's top-level dialect keyword (`spec`, `requirements`,
+/// `refinement`, `governance`, `causal`, ...): the first token on the first
+/// non-blank, non-`//`-comment line.
+#[allow(dead_code)]
+pub fn top_level_keyword(source: &str) -> Option<&str> {
+    source
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with("//"))
+        .and_then(|line| line.split_whitespace().next())
+}
+
+/// Parse the `// key: value` header comments in the first 10 lines: the
+/// `expected-command` / `expected-result` / `expected-kind` /
+/// `expected-helper` convention `examples/gallery/{valid,errors,adversarial}`
+/// use.
+#[allow(dead_code)]
+pub fn headers(source: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for line in source.lines().take(10) {
+        let Some(body) = line.trim().strip_prefix("//") else {
+            continue;
+        };
+        if let Some((key, value)) = body.trim().split_once(':') {
+            out.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
+    }
+    out
+}


### PR DESCRIPTION
# Problem

#537 C4 requires every corpus artifact bound to the command that actually evaluates it. After #616 (refinement mappings), two categories remained natively unowned (#645):

- The ~38 `expected-command`/`expected-result`/`expected-kind` headers under `examples/gallery/{valid,errors,adversarial}` had never been executed as declared by any native test — the only oracle was frozen-Python `test_gallery.py`, which the product gate does not run. 12 fixtures were referenced by no native test at all; 3 of those declare verdicts that only reproduce under a non-default flag (`--vacuity error` / `--deadlock error`).
- Evidence-only documents (3 `causal`, 3 fsl-ai) were exercised only by fixed-path issue tests; nothing walked the corpus and failed on an unregistered one.

# Contract change

- **`rust/fslc/tests/corpus_expectation_manifest.rs` (new)**: walks `specs/`+`examples/`, reads every `expected-command` header at test time (the header *is* the declaration — nothing to keep in sync), runs the declared command line verbatim (flags included), and compares `result`, declared `kind`, and the exit code the production `fslc_rust::outcome` module binds to that result. Every gallery file must carry a header or a reasoned, re-measured `StructuralExclusion` (11 entries, each citing the registry that owns the file, re-checked every run). The two `refine`-targeted headers stay owned by `refine_corpus_parity.rs`, with a premise test asserting they are still named there. `injected/` keeps its detector matrix, with a premise test that every file there declares its `inject`/`expect-detector` header. Negative control proves the comparator reports wrong result/kind/exit.
  - **All 37 executed fixtures reproduce their declaration natively — zero mismatches, zero exclusions needed**, including the 12 never-run fixtures and the 3 flag-dependent ones.
- **`rust/fslc/tests/evidence_corpus_manifest.rs` (new)**: classifies the corpus with the same native functions `fslc ai check`'s own dispatch uses (`is_causal_source` / `is_ai_project` / `dialect_keyword` — no fourth string sniff), requires bidirectional registration (6 rows + 1 reasoned exclusion), machine-checks each row's `declared_by` citation, runs the registered command, compares result + exit. Negative controls for the comparator and the classifier.
- **`rust/fslc/tests/corpus_check_sweep.rs`**: the `declares_error && targets_check` special case moved to the expectation manifest (single owner per declaration); the sweep keeps (i) undeclared files must not fail `check` and (ii) the C2 conservation law.
- **`rust/fslc/tests/support/mod.rs` (new)**: the corpus-walk helpers (`root`/`collect_fsl_files`/`repo_relative`/`headers`/`top_level_keyword`) previously duplicated across corpus tests, now shared by all four.
- `docs/DESIGN-conformance-harness.md`: "Corpus expectation ownership (#537 C4)" — the category→owning-test map, the Worker column already satisfied by `test-browser.mjs`, and the honest residual (span has no header-declared expectation anywhere; not claimed).

# Test evidence

Exit codes measured directly, no pipes (an earlier self-check that used `| tail` was caught and redone):

- `cargo fmt --check` 0; `cargo clippy --workspace --all-targets --locked -- -D warnings` 0
- `corpus_expectation_manifest` 6/6; `evidence_corpus_manifest` 6/6; `corpus_check_sweep` 3/3; `refine_corpus_parity` 4/4
- `./tools/check-native-integration.sh rust` 0 (post-review-fix rerun); `tools/run-fault-operators.sh` 0 (4 operators primary=failed/blind=ok, both controls correct)

Closes #645. Part of #537 C4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
