### PR TITLE
fix(verifier): enforce bounded partial-operation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed raw `fsl_verifier::verify_bounded*` calls bypassing the automatic
+  action-context partial-operation check. Symbolic BMC now reports replayable
+  `partial_op` evidence for ordered guards, reached action bodies, and
+  `ensures`, including selected-property, supplied-state, and nondeterministic
+  init paths; native CLI and Worker no longer source `partial_op` from their
+  separate concrete boundary pre-scan (#651).
 - Fixed `domain` saga lowering so effect-owned outcome events cannot bypass the
   effect correlation guard through weaker generated observation actions. Three
   observation actions disappear from generated kernels (#640).

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -100,8 +100,10 @@ Concrete execution requires a deterministic initial state. Static check at
   engine's own construction check (`explicit::check_deterministic_init`, which
   `Monitor::new` now reuses) — every caller that asks `Monitor::new` to compute
   the concrete initial state from `init` gets it, including `replay`'s witness
-  reconstruction and BMC's concrete pre-scan (`find_boundary_violation`).
-  A caller that already has its own complete concrete initial state — an
+  reconstruction and concrete boundary/conformance tooling.
+  Symbolic BMC performs its action-context partial-operation check within
+  `verify_bounded*` and does not construct a Monitor first (#651). A caller
+  that already has its own complete concrete initial state — an
   observed replay trace's own step 0, an explicit `--from-state`/
   `--initial-state` snapshot, or a BMC witness's first state — is not asking
   `init` to compute anything, so it builds through `Monitor::from_state`

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -501,7 +501,7 @@ observed CLI output:
 | R3 | Inline `state { x: T = e }` init reaches the same states as an equivalent explicit `init` block | LANGUAGE.md S2:499-508 ("normalized to an ordinary root assignment...same semantics as an equivalent `init` block") | Assigning the same root both inline and in `init` is `build_model`'s named semantic error |
 | R4 | Disjoint simultaneous assignments reach the same states regardless of source order | LANGUAGE.md S5:644-661 ("all right-hand sides...read the old state...frame condition is automatic") | Assigning the same variable twice on one path is the named semantic error |
 | R5 | A domain-bound-coincident invariant (`x <= hi`, textually equal to the type's own `hi`) holds at every declared size by construction | LANGUAGE.md S6 "Type bounds" (automatic, so a variable can never leave its own declared bound) | Widening the domain past the invariant's stale literal bound changes the verdict to `violated`; also reproduced mechanically via `enumerate_builtin_mutants`'s `type_bound_hi_plus1` |
-| R6 | `/`/`%` are total in property context but `partial_op` in action context | LANGUAGE.md S3:557-570 | The same expression in action context; see "Two confirmed findings" for what raw `verify_bounded` actually checks here |
+| R6 | `/`/`%` are total in property context but `partial_op` in action context | LANGUAGE.md S3:557-570 | The same expression in action context is checked directly by raw `verify_bounded`; the six operation fixtures must agree across all four native engines |
 | R7 | `entity`/`number` + `verify` reaches the same states as the hand-written lowered `type` | LANGUAGE.md S2:485-486 ("desugars to `type`") | Shifting the lowered bound by +1 past the declared size is detected |
 
 `R4`'s `assignment_remove` and `R6`'s `equality_operator_flip` reuse of
@@ -516,47 +516,40 @@ equivalent candidate is why R5's mutate-reuse test uses a separate,
 dedicated fixture instead of R5's own; see `relations.rs`'s
 `r5_mutate_kill_fixture` doc comment for the full account.
 
-### Two confirmed findings
+### Confirmed finding
 
-Both are recorded as re-measured facts, not silently normalized away or
-excluded:
+The remaining finding is recorded as a re-measured fact, not silently
+normalized away or excluded:
 
-1. **A partial Seq read (`head()`) evaluated in property context on an
-   empty sequence disagrees across engines.** `fsl_runtime::verify_explicit`
-   and `fsl_runtime::bfs` both raise a raw `RuntimeError`
-   ("`head()` on empty sequence") instead of returning a verdict, because
-   `Monitor::current_violation[_selected]` — unlike
-   `Monitor::execute_selected`'s post-step invariant check — does not catch
-   `is_partial_operation_error` and convert it to a `partial_op` `Violation`.
-   `fsl_verifier::verify_bounded` instead returns a *verdict*: `violated`,
-   `kind: "invariant"` (not `partial_op`), naming the user's own invariant,
-   at step 0 — its symbolic Seq encoding treats an out-of-range read as
-   *defined* with some solver-chosen value outside the element type's own
-   declared bound, rather than as undefined the way the concrete engines
-   (and LANGUAGE.md's own account of `/`/`%`, by contrast) treat it. Root
-   cause in the symbolic encoding is not diagnosed here; that is for the
-   tracking issue. Self-retiring exclusion:
-   `relations.rs::r6_property_context_seq_head_disagrees_across_engines_self_retiring_exclusion`
-   re-measures the exact `(kind, name, step)` and both error messages on
-   every run.
+**A partial Seq read (`head()`) evaluated in property context on an
+empty sequence disagrees across engines.** `fsl_runtime::verify_explicit`
+and `fsl_runtime::bfs` both raise a raw `RuntimeError`
+("`head()` on empty sequence") instead of returning a verdict, because
+`Monitor::current_violation[_selected]` — unlike
+`Monitor::execute_selected`'s post-step invariant check — does not catch
+`is_partial_operation_error` and convert it to a `partial_op` `Violation`.
+`fsl_verifier::verify_bounded` instead returns a *verdict*: `violated`,
+`kind: "invariant"` (not `partial_op`), naming the user's own invariant,
+at step 0 — its symbolic Seq encoding treats an out-of-range read as
+*defined* with some solver-chosen value outside the element type's own
+declared bound, rather than as undefined the way the concrete engines
+(and LANGUAGE.md's own account of `/`/`%`, by contrast) treat it. Root
+cause in the symbolic encoding is not diagnosed here; that is for the
+tracking issue. Self-retiring exclusion:
+`relations.rs::r6_property_context_seq_head_disagrees_across_engines_self_retiring_exclusion`
+re-measures the exact `(kind, name, step)` and both error messages on
+every run.
 
-2. **`fsl_verifier::verify_bounded` does not perform LANGUAGE.md S6's
-   automatic "Partial operations" check at all**, for any of the six named
-   operations, in action context. `rust/fsl-verifier/src/bmc.rs` has no
-   `partial_op` handling anywhere in it; the CLI's `--engine bmc`
-   `partial_op` classification comes from `rust/fslc/src/verification.rs`'s
-   `run_bmc_filtered` merging in a *concrete* pre-scan
-   (`fsl_runtime::find_boundary_violation`), not from the solver. This is a
-   scope boundary this suite documents rather than a bug: raw
-   `verify_bounded`'s outcome for these six fixtures ranges from a clean
-   verdict (`divide`/`remainder`) to a spurious `type_bound` on the
-   assigned scalar (`head`/`at`/index — the same symbolic-Seq gap as
-   finding 1, surfacing differently) to `Err("model sequence length is
-   negative")` (`pop`) — all recorded, none asserted, in
-   `relations.rs::r6_action_context_partial_operations_are_caught_only_by_the_concrete_engines`.
-   The three concrete-family engines (Monitor BFS / explicit /
-   `find_boundary_violation`) agree with each other on `partial_op` for
-   all six.
+The former raw-API gap for action-context partial operations was resolved by
+#651. `fsl_verifier::verify_bounded` now applies backend-neutral symbolic
+definedness at the public verifier boundary for ordered guards, reached body
+expressions, and `ensures`. The CLI and Worker no longer consume `partial_op`
+from their concrete boundary pre-scan; non-partial outcomes that the bounded
+symbolic value cannot represent still retain that exact concrete evidence. The
+R6 fixtures assert Monitor BFS, explicit,
+`find_boundary_violation`, and raw BMC agree on `partial_op` for all six named
+operations. Property-context totalization remains outside that action-context
+classification and is still covered by the finding above.
 
 ### Z3js / Worker parity ownership
 

--- a/docs/DESIGN-kernel-contract.md
+++ b/docs/DESIGN-kernel-contract.md
@@ -258,13 +258,19 @@ unbounded integer terms, agreement uses a separate typed definedness predicate
 that follows native short-circuit, statement-branch, guard, post-property, and
 checked-i64 evaluation order. A non-partial claim is rejected when its reached
 path is undefined; an untaken partial expression does not make a valid outcome
-unsupported. Agreement-only fallback values let zero-capacity sequence terms
-be constructed under those predicates; ordinary BMC and induction retain their
-existing fail-closed evaluation. Exact `partial_op` classification and concrete
-evidence that the bounded symbolic representation cannot retain, such as an
-over-capacity sequence suffix, return an error rather than green until an exact
-partial-evidence oracle is available. Concrete conformance vectors remain
-authoritative for `partial_op` rollback meanwhile.
+unsupported. The same backend-neutral traversal returns both full definedness
+and the first reached partial operation for ordinary BMC. Ordered guards,
+reached body expressions, and `ensures` classify only the six LANGUAGE.md
+partial operations, while an earlier checked integer overflow or invalid finite
+Map lookup remains a fail-closed evaluation error instead of being relabeled by
+a later partial operation.
+This keeps action-context `partial_op` classification inside the public
+`verify_bounded*` boundary without adding a production dependency on
+`fsl-runtime`. Agreement-only fallback values still let zero-capacity sequence
+terms be constructed under the broader conformance predicates. Concrete
+conformance vectors remain authoritative for exact rollback evidence that a
+bounded symbolic representation cannot retain, such as an over-capacity
+sequence suffix. Property-context totalization is unchanged.
 The solver-free `fsl-runtime` dependency boundary remains intact.
 
 ## CLI and API

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -159,7 +159,7 @@ pub fn eval(
                     .cloned()
                     .ok_or_else(|| runtime_error("map index outside finite key domain")),
                 Value::Seq(values) => values
-                    .get(as_usize(index)?)
+                    .get(as_usize(index, "sequence index out of range")?)
                     .cloned()
                     .ok_or_else(|| runtime_error("sequence index out of range")),
                 _ => Err(runtime_error("indexing requires a map or sequence")),
@@ -429,7 +429,7 @@ fn eval_method(
                 .cloned()
                 .ok_or_else(|| runtime_error("head() on empty sequence")),
             ("at", [index]) => sequence
-                .get(as_usize(index.clone())?)
+                .get(as_usize(index.clone(), "at() index out of range")?)
                 .cloned()
                 .ok_or_else(|| runtime_error("at() index out of range")),
             ("size", []) => Ok(Value::Int(i64_len(sequence.len())?)),
@@ -718,8 +718,8 @@ fn as_int(value: Value) -> Result<i64, RuntimeError> {
     }
 }
 
-fn as_usize(value: Value) -> Result<usize, RuntimeError> {
-    usize::try_from(as_int(value)?).map_err(|_| runtime_error("index must be non-negative"))
+fn as_usize(value: Value, message: &str) -> Result<usize, RuntimeError> {
+    usize::try_from(as_int(value)?).map_err(|_| runtime_error(message))
 }
 
 fn i64_len(value: usize) -> Result<i64, RuntimeError> {
@@ -2354,18 +2354,41 @@ fn replay_trace_with_initial(
             .action
             .as_ref()
             .ok_or_else(|| runtime_error(format!("trace step {expected_step} has no action")))?;
-        let enabled = monitor.enabled()?;
-        let instance = enabled
-            .iter()
-            .find(|instance| instance.action == action.name && instance.params == action.params)
-            .ok_or_else(|| {
-                runtime_error(format!(
-                    "trace action '{}' is not enabled at step {expected_step}",
-                    action.name
-                ))
-            })?;
         let before = monitor.state.clone();
-        let stepped = monitor.step(instance)?;
+        let stepped = match monitor.enabled() {
+            Ok(enabled) => {
+                let instance = enabled
+                    .iter()
+                    .find(|instance| {
+                        instance.action == action.name && instance.params == action.params
+                    })
+                    .ok_or_else(|| {
+                        runtime_error(format!(
+                            "trace action '{}' is not enabled at step {expected_step}",
+                            action.name
+                        ))
+                    })?;
+                monitor.step(instance)?
+            }
+            Err(error)
+                if expected_step + 1 == trace.len()
+                    && is_partial_operation_error(&error.message) =>
+            {
+                let attempted = monitor.attempt(&action.name, &action.params)?;
+                if attempted
+                    .violation
+                    .as_ref()
+                    .is_none_or(|violation| violation.kind != "partial_op")
+                {
+                    return Err(runtime_error(format!(
+                        "trace action '{}' does not reproduce a partial operation at step {expected_step}",
+                        action.name
+                    )));
+                }
+                attempted
+            }
+            Err(error) => return Err(error),
+        };
         let observed_state = stepped.attempted_state.as_ref().unwrap_or(&stepped.state);
         if observed_state != &entry.state {
             return Err(runtime_error(format!(
@@ -3027,7 +3050,7 @@ fn assign(
                     values.insert(index, value);
                 }
                 Value::Seq(values) => {
-                    let index = as_usize(index)?;
+                    let index = as_usize(index, "sequence index out of range")?;
                     let slot = values
                         .get_mut(index)
                         .ok_or_else(|| runtime_error("sequence assignment index out of range"))?;

--- a/rust/fsl-verifier/src/bmc.rs
+++ b/rust/fsl-verifier/src/bmc.rs
@@ -2,16 +2,18 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use fsl_core::{FslValue, KernelModel, LeadsToDef, TraceStep};
+use fsl_core::{FslValue, KernelModel, LeadsToDef, TraceAction, TraceStep};
 use fsl_solver::{SatResult, SmtSolver};
 
 use crate::VerifyError;
-use crate::eval::eval;
+use crate::eval::{eval, evaluation_status};
 use crate::liveness::{LeadstoBinding, leadsto_bindings, leadsto_condition};
 use crate::symmetry::canonical_constraint;
 use crate::trace::project_trace;
 use crate::transition::{
-    ActionInstance, action_guards, action_instances, init_constraints, transition_constraint,
+    ActionInstance, action_guard_definedness, action_guards,
+    action_has_partial_operation_candidate, action_instances, action_statements_evaluation_status,
+    init_constraints, transition_constraint,
 };
 use crate::vacuity::{VacuityFinding, retain_covered, static_findings};
 use crate::value::{
@@ -182,6 +184,10 @@ async fn verify_bounded_config<S: SmtSolver>(
         .collect::<BTreeSet<_>>();
     let mut states = vec![initial];
     let mut choices = Vec::new();
+    let has_action_partial_operation_candidates = model
+        .actions
+        .iter()
+        .any(action_has_partial_operation_candidate);
 
     for step in 0..=depth {
         if let Some(violation) = check_state_properties(
@@ -194,6 +200,16 @@ async fn verify_bounded_config<S: SmtSolver>(
             checked_bounds,
         )
         .await?
+        {
+            result.violation = Some(violation);
+            return Ok(result);
+        }
+
+        if step < depth
+            && has_action_partial_operation_candidates
+            && let Some(violation) =
+                check_action_partial_operations(solver, model, &states, &choices, &instances, step)
+                    .await?
         {
             result.violation = Some(violation);
             return Ok(result);
@@ -399,14 +415,57 @@ async fn check_state_properties<S: SmtSolver>(
         if action.ensures.is_empty() {
             continue;
         }
-        let (guards, mut bindings) =
-            action_guards(solver, model, action, &states[step - 1], &instance.params)?;
+        let guard_status =
+            action_guard_definedness(solver, model, action, &states[step - 1], &instance.params)?;
+        let mut bindings = guard_status.bindings;
+        let body_status = action_statements_evaluation_status(
+            solver,
+            model,
+            action,
+            &states[step - 1],
+            &bindings,
+        )?;
         let selected = solver.equal(
             &choices[step - 1],
             &solver.int_value(i64_index(instance_index)?),
         )?;
+        let mut reached =
+            solver.and(&[selected, guard_status.enabled, body_status.fully_defined])?;
         for ensure in &action.ensures {
             solver.set_query_context("ensures", &action.name);
+            let ensure_status = evaluation_status(
+                solver,
+                model,
+                ensure,
+                &states[step],
+                &bindings,
+                Some(&states[step - 1]),
+            )?;
+            let partial = solver.and(&[reached.clone(), ensure_status.first_partial])?;
+            if probe(solver, &partial).await? {
+                return Ok(Some(
+                    make_violation(
+                        solver,
+                        model,
+                        "partial_op",
+                        format!("_partial_{}", action.name),
+                        &partial,
+                        states,
+                        choices,
+                        instances,
+                        step,
+                    )
+                    .await?,
+                ));
+            }
+            let undefined =
+                solver.and(&[reached.clone(), solver.not(&ensure_status.fully_defined)?])?;
+            if probe(solver, &undefined).await? {
+                return Err(VerifyError::new(format!(
+                    "action '{}' ensures evaluation has a non-partial failure",
+                    action.name
+                )));
+            }
             let value = eval(
                 solver,
                 model,
@@ -415,9 +474,11 @@ async fn check_state_properties<S: SmtSolver>(
                 &mut bindings,
                 Some(&states[step - 1]),
             )?;
-            let mut violation = vec![selected.clone(), solver.not(bool_term(&value)?)?];
-            violation.extend(guards.clone());
-            let failure = solver.and(&violation)?;
+            let failure = solver.and(&[
+                reached.clone(),
+                ensure_status.fully_defined.clone(),
+                solver.not(bool_term(&value)?)?,
+            ])?;
             if probe(solver, &failure).await? {
                 return Ok(Some(
                     make_violation(
@@ -434,9 +495,148 @@ async fn check_state_properties<S: SmtSolver>(
                     .await?,
                 ));
             }
+            reached = solver.and(&[
+                reached,
+                ensure_status.fully_defined,
+                bool_term(&value)?.clone(),
+            ])?;
         }
     }
     Ok(None)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn check_action_partial_operations<S: SmtSolver>(
+    solver: &mut S,
+    model: &KernelModel,
+    states: &[SymbolicState<S::Term>],
+    choices: &[S::Term],
+    instances: &[ActionInstance<S::Term>],
+    step: usize,
+) -> Result<Option<BmcViolation>, VerifyError> {
+    for instance in instances {
+        let action = &model.actions[instance.action_index];
+        let guard_evaluation =
+            action_guard_definedness(solver, model, action, &states[step], &instance.params)?;
+        let body_status = action_statements_evaluation_status(
+            solver,
+            model,
+            action,
+            &states[step],
+            &guard_evaluation.bindings,
+        )?;
+        let mut ensures_have_partial_operation = false;
+        for ensure in &action.ensures {
+            ensures_have_partial_operation |= evaluation_status(
+                solver,
+                model,
+                ensure,
+                &states[step],
+                &guard_evaluation.bindings,
+                Some(&states[step]),
+            )?
+            .has_partial_operation;
+        }
+        if !guard_evaluation.has_partial_operation
+            && !body_status.has_partial_operation
+            && !ensures_have_partial_operation
+        {
+            continue;
+        }
+        let guard_failure = guard_evaluation.first_partial;
+        solver.set_query_context("partial_op", &action.name);
+        if probe(solver, &guard_failure).await? {
+            return Ok(Some(
+                make_action_partial_operation_violation(
+                    solver,
+                    model,
+                    action,
+                    instance,
+                    &guard_failure,
+                    states,
+                    choices,
+                    instances,
+                    step,
+                )
+                .await?,
+            ));
+        }
+        let guard_undefined = solver.not(&guard_evaluation.defined)?;
+        if probe(solver, &guard_undefined).await? {
+            return Err(VerifyError::new(format!(
+                "action '{}' guard evaluation has a non-partial failure",
+                action.name
+            )));
+        }
+
+        let body_failure =
+            solver.and(&[guard_evaluation.enabled.clone(), body_status.first_partial])?;
+        if probe(solver, &body_failure).await? {
+            return Ok(Some(
+                make_action_partial_operation_violation(
+                    solver,
+                    model,
+                    action,
+                    instance,
+                    &body_failure,
+                    states,
+                    choices,
+                    instances,
+                    step,
+                )
+                .await?,
+            ));
+        }
+        let body_undefined = solver.and(&[
+            guard_evaluation.enabled.clone(),
+            solver.not(&body_status.fully_defined)?,
+        ])?;
+        if probe(solver, &body_undefined).await? {
+            return Err(VerifyError::new(format!(
+                "action '{}' body evaluation has a non-partial failure",
+                action.name
+            )));
+        }
+    }
+    Ok(None)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn make_action_partial_operation_violation<S: SmtSolver>(
+    solver: &mut S,
+    model: &KernelModel,
+    action: &fsl_core::ActionDef,
+    instance: &ActionInstance<S::Term>,
+    condition: &S::Term,
+    states: &[SymbolicState<S::Term>],
+    choices: &[S::Term],
+    instances: &[ActionInstance<S::Term>],
+    step: usize,
+) -> Result<BmcViolation, VerifyError> {
+    let mut trace =
+        build_witness(solver, model, condition, states, choices, instances, step).await?;
+    let state = trace
+        .last()
+        .ok_or_else(|| VerifyError::new("partial-operation witness is empty"))?
+        .state
+        .clone();
+    trace.push(TraceStep {
+        step: step + 1,
+        state,
+        action: Some(TraceAction {
+            name: action.name.clone(),
+            params: instance.concrete_params.clone(),
+        }),
+        changes: BTreeMap::new(),
+    });
+    Ok(BmcViolation {
+        kind: "partial_op".to_owned(),
+        name: format!("_partial_{}", action.name),
+        step: step + 1,
+        last_action: Some(action.name.clone()),
+        trace,
+        leads_to: None,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/rust/fsl-verifier/src/eval.rs
+++ b/rust/fsl-verifier/src/eval.rs
@@ -391,7 +391,6 @@ fn relation_reachability_table<S: SmtSolver>(
 /// without a partial operation, checked integer overflow, or invalid finite
 /// lookup. Unlike [`eval`], this preserves native short-circuit and conditional
 /// evaluation paths.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn definedness<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
@@ -400,13 +399,160 @@ pub(crate) fn definedness<S: SmtSolver>(
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
 ) -> Result<S::Term, VerifyError> {
+    Ok(evaluation_status(solver, model, expr, state, bindings, old_state)?.fully_defined)
+}
+
+#[derive(Clone)]
+pub(crate) struct EvaluationStatus<T> {
+    pub fully_defined: T,
+    pub first_partial: T,
+    pub has_partial_operation: bool,
+}
+
+pub(crate) fn expression_has_partial_operation_candidate(expr: &Expr) -> bool {
+    match expr {
+        Expr::Index(_, _) => true,
+        Expr::Method {
+            receiver,
+            name,
+            args,
+        } => {
+            matches!(name.as_str(), "head" | "pop" | "at")
+                || expression_has_partial_operation_candidate(receiver)
+                || args.iter().any(expression_has_partial_operation_candidate)
+        }
+        Expr::Binary { op, left, right } => {
+            matches!(op.as_str(), "/" | "%")
+                || expression_has_partial_operation_candidate(left)
+                || expression_has_partial_operation_candidate(right)
+        }
+        Expr::Some(inner)
+        | Expr::Neg(inner)
+        | Expr::Not(inner)
+        | Expr::Field(inner, _)
+        | Expr::Stage { entity: inner, .. }
+        | Expr::UnaryNamed { expr: inner, .. }
+        | Expr::Is { expr: inner, .. } => expression_has_partial_operation_candidate(inner),
+        Expr::Set(items) | Expr::Seq(items) | Expr::Call { args: items, .. } => {
+            items.iter().any(expression_has_partial_operation_candidate)
+        }
+        Expr::Struct { fields, .. } => fields
+            .iter()
+            .any(|(_, value)| expression_has_partial_operation_candidate(value)),
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            expression_has_partial_operation_candidate(condition)
+                || expression_has_partial_operation_candidate(then_expr)
+                || expression_has_partial_operation_candidate(else_expr)
+        }
+        Expr::Quantified { binder, body, .. } => {
+            binder_has_partial_operation_candidate(binder)
+                || expression_has_partial_operation_candidate(body)
+        }
+        Expr::Aggregate { binder, value, .. } => {
+            binder_has_partial_operation_candidate(binder)
+                || value
+                    .as_deref()
+                    .is_some_and(expression_has_partial_operation_candidate)
+        }
+        Expr::BinaryNamed { left, right, .. } => {
+            expression_has_partial_operation_candidate(left)
+                || expression_has_partial_operation_candidate(right)
+        }
+        Expr::TernaryNamed {
+            first,
+            second,
+            third,
+            ..
+        } => {
+            expression_has_partial_operation_candidate(first)
+                || expression_has_partial_operation_candidate(second)
+                || expression_has_partial_operation_candidate(third)
+        }
+        Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => false,
+    }
+}
+
+pub(crate) fn binder_has_partial_operation_candidate(binder: &Binder) -> bool {
+    match binder {
+        Binder::Typed { where_expr, .. } => where_expr
+            .as_deref()
+            .is_some_and(expression_has_partial_operation_candidate),
+        Binder::Range {
+            lo, hi, where_expr, ..
+        } => {
+            expression_has_partial_operation_candidate(lo)
+                || expression_has_partial_operation_candidate(hi)
+                || where_expr
+                    .as_deref()
+                    .is_some_and(expression_has_partial_operation_candidate)
+        }
+        Binder::Collection {
+            collection,
+            where_expr,
+            ..
+        } => {
+            expression_has_partial_operation_candidate(collection)
+                || where_expr
+                    .as_deref()
+                    .is_some_and(expression_has_partial_operation_candidate)
+        }
+    }
+}
+
+fn safe_status<S: SmtSolver>(solver: &S) -> EvaluationStatus<S::Term> {
+    EvaluationStatus {
+        fully_defined: solver.bool_value(true),
+        first_partial: solver.bool_value(false),
+        has_partial_operation: false,
+    }
+}
+
+pub(crate) fn sequence_statuses<S: SmtSolver>(
+    solver: &S,
+    statuses: impl IntoIterator<Item = EvaluationStatus<S::Term>>,
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
+    let mut fully_defined = solver.bool_value(true);
+    let mut first_partial = solver.bool_value(false);
+    let mut has_partial_operation = false;
+    for status in statuses {
+        has_partial_operation |= status.has_partial_operation;
+        first_partial = solver.or(&[
+            first_partial,
+            solver.and(&[fully_defined.clone(), status.first_partial])?,
+        ])?;
+        fully_defined = solver.and(&[fully_defined, status.fully_defined])?;
+    }
+    Ok(EvaluationStatus {
+        fully_defined,
+        first_partial,
+        has_partial_operation,
+    })
+}
+
+/// Build the path-sensitive conditions that concrete evaluation completes and
+/// that its first reached failure is one of LANGUAGE.md §6's six classified
+/// partial operations.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub(crate) fn evaluation_status<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    expr: &Expr,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+    old_state: Option<&SymbolicState<S::Term>>,
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     match expr {
         Expr::Num(_) | Expr::Bool(_) | Expr::None | Expr::Var(_) | Expr::EnumMember { .. } => {
-            Ok(solver.bool_value(true))
+            Ok(safe_status(solver))
         }
         Expr::UnaryNamed {
             name, expr: inner, ..
-        } if name == "old" => definedness(
+        } if name == "old" => evaluation_status(
             solver,
             model,
             inner,
@@ -416,23 +562,39 @@ pub(crate) fn definedness<S: SmtSolver>(
         ),
         Expr::Neg(inner) => {
             let mut local = bindings.clone();
-            let inner_defined = definedness(solver, model, inner, state, &local, old_state)?;
+            let inner_status = evaluation_status(solver, model, inner, state, &local, old_state)?;
             let inner = eval(solver, model, inner, state, &mut local, old_state)?;
-            Ok(solver.and(&[
-                inner_defined,
-                solver.not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
-            ])?)
+            sequence_statuses(
+                solver,
+                [
+                    inner_status,
+                    EvaluationStatus {
+                        fully_defined: solver
+                            .not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
+                        first_partial: solver.bool_value(false),
+                        has_partial_operation: false,
+                    },
+                ],
+            )
         }
         Expr::UnaryNamed {
             name, expr: inner, ..
         } if name == "abs" => {
             let mut local = bindings.clone();
-            let inner_defined = definedness(solver, model, inner, state, &local, old_state)?;
+            let inner_status = evaluation_status(solver, model, inner, state, &local, old_state)?;
             let inner = eval(solver, model, inner, state, &mut local, old_state)?;
-            Ok(solver.and(&[
-                inner_defined,
-                solver.not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
-            ])?)
+            sequence_statuses(
+                solver,
+                [
+                    inner_status,
+                    EvaluationStatus {
+                        fully_defined: solver
+                            .not(&solver.equal(int_term(&inner)?, &solver.int_value(i64::MIN))?)?,
+                        first_partial: solver.bool_value(false),
+                        has_partial_operation: false,
+                    },
+                ],
+            )
         }
         Expr::Some(inner)
         | Expr::Not(inner)
@@ -440,10 +602,10 @@ pub(crate) fn definedness<S: SmtSolver>(
         | Expr::Is { expr: inner, .. }
         | Expr::Stage { entity: inner, .. }
         | Expr::UnaryNamed { expr: inner, .. } => {
-            definedness(solver, model, inner, state, bindings, old_state)
+            evaluation_status(solver, model, inner, state, bindings, old_state)
         }
         Expr::Set(items) | Expr::Seq(items) | Expr::Call { args: items, .. } => {
-            ordered_definedness(solver, model, items, state, bindings, old_state)
+            ordered_evaluation_status(solver, model, items, state, bindings, old_state)
         }
         Expr::Struct { name, fields } => {
             let TypeDef::Struct {
@@ -473,16 +635,29 @@ pub(crate) fn definedness<S: SmtSolver>(
                     "struct '{name}' has the wrong number of fields"
                 )));
             }
-            ordered_definedness_refs(solver, model, &items, state, bindings, old_state)
+            ordered_evaluation_status_refs(solver, model, &items, state, bindings, old_state)
         }
         Expr::Index(base, index) => {
             let mut local = bindings.clone();
-            let base_defined = definedness(solver, model, base, state, &local, old_state)?;
+            let base_status = evaluation_status(solver, model, base, state, &local, old_state)?;
             let base_value = eval(solver, model, base, state, &mut local, old_state)?;
-            let index_defined = definedness(solver, model, index, state, &local, old_state)?;
+            let index_status = evaluation_status(solver, model, index, state, &local, old_state)?;
             let index_value = eval(solver, model, index, state, &mut local, old_state)?;
-            let accessible = index_accessible(solver, model, &base_value, &index_value)?;
-            Ok(solver.and(&[base_defined, index_defined, accessible])?)
+            let fully_accessible = index_accessible(solver, model, &base_value, &index_value)?;
+            let partial_accessible =
+                partial_operation_index_accessible(solver, &base_value, &index_value)?;
+            sequence_statuses(
+                solver,
+                [
+                    base_status,
+                    index_status,
+                    EvaluationStatus {
+                        fully_defined: fully_accessible,
+                        first_partial: solver.not(&partial_accessible)?,
+                        has_partial_operation: matches!(base_value, SymbolicValue::Seq { .. }),
+                    },
+                ],
+            )
         }
         Expr::Method {
             receiver,
@@ -490,42 +665,68 @@ pub(crate) fn definedness<S: SmtSolver>(
             args,
         } => {
             let mut local = bindings.clone();
-            let receiver_defined = definedness(solver, model, receiver, state, &local, old_state)?;
+            let receiver_status =
+                evaluation_status(solver, model, receiver, state, &local, old_state)?;
             let receiver_value = eval(solver, model, receiver, state, &mut local, old_state)?;
-            let arguments_defined =
-                ordered_definedness(solver, model, args, state, &local, old_state)?;
+            let arguments_status =
+                ordered_evaluation_status(solver, model, args, state, &local, old_state)?;
             let argument_values = args
                 .iter()
                 .map(|argument| eval(solver, model, argument, state, &mut local, old_state))
                 .collect::<Result<Vec<_>, _>>()?;
             let operation_defined =
                 method_definedness(solver, name, &receiver_value, argument_values.as_slice())?;
-            Ok(solver.and(&[receiver_defined, arguments_defined, operation_defined])?)
+            sequence_statuses(
+                solver,
+                [
+                    receiver_status,
+                    arguments_status,
+                    EvaluationStatus {
+                        fully_defined: operation_defined.clone(),
+                        first_partial: solver.not(&operation_defined)?,
+                        has_partial_operation: matches!(
+                            (&receiver_value, name.as_str(), argument_values.as_slice()),
+                            (SymbolicValue::Seq { .. }, "head" | "pop", [])
+                                | (SymbolicValue::Seq { .. }, "at", [_])
+                        ),
+                    },
+                ],
+            )
         }
         Expr::Binary { op, left, right } => {
             let mut local = bindings.clone();
-            let left_defined = definedness(solver, model, left, state, &local, old_state)?;
+            let left_status = evaluation_status(solver, model, left, state, &local, old_state)?;
             let left_value = eval(solver, model, left, state, &mut local, old_state)?;
-            let right_defined = definedness(solver, model, right, state, &local, old_state)?;
+            let right_status = evaluation_status(solver, model, right, state, &local, old_state)?;
             let right_value = eval(solver, model, right, state, &mut local, old_state)?;
             let reached_right = match op.as_str() {
                 "and" | "=>" => bool_term(&left_value)?.clone(),
                 "or" => solver.not(bool_term(&left_value)?)?,
                 _ => solver.bool_value(true),
             };
-            let mut parts = vec![
-                left_defined,
-                solver.implies(&reached_right, &right_defined)?,
-            ];
+            let first_partial = solver.or(&[
+                left_status.first_partial,
+                solver.and(&[
+                    left_status.fully_defined.clone(),
+                    reached_right.clone(),
+                    right_status.first_partial,
+                ])?,
+            ])?;
+            let operands_defined = solver.and(&[
+                left_status.fully_defined,
+                solver.implies(&reached_right, &right_status.fully_defined)?,
+            ])?;
+            let mut parts = vec![operands_defined.clone()];
+            let mut operation_partial = solver.bool_value(false);
             if matches!(op.as_str(), "/" | "%") {
-                parts.push(
-                    solver.not(&solver.equal(int_term(&right_value)?, &solver.int_value(0))?)?,
-                );
+                let zero = solver.equal(int_term(&right_value)?, &solver.int_value(0))?;
+                parts.push(solver.not(&zero)?);
                 let overflow = solver.and(&[
                     solver.equal(int_term(&left_value)?, &solver.int_value(i64::MIN))?,
                     solver.equal(int_term(&right_value)?, &solver.int_value(-1))?,
                 ])?;
                 parts.push(solver.not(&overflow)?);
+                operation_partial = solver.and(&[operands_defined, zero])?;
             } else if matches!(op.as_str(), "+" | "-" | "*") {
                 let result = match op.as_str() {
                     "+" => solver.add(int_term(&left_value)?, int_term(&right_value)?)?,
@@ -535,7 +736,13 @@ pub(crate) fn definedness<S: SmtSolver>(
                 };
                 parts.push(i64_term_is_in_range(solver, &result)?);
             }
-            Ok(solver.and(&parts)?)
+            Ok(EvaluationStatus {
+                fully_defined: solver.and(&parts)?,
+                first_partial: solver.or(&[first_partial, operation_partial])?,
+                has_partial_operation: left_status.has_partial_operation
+                    || right_status.has_partial_operation
+                    || matches!(op.as_str(), "/" | "%"),
+            })
         }
         Expr::Conditional {
             condition,
@@ -544,28 +751,47 @@ pub(crate) fn definedness<S: SmtSolver>(
             ..
         } => {
             let mut local = bindings.clone();
-            let condition_defined =
-                definedness(solver, model, condition, state, &local, old_state)?;
+            let condition_status =
+                evaluation_status(solver, model, condition, state, &local, old_state)?;
             let condition_value = eval(solver, model, condition, state, &mut local, old_state)?;
-            let then_defined = definedness(solver, model, then_expr, state, &local, old_state)?;
-            let else_defined = definedness(solver, model, else_expr, state, &local, old_state)?;
-            Ok(solver.and(&[
-                condition_defined,
-                solver.ite(bool_term(&condition_value)?, &then_defined, &else_defined)?,
-            ])?)
+            let then_status =
+                evaluation_status(solver, model, then_expr, state, &local, old_state)?;
+            let else_status =
+                evaluation_status(solver, model, else_expr, state, &local, old_state)?;
+            let branch_defined = solver.ite(
+                bool_term(&condition_value)?,
+                &then_status.fully_defined,
+                &else_status.fully_defined,
+            )?;
+            let branch_partial = solver.ite(
+                bool_term(&condition_value)?,
+                &then_status.first_partial,
+                &else_status.first_partial,
+            )?;
+            Ok(EvaluationStatus {
+                fully_defined: solver
+                    .and(&[condition_status.fully_defined.clone(), branch_defined])?,
+                first_partial: solver.or(&[
+                    condition_status.first_partial,
+                    solver.and(&[condition_status.fully_defined, branch_partial])?,
+                ])?,
+                has_partial_operation: condition_status.has_partial_operation
+                    || then_status.has_partial_operation
+                    || else_status.has_partial_operation,
+            })
         }
         Expr::Quantified {
             quantifier,
             binder,
             body,
-        } => quantified_definedness(
+        } => quantified_evaluation_status(
             solver, model, quantifier, binder, body, state, bindings, old_state,
         ),
         Expr::Aggregate {
             kind,
             binder,
             value,
-        } => aggregate_definedness(
+        } => aggregate_evaluation_status(
             solver,
             model,
             *kind,
@@ -575,7 +801,7 @@ pub(crate) fn definedness<S: SmtSolver>(
             bindings,
             old_state,
         ),
-        Expr::BinaryNamed { left, right, .. } => ordered_definedness_refs(
+        Expr::BinaryNamed { left, right, .. } => ordered_evaluation_status_refs(
             solver,
             model,
             &[left.as_ref(), right.as_ref()],
@@ -588,7 +814,7 @@ pub(crate) fn definedness<S: SmtSolver>(
             second,
             third,
             ..
-        } => ordered_definedness_refs(
+        } => ordered_evaluation_status_refs(
             solver,
             model,
             &[first.as_ref(), second.as_ref(), third.as_ref()],
@@ -599,35 +825,49 @@ pub(crate) fn definedness<S: SmtSolver>(
     }
 }
 
-fn ordered_definedness<S: SmtSolver>(
+fn ordered_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     expressions: &[Expr],
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
-) -> Result<S::Term, VerifyError> {
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     let expressions = expressions.iter().collect::<Vec<_>>();
-    ordered_definedness_refs(solver, model, &expressions, state, bindings, old_state)
+    ordered_evaluation_status_refs(solver, model, &expressions, state, bindings, old_state)
 }
 
-fn ordered_definedness_refs<S: SmtSolver>(
+fn ordered_evaluation_status_refs<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     expressions: &[&Expr],
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
-) -> Result<S::Term, VerifyError> {
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     let mut local = bindings.clone();
-    let mut terms = Vec::new();
+    let mut statuses = Vec::new();
     for expression in expressions {
-        terms.push(definedness(
+        statuses.push(evaluation_status(
             solver, model, expression, state, &local, old_state,
         )?);
         let _ = eval(solver, model, expression, state, &mut local, old_state)?;
     }
-    Ok(solver.and(&terms)?)
+    sequence_statuses(solver, statuses)
+}
+
+pub(crate) fn partial_operation_index_accessible<S: SmtSolver>(
+    solver: &S,
+    base: &SymbolicValue<S::Term>,
+    index: &SymbolicValue<S::Term>,
+) -> Result<S::Term, VerifyError> {
+    match base {
+        SymbolicValue::Seq { len, .. } => Ok(solver.and(&[
+            solver.ge(int_term(index)?, &solver.int_value(0))?,
+            solver.lt(int_term(index)?, len)?,
+        ])?),
+        _ => Ok(solver.bool_value(true)),
+    }
 }
 
 pub(crate) fn index_accessible<S: SmtSolver>(
@@ -679,8 +919,8 @@ fn method_definedness<S: SmtSolver>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn quantified_definedness<S: SmtSolver>(
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn quantified_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     quantifier: &str,
@@ -689,46 +929,73 @@ fn quantified_definedness<S: SmtSolver>(
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
-) -> Result<S::Term, VerifyError> {
-    let mut terms = vec![binder_source_definedness(
-        solver, model, binder, state, bindings, old_state,
-    )?];
-    let mut reaches_candidate = solver.bool_value(true);
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
+    let source_status =
+        binder_source_evaluation_status(solver, model, binder, state, bindings, old_state)?;
+    let mut fully_defined = source_status.fully_defined.clone();
+    let mut first_partial = source_status.first_partial;
+    let mut has_partial_operation = source_status.has_partial_operation;
+    let mut active = source_status.fully_defined;
     for (name, value, membership) in
         binder_candidates(solver, model, binder, state, bindings, old_state)?
     {
         let mut local = bindings.clone();
         local.insert(name, value);
         let membership = membership.unwrap_or_else(|| solver.bool_value(true));
-        let where_defined = binder_where_expression(binder).map_or_else(
-            || Ok(solver.bool_value(true)),
-            |where_expr| definedness(solver, model, where_expr, state, &local, old_state),
+        let where_status = binder_where_expression(binder).map_or_else(
+            || Ok(safe_status(solver)),
+            |where_expr| evaluation_status(solver, model, where_expr, state, &local, old_state),
         )?;
-        terms.push(solver.implies(
-            &solver.and(&[reaches_candidate.clone(), membership.clone()])?,
-            &where_defined,
-        )?);
+        let where_reached = solver.and(&[active.clone(), membership.clone()])?;
+        has_partial_operation |= where_status.has_partial_operation;
+        first_partial = solver.or(&[
+            first_partial,
+            solver.and(&[where_reached.clone(), where_status.first_partial])?,
+        ])?;
         let where_term = binder_where(solver, model, binder, state, &mut local, old_state)?
             .unwrap_or_else(|| solver.bool_value(true));
-        let selected = solver.and(&[membership, where_term])?;
-        let body_defined = definedness(solver, model, body, state, &local, old_state)?;
-        terms.push(solver.implies(
-            &solver.and(&[reaches_candidate.clone(), selected.clone()])?,
-            &body_defined,
-        )?);
+        let body_reached = solver.and(&[
+            where_reached.clone(),
+            where_status.fully_defined.clone(),
+            where_term.clone(),
+        ])?;
+        let body_status = evaluation_status(solver, model, body, state, &local, old_state)?;
+        has_partial_operation |= body_status.has_partial_operation;
+        first_partial = solver.or(&[
+            first_partial,
+            solver.and(&[body_reached.clone(), body_status.first_partial])?,
+        ])?;
+        let where_ok = solver.implies(&where_reached, &where_status.fully_defined)?;
+        let body_ok = solver.implies(&body_reached, &body_status.fully_defined)?;
+        fully_defined = solver.and(&[fully_defined, where_ok, body_ok])?;
+
         let body_value = eval(solver, model, body, state, &mut local, old_state)?;
-        let continues = if quantifier == "forall" {
-            solver.or(&[solver.not(&selected)?, bool_term(&body_value)?.clone()])?
+        let body_continues = if quantifier == "forall" {
+            bool_term(&body_value)?.clone()
         } else {
-            solver.or(&[solver.not(&selected)?, solver.not(bool_term(&body_value)?)?])?
+            solver.not(bool_term(&body_value)?)?
         };
-        reaches_candidate = solver.and(&[reaches_candidate, continues])?;
+        let candidate_continues = solver.or(&[
+            solver.not(&membership)?,
+            solver.and(&[
+                where_status.fully_defined,
+                solver.or(&[
+                    solver.not(&where_term)?,
+                    solver.and(&[body_status.fully_defined, body_continues])?,
+                ])?,
+            ])?,
+        ])?;
+        active = solver.and(&[active, candidate_continues])?;
     }
-    Ok(solver.and(&terms)?)
+    Ok(EvaluationStatus {
+        fully_defined,
+        first_partial,
+        has_partial_operation,
+    })
 }
 
-#[allow(clippy::too_many_arguments)]
-fn aggregate_definedness<S: SmtSolver>(
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn aggregate_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     kind: AggregateKind,
@@ -737,10 +1004,13 @@ fn aggregate_definedness<S: SmtSolver>(
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
-) -> Result<S::Term, VerifyError> {
-    let mut terms = vec![binder_source_definedness(
-        solver, model, binder, state, bindings, old_state,
-    )?];
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
+    let source_status =
+        binder_source_evaluation_status(solver, model, binder, state, bindings, old_state)?;
+    let mut fully_defined = source_status.fully_defined.clone();
+    let mut first_partial = source_status.first_partial;
+    let mut has_partial_operation = source_status.has_partial_operation;
+    let mut active = source_status.fully_defined;
     let mut sum = solver.int_value(0);
     for (name, candidate, membership) in
         binder_candidates(solver, model, binder, state, bindings, old_state)?
@@ -748,26 +1018,52 @@ fn aggregate_definedness<S: SmtSolver>(
         let mut local = bindings.clone();
         local.insert(name, candidate);
         let membership = membership.unwrap_or_else(|| solver.bool_value(true));
-        let where_defined = binder_where_expression(binder).map_or_else(
-            || Ok(solver.bool_value(true)),
-            |where_expr| definedness(solver, model, where_expr, state, &local, old_state),
+        let where_status = binder_where_expression(binder).map_or_else(
+            || Ok(safe_status(solver)),
+            |where_expr| evaluation_status(solver, model, where_expr, state, &local, old_state),
         )?;
-        terms.push(solver.implies(&membership, &where_defined)?);
+        let where_reached = solver.and(&[active.clone(), membership])?;
+        has_partial_operation |= where_status.has_partial_operation;
+        first_partial = solver.or(&[
+            first_partial,
+            solver.and(&[where_reached.clone(), where_status.first_partial])?,
+        ])?;
         let where_term = binder_where(solver, model, binder, state, &mut local, old_state)?
             .unwrap_or_else(|| solver.bool_value(true));
+        let mut iteration_ok = solver.implies(&where_reached, &where_status.fully_defined)?;
         if let Some(value) = value {
-            let value_defined = definedness(solver, model, value, state, &local, old_state)?;
-            let selected = solver.and(&[membership, where_term])?;
-            terms.push(solver.implies(&selected, &value_defined)?);
+            let value_reached =
+                solver.and(&[where_reached, where_status.fully_defined, where_term])?;
+            let value_status = evaluation_status(solver, model, value, state, &local, old_state)?;
+            has_partial_operation |= value_status.has_partial_operation;
+            first_partial = solver.or(&[
+                first_partial,
+                solver.and(&[value_reached.clone(), value_status.first_partial])?,
+            ])?;
+            iteration_ok = solver.and(&[
+                iteration_ok,
+                solver.implies(&value_reached, &value_status.fully_defined)?,
+            ])?;
             if kind == AggregateKind::Sum {
                 let value = eval(solver, model, value, state, &mut local, old_state)?;
                 let next_sum = solver.add(&sum, int_term(&value)?)?;
-                terms.push(solver.implies(&selected, &i64_term_is_in_range(solver, &next_sum)?)?);
-                sum = solver.ite(&selected, &next_sum, &sum)?;
+                let sum_reached =
+                    solver.and(&[value_reached.clone(), value_status.fully_defined])?;
+                iteration_ok = solver.and(&[
+                    iteration_ok,
+                    solver.implies(&sum_reached, &i64_term_is_in_range(solver, &next_sum)?)?,
+                ])?;
+                sum = solver.ite(&value_reached, &next_sum, &sum)?;
             }
         }
+        fully_defined = solver.and(&[fully_defined, iteration_ok.clone()])?;
+        active = solver.and(&[active, iteration_ok])?;
     }
-    Ok(solver.and(&terms)?)
+    Ok(EvaluationStatus {
+        fully_defined,
+        first_partial,
+        has_partial_operation,
+    })
 }
 
 fn i64_term_is_in_range<S: SmtSolver>(solver: &S, term: &S::Term) -> Result<S::Term, VerifyError> {
@@ -778,17 +1074,17 @@ fn i64_term_is_in_range<S: SmtSolver>(solver: &S, term: &S::Term) -> Result<S::T
 }
 
 #[allow(clippy::too_many_arguments)]
-fn binder_source_definedness<S: SmtSolver>(
+fn binder_source_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     binder: &Binder,
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
     old_state: Option<&SymbolicState<S::Term>>,
-) -> Result<S::Term, VerifyError> {
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     match binder {
-        Binder::Typed { .. } => Ok(solver.bool_value(true)),
-        Binder::Range { lo, hi, .. } => ordered_definedness_refs(
+        Binder::Typed { .. } => Ok(safe_status(solver)),
+        Binder::Range { lo, hi, .. } => ordered_evaluation_status_refs(
             solver,
             model,
             &[lo.as_ref(), hi.as_ref()],
@@ -797,7 +1093,7 @@ fn binder_source_definedness<S: SmtSolver>(
             old_state,
         ),
         Binder::Collection { collection, .. } => {
-            definedness(solver, model, collection, state, bindings, old_state)
+            evaluation_status(solver, model, collection, state, bindings, old_state)
         }
     }
 }

--- a/rust/fsl-verifier/src/transition.rs
+++ b/rust/fsl-verifier/src/transition.rs
@@ -9,7 +9,11 @@ use fsl_core::{
 use fsl_solver::SmtSolver;
 
 use crate::VerifyError;
-use crate::eval::{binder_values, binder_where, definedness, eval, index_accessible};
+use crate::eval::{
+    EvaluationStatus, binder_has_partial_operation_candidate, binder_values, binder_where, eval,
+    evaluation_status, expression_has_partial_operation_candidate, index_accessible,
+    partial_operation_index_accessible, sequence_statuses,
+};
 use crate::value::{
     Bindings, SymbolicState, SymbolicValue, bool_term, coerce, i64_index, ite_value, logical_equal,
     select_finite, store_finite,
@@ -31,7 +35,61 @@ pub(crate) struct ActionInstance<T> {
 pub(crate) struct ActionGuardDefinedness<T> {
     pub enabled: T,
     pub defined: T,
+    pub first_partial: T,
+    pub has_partial_operation: bool,
     pub bindings: Bindings<T>,
+}
+
+pub(crate) fn action_has_partial_operation_candidate(action: &ActionDef) -> bool {
+    action.guards.iter().any(|guard| match guard {
+        ActionGuard::Let(_, expr) | ActionGuard::Requires(expr) => {
+            expression_has_partial_operation_candidate(expr)
+        }
+    }) || action
+        .statements
+        .iter()
+        .any(statement_has_partial_operation_candidate)
+        || action
+            .ensures
+            .iter()
+            .any(expression_has_partial_operation_candidate)
+}
+
+fn statement_has_partial_operation_candidate(statement: &Statement) -> bool {
+    match statement {
+        Statement::Assign { target, value, .. } => {
+            expression_has_partial_operation_candidate(value)
+                || lvalue_has_partial_operation_candidate(target)
+        }
+        Statement::If {
+            condition,
+            then_statements,
+            else_statements,
+            ..
+        } => {
+            expression_has_partial_operation_candidate(condition)
+                || then_statements
+                    .iter()
+                    .chain(else_statements)
+                    .any(statement_has_partial_operation_candidate)
+        }
+        Statement::ForAll {
+            binder, statements, ..
+        } => {
+            binder_has_partial_operation_candidate(binder)
+                || statements
+                    .iter()
+                    .any(statement_has_partial_operation_candidate)
+        }
+    }
+}
+
+fn lvalue_has_partial_operation_candidate(target: &LValue) -> bool {
+    match target {
+        LValue::Var(_) => false,
+        LValue::Index(_, _) => true,
+        LValue::Field(base, _) => lvalue_has_partial_operation_candidate(base),
+    }
 }
 
 pub(crate) fn action_instances<S: SmtSolver>(
@@ -112,23 +170,33 @@ pub(crate) fn action_guard_definedness<S: SmtSolver>(
 ) -> Result<ActionGuardDefinedness<S::Term>, VerifyError> {
     let mut bindings = params.clone();
     let mut reaches_guard = solver.bool_value(true);
-    let mut guard_terms = Vec::new();
+    let mut fully_defined = solver.bool_value(true);
+    let mut first_partial = solver.bool_value(false);
+    let mut has_partial_operation = false;
     for guard in &action.guards {
         let expression = match guard {
             ActionGuard::Let(_, expression) | ActionGuard::Requires(expression) => expression,
         };
-        let expression_defined = definedness(solver, model, expression, state, &bindings, None)?;
-        guard_terms.push(solver.implies(&reaches_guard, &expression_defined)?);
+        let status = evaluation_status(solver, model, expression, state, &bindings, None)?;
+        has_partial_operation |= status.has_partial_operation;
+        first_partial = solver.or(&[
+            first_partial,
+            solver.and(&[reaches_guard.clone(), status.first_partial])?,
+        ])?;
+        fully_defined = solver.and(&[
+            fully_defined,
+            solver.implies(&reaches_guard, &status.fully_defined)?,
+        ])?;
         let value = eval(solver, model, expression, state, &mut bindings, None)?;
         match guard {
             ActionGuard::Let(name, _) => {
-                reaches_guard = solver.and(&[reaches_guard, expression_defined])?;
+                reaches_guard = solver.and(&[reaches_guard, status.fully_defined])?;
                 bindings.insert(name.clone(), value);
             }
             ActionGuard::Requires(_) => {
                 reaches_guard = solver.and(&[
                     reaches_guard,
-                    expression_defined,
+                    status.fully_defined,
                     bool_term(&value)?.clone(),
                 ])?;
             }
@@ -136,7 +204,9 @@ pub(crate) fn action_guard_definedness<S: SmtSolver>(
     }
     Ok(ActionGuardDefinedness {
         enabled: reaches_guard,
-        defined: solver.and(&guard_terms)?,
+        defined: fully_defined,
+        first_partial,
+        has_partial_operation,
         bindings,
     })
 }
@@ -148,7 +218,17 @@ pub(crate) fn action_statements_definedness<S: SmtSolver>(
     state: &SymbolicState<S::Term>,
     bindings: &Bindings<S::Term>,
 ) -> Result<S::Term, VerifyError> {
-    statements_definedness(
+    Ok(action_statements_evaluation_status(solver, model, action, state, bindings)?.fully_defined)
+}
+
+pub(crate) fn action_statements_evaluation_status<S: SmtSolver>(
+    solver: &S,
+    model: &KernelModel,
+    action: &ActionDef,
+    state: &SymbolicState<S::Term>,
+    bindings: &Bindings<S::Term>,
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
+    statements_evaluation_status(
         solver,
         model,
         &action.statements,
@@ -157,33 +237,37 @@ pub(crate) fn action_statements_definedness<S: SmtSolver>(
     )
 }
 
-fn statements_definedness<S: SmtSolver>(
+fn statements_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     statements: &[Statement],
     read_state: &SymbolicState<S::Term>,
     bindings: &mut Bindings<S::Term>,
-) -> Result<S::Term, VerifyError> {
-    let terms = statements
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
+    let statuses = statements
         .iter()
-        .map(|statement| statement_definedness(solver, model, statement, read_state, bindings))
+        .map(|statement| {
+            statement_evaluation_status(solver, model, statement, read_state, bindings)
+        })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(solver.and(&terms)?)
+    sequence_statuses(solver, statuses)
 }
 
-fn statement_definedness<S: SmtSolver>(
+#[allow(clippy::too_many_lines)]
+fn statement_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     statement: &Statement,
     read_state: &SymbolicState<S::Term>,
     bindings: &mut Bindings<S::Term>,
-) -> Result<S::Term, VerifyError> {
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     match statement {
         Statement::Assign { target, value, .. } => {
-            let value_defined = definedness(solver, model, value, read_state, bindings, None)?;
+            let value_status = evaluation_status(solver, model, value, read_state, bindings, None)?;
             let _ = eval(solver, model, value, read_state, bindings, None)?;
-            let target_defined = lvalue_definedness(solver, model, target, read_state, bindings)?;
-            Ok(solver.and(&[value_defined, target_defined])?)
+            let target_status =
+                lvalue_evaluation_status(solver, model, target, read_state, bindings)?;
+            sequence_statuses(solver, [value_status, target_status])
         }
         Statement::If {
             condition,
@@ -191,81 +275,148 @@ fn statement_definedness<S: SmtSolver>(
             else_statements,
             ..
         } => {
-            let condition_defined =
-                definedness(solver, model, condition, read_state, bindings, None)?;
+            let condition_status =
+                evaluation_status(solver, model, condition, read_state, bindings, None)?;
             let condition = eval(solver, model, condition, read_state, bindings, None)?;
-            let then_defined = statements_definedness(
+            let then_status = statements_evaluation_status(
                 solver,
                 model,
                 then_statements,
                 read_state,
                 &mut bindings.clone(),
             )?;
-            let else_defined = statements_definedness(
+            let else_status = statements_evaluation_status(
                 solver,
                 model,
                 else_statements,
                 read_state,
                 &mut bindings.clone(),
             )?;
-            Ok(solver.and(&[
-                condition_defined,
-                solver.ite(bool_term(&condition)?, &then_defined, &else_defined)?,
-            ])?)
+            let branch_defined = solver.ite(
+                bool_term(&condition)?,
+                &then_status.fully_defined,
+                &else_status.fully_defined,
+            )?;
+            let branch_partial = solver.ite(
+                bool_term(&condition)?,
+                &then_status.first_partial,
+                &else_status.first_partial,
+            )?;
+            Ok(EvaluationStatus {
+                fully_defined: solver
+                    .and(&[condition_status.fully_defined.clone(), branch_defined])?,
+                first_partial: solver.or(&[
+                    condition_status.first_partial,
+                    solver.and(&[condition_status.fully_defined, branch_partial])?,
+                ])?,
+                has_partial_operation: condition_status.has_partial_operation
+                    || then_status.has_partial_operation
+                    || else_status.has_partial_operation,
+            })
         }
         Statement::ForAll {
             binder, statements, ..
         } => {
-            let mut terms = Vec::new();
+            let mut active = solver.bool_value(true);
+            let mut fully_defined = solver.bool_value(true);
+            let mut first_partial = solver.bool_value(false);
+            let mut has_partial_operation = false;
             for (name, value) in binder_values(solver, model, binder)? {
                 let mut local = bindings.clone();
                 local.insert(name, value);
-                let where_defined = match binder {
+                let where_status = match binder {
                     fsl_core::KernelBinder::Typed { where_expr, .. }
                     | fsl_core::KernelBinder::Range { where_expr, .. }
                     | fsl_core::KernelBinder::Collection { where_expr, .. } => {
                         where_expr.as_deref().map_or_else(
-                            || Ok(solver.bool_value(true)),
+                            || {
+                                Ok(EvaluationStatus {
+                                    fully_defined: solver.bool_value(true),
+                                    first_partial: solver.bool_value(false),
+                                    has_partial_operation: false,
+                                })
+                            },
                             |expression| {
-                                definedness(solver, model, expression, read_state, &local, None)
+                                evaluation_status(
+                                    solver, model, expression, read_state, &local, None,
+                                )
                             },
                         )?
                     }
                 };
+                first_partial = solver.or(&[
+                    first_partial,
+                    solver.and(&[active.clone(), where_status.first_partial])?,
+                ])?;
+                has_partial_operation |= where_status.has_partial_operation;
                 let where_term = binder_where(solver, model, binder, read_state, &mut local, None)?
                     .unwrap_or_else(|| solver.bool_value(true));
-                let body_defined =
-                    statements_definedness(solver, model, statements, read_state, &mut local)?;
-                terms.push(
-                    solver.and(&[where_defined, solver.implies(&where_term, &body_defined)?])?,
-                );
+                let body_reached = solver.and(&[
+                    active.clone(),
+                    where_status.fully_defined.clone(),
+                    where_term,
+                ])?;
+                let body_status = statements_evaluation_status(
+                    solver, model, statements, read_state, &mut local,
+                )?;
+                has_partial_operation |= body_status.has_partial_operation;
+                first_partial = solver.or(&[
+                    first_partial,
+                    solver.and(&[body_reached.clone(), body_status.first_partial])?,
+                ])?;
+                let iteration_ok = solver.and(&[
+                    where_status.fully_defined,
+                    solver.implies(&body_reached, &body_status.fully_defined)?,
+                ])?;
+                fully_defined = solver.and(&[fully_defined, iteration_ok.clone()])?;
+                active = solver.and(&[active, iteration_ok])?;
             }
-            Ok(solver.and(&terms)?)
+            Ok(EvaluationStatus {
+                fully_defined,
+                first_partial,
+                has_partial_operation,
+            })
         }
     }
 }
 
-fn lvalue_definedness<S: SmtSolver>(
+fn lvalue_evaluation_status<S: SmtSolver>(
     solver: &S,
     model: &KernelModel,
     target: &LValue,
     read_state: &SymbolicState<S::Term>,
     bindings: &mut Bindings<S::Term>,
-) -> Result<S::Term, VerifyError> {
+) -> Result<EvaluationStatus<S::Term>, VerifyError> {
     match target {
-        LValue::Var(_) => Ok(solver.bool_value(true)),
+        LValue::Var(_) => Ok(EvaluationStatus {
+            fully_defined: solver.bool_value(true),
+            first_partial: solver.bool_value(false),
+            has_partial_operation: false,
+        }),
         LValue::Index(name, index) => {
-            let index_defined = definedness(solver, model, index, read_state, bindings, None)?;
+            let index_status = evaluation_status(solver, model, index, read_state, bindings, None)?;
             let index_value = eval(solver, model, index, read_state, bindings, None)?;
             let root = read_state
                 .get(name)
                 .ok_or_else(|| VerifyError::new(format!("unknown state variable '{name}'")))?;
-            Ok(solver.and(&[
-                index_defined,
-                index_accessible(solver, model, root, &index_value)?,
-            ])?)
+            let fully_accessible = index_accessible(solver, model, root, &index_value)?;
+            let partial_accessible =
+                partial_operation_index_accessible(solver, root, &index_value)?;
+            sequence_statuses(
+                solver,
+                [
+                    index_status,
+                    EvaluationStatus {
+                        fully_defined: fully_accessible,
+                        first_partial: solver.not(&partial_accessible)?,
+                        has_partial_operation: matches!(root, SymbolicValue::Seq { .. }),
+                    },
+                ],
+            )
         }
-        LValue::Field(base, _) => lvalue_definedness(solver, model, base, read_state, bindings),
+        LValue::Field(base, _) => {
+            lvalue_evaluation_status(solver, model, base, read_state, bindings)
+        }
     }
 }
 

--- a/rust/fsl-verifier/tests/partial_operations.rs
+++ b/rust/fsl-verifier/tests/partial_operations.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, FslValue, KernelModel, build_model, parse_kernel_source};
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn model(source: &str) -> KernelModel {
+    let kernel =
+        parse_kernel_source(source, &FsResolver::new(".")).expect("parse partial-op model");
+    build_model(kernel).expect("build partial-op model")
+}
+
+#[test]
+fn selected_bounds_do_not_disable_automatic_partial_operation_checks() {
+    let model = model(
+        r"
+spec SelectedPartial {
+  type Small = -3..3
+  state { dividend: Small, divisor: Small, quotient: Small }
+  init { dividend = -3  divisor = 0  quotient = 0 }
+  action divide() { quotient = dividend / divisor }
+}
+",
+    );
+    let selected = BTreeSet::new();
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded_selected(
+        &model,
+        &mut solver,
+        1,
+        Some(&selected),
+    ))
+    .expect("verify selected properties");
+
+    let violation = result.violation.expect("partial operation violation");
+    assert_eq!(
+        (
+            violation.kind.as_str(),
+            violation.name.as_str(),
+            violation.step
+        ),
+        ("partial_op", "_partial_divide", 1)
+    );
+}
+
+#[test]
+fn supplied_initial_state_controls_partial_operation_reachability() {
+    let model = model(
+        r"
+spec SnapshotPartial {
+  type Small = -3..3
+  state { dividend: Small, divisor: Small, quotient: Small }
+  init { dividend = -3  divisor = 1  quotient = 0 }
+  action divide() { quotient = dividend / divisor }
+}
+",
+    );
+    let mut ordinary_solver = fsl_solver_z3::Z3Solver::new().expect("create ordinary solver");
+    let ordinary = block_on(fsl_verifier::verify_bounded(
+        &model,
+        &mut ordinary_solver,
+        1,
+    ))
+    .expect("verify spec init");
+    assert!(ordinary.violation.is_none(), "{ordinary:?}");
+
+    let snapshot = BTreeMap::from([
+        ("dividend".to_owned(), FslValue::Int(-3)),
+        ("divisor".to_owned(), FslValue::Int(0)),
+        ("quotient".to_owned(), FslValue::Int(0)),
+    ]);
+    let mut snapshot_solver = fsl_solver_z3::Z3Solver::new().expect("create snapshot solver");
+    let result = block_on(fsl_verifier::verify_bounded_from_state(
+        &model,
+        &mut snapshot_solver,
+        1,
+        None,
+        &snapshot,
+    ))
+    .expect("verify supplied initial state");
+
+    let violation = result.violation.expect("snapshot partial operation");
+    assert_eq!(violation.kind, "partial_op");
+    assert_eq!(violation.step, 1);
+    assert_eq!(violation.trace[0].state, snapshot);
+}
+
+#[test]
+fn guard_order_short_circuits_unreached_partial_operations() {
+    let model = model(
+        r"
+spec GuardShortCircuit {
+  type Item = 0..1
+  state { queue: Seq<Item, 1> }
+  init { queue = Seq {} }
+  action blocked() {
+    requires false
+    requires queue.head() == 0
+    queue = queue
+  }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect("verify short-circuited guard");
+
+    assert!(result.violation.is_none(), "{result:?}");
+}
+
+#[test]
+fn initial_invariants_precede_future_action_partial_operations() {
+    let model = model(
+        r"
+spec InitialPrecedence {
+  type Small = 0..1
+  state { divisor: Small, quotient: Small }
+  init { divisor = 0  quotient = 0 }
+  action divide() { quotient = 1 / divisor }
+  invariant InitiallyFalse { quotient == 1 }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect("verify failure precedence");
+
+    let violation = result.violation.expect("initial invariant violation");
+    assert_eq!(
+        (
+            violation.kind.as_str(),
+            violation.name.as_str(),
+            violation.step
+        ),
+        ("invariant", "InitiallyFalse", 0)
+    );
+}
+
+#[test]
+fn post_state_properties_precede_ensures_partial_operations() {
+    let model = model(
+        r"
+spec PostStatePrecedence {
+  type Small = 0..1
+  state { value: Small, queue: Seq<Small, 1> }
+  init { value = 0  queue = Seq {} }
+  action break_post_state() {
+    value = 1
+    ensures queue.head() == 0
+  }
+  invariant MustStayZero { value == 0 }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect("verify post-state precedence");
+
+    let violation = result.violation.expect("post-state invariant violation");
+    assert_eq!(
+        (
+            violation.kind.as_str(),
+            violation.name.as_str(),
+            violation.step
+        ),
+        ("invariant", "MustStayZero", 1)
+    );
+}
+
+#[test]
+fn reached_requires_and_ensures_partial_operations_are_classified() {
+    for (source, action) in [
+        (
+            r"
+spec RequiresPartial {
+  type Item = 0..1
+  state { queue: Seq<Item, 1> }
+  init { queue = Seq {} }
+  action inspect() { requires queue.head() == 0  queue = queue }
+}
+",
+            "inspect",
+        ),
+        (
+            r"
+spec EnsuresPartial {
+  type Item = 0..1
+  state { queue: Seq<Item, 1> }
+  init { queue = Seq {} }
+  action inspect() { queue = queue  ensures queue.head() == 0 }
+}
+",
+            "inspect",
+        ),
+    ] {
+        let model = model(source);
+        let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+        let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+            .expect("verify action-context partial operation");
+        let violation = result.violation.expect("partial operation violation");
+        let expected_name = format!("_partial_{action}");
+        fsl_runtime::replay_trace(model, &violation.trace)
+            .expect("partial-operation trace must replay through Monitor");
+        assert_eq!(
+            (
+                violation.kind.as_str(),
+                violation.name.as_str(),
+                violation.step
+            ),
+            ("partial_op", expected_name.as_str(), 1)
+        );
+    }
+}
+
+#[test]
+fn guard_partial_replay_rejects_a_fabricated_successor() {
+    let model = model(
+        r"
+spec GuardReplayControl {
+  type Item = 0..1
+  state { queue: Seq<Item, 1> }
+  init { queue = Seq {} }
+  action inspect() { requires queue.head() == 0  queue = queue }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let result = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect("verify guard partial operation");
+    let mut trace = result.violation.expect("guard partial operation").trace;
+    trace
+        .last_mut()
+        .expect("attempted trace step")
+        .state
+        .insert("queue".to_owned(), FslValue::Seq(vec![FslValue::Int(0)]));
+
+    let error = fsl_runtime::replay_trace(model, &trace)
+        .expect_err("fabricated partial-operation successor must be rejected");
+    assert!(error.to_string().contains("state mismatch"), "{error}");
+}
+
+#[test]
+fn earlier_checked_overflow_is_not_relabelled_by_a_later_body_partial_operation() {
+    let model = model(
+        r"
+spec BodyFailureOrder {
+  state { maximum: Int, quotient: Int }
+  init { maximum = 9223372036854775807  quotient = 0 }
+  action overflow_first() {
+    maximum = maximum + 1
+    quotient = 1 / 0
+  }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect_err("checked overflow must fail closed before the later partial operation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("body evaluation has a non-partial failure"),
+        "{error}"
+    );
+}
+
+#[test]
+fn earlier_checked_overflow_inside_ensures_is_not_relabelled_as_partial() {
+    let model = model(
+        r"
+spec EnsuresFailureOrder {
+  state { maximum: Int }
+  init { maximum = 9223372036854775807 }
+  action inspect() {
+    maximum = maximum
+    ensures (maximum + 1 > 0) and (1 / 0 == 0)
+  }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect_err("checked overflow must fail closed before the later ensures partial operation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ensures evaluation has a non-partial failure"),
+        "{error}"
+    );
+}
+
+#[test]
+fn body_overflow_precedes_a_partial_operation_found_only_in_ensures() {
+    let model = model(
+        r"
+spec BodyBeforeEnsuresFailureOrder {
+  state { maximum: Int }
+  init { maximum = 9223372036854775807 }
+  action overflow_first() {
+    maximum = maximum + 1
+    ensures 1 / 0 == 0
+  }
+}
+",
+    );
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
+    let error = block_on(fsl_verifier::verify_bounded(&model, &mut solver, 1))
+        .expect_err("body overflow must fail closed before an ensures-only partial operation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("body evaluation has a non-partial failure"),
+        "{error}"
+    );
+}

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -392,15 +392,12 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             Ok(deadlock) => deadlock,
             Err(message) => return error(solver_version, "usage", message),
         };
-    // Mirrors the native CLI's `prepare_bmc` (`fslc/src/verification.rs`):
-    // this pre-scan is an optional shortcut ahead of the full solve below
-    // and needs a deterministic concrete initial state to run at all
-    // (#519). Skip it rather than failing the whole command when a model's
-    // init legitimately leaves some state free — the full solve below
-    // still explores every admissible initial value symbolically.
+    // Preserve exact concrete evidence for boundary outcomes the bounded
+    // symbolic value cannot represent. `partial_op` is intentionally left to
+    // the public symbolic verifier boundary itself (#651).
     if fsl_runtime::deterministic_initial_state(&model).is_ok() {
         match fsl_runtime::find_boundary_violation(model.clone(), request.options.depth) {
-            Ok(Some((violation, trace))) => {
+            Ok(Some((violation, trace))) if violation.kind != "partial_op" => {
                 let statistics = fsl_solver::VerificationStatistics::default();
                 return fslc_rust::verification_output::render_boundary_output(
                     envelope(solver_version),
@@ -417,7 +414,7 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
                 )
                 .0;
             }
-            Ok(None) => {}
+            Ok(Some(_) | None) => {}
             Err(failure) => {
                 return verifier_error(solver_version, &failure);
             }

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -972,19 +972,16 @@ fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc
         request.selection.property,
         request.selection.excluded,
     );
-    // `find_boundary_violation` is a concrete pre-scan: an optional
-    // shortcut ahead of the full Z3-backed solve below, not the source of
-    // verify's soundness. It needs a deterministic concrete initial state
-    // to run at all (#519); a model whose init leaves some state free is
-    // still fully supported by `solve_bmc`, which explores every
-    // admissible initial value symbolically, so skip the shortcut rather
-    // than failing the whole command when it does not apply.
+    // Some concrete boundary outcomes (notably an over-capacity Seq successor)
+    // cannot be represented by the bounded symbolic value and must retain the
+    // exact Monitor evidence. Action-context `partial_op` is deliberately not
+    // consumed here: it belongs to `verify_bounded*` itself (#651).
     if checked_bounds.is_none()
         && request.initial_state.is_none()
         && fsl_runtime::deterministic_initial_state(&model).is_ok()
     {
         match fsl_runtime::find_boundary_violation(model.clone(), request.depth) {
-            Ok(Some((violation, trace))) => {
+            Ok(Some((violation, trace))) if violation.kind != "partial_op" => {
                 let statistics = fsl_solver::VerificationStatistics::default();
                 return Err(fslc_rust::verification_output::render_boundary_output(
                     envelope(),
@@ -1000,7 +997,7 @@ fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc
                     },
                 ));
             }
-            Ok(None) => {}
+            Ok(Some(_) | None) => {}
             Err(error) => return Err((semantic_error_output(&error.to_string()), 2)),
         }
     }

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -916,6 +916,14 @@ pub fn render_bmc_output(
     options: BmcOutputOptions<'_>,
 ) -> (Value, i32) {
     if let Some(violation) = &result.violation {
+        if violation.kind == "partial_op" {
+            let boundary = fsl_runtime::Violation {
+                kind: violation.kind.clone(),
+                name: violation.name.clone(),
+                step: violation.step,
+            };
+            return render_boundary_output(envelope, model, &boundary, &violation.trace, &options);
+        }
         return render_violation(envelope, model, violation, &options);
     }
     let unreached = result

--- a/rust/fslc/tests/issue_651_bmc_partial_operations.rs
+++ b/rust/fslc/tests/issue_651_bmc_partial_operations.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-651-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn verify(fixture: &Fixture) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            fixture.text(),
+            "--depth",
+            "1",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ])
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+#[test]
+fn bmc_reports_a_replayable_partial_operation_from_nondeterministic_init() {
+    let fixture = Fixture::new(
+        "nondeterministic-init",
+        r"
+spec NondeterministicPartial {
+  type Small = -3..3
+  state { dividend: Small, choose_zero: Bool, quotient: Small }
+  init { dividend = -3  quotient = 0 }
+  action divide() { quotient = dividend / (if choose_zero then 0 else 1) }
+}
+",
+    );
+    let (output, status) = verify(&fixture);
+
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated", "{output:#}");
+    assert_eq!(output["violation_kind"], "partial_op", "{output:#}");
+    assert_eq!(output["invariant"], "_partial_divide", "{output:#}");
+    assert_eq!(output["violated_at_step"], 1, "{output:#}");
+    assert_eq!(output["last_action"]["name"], "divide", "{output:#}");
+    assert_eq!(output["trace_type"], "partial_op", "{output:#}");
+    assert_eq!(
+        output["faithfulness_class"], "partial_op_unguarded",
+        "{output:#}"
+    );
+    assert_eq!(
+        output["trace"].as_array().map(Vec::len),
+        Some(2),
+        "{output:#}"
+    );
+}
+
+#[test]
+fn bmc_preserves_initial_property_precedence_over_future_partial_operations() {
+    let fixture = Fixture::new(
+        "initial-precedence",
+        r"
+spec InitialPrecedence {
+  type Small = 0..1
+  state { divisor: Small, quotient: Small }
+  init { divisor = 0  quotient = 0 }
+  action divide() { quotient = 1 / divisor }
+  invariant InitiallyFalse { quotient == 1 }
+}
+",
+    );
+    let (output, status) = verify(&fixture);
+
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["violation_kind"], "invariant", "{output:#}");
+    assert_eq!(output["invariant"], "InitiallyFalse", "{output:#}");
+    assert_eq!(output["violated_at_step"], 0, "{output:#}");
+}

--- a/rust/fslc/tests/typed_agreement/generator.rs
+++ b/rust/fslc/tests/typed_agreement/generator.rs
@@ -619,11 +619,10 @@ pub fn expression_sweep() -> Vec<ExpressionModel> {
 /// `divide`/`remainder`, each in action context (guarded, so no partial-op
 /// boundary is ever crossed here -- that boundary is exercised by the
 /// dedicated, unguarded action-context tests in `relations.rs`'s R6 section
-/// instead, because `fsl_verifier::verify_bounded` does not perform the
-/// automatic "Partial operations" check on its own; see that section's
-/// module doc) and in property context, where S3:561-563 guarantees
-/// totalization. `head`/`pop`/`at`/index are exercised only in
-/// `relations.rs` for the same reason, not swept here.
+/// instead, where all four native engines must agree) and in property context,
+/// where S3:561-563 guarantees totalization. `head`/`pop`/`at`/index are
+/// exercised only in `relations.rs`, which owns the full automatic-boundary
+/// matrix rather than duplicating it in this successful-transition sweep.
 #[derive(Clone, Debug)]
 pub struct OperationModel {
     pub id: String,

--- a/rust/fslc/tests/typed_agreement/relations.rs
+++ b/rust/fslc/tests/typed_agreement/relations.rs
@@ -8,15 +8,14 @@
 //! declared structurally (domain bound coincides with the invariant bound
 //! by construction) before the mutation that breaks it runs.
 //!
-//! R6 additionally records two confirmed cross-engine findings instead of
-//! silently normalizing them away: a self-retiring exclusion for
+//! R6 additionally records the remaining confirmed cross-engine finding as a
+//! self-retiring exclusion for
 //! `head()` read from property context on an empty sequence (BMC finds a
-//! spurious `violated`/`invariant` while the concrete engines correctly
-//! error), and a documented scope boundary for the six partial operations
-//! in *action* context (`fsl_verifier::verify_bounded` alone does not
-//! perform LANGUAGE.md S6's automatic "Partial operations" check at all --
-//! only the concrete engines and the CLI's own `find_boundary_violation`
-//! pre-scan do).
+//! spurious `violated`/`invariant` while the concrete engines correctly error).
+//! Action-context partial operations are a direct four-engine agreement anchor:
+//! Monitor BFS, explicit, the concrete boundary oracle, and raw
+//! `fsl_verifier::verify_bounded` must all classify the six named operations
+//! as `partial_op`.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -488,19 +487,14 @@ fn r5_domain_size_boundary_verdict_change_matches_the_declared_structural_expect
 // R6: short-circuit / partial operation / Euclidean division duality.
 // LANGUAGE.md S3:557-570: `/`/`%` are total in property context (`a/0==0`,
 // `a%0==0`) but still reported `partial_op` when read unguarded in an
-// action's requires/body/ensures -- a contract about `fslc verify`'s
-// observable behavior, not about the bare `fsl_verifier::verify_bounded`
-// function alone; see
-// `assert_action_context_partial_op_is_caught_only_concretely`'s doc for why
-// those two are not the same thing. `docs/LANGUAGE.md` S6's "Partial
-// operations" row scopes the *checked* class to action context; it makes no
-// totalization promise for `head`/`pop`/`at`/index the way S3 explicitly
-// does for `/`/`%`, so this suite exercises the six named operations in
-// action context via the dedicated tests below (not
-// `generator.rs::operation_sweep`, which only carries the safe/totalized
-// entries `engines::run_agreement`'s raw-BMC comparison can actually make),
-// and records the property-context asymmetry as its own finding below
-// instead of assuming S3's `/`/`%` guarantee extends to them.
+// action's requires/body/ensures through every public verifier entry point,
+// including bare `fsl_verifier::verify_bounded`. `docs/LANGUAGE.md` S6's
+// "Partial operations" row scopes the *checked* class to action context; it
+// makes no totalization promise for `head`/`pop`/`at`/index the way S3
+// explicitly does for `/`/`%`, so this suite exercises the six named
+// operations in action context via the dedicated tests below and records the
+// property-context asymmetry as its own finding instead of assuming S3's
+// `/`/`%` guarantee extends to them.
 // ---------------------------------------------------------------------
 
 #[test]
@@ -526,28 +520,10 @@ spec R6Euclid {
     );
 }
 
-/// The automatic "Partial operations" check (`docs/LANGUAGE.md` S6, action
-/// context only) is not performed by `fsl_verifier::verify_bounded`'s own
-/// symbolic loop: `rust/fsl-verifier/src/bmc.rs` has no `partial_op`
-/// handling anywhere in it. `rust/fslc/src/verification.rs`'s
-/// `run_bmc_filtered` produces the CLI's `--engine bmc` `partial_op`
-/// classification by merging in a *concrete* pre-scan
-/// (`fsl_runtime::find_boundary_violation`), not from the solver. So the
-/// three-way comparison this suite uses everywhere else
-/// (`engines::run_agreement`, which asserts raw `verify_bounded` agrees
-/// with Monitor BFS / explicit) does not apply to an unguarded
-/// action-context partial operation: raw `verify_bounded` reports Clean by
-/// construction, which is a documented capability gap in what the bare
-/// solver checks, not a disagreement to investigate. This asserts the
-/// concrete family (Monitor BFS / explicit / the concrete
-/// `find_boundary_violation` pre-scan the CLI itself relies on) agrees
-/// among itself, and separately documents raw BMC's Clean result, for one
-/// of `docs/LANGUAGE.md` S6's six named partial operations.
-fn assert_action_context_partial_op_is_caught_only_concretely(
-    id: &str,
-    source: &str,
-    depth: usize,
-) {
+/// LANGUAGE.md S6's action-context automatic check belongs to the public
+/// verifier boundary, not to a caller-owned pre-scan. Each operation must
+/// produce the same first failure and replayable evidence through raw BMC.
+fn assert_action_context_partial_op_agrees_across_engines(id: &str, source: &str, depth: usize) {
     let model = build(id, source);
 
     let bfs_violation = fsl_runtime::bfs(model.clone(), depth)
@@ -575,32 +551,41 @@ fn assert_action_context_partial_op_is_caught_only_concretely(
         "'{id}': find_boundary_violation kind"
     );
 
-    // Raw `verify_bounded` is not asserted against here at all: it never
-    // performs the "Partial operations" check itself (confirmed above the
-    // module), but its own *unrelated* automatic type-bound check can still
-    // independently misfire on the same underlying symbolic-Seq gap this
-    // module's `r6_property_context_seq_head_disagrees_across_engines_...`
-    // test documents -- observed outcomes range from a clean verdict
-    // (`divide`/`remainder`), to a spurious `type_bound` on the assigned
-    // scalar (`head`/`at`/index), to `verify_bounded` itself returning
-    // `Err("model sequence length is negative")` (`pop`). All three are the
-    // same underlying symbolic-Seq gap surfacing differently depending on
-    // where the phantom value flows, not independent findings, so this
-    // helper does not assert a specific raw-BMC outcome per operation --
-    // only records whichever one occurs for visibility.
     let mut solver = fsl_solver_z3::Z3Solver::new().expect("create solver");
-    match engines::block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth)) {
-        Ok(bmc) => eprintln!(
-            "'{id}': raw verify_bounded (not asserted) = {:?}",
-            bmc.violation
+    let bmc = engines::block_on(fsl_verifier::verify_bounded(&model, &mut solver, depth))
+        .unwrap_or_else(|error| panic!("'{id}': raw verify_bounded errored: {error}"));
+    let bmc_violation = bmc
+        .violation
+        .unwrap_or_else(|| panic!("'{id}': raw verify_bounded found no violation"));
+    assert_eq!(
+        (
+            bmc_violation.kind.as_str(),
+            bmc_violation.name.as_str(),
+            bmc_violation.step,
         ),
-        Err(error) => eprintln!("'{id}': raw verify_bounded (not asserted) errored: {error}"),
-    }
+        (
+            boundary_violation.kind.as_str(),
+            boundary_violation.name.as_str(),
+            boundary_violation.step,
+        ),
+        "'{id}': raw BMC and the concrete boundary oracle disagree"
+    );
+    assert_eq!(
+        bmc_violation.last_action.as_deref(),
+        bmc_violation
+            .trace
+            .last()
+            .and_then(|step| step.action.as_ref())
+            .map(|action| action.name.as_str()),
+        "'{id}': last_action does not match the trace"
+    );
+    fsl_runtime::replay_trace(model, &bmc_violation.trace)
+        .unwrap_or_else(|error| panic!("'{id}': raw BMC trace is not replayable: {error}"));
 }
 
 #[test]
-fn r6_action_context_partial_operations_are_caught_only_by_the_concrete_engines() {
-    assert_action_context_partial_op_is_caught_only_concretely(
+fn r6_action_context_partial_operations_agree_across_all_engines() {
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_head",
         r"
 spec R6ActionHead {
@@ -612,7 +597,7 @@ spec R6ActionHead {
 ",
         2,
     );
-    assert_action_context_partial_op_is_caught_only_concretely(
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_pop",
         r"
 spec R6ActionPop {
@@ -624,7 +609,7 @@ spec R6ActionPop {
 ",
         2,
     );
-    assert_action_context_partial_op_is_caught_only_concretely(
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_at",
         r"
 spec R6ActionAt {
@@ -636,7 +621,7 @@ spec R6ActionAt {
 ",
         2,
     );
-    assert_action_context_partial_op_is_caught_only_concretely(
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_index",
         r"
 spec R6ActionIndex {
@@ -648,7 +633,7 @@ spec R6ActionIndex {
 ",
         2,
     );
-    assert_action_context_partial_op_is_caught_only_concretely(
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_divide",
         r"
 spec R6ActionDivide {
@@ -660,7 +645,7 @@ spec R6ActionDivide {
 ",
         2,
     );
-    assert_action_context_partial_op_is_caught_only_concretely(
+    assert_action_context_partial_op_agrees_across_engines(
         "r6_action_remainder",
         r"
 spec R6ActionRemainder {
@@ -668,6 +653,30 @@ spec R6ActionRemainder {
   state { x: Small, y: Small, r: Small }
   init { x = -3 y = 0 r = 0 }
   action remainder_unguarded() { r = x % y }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_agrees_across_engines(
+        "r6_action_negative_at",
+        r"
+spec R6ActionNegativeAt {
+  type Small = -3..3
+  state { q: Seq<Small, 2>, last: Small }
+  init { q = Seq { 0 }  last = 0 }
+  action read_negative() { last = q.at(-1) }
+}
+",
+        2,
+    );
+    assert_action_context_partial_op_agrees_across_engines(
+        "r6_action_negative_index",
+        r"
+spec R6ActionNegativeIndex {
+  type Small = -3..3
+  state { q: Seq<Small, 2>, last: Small }
+  init { q = Seq { 0 }  last = 0 }
+  action read_negative() { last = q[-1] }
 }
 ",
         2,


### PR DESCRIPTION
## Problem

`verify_bounded*` did not enforce the language contract for action-context partial
operations by itself. The native CLI compensated with a concrete pre-scan, so direct
verifier callers and specialized paths (selection, snapshots, and nondeterminism)
could bypass the automatic `partial_op/_partial_<action>` failure boundary.

Closes #651.

## Contract and approach

- Make the public bounded verifier own action guard/body/ensures partial-operation
  classification.
- Preserve evaluation order and report the first failure: an earlier non-partial
  undefined expression still fails closed instead of being relabeled as a later
  partial operation.
- Return replayable attempted-step evidence for partial action failures, including
  guard failures that roll back.
- Keep the concrete pre-scan only for exact non-`partial_op` boundary evidence.
- Use a conservative, exhaustive AST candidate gate only to avoid building unused
  SMT status terms for models that cannot contain partial operations. Actual
  classification remains symbolic and path-sensitive.
- Preserve the existing JSON envelope, exit codes, native/Worker parity, and frozen
  Python compatibility surface.

Property-context `Seq` semantics remain outside this change and are tracked by #650.

## What changed

- Added paired symbolic evaluation status (`fully_defined` plus first partial
  operation) across expressions, action guards, statements, lvalues, and ensures.
- Integrated that status into BMC before transition constraints and post-state
  checks, while preserving first-failure ordering.
- Aligned runtime replay classification for negative `Seq` indexes and final
  guard-partial attempted steps.
- Routed native CLI and Worker BMC partial failures through the shared boundary
  renderer.
- Added verifier, CLI, typed-agreement, replay, nondeterministic, precedence, and
  negative-index regressions.
- Updated the Kernel, bridge, and conformance-harness design contracts and changelog.

## Implementation local-optima audit

The caller-owned concrete pre-scan was a mixed externalization/time-delayed local
optimum (severity 11/15, confidence C3): it reused concrete semantics and produced
good local evidence, but shifted correctness costs to every raw verifier caller and
diverged on specialized execution paths. This PR inverts ownership to the public
verifier boundary.

Two tempting broader changes were rejected:

- Removing the concrete scan entirely loses exact evidence for non-partial
  over-capacity `Seq` behavior.
- Using static AST analysis to classify failures would lose path sensitivity. The
  AST walk is only a conservative no-candidate optimization.

Residual unknown: this change has no standalone SMT-growth benchmark. Exact
test-generation witnesses and all native/browser parity cases are covered by the
product gate.

## Invariants and review focus

| Invariant | Evidence |
| --- | --- |
| Symbolic, concrete Monitor, and solver-free BFS agree | typed-agreement regressions |
| First failure wins | overflow-before-partial and body-before-ensures regressions |
| Failures remain replayable | attempted-step replay regressions |
| Native CLI and Worker remain contract-identical | browser parity: 417 cases |

Please focus review on:

- `rust/fsl-verifier/src/{eval,transition,bmc}.rs`
- the boundary rendering/replay changes in `rust/fslc`, `rust/fsl-wasm`, and
  `rust/fsl-runtime`
- the conservative completeness of the AST candidate gate

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
- `./tools/check-native-integration.sh`

The complete product gate passed, including 417 browser parity cases and four
calibrated fault operators. An independent review after the final candidate-gate
change found no unresolved issues.

## Rollout and rollback

No migration or configuration change is required. Roll out with the normal native
binary/Worker release. Reverting commit `85e4e78` restores the previous verifier
behavior if a regression is found.
