### PR TITLE
chore(release): v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-07-30
+
 - Semantic Assurance Matrix slices 2/3 add source-derived `expr` (24
   `Expr` + 4 `AggregateKind` rows), `types` (9 `TypeRef` + 3 `TypeDef`
   rows), and `dialects` (all 10 `frontends!` keywords) axes for issue #537
@@ -4158,7 +4160,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/ymm-oss/fsl/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/ymm-oss/fsl/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/ymm-oss/fsl/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/ymm-oss/fsl/compare/v2.7.0...v3.0.0

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -373,14 +373,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.0.0"
+version = "4.1.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7857,11 +7857,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8013,11 +8013,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8038,11 +8038,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8094,11 +8094,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8119,11 +8119,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8158,11 +8158,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8189,11 +8189,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8218,11 +8218,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8248,11 +8248,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8276,11 +8276,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8306,11 +8306,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8334,11 +8334,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8364,11 +8364,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8392,11 +8392,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8423,11 +8423,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8452,11 +8452,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8483,11 +8483,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8512,11 +8512,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8542,11 +8542,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",
@@ -8570,11 +8570,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.0.0"
+              "version": "4.1.0"
             },
             "solver": {
               "name": "z3",


### PR DESCRIPTION
# Problem

`main` is 22 commits ahead of `v4.0.0` with no release. The accumulated work includes real crash fixes (stack safety across all platforms), exit-code corrections that align behavior with the already-documented contract, and the completed Semantic Assurance Program (#537, all seven contracts). This is the release-commit preparation step of `docs/RELEASE.md` §1.

# Contract change

Version-only. No product behavior changes in this commit:

- `rust/Cargo.toml` `[workspace.package].version` 4.0.0 → 4.1.0; `rust/Cargo.lock` regenerated by Cargo (11 workspace members, version lines only — not hand-edited).
- `editors/vscode` bumped to 4.1.0 via `npm version` so the release unit stays atomic (`native_release_unit_is_atomic_pinned_and_platform_closed` enforces this).
- `domain_characterization/baseline.v1.json` regenerated with `UPDATE_DOMAIN_CHARACTERIZATION=1` — **diff verified to contain version strings only** (40 lines, no contract change).
- `CHANGELOG.md`: `[Unreleased]` (458 lines) moved under `## [4.1.0] - 2026-07-30`, empty `[Unreleased]` retained, link references updated.

## Why minor, not major

Three commits carry `!`, but none is an intentional contract redesign:

- **#592 (`fslc ledger` exit code)** and **#537 C2 (outcome classification)** correct behavior that *contradicted* `docs/LANGUAGE.md`'s exit-code table — the documented contract is unchanged; the implementation now honors it. A spec that returned a failure verdict previously exited 0.
- **#622 (kernel AST projection)** renamed an internal function and removed serde re-serialization; byte-identity of the `fsl-kernel-ast-v1+sha256` input was proven by two independent differential sweeps (633 comparisons each, control-first, zero mismatches).

Treating documented-contract *conformance* fixes as major would drain the signal from major. The release notes lead with these behavior corrections so users with exit-code-sensitive automation are warned.

## Known issues shipping with this release

`#650` and `#651` (found by this release's own C6 typed-agreement suite): the symbolic Seq encoding treats an out-of-range `head()` in property context as defined, and `verify_bounded` alone performs no partial-operation check. Both are library-boundary issues — the CLI's concrete pre-scan reaches these cases first, so `fslc` users see `result:"error"`/`kind:"semantics"`, not a wrong verdict. Registered as self-retiring exclusions; fixes are follow-ups.

# Test evidence

Exit codes measured directly, no pipes:

- `cargo check --manifest-path rust/Cargo.toml --workspace` 0; same `--locked` 0
- `cargo run -p fslc-rust --bin fslc -- --version` prints exactly `fslc 4.1.0`
- `UPDATE_DOMAIN_CHARACTERIZATION=1 cargo test --test domain_expression_characterization --locked` 0, diff reviewed
- **`./tools/check-native-integration.sh` 0** — the complete product gate: rust workspace, wasm (417 parity cases, `nativeParity: true`), fault operators (4 calibrated, primary=failed/blind=ok, both controls correct)

Next steps after merge (`docs/RELEASE.md` §2-3): record the merged SHA as the candidate, dispatch `release.yml` on it, open the `main → production` promotion PR, then revalidate and tag on the production HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
