### PR TITLE
test(assurance): register the expr, types, and dialects axes (#537 C3 slices 2+3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Semantic Assurance Matrix slices 2/3 add source-derived `expr` (24
+  `Expr` + 4 `AggregateKind` rows), `types` (9 `TypeRef` + 3 `TypeDef`
+  rows), and `dialects` (all 10 `frontends!` keywords) axes for issue #537
+  C3. A 25-model deterministic C6 family now checks all evaluator-reachable
+  expression variants and all type rows across Monitor BFS / explicit / BMC,
+  with a known-violating paired control for every model, while `Call`/`Stage`,
+  standalone refinement checks, and the Worker's missing agent path are
+  recorded with fail-closed evidence.
 - `rust/fslc/tests/typed_agreement.rs` introduces the C6 typed generative /
   metamorphic cross-engine agreement suite (issue #537 C6 slice 1, issue
   #648, `docs/DESIGN-conformance-harness.md` "Typed generative / metamorphic

--- a/docs/DESIGN-assurance-matrix.md
+++ b/docs/DESIGN-assurance-matrix.md
@@ -9,9 +9,10 @@ generalized across every semantic/product surface: rows are semantic
 features, columns are verification/rendering surfaces, and every cell is one
 of `exercised` / `rejecting-control` / `unsupported-fail-closed` /
 `not-applicable` (with a reason), never blank. This document is the accepted
-design for slice 1: the mechanism (`Claim`/`Citation`/aggregator/negative
-controls) plus two fully-registered axes (`outcome_kind`, `violation_kind`)
-and one axis pending citation completion (`properties`).
+design for slices 1–3: the mechanism
+(`Claim`/`Citation`/aggregator/negative controls) and the fully registered
+`outcome_kind`, `violation_kind`, `properties`, `expr`, `types`, and
+`dialects` axes.
 
 This is not the assurance-*class* vocabulary in
 [`DESIGN-assurance-classes.md`](DESIGN-assurance-classes.md) (`proved` /
@@ -54,7 +55,10 @@ No new crate, no central hand-written table.
   types and their `recheck`/`check_complete`/`check_citations` methods.
 - `rust/fslc/tests/assurance/outcome_kind.rs`,
   `rust/fslc/tests/assurance/violation_kind.rs`,
-  `rust/fslc/tests/assurance/properties.rs` — one module per semantic-surface
+  `rust/fslc/tests/assurance/properties.rs`,
+  `rust/fslc/tests/assurance/expr.rs`,
+  `rust/fslc/tests/assurance/types.rs`, and
+  `rust/fslc/tests/assurance/dialects.rs` — one module per semantic-surface
   axis. Each module owns its own `axis()` constructor and any small targeted
   test it needed to write because no existing test cleanly covered a cell.
 
@@ -300,15 +304,101 @@ property group, the anchor is the kernel schema's `properties.required`
 list plus `kernel_schema_property_groups_match_the_axis_rows` (see the
 `properties` axis section above).
 
-## Slice 2 / slice 3 plan
+## Slices 2 and 3: expressions, types, and dialects (implemented)
 
-- **Slice 2** (`expr` axis): `fsl_syntax::Expr`'s 22 variants +
-  `AggregateKind`'s 4, connecting to C6's typed generative/metamorphic
-  agreement sweep once that lands.
-- **Slice 3**: `types` axis (`TypeRef`'s 9 variants, `TypeDef`'s 3),
-  `dialects` axis (`dispatch.rs`'s `DIALECT_KEYWORDS`, single-sourced from
-  the `frontends!` macro). Also: extend the specs-only BMC/explicit
-  agreement sweep (`explicit_engine.rs`'s largest existing cell,
-  `explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec`) to cover
-  `examples/`, and add an `induction` column to that sweep once a
-  representative induction-provable subset of the corpus is identified.
+### `expr` axis (slice 2)
+
+`assurance/enum_rows.rs` derives 24 `Expr` rows and four `AggregateKind` rows
+through declarations that generate both an exhaustive match on the real enum
+and the witnesses used to enumerate it. The earlier plan's count of 22 was
+stale: `Call` and `Stage` are live syntax variants, although neither is
+allowed to reach a checked Kernel evaluator. The axis and the C6 sweep consume
+this shared source-coupled inventory, so adding a variant cannot be repaired by
+updating a label match while forgetting its row or generated-model posture.
+
+Declared columns are `Monitor` and `BMC` (28 × 2 = 56 cells). The explicit
+engine is deliberately not a third expression column: it drives the same
+concrete evaluator as Monitor. It remains present in the C6 agreement sweep
+as an independent exploration/verdict/replay control, but does not constitute
+a third expression implementation.
+
+- 52 cells are `Exercised`: the 22 evaluator-reachable `Expr` variants and
+  four `AggregateKind` rows on both columns.
+- Four cells are `UnsupportedFailClosed`: `Expr::Call` and `Expr::Stage` on
+  both columns. `PredicateExpander` eliminates valid direct-spec calls and
+  `StageResolver` eliminates valid business/requirements stage access during
+  lowering. `typecheck.rs::infer_type_inner` rejects either form if it leaks
+  into the public Kernel. The targeted control
+  `unlowered_call_and_stage_fail_closed_before_evaluator_entry` injects each
+  into a parsed typed surface tree, re-runs the ordinary semantic build gate,
+  and observes the named rejection before either evaluator can run.
+
+The exercising citation is executable, not prose:
+`typed_agreement.rs::expression_variant_sweep_agrees_across_all_three_engines_and_covers_all_types`.
+`generator.rs::expression_sweep` supplies 25 deterministic, in-process models:
+one for each non-aggregate checked variant and one for each of the four
+aggregate kinds (so `Expr::Aggregate` is observed four times). Each model is
+parsed and checked, its designated variant is confirmed in the resulting
+expression tree, and then Monitor BFS / explicit / BMC verdict, replay, and
+sampled-successor admission are compared. Every positive model must be clean;
+the test then negates its known-true `Variant` expression and requires all
+three engines to report the same step-zero invariant violation. The
+`unique`/`exactlyOne` models additionally exercise zero, one, and two matching
+bindings. `Expr::EnumMember`, which ordinary
+enum tokens do not retain as a direct-spec node, uses the documented
+`build_surface_model` typed-AST mutation gate and is re-typechecked before the
+same comparison. `sweep_summary.rs` records a per-row
+`expression_variants={...}` / `aggregate_kinds={...}` summary; this is the
+explicit C6 `sweep_summary` → C3 `Citation` connection planned in slice 1.
+
+### `types` axis (slice 3)
+
+The shared source-coupled declarations in `assurance/enum_rows.rs` likewise
+derive all nine `TypeRef` rows and all three `TypeDef` rows through exhaustive
+matches plus generated witnesses. Declared columns are `Monitor` and `BMC`
+(12 × 2 = 24 cells), all `Exercised`.
+
+The expression family deliberately carries `Int`, `Bool`, `Named`, inline
+`Range`, `Map`, `Relation`, `Set`, `Seq`, and `Option` state/type positions,
+plus `Domain`, `Enum`, and `Struct` definitions. The C6 test recursively reads
+the checked `KernelModel` type inventory, requires all 12 rows, then passes the
+same models through concrete and symbolic evaluation. The type cells therefore
+cite observed value construction/comparison rather than a parser-only mention.
+
+### `dialects` axis (slice 3)
+
+`assurance/dialects.rs` reads its ten rows directly from
+`fsl_syntax::DIALECT_KEYWORDS`, which the `frontends!` macro emits from the
+same invocation that builds the dispatch table. No second ten-string row list
+exists. `every_registered_dialect_has_a_corpus_representative_and_reviewed_posture`
+also derives the observed corpus set with `dialect_keyword`; a frontend
+addition fails an explicit rejecting default in each posture mapping until its
+CLI, Worker, and corpus ownership are adjudicated.
+
+Declared columns are `CLI check`, `Worker`, and `corpus` (10 × 3 = 30 cells):
+
+- 27 cells are `Exercised`. Ordinary dialect checks cite the native bare-check
+  sweep; Worker cells cite the all-corpus normalized-envelope parity harness;
+  corpus ownership cites the C4 bare-check/gallery, refinement, or evidence
+  manifest appropriate to the dialect.
+- Three cells are `UnsupportedFailClosed`. Two are `refinement`: a mapping has
+  no standalone Kernel `state`, so native bare `check` refuses it and the
+  Worker parity corpus confirms the same refusal. Its actual semantics remain
+  owned and exercised by `refine_corpus_parity.rs` under `fslc refine`. The
+  third is `agent` × Worker: native runs its lenient agent analysis while the
+  Worker has no agent path and stops at the Kernel lowering gate.
+  `test-browser.mjs::assertAgentWorkerProbeFailsClosed` is the agent-specific,
+  self-retiring error assertion. The harness's other three unsupported probes
+  are causal documents, but causal intentionally bypasses `frontends!` and is
+  therefore not a dialect-axis row.
+
+### Deferred corpus/induction expansion
+
+The earlier “also” item is not implemented in slices 2/3: the specs-only
+BMC/explicit corpus sweep is not extended to `examples/`, and no induction
+column is added. That work first needs execution-cost measurement and a
+declared representative subset whose properties are genuinely
+induction-provable; adding the whole corpus would conflate unsupported or
+bounded-only properties with missing assurance. A later independent slice
+should measure the expanded sweep, publish the subset rule, and only then
+register those columns.

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -465,6 +465,25 @@ context; `head`/`pop`/`at`/index and the unguarded `divide`/`remainder`
 boundary live as dedicated `relations.rs` R6 tests instead (see "Two
 confirmed findings" below for why). Both floors are asserted in
 `typed_agreement.rs` (`DOMAIN_SWEEP_FLOOR = 15`, `OPERATION_SWEEP_FLOOR = 4`).
+
+Slice 2 adds `generator.rs::expression_sweep`: 25 deterministic models
+designate every evaluator-reachable `Expr` variant, with separate models for
+all four `AggregateKind` values. Each model carries the same finite schema
+containing all nine `TypeRef` and all three `TypeDef` rows. The test confirms
+the designated expression node in the checked model, derives and checks the
+12-row type inventory, then runs the same Monitor BFS / explicit / BMC
+agreement, replay, and successor-admission path as the earlier families.
+The source-coupled row declarations generate both their exhaustive enum match
+and enumeration witnesses; the generated-model labels must equal those row
+sets exactly. Each positive model must return a clean verdict, after which its
+known-true invariant is negated and all three engines must detect the same
+step-zero violation. The `unique` and `exactlyOne` representatives cover zero,
+one, and multiple matching bindings rather than only their empty case.
+`Expr::EnumMember` is a typed generated form rather than a retained
+direct-spec token, so its family starts from a parsed model, replaces the
+token in the typed surface tree, and re-runs `build_surface_model` before any
+evaluator sees it.
+
 The whole suite — generation, all engines, replay, successor sampling, and
 all R1-R7 relations — runs in well under a second; the ~2-minute budget
 the C6 brief set was never approached, so the generation space was not
@@ -548,17 +567,28 @@ parity suite, which this C6 slice does not duplicate. C6 compares the
 three engines native tests *can* reach; a browser-side C6 sweep, if ever
 needed, is a Worker-suite concern, not a gap in this one.
 
-### Slice 2 plan
+### Slice 2 implementation
 
-`sweep_summary.rs` aggregates `(domain kind, domain size, property kind,
-state-variable count, action count, guarded, fair, operation/context)`
-counts and prints them at the end of `domain_sweep_agrees_across_all_three_engines`
-and `operation_sweep_agrees_across_all_three_engines` — a machine-readable,
-re-runnable count slice 2's C3 `expr` axis can cite instead of a prose
-claim. Slice 1 does not register an axis with `assurance_matrix.rs`; that
-registration, plus sweeping the full 22-variant `Expr` enum (this slice's
-generator covers arithmetic, comparison, logical, and the six partial
-operations, not aggregates/binders/relations), is slice 2's scope.
+`sweep_summary.rs` now aggregates `(domain kind, domain size, property kind,
+state-variable count, action count, guarded, fair, expression variant,
+aggregate kind, type row, operation/context)` counts. The
+`expression_variant_sweep_agrees_across_all_three_engines_and_covers_all_types`
+test prints a machine-readable `expression_variants={...}`,
+`aggregate_kinds={...}`, and `type_rows={...}` slice after the generated run.
+`assurance/expr.rs` and `assurance/types.rs` cite that exact test, completing
+the planned `sweep_summary` → C3 matrix connection.
+
+The live syntax enum has 24 variants, correcting slice 1's stale count of 22.
+The 22 checked-kernel variants are swept. `Call` is expanded by
+`PredicateExpander` and `Stage` by `StageResolver`; the C3 axis records both as
+fail-closed unsupported on evaluator columns and owns a typed-AST injection
+control proving a leaked form is rejected by the semantic build gate. Each
+checked variant/type model also owns its paired invariant-negation control, so
+the new agreement anchor proves it can reject a known semantic violation. No
+new cross-engine disagreement was found by this family. The two existing R6/Seq
+findings remain the only self-retiring exclusions and are not weakened or
+reclassified by the safe Map-index / collection-method representatives used
+for the variant rows.
 
 ## Coupled changes
 

--- a/rust/fsl-wasm/test-browser.mjs
+++ b/rust/fsl-wasm/test-browser.mjs
@@ -495,9 +495,18 @@ for (let index = 0; index < parityCases.length; index += 1) {
 // comparison needed. See the comment on that earlier assertion for why it
 // would be unsound to skip.
 const staleExclusions = [];
+function assertAgentWorkerProbeFailsClosed(probe, envelope) {
+  if (probe.documentType === "agent" && envelope?.result !== "error") {
+    throw new Error(
+      `${probe.path}: the Worker now returns ${JSON.stringify(envelope?.result)} for the agent `
+      + "document, so the agent fail-closed assurance cell and unsupportedDocuments entry are stale.",
+    );
+  }
+}
 for (let index = 0; index < exclusionProbes.length; index += 1) {
   const probe = exclusionProbes[index];
   const envelope = browser.parityEnvelopes[parityCases.length + index];
+  assertAgentWorkerProbeFailsClosed(probe, envelope);
   if (envelope?.result !== "error") {
     staleExclusions.push(
       `${probe.path}: the Worker now returns ${JSON.stringify(envelope?.result)} for this `

--- a/rust/fslc/tests/assurance/dialects.rs
+++ b/rust/fslc/tests/assurance/dialects.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `dialects` axis: every keyword emitted by
+//! `fsl_syntax::dispatch::frontends!` (issue #537 C3 slice 3).
+//!
+//! Rows reference `DIALECT_KEYWORDS` directly. Explicit posture matches and
+//! the corpus-representation test make a new frontend fail this slice until
+//! its CLI, Worker, and C4 ownership posture is reviewed.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::claim::{Axis, Citation, Claim};
+use crate::support::{corpus_files, root};
+
+const BARE_CHECK_SWEEP: Citation = Citation {
+    path: "rust/fslc/tests/corpus_check_sweep.rs",
+    anchor: "fn every_corpus_spec_checks_ok_or_declares_its_error()",
+};
+const REFINEMENT_CHECK_CONTROL: Citation = Citation {
+    path: "rust/fslc/tests/assurance/dialects.rs",
+    anchor: "fn refinement_bare_check_fails_closed_and_stays_owned_by_refine()",
+};
+const AGENT_CHECK: Citation = Citation {
+    path: "rust/fslc/tests/issue_468_recursive_agent.rs",
+    anchor: "fn check_is_parseable_for_corpus_sweeps_and_stays_lenient_on_the_top_level_result()",
+};
+const WORKER_PARITY: Citation = Citation {
+    path: "rust/fsl-wasm/test-browser.mjs",
+    anchor: "const envelopeDifferences = differences(",
+};
+const WORKER_AGENT_EXCLUSION: Citation = Citation {
+    path: "rust/fsl-wasm/test-browser.mjs",
+    anchor: "function assertAgentWorkerProbeFailsClosed(probe, envelope) {",
+};
+const WORKER_REFINEMENT_CONTROL: Citation = Citation {
+    path: "rust/fsl-wasm/test-browser.mjs",
+    anchor: "const retiredRefinementCase = \"specs/cart_refines.fsl\";",
+};
+const REFINEMENT_OWNER: Citation = Citation {
+    path: "rust/fslc/tests/refine_corpus_parity.rs",
+    anchor: "fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping()",
+};
+const EVIDENCE_OWNER: Citation = Citation {
+    path: "rust/fslc/tests/evidence_corpus_manifest.rs",
+    anchor: "fn native_matches_the_declared_expectation_for_every_registered_row()",
+};
+const EXPECTATION_OWNER: Citation = Citation {
+    path: "rust/fslc/tests/corpus_expectation_manifest.rs",
+    anchor: "fn native_matches_the_declared_expectation_for_every_registered_fixture()",
+};
+
+fn cli_claim(row: &'static str) -> Claim {
+    match row {
+        "refinement" => Claim::UnsupportedFailClosed {
+            by: REFINEMENT_CHECK_CONTROL,
+        },
+        "agent" => Claim::Exercised { by: AGENT_CHECK },
+        "spec" | "compose" | "business" | "governance" | "requirements" | "domain" | "dbsystem"
+        | "ai_component" => Claim::Exercised {
+            by: BARE_CHECK_SWEEP,
+        },
+        _ => panic!("unreviewed dialect '{row}' has no CLI-check posture"),
+    }
+}
+
+fn worker_claim(row: &'static str) -> Claim {
+    match row {
+        "agent" => Claim::UnsupportedFailClosed {
+            by: WORKER_AGENT_EXCLUSION,
+        },
+        "refinement" => Claim::UnsupportedFailClosed {
+            by: WORKER_REFINEMENT_CONTROL,
+        },
+        "spec" | "compose" | "business" | "governance" | "requirements" | "domain" | "dbsystem"
+        | "ai_component" => Claim::Exercised { by: WORKER_PARITY },
+        _ => panic!("unreviewed dialect '{row}' has no Worker posture"),
+    }
+}
+
+fn corpus_claim(row: &'static str) -> Claim {
+    match row {
+        "refinement" => Claim::Exercised {
+            by: REFINEMENT_OWNER,
+        },
+        "agent" | "ai_component" => Claim::Exercised { by: EVIDENCE_OWNER },
+        "spec" => Claim::Exercised {
+            by: EXPECTATION_OWNER,
+        },
+        "compose" | "business" | "governance" | "requirements" | "domain" | "dbsystem" => {
+            Claim::Exercised {
+                by: BARE_CHECK_SWEEP,
+            }
+        }
+        _ => panic!("unreviewed dialect '{row}' has no C4 corpus owner"),
+    }
+}
+
+#[must_use]
+pub fn axis() -> Axis {
+    fsl_syntax::validate_frontend_registry().expect("valid frontend registry");
+    let rows = fsl_syntax::DIALECT_KEYWORDS.to_vec();
+    let columns = vec!["CLI check", "Worker", "corpus"];
+    let mut cells: BTreeMap<(&'static str, &'static str), Claim> = BTreeMap::new();
+
+    for &row in &rows {
+        cells.insert((row, "CLI check"), cli_claim(row));
+        cells.insert((row, "Worker"), worker_claim(row));
+        cells.insert((row, "corpus"), corpus_claim(row));
+    }
+
+    Axis {
+        name: "dialects",
+        rows,
+        columns,
+        cells,
+    }
+}
+
+/// Registry-derived representation gate. The global corpus floors in the C4
+/// owners do not by themselves prove that every frontend still has an
+/// artifact, so this test derives the observed set with `dialect_keyword`
+/// and requires every `frontends!` keyword to remain represented.
+#[test]
+fn every_registered_dialect_has_a_corpus_representative_and_reviewed_posture() {
+    fsl_syntax::validate_frontend_registry().expect("valid frontend registry");
+    let reviewed_axis = axis();
+    assert_eq!(reviewed_axis.rows, fsl_syntax::DIALECT_KEYWORDS);
+    let repository = root();
+    let mut observed = BTreeSet::new();
+    for path in corpus_files(&repository) {
+        let source = std::fs::read_to_string(&path).expect("read corpus source");
+        if let Ok(keyword) = fsl_syntax::dialect_keyword(&source) {
+            observed.insert(keyword);
+        }
+    }
+    let missing = fsl_syntax::DIALECT_KEYWORDS
+        .iter()
+        .copied()
+        .filter(|keyword| !observed.contains(keyword))
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "registered dialects without a specs/examples corpus representative: {missing:?}"
+    );
+}
+
+/// `refinement` is a registered parser frontend, but a mapping is evaluated
+/// by `fslc refine`, not as a standalone Kernel spec. Bare `check` must
+/// refuse it instead of reporting a misleading success. C4's refinement
+/// manifest separately exercises the owning command for every mapping.
+#[test]
+fn refinement_bare_check_fails_closed_and_stays_owned_by_refine() {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["check", "specs/cart_refines.fsl"])
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("native check stdout JSON");
+    assert_eq!(output.status.code(), Some(2), "{envelope}");
+    assert_eq!(envelope["result"], "error");
+    assert!(
+        envelope["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("no state block")),
+        "{envelope}"
+    );
+}

--- a/rust/fslc/tests/assurance/enum_rows.rs
+++ b/rust/fslc/tests/assurance/enum_rows.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Source-coupled row registries for the expression and type axes.
+//!
+//! Each macro invocation emits both the exhaustive match over the real enum
+//! and the witnesses used to enumerate its rows. Adding an enum variant
+//! therefore fails compilation until the same declaration supplies its row
+//! and witness; the axis and C6 coverage checks consume these generated rows
+//! rather than maintaining independent constructor lists or count floors.
+
+use fsl_core::{TypeDef, TypeRef};
+use fsl_syntax::{
+    AggregateKind, Binder, ConditionalSpans, Expr, Pattern, QualifiedName, SourcePos, Span,
+};
+
+macro_rules! define_variant_rows {
+    (
+        $label_fn:ident,
+        $rows_fn:ident,
+        $enum_ty:ty,
+        {
+            $(
+                $pattern:pat => ($label:literal, $witness:expr)
+            ),+ $(,)?
+        }
+    ) => {
+        #[must_use]
+        pub fn $label_fn(value: &$enum_ty) -> &'static str {
+            match value {
+                $($pattern => $label),+
+            }
+        }
+
+        #[must_use]
+        pub fn $rows_fn() -> Vec<&'static str> {
+            vec![
+                $(
+                    {
+                        let witness: $enum_ty = $witness;
+                        $label_fn(&witness)
+                    }
+                ),+
+            ]
+        }
+    };
+}
+
+fn span() -> Span {
+    Span {
+        start: SourcePos {
+            offset: 0,
+            line: 1,
+            column: 1,
+        },
+        end: SourcePos {
+            offset: 0,
+            line: 1,
+            column: 1,
+        },
+    }
+}
+
+fn binder() -> Binder {
+    Binder::Typed {
+        name: "item".to_owned(),
+        type_name: QualifiedName {
+            namespace: None,
+            name: "Item".to_owned(),
+        },
+        where_expr: None,
+    }
+}
+
+define_variant_rows!(
+    expr_variant_row,
+    expr_variant_rows,
+    Expr,
+    {
+        Expr::Num(_) => ("Expr::Num", Expr::Num(0)),
+        Expr::Bool(_) => ("Expr::Bool", Expr::Bool(false)),
+        Expr::None => ("Expr::None", Expr::None),
+        Expr::Some(_) => ("Expr::Some", Expr::Some(Box::new(Expr::Num(0)))),
+        Expr::Set(_) => ("Expr::Set", Expr::Set(Vec::new())),
+        Expr::Seq(_) => ("Expr::Seq", Expr::Seq(Vec::new())),
+        Expr::Struct { .. } => (
+            "Expr::Struct",
+            Expr::Struct {
+                name: "Payload".to_owned(),
+                fields: Vec::new(),
+            }
+        ),
+        Expr::Var(_) => ("Expr::Var", Expr::Var("value".to_owned())),
+        Expr::EnumMember { .. } => (
+            "Expr::EnumMember",
+            Expr::EnumMember {
+                type_name: "Status".to_owned(),
+                member: "Pending".to_owned(),
+            }
+        ),
+        Expr::Call { .. } => (
+            "Expr::Call",
+            Expr::Call {
+                name: "predicate".to_owned(),
+                args: Vec::new(),
+                span: span(),
+            }
+        ),
+        Expr::Index(_, _) => (
+            "Expr::Index",
+            Expr::Index(
+                Box::new(Expr::Var("map".to_owned())),
+                Box::new(Expr::Num(0)),
+            )
+        ),
+        Expr::Field(_, _) => (
+            "Expr::Field",
+            Expr::Field(
+                Box::new(Expr::Var("payload".to_owned())),
+                "value".to_owned(),
+            )
+        ),
+        Expr::Method { .. } => (
+            "Expr::Method",
+            Expr::Method {
+                receiver: Box::new(Expr::Var("set".to_owned())),
+                name: "size".to_owned(),
+                args: Vec::new(),
+            }
+        ),
+        Expr::Binary { .. } => (
+            "Expr::Binary",
+            Expr::Binary {
+                op: "==".to_owned(),
+                left: Box::new(Expr::Num(0)),
+                right: Box::new(Expr::Num(0)),
+            }
+        ),
+        Expr::Neg(_) => ("Expr::Neg", Expr::Neg(Box::new(Expr::Num(0)))),
+        Expr::Not(_) => ("Expr::Not", Expr::Not(Box::new(Expr::Bool(false)))),
+        Expr::Conditional { .. } => (
+            "Expr::Conditional",
+            Expr::Conditional {
+                condition: Box::new(Expr::Bool(true)),
+                then_expr: Box::new(Expr::Bool(true)),
+                else_expr: Box::new(Expr::Bool(false)),
+                spans: Box::new(ConditionalSpans {
+                    condition: span(),
+                    then_expr: span(),
+                    else_expr: span(),
+                }),
+            }
+        ),
+        Expr::Is { .. } => (
+            "Expr::Is",
+            Expr::Is {
+                expr: Box::new(Expr::None),
+                pattern: Pattern::None,
+            }
+        ),
+        Expr::Quantified { .. } => (
+            "Expr::Quantified",
+            Expr::Quantified {
+                quantifier: "forall".to_owned(),
+                binder: binder(),
+                body: Box::new(Expr::Bool(true)),
+            }
+        ),
+        Expr::Aggregate { .. } => (
+            "Expr::Aggregate",
+            Expr::Aggregate {
+                kind: AggregateKind::Count,
+                binder: binder(),
+                value: None,
+            }
+        ),
+        Expr::Stage { .. } => (
+            "Expr::Stage",
+            Expr::Stage {
+                process: None,
+                entity: Box::new(Expr::Var("item".to_owned())),
+                entity_span: span(),
+                span: span(),
+            }
+        ),
+        Expr::UnaryNamed { .. } => (
+            "Expr::UnaryNamed",
+            Expr::UnaryNamed {
+                name: "abs".to_owned(),
+                expr: Box::new(Expr::Num(0)),
+                span: span(),
+            }
+        ),
+        Expr::BinaryNamed { .. } => (
+            "Expr::BinaryNamed",
+            Expr::BinaryNamed {
+                name: "min".to_owned(),
+                left: Box::new(Expr::Num(0)),
+                right: Box::new(Expr::Num(1)),
+            }
+        ),
+        Expr::TernaryNamed { .. } => (
+            "Expr::TernaryNamed",
+            Expr::TernaryNamed {
+                name: "rel_reachable".to_owned(),
+                first: Box::new(Expr::Var("relation".to_owned())),
+                second: Box::new(Expr::Num(0)),
+                third: Box::new(Expr::Num(1)),
+            }
+        ),
+    }
+);
+
+define_variant_rows!(
+    aggregate_kind_row,
+    aggregate_kind_rows,
+    AggregateKind,
+    {
+        AggregateKind::Count => ("AggregateKind::Count", AggregateKind::Count),
+        AggregateKind::Sum => ("AggregateKind::Sum", AggregateKind::Sum),
+        AggregateKind::Unique => ("AggregateKind::Unique", AggregateKind::Unique),
+        AggregateKind::ExactlyOne => (
+            "AggregateKind::ExactlyOne",
+            AggregateKind::ExactlyOne
+        ),
+    }
+);
+
+define_variant_rows!(
+    type_ref_row,
+    type_ref_rows,
+    TypeRef,
+    {
+        TypeRef::Int => ("TypeRef::Int", TypeRef::Int),
+        TypeRef::Bool => ("TypeRef::Bool", TypeRef::Bool),
+        TypeRef::Named(_) => ("TypeRef::Named", TypeRef::Named("Named".to_owned())),
+        TypeRef::Range(_, _) => ("TypeRef::Range", TypeRef::Range(0, 1)),
+        TypeRef::Map(_, _) => (
+            "TypeRef::Map",
+            TypeRef::Map(Box::new(TypeRef::Bool), Box::new(TypeRef::Bool))
+        ),
+        TypeRef::Relation(_, _) => (
+            "TypeRef::Relation",
+            TypeRef::Relation(Box::new(TypeRef::Bool), Box::new(TypeRef::Bool))
+        ),
+        TypeRef::Set(_) => ("TypeRef::Set", TypeRef::Set(Box::new(TypeRef::Bool))),
+        TypeRef::Seq(_, _) => (
+            "TypeRef::Seq",
+            TypeRef::Seq(Box::new(TypeRef::Bool), 1)
+        ),
+        TypeRef::Option(_) => (
+            "TypeRef::Option",
+            TypeRef::Option(Box::new(TypeRef::Bool))
+        ),
+    }
+);
+
+define_variant_rows!(
+    type_def_row,
+    type_def_rows,
+    TypeDef,
+    {
+        TypeDef::Domain { .. } => (
+            "TypeDef::Domain",
+            TypeDef::Domain {
+                lo: 0,
+                hi: 1,
+                symmetric: false,
+            }
+        ),
+        TypeDef::Enum { .. } => (
+            "TypeDef::Enum",
+            TypeDef::Enum {
+                members: vec!["Member".to_owned()],
+                symmetric: false,
+            }
+        ),
+        TypeDef::Struct { .. } => (
+            "TypeDef::Struct",
+            TypeDef::Struct { fields: Vec::new() }
+        ),
+    }
+);
+
+#[must_use]
+#[allow(dead_code)] // Used by assurance_matrix; this file is also compiled by typed_agreement.
+pub fn expression_rows() -> Vec<&'static str> {
+    expr_variant_rows()
+        .into_iter()
+        .chain(aggregate_kind_rows())
+        .collect()
+}
+
+#[must_use]
+#[allow(dead_code)] // Used by typed_agreement; this file is also compiled by assurance_matrix.
+pub fn checked_expr_variant_rows() -> Vec<&'static str> {
+    expr_variant_rows()
+        .into_iter()
+        .filter(|row| !matches!(*row, "Expr::Call" | "Expr::Stage"))
+        .collect()
+}
+
+#[must_use]
+pub fn type_rows() -> Vec<&'static str> {
+    type_ref_rows().into_iter().chain(type_def_rows()).collect()
+}

--- a/rust/fslc/tests/assurance/expr.rs
+++ b/rust/fslc/tests/assurance/expr.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `expr` axis: all 24 live `fsl_syntax::Expr` variants plus all four
+//! `AggregateKind` values (issue #537 C3 slice 2).
+//!
+//! Declared columns are `Monitor` and `BMC`, the concrete and symbolic
+//! expression evaluators. The explicit engine is not a third expression
+//! implementation: it drives the same concrete Monitor evaluator, and the
+//! C6 sweep cited below still includes it as a three-engine verdict and
+//! successor-agreement control.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fsl_core::{FsResolver, build_surface_model, parse_kernel_source};
+use fsl_syntax::{Expr, SourcePos, Span, SpecItem};
+
+use crate::claim::{Axis, Citation, Claim};
+use crate::enum_rows::expression_rows;
+
+const SWEEP: Citation = Citation {
+    path: "rust/fslc/tests/typed_agreement.rs",
+    anchor: "fn expression_variant_sweep_agrees_across_all_three_engines_and_covers_all_types()",
+};
+
+const FAIL_CLOSED_CONTROL: Citation = Citation {
+    path: "rust/fslc/tests/assurance/expr.rs",
+    anchor: "fn unlowered_call_and_stage_fail_closed_before_evaluator_entry()",
+};
+
+fn span() -> Span {
+    Span {
+        start: SourcePos {
+            offset: 0,
+            line: 1,
+            column: 1,
+        },
+        end: SourcePos {
+            offset: 0,
+            line: 1,
+            column: 1,
+        },
+    }
+}
+
+#[must_use]
+pub fn axis() -> Axis {
+    let rows = expression_rows();
+    let columns = vec!["Monitor", "BMC"];
+    let mut cells: BTreeMap<(&'static str, &'static str), Claim> = BTreeMap::new();
+    for &row in &rows {
+        let unsupported = matches!(row, "Expr::Call" | "Expr::Stage");
+        for &column in &columns {
+            cells.insert(
+                (row, column),
+                if unsupported {
+                    Claim::UnsupportedFailClosed {
+                        by: FAIL_CLOSED_CONTROL,
+                    }
+                } else {
+                    Claim::Exercised { by: SWEEP }
+                },
+            );
+        }
+    }
+    Axis {
+        name: "expr",
+        rows,
+        columns,
+        cells,
+    }
+}
+
+#[test]
+fn expression_rows_are_complete_and_unique() {
+    let rows = expression_rows();
+    assert_eq!(rows.len(), 28, "24 Expr rows plus 4 AggregateKind rows");
+    assert_eq!(
+        rows.iter().copied().collect::<BTreeSet<_>>().len(),
+        rows.len(),
+        "expression-axis rows must be unique"
+    );
+}
+
+fn replace_variant_expression(expression: Expr) -> Result<(), String> {
+    let source = "spec SurfaceLeak { state { ready: Bool } init { ready = true } \
+                  action stay() { ready = ready } invariant Variant { true } }";
+    let kernel = parse_kernel_source(source, &FsResolver::new("."))
+        .map_err(|error| format!("parse control model: {error}"))?;
+    let mut syntax = kernel.into_syntax();
+    let target = syntax
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SpecItem::Invariant { name, expr, .. } if name == "Variant" => Some(expr),
+            _ => None,
+        })
+        .ok_or_else(|| "control model has no Variant invariant".to_owned())?;
+    **target = expression;
+    build_surface_model(syntax)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+/// Observation control for the two surface-only variants. Direct-spec
+/// predicate expansion and business/requirements stage resolution normally
+/// eliminate these forms. Injecting either into the typed surface tree and
+/// re-running the semantic build gate must reject it before Monitor or BMC
+/// can evaluate a misleading default.
+#[test]
+fn unlowered_call_and_stage_fail_closed_before_evaluator_entry() {
+    let location = span();
+    let call_error = replace_variant_expression(Expr::Call {
+        name: "leaked_predicate".to_owned(),
+        args: Vec::new(),
+        span: location,
+    })
+    .expect_err("unlowered Call must fail closed");
+    assert!(
+        call_error.contains("unlowered predicate call 'leaked_predicate' in public Kernel"),
+        "{call_error}"
+    );
+
+    let stage_error = replace_variant_expression(Expr::Stage {
+        process: None,
+        entity: Box::new(Expr::Var("ready".to_owned())),
+        entity_span: location,
+        span: location,
+    })
+    .expect_err("unlowered Stage must fail closed");
+    assert!(
+        stage_error.contains("unlowered stage access in public Kernel"),
+        "{stage_error}"
+    );
+}

