### PR TITLE
fix(fslc): keep kernel warnings and action coverage in the domain check projection (#641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- `fslc domain check` now preserves the nested kernel's `warnings` and
+  `action_coverage`, so vacuity and generated-action coverage diagnostics remain
+  visible to domain users instead of being dropped by the stable projection
+  (#641).
+
 ## [4.1.0] - 2026-07-30
 
 - Semantic Assurance Matrix slices 2/3 add source-derived `expr` (24

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6108,6 +6108,11 @@ fn stable_kernel_projection(kernel: Value) -> Value {
             "blame",
             "last_action",
             "trace",
+            // Issue #641. Vacuity/coverage diagnostics are quality signals on
+            // the generated kernel itself: an unreachable generated action can
+            // signal a lowering bug, so these channels fold with the verdict.
+            "warnings",
+            "action_coverage",
         ]
         .into_iter()
         .filter_map(|key| {

--- a/rust/fslc/tests/fixtures/issue_641_domain_clean.fsl
+++ b/rust/fslc/tests/fixtures/issue_641_domain_clean.fsl
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #641 negative control: both decisions are reachable and the aggregate never
+// deadlocks, so no kernel warning should be projected by `domain check`.
+domain CleanDiagnosticDomain {
+  implementation_profile functional_ddd
+
+  enum Status { Open, Closed }
+
+  aggregate Doc {
+    id DocId
+
+    state {
+      status: Status = Open;
+    }
+
+    command CloseDoc {}
+    command ReopenDoc {}
+    event DocClosed {}
+    event DocReopened {}
+
+    decide CloseDoc {
+      requires status == Open
+      emits DocClosed
+    }
+
+    decide ReopenDoc {
+      requires status == Closed
+      emits DocReopened
+    }
+
+    evolve DocClosed {
+      status = Closed
+    }
+
+    evolve DocReopened {
+      status = Open
+    }
+
+    invariant openOrClosed { status == Open || status == Closed }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_641_domain_unreachable_decide.fsl
+++ b/rust/fslc/tests/fixtures/issue_641_domain_unreachable_decide.fsl
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #641 warning fixture: `TouchDoc` remains enabled while `ArchiveDoc` is
+// structurally unreachable because no event can move status to Archived.
+domain UnreachableDecisionDomain {
+  implementation_profile functional_ddd
+
+  enum Status { Open, Archived }
+
+  aggregate Doc {
+    id DocId
+
+    state {
+      status: Status = Open;
+    }
+
+    command TouchDoc {}
+    command ArchiveDoc {}
+    event DocTouched {}
+    event DocArchived {}
+
+    decide TouchDoc {
+      emits DocTouched
+    }
+
+    decide ArchiveDoc {
+      requires status == Archived
+      emits DocArchived
+    }
+
+    evolve DocTouched {
+      status = Open
+    }
+    evolve DocArchived {}
+
+    invariant knownStatus { status == Open || status == Archived }
+  }
+}

--- a/rust/fslc/tests/issue_641_domain_check_kernel_warnings.rs
+++ b/rust/fslc/tests/issue_641_domain_check_kernel_warnings.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Regression coverage for #641: `fslc domain check` must preserve the
+//! nested kernel's vacuity warnings and action coverage because they qualify
+//! confidence in the generated kernel verdict. In particular, an unreachable
+//! generated action can signal a domain-lowering defect even when the bounded
+//! kernel result is otherwise `verified`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+const WARNING: &str = "rust/fslc/tests/fixtures/issue_641_domain_unreachable_decide.fsl";
+const CLEAN: &str = "rust/fslc/tests/fixtures/issue_641_domain_clean.fsl";
+
+/// The issue #641 contract: a verified generated kernel can still carry a
+/// vacuity warning that qualifies the verdict, so `domain check` must keep
+/// the non-empty warning channel in its nested stable projection.
+#[test]
+fn domain_check_preserves_kernel_warnings() {
+    let (check, status) = run(&["domain", "check", WARNING, "--depth", "4"]);
+    assert_eq!(status, 0, "{check:#}");
+    assert!(
+        check["kernel"]["warnings"]
+            .as_array()
+            .is_some_and(|warnings| !warnings.is_empty()),
+        "{check:#}"
+    );
+}
+
+/// Negative control: a domain whose decisions are all covered and whose
+/// state cannot deadlock must remain warning-free, so projecting the channel
+/// does not manufacture diagnostics or alter the successful domain verdict.
+#[test]
+fn domain_check_does_not_overfire_kernel_warnings() {
+    let (check, status) = run(&["domain", "check", CLEAN, "--depth", "4"]);
+    assert_eq!(status, 0, "{check:#}");
+    assert_eq!(check["result"], "verified_under_assumptions");
+    let warnings = &check["kernel"]["warnings"];
+    assert!(
+        warnings.is_null() || warnings.as_array().is_some_and(std::vec::Vec::is_empty),
+        "{check:#}"
+    );
+}
+
+/// Action coverage is the structured companion to a never-enabled warning:
+/// domain users need the generated action's coverage object to distinguish
+/// a lowering-quality signal from a bare bounded verdict.
+#[test]
+fn domain_check_preserves_kernel_action_coverage() {
+    let (check, status) = run(&["domain", "check", WARNING, "--depth", "4"]);
+    assert_eq!(status, 0, "{check:#}");
+    assert!(check["kernel"]["action_coverage"].is_object(), "{check:#}");
+}


### PR DESCRIPTION
## Problem

`fslc domain check`'s nested `kernel` summary carried only
`{spec, result, depth, checked_to_depth, completeness}`. `warnings` and
`action_coverage` were dropped, so a generated action that is structurally
unreachable inside the lowered kernel — a lowering-defect signal — was
invisible behind `findings: []` / `kernel.result: "verified"` / exit 0. The
diagnostic could only be recovered by running `domain expand` plus a bare
`fslc verify` by hand.

Measured on the released 4.1.0 binary with a domain whose `decide` guard is
unsatisfiable:

```
fslc domain check <fixture> --depth 4
→ kernel keys: [checked_to_depth, completeness, depth, result, spec]

fslc domain expand <fixture> -o expanded.fsl && fslc verify expanded.fsl --depth 4
→ warnings: action 'doc_archive_doc' is never enabled within depth 4 …
→ action_coverage.doc_archive_doc.covered = false
```

## Contract change

`stable_kernel_projection` (`rust/fslc/src/main.rs`) is a positive allowlist of
the keys copied from the kernel verdict into the nested `kernel` object.
`warnings` and `action_coverage` join it.

Vacuity and coverage are quality signals on the generated kernel itself: an
unreachable generated action can signal a lowering bug, so these channels fold
through with the verdict. #515 fixed the *verdict* fold; the warning channel
stayed inside the same allowlist.

The projection is called from `run_domain_check` only — `db check` reaches its
nested kernel by a different path and is unaffected.

Product diff is 5 lines.

## Test evidence

`rust/fslc/tests/issue_641_domain_check_kernel_warnings.rs` — 3 tests:

| Test | Asserts |
|---|---|
| `domain_check_preserves_kernel_warnings` | non-empty `kernel.warnings` on the warning fixture |
| `domain_check_does_not_overfire_kernel_warnings` | clean fixture stays `verified_under_assumptions` / exit 0 with no warnings |
| `domain_check_preserves_kernel_action_coverage` | `kernel.action_coverage` is an object |

**Negative control (measured):** reverting the two allowlist entries fails
`domain_check_preserves_kernel_warnings` and
`domain_check_preserves_kernel_action_coverage`, while the over-fire control
still passes.

The warning fixture deliberately contains **no saga**, so it stays stable
across the #640 saga-lowering fix rather than depending on that defect.

Gates, all green:

```
issue_641_domain_check_kernel_warnings   3 passed; 0 failed
issue_515_domain_check_false_green       4 passed; 0 failed
cargo test --workspace --locked          60 suites, 0 FAILED
cargo fmt --check                        clean
cargo clippy --workspace --all-targets   clean
```

## Linked issue

Closes #641. Found by the FSL field-application study (Case F2); triaged and
reproduced against the released 4.1.0 binary.

## Docs / skills

`skills/fsl/reference.md` and `docs/DESIGN-domain.md` do not enumerate the
nested kernel summary's keys, so neither needed a change. `CHANGELOG.md`
`[Unreleased]` records the behaviour change.
