### PR TITLE
ci: give the promotion-only Linux Z3 gate a cold-build budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,16 @@ jobs:
     name: native Z3 4.16 (ubuntu-latest)
     if: github.event_name == 'pull_request' && github.base_ref == 'production'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # Promotion-only, and always a cold build: this job runs on so few commits
+    # that `Swatinem/rust-cache` reports "No cache found" every time, so the
+    # budget must cover vendored Z3 plus the whole `fslc-rust` suite from
+    # scratch. Measured cold: 32m43s at the v4.0.0 promotion, over 40m at the
+    # v4.1.0 promotion once issue #537's suites landed -- the job was killed
+    # mid-suite with every test that had run passing. Raised rather than
+    # narrowed: the same `cargo test --locked` must still pass in full, and a
+    # gate that runs out of wall clock reports a failure it did not observe.
+    # Splitting or caching this job is tracked in issue #655.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Problem

The v4.1.0 promotion (PR #657) failed its required `product gate`, and the failure was a wall-clock ceiling, not a defect:

- `native Z3 4.16 (ubuntu-latest)` — required only for `base_ref == production` — ran 07:26:35 → 08:06:51, exactly its `timeout-minutes: 40`, and was **cancelled mid-test-suite**. Every test that had run passed.
- `product gate` then failed on the cancelled dependency (`PRODUCTION_NATIVE_Z3_LINUX: cancelled`), exactly as designed.

Root cause, measured rather than assumed:

- The job logs `No cache found` on the `Swatinem/rust-cache` step. It runs only on promotion PRs, so its cache is never warm — the budget must cover a cold vendored-Z3 build plus the entire `fslc-rust` suite.
- Cold-build baseline at the **v4.0.0** promotion (run 30213848646): **32m43s** against the 40-minute budget — 7 minutes of headroom.
- Issue #537's suites (`typed_agreement`, `self_conformance`, `assurance_matrix`, `corpus_expectation_manifest`, `evidence_corpus_manifest`, plus the corpus files they added) consumed that headroom.

# Contract change

`timeout-minutes: 40` → `90` for `production-native-z3-linux`, with the measurement recorded in a comment.

Nothing about what the job verifies changes: `cargo test --locked -p fsl-solver-z3 -p fsl-verifier -p fslc-rust` still has to pass in full. The alternative — trimming the crate set or the corpus to fit the old budget — would narrow promotion evidence to fit a clock, which is precisely the kind of green-by-weakening this repository forbids. A gate that runs out of wall clock reports a failure it never observed.

90 minutes is ~2.7× the last measured cold run, leaving room for the suite to keep growing before this needs attention again. Making the job structurally cheaper (a shared cache key with `rust workspace`, or splitting the crate set) is tracked in #655, which flagged CI wall-clock as an externalized cost of this batch before it became a blocker.

# Test evidence

- `.github/workflows/ci.yml` parses (`yaml.safe_load`); the job's `timeout-minutes` reads `90` and its final step's `run` is byte-identical to before.
- The real verification is the re-promotion itself: the same job must now complete and pass within the new budget. If it does not, this diagnosis was wrong and the job needs to be split rather than given more time.

Blocks: the v4.1.0 promotion. After this merges, the release candidate SHA moves to this commit and the promotion evidence (artifact dry-run + gates) is regenerated against it, per `docs/RELEASE.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM7xzpRb2oMY1ccD6gDRF