--- a/rust/fslc/tests/assurance/types.rs
+++ b/rust/fslc/tests/assurance/types.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! `types` axis: all 9 `fsl_core::model::TypeRef` variants and all three
+//! `TypeDef` variants (issue #537 C3 slice 3).
+//!
+//! The expression-variant C6 family deliberately carries every type row in
+//! each model schema and asserts the source-derived 12-row inventory before
+//! running Monitor BFS / explicit / BMC agreement. This axis declares the
+//! two expression evaluator columns, `Monitor` and `BMC`; explicit remains a
+//! concrete-path control rather than a distinct type implementation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::claim::{Axis, Citation, Claim};
+use crate::enum_rows::type_rows;
+
+const SWEEP: Citation = Citation {
+    path: "rust/fslc/tests/typed_agreement.rs",
+    anchor: "fn expression_variant_sweep_agrees_across_all_three_engines_and_covers_all_types()",
+};
+
+#[must_use]
+pub fn axis() -> Axis {
+    let rows = type_rows();
+    let columns = vec!["Monitor", "BMC"];
+    let mut cells: BTreeMap<(&'static str, &'static str), Claim> = BTreeMap::new();
+    for &row in &rows {
+        for &column in &columns {
+            cells.insert((row, column), Claim::Exercised { by: SWEEP });
+        }
+    }
+    Axis {
+        name: "types",
+        rows,
+        columns,
+        cells,
+    }
+}
+
+#[test]
+fn type_rows_are_complete_and_unique() {
+    let rows = type_rows();
+    assert_eq!(rows.len(), 12, "9 TypeRef rows plus 3 TypeDef rows");
+    assert_eq!(
+        rows.iter().copied().collect::<BTreeSet<_>>().len(),
+        rows.len(),
+        "type-axis rows must be unique"
+    );
+}

