### PR TITLE
chore(release): v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-08-03
+
 - Fixed native Rust business-dialect precedence policies so `every <Entity>
   reaching ... must have passed through ...` lowers to deduplicated history
   state, transition updates, the attributed no-bypass invariant, and its
@@ -4253,7 +4255,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.1.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.2.0...HEAD
+[4.2.0]: https://github.com/ymm-oss/fsl/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/ymm-oss/fsl/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/ymm-oss/fsl/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/ymm-oss/fsl/compare/v3.0.0...v3.1.0

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -373,14 +373,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.1.0"
+version = "4.2.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7584,11 +7584,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7740,11 +7740,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7765,11 +7765,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7818,11 +7818,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7843,11 +7843,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7882,11 +7882,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7913,11 +7913,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7942,11 +7942,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -7972,11 +7972,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8000,11 +8000,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8030,11 +8030,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8058,11 +8058,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8088,11 +8088,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8116,11 +8116,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8147,11 +8147,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8176,11 +8176,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8207,11 +8207,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8236,11 +8236,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8266,11 +8266,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",
@@ -8294,11 +8294,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.1.0"
+              "version": "4.2.0"
             },
             "solver": {
               "name": "z3",


### PR DESCRIPTION
## Problem

Prepare the verified v4.2.0 release candidate from current `main`.

## Contract change

- Bump the native Rust workspace and VS Code extension to 4.2.0.
- Regenerate the Cargo/npm lockfiles and the version-bearing domain characterization snapshot.
- Promote the complete Unreleased notes into a non-empty `4.2.0` section dated 2026-08-03.
- Keep the frozen Python compatibility package at 2.7.0.

## Product evidence

- `PATH=<mise-node-22.22.1>:$PATH ./tools/check-native-integration.sh` — passed (exit 0).
- Rust workspace fmt, clippy, test, build, LSP, CLI and schema/integration gates — passed.
- Native/WASM browser parity — passed (`parityCases: 421`, `exclusionProbes: 4`).
- Complete semantic mutation gate — passed (`55 mutants tested: 47 caught, 8 unviable`; survivor/timeout/unknown: 0).
- FSL Logic scheduled tier — passed (`cases=1152`).
- `fslc --version` — `fslc 4.2.0`.
- Regenerated domain characterization test — 3 passed.
- `git diff --check` — passed.

## Documentation and skills

- Updated `CHANGELOG.md`; no language contract or agent-skill changes are required for this version-only release preparation.

## Residual risk

- Local Node.js 25 showed a Chrome DevTools execution-context incompatibility in the WASM browser runner; the full product gate was rerun and passed with the stable installed Node.js 22.22.1 runtime. No product source workaround was added.