### PR TITLE
test(fslc,verifier): add the C6 typed generative / metamorphic agreement suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `rust/fslc/tests/typed_agreement.rs` introduces the C6 typed generative /
+  metamorphic cross-engine agreement suite (issue #537 C6 slice 1, issue
+  #648, `docs/DESIGN-conformance-harness.md` "Typed generative / metamorphic
+  agreement"): a deterministic structural generator (15 domain-axis models
+  + 4 operation-axis models, no randomness) builds checked `KernelModel`s
+  and compares Monitor BFS / explicit / BMC verdicts, replay, and successor
+  admission, plus seven metamorphic relations (alpha rename, BOM/trivia,
+  inline-vs-explicit init, disjoint assignment reorder, domain-size
+  boundary, short-circuit/partial/Euclidean duality, entity/number sugar vs
+  lowered type) each with a positive test and a negative control. Two
+  confirmed cross-engine findings are recorded as re-measured, self-retiring
+  exclusions rather than normalized away: `verify_bounded`'s symbolic Seq
+  encoding treats an out-of-range `head()` read in property context as
+  *defined* with an out-of-bound value instead of undefined (a spurious
+  `violated`/`invariant`, disagreeing with the concrete engines' correct
+  error); and `verify_bounded` alone never performs LANGUAGE.md's automatic
+  "Partial operations" check in action context at all (the CLI's
+  `--engine bmc` classification comes from a separate concrete pre-scan,
+  `find_boundary_violation`, not the solver).
 - `rust/fslc/tests/assurance_matrix.rs` introduces the federated Semantic
   Assurance Matrix skeleton (issue #537 C3 slice 1,
   `docs/DESIGN-assurance-matrix.md`): axis modules under `tests/assurance/`

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -369,6 +369,130 @@ that is already red proves nothing either way — says no input reaches it, and
 the honest output is a recorded measurement rather than a new operator or a
 fixture nobody can build.
 