--- a/rust/fslc/tests/assurance_matrix.rs
+++ b/rust/fslc/tests/assurance_matrix.rs
@@ -26,10 +26,20 @@
 
 #[path = "assurance/claim.rs"]
 mod claim;
+#[path = "assurance/dialects.rs"]
+mod dialects;
+#[path = "assurance/enum_rows.rs"]
+mod enum_rows;
+#[path = "assurance/expr.rs"]
+mod expr;
 #[path = "assurance/outcome_kind.rs"]
 mod outcome_kind;
 #[path = "assurance/properties.rs"]
 mod properties;
+#[path = "support/mod.rs"]
+mod support;
+#[path = "assurance/types.rs"]
+mod types;
 #[path = "assurance/violation_kind.rs"]
 mod violation_kind;
 
@@ -40,6 +50,9 @@ fn axes() -> Vec<Axis> {
         outcome_kind::axis(),
         violation_kind::axis(),
         properties::axis(),
+        expr::axis(),
+        types::axis(),
+        dialects::axis(),
     ]
 }
 

--- a/rust/fslc/tests/typed_agreement.rs
+++ b/rust/fslc/tests/typed_agreement.rs
@@ -8,7 +8,9 @@
 //! structural axis enumeration (`generator.rs`), compares Monitor BFS /
 //! explicit / BMC bounded verdicts and successors (`engines.rs`), and checks
 //! seven metamorphic relations with a negative control each (`relations.rs`).
-//! `sweep_summary.rs` aggregates what each sweep actually exercised.
+//! `sweep_summary.rs` aggregates what each sweep actually exercised. Slice 2
+//! adds an expression-variant family that is also the exercising evidence for
+//! the C3 `expr` and `types` axes.
 //!
 //! See `docs/DESIGN-conformance-harness.md`'s "Typed generative /
 //! metamorphic agreement (#537 C6)" section for the accepted design this
@@ -16,6 +18,8 @@
 
 #[path = "typed_agreement/engines.rs"]
 mod engines;
+#[path = "assurance/enum_rows.rs"]
+mod enum_rows;
 #[path = "typed_agreement/generator.rs"]
 mod generator;
 #[path = "typed_agreement/relations.rs"]
@@ -23,7 +27,15 @@ mod relations;
 #[path = "typed_agreement/sweep_summary.rs"]
 mod sweep_summary;
 
-use generator::{PropertyKind, domain_sweep, operation_sweep};
+use std::collections::BTreeSet;
+
+use enum_rows::{
+    aggregate_kind_row, aggregate_kind_rows, checked_expr_variant_rows, expr_variant_row,
+    type_def_row, type_ref_row, type_rows,
+};
+use fsl_core::{KernelModel, TypeDef, TypeRef};
+use fsl_syntax::{Binder, Expr};
+use generator::{PropertyKind, domain_sweep, expression_sweep, operation_sweep};
 use sweep_summary::SweepSummary;
 
 /// Generator floor, asserted per the brief and design's "assert model