+## Typed generative / metamorphic agreement (#537 C6)
+
+`rust/fsl-verifier/tests/expression_agreement.rs` and `explicit_engine.rs`'s
+corpus sweep proved agreement on hand-written fixtures and the existing
+`specs/` corpus. Neither swept a *generated* model family, and nothing
+executably anchored a dialect construct's semantics against its documented
+desugaring. C6 slice 1
+(`rust/fslc/tests/typed_agreement.rs` + `rust/fslc/tests/typed_agreement/`)
+closes both gaps: a deterministic structural generator produces checked
+`KernelModel`s (never string fuzz — every model goes through
+`parse_kernel_source` + `build_model`, the same on-ramp `fslc` itself uses),
+compared across the three engines that do not depend on Z3js
+(`fsl_runtime::bfs` "Monitor BFS", `fsl_runtime::verify_explicit`, and
+`fsl_verifier::verify_bounded` "BMC", native Z3), plus seven metamorphic
+relations each with a positive test and a negative control.
+
+### Generation space
+
+`generator.rs::domain_sweep` crosses `docs/LANGUAGE.md` S2's four scalar
+domain kinds (`range`/`entity`/`number`/`enum`) at fifteen `(kind, size)`
+pairs against a structural variant selected by index (state-variable count
+1-2, action count 1-3, guard present/absent, fairness, and one of the five
+checkable property kinds — invariant/reachable/leadsTo/trans/terminal —
+so each kind is exercised at least once). `generator.rs::operation_sweep`
+covers `divide`/`remainder` in both property and (guarded, safe) action
+context; `head`/`pop`/`at`/index and the unguarded `divide`/`remainder`
+boundary live as dedicated `relations.rs` R6 tests instead (see "Two
+confirmed findings" below for why). Both floors are asserted in
+`typed_agreement.rs` (`DOMAIN_SWEEP_FLOOR = 15`, `OPERATION_SWEEP_FLOOR = 4`).
+The whole suite — generation, all engines, replay, successor sampling, and
+all R1-R7 relations — runs in well under a second; the ~2-minute budget
+the C6 brief set was never approached, so the generation space was not
+narrowed to fit it.
+
+### Metamorphic relations
+
+Each relation cites the `docs/LANGUAGE.md` contract sentence it tests, not
+observed CLI output:
+
+| # | Relation | Contract citation | Negative control |
+|---|---|---|---|
+| R1 | Alpha rename (whole-token substitution over every position `reserved.rs::check_reserved_names` walks) leaves the verdict unchanged | Pure syntactic substitution over an already-typechecked program (no direct citation needed; the rename fixture cross-checks its own position coverage against `check_reserved_names`'s source text) | Renaming onto an existing name is a duplicate declaration, rejected by `build_model` |
+| R2 | Leading BOM + trivia leaves the verdict unchanged | `lexer.rs::skip_trivia`: a BOM is trivia only at `offset == 0` | A BOM inside an identifier is a parse error |
+| R3 | Inline `state { x: T = e }` init reaches the same states as an equivalent explicit `init` block | LANGUAGE.md S2:499-508 ("normalized to an ordinary root assignment...same semantics as an equivalent `init` block") | Assigning the same root both inline and in `init` is `build_model`'s named semantic error |
+| R4 | Disjoint simultaneous assignments reach the same states regardless of source order | LANGUAGE.md S5:644-661 ("all right-hand sides...read the old state...frame condition is automatic") | Assigning the same variable twice on one path is the named semantic error |
+| R5 | A domain-bound-coincident invariant (`x <= hi`, textually equal to the type's own `hi`) holds at every declared size by construction | LANGUAGE.md S6 "Type bounds" (automatic, so a variable can never leave its own declared bound) | Widening the domain past the invariant's stale literal bound changes the verdict to `violated`; also reproduced mechanically via `enumerate_builtin_mutants`'s `type_bound_hi_plus1` |
+| R6 | `/`/`%` are total in property context but `partial_op` in action context | LANGUAGE.md S3:557-570 | The same expression in action context; see "Two confirmed findings" for what raw `verify_bounded` actually checks here |
+| R7 | `entity`/`number` + `verify` reaches the same states as the hand-written lowered `type` | LANGUAGE.md S2:485-486 ("desugars to `type`") | Shifting the lowered bound by +1 past the declared size is detected |
+
+`R4`'s `assignment_remove` and `R6`'s `equality_operator_flip` reuse of
+`fsl_tools::enumerate_builtin_mutants` follow the same discipline as
+`injection_detector_matrix.rs`: each candidate mutant's non-equivalence was
+measured (it must change the BMC verdict or fail to build) before the
+"must be a kill" assertion was written, and the first `type_bound_hi_plus1`
+candidate tried against R5's own fixture turned out equivalent — the
+mutation left the action's independently-derived wraparound modulus
+unchanged, so the widened domain was never actually reachable. That
+equivalent candidate is why R5's mutate-reuse test uses a separate,
+dedicated fixture instead of R5's own; see `relations.rs`'s
+`r5_mutate_kill_fixture` doc comment for the full account.
+
+### Two confirmed findings
+
+Both are recorded as re-measured facts, not silently normalized away or
+excluded:
+
+1. **A partial Seq read (`head()`) evaluated in property context on an
+   empty sequence disagrees across engines.** `fsl_runtime::verify_explicit`
+   and `fsl_runtime::bfs` both raise a raw `RuntimeError`
+   ("`head()` on empty sequence") instead of returning a verdict, because
+   `Monitor::current_violation[_selected]` — unlike
+   `Monitor::execute_selected`'s post-step invariant check — does not catch
+   `is_partial_operation_error` and convert it to a `partial_op` `Violation`.
+   `fsl_verifier::verify_bounded` instead returns a *verdict*: `violated`,
+   `kind: "invariant"` (not `partial_op`), naming the user's own invariant,
+   at step 0 — its symbolic Seq encoding treats an out-of-range read as
+   *defined* with some solver-chosen value outside the element type's own
+   declared bound, rather than as undefined the way the concrete engines
+   (and LANGUAGE.md's own account of `/`/`%`, by contrast) treat it. Root
+   cause in the symbolic encoding is not diagnosed here; that is for the
+   tracking issue. Self-retiring exclusion:
+   `relations.rs::r6_property_context_seq_head_disagrees_across_engines_self_retiring_exclusion`
+   re-measures the exact `(kind, name, step)` and both error messages on
+   every run.
+
+2. **`fsl_verifier::verify_bounded` does not perform LANGUAGE.md S6's
+   automatic "Partial operations" check at all**, for any of the six named
+   operations, in action context. `rust/fsl-verifier/src/bmc.rs` has no
+   `partial_op` handling anywhere in it; the CLI's `--engine bmc`
+   `partial_op` classification comes from `rust/fslc/src/verification.rs`'s
+   `run_bmc_filtered` merging in a *concrete* pre-scan
+   (`fsl_runtime::find_boundary_violation`), not from the solver. This is a
+   scope boundary this suite documents rather than a bug: raw
+   `verify_bounded`'s outcome for these six fixtures ranges from a clean
+   verdict (`divide`/`remainder`) to a spurious `type_bound` on the
+   assigned scalar (`head`/`at`/index — the same symbolic-Seq gap as
+   finding 1, surfacing differently) to `Err("model sequence length is
+   negative")` (`pop`) — all recorded, none asserted, in
+   `relations.rs::r6_action_context_partial_operations_are_caught_only_by_the_concrete_engines`.
+   The three concrete-family engines (Monitor BFS / explicit /
+   `find_boundary_violation`) agree with each other on `partial_op` for
+   all six.
+
+### Z3js / Worker parity ownership
+
+`fsl-solver-z3js` is `wasm-bindgen`-only and structurally unreachable from
+native `cargo test` — there is no native code path that links it. That
+column is not silently skipped: it is owned by `test-browser.mjs`'s Worker
+parity suite, which this C6 slice does not duplicate. C6 compares the
+three engines native tests *can* reach; a browser-side C6 sweep, if ever
+needed, is a Worker-suite concern, not a gap in this one.
+
+### Slice 2 plan
+
+`sweep_summary.rs` aggregates `(domain kind, domain size, property kind,
+state-variable count, action count, guarded, fair, operation/context)`
+counts and prints them at the end of `domain_sweep_agrees_across_all_three_engines`
+and `operation_sweep_agrees_across_all_three_engines` — a machine-readable,
+re-runnable count slice 2's C3 `expr` axis can cite instead of a prose
+claim. Slice 1 does not register an axis with `assurance_matrix.rs`; that
+registration, plus sweeping the full 22-variant `Expr` enum (this slice's
+generator covers arithmetic, comparison, logical, and the six partial
+operations, not aggregates/binders/relations), is slice 2's scope.
+
 ## Coupled changes
 
 `CONTRIBUTING.md` "Adding a language feature" gains: register any new dialect's

--- a/rust/fslc/tests/typed_agreement.rs
+++ b/rust/fslc/tests/typed_agreement.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! C6 typed generative / metamorphic cross-engine agreement suite (#537 C6
+//! slice 1, issue #648).
+//!
+//! Generates checked `KernelModel`s (never string fuzz) from a deterministic
+//! structural axis enumeration (`generator.rs`), compares Monitor BFS /
+//! explicit / BMC bounded verdicts and successors (`engines.rs`), and checks
+//! seven metamorphic relations with a negative control each (`relations.rs`).
+//! `sweep_summary.rs` aggregates what each sweep actually exercised.
+//!
+//! See `docs/DESIGN-conformance-harness.md`'s "Typed generative /
+//! metamorphic agreement (#537 C6)" section for the accepted design this
+//! implements, including why Z3js/Worker parity is out of scope here.
+
+#[path = "typed_agreement/engines.rs"]
+mod engines;
+#[path = "typed_agreement/generator.rs"]
+mod generator;
+#[path = "typed_agreement/relations.rs"]
+mod relations;
+#[path = "typed_agreement/sweep_summary.rs"]
+mod sweep_summary;
+
+use generator::{PropertyKind, domain_sweep, operation_sweep};
+use sweep_summary::SweepSummary;
+
+/// Generator floor, asserted per the brief and design's "assert model
+/// count is at least N" requirement: `domain_axis` has 15 `(kind, size)`
+/// pairs (S2's four scalar domain kinds), so anything below that means the
+/// axis enumeration itself regressed.
+const DOMAIN_SWEEP_FLOOR: usize = 15;
+/// `divide`/`remainder` guarded-action-context plus property-context
+/// entries. `head`/`pop`/`at`/index and the unguarded divide/remainder
+/// action-context boundary are exercised as dedicated `relations.rs` R6
+/// tests instead of this sweep; see `generator.rs::operation_sweep`'s doc.
+const OPERATION_SWEEP_FLOOR: usize = 4;
+
+#[test]
+fn domain_sweep_meets_its_generator_floor_and_covers_every_property_kind() {
+    let models = domain_sweep();
+    assert!(
+        models.len() >= DOMAIN_SWEEP_FLOOR,
+        "domain sweep floor: expected >= {DOMAIN_SWEEP_FLOOR}, got {}",
+        models.len()
+    );
+    for kind in [
+        PropertyKind::Invariant,
+        PropertyKind::Reachable,
+        PropertyKind::LeadsTo,
+        PropertyKind::Trans,
+        PropertyKind::Terminal,
+    ] {
+        assert!(
+            models.iter().any(|model| model.property_kind == kind),
+            "domain sweep must exercise property kind '{}' at least once",
+            kind.label()
+        );
+    }
+}
+
+#[test]
+fn operation_sweep_meets_its_generator_floor() {
+    let models = operation_sweep();
+    assert!(
+        models.len() >= OPERATION_SWEEP_FLOOR,
+        "operation sweep floor: expected >= {OPERATION_SWEEP_FLOOR}, got {}",
+        models.len()
+    );
+}
+
+/// The main sweep: every domain-axis model must build and its Monitor
+/// BFS / explicit / BMC verdicts must agree (`engines::run_agreement`
+/// panics on disagreement, so a clean run here already *is* the "zero
+/// cross-engine disagreements" evidence the brief asks to report).
+#[test]
+fn domain_sweep_agrees_across_all_three_engines() {
+    let mut summary = SweepSummary::default();
+    for model in domain_sweep() {
+        let built = engines::build(&model.id, &model.source);
+        engines::run_agreement(&model.id, &built, model.depth);
+        summary.record_domain_model(
+            model.domain_kind.label(),
+            model.domain_size,
+            model.property_kind.label(),
+            model.state_vars,
+            model.action_count,
+            model.guarded,
+            model.fair,
+        );
+    }
+    eprintln!("domain sweep summary: {summary}");
+}
+
+#[test]
+fn operation_sweep_agrees_across_all_three_engines() {
+    let mut summary = SweepSummary::default();
+    for model in operation_sweep() {
+        let built = engines::build(&model.id, &model.source);
+        engines::run_agreement(&model.id, &built, model.depth);
+        summary.record_operation_model(model.operation, model.context);
+    }
+    eprintln!("operation sweep summary: {summary}");
+}

--- a/rust/fslc/tests/typed_agreement/engines.rs
+++ b/rust/fslc/tests/typed_agreement/engines.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Builds a model from generated FSL source and runs the three native
+//! engines named in `docs/DESIGN-conformance-harness.md`'s C6 section --
+//! `fsl_runtime::bfs` ("Monitor BFS"), `fsl_runtime::verify_explicit`
+//! ("explicit"), and `fsl_verifier::verify_bounded` ("BMC", native Z3) --
+//! comparing verdicts, replaying evidence through `replay_trace`, and
+//! sampling successor admission through `transition_matches_step`.
+//!
+//! `block_on` is copied from `rust/fsl-verifier/tests/expression_agreement.rs`
+//! rather than shared, matching that file's own choice not to add a tokio
+//! dependency for one hand-rolled poll loop.
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, KernelModel, build_model, parse_kernel_source};
+use fsl_runtime::{Monitor, State, Violation};
+
+pub fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+/// Parse and typecheck one generated FSL source string.
+///
+/// # Panics
+///
+/// Panics (failing the calling test) when the model does not build: per the
+/// brief, a generator that emits an invalid model is a generator bug, not
+/// evidence to report.
+#[must_use]
+pub fn build(id: &str, source: &str) -> KernelModel {
+    let resolver = FsResolver::new(".");
+    let kernel = parse_kernel_source(source, &resolver)
+        .unwrap_or_else(|error| panic!("generator bug: '{id}' did not parse: {error}\n{source}"));
+    build_model(kernel).unwrap_or_else(|error| {
+        panic!("generator bug: '{id}' did not typecheck: {error}\n{source}")
+    })
+}
+
+/// A verdict normalized across the three engines: no violation, or the
+/// `(kind, name, step)` of the first one found. All three engines share the
+/// same `Violation` step convention (rooted in `Monitor`'s step counter), so
+/// no "proved"-vs-"verified" wording normalization is needed here the way
+/// the CLI-level corpus sweep in `explicit_engine.rs` needs one -- that
+/// wording is a CLI presentation-layer artifact, not part of these structs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Verdict {
+    Clean,
+    Violated {
+        kind: String,
+        name: String,
+        step: usize,
+    },
+}
+
+impl From<Option<Violation>> for Verdict {
+    fn from(violation: Option<Violation>) -> Self {
+        match violation {
+            None => Verdict::Clean,
+            Some(violation) => Verdict::Violated {
+                kind: violation.kind,
+                name: violation.name,
+                step: violation.step,
+            },
+        }
+    }
+}
+
+/// Run all engines relevant to `model` at `depth`, assert three-way
+/// agreement on the invariant/trans/reachable/type-bound verdict, and
+/// return that agreed verdict.
+///
+/// `LeadsTo` properties are out of scope for `verify_explicit`
+/// (`fsl_runtime::explicit_unsupported_reason` rejects any model that
+/// declares one) and are invisible to `fsl_runtime::bfs` (it never reads
+/// `model.leadstos`), so a model with a `leadsTo` property runs BMC only;
+/// see the module doc and `docs/DESIGN-conformance-harness.md` C6 for why
+/// asserting bfs/explicit "agreement" there would be vacuous rather than
+/// evidence.
+///
+/// # Panics
+///
+/// Panics on disagreement, an engine error other than the documented
+/// leadsTo boundary, or a witness/successor check failure.
+pub fn run_agreement(id: &str, model: &KernelModel, depth: usize) -> Verdict {
+    let bfs_result = fsl_runtime::bfs(model.clone(), depth)
+        .unwrap_or_else(|error| panic!("'{id}': Monitor BFS engine errored: {error}"));
+    let bfs_verdict = Verdict::from(bfs_result.violation.clone());
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create Z3 solver");
+    let bmc_result = block_on(fsl_verifier::verify_bounded(model, &mut solver, depth))
+        .unwrap_or_else(|error| panic!("'{id}': BMC engine errored: {error}"));
+    let bmc_verdict = Verdict::from(bmc_result.violation.clone().map(|violation| Violation {
+        kind: violation.kind,
+        name: violation.name,
+        step: violation.step,
+    }));
+
+    let has_leadsto = !model.leadstos.is_empty();
+    let explicit = if has_leadsto {
+        let reason = fsl_runtime::explicit_unsupported_reason(model).unwrap_or_else(|| {
+            panic!("'{id}': model declares leadsTo but explicit_unsupported_reason allowed it")
+        });
+        assert!(
+            reason.contains("leadsTo"),
+            "'{id}': explicit rejection reason changed shape, re-check the documented boundary: {reason}"
+        );
+        None
+    } else {
+        let explicit_result = fsl_runtime::verify_explicit(model.clone(), depth, 1_000_000)
+            .unwrap_or_else(|error| panic!("'{id}': explicit engine errored: {error}"));
+        let explicit_verdict =
+            Verdict::from(
+                explicit_result
+                    .violation
+                    .clone()
+                    .map(|violation| Violation {
+                        kind: violation.violation.kind,
+                        name: violation.violation.name,
+                        step: violation.violation.step,
+                    }),
+            );
+        assert_eq!(
+            bfs_verdict, explicit_verdict,
+            "'{id}': Monitor BFS and explicit disagree (bfs={bfs_verdict:?} explicit={explicit_verdict:?})"
+        );
+        assert_eq!(
+            explicit_verdict, bmc_verdict,
+            "'{id}': explicit and BMC disagree (explicit={explicit_verdict:?} bmc={bmc_verdict:?})"
+        );
+        Some((explicit_verdict, explicit_result))
+    };
+
+    if !has_leadsto {
+        assert_eq!(
+            bfs_verdict, bmc_verdict,
+            "'{id}': Monitor BFS and BMC disagree (bfs={bfs_verdict:?} bmc={bmc_verdict:?})"
+        );
+    }
+
+    if let Some((_, explicit_result)) = &explicit
+        && let Some(violation) = &explicit_result.violation
+    {
+        fsl_runtime::replay_trace(model.clone(), &violation.trace).unwrap_or_else(|error| {
+            panic!("'{id}': explicit violation trace did not replay: {error}")
+        });
+    }
+    if let Some(violation) = &bmc_result.violation {
+        fsl_runtime::replay_trace(model.clone(), &violation.trace)
+            .unwrap_or_else(|error| panic!("'{id}': BMC violation trace did not replay: {error}"));
+    }
+
+    sample_successor_admission(id, model, depth);
+
+    bmc_verdict
+}
+
+/// Walk `model` concretely for up to `depth` steps taking the first enabled
+/// action at each state (deterministic: no randomness), and assert every
+/// concrete step is admitted by the symbolic transition relation for the
+/// same action instance and successor
+/// (`fsl_verifier::transition_matches_step`, design step 7).
+fn sample_successor_admission(id: &str, model: &KernelModel, depth: usize) {
+    let mut monitor = Monitor::new(model.clone())
+        .unwrap_or_else(|error| panic!("'{id}': Monitor::new errored: {error}"));
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create Z3 solver");
+    for _ in 0..depth {
+        let enabled = monitor
+            .enabled()
+            .unwrap_or_else(|error| panic!("'{id}': Monitor::enabled errored: {error}"));
+        let Some(action) = enabled.into_iter().next() else {
+            break;
+        };
+        let current: State = monitor.state.clone();
+        let stepped = monitor
+            .step(&action)
+            .unwrap_or_else(|error| panic!("'{id}': Monitor::step errored: {error}"));
+        if stepped.violation.is_some() {
+            break;
+        }
+        let admitted = block_on(fsl_verifier::transition_matches_step(
+            model,
+            &mut solver,
+            &current,
+            &stepped.action,
+            &stepped.params,
+            &stepped.state,
+        ))
+        .unwrap_or_else(|error| panic!("'{id}': transition_matches_step errored: {error}"));
+        assert!(
+            admitted,
+            "'{id}': a real concrete step by '{}' was not admitted by the symbolic transition relation",
+            stepped.action
+        );
+    }
+}

--- a/rust/fslc/tests/typed_agreement/generator.rs
+++ b/rust/fslc/tests/typed_agreement/generator.rs
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Deterministic structural generator for the C6 typed generative /
+//! metamorphic agreement suite (#537 C6 slice 1, issue #648).
+//!
+//! Every model is produced by iterating fixed, named axes -- no randomness,
+//! no wall-clock reads -- so a failing model is reproducible from its `id`
+//! alone. Two families:
+//!
+//! - [`domain_sweep`]: domain kind x domain size x structural shape
+//!   (state-variable count, action count, guard, fairness, property kind).
+//!   Fifteen `(kind, size)` pairs from `docs/LANGUAGE.md` S2's four scalar
+//!   domain kinds, each crossed with a structural variant selected by index
+//!   so every one of the five checkable property kinds
+//!   (invariant/reachable/leadsTo/trans/terminal) is exercised at least
+//!   once (`PROPERTY_KINDS.len() == 5` divides the 15-entry axis evenly).
+//! - [`operation_sweep`]: the six partial operations `docs/LANGUAGE.md` S6
+//!   names (`head`/`pop`/`at`/index/`divide`/`remainder`), each placed at
+//!   its documented boundary. See the module doc on `relations.rs` R6 for
+//!   why `head`/`pop`/`at`/index are generated only in action context.
+//!
+//! `type Domain = 1..0` is this codebase's existing idiom for an empty
+//! finite domain (`rust/fsl-verifier/tests/expression_agreement.rs`,
+//! `bounded_verification_stops_after_initial_state_without_action_instances`).
+//! Size-0 and the +-1 domain boundary are R5's concern (`relations.rs`), not
+//! this generic sweep: a size-0 *state-variable* domain has no valid initial
+//! value, so the size axis here starts at 1 and R5 builds the empty-domain
+//! shape itself, matching how the existing corpus already uses it.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DomainKind {
+    Range,
+    Entity,
+    Number,
+    Enum,
+}
+
+impl DomainKind {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            DomainKind::Range => "range",
+            DomainKind::Entity => "entity",
+            DomainKind::Number => "number",
+            DomainKind::Enum => "enum",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PropertyKind {
+    Invariant,
+    Reachable,
+    LeadsTo,
+    Trans,
+    Terminal,
+}
+
+impl PropertyKind {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            PropertyKind::Invariant => "invariant",
+            PropertyKind::Reachable => "reachable",
+            PropertyKind::LeadsTo => "leadsTo",
+            PropertyKind::Trans => "trans",
+            PropertyKind::Terminal => "terminal",
+        }
+    }
+}
+
+const PROPERTY_KINDS: [PropertyKind; 5] = [
+    PropertyKind::Invariant,
+    PropertyKind::Reachable,
+    PropertyKind::LeadsTo,
+    PropertyKind::Trans,
+    PropertyKind::Terminal,
+];
+
+/// One generated model plus the sweep coordinates that produced it, so a
+/// failing agreement check can cite the exact axis combination without
+/// re-deriving it from `source`.
+#[derive(Clone, Debug)]
+pub struct GeneratedModel {
+    pub id: String,
+    pub source: String,
+    pub domain_kind: DomainKind,
+    pub domain_size: i64,
+    pub state_vars: usize,
+    pub action_count: usize,
+    pub guarded: bool,
+    pub fair: bool,
+    pub property_kind: PropertyKind,
+    pub depth: usize,
+}
+
+fn domain_axis() -> Vec<(DomainKind, i64)> {
+    let mut axis = Vec::new();
+    for size in [1, 2, 3, 4] {
+        axis.push((DomainKind::Range, size));
+    }
+    for size in [1, 2, 3] {
+        axis.push((DomainKind::Entity, size));
+    }
+    for size in [1, 2, 3, 4] {
+        axis.push((DomainKind::Number, size));
+    }
+    for size in [1, 2, 3, 4] {
+        axis.push((DomainKind::Enum, size));
+    }
+    axis
+}
+
+/// The domain x structure grid described in the module doc.
+#[must_use]
+pub fn domain_sweep() -> Vec<GeneratedModel> {
+    domain_axis()
+        .into_iter()
+        .enumerate()
+        .map(|(index, (kind, size))| build_domain_model(index, kind, size))
+        .collect()
+}
+
+struct IntDomain {
+    type_name: String,
+    decl: String,
+    trailer: Option<String>,
+    lo: i64,
+    hi: i64,
+}
+
+fn int_domain(kind: DomainKind, index: usize, size: i64) -> IntDomain {
+    let hi = size - 1;
+    match kind {
+        DomainKind::Range => {
+            let type_name = format!("D{index}");
+            IntDomain {
+                decl: format!("type {type_name} = 0..{hi}"),
+                trailer: None,
+                type_name,
+                lo: 0,
+                hi,
+            }
+        }
+        DomainKind::Entity => {
+            let type_name = format!("E{index}");
+            IntDomain {
+                decl: format!("entity {type_name}"),
+                trailer: Some(format!("verify {{ instances {type_name} = {size} }}")),
+                type_name,
+                lo: 0,
+                hi,
+            }
+        }
+        DomainKind::Number => {
+            let type_name = format!("N{index}");
+            IntDomain {
+                decl: format!("number {type_name}"),
+                trailer: Some(format!("verify {{ values {type_name} = 0..{hi} }}")),
+                type_name,
+                lo: 0,
+                hi,
+            }
+        }
+        DomainKind::Enum => unreachable!("enum uses build_enum_model"),
+    }
+}
+
+fn build_domain_model(index: usize, kind: DomainKind, size: i64) -> GeneratedModel {
+    let state_vars = if index.is_multiple_of(2) { 1 } else { 2 };
+    let action_count = 1 + index % 3;
+    let guarded = index.is_multiple_of(2);
+    let fair = index.is_multiple_of(3);
+    let property_kind = PROPERTY_KINDS[index % PROPERTY_KINDS.len()];
+    let id = format!(
+        "domain_{}_{size}_sv{state_vars}_ac{action_count}_{}",
+        kind.label(),
+        property_kind.label()
+    );
+    let source = if matches!(kind, DomainKind::Enum) {
+        render_enum_model(
+            index,
+            size,
+            state_vars,
+            action_count,
+            guarded,
+            fair,
+            property_kind,
+        )
+    } else {
+        render_int_model(
+            int_domain(kind, index, size),
+            index,
+            state_vars,
+            action_count,
+            guarded,
+            fair,
+            property_kind,
+        )
+    };
+    GeneratedModel {
+        id,
+        source,
+        domain_kind: kind,
+        domain_size: size,
+        state_vars,
+        action_count,
+        guarded,
+        fair,
+        property_kind,
+        depth: 6,
+    }
+}
+
+fn render_int_model(
+    domain: IntDomain,
+    index: usize,
+    state_vars: usize,
+    action_count: usize,
+    guarded: bool,
+    fair: bool,
+    property_kind: PropertyKind,
+) -> String {
+    let IntDomain {
+        type_name,
+        decl,
+        trailer,
+        lo,
+        hi,
+    } = domain;
+    let size = hi - lo + 1;
+    let mut source = format!("spec IntDomain{index} {{\n  {decl}\n  state {{\n    x: {type_name}");
+    if state_vars == 2 {
+        source.push_str(",\n    flag: Bool");
+    }
+    source.push_str("\n  }\n  init {\n");
+    let _ = writeln!(source, "    x = {lo}");
+    if state_vars == 2 {
+        source.push_str("    flag = false\n");
+    }
+    source.push_str("  }\n");
+
+    let advance_prefix = if fair { "fair action" } else { "action" };
+    let advance = if guarded {
+        format!("{advance_prefix} advance() {{\n    requires x < {hi}\n    x = x + 1\n  }}\n")
+    } else {
+        format!("{advance_prefix} advance() {{\n    x = (x + 1) % {size}\n  }}\n")
+    };
+    let reset = format!("action reset() {{\n    requires x == {hi}\n    x = {lo}\n  }}\n");
+    let extra = if state_vars == 2 {
+        "action toggle() {\n    flag = not flag\n  }\n".to_owned()
+    } else {
+        "action hold() {\n    x = x\n  }\n".to_owned()
+    };
+    for action in [advance, reset, extra].into_iter().take(action_count) {
+        source.push_str("  ");
+        source.push_str(&action);
+    }
+
+    match property_kind {
+        PropertyKind::Invariant => {
+            let _ = writeln!(source, "  invariant Bounded {{ x >= {lo} and x <= {hi} }}");
+        }
+        PropertyKind::Reachable => {
+            let _ = writeln!(source, "  reachable ReachedHi {{ x == {hi} }}");
+        }
+        PropertyKind::LeadsTo => {
+            let _ = writeln!(source, "  leadsTo Advances {{ x == {lo} ~> x == {hi} }}");
+        }
+        PropertyKind::Trans => {
+            let _ = writeln!(source, "  trans Monotone {{ x >= old(x) or x == {lo} }}");
+        }
+        PropertyKind::Terminal => {
+            let _ = writeln!(source, "  invariant Bounded {{ x >= {lo} and x <= {hi} }}");
+            let _ = writeln!(source, "  terminal {{ x == {hi} }}");
+        }
+    }
+    source.push_str("}\n");
+    if let Some(trailer) = trailer {
+        source.push_str(&trailer);
+        source.push('\n');
+    }
+    source
+}
+
+fn render_enum_model(
+    index: usize,
+    size: i64,
+    state_vars: usize,
+    action_count: usize,
+    guarded: bool,
+    fair: bool,
+    property_kind: PropertyKind,
+) -> String {
+    let type_name = format!("Enm{index}");
+    let members: Vec<String> = (0..size).map(|k| format!("M{k}")).collect();
+    let lo = members
+        .first()
+        .expect("enum has at least one member")
+        .clone();
+    let hi = members
+        .last()
+        .expect("enum has at least one member")
+        .clone();
+    let mut source = format!(
+        "spec EnumDomain{index} {{\n  enum {type_name} {{ {} }}\n  state {{\n    x: {type_name}",
+        members.join(", ")
+    );
+    if state_vars == 2 {
+        source.push_str(",\n    flag: Bool");
+    }
+    let _ = writeln!(source, "\n  }}\n  init {{\n    x = {lo}");
+    if state_vars == 2 {
+        source.push_str("    flag = false\n");
+    }
+    source.push_str("  }\n");
+
+    let first_action_prefix = if fair { "fair action" } else { "action" };
+    let mut actions = Vec::new();
+    if guarded {
+        for window in members.windows(2) {
+            let prefix = if actions.is_empty() {
+                first_action_prefix
+            } else {
+                "action"
+            };
+            actions.push(format!(
+                "{prefix} advance_{}() {{\n    requires x == {}\n    x = {}\n  }}\n",
+                actions.len(),
+                window[0],
+                window[1]
+            ));
+        }
+        actions.push(format!(
+            "action reset() {{\n    requires x == {hi}\n    x = {lo}\n  }}\n"
+        ));
+    } else {
+        let mut chain = lo.clone();
+        for window in members.windows(2).rev() {
+            chain = format!(
+                "if x == {} then {}\n           else {chain}",
+                window[0], window[1]
+            );
+        }
+        actions.push(format!(
+            "{first_action_prefix} advance() {{\n    x = {chain}\n  }}\n"
+        ));
+    }
+    if state_vars == 2 {
+        actions.push("action toggle() {\n    flag = not flag\n  }\n".to_owned());
+    } else {
+        actions.push("action hold() {\n    x = x\n  }\n".to_owned());
+    }
+    for action in actions.into_iter().take(action_count.max(1)) {
+        source.push_str("  ");
+        source.push_str(&action);
+    }
+
+    match property_kind {
+        PropertyKind::Invariant => {
+            let _ = writeln!(source, "  invariant Known {{ x == {lo} or x != {lo} }}");
+        }
+        PropertyKind::Reachable => {
+            let _ = writeln!(source, "  reachable ReachedHi {{ x == {hi} }}");
+        }
+        PropertyKind::LeadsTo => {
+            let _ = writeln!(source, "  leadsTo Advances {{ x == {lo} ~> x == {hi} }}");
+        }
+        PropertyKind::Trans => {
+            let _ = writeln!(source, "  trans StaysKnown {{ old(x) == old(x) }}");
+        }
+        PropertyKind::Terminal => {
+            let _ = writeln!(source, "  invariant Known {{ x == {lo} or x != {lo} }}");
+            let _ = writeln!(source, "  terminal {{ x == {hi} }}");
+        }
+    }
+    source.push_str("}\n");
+    source
+}
+
+/// `divide`/`remainder`, each in action context (guarded, so no partial-op
+/// boundary is ever crossed here -- that boundary is exercised by the
+/// dedicated, unguarded action-context tests in `relations.rs`'s R6 section
+/// instead, because `fsl_verifier::verify_bounded` does not perform the
+/// automatic "Partial operations" check on its own; see that section's
+/// module doc) and in property context, where S3:561-563 guarantees
+/// totalization. `head`/`pop`/`at`/index are exercised only in
+/// `relations.rs` for the same reason, not swept here.
+#[derive(Clone, Debug)]
+pub struct OperationModel {
+    pub id: String,
+    pub source: String,
+    pub operation: &'static str,
+    pub context: &'static str,
+    pub depth: usize,
+}
+
+#[must_use]
+pub fn operation_sweep() -> Vec<OperationModel> {
+    vec![
+        OperationModel {
+            id: "operation_divide_action".to_owned(),
+            source: r"
+spec OperationDivideAction {
+  type Small = -3..3
+  state { x: Small, y: Small, q: Small }
+  init { x = -3 y = 0 q = 0 }
+  action step() {
+    requires y != 0
+    q = x / y
+    y = y + 1
+  }
+  invariant Euclid { y == 0 or x == y * (x / y) + (x % y) }
+}
+"
+            .to_owned(),
+            operation: "divide",
+            context: "action",
+            depth: 4,
+        },
+        OperationModel {
+            id: "operation_remainder_action".to_owned(),
+            source: r"
+spec OperationRemainderAction {
+  type Small = -3..3
+  state { x: Small, y: Small, r: Small }
+  init { x = -3 y = 0 r = 0 }
+  action step() {
+    requires y != 0
+    r = x % y
+    y = y + 1
+  }
+  invariant BoundedRemainder { y == 0 or (0 <= r and r < 3) or (-3 < r and r <= 0) }
+}
+"
+            .to_owned(),
+            operation: "remainder",
+            context: "action",
+            depth: 4,
+        },
+        OperationModel {
+            id: "operation_divide_property".to_owned(),
+            source: r"
+spec OperationDivideProperty {
+  type Small = -3..3
+  state { x: Small }
+  init { x = 0 }
+  action stay() { x = x }
+  invariant ZeroDivTotal { 5 / 0 == 0 and x / 0 == 0 }
+}
+"
+            .to_owned(),
+            operation: "divide",
+            context: "property",
+            depth: 2,
+        },
+        OperationModel {
+            id: "operation_remainder_property".to_owned(),
+            source: r"
+spec OperationRemainderProperty {
+  type Small = -3..3
+  state { x: Small }
+  init { x = 0 }
+  action stay() { x = x }
+  invariant ZeroModTotal { 5 % 0 == 0 and x % 0 == 0 }
+}
+"
+            .to_owned(),
+            operation: "remainder",
+            context: "property",
+            depth: 2,
+        },
+    ]
+}
+
+use std::fmt::Write as _;

--- a/rust/fslc/tests/typed_agreement/relations.rs
+++ b/rust/fslc/tests/typed_agreement/relations.rs
@@ -1,0 +1,971 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Metamorphic relations R1-R7 (#537 C6 slice 1, issue #648), each with a
+//! positive test and a negative control. Every positive expectation cites
+//! the `docs/LANGUAGE.md` contract sentence it is licensed by (never
+//! transcribed from observed CLI output); R5's boundary expectation is
+//! declared structurally (domain bound coincides with the invariant bound
+//! by construction) before the mutation that breaks it runs.
+//!
+//! R6 additionally records two confirmed cross-engine findings instead of
+//! silently normalizing them away: a self-retiring exclusion for
+//! `head()` read from property context on an empty sequence (BMC finds a
+//! spurious `violated`/`invariant` while the concrete engines correctly
+//! error), and a documented scope boundary for the six partial operations
+//! in *action* context (`fsl_verifier::verify_bounded` alone does not
+//! perform LANGUAGE.md S6's automatic "Partial operations" check at all --
+//! only the concrete engines and the CLI's own `find_boundary_violation`
+//! pre-scan do).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_core::{FsResolver, KernelModel, build_model, parse_kernel_source};
+use fsl_runtime::{Monitor, State};
+use fsl_tools::{BuiltinMutant, enumerate_builtin_mutants};
+
+use super::engines;
+
+fn build(id: &str, source: &str) -> KernelModel {
+    engines::build(id, source)
+}
+
+/// Full-depth solver-free reachable-state enumeration by direct `Monitor`
+/// walk (no invariant checking -- these fixtures are constructed to be
+/// violation-free, and verdict agreement is checked separately). Used only
+/// for relations that keep identical variable/type names between variants
+/// (R3, R4, R7); R1 renames names, so state sets are compared as `Clean`
+/// verdicts instead, not as raw sets.
+fn reachable_states(model: &KernelModel, depth: usize) -> BTreeSet<State> {
+    let initial = Monitor::new(model.clone()).expect("Monitor::new for reachable-state walk");
+    let mut visited = BTreeSet::from([initial.state.clone()]);
+    let mut frontier = vec![initial];
+    for _ in 0..depth {
+        let mut next = Vec::new();
+        for monitor in &frontier {
+            let enabled = monitor.enabled().expect("enabled");
+            for action in enabled {
+                let mut child = monitor.clone();
+                let stepped = child.step(&action).expect("step");
+                if stepped.violation.is_some() {
+                    continue;
+                }
+                if visited.insert(child.state.clone()) {
+                    next.push(child);
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    visited
+}
+
+// ---------------------------------------------------------------------
+// R1: alpha rename.
+// LANGUAGE.md does not need to license this one directly: renaming every
+// declaration and reference to it is a pure syntactic substitution over an
+// already-typechecked program, so the *typed* semantics (what `build_model`
+// produces) cannot depend on the spelling. The contract this leans on is
+// `reserved.rs::check_reserved_names`'s own position enumeration, which the
+// self-check below cross-references so the rename fixture cannot silently
+// stop covering a position category that gains one.
+// ---------------------------------------------------------------------
+
+const R1_BASE: &str = r"
+spec RenameBase {
+  const Limit = 2
+  type Slot = 0..2
+  enum Stage { Open, Closed }
+  state {
+    x: Slot,
+    stage: Stage
+  }
+  init {
+    x = 0
+    stage = Open
+  }
+  action advance(step: Slot) {
+    requires x + step <= Limit
+    x = x + step
+  }
+  action close() {
+    requires stage == Open
+    stage = Closed
+  }
+  invariant Bounded { x >= 0 and x <= Limit }
+}
+";
+
+/// Whole-token identifier substitution: every maximal run of
+/// `[A-Za-z0-9_]` that exactly matches a key in `renames` is replaced by its
+/// value, everywhere it occurs (declaration and every reference alike) --
+/// this is what makes it an *alpha* rename rather than a single-site edit.
+fn rename_identifiers(source: &str, renames: &BTreeMap<String, String>) -> String {
+    let mut output = String::with_capacity(source.len());
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let ch = source[i..].chars().next().expect("valid UTF-8 boundary");
+        if ch.is_alphabetic() || ch == '_' {
+            let start = i;
+            let mut end = i + ch.len_utf8();
+            while end < bytes.len() {
+                let next_ch = source[end..].chars().next().expect("valid UTF-8 boundary");
+                if next_ch.is_alphanumeric() || next_ch == '_' {
+                    end += next_ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            let token = &source[start..end];
+            output.push_str(renames.get(token).map_or(token, String::as_str));
+            i = end;
+        } else {
+            output.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+    output
+}
+
+fn r1_renames() -> BTreeMap<String, String> {
+    BTreeMap::from(
+        [
+            ("RenameBase", "RenameBaseRenamed"),
+            ("Limit", "Cap"),
+            ("Slot", "Cell"),
+            ("Stage", "Phase"),
+            ("Open", "Started"),
+            ("Closed", "Finished"),
+            ("x", "pos"),
+            ("stage", "phase"),
+            ("advance", "step_forward"),
+            ("step", "amount"),
+            ("close", "finish"),
+            ("Bounded", "WithinLimit"),
+        ]
+        .map(|(from, to)| (from.to_owned(), to.to_owned())),
+    )
+}
+
+/// Position categories `reserved.rs::check_reserved_names` walks, by the
+/// exact string literal it passes to `check`/`check_param`/`check_binder`.
+/// Cross-referenced against the source text so a category rename or
+/// addition there fails this test loudly instead of leaving R1's coverage
+/// claim stale. `def`/`def parameter`/struct positions are intentionally
+/// not exercised by `R1_BASE` (no `def` or `struct` item); the whole-token
+/// substitution mechanism does not distinguish position categories, so this
+/// records which categories the *fixture* instantiates, not a gap in the
+/// substitution mechanism itself.
+const R1_COVERED_POSITION_CATEGORIES: &[&str] = &[
+    "specification",
+    "const",
+    "type",
+    "enum",
+    "enum member",
+    "state variable",
+    "action",
+    "parameter",
+    "property",
+];
+
+#[test]
+fn r1_rename_fixture_position_categories_still_exist_in_check_reserved_names() {
+    let source = include_str!("../../../fsl-core/src/reserved.rs");
+    for category in R1_COVERED_POSITION_CATEGORIES {
+        assert!(
+            source.contains(&format!("\"{category}\"")),
+            "reserved.rs no longer checks the '{category}' position that R1's rename \
+             fixture claims to cover; update R1_COVERED_POSITION_CATEGORIES and R1_BASE"
+        );
+    }
+}
+
+#[test]
+fn r1_alpha_rename_preserves_verdict_across_all_engines() {
+    let renamed_source = rename_identifiers(R1_BASE, &r1_renames());
+
+    let original = build("r1_original", R1_BASE);
+    let renamed = build("r1_renamed", &renamed_source);
+
+    let original_run = engines::run_agreement("r1_original", &original, 4);
+    let renamed_run = engines::run_agreement("r1_renamed", &renamed, 4);
+
+    assert_eq!(
+        original_run,
+        engines::Verdict::Clean,
+        "R1 baseline must be clean by construction"
+    );
+    assert_eq!(
+        renamed_run,
+        engines::Verdict::Clean,
+        "alpha rename must not change the verdict (BMC saw {renamed_run:?})"
+    );
+}
+
+/// Negative control: renaming a declaration onto an *existing* name is a
+/// collision, not a rename, and must be rejected.
+#[test]
+fn r1_negative_control_rejects_a_colliding_rename() {
+    let collision = BTreeMap::from([("Slot".to_owned(), "Stage".to_owned())]);
+    let collided_source = rename_identifiers(R1_BASE, &collision);
+
+    let resolver = FsResolver::new(".");
+    match parse_kernel_source(&collided_source, &resolver) {
+        Err(_) => {} // rejected at parse time: also valid evidence of detection
+        Ok(kernel) => {
+            build_model(kernel).expect_err(
+                "renaming 'Slot' onto the existing enum name 'Stage' must be rejected as a \
+                 duplicate declaration, not silently accepted",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// R2: BOM / trivia.
+// `rust/fsl-syntax/src/lexer.rs` `skip_trivia`: a BOM is only trivia at
+// `self.offset == 0`, i.e. the very start of the source. Anywhere else it is
+// just another character the lexer does not recognize.
+// ---------------------------------------------------------------------
+
+const R2_BASE: &str = r"
+spec BomBase {
+  type D = 0..2
+  state { x: D }
+  init { x = 0 }
+  action advance() {
+    requires x < 2
+    x = x + 1
+  }
+  invariant Bounded { x >= 0 and x <= 2 }
+}
+";
+
+#[test]
+fn r2_leading_bom_and_trivia_preserve_verdict() {
+    let with_bom_and_trivia =
+        format!("\u{FEFF}   \n// C6 R2: leading trivia after the BOM\n{R2_BASE}");
+
+    let plain = build("r2_plain", R2_BASE);
+    let decorated = build("r2_bom_trivia", &with_bom_and_trivia);
+
+    let plain_run = engines::run_agreement("r2_plain", &plain, 3);
+    let decorated_run = engines::run_agreement("r2_bom_trivia", &decorated, 3);
+
+    assert_eq!(plain_run, engines::Verdict::Clean);
+    assert_eq!(decorated_run, engines::Verdict::Clean);
+}
+
+/// Negative control: a BOM inserted mid-identifier is not trivia (offset != 0),
+/// so it must be a parse error rather than silently ignored or accepted as an
+/// identifier character.
+#[test]
+fn r2_negative_control_rejects_bom_inside_an_identifier() {
+    let mutated = R2_BASE.replacen("advance", "adv\u{FEFF}ance", 1);
+    let resolver = FsResolver::new(".");
+    parse_kernel_source(&mutated, &resolver)
+        .expect_err("a BOM inside an identifier must be a parse error, not silently accepted");
+}
+
+// ---------------------------------------------------------------------
+// R3: inline init <-> explicit init block.
+// LANGUAGE.md S2:499-508: an inline `name: Type = expr` initializer "is
+// normalized to an ordinary root assignment before checking, so Monitor,
+// explicit exploration, BMC, induction, and Public Kernel v1 observe the
+// same semantics as an equivalent `init` block" and "Assigning the same
+// root both inline and in `init` is a semantic error that reports both
+// source locations."
+// ---------------------------------------------------------------------
+
+const R3_INLINE: &str = r"
+spec R3Inline {
+  type D = 0..2
+  state {
+    x: D = 0,
+    y: Bool = false
+  }
+  action advance() {
+    requires x < 2
+    x = x + 1
+    y = not y
+  }
+  invariant Bounded { x >= 0 and x <= 2 }
+}
+";
+
+const R3_EXPLICIT: &str = r"
+spec R3Explicit {
+  type D = 0..2
+  state {
+    x: D,
+    y: Bool
+  }
+  init {
+    x = 0
+    y = false
+  }
+  action advance() {
+    requires x < 2
+    x = x + 1
+    y = not y
+  }
+  invariant Bounded { x >= 0 and x <= 2 }
+}
+";
+
+#[test]
+fn r3_inline_init_matches_explicit_init_block_verdict_and_reachable_states() {
+    let inline = build("r3_inline", R3_INLINE);
+    let explicit = build("r3_explicit", R3_EXPLICIT);
+
+    let inline_run = engines::run_agreement("r3_inline", &inline, 4);
+    let explicit_run = engines::run_agreement("r3_explicit", &explicit, 4);
+    assert_eq!(inline_run, engines::Verdict::Clean);
+    assert_eq!(explicit_run, engines::Verdict::Clean);
+
+    let inline_states = reachable_states(&inline, 4);
+    let explicit_states = reachable_states(&explicit, 4);
+    assert_eq!(
+        inline_states, explicit_states,
+        "LANGUAGE.md S2:499-508: inline init must reach exactly the states an equivalent \
+         explicit init block reaches"
+    );
+}
+
+/// Negative control: assigning the same root both inline and in `init` is
+/// LANGUAGE.md's own named semantic error.
+#[test]
+fn r3_negative_control_rejects_the_same_root_assigned_inline_and_in_init() {
+    let source = r"
+spec R3DoubleAssign {
+  type D = 0..2
+  state { x: D = 0 }
+  init { x = 1 }
+  action stay() { x = x }
+  invariant Any { x >= 0 }
+}
+";
+    let resolver = FsResolver::new(".");
+    let kernel = parse_kernel_source(source, &resolver).expect("parses");
+    let error = build_model(kernel)
+        .expect_err("assigning 'x' both inline and in init must be a semantic error");
+    assert!(
+        error
+            .message
+            .contains("both an inline initializer and init"),
+        "unexpected message: {}",
+        error.message
+    );
+}
+
+// ---------------------------------------------------------------------
+// R4: disjoint simultaneous assignment reorder.
+// LANGUAGE.md S5:644-661: "all right-hand sides in an action body read the
+// old state. Variables that are not assigned do not change (the frame
+// condition is automatic)" -- so two assignments to *different* variables in
+// one action body have no data dependency on each other's order.
+// ---------------------------------------------------------------------
+
+fn r4_source(first: &str, second: &str) -> String {
+    format!(
+        r"
+spec R4Reorder {{
+  type D = 0..2
+  state {{ a: D, b: D }}
+  init {{ a = 0 b = 0 }}
+  action step() {{
+    requires a == 0
+    {first}
+    {second}
+  }}
+  invariant BothOrNeither {{ (a == 1) == (b == 2) }}
+}}
+"
+    )
+}
+
+#[test]
+fn r4_disjoint_assignment_reorder_matches_verdict_and_reachable_states() {
+    let forward = build("r4_forward", &r4_source("a = 1", "b = 2"));
+    let reordered = build("r4_reordered", &r4_source("b = 2", "a = 1"));
+
+    let forward_run = engines::run_agreement("r4_forward", &forward, 3);
+    let reordered_run = engines::run_agreement("r4_reordered", &reordered, 3);
+    assert_eq!(forward_run, engines::Verdict::Clean);
+    assert_eq!(reordered_run, engines::Verdict::Clean);
+
+    let forward_states = reachable_states(&forward, 3);
+    let reordered_states = reachable_states(&reordered, 3);
+    assert_eq!(
+        forward_states, reordered_states,
+        "LANGUAGE.md S5:644-661: disjoint simultaneous assignments must reach the same states \
+         regardless of source order"
+    );
+}
+
+/// Negative control: assigning the same variable twice on one execution path
+/// is LANGUAGE.md's own named semantic error ("Double assignment").
+#[test]
+fn r4_negative_control_rejects_the_same_variable_assigned_twice() {
+    let source = r"
+spec R4DoubleAssign {
+  type D = 0..2
+  state { a: D }
+  init { a = 0 }
+  action step() {
+    a = 1
+    a = 2
+  }
+  invariant Any { a >= 0 }
+}
+";
+    let resolver = FsResolver::new(".");
+    let kernel = parse_kernel_source(source, &resolver).expect("parses");
+    build_model(kernel).expect_err("assigning 'a' twice on one path must be a semantic error");
+}
+
+// ---------------------------------------------------------------------
+// R5: finite domain size boundary.
+// The expectation is declared structurally, not from observed output: an
+// invariant whose bound is textually identical to the domain's declared
+// `hi` can never be violated, for any domain size, because a state variable
+// can never leave its own declared bound (LANGUAGE.md S6 "Type bounds" is
+// automatic). Widening the domain by 1 while leaving the invariant's literal
+// bound unchanged breaks that coincidence by construction.
+// ---------------------------------------------------------------------
+
+fn r5_source(hi: i64, invariant_bound: i64) -> String {
+    format!(
+        r"
+spec R5Boundary {{
+  type D = 0..{hi}
+  state {{ x: D }}
+  init {{ x = 0 }}
+  action advance() {{
+    x = (x + 1) % {size}
+  }}
+  invariant TightBound {{ x <= {invariant_bound} }}
+}}
+",
+        size = hi + 1
+    )
+}
+
+#[test]
+fn r5_domain_size_boundary_verdict_change_matches_the_declared_structural_expectation() {
+    // Declared upfront: for any domain size N (hi = N-1), `x <= hi` can never
+    // be violated because it restates the type's own automatic bound. This
+    // must hold at N=1, N=2, N=3 alike.
+    for size in [1_i64, 2, 3] {
+        let hi = size - 1;
+        let model = build(&format!("r5_size_{size}"), &r5_source(hi, hi));
+        let run = engines::run_agreement(&format!("r5_size_{size}"), &model, 4);
+        assert_eq!(
+            run,
+            engines::Verdict::Clean,
+            "declared expectation: a domain-bound-coincident invariant holds at every size"
+        );
+    }
+
+    // Declared upfront: widening the domain to hi+1 while leaving the
+    // invariant's literal bound at the old hi breaks the coincidence, so the
+    // wrapped value hi+1 now both stays in-domain (no type_bound violation)
+    // and violates the stale invariant.
+    let widened = build("r5_widened", &r5_source(3, 2));
+    let widened_run = engines::run_agreement("r5_widened", &widened, 4);
+    assert!(
+        matches!(widened_run, engines::Verdict::Violated { .. }),
+        "declared expectation: widening the domain past the invariant's literal bound must \
+         change the verdict to violated (got {widened_run:?})"
+    );
+}
+
+// ---------------------------------------------------------------------
+// R6: short-circuit / partial operation / Euclidean division duality.
+// LANGUAGE.md S3:557-570: `/`/`%` are total in property context (`a/0==0`,
+// `a%0==0`) but still reported `partial_op` when read unguarded in an
+// action's requires/body/ensures -- a contract about `fslc verify`'s
+// observable behavior, not about the bare `fsl_verifier::verify_bounded`
+// function alone; see
+// `assert_action_context_partial_op_is_caught_only_concretely`'s doc for why
+// those two are not the same thing. `docs/LANGUAGE.md` S6's "Partial
+// operations" row scopes the *checked* class to action context; it makes no
+// totalization promise for `head`/`pop`/`at`/index the way S3 explicitly
+// does for `/`/`%`, so this suite exercises the six named operations in
+// action context via the dedicated tests below (not
+// `generator.rs::operation_sweep`, which only carries the safe/totalized
+// entries `engines::run_agreement`'s raw-BMC comparison can actually make),
+// and records the property-context asymmetry as its own finding below
+// instead of assuming S3's `/`/`%` guarantee extends to them.
+// ---------------------------------------------------------------------
+
+#[test]
+fn r6_euclidean_identity_is_proved_and_totalized_in_property_context() {
+    let source = r"
+spec R6Euclid {
+  type Small = -3..3
+  state { x: Small }
+  init { x = 0 }
+  action stay() { x = x }
+  invariant EuclidNonzero { x == 2 * (x / 2) + (x % 2) }
+  invariant EuclidRemainderRange { 0 <= x % 2 and x % 2 < 2 }
+  invariant ZeroDivTotal { x / 0 == 0 and x % 0 == 0 }
+}
+";
+    let model = build("r6_euclid_property", source);
+    let run = engines::run_agreement("r6_euclid_property", &model, 3);
+    assert_eq!(
+        run,
+        engines::Verdict::Clean,
+        "LANGUAGE.md S3:559-563: the Euclidean identity and the /0,%0 total value must both \
+         verify cleanly in property context"
+    );
+}
+
+/// The automatic "Partial operations" check (`docs/LANGUAGE.md` S6, action
+/// context only) is not performed by `fsl_verifier::verify_bounded`'s own
+/// symbolic loop: `rust/fsl-verifier/src/bmc.rs` has no `partial_op`
+/// handling anywhere in it. `rust/fslc/src/verification.rs`'s
+/// `run_bmc_filtered` produces the CLI's `--engine bmc` `partial_op`
+/// classification by merging in a *concrete* pre-scan
+/// (`fsl_runtime::find_boundary_violation`), not from the solver. So the
+/// three-way comparison this suite uses everywhere else
+/// (`engines::run_agreement`, which asserts raw `verify_bounded` agrees
+/// with Monitor BFS / explicit) does not apply to an unguarded
+/// action-context partial operation: raw `verify_bounded` reports Clean by
+/// construction, which is a documented capability gap in what the bare
+/// solver checks, not a disagreement to investigate. This asserts the
+/// concrete family (Monitor BFS / explicit / the concrete
+/// `find_boundary_violation` pre-scan the CLI itself relies on) agrees
+/// among itself, and separately documents raw BMC's Clean result, for one
+/// of `docs/LANGUAGE.md` S6's six named partial operations.
+fn assert_action_context_partial_op_is_caught_only_concretely(
+    id: &str,
+    source: &str,
+    depth: usize,
+) {
+    let model = build(id, source);
+
+    let bfs_violation = fsl_runtime::bfs(model.clone(), depth)
+        .unwrap_or_else(|error| panic!("'{id}': Monitor BFS errored: {error}"))
+        .violation
+        .unwrap_or_else(|| panic!("'{id}': Monitor BFS found no violation"));
+    assert_eq!(bfs_violation.kind, "partial_op", "'{id}': Monitor BFS kind");
+
+    let explicit_violation = fsl_runtime::verify_explicit(model.clone(), depth, 1_000)
+        .unwrap_or_else(|error| panic!("'{id}': explicit errored: {error}"))
+        .violation
+        .unwrap_or_else(|| panic!("'{id}': explicit found no violation"))
+        .violation;
+    assert_eq!(
+        (explicit_violation.kind.as_str(), explicit_violation.step),
+        (bfs_violation.kind.as_str(), bfs_violation.step),
+        "'{id}': Monitor BFS and explicit disagree"
+    );
+
+    let (boundary_violation, _trace) = fsl_runtime::find_boundary_violation(model.clone(), depth)
+        .unwrap_or_else(|error| panic!("'{id}': find_boundary_violation errored: {error}"))
+        .unwrap_or_else(|| panic!("'{id}': find_boundary_violation found no violation"));
+    assert_eq!(
+        boundary_violation.kind, "partial_op",
+        "'{id}': find_boundary_violation kind"
+    );
+
+    // Raw `verify_bounded` is not asserted against here at all: it never
+    // performs the "Partial operations" check itself (confirmed above the
+    // module), but its own *unrelated* automatic type-bound check can still
+    // independently misfire on the same underlying symbolic-Seq gap this
+    // module's `r6_property_context_seq_head_disagrees_across_engines_...`
+    // test documents -- observed outcomes range from a clean verdict
+    // (`divide`/`remainder`), to a spurious `type_bound` on the assigned
+    // scalar (`head`/`at`/index), to `verify_bounded` itself returning
+    // `Err("model sequence length is negative")` (`pop`). All three are the
+    // same underlying symbolic-Seq gap surfacing differently depending on
+    // where the phantom value flows, not independent findings, so this
+    // helper does not assert a specific raw-BMC outcome per operation --
+    // only records whichever one occurs for visibility.
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    match engines::block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth)) {
+        Ok(bmc) => eprintln!(
+            "'{id}': raw verify_bounded (not asserted) = {:?}",
+            bmc.violation
+        ),
+        Err(error) => eprintln!("'{id}': raw verify_bounded (not asserted) errored: {error}"),
+    }
+}
+
+#[test]
+fn r6_action_context_partial_operations_are_caught_only_by_the_concrete_engines() {
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_head",
+        r"
+spec R6ActionHead {
+  type Item = 0..2
+  state { queue: Seq<Item, 2>, last: Item }
+  init { queue = Seq {} last = 0 }
+  action drain() { last = queue.head() }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_pop",
+        r"
+spec R6ActionPop {
+  type Item = 0..2
+  state { queue: Seq<Item, 2> }
+  init { queue = Seq {} }
+  action drain() { queue = queue.pop() }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_at",
+        r"
+spec R6ActionAt {
+  type Item = 0..2
+  state { queue: Seq<Item, 2>, picked: Item }
+  init { queue = Seq {} picked = 0 }
+  action pick() { picked = queue.at(0) }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_index",
+        r"
+spec R6ActionIndex {
+  type Item = 0..2
+  state { queue: Seq<Item, 2>, picked: Item }
+  init { queue = Seq {} picked = 0 }
+  action pick() { picked = queue[0] }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_divide",
+        r"
+spec R6ActionDivide {
+  type Small = -3..3
+  state { x: Small, y: Small, q: Small }
+  init { x = -3 y = 0 q = 0 }
+  action divide_unguarded() { q = x / y }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_is_caught_only_concretely(
+        "r6_action_remainder",
+        r"
+spec R6ActionRemainder {
+  type Small = -3..3
+  state { x: Small, y: Small, r: Small }
+  init { x = -3 y = 0 r = 0 }
+  action remainder_unguarded() { r = x % y }
+}
+",
+        2,
+    );
+}
+
+/// #537 C6 slice 1 finding, recorded as a self-retiring exclusion rather
+/// than silently normalized away: a partial Seq read (`head`) evaluated in
+/// *property* context on a sequence that is empty at the initial state
+/// disagrees across engines instead of being caught uniformly.
+///
+/// Observed (this test re-measures every value below on every run):
+///
+/// - `fsl_runtime::verify_explicit` / `fsl_runtime::bfs` ("Monitor BFS"):
+///   both raise a raw `RuntimeError` ("`head()` on empty sequence") instead of
+///   returning a verdict. Both call `Monitor::current_violation[_selected]`,
+///   which -- unlike `Monitor::execute_selected`'s post-step invariant check
+///   -- does not catch `is_partial_operation_error` and convert it to a
+///   `partial_op` `Violation`; the CLI surfaces this as
+///   `result:"error"`/`kind:"semantics"` rather than a verdict at all.
+/// - BMC (`verify_bounded`): returns a *verdict*, not an error --
+///   `violated`, `kind:"invariant"` (the plain property-failure
+///   classification, not `partial_op`), `name:"HeadRead"` (the invariant's
+///   own declared name), at `step:0` (the initial state itself, before any
+///   action runs). The witness trace's projected state shows `queue` as the
+///   empty sequence it actually is at init. This means BMC's symbolic
+///   encoding treats `queue.head()` on an empty sequence as *defined* with
+///   some value the solver is free to pick outside `Item`'s `0..2` bound,
+///   rather than as undefined the way the concrete engines (and this
+///   suite's own `Monitor`-direct walk) treat it -- a distinct, and
+///   arguably more concerning, discrepancy than "differing labels for the
+///   same undefinedness": BMC is not applying LANGUAGE.md's action-context
+///   `partial_op` treatment here at all, and property-context totalization
+///   is only documented for `/`/`%` (S3:561-563), not for `head`. Root
+///   cause in the symbolic Seq encoding is not diagnosed here; that is a
+///   question for the tracking issue, not this suite.
+///
+/// A fix that makes the two engine families agree turns the `expect_err`
+/// calls or the `kind`/`name`/`step` assertions below into failures, so the
+/// exclusion cannot go stale silently.
+#[test]
+fn r6_property_context_seq_head_disagrees_across_engines_self_retiring_exclusion() {
+    let source = r"
+spec R6HeadPropertyDisagreement {
+  type Item = 0..2
+  state { queue: Seq<Item, 2> }
+  init { queue = Seq {} }
+  action stay() { queue = queue }
+  invariant HeadRead { queue.head() >= 0 }
+}
+";
+    let model = build("r6_head_property_disagreement", source);
+
+    let bfs_error = fsl_runtime::bfs(model.clone(), 2).expect_err(
+        "premise re-measurement: Monitor BFS must still error on an empty-sequence head() \
+         read in property context; if this now returns Ok, the engines agree and this \
+         exclusion (and the R6 doc note) must be retired",
+    );
+    assert!(
+        bfs_error.message.contains("head() on empty sequence"),
+        "bfs error message changed shape, re-check the exclusion: {bfs_error}"
+    );
+
+    let explicit_error = fsl_runtime::verify_explicit(model.clone(), 2, 100).expect_err(
+        "premise re-measurement: explicit must still error the same way as Monitor BFS",
+    );
+    assert!(
+        explicit_error.message.contains("head() on empty sequence"),
+        "explicit error message changed shape, re-check the exclusion: {explicit_error}"
+    );
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let bmc_result = engines::block_on(fsl_verifier::verify_bounded(&model, &mut solver, 2))
+        .expect("premise re-measurement: BMC must still return a clean Result, not error");
+    let violation = bmc_result
+        .violation
+        .expect("premise re-measurement: BMC must still report a violation, not a clean verdict");
+    assert_eq!(
+        (
+            violation.kind.as_str(),
+            violation.name.as_str(),
+            violation.step
+        ),
+        ("invariant", "HeadRead", 0),
+        "BMC's classification of the same condition changed shape, re-check the exclusion: \
+         {violation:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// R7: entity / number sugar vs hand-written lowered kernel type.
+// LANGUAGE.md S2:485-486: "Entity kind ... desugars to type Claim =
+// 0..N-1" and "Number kind ... desugars to type".
+// ---------------------------------------------------------------------
+
+const R7_BODY_TEMPLATE: &str = r"
+  state { x: Item }
+  init { x = 0 }
+  action advance() {
+    requires x < {hi}
+    x = x + 1
+  }
+  invariant Bounded { x >= 0 and x <= {hi} }
+";
+
+#[test]
+fn r7_entity_desugar_matches_hand_written_lowered_type() {
+    let sugar = format!(
+        "spec R7EntitySugar {{\n  entity Item\n{}}}\nverify {{ instances Item = 3 }}\n",
+        R7_BODY_TEMPLATE.replace("{hi}", "2")
+    );
+    let lowered = format!(
+        "spec R7EntityLowered {{\n  type Item = 0..2\n{}}}\n",
+        R7_BODY_TEMPLATE.replace("{hi}", "2")
+    );
+
+    let sugar_model = build("r7_entity_sugar", &sugar);
+    let lowered_model = build("r7_entity_lowered", &lowered);
+
+    let sugar_run = engines::run_agreement("r7_entity_sugar", &sugar_model, 4);
+    let lowered_run = engines::run_agreement("r7_entity_lowered", &lowered_model, 4);
+    assert_eq!(sugar_run, engines::Verdict::Clean);
+    assert_eq!(lowered_run, engines::Verdict::Clean);
+
+    assert_eq!(
+        reachable_states(&sugar_model, 4),
+        reachable_states(&lowered_model, 4),
+        "LANGUAGE.md S2:485-486: 'entity Item' + 'verify instances Item = 3' must reach exactly \
+         the states 'type Item = 0..2' reaches"
+    );
+}
+
+#[test]
+fn r7_number_desugar_matches_hand_written_lowered_type() {
+    let sugar = format!(
+        "spec R7NumberSugar {{\n  number Item\n{}}}\nverify {{ values Item = 0..2 }}\n",
+        R7_BODY_TEMPLATE.replace("{hi}", "2")
+    );
+    let lowered = format!(
+        "spec R7NumberLowered {{\n  type Item = 0..2\n{}}}\n",
+        R7_BODY_TEMPLATE.replace("{hi}", "2")
+    );
+
+    let sugar_model = build("r7_number_sugar", &sugar);
+    let lowered_model = build("r7_number_lowered", &lowered);
+
+    assert_eq!(
+        reachable_states(&sugar_model, 4),
+        reachable_states(&lowered_model, 4),
+        "LANGUAGE.md S2:485-486: 'number Item' + 'verify values Item = 0..2' must reach exactly \
+         the states 'type Item = 0..2' reaches"
+    );
+}
+
+/// Negative control: shifting the hand-written lowered bound by 1 relative
+/// to the entity's declared instance count must be detected -- it lets `x`
+/// reach a value the entity-sugar side's invariant (calibrated to the
+/// declared size) forbids.
+#[test]
+fn r7_negative_control_detects_a_mis_lowered_bound() {
+    let sugar = format!(
+        "spec R7EntitySugarNeg {{\n  entity Item\n{}}}\nverify {{ instances Item = 3 }}\n",
+        R7_BODY_TEMPLATE.replace("{hi}", "2")
+    );
+    // Shifted by +1: the lowered type now admits x == 3, one past the
+    // entity's declared instance count, while the guard/invariant literal
+    // bound in the template stays at 2 (mirroring the sugar side).
+    let mis_lowered = "spec R7EntityLoweredNeg {\n  type Item = 0..3\n  state { x: Item }\n  init { x = 0 }\n  \
+         action advance() {\n    x = x + 1\n  }\n  invariant Bounded { x >= 0 and x <= 2 }\n}\n";
+
+    let sugar_model = build("r7_entity_sugar_neg", &sugar);
+    let mis_lowered_model = build("r7_entity_lowered_neg", mis_lowered);
+
+    let sugar_run = engines::run_agreement("r7_entity_sugar_neg", &sugar_model, 4);
+    assert_eq!(sugar_run, engines::Verdict::Clean);
+
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let mis_lowered_bmc = engines::block_on(fsl_verifier::verify_bounded(
+        &mis_lowered_model,
+        &mut solver,
+        4,
+    ))
+    .expect("bmc run on mis-lowered variant");
+    assert!(
+        mis_lowered_bmc.violation.is_some(),
+        "a lowered bound shifted +1 past the entity's declared size must be detected as a \
+         disagreement, not silently accepted as equivalent"
+    );
+}
+
+// ---------------------------------------------------------------------
+// `enumerate_builtin_mutants` reuse: kill-controls per the brief's mutate-
+// reuse instruction. Each mutant's non-equivalence is *measured* here (the
+// BMC verdict flips from Clean to Violated, or the mutant fails to build)
+// rather than assumed; the comment beside each `.find` records the measured
+// selection basis, and an equivalent candidate is never substituted in to
+// pad the count.
+// ---------------------------------------------------------------------
+
+fn assert_builtin_mutant_is_a_kill(op: &str, mutant: &BuiltinMutant, depth: usize) {
+    let Ok(kernel) = fsl_core::lower_direct_spec(mutant.spec.clone()) else {
+        return; // failing to build is itself a valid "kill" per the brief
+    };
+    let Ok(model) = build_model(kernel) else {
+        return;
+    };
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let bmc = engines::block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth))
+        .unwrap_or_else(|error| panic!("bmc run on '{op}' mutant errored: {error}"));
+    assert!(
+        bmc.violation.is_some(),
+        "mutant '{op}' is equivalent (still verifies clean) -- reselect a non-equivalent \
+         instance and record the new selection basis"
+    );
+}
+
+/// A dedicated fixture for the `type_bound_hi_plus1` kill-control, distinct
+/// from `r5_source`: `r5_source`'s action recomputes its wraparound modulus
+/// as `hi + 1` fresh from the *hand-edited* source text (see its negative
+/// control above, which calls `r5_source` directly with a new `hi`), but
+/// `enumerate_builtin_mutants` only rewrites the `type` item's literal bound
+/// -- it does not know the action body's `% size` literal was derived from
+/// that same bound, so mutating `r5_source(2, 2)` in place leaves the
+/// action wrapping at the *old* modulus and the mutant is equivalent
+/// (measured, not assumed: this was the first candidate tried, and
+/// `assert_builtin_mutant_is_a_kill` caught it -- see the git history of
+/// this file). This fixture's action has no bound-matching literal at all
+/// (an unguarded `x = x + 1`), so widening the type's `hi` is the only
+/// thing that changes whether `x` can reach a value the stale invariant
+/// forbids.
+fn r5_mutate_kill_fixture() -> &'static str {
+    r"
+spec R5MutateKill {
+  type D = 0..2
+  state { x: D }
+  init { x = 0 }
+  action advance() {
+    x = x + 1
+  }
+  invariant TightBound { x <= 2 }
+}
+"
+}
+
+#[test]
+fn mutate_reuse_kill_controls_are_measured_non_equivalent_and_detected() {
+    // R5: type_bound_hi_plus1. Measured basis: widening D's hi from 2 to 3
+    // lets the unguarded `advance` reach x == 3 within depth 3, violating
+    // the invariant's literal (unmutated) bound of 2.
+    let r5_spec =
+        fsl_syntax::parse_surface_spec(r5_mutate_kill_fixture()).expect("parse R5 fixture");
+    let r5_mutants = enumerate_builtin_mutants(&r5_spec);
+    let hi_plus1 = r5_mutants
+        .iter()
+        .find(|mutant| mutant.op == "type_bound_hi_plus1")
+        .expect("type_bound_hi_plus1 mutant must exist for R5's single domain type");
+    assert_builtin_mutant_is_a_kill("type_bound_hi_plus1", hi_plus1, 3);
+
+    // R6: equality_operator_flip on a requires guard whose flip newly admits
+    // a previously-unreachable action. Measured basis: the fixture has
+    // exactly one `==`/`!=` comparison inside a mutated scope (action
+    // requires/body/ensures; invariants are not mutated by this tool), so
+    // the single `equality_operator_flip` candidate is unambiguous. Flipping
+    // `x == 1` to `x != 1` makes `risky` enabled from the initial state
+    // (x == 0) instead of `safe`'s unconditional identity update, and
+    // `risky` sets x = 2, immediately violating NeverTwo.
+    let r6_source = r"
+spec R6EqualityKill {
+  type D = 0..2
+  state { x: D }
+  init { x = 0 }
+  action safe() {
+    x = 0
+  }
+  action risky() {
+    requires x == 1
+    x = 2
+  }
+  invariant NeverTwo { x != 2 }
+}
+";
+    let r6_spec = fsl_syntax::parse_surface_spec(r6_source).expect("parse R6 equality fixture");
+    let r6_mutants = enumerate_builtin_mutants(&r6_spec);
+    let flip = r6_mutants
+        .iter()
+        .find(|mutant| mutant.op == "equality_operator_flip")
+        .expect("equality_operator_flip mutant must exist for R6's requires guard");
+    assert_builtin_mutant_is_a_kill("equality_operator_flip", flip, 2);
+
+    // R4: assignment_remove on one of the disjoint assignments. Measured
+    // basis: removing `b = 2` leaves `b` unchanged after the step, breaking
+    // BothOrNeither ((a == 1) == (b == 2)).
+    let r4_spec =
+        fsl_syntax::parse_surface_spec(&r4_source("a = 1", "b = 2")).expect("parse R4 fixture");
+    let r4_mutants = enumerate_builtin_mutants(&r4_spec);
+    let removed = r4_mutants
+        .iter()
+        .find(|mutant| mutant.op == "assignment_remove")
+        .expect("assignment_remove mutant must exist for R4's disjoint assignments");
+    assert_builtin_mutant_is_a_kill("assignment_remove", removed, 3);
+}

--- a/rust/fslc/tests/typed_agreement/sweep_summary.rs
+++ b/rust/fslc/tests/typed_agreement/sweep_summary.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Machine-readable sweep summary: counts of (domain kind, domain size,
+//! property kind, operation/context) this run actually exercised, printed
+//! at the end of each sweep test so a future #537 C3 slice-2 `expr` axis
+//! citation can point at a specific, re-runnable count instead of a prose
+//! claim. Slice 1 only aggregates; it does not register an axis with the C3
+//! matrix (`assurance_matrix.rs`) -- that is slice 2's job, per
+//! `docs/DESIGN-conformance-harness.md`'s C6 section.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Default, Debug)]
+pub struct SweepSummary {
+    domain_kind_counts: BTreeMap<String, usize>,
+    domain_size_counts: BTreeMap<i64, usize>,
+    property_kind_counts: BTreeMap<String, usize>,
+    state_var_counts: BTreeMap<usize, usize>,
+    action_counts: BTreeMap<usize, usize>,
+    guarded_count: usize,
+    fair_count: usize,
+    operation_counts: BTreeMap<String, usize>,
+    total_models: usize,
+}
+
+impl SweepSummary {
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_domain_model(
+        &mut self,
+        domain_kind: &str,
+        domain_size: i64,
+        property_kind: &str,
+        state_vars: usize,
+        action_count: usize,
+        guarded: bool,
+        fair: bool,
+    ) {
+        *self
+            .domain_kind_counts
+            .entry(domain_kind.to_owned())
+            .or_insert(0) += 1;
+        *self.domain_size_counts.entry(domain_size).or_insert(0) += 1;
+        *self
+            .property_kind_counts
+            .entry(property_kind.to_owned())
+            .or_insert(0) += 1;
+        *self.state_var_counts.entry(state_vars).or_insert(0) += 1;
+        *self.action_counts.entry(action_count).or_insert(0) += 1;
+        if guarded {
+            self.guarded_count += 1;
+        }
+        if fair {
+            self.fair_count += 1;
+        }
+        self.total_models += 1;
+    }
+
+    pub fn record_operation_model(&mut self, operation: &str, context: &str) {
+        *self
+            .operation_counts
+            .entry(format!("{operation}/{context}"))
+            .or_insert(0) += 1;
+        self.total_models += 1;
+    }
+}
+
+impl fmt::Display for SweepSummary {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "total_models={} domain_kinds={:?} domain_sizes={:?} property_kinds={:?} \
+             state_vars={:?} action_counts={:?} guarded={} fair={} operations={:?}",
+            self.total_models,
+            self.domain_kind_counts,
+            self.domain_size_counts,
+            self.property_kind_counts,
+            self.state_var_counts,
+            self.action_counts,
+            self.guarded_count,
+            self.fair_count,
+            self.operation_counts
+        )
+    }
+}


### PR DESCRIPTION
# Problem

#537 C6 requires typed generative / metamorphic agreement: generate checked `KernelModel`s (never string fuzz), compare Monitor/explicit-BFS/BMC bounded verdicts and successors, and check named metamorphic relations with a negative control each. No such suite existed — cross-engine agreement was only exercised by hand-written fixtures, and no test compared a dialect construct's semantics against its documented desugaring.

# Contract change

- **`rust/fslc/tests/typed_agreement.rs` + `typed_agreement/{generator,engines,relations,sweep_summary}.rs` (new)**: a deterministic structural generator (no randomness, no clocks) builds 15 domain-axis models (range/entity/number/enum × size × structural shape, covering all five checkable property kinds) and 4 operation-axis models (divide/remainder in property and action context). Every model builds (typechecks) and its Monitor BFS / explicit / BMC verdicts, kinds, and steps must agree; every violation/witness trace replays through `replay_trace`; sampled concrete steps are checked against the symbolic transition relation (`transition_matches_step`).
- Seven metamorphic relations (R1-R7), each with a positive test and a negative control, every positive expectation cited to a `docs/LANGUAGE.md` contract sentence (never transcribed from observed output): alpha rename, BOM/trivia, inline-vs-explicit init, disjoint assignment reorder, domain-size boundary, partial-op/Euclidean duality, entity/number sugar vs hand-written lowered type. Three `enumerate_builtin_mutants` operators reused as measured non-equivalent kill-controls (selection basis recorded, one initially-equivalent candidate rejected and documented).
- **Two cross-engine disagreements found and recorded as self-retiring exclusions, not silently normalized**:
  1. `head()` on an empty `Seq` evaluated in **property** context: Monitor BFS/explicit correctly raise a `RuntimeError`; `verify_bounded`'s symbolic Seq encoding instead returns a *verdict* (`violated`/`kind:"invariant"`, step 0) built on a solver-chosen out-of-bound phantom value — the same freedom that produces this false positive could produce a false negative on the other polarity.
  2. `fsl_verifier::verify_bounded` alone performs none of LANGUAGE.md §6's automatic "Partial operations" check in action context, for any of the six named operations — the CLI's `--engine bmc` classification depends entirely on a separate concrete pre-scan (`find_boundary_violation`) that `run_bmc_filtered` merges in; a bare-library or future Worker-verb caller would silently lose the lane.
- Z3js recorded as structurally unreachable from native tests (`wasm-bindgen`-only crate) — that column stays owned by `test-browser.mjs` Worker parity, not silently skipped.
- `docs/DESIGN-conformance-harness.md`: "Typed generative / metamorphic agreement (#537 C6)" section — generation space, relation table with citations, the two findings, ownership boundaries, slice 2 plan (`sweep_summary.rs` aggregates a machine-readable count a future C3 `expr` axis can cite).

# Test evidence

Exit codes measured directly, no pipes:

- `cargo fmt --check` 0; `cargo clippy --workspace --all-targets --locked -- -D warnings` 0
- `typed_agreement` 21/21 pass, 0.39s wall-clock
- `cargo test -p fsl-verifier -p fsl-runtime --locked` 0 (all suites green, no regression from the two-finding discovery or the mutate-reuse fixtures)
- `./tools/check-native-integration.sh rust` 0; `wasm` 0 (415 parity cases, 4 exclusion probes)
- `tools/run-fault-operators.sh` 0 (4 operators primary=failed/blind=ok, both controls correct)

Closes #648. Part of #537 C6 slice 1. Two follow-up issues filed for the confirmed cross-engine findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