@@ -36,6 +48,9 @@ const DOMAIN_SWEEP_FLOOR: usize = 15;
 /// action-context boundary are exercised as dedicated `relations.rs` R6
 /// tests instead of this sweep; see `generator.rs::operation_sweep`'s doc.
 const OPERATION_SWEEP_FLOOR: usize = 4;
+/// 21 non-aggregate executable variants plus four separate aggregate-kind
+/// models. `Call` and `Stage` are fail-closed before evaluator entry.
+const EXPRESSION_SWEEP_FLOOR: usize = 25;
 
 #[test]
 fn domain_sweep_meets_its_generator_floor_and_covers_every_property_kind() {
@@ -68,6 +83,250 @@ fn operation_sweep_meets_its_generator_floor() {
         "operation sweep floor: expected >= {OPERATION_SWEEP_FLOOR}, got {}",
         models.len()
     );
+}
+
+fn visit_binder(
+    binder: &Binder,
+    expr_rows: &mut BTreeSet<&'static str>,
+    aggregate_rows: &mut BTreeSet<&'static str>,
+) {
+    match binder {
+        Binder::Typed { where_expr, .. } => {
+            if let Some(expression) = where_expr {
+                visit_expr(expression, expr_rows, aggregate_rows);
+            }
+        }
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
+            visit_expr(lo, expr_rows, aggregate_rows);
+            visit_expr(hi, expr_rows, aggregate_rows);
+            if let Some(expression) = where_expr {
+                visit_expr(expression, expr_rows, aggregate_rows);
+            }
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            visit_expr(collection, expr_rows, aggregate_rows);
+            if let Some(expression) = where_expr {
+                visit_expr(expression, expr_rows, aggregate_rows);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn visit_expr(
+    expr: &Expr,
+    expr_rows: &mut BTreeSet<&'static str>,
+    aggregate_rows: &mut BTreeSet<&'static str>,
+) {
+    expr_rows.insert(expr_variant_row(expr));
+    match expr {
+        Expr::Some(value)
+        | Expr::Neg(value)
+        | Expr::Not(value)
+        | Expr::Field(value, _)
+        | Expr::Stage { entity: value, .. }
+        | Expr::UnaryNamed { expr: value, .. }
+        | Expr::Is { expr: value, .. } => visit_expr(value, expr_rows, aggregate_rows),
+        Expr::Set(values) | Expr::Seq(values) => {
+            for value in values {
+                visit_expr(value, expr_rows, aggregate_rows);
+            }
+        }
+        Expr::Struct { fields, .. } => {
+            for (_, value) in fields {
+                visit_expr(value, expr_rows, aggregate_rows);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for argument in args {
+                visit_expr(argument, expr_rows, aggregate_rows);
+            }
+        }
+        Expr::Index(left, right)
+        | Expr::Binary { left, right, .. }
+        | Expr::BinaryNamed { left, right, .. } => {
+            visit_expr(left, expr_rows, aggregate_rows);
+            visit_expr(right, expr_rows, aggregate_rows);
+        }
+        Expr::Method { receiver, args, .. } => {
+            visit_expr(receiver, expr_rows, aggregate_rows);
+            for argument in args {
+                visit_expr(argument, expr_rows, aggregate_rows);
+            }
+        }
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            visit_expr(condition, expr_rows, aggregate_rows);
+            visit_expr(then_expr, expr_rows, aggregate_rows);
+            visit_expr(else_expr, expr_rows, aggregate_rows);
+        }
+        Expr::Quantified { binder, body, .. } => {
+            visit_binder(binder, expr_rows, aggregate_rows);
+            visit_expr(body, expr_rows, aggregate_rows);
+        }
+        Expr::Aggregate {
+            kind,
+            binder,
+            value,
+        } => {
+            aggregate_rows.insert(aggregate_kind_row(kind));
+            visit_binder(binder, expr_rows, aggregate_rows);
+            if let Some(value) = value {
+                visit_expr(value, expr_rows, aggregate_rows);
+            }
+        }
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => {
+            visit_expr(first, expr_rows, aggregate_rows);
+            visit_expr(second, expr_rows, aggregate_rows);
+            visit_expr(third, expr_rows, aggregate_rows);
+        }
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {}
+    }
+}
+
+fn visit_type_ref(ty: &TypeRef, rows: &mut BTreeSet<&'static str>) {
+    rows.insert(type_ref_row(ty));
+    match ty {
+        TypeRef::Map(key, value) | TypeRef::Relation(key, value) => {
+            visit_type_ref(key, rows);
+            visit_type_ref(value, rows);
+        }
+        TypeRef::Set(item) | TypeRef::Seq(item, _) | TypeRef::Option(item) => {
+            visit_type_ref(item, rows);
+        }
+        TypeRef::Int | TypeRef::Bool | TypeRef::Named(_) | TypeRef::Range(_, _) => {}
+    }
+}
+
+fn model_type_rows(model: &KernelModel) -> BTreeSet<&'static str> {
+    let mut rows = BTreeSet::new();
+    for (_, ty) in &model.state {
+        visit_type_ref(ty, &mut rows);
+    }
+    for definition in model.types.values() {
+        rows.insert(type_def_row(definition));
+        if let TypeDef::Struct { fields } = definition {
+            for (_, ty) in fields {
+                visit_type_ref(ty, &mut rows);
+            }
+        }
+    }
+    rows
+}
+
+/// Slice-2 expression/type family: every evaluator-reachable `Expr` variant
+/// is present in a checked model and passes Monitor BFS / explicit / BMC
+/// verdict, replay, and successor agreement. Four aggregate models make the
+/// `AggregateKind` inventory explicit. The same model schema contains all 9
+/// `TypeRef` and all 3 `TypeDef` variants, so this is also the C3 `types`
+/// axis's concrete/symbolic value-generation evidence.
+#[test]
+fn expression_variant_sweep_agrees_across_all_three_engines_and_covers_all_types() {
+    let models = expression_sweep();
+    assert!(
+        models.len() >= EXPRESSION_SWEEP_FLOOR,
+        "expression sweep floor: expected >= {EXPRESSION_SWEEP_FLOOR}, got {}",
+        models.len()
+    );
+
+    let mut designated_expr_rows = BTreeSet::new();
+    let mut designated_aggregate_rows = BTreeSet::new();
+    let mut observed_type_rows = BTreeSet::new();
+    let mut summary = SweepSummary::default();
+
+    for generated in models {
+        let model = engines::build_expression(&generated.id, &generated.source, generated.build);
+        let property = model
+            .invariants
+            .iter()
+            .find(|property| property.name == "Variant")
+            .unwrap_or_else(|| panic!("'{}': Variant invariant disappeared", generated.id));
+        let mut expr_rows = BTreeSet::new();
+        let mut aggregate_rows = BTreeSet::new();
+        visit_expr(&property.expr, &mut expr_rows, &mut aggregate_rows);
+        assert!(
+            expr_rows.contains(generated.expr_variant),
+            "'{}': generated model does not contain designated row {}; observed={expr_rows:?}",
+            generated.id,
+            generated.expr_variant
+        );
+        if let Some(kind) = generated.aggregate_kind {
+            assert!(
+                aggregate_rows.contains(kind),
+                "'{}': generated model does not contain designated row {kind}; observed={aggregate_rows:?}",
+                generated.id
+            );
+            designated_aggregate_rows.insert(kind);
+        }
+
+        let verdict = engines::run_agreement(&generated.id, &model, generated.depth);
+        assert_eq!(
+            verdict,
+            engines::Verdict::Clean,
+            "'{}': the positive expression model must satisfy Variant",
+            generated.id
+        );
+        let mut negative = model.clone();
+        let property = negative
+            .invariants
+            .iter_mut()
+            .find(|property| property.name == "Variant")
+            .unwrap_or_else(|| panic!("'{}': Variant invariant disappeared", generated.id));
+        let positive = std::mem::replace(&mut property.expr, Expr::Bool(false));
+        property.expr = Expr::Not(Box::new(positive));
+        let negative_id = format!("{}_negative_control", generated.id);
+        let negative_verdict = engines::run_agreement(&negative_id, &negative, generated.depth);
+        assert_eq!(
+            negative_verdict,
+            engines::Verdict::Violated {
+                kind: "invariant".to_owned(),
+                name: "Variant".to_owned(),
+                step: 0,
+            },
+            "'{}': negating the known-true expression must be detected as an initial invariant violation by all three engines",
+            generated.id
+        );
+        designated_expr_rows.insert(generated.expr_variant);
+        let type_rows = model_type_rows(&model);
+        observed_type_rows.extend(type_rows.iter().copied());
+        summary.record_expression_model(
+            generated.expr_variant,
+            generated.aggregate_kind,
+            type_rows,
+        );
+    }
+
+    let expected_expr_rows = checked_expr_variant_rows().into_iter().collect();
+    assert_eq!(
+        designated_expr_rows, expected_expr_rows,
+        "the expression family must designate exactly the source-coupled evaluator-reachable Expr rows"
+    );
+    let expected_aggregate_rows = aggregate_kind_rows().into_iter().collect();
+    assert_eq!(
+        designated_aggregate_rows, expected_aggregate_rows,
+        "every source-coupled AggregateKind row must have a generated model"
+    );
+    let expected_type_rows = type_rows().into_iter().collect();
+    assert_eq!(
+        observed_type_rows, expected_type_rows,
+        "the expression family must carry exactly the source-coupled TypeRef/TypeDef rows through concrete and symbolic evaluation"
+    );
+    eprintln!("expression/type sweep summary: {summary}");
 }
 
 /// The main sweep: every domain-axis model must build and its Monitor

--- a/rust/fslc/tests/typed_agreement/engines.rs
+++ b/rust/fslc/tests/typed_agreement/engines.rs
@@ -16,8 +16,11 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use fsl_core::{FsResolver, KernelModel, build_model, parse_kernel_source};
+use fsl_core::{FsResolver, KernelModel, build_model, build_surface_model, parse_kernel_source};
 use fsl_runtime::{Monitor, State, Violation};
+use fsl_syntax::{Expr, SpecItem};
+
+use crate::generator::ExpressionBuild;
 
 pub fn block_on<F: Future>(future: F) -> F::Output {
     let mut future = pin!(future);
@@ -43,6 +46,46 @@ pub fn build(id: &str, source: &str) -> KernelModel {
         .unwrap_or_else(|error| panic!("generator bug: '{id}' did not parse: {error}\n{source}"));
     build_model(kernel).unwrap_or_else(|error| {
         panic!("generator bug: '{id}' did not typecheck: {error}\n{source}")
+    })
+}
+
+/// Build one expression-axis model through the ordinary parse/lower/typecheck
+/// path. `EnumMemberTypedAst` additionally replaces the parsed enum token
+/// with the typed `Expr::EnumMember` form before re-running
+/// `build_surface_model`, the public semantic gate specifically provided for
+/// typed AST mutations.
+#[must_use]
+pub fn build_expression(id: &str, source: &str, build_kind: ExpressionBuild) -> KernelModel {
+    if build_kind == ExpressionBuild::ParsedSource {
+        return build(id, source);
+    }
+
+    let resolver = FsResolver::new(".");
+    let kernel = parse_kernel_source(source, &resolver)
+        .unwrap_or_else(|error| panic!("generator bug: '{id}' did not parse: {error}\n{source}"));
+    let mut syntax = kernel.into_syntax();
+    let expression = syntax
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SpecItem::Invariant { name, expr, .. } if name == "Variant" => Some(expr.as_mut()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("generator bug: '{id}' has no Variant invariant"));
+    let Expr::Binary { right, .. } = expression else {
+        panic!("generator bug: '{id}' EnumMember probe is not a binary expression");
+    };
+    assert!(
+        matches!(right.as_ref(), Expr::Var(name) if name == "Pending"),
+        "generator bug: '{id}' EnumMember probe no longer has Pending on the right: {right:?}"
+    );
+    **right = Expr::EnumMember {
+        type_name: "Status".to_owned(),
+        member: "Pending".to_owned(),
+    };
+
+    build_surface_model(syntax).unwrap_or_else(|error| {
+        panic!("generator bug: '{id}' typed AST did not typecheck: {error}\n{source}")
     })
 }
 

--- a/rust/fslc/tests/typed_agreement/generator.rs
+++ b/rust/fslc/tests/typed_agreement/generator.rs
@@ -19,6 +19,10 @@
 //!   names (`head`/`pop`/`at`/index/`divide`/`remainder`), each placed at
 //!   its documented boundary. See the module doc on `relations.rs` R6 for
 //!   why `head`/`pop`/`at`/index are generated only in action context.
+//! - [`expression_sweep`]: one checked model per executable `Expr` variant,
+//!   with four models for the four `AggregateKind` values. `Call` and
+//!   `Stage` are deliberately absent because direct/dialect lowering must
+//!   eliminate them before a checked Kernel model reaches an evaluator.
 //!
 //! `type Domain = 1..0` is this codebase's existing idiom for an empty
 //! finite domain (`rust/fsl-verifier/tests/expression_agreement.rs`,
@@ -377,6 +381,239 @@ fn render_enum_model(
     }
     source.push_str("}\n");
     source
+}
+
+/// How an expression model enters the checked Kernel.
+///
+/// Ordinary enum tokens remain `Expr::Var` in parsed direct specs.
+/// `Expr::EnumMember` is synthesized by typed lowering paths such as enum
+/// conversion and aggregate normalization, so its deterministic C6 model
+/// mutates the already-parsed typed surface tree and then re-runs
+/// `build_surface_model` (the public semantic gate for typed AST mutations).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExpressionBuild {
+    ParsedSource,
+    EnumMemberTypedAst,
+}
+
+/// One deterministic expression-variant model and the matrix row(s) it
+/// exercises. `aggregate_kind` is populated only for the four aggregate
+/// models; all other models exercise one `Expr` row.
+#[derive(Clone, Debug)]
+pub struct ExpressionModel {
+    pub id: String,
+    pub source: String,
+    pub expr_variant: &'static str,
+    pub aggregate_kind: Option<&'static str>,
+    pub build: ExpressionBuild,
+    pub depth: usize,
+}
+
+fn expression_model(
+    index: usize,
+    expr_variant: &'static str,
+    aggregate_kind: Option<&'static str>,
+    expression: &str,
+    build: ExpressionBuild,
+) -> ExpressionModel {
+    let source = format!(
+        r"
+spec ExpressionVariant{index} {{
+  type Item = 0..2
+  enum Status {{ Pending, Done }}
+  struct Payload {{ value: Item, ready: Bool }}
+  state {{
+    raw: Int,
+    bounded: 0..1,
+    x: Item,
+    flag: Bool,
+    optional: Option<Item>,
+    selected: Set<Item>,
+    queue: Seq<Item, 3>,
+    payload: Payload,
+    lookup: Map<Item, Item>,
+    edges: relation Item -> Item,
+    status: Status
+  }}
+  init {{
+    raw = 0
+    bounded = 0
+    x = 0
+    flag = true
+    optional = none
+    selected = Set {{}}
+    queue = Seq {{}}
+    payload = Payload {{ value: 0, ready: true }}
+    forall i: Item {{ lookup[i] = 0 }}
+    edges = Set {{}}
+    status = Pending
+  }}
+  action stay() {{ x = x }}
+  invariant Variant {{ {expression} }}
+}}
+"
+    );
+    ExpressionModel {
+        id: format!("expr_variant_{index}_{expr_variant}"),
+        source,
+        expr_variant,
+        aggregate_kind,
+        build,
+        depth: 2,
+    }
+}
+
+/// Deterministic C6 family for every checked-kernel `Expr` variant.
+///
+/// There are 25 models: 21 non-aggregate executable variants and four
+/// aggregate-kind models. The `Expr::Aggregate` row is therefore observed
+/// four times. The two remaining live syntax variants (`Call`, `Stage`) are
+/// exercised by fail-closed controls in `assurance/expr.rs`, not by an
+/// evaluator agreement model, because allowing either into a checked
+/// Kernel would itself violate the lowering contract.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn expression_sweep() -> Vec<ExpressionModel> {
+    [
+        ("Expr::Num", None, "0 == 0", ExpressionBuild::ParsedSource),
+        ("Expr::Bool", None, "true", ExpressionBuild::ParsedSource),
+        (
+            "Expr::None",
+            None,
+            "optional == none",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Some",
+            None,
+            "some(0) != optional",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Set",
+            None,
+            "selected == Set {}",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Seq",
+            None,
+            "queue == Seq {}",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Struct",
+            None,
+            "payload == Payload { value: 0, ready: true }",
+            ExpressionBuild::ParsedSource,
+        ),
+        ("Expr::Var", None, "x == x", ExpressionBuild::ParsedSource),
+        (
+            "Expr::EnumMember",
+            None,
+            "status == Pending",
+            ExpressionBuild::EnumMemberTypedAst,
+        ),
+        (
+            "Expr::Index",
+            None,
+            "lookup[0] == 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Field",
+            None,
+            "payload.value == 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Method",
+            None,
+            "selected.size() == 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Binary",
+            None,
+            "x + 1 >= 1 and flag",
+            ExpressionBuild::ParsedSource,
+        ),
+        ("Expr::Neg", None, "-x <= 0", ExpressionBuild::ParsedSource),
+        (
+            "Expr::Not",
+            None,
+            "not false",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Conditional",
+            None,
+            "if flag then x == 0 else x != 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Is",
+            None,
+            "not (optional is some(value))",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Quantified",
+            None,
+            "forall i: Item { lookup[i] >= 0 }",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Aggregate",
+            Some("AggregateKind::Count"),
+            "count(i: Item where i >= 0) == 3",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Aggregate",
+            Some("AggregateKind::Sum"),
+            "sum(i in 0..2 of i) == 3",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Aggregate",
+            Some("AggregateKind::Unique"),
+            "unique(i: Item where false) and unique(i: Item where i == 0) and not unique(i: Item where true)",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::Aggregate",
+            Some("AggregateKind::ExactlyOne"),
+            "not exactlyOne(i: Item where false) and exactlyOne(i: Item where i == 0) and not exactlyOne(i: Item where true)",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::UnaryNamed",
+            None,
+            "abs(raw) == 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::BinaryNamed",
+            None,
+            "min(raw, 1) == 0",
+            ExpressionBuild::ParsedSource,
+        ),
+        (
+            "Expr::TernaryNamed",
+            None,
+            "not reachable(edges, 0, 0)",
+            ExpressionBuild::ParsedSource,
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(
+        |(index, (expr_variant, aggregate_kind, expression, build))| {
+            expression_model(index, expr_variant, aggregate_kind, expression, build)
+        },
+    )
+    .collect()
 }
 
 /// `divide`/`remainder`, each in action context (guarded, so no partial-op

--- a/rust/fslc/tests/typed_agreement/sweep_summary.rs
+++ b/rust/fslc/tests/typed_agreement/sweep_summary.rs
@@ -2,12 +2,11 @@
 // Copyright 2026 Ryoichi Izumita
 
 //! Machine-readable sweep summary: counts of (domain kind, domain size,
-//! property kind, operation/context) this run actually exercised, printed
+//! property kind, expression variant, aggregate kind, type row, and
+//! operation/context) this run actually exercised, printed
 //! at the end of each sweep test so a future #537 C3 slice-2 `expr` axis
 //! citation can point at a specific, re-runnable count instead of a prose
-//! claim. Slice 1 only aggregates; it does not register an axis with the C3
-//! matrix (`assurance_matrix.rs`) -- that is slice 2's job, per
-//! `docs/DESIGN-conformance-harness.md`'s C6 section.
+//! claim. Slice 2 registers that citation with the C3 matrix.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -21,6 +20,9 @@ pub struct SweepSummary {
     action_counts: BTreeMap<usize, usize>,
     guarded_count: usize,
     fair_count: usize,
+    expression_variant_counts: BTreeMap<String, usize>,
+    aggregate_kind_counts: BTreeMap<String, usize>,
+    type_row_counts: BTreeMap<String, usize>,
     operation_counts: BTreeMap<String, usize>,
     total_models: usize,
 }
@@ -64,6 +66,28 @@ impl SweepSummary {
             .or_insert(0) += 1;
         self.total_models += 1;
     }
+
+    pub fn record_expression_model(
+        &mut self,
+        expr_variant: &str,
+        aggregate_kind: Option<&str>,
+        type_rows: impl IntoIterator<Item = &'static str>,
+    ) {
+        *self
+            .expression_variant_counts
+            .entry(expr_variant.to_owned())
+            .or_insert(0) += 1;
+        if let Some(kind) = aggregate_kind {
+            *self
+                .aggregate_kind_counts
+                .entry(kind.to_owned())
+                .or_insert(0) += 1;
+        }
+        for row in type_rows {
+            *self.type_row_counts.entry(row.to_owned()).or_insert(0) += 1;
+        }
+        self.total_models += 1;
+    }
 }
 
 impl fmt::Display for SweepSummary {
@@ -71,7 +95,8 @@ impl fmt::Display for SweepSummary {
         write!(
             formatter,
             "total_models={} domain_kinds={:?} domain_sizes={:?} property_kinds={:?} \
-             state_vars={:?} action_counts={:?} guarded={} fair={} operations={:?}",
+             state_vars={:?} action_counts={:?} guarded={} fair={} \
+             expression_variants={:?} aggregate_kinds={:?} type_rows={:?} operations={:?}",
             self.total_models,
             self.domain_kind_counts,
             self.domain_size_counts,
@@ -80,6 +105,9 @@ impl fmt::Display for SweepSummary {
             self.action_counts,
             self.guarded_count,
             self.fair_count,
+            self.expression_variant_counts,
+            self.aggregate_kind_counts,
+            self.type_row_counts,
             self.operation_counts
         )
     }


### PR DESCRIPTION
# Problem

#537 C3's matrix skeleton (#647) shipped with three axes; the design doc's slice 2/3 plan left the semantic core unregistered: expression forms, type forms, and dialect lowerings had no matrix rows, and the C6 generator (#652) did not yet sweep aggregates/binders/relations.

# Contract change

- **`tests/assurance/expr.rs` (new)**: 28 rows (`fsl_syntax::Expr` — 24 variants, not the 22 an earlier survey counted — plus `AggregateKind` 4) × {Monitor, BMC}. 52 cells Exercised via the extended C6 sweep; 4 UnsupportedFailClosed (`Expr::Call`, `Expr::Stage` — removed by PredicateExpander/StageResolver before any evaluator, proven by typed-AST injection tests asserting the exact fail-closed errors).
- **`tests/assurance/types.rs` (new)**: 12 rows (`TypeRef` 9 + `TypeDef` 3) × {Monitor, BMC}, all Exercised.
- **`tests/assurance/dialects.rs` (new)**: 10 rows (`DIALECT_KEYWORDS`, single-sourced) × {CLI check, Worker, corpus}: 27 Exercised + 3 structural N/A (refinement has no state block for `check`; refinement/agent are Worker-excluded), consistent with the C4 ownership map.
- **`tests/assurance/enum_rows.rs` (new)**: the compile-coupled row derivations (exhaustive matches over the real enums — a new variant is a compile error here).
- **C6 generator extension**: 25 new deterministic expression-family models sweep every evaluator-reachable Expr variant. The sweep test AST-visits each model to prove the designated variant is really present, runs three-engine agreement, adds a per-model negative control (negated invariant must be detected identically by all three engines), and asserts set-equality between swept rows and the enum-derived row lists (bidirectional per-variant coverage). Zero new cross-engine disagreements (#650/#651 unchanged, avoided via safe representatives).
- **`test-browser.mjs`**: the agent Worker-probe fail-closed behavior is now a named assertion (`assertAgentWorkerProbeFailsClosed`) so the dialects axis Worker cell has a stable machine-checked anchor.
- Docs: DESIGN-assurance-matrix.md slices 2/3 recorded as implemented (110 cells: 103 Exercised / 7 UnsupportedFailClosed / 0 unexplained); DESIGN-conformance-harness.md C6 slice-2 plan marked done; the examples/-sweep extension + induction column remain explicitly out of scope with a follow-up note.

# Test evidence

Exit codes measured directly:

- `cargo fmt --check` 0; `cargo clippy --workspace --all-targets --locked -- -D warnings` 0
- `assurance_matrix` 18 tests, `typed_agreement` 22 tests — all pass (0.76s warm)
- `./tools/check-native-integration.sh rust` 0 (703s); `tools/run-fault-operators.sh` 0 (186s)
- `wasm` gate: exit 0 (415 parity cases, nativeParity true; rerun outside the Codex sandbox whose loopback restriction blocks the browser harness)

Part of #537 C3 (slices 2+3 — completes the C3 contract's axis registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
