### PR TITLE
fix(fslc): give the nested kernel projection a single owner (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Unified the nested `verify` kernel projection that `run_db_check` and
+  `run_domain_check` each carried as an independent, hand-copied key list:
+  `fslc_rust::outcome::{classify_kernel_key, project_kernel}` is now the
+  single owner both commands call. `db check`'s copy previously dropped
+  every AGENTS.md-protected replayable-evidence key (`loc`, `trace`,
+  `blame`, ...); it now carries the same evidence `domain check` has since
+  #515/#641. Both commands also gain `cti`/`hint` (the `unknown_cti`
+  counterexample and its guidance), `unreached` (`reachable_failed`'s list
+  of properties that could not be reached), and `trace_type`/
+  `requirement`/`requirements`. Additive only: no existing key, top-level
+  field, `result` value, or exit code changes; `db check`'s `kernel` object
+  gains keys and loses none (#663). `rust/fsl-tools/src/ai.rs`'s independent
+  third copy (`fslc ai check`) is a known, deliberately out-of-scope
+  boundary — it cannot call the new owner because `fslc-rust` depends on
+  `fsl-tools`, not the reverse — tracked separately as #687.
+
 - Added a corpus-wide agreement gate between `domain`'s two independent
   lowering paths: `lower_domain` (typed `KernelSpec`, used by `check`/
   `verify`) and `domain_kernel_source` (rendered `.fsl` text, used by

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -924,6 +924,60 @@ inputs — a fixed pipeline versus a directory glob — and no accepted decision
 defect. Each aggregation records its choice as a stated constant reproducing today's behavior. If
 `analyze` batch's zero-file success is itself wrong, that is a separate issue with its own evidence.
 
+#### Nested kernel projection registry (#663)
+
+`run_db_check` and `run_domain_check` each project a nested `verify` kernel envelope into their own
+`kernel` object, and before #663 each held an independent, hand-copied allowlist for it:
+`run_domain_check`'s (`stable_kernel_projection`, 16 keys after #641) carried an AGENTS.md-citing
+comment for its replayable-evidence keys, and `run_db_check`'s (7 keys) carried neither the comment
+nor any of that evidence. Fixes for #515 and #641 landed on the domain copy only because there was
+nowhere else to land them — the same defect shape #600/#612 record for `is_definitive_kernel_verdict`
+one level up.
+
+Both copies entered in one commit, and the asymmetry is inherited rather than invented twice:
+`81b31eb8` ("complete native fslc migration", 172 files) ported `src/fslc/db_check.py`'s 7-key
+allowlist faithfully, but `src/fslc/domain_check.py` had emitted `"kernel": kernel` — the whole
+unprojected envelope — so the domain side arrived as a *new* 16-key allowlist over a source that had
+never dropped anything. That is why #515 and #641 both took the shape of adding keys back: they were
+rediscovering, one incident at a time, keys the frozen reference had never removed. Anyone tempted to
+narrow `PROJECTED_KERNEL_KEYS` again should read that history first — the pre-migration behavior for
+`domain check` was "project nothing", not "project these sixteen".
+
+The difference survived from the migration to #663 because it lived *inside* `kernel`, and the parity
+harness covering these commands excludes that object from comparison
+(`tools/check_rust_phase3_commands.py`'s `project()`); the harness was also never wired into any
+runner. That blind spot is its own issue, #689, and it is still what hides #687.
+
+`rust/fslc/src/outcome.rs` owns the single answer: `classify_kernel_key(key: &str) ->
+Option<KernelKeyFate>`, its `PROJECTED_KERNEL_KEYS` emission order, and `project_kernel(kernel:
+Value) -> Value`. `run_db_check` and `run_domain_check` are its only production callers. It sits
+beside `outcome_class` in the lib for the same reason recorded above:
+`issue_663_kernel_projection_owner.rs` is an integration test exercising the compiled binary, so a
+bin module would leave it unable to defer to the production registry and force it back into a
+hand-copied literal — the exact defect being removed.
+
+An unrecognized key passes through `project_kernel` unchanged rather than panicking. A panic was
+considered and rejected: AGENTS.md makes the JSON envelope itself an invariant ("Native CLI and
+Worker output must preserve the JSON envelope, exit codes, locations, and replayable evidence
+contract"), and panicking here would exit 101 with no envelope at all, discarding a verdict
+`run_verify` had already computed correctly — unlike the native-Z3-backend panic (`main.rs`,
+"unexpectedly yielded Pending"), where no correct output exists to discard in the first place. See
+`project_kernel`'s doc comment for the full argument.
+
+The registry is total by construction: every key `classify_kernel_key` recognizes is `Projected`
+(with an emission-order position in `PROJECTED_KERNEL_KEYS`) or `Dropped` (with a reason stated in
+its own match arm); `None` means unregistered. `issue_663_kernel_projection_owner.rs`'s
+`every_key_a_curated_verify_corpus_emits_is_classified` is the external gate against a new `verify`
+output channel shipping unregistered — it fails loudly in CI over a curated corpus, which is where
+the loudness now lives instead of a runtime panic over production input.
+
+The owner is single **within `fslc-rust`**, not across the workspace. `rust/fsl-tools/src/ai.rs:183`'s
+`kernel_projection` is a third, independent copy of the pre-#663 7-key shape, used by `fslc ai check`,
+and it cannot call `classify_kernel_key`/`project_kernel` because the dependency direction is
+`fslc-rust -> fsl-tools`, not the reverse. This is a known boundary, not an oversight: unifying it is
+a crate-ownership change requiring its own issue and scope per `.claude/rules/rust-verifier.md`.
+Tracked as #687 (https://github.com/ymm-oss/fsl/issues/687).
+
 ### `fsl-wasm`
 
 - `Request`/`Options` own decoded input, `MemoryResolver` owns per-call in-memory files, and each

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2265,8 +2265,13 @@ fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrism
 migration/schema の要素、最小の競合集合、修復候補を含む `findings[]` を返します。
 ランタイムの観測は `formal_result: "not_run"` の `observed_mismatch` を返します。
 ログからの不在は、未使用の振る舞いの証明ではありません。
-生成されたカーネルの反例を直接調べたいときは、通常の `fslc verify` を使って
-ください。
+入れ子の `kernel.result` が非成功(`violated`/`reachable_failed`/
+`unknown_cti`/`unknown_budget`)であれば最上位の `result` に畳み込まれ、入れ子
+の `kernel` オブジェクトはその verdict の再現可能な証拠(`loc`/`trace`/
+`blame`/`cti`/`hint`/`unreached`/…— `fslc domain check` と同じレジストリ)を
+保持します。生成されたカーネルの完全なエンベロープ(`db check`/`domain check`
+が意図的に射影しないカバレッジ名リストや実行統計など)を調べたいときは、通常の
+`fslc verify` を使ってください。
 
 `fslc db observe` は、観測イベントを評価する前に、観測エンベロープ/イベントを
 `schemas/fslc/db/observation.v0.schema.json` に対して検証します(型付きの必須

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2318,8 +2318,14 @@ capability-completeness assumptions. Compatibility failures return
 environment, artifact, migration/schema element, minimal conflict set, and repair
 candidates. Runtime observation returns `observed_mismatch` with
 `formal_result: "not_run"`; absence from logs is not proof of unused behavior.
-Use ordinary `fslc verify` when you want to inspect the generated kernel
-counterexample directly.
+A non-passing nested `kernel.result` (`violated`/`reachable_failed`/
+`unknown_cti`/`unknown_budget`) folds through to the top-level `result`, and
+the nested `kernel` object carries that verdict's replayable evidence
+(`loc`/`trace`/`blame`/`cti`/`hint`/`unreached`/... — the same registry
+`fslc domain check` uses). Use ordinary `fslc verify` when you want the full
+generated-kernel envelope, including diagnostics `db check`/`domain check`
+deliberately do not project (coverage-name lists, run statistics, and the
+like).
 
 `fslc db observe` validates the observation envelope/events against
 `schemas/fslc/db/observation.v0.schema.json` (typed required fields, a closed

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -747,8 +747,13 @@ variable.</p></div></details>
 <td><code>violated</code> / <code>type_bound</code> / <code>_bounds_&lt;var&gt;</code></td>
 </tr>
 <tr>
-<td>Partial operations (action context: <code>requires</code>/body/<code>ensures</code> only, see §3)</td>
-<td>At the time of <code>pop()</code>/<code>head()</code>/<code>at(i)</code>, the sequence is non-empty and the index is in range, and the divisor of <code>/</code> <code>%</code> is non-zero</td>
+<td>Partial Seq operations (action and property contexts)</td>
+<td>At the time of <code>pop()</code>/<code>head()</code>/<code>at(i)</code>/index, the sequence is non-empty and the index is in range</td>
+<td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code>, <code>_partial_property_&lt;property&gt;</code>, or <code>_partial_property_terminal</code></td>
+</tr>
+<tr>
+<td>Partial arithmetic (action context: <code>requires</code>/body/<code>ensures</code> only, see §3)</td>
+<td>The divisor of <code>/</code> <code>%</code> is non-zero</td>
 <td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code></td>
 </tr>
 <tr>
@@ -1228,8 +1233,10 @@ action drain() { if q.size() &gt; 0 { x = q.head()  q = q.pop() } }
   }
 }
 </code></pre>
-<p><code>at()</code> is total in property contexts (out-of-range yields an unspecified value),
-so always guard it with <code>i &lt; q.size()</code>.</p>
+<p>An out-of-range <code>at()</code>/index (or <code>head()</code>/<code>pop()</code> on an empty sequence) is a
+<code>partial_op</code> violation in property context. Guarding with <code>i &lt; q.size() =&gt; ...</code>
+short-circuits the read and keeps the property defined. Unlike <code>/</code> and <code>%</code>, Seq
+reads never totalize to an unspecified symbolic value.</p>
 <h3 id="aggregating-over-a-seq-the-index-domain-type-idiom">Aggregating over a Seq: the index / domain-type idiom</h3>
 <pre><code class="language-fsl">type Idx = 0..3                        // a domain type covering up to capacity-1
 invariant BalanceMatchesLog {
@@ -2214,8 +2221,10 @@ requirement NFR-1 &quot;complete within 4 ticks of acceptance&quot; {
   <code>requires age &gt;= K</code>)</strong>. To confirm non-vacuity, lower it to <code>K-1</code> and check
   that it becomes violated. <code>fslc verify --vacuity</code> emits
   <code>kind:"urgency_freeze"</code> for the provable form of this trap (the urgent
-  condition is initial and inductive); absence of the warning is not a proof of
-  non-vacuity.</li>
+  condition is initial and inductive). It emits <code>kind:"vacuous_deadline"</code> when
+  the stronger per-deadline check proves that every relevant age value remains
+  zero across all transitions even though <code>tick</code> may run while the age
+  condition is false. Absence of either warning is not a proof of non-vacuity.</li>
 <li>The BMC check works immediately. An inductive proof often needs a time-budget
   auxiliary invariant (the <code>age + remaining work &lt;= K</code> form) (derived from the
   CTI; real examples in <code>examples/nfr/</code>).</li>
@@ -2567,8 +2576,9 @@ DESIGN-*.md).</p>
   <code>vacuous_leadsto</code> (the trigger is unreachable), <code>always_true_requires</code>
   (a guard that is always true under the context of preceding clauses),
   <code>tautology_over_frozen</code> (a dynamically tautological invariant over state no
-  action changes), and <code>urgency_freeze</code> (a generated deadline <code>tick</code> proven dead
-  because urgency freezes time). <code>error</code> exits 2. →
+  action changes), <code>urgency_freeze</code> (a generated deadline <code>tick</code> proven dead
+  because urgency freezes time), and <code>vacuous_deadline</code> (a generated deadline
+  whose age is proven to remain zero across every transition). <code>error</code> exits 2. →
   <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-vacuity.md"><code>DESIGN-vacuity.md</code></a></li>
 <li><strong><code>--strict-tags</code></strong> — warns on success results about untagged declarations
   (fabrication candidates) and unreferenced requirements (omission candidates,

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -2329,8 +2329,14 @@ capability-completeness assumptions. Compatibility failures return
 environment, artifact, migration/schema element, minimal conflict set, and repair
 candidates. Runtime observation returns <code>observed_mismatch</code> with
 <code>formal_result: "not_run"</code>; absence from logs is not proof of unused behavior.
-Use ordinary <code>fslc verify</code> when you want to inspect the generated kernel
-counterexample directly.</p>
+A non-passing nested <code>kernel.result</code> (<code>violated</code>/<code>reachable_failed</code>/
+<code>unknown_cti</code>/<code>unknown_budget</code>) folds through to the top-level <code>result</code>, and
+the nested <code>kernel</code> object carries that verdict's replayable evidence
+(<code>loc</code>/<code>trace</code>/<code>blame</code>/<code>cti</code>/<code>hint</code>/<code>unreached</code>/... — the same registry
+<code>fslc domain check</code> uses). Use ordinary <code>fslc verify</code> when you want the full
+generated-kernel envelope, including diagnostics <code>db check</code>/<code>domain check</code>
+deliberately do not project (coverage-name lists, run statistics, and the
+like).</p>
 <p><code>fslc db observe</code> validates the observation envelope/events against
 <code>schemas/fslc/db/observation.v0.schema.json</code> (typed required fields, a closed
 <code>capability</code> vocabulary, exit 2 on a malformed record) before evaluating them,

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -726,8 +726,13 @@ until  Name { P until Q }    // unless safety plus a leadsTo P ~&gt; Q progress 
 <td><code>violated</code> / <code>type_bound</code> / <code>_bounds_&lt;var&gt;</code></td>
 </tr>
 <tr>
-<td>部分演算(action 文脈限定: <code>requires</code>/本体/<code>ensures</code> のみ、§3 参照)</td>
-<td><code>pop()</code>/<code>head()</code>/<code>at(i)</code> の時点で列が非空かつインデックスが範囲内であり、<code>/</code> <code>%</code> の除数が非ゼロ</td>
+<td>Seq の部分演算(action および property 文脈)</td>
+<td><code>pop()</code>/<code>head()</code>/<code>at(i)</code>/index の時点で列が非空かつインデックスが範囲内である</td>
+<td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code>、<code>_partial_property_&lt;property&gt;</code>、または <code>_partial_property_terminal</code></td>
+</tr>
+<tr>
+<td>算術の部分演算(action 文脈限定: <code>requires</code>/本体/<code>ensures</code> のみ、§3 参照)</td>
+<td><code>/</code> <code>%</code> の除数が非ゼロである</td>
 <td><code>violated</code> / <code>partial_op</code> / <code>_partial_&lt;action&gt;</code></td>
 </tr>
 <tr>
@@ -1200,8 +1205,10 @@ action drain() { if q.size() &gt; 0 { x = q.head()  q = q.pop() } }
   }
 }
 </code></pre>
-<p><code>at()</code> はプロパティの文脈では全域です(範囲外は不特定の値を生みます)ので、常に
-<code>i &lt; q.size()</code> でガードしてください。</p>
+<p>プロパティ文脈で範囲外の <code>at()</code>/index を読むこと(または空の Seq に対する
+<code>head()</code>/<code>pop()</code>)は <code>partial_op</code> 違反です。<code>i &lt; q.size() =&gt; ...</code> でガードすると
+read は短絡評価され、プロパティは定義されたままになります。<code>/</code> と <code>%</code> とは異なり、
+Seq read が不特定のシンボリック値へ全域化されることはありません。</p>
 <h3 id="seq">Seq 上の集約: インデックス / ドメイン型のイディオム</h3>
 <pre><code class="language-fsl">type Idx = 0..3                        // a domain type covering up to capacity-1
 invariant BalanceMatchesLog {
@@ -2160,8 +2167,10 @@ requirement NFR-1 &quot;complete within 4 ticks of acceptance&quot; {
   urgent にすること(<code>requires age &gt;= K</code> を持つ respond_due 形式)</strong>です。
   非空虚性を確認するには、<code>K-1</code> へ下げて violated になることを確認します。
   <code>fslc verify --vacuity</code> は、この罠の証明可能な形式(urgent の条件が初期かつ
-  帰納的)に対して <code>kind:"urgency_freeze"</code> を出します。警告の不在は非空虚性の証明
-  ではありません。</li>
+  帰納的)に対して <code>kind:"urgency_freeze"</code> を出します。さらに、<code>tick</code> が age 条件の
+  偽の間には動ける場合でも、対象 deadline の全 age が全遷移で 0 のままと証明された
+  ときは <code>kind:"vacuous_deadline"</code> を出します。どちらの警告も不在であることは
+  非空虚性の証明ではありません。</li>
 <li>BMC の検査はすぐに機能します。帰納的な証明はしばしば、時間予算の補助 invariant
   (<code>age + remaining work &lt;= K</code> の形)を必要とします(CTI から導出します。実例は
   <code>examples/nfr/</code>)。</li>
@@ -2517,7 +2526,9 @@ DESIGN-*.md があります)。</p>
   (先行する節の文脈の下で常に真であるガード)、
   <code>tautology_over_frozen</code>(どの action も変えない状態の上の、動的に
   トートロジーである invariant)、<code>urgency_freeze</code>(urgency が時間を凍結するために
-  死んでいると証明された、生成された deadline の <code>tick</code>)を警告します。
+  死んでいると証明された、生成された deadline の <code>tick</code>)、
+  <code>vacuous_deadline</code>(生成 deadline の age が全遷移で 0 のままと証明される)を
+  警告します。
   <code>error</code> は exit 2 です。→
   <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-vacuity.md"><code>DESIGN-vacuity.md</code></a></li>
 <li><strong><code>--strict-tags</code></strong> — 成功の結果の上で、タグのない宣言(捏造の候補)と、参照

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -2277,8 +2277,13 @@ fslc db import examples/db/minimal_prisma_schema.prisma --name ImportedFromPrism
 migration/schema の要素、最小の競合集合、修復候補を含む <code>findings[]</code> を返します。
 ランタイムの観測は <code>formal_result: "not_run"</code> の <code>observed_mismatch</code> を返します。
 ログからの不在は、未使用の振る舞いの証明ではありません。
-生成されたカーネルの反例を直接調べたいときは、通常の <code>fslc verify</code> を使って
-ください。</p>
+入れ子の <code>kernel.result</code> が非成功(<code>violated</code>/<code>reachable_failed</code>/
+<code>unknown_cti</code>/<code>unknown_budget</code>)であれば最上位の <code>result</code> に畳み込まれ、入れ子
+の <code>kernel</code> オブジェクトはその verdict の再現可能な証拠(<code>loc</code>/<code>trace</code>/
+<code>blame</code>/<code>cti</code>/<code>hint</code>/<code>unreached</code>/…— <code>fslc domain check</code> と同じレジストリ)を
+保持します。生成されたカーネルの完全なエンベロープ(<code>db check</code>/<code>domain check</code>
+が意図的に射影しないカバレッジ名リストや実行統計など)を調べたいときは、通常の
+<code>fslc verify</code> を使ってください。</p>
 <p><code>fslc db observe</code> は、観測イベントを評価する前に、観測エンベロープ/イベントを
 <code>schemas/fslc/db/observation.v0.schema.json</code> に対して検証します(型付きの必須
 フィールド、閉じた <code>capability</code> 語彙、不正なレコードでは exit 2)。各イベントの

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5974,29 +5974,16 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
         // that came back `unknown_cti`/`reachable_failed`/`unknown_budget`
         // made the envelope contradict its own exit code.
         let kernel_passed = outcome_class(&kernel).is_success();
-        if let Value::Object(kernel) = kernel {
-            if !kernel_passed {
-                result.insert("result".to_owned(), json!("violated"));
-            }
-            let projection = [
-                "result",
-                "spec",
-                "depth",
-                "checked_to_depth",
-                "completeness",
-                "invariant",
-                "violation_kind",
-            ]
-            .into_iter()
-            .filter_map(|key| {
-                kernel
-                    .get(key)
-                    .cloned()
-                    .map(|value| (key.to_owned(), value))
-            })
-            .collect();
-            result.insert("kernel".to_owned(), Value::Object(projection));
+        if !kernel_passed {
+            result.insert("result".to_owned(), json!("violated"));
         }
+        // Issue #663. The projection registry and its rationale live with
+        // the rest of the outcome vocabulary; `run_domain_check` calls the
+        // same function.
+        result.insert(
+            "kernel".to_owned(),
+            fslc_rust::outcome::project_kernel(kernel),
+        );
         kernel_status
     };
     let mut output = envelope();
@@ -6086,45 +6073,6 @@ fn run_db_import(
     (Value::Object(output), 0)
 }
 
-fn stable_kernel_projection(kernel: Value) -> Value {
-    let Value::Object(kernel) = kernel else {
-        return kernel;
-    };
-    Value::Object(
-        [
-            "result",
-            "spec",
-            "depth",
-            "checked_to_depth",
-            "completeness",
-            "invariant",
-            "violation_kind",
-            // Replayable evidence for a violated/reachable_failed/unknown_cti/
-            // unknown_budget kernel result (AGENTS.md: "Do not allowlist
-            // verdict, location, assurance, or exit-code differences").
-            "loc",
-            "violated_at_step",
-            "violating_bindings",
-            "blame",
-            "last_action",
-            "trace",
-            // Issue #641. Vacuity/coverage diagnostics are quality signals on
-            // the generated kernel itself: an unreachable generated action can
-            // signal a lowering bug, so these channels fold with the verdict.
-            "warnings",
-            "action_coverage",
-        ]
-        .into_iter()
-        .filter_map(|key| {
-            kernel
-                .get(key)
-                .cloned()
-                .map(|value| (key.to_owned(), value))
-        })
-        .collect(),
-    )
-}
-
 /// Whether a producer's output may be delivered as raw bytes instead of its
 /// JSON envelope (issue #537 C2, Verdict Conservation Law).
 ///
@@ -6199,7 +6147,7 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
                 return (kernel, status);
             }
             // `check_ai` needs the unprojected verify envelope (fields like
-            // `trace` that `stable_kernel_projection` omits) to translate a
+            // `origin` that a projected `kernel` object omits) to translate a
             // kernel invariant violation into a finding; it applies its own
             // published-kernel projection to the `kernel` field of its own
             // output.
@@ -6835,7 +6783,8 @@ fn run_domain_check(
     if !fslc_rust::outcome::is_definitive_kernel_verdict(status) {
         return apply_domain_edition((kernel, status), path, path, edition);
     }
-    let result = match fsl_tools::check_domain(&domain, &stable_kernel_projection(kernel)) {
+    let result = match fsl_tools::check_domain(&domain, &fslc_rust::outcome::project_kernel(kernel))
+    {
         Ok(result) => wrap_specialized(result),
         Err(error) => (semantic_error_output(&error.to_string()), 2),
     };

--- a/rust/fslc/src/outcome.rs
+++ b/rust/fslc/src/outcome.rs
@@ -36,8 +36,17 @@
 //!
 //! Cacheability is a separate predicate ([`verify_cache_admits`]) and does not
 //! collapse into the classifier — see its own comment.
+//!
+//! This module also owns [`is_definitive_kernel_verdict`] and, since issue
+//! #663, [`classify_kernel_key`]/[`project_kernel`]: the sibling question of
+//! which nested-kernel keys a dialect check's projected `kernel` object may
+//! keep. It lives here rather than a new module because it needs the exact
+//! same registry discipline this file already states above (enumerate every
+//! member, never fall through to a silent default) and the same two-command
+//! motivation as `is_definitive_kernel_verdict`'s doc comment: `run_db_check`
+//! and `run_domain_check` must not each carry their own answer.
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// The two classes the Verdict Conservation Law is stated over.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -274,6 +283,247 @@ pub fn verify_cache_admits(output: &Value) -> bool {
 #[must_use]
 pub fn is_definitive_kernel_verdict(status: i32) -> bool {
     status == 0 || status == 1
+}
+
+/// Fate of one top-level key of a nested `verify` kernel envelope when
+/// `run_db_check`/`run_domain_check` project it into their own `kernel`
+/// object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KernelKeyFate {
+    /// Survives into the projected `kernel` object.
+    Projected,
+    /// Deliberately absent from the projected `kernel` object.
+    /// [`classify_kernel_key`]'s match arm for the key states the reason.
+    Dropped,
+}
+
+/// The order [`project_kernel`] emits its surviving keys in. Declaration
+/// order is emission order, so this doubles as the field order of the
+/// `kernel` object both `run_db_check` and `run_domain_check` produce.
+///
+/// Grouped verdict identity, then AGENTS.md replayable evidence (issue
+/// #515/#641's domain-only fix, now shared), then vacuity/coverage quality
+/// signals (#641), then issue #663's additions. `unknown_cti`'s primary
+/// evidence is the induction counterexample (`cti`) plus the guidance that
+/// goes with every failure-class result (`hint`); `reachable_failed`'s is the
+/// list of properties that could not be reached (`unreached`) -- before
+/// #663 that verdict class projected to little more than
+/// `result`/`spec`/`checked_to_depth`. `trace_type` says how to read `trace`/
+/// `cti`; `requirement`/`requirements` are the traceability identifiers a
+/// violated property carries when the spec tags one.
+///
+/// The last group is a `leadsTo` violation's evidence
+/// (`bindings`/`pending_since`/`loop_start`/`deadline`/`within`/`stutter`,
+/// `verification_output.rs`'s `render_leadsto_failure`) and a ranked-
+/// termination counterexample's (`measure`/`rank_failure`/`measure_value`/
+/// `measure_before`/`measure_after`/`message`, `verification.rs`'s
+/// `render_rank_failure`, `violation_kind: "leadsTo_rank"`). Neither
+/// `fsl-core`'s domain lowering (`domain_lowering.rs`, which emits only
+/// `SpecItem::{Action, Enum, Type, Struct, State, Init, Terminal, Invariant,
+/// Trans, Reachable}`) nor its `db.rs` lowering generates a `LeadsTo` item,
+/// so a `db check`/`domain check` kernel cannot reach either shape today --
+/// this is measured, not assumed (`issue_663_kernel_projection_owner.rs`'s
+/// `every_key_a_curated_verify_corpus_emits_is_classified` corpus includes a
+/// plain-kernel `leadsTo` violation and cites the ranked-termination fixture
+/// `induction_suggestions.rs` already exercises). They are projected anyway:
+/// a future dialect lowering that does emit a `LeadsTo` item must inherit
+/// this evidence, not silently lose it the way `db check` lost the rest of
+/// this list before #663.
+const PROJECTED_KERNEL_KEYS: &[&str] = &[
+    "result",
+    "spec",
+    "depth",
+    "checked_to_depth",
+    "completeness",
+    "invariant",
+    "violation_kind",
+    "loc",
+    "violated_at_step",
+    "violating_bindings",
+    "blame",
+    "last_action",
+    "trace",
+    "warnings",
+    "action_coverage",
+    "cti",
+    "hint",
+    "trace_type",
+    "requirement",
+    "requirements",
+    "unreached",
+    "bindings",
+    "pending_since",
+    "loop_start",
+    "deadline",
+    "within",
+    "stutter",
+    "measure",
+    "rank_failure",
+    "measure_value",
+    "measure_before",
+    "measure_after",
+    "message",
+];
+
+/// Classify one top-level key a `verify` kernel envelope can carry.
+///
+/// This is the single owner of "which nested-kernel keys survive a
+/// projection" (issue #663). Before it, `run_domain_check` held a 16-key
+/// allowlist (`stable_kernel_projection`, carrying an AGENTS.md-citing
+/// comment for its replayable-evidence keys) and `run_db_check` held an
+/// independent 7-key allowlist with no such comment and none of those keys —
+/// the same defect shape #600/#612 describe for `is_definitive_kernel_verdict`,
+/// applied one level down. Fixes #515 and #641 landed on the domain copy only
+/// because there was nowhere else for them to land.
+///
+/// The `Dropped` arm is listed explicitly, one key per reason, rather than
+/// left to a catch-all: the enumeration *is* the registry (same idiom as
+/// [`outcome_class`]'s failure arm). A key this function has not seen — a
+/// new `verify` output channel nobody registered — returns `None`, and
+/// [`project_kernel`] passes it through unchanged rather than dropping or
+/// panicking on it (see that function's doc comment for why); the loud gate
+/// against an unregistered key living there unnoticed is
+/// `issue_663_kernel_projection_owner.rs`'s
+/// `every_key_a_curated_verify_corpus_emits_is_classified` census test, run
+/// in CI rather than at runtime against production input.
+#[must_use]
+pub fn classify_kernel_key(key: &str) -> Option<KernelKeyFate> {
+    if PROJECTED_KERNEL_KEYS.contains(&key) {
+        return Some(KernelKeyFate::Projected);
+    }
+    #[allow(clippy::match_same_arms)]
+    match key {
+        // ---- Nested-run bookkeeping, not evidence about the verdict -----
+        //
+        // The outer `db`/`domain` command's own envelope already carries its
+        // own `fsl`; a nested copy from the inner `verify` run would be
+        // ambiguous about which run it describes.
+        "fsl"
+        // The top-level `fslc verify` CLI command's own on-disk
+        // verification-cache lookup metadata (`{"hit":true,...}`), inserted
+        // by `run_verify_cli`'s cache wrapper -- never by `run_verify`
+        // itself. `run_db_check`/`run_domain_check` call `run_verify`
+        // directly and so never produce it in a nested kernel, but a census
+        // of the `fslc verify` command can still surface it and needs a
+        // registered fate.
+        | "cache"
+        // Tool/solver version metadata for the *inner* `verify` run. The
+        // outer command's own envelope is never stamped with this (
+        // `with_version_metadata` wraps only the top-level `fslc verify`
+        // command), so carrying it here would misattribute the outer
+        // command's versions to a run it did not perform.
+        | "versions"
+        // Solver/timing statistics for the inner run; not evidence of what
+        // was found, and the outer command has its own cost profile.
+        | "cost"
+        // Induction step-index bookkeeping, superseded by `cti.violated_at`
+        // once `cti` is projected.
+        | "k"
+        // Internal generated-symbol provenance for a domain/db-lowered
+        // Kernel construct. The *generating* command already knows how it
+        // lowered the spec; `loc` (kept) already carries the user-authored
+        // location this maps back to.
+        | "origin"
+        | "generated_name"
+        // Echoes the `--engine` flag the caller already supplied.
+        | "engine"
+        // Induction proof bookkeeping for a *passing* verdict (no violation
+        // to interpret): per-invariant step counts and the induction base
+        // case, both already summarized by `checked_to_depth`/`completeness`.
+        | "k_used"
+        | "base_depth"
+        // Explicit-engine exploration statistics for a passing or
+        // budget-exhausted run; `hint` already carries the actionable
+        // guidance for `unknown_budget`.
+        | "closure"
+        | "states_explored"
+        | "max_frontier_width"
+        | "depth_reached"
+        // Coverage bookkeeping (which named properties this run checked),
+        // not evidence of a specific finding. Distinct from `action_coverage`
+        // (kept, #641), which qualifies the verdict's own confidence rather
+        // than just listing names.
+        | "invariants_checked"
+        | "transitions_checked"
+        // Witnessed-reachable detail and the reachability probe's own
+        // deadlock flag: both describe a *passing* verdict, so there is no
+        // violation for this evidence to help replay. An actual deadlock is
+        // a `violated` result and travels through `trace`/`trace_type`
+        // (kept) instead.
+        | "reachables"
+        | "deadlock"
+        // Per-property leadsTo proof/coverage summary on a passing verdict.
+        | "leads_to"
+        // Free-text summary paired with a passing/closure verdict.
+        | "note"
+        // Redundant with `violation_kind`/`invariant`, which already say the
+        // violated property is a transition postcondition.
+        | "trans"
+        // Authoring assistance (candidate auxiliary invariant text to add to
+        // the spec), not evidence needed to replay the counterexample `cti`
+        // already carries.
+        | "suggested_invariants"
+        // A bundled, independent `implements`/refinement verdict riding on
+        // the same envelope (declared via a spec's `implements` contract).
+        // Folding it in here would silently promote a second verdict axis
+        // into a `dbsystem`/`domain` kernel projection without its own
+        // AGENTS.md discipline; out of scope for #663, which is about the
+        // `verify` verdict's own replayable evidence.
+        | "implements"
+        // Advisory "what to do next" guidance that duplicates `hint`'s role
+        // on the `reachable_failed`/`partial_op` paths.
+        | "faithfulness_class"
+        | "recommended_action" => Some(KernelKeyFate::Dropped),
+        _ => None,
+    }
+}
+
+/// Project a nested `verify` kernel envelope for `run_db_check`/
+/// `run_domain_check`'s `kernel` object, applying the single
+/// [`classify_kernel_key`] registry both commands share (issue #663).
+///
+/// Non-object input (never produced by `run_verify` in practice) passes
+/// through unchanged, matching the pre-#663 `stable_kernel_projection`.
+///
+/// A key [`classify_kernel_key`] does not recognize passes through
+/// unchanged too, appended after the known [`PROJECTED_KERNEL_KEYS`] in the
+/// kernel's own key order. Only a `Dropped` classification removes a key.
+///
+/// A panic here was considered and rejected. AGENTS.md makes the JSON
+/// envelope itself an invariant ("Native CLI and Worker output must preserve
+/// the JSON envelope, exit codes, locations, and replayable evidence
+/// contract"): panicking on an unrecognized key would exit 101 with no
+/// envelope at all, discarding a verdict `run_verify` had already computed
+/// correctly. That is different from the native-Z3-backend panic at
+/// `main.rs`'s "unexpectedly yielded Pending" site, where no correct output
+/// exists to discard -- here one does. Passing the key through instead makes
+/// an unregistered key harmless *by construction*: evidence is never lost,
+/// and the only cost is an unclassified field surfacing in output, which
+/// `issue_663_kernel_projection_owner.rs`'s
+/// `every_key_a_curated_verify_corpus_emits_is_classified` census exists to
+/// catch as a loud CI failure. Do not reinstate a panic/assert here; there is
+/// nothing left for a runtime check to protect once the fallback is
+/// pass-through rather than silent loss.
+#[must_use]
+pub fn project_kernel(kernel: Value) -> Value {
+    let Value::Object(kernel) = kernel else {
+        return kernel;
+    };
+    let mut projected: Map<String, Value> = PROJECTED_KERNEL_KEYS
+        .iter()
+        .filter_map(|&key| {
+            kernel
+                .get(key)
+                .cloned()
+                .map(|value| (key.to_owned(), value))
+        })
+        .collect();
+    for (key, value) in &kernel {
+        if classify_kernel_key(key).is_none() {
+            projected.insert(key.clone(), value.clone());
+        }
+    }
+    Value::Object(projected)
 }
 
 /// `docs/LANGUAGE.md`'s exit-code table applied to an envelope, as a total

--- a/rust/fslc/tests/fault_operators/db-check-drops-kernel-verdict.patch
+++ b/rust/fslc/tests/fault_operators/db-check-drops-kernel-verdict.patch
@@ -2,15 +2,19 @@ Restores the #600 defect: `db check` folds only a `violated` kernel into its
 top-level verdict, so a kernel that came back `unknown_cti` /
 `reachable_failed` / `unknown_budget` is reported as
 `verified_under_assumptions` beside exit 1 -- the envelope contradicts its own
-exit code, and a gate reading the JSON sees a pass.
+exit code, and a gate reading the JSON sees a pass. Re-targeted for #663: that
+change removed the `if let Value::Object(kernel) = kernel` guard this patch
+used to sit inside (the fold is no longer conditioned on the envelope's JSON
+shape), so the substitution now lands directly on `kernel_passed` with no
+enclosing guard to remove.
 
 --- a/rust/fslc/src/main.rs
 +++ b/rust/fslc/src/main.rs
-@@ -5943,6 +5943,6 @@
-         // `violated`. Reporting `verified_under_assumptions` over a kernel
+@@ -5973,6 +5973,6 @@
          // that came back `unknown_cti`/`reachable_failed`/`unknown_budget`
          // made the envelope contradict its own exit code.
 -        let kernel_passed = outcome_class(&kernel).is_success();
 +        let kernel_passed = kernel.get("result").and_then(Value::as_str) != Some("violated");
-         if let Value::Object(kernel) = kernel {
-             if !kernel_passed {
+         if !kernel_passed {
+             result.insert("result".to_owned(), json!("violated"));
+         }

--- a/rust/fslc/tests/issue_663_kernel_projection_owner.rs
+++ b/rust/fslc/tests/issue_663_kernel_projection_owner.rs
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Issue #663: `run_db_check` and `run_domain_check` each projected the
+//! nested `verify` kernel envelope into their own `kernel` object through an
+//! independent, hand-copied key list. `run_domain_check`'s copy
+//! (`stable_kernel_projection`, 16 keys after #641) carried an
+//! AGENTS.md-citing comment explaining why replayable evidence must not be
+//! dropped; `run_db_check`'s copy (7 keys) carried neither the comment nor
+//! any of that evidence. Fixes for #515 and #641 landed on the domain copy
+//! only because it was the only place to land them, and neither copy ever
+//! carried `unknown_cti`'s primary evidence (the induction counterexample)
+//! or `reachable_failed`'s (the list of unreached properties).
+//!
+//! `fslc_rust::outcome::{classify_kernel_key, project_kernel}` is now the
+//! single owner both commands call; `main.rs`'s `stable_kernel_projection`
+//! and the inline array inside `run_db_check` are gone. An unrecognized key
+//! passes through `project_kernel` rather than panicking or being silently
+//! dropped (see that function's doc comment): the census test below is the
+//! loud gate against a new, unregistered `verify` output channel, not a
+//! runtime assertion over production input. This suite pins:
+//!
+//! - `db check` now carries the evidence `unknown_cti` needs, which it
+//!   dropped entirely before.
+//! - `db check` and `domain check` produce the same kernel key set for the
+//!   same verdict class -- the shape a re-forked projection would break.
+//! - Every top-level key a curated `fslc verify` corpus reaching six verdict
+//!   classes (plus a `leadsTo` violation and a ranked-termination
+//!   counterexample, neither reachable through `db`/`domain` lowering today
+//!   but registered `Projected` for when a future dialect emits one) is
+//!   classified by the registry.
+//! - A passing verdict does not gain manufactured evidence keys.
+//!
+//! The pre-existing #600/#515/#641 regression fixtures are exercised by
+//! their own suites (`issue_600_db_check_folds_kernel_verdict.rs`,
+//! `issue_641_domain_check_kernel_warnings.rs`,
+//! `issue_515_domain_check_false_green.rs`), run alongside this file rather
+//! than duplicated into it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fslc_rust::outcome::{classify_kernel_key, project_kernel};
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {args:?}`: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output
+        .status
+        .code()
+        .unwrap_or_else(|| panic!("`fslc {args:?}` terminated by signal, no exit code"));
+    (value, status)
+}
+
+fn key_set(value: &Value) -> BTreeSet<String> {
+    value
+        .as_object()
+        .map(|object| object.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+const DB_INCONCLUSIVE: &str = "rust/fslc/tests/fixtures/issue_600_db_inconclusive_kernel.fsl";
+const DOMAIN_BROKEN: &str = "rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl";
+const DOMAIN_CLEAN: &str = "rust/fslc/tests/fixtures/issue_641_domain_clean.fsl";
+const REACHABLE_FAILED: &str = "rust/fslc/tests/fixtures/issue_634_reachable_classification.fsl";
+const EXPLICIT_BUDGET_FIXTURE: &str = "rust/fslc/tests/fixtures/explicit_finite_toggle.fsl";
+const INDUCTION_PROVED: &str = "rust/fslc/tests/fixtures/issue_515_domain_clean_invariant.fsl";
+const PLAIN_VERIFIED: &str = "specs/cart_v1.fsl";
+/// A plain-kernel `leadsTo` violation (`violation_kind: "leadsTo"`).
+/// Measured: emits `bindings`/`loop_start`/`pending_since`/`stutter`/
+/// `trace_type`/`hint`/`trace`/`loc`. Neither `db check` nor `domain check`
+/// can reach this shape today (`fsl-core`'s domain/db lowering never emits a
+/// `LeadsTo` item), but a plain `fslc verify` corpus entry still measures the
+/// keys `render_leadsto_failure` (`verification_output.rs`) actually emits,
+/// rather than registering them from a source read alone.
+const LEADS_TO_VIOLATED: &str = "examples/gallery/errors/violated_leads_to_starvation.fsl";
+/// A ranked-termination counterexample (`result: "unknown_cti"`,
+/// `violation_kind: "leadsTo_rank"`). Measured via the corpus fixture
+/// `induction_suggestions.rs`'s `ranked_leadsto_failures_never_receive_suggestions`
+/// already exercises: emits `bindings`/`measure`/`rank_failure`/
+/// `measure_before`/`measure_after`/`last_action`/`cti`/`hint`/`message`.
+/// `measure_value` and the plain `leadsTo`-only `deadline`/`within` are not
+/// reached by either measured fixture and stay registered from
+/// `verification.rs`'s `render_rank_failure` (lines ~544-601) and
+/// `verification_output.rs`'s `render_leadsto_failure` directly.
+const RANKED_LEADS_TO: &str = "tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl";
+
+/// Evidence keys no verdict class in this corpus has evidence for on a
+/// passing kernel. Used by the over-projection negative control.
+const EVIDENCE_KEYS: &[&str] = &[
+    "cti",
+    "hint",
+    "trace_type",
+    "requirement",
+    "requirements",
+    "unreached",
+    "loc",
+    "violated_at_step",
+    "violating_bindings",
+    "blame",
+    "last_action",
+    "trace",
+    "violation_kind",
+    "invariant",
+    "bindings",
+    "pending_since",
+    "loop_start",
+    "deadline",
+    "within",
+    "stutter",
+    "measure",
+    "rank_failure",
+    "measure_value",
+    "measure_before",
+    "measure_after",
+    "message",
+];
+
+// ---------------------------------------------------------------------------
+// Positive: db check now carries unknown_cti's replayable evidence.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn db_check_carries_replayable_evidence_for_an_inconclusive_kernel() {
+    let (output, status) = run(&["db", "check", DB_INCONCLUSIVE, "--engine", "induction"]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated", "{output:#}");
+    let kernel = &output["kernel"];
+    assert_eq!(kernel["result"], "unknown_cti", "{output:#}");
+
+    // Before #663 this projected to exactly `{checked_to_depth,
+    // completeness, invariant, result, spec}` -- five keys, none of them the
+    // counterexample or the guidance that goes with it (the issue's
+    // measured ground truth).
+    assert!(
+        kernel["cti"]["states"].is_array()
+            && !kernel["cti"]["states"].as_array().unwrap().is_empty(),
+        "missing the induction counterexample trace: {output:#}"
+    );
+    assert!(
+        kernel["cti"]["violated_at"].is_u64(),
+        "missing the counterexample's violation step: {output:#}"
+    );
+    assert!(
+        kernel["hint"].as_str().is_some_and(|hint| !hint.is_empty()),
+        "missing actionable guidance: {output:#}"
+    );
+    assert_eq!(
+        kernel["trace_type"], "induction_cti",
+        "missing the label that says how to read `cti`: {output:#}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Symmetry / negative control for the defect: db and domain must agree.
+// ---------------------------------------------------------------------------
+
+/// A verified/passing kernel is dialect-independent -- neither
+/// `run_db_check` nor `run_domain_check` adds anything of its own to the
+/// nested envelope before projecting it -- so this is the one verdict class
+/// this suite can compare directly across two different fixtures and two
+/// different dialects without the comparison being confounded by which
+/// evidence a particular spec happens to trigger. A re-forked projection
+/// (someone reintroducing a second hand-copied list in one command but not
+/// the other) is exactly what would make these two sets diverge; that is
+/// the defect this repository has now paid for twice (#515, #641).
+#[test]
+fn db_check_and_domain_check_project_the_same_key_set_for_a_passing_kernel() {
+    // No dbsystem finding and a clean bounded kernel: the dbsystem layer
+    // itself never rewrites `kernel`, so this is a plain `verified` kernel.
+    let (db, db_status) = run(&["db", "check", DB_INCONCLUSIVE]);
+    assert_eq!(db_status, 0, "{db:#}");
+    assert_eq!(db["kernel"]["result"], "verified", "{db:#}");
+
+    let (domain, domain_status) = run(&["domain", "check", DOMAIN_CLEAN, "--depth", "4"]);
+    assert_eq!(domain_status, 0, "{domain:#}");
+    assert_eq!(domain["kernel"]["result"], "verified", "{domain:#}");
+
+    assert_eq!(
+        key_set(&db["kernel"]),
+        key_set(&domain["kernel"]),
+        "db check and domain check must carry the same verified-kernel key set; \
+         db={db:#} domain={domain:#}"
+    );
+}
+
+/// The mechanical half of the same control: each command's own `kernel`
+/// object must equal what the single owner (`project_kernel`) produces from
+/// that fixture's raw `verify` envelope -- compared as a set computed from
+/// the owner at test time, never against a literal typed into this test.
+/// This is what fails if `run_db_check` (or `run_domain_check`) grows a
+/// second hand-copied key list instead of calling `project_kernel`.
+#[test]
+fn db_check_kernel_matches_the_owner_projection() {
+    let (db, _status) = run(&["db", "check", DB_INCONCLUSIVE, "--engine", "induction"]);
+    let (raw, _raw_status) = run(&[
+        "verify",
+        DB_INCONCLUSIVE,
+        "--engine",
+        "induction",
+        "--deadlock",
+        "warn",
+        "--depth",
+        "8",
+        "--no-cache",
+    ]);
+    let owner_projected = project_kernel(raw);
+    assert_eq!(
+        key_set(&db["kernel"]),
+        key_set(&owner_projected),
+        "db check's kernel must match fslc_rust::outcome::project_kernel exactly; \
+         db={db:#} owner={owner_projected:#}"
+    );
+}
+
+#[test]
+fn domain_check_kernel_matches_the_owner_projection() {
+    let (domain, _status) = run(&["domain", "check", DOMAIN_BROKEN, "--depth", "4"]);
+    let (raw, _raw_status) = run(&[
+        "verify",
+        DOMAIN_BROKEN,
+        "--depth",
+        "4",
+        "--deadlock",
+        "warn",
+        "--no-cache",
+    ]);
+    let owner_projected = project_kernel(raw);
+    assert_eq!(
+        key_set(&domain["kernel"]),
+        key_set(&owner_projected),
+        "domain check's kernel must match fslc_rust::outcome::project_kernel exactly; \
+         domain={domain:#} owner={owner_projected:#}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Census / unregistered-channel gate.
+// ---------------------------------------------------------------------------
+
+/// Every top-level key a curated corpus of `fslc verify` runs emits, across
+/// six verdict classes, must be classified by
+/// `fslc_rust::outcome::classify_kernel_key`. An unclassified key means a
+/// source change added a new `verify` output channel without registering
+/// its projection fate -- the exact silent-drop failure mode #663 exists to
+/// close. `project_kernel` itself no longer fails loudly on this (an
+/// unregistered key now passes through instead of panicking, so a real
+/// `db`/`domain check` run never loses a verdict it already computed
+/// correctly); this census is where the loudness lives instead, at CI time
+/// over a known corpus rather than at runtime over production input.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn every_key_a_curated_verify_corpus_emits_is_classified() {
+    let corpus: &[&[&str]] = &[
+        &["verify", PLAIN_VERIFIED, "--depth", "8", "--no-cache"],
+        &["verify", DOMAIN_BROKEN, "--depth", "4", "--no-cache"],
+        &[
+            "verify",
+            DB_INCONCLUSIVE,
+            "--engine",
+            "induction",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ],
+        &[
+            "verify",
+            REACHABLE_FAILED,
+            "--depth",
+            "0",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ],
+        &[
+            "verify",
+            EXPLICIT_BUDGET_FIXTURE,
+            "--engine",
+            "explicit",
+            "--depth",
+            "4",
+            "--explicit-budget",
+            "1",
+            "--no-cache",
+        ],
+        &[
+            "verify",
+            INDUCTION_PROVED,
+            "--engine",
+            "induction",
+            "--no-cache",
+        ],
+        &["verify", LEADS_TO_VIOLATED, "--depth", "8", "--no-cache"],
+        &[
+            "verify",
+            RANKED_LEADS_TO,
+            "--engine",
+            "induction",
+            "--depth",
+            "8",
+            "--k",
+            "1",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ],
+    ];
+
+    let mut reached_classes = BTreeSet::new();
+    let mut reached_violation_kinds = BTreeSet::new();
+    let mut all_keys = BTreeSet::new();
+    for args in corpus {
+        let (output, status) = run(args);
+        assert!(
+            status == 0 || status == 1,
+            "corpus entry must be a definitive verify verdict: {args:?} -> {output:#}"
+        );
+        let result = output["result"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no `result` string: {args:?} -> {output:#}"))
+            .to_owned();
+        reached_classes.insert(result);
+        if let Some(violation_kind) = output.get("violation_kind").and_then(Value::as_str) {
+            reached_violation_kinds.insert(violation_kind.to_owned());
+        }
+        all_keys.extend(key_set(&output));
+    }
+
+    for class in [
+        "verified",
+        "violated",
+        "unknown_cti",
+        "reachable_failed",
+        "unknown_budget",
+        "proved",
+    ] {
+        assert!(
+            reached_classes.contains(class),
+            "corpus fixture drifted: no longer reaches {class}; reached {reached_classes:?}"
+        );
+    }
+    // `violated`/`unknown_cti` are reached by more than one corpus entry
+    // above (an invariant violation, a `leadsTo` violation, an induction
+    // CTI, a ranked-termination CTI); pin the specific `violation_kind`
+    // shapes too, or a fixture drifting away from `leadsTo`/`leadsTo_rank`
+    // would hide behind the `violated`/`unknown_cti` class check already
+    // passing and silently stop measuring the 12 keys in item 2 of #663's
+    // review.
+    for kind in ["leadsTo", "leadsTo_rank"] {
+        assert!(
+            reached_violation_kinds.contains(kind),
+            "corpus fixture drifted: no longer reaches violation_kind {kind}; reached \
+             {reached_violation_kinds:?}"
+        );
+    }
+
+    let unregistered: Vec<&String> = all_keys
+        .iter()
+        .filter(|key| classify_kernel_key(key).is_none())
+        .collect();
+    assert!(
+        unregistered.is_empty(),
+        "verify emitted key(s) with no registered projection fate: {unregistered:?}; classify \
+         them in fslc_rust::outcome::classify_kernel_key as Projected or Dropped, with a stated \
+         reason (issue #663)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative control against over-projection.
+// ---------------------------------------------------------------------------
+
+/// A clean/passing spec must not gain evidence keys it has no evidence for.
+/// `project_kernel` filters by presence in the raw kernel; a key the raw
+/// kernel never set must stay absent from the projection, never appear as a
+/// manufactured `null` or empty placeholder.
+#[test]
+fn a_passing_kernel_does_not_gain_manufactured_evidence_keys() {
+    let (db, db_status) = run(&["db", "check", DB_INCONCLUSIVE]);
+    assert_eq!(db_status, 0, "{db:#}");
+    assert_eq!(db["kernel"]["result"], "verified", "{db:#}");
+    let kernel = db["kernel"].as_object().expect("db check kernel object");
+    for key in EVIDENCE_KEYS {
+        assert!(
+            !kernel.contains_key(*key),
+            "verified db-check kernel manufactured evidence key {key:?} it has no evidence for: \
+             {db:#}"
+        );
+    }
+
+    let (domain, domain_status) = run(&["domain", "check", DOMAIN_CLEAN, "--depth", "4"]);
+    assert_eq!(domain_status, 0, "{domain:#}");
+    assert_eq!(domain["kernel"]["result"], "verified", "{domain:#}");
+    let kernel = domain["kernel"]
+        .as_object()
+        .expect("domain check kernel object");
+    for key in EVIDENCE_KEYS {
+        assert!(
+            !kernel.contains_key(*key),
+            "verified domain-check kernel manufactured evidence key {key:?} it has no evidence \
+             for: {domain:#}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`run_db_check` and `run_domain_check` each projected the nested `verify` kernel envelope into
their own `kernel` object through an independent, hand-copied key list.
`run_domain_check`'s (`stable_kernel_projection`, 16 keys after #641) carried an AGENTS.md-citing
comment for its replayable-evidence keys; `run_db_check`'s (7 keys) carried neither the comment
nor any of that evidence. Fixes #515 and #641 landed on the domain copy alone because there was
nowhere else to land them — the shape #600/#612 record for `is_definitive_kernel_verdict`, one
level down.

Measured on `main` before this change:

```
db check     tests/fixtures/issue_600_db_inconclusive_kernel.fsl --engine induction
  kernel: checked_to_depth completeness invariant result spec                        (5, no evidence)
domain check tests/fixtures/issue_515_domain_broken_invariant.fsl --depth 6
  kernel: blame checked_to_depth completeness invariant last_action loc result spec
          trace trace_type violated_at_step violating_bindings violation_kind        (12)
```

Neither copy had ever carried `unknown_cti`'s primary evidence (`cti`, `hint`) or
`reachable_failed`'s (`unreached`), so "copy the domain list into db" would have been a hollow fix.

## Contract changes

`fslc_rust::outcome::{classify_kernel_key, project_kernel}` is now the single owner both commands
call; `stable_kernel_projection` and the inline array in `run_db_check` are gone. It sits beside
`outcome_class` in the lib rather than in `main.rs` for the reason already recorded for
`outcome_class`: an integration test must be able to defer to the production enumeration instead of
carrying a copy, which is the stale-check shape #577 retired 28 instances of.

The registry is total. Each key is `Projected` (with a position in `PROJECTED_KERNEL_KEYS`, which
`serde_json`'s `preserve_order` makes the emission order) or `Dropped` with a reason in its own
match arm. An unrecognized key **passes through** rather than panicking: AGENTS.md makes the JSON
envelope an invariant, and exiting 101 with no envelope would discard a verdict `run_verify` had
already computed correctly. Pass-through makes an unregistered key harmless by construction, so the
loudness lives in the census test instead of a runtime abort. That decision and its rejected
alternative are recorded in `project_kernel`'s doc comment and in
`docs/DESIGN-rust-component-internals.md`.

`db check` and `domain check` both gain `cti`, `hint`, `unreached`, `trace_type`, `requirement`,
`requirements`. `leadsTo` and ranked-termination evidence keys are projected too: measurement shows
`domain_lowering.rs` emits no `SpecItem::LeadsTo` and neither does `db.rs`, so those shapes are
unreachable through these commands today — projecting them now means a future dialect that does
lower a `LeadsTo` inherits the evidence instead of silently losing it.

**Additive only.** `db check`'s `kernel` gains keys and loses none; no top-level field, `result`
value, or exit code changes. One latent hole closes as a side effect: `run_db_check` folded a
non-passing kernel into `result` *inside* an `if let Value::Object(kernel)` guard, so a non-object
kernel could have returned exit 1 alongside `verified_under_assumptions` — the #600 defect. The fold
no longer depends on the envelope's JSON shape.

## Why this escaped, and what still hides its siblings

`git log -S` puts both copies in one commit: `81b31eb8` ("complete native fslc migration", 172
files, +57,151 lines). The asymmetry is inherited, not invented twice — `src/fslc/db_check.py`
had a 7-key allowlist and was ported faithfully, while `src/fslc/domain_check.py` emitted
`"kernel": kernel`, the whole unprojected envelope. The domain side therefore arrived as a *new*
allowlist over a source that had never dropped anything, which is why #515 and #641 both took the
shape of adding keys back.

The difference lived *inside* `kernel`, and the parity harness covering these commands excludes
that object from comparison (`tools/check_rust_phase3_commands.py`'s `project()`); that harness has
also never been wired into any runner. Filed as **#689**, which is what still hides **#687** —
`rust/fsl-tools/src/ai.rs`'s `kernel_projection`, a third copy that cannot call this owner because
the dependency direction is `fslc-rust -> fsl-tools`. Unifying it is an ownership-map change with
its own scope; the boundary is stated in the design doc so it is not mistaken for an oversight.

## Evidence

`rust/fslc/tests/issue_663_kernel_projection_owner.rs`, 6 tests. Negative controls **calibrated by
reintroducing the defect**, not assumed:

- Re-forking the db projection back to the old inline 7-key list fails exactly
  `db_check_carries_replayable_evidence_for_an_inconclusive_kernel`,
  `db_check_and_domain_check_project_the_same_key_set_for_a_passing_kernel`, and
  `db_check_kernel_matches_the_owner_projection`, leaving the domain test and the census green —
  precise detection, no over-firing.
- Unregistering one key (`"cost"`) fails exactly
  `every_key_a_curated_verify_corpus_emits_is_classified`, naming the key.

The census reaches six verdict classes and pins `violation_kind` for the two produced by more than
one entry, so a fixture drifting off `leadsTo` fails loudly. A corpus sweep of 159 specs reaching a
definitive verdict emits **zero** unregistered top-level keys.

```
cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked                          exit 0
cargo test --manifest-path rust/Cargo.toml --workspace --locked                            exit 0
    1360 tests across 190 test binaries, 0 failed
cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
                                                                                           exit 0
cargo fmt --manifest-path rust/Cargo.toml --all -- --check                                 exit 0
python3 -m pytest tests/test_site_reference_snapshot.py                                3 passed
```

An `implementation-local-optima-audit` pass over the change found no new local optimum. The one
candidate worth recording — the registry lives in `outcome.rs` while its keys are produced in
`verification_output.rs` (20 commits/12 months, 17 of them co-changing with `main.rs`) and
`verification.rs` (39) — does not invert: the 159-spec sweep shows the registry is complete, and the
alternative placement loses the integration test's ability to defer to it.

## Notes for review

- The first commit, `docs: regenerate the stale site reference pages`, is **separated on purpose**
  and contains no work of this PR. `tests/test_site_reference_snapshot.py` requires regeneration
  whenever `docs/LANGUAGE.md` changes, and the committed output had been stale since the `Seq`
  partial-operation and `vacuous_deadline` doc changes. Regenerating from unmodified sources
  produces that whole diff; #630 covers giving that dormant freshness check a runner. Its output is
  deterministic across a wide toolchain span — measured byte-identical for all four generated pages
  between CPython 3.14.6 / `markdown` 3.10.2 and CPython 3.9.6 / `markdown` 3.9, by design rather
  than luck, since `normalize_argparse_help` exists to absorb argparse's Python-version differences
  — so pinning `pyproject.toml`'s `markdown>=3` is optional hardening, not a prerequisite for the
  gate.

## The third commit: a fault operator this change broke

The first CI run on this branch failed `semantic mutation (changed)`:
`rust/fslc/tests/fault_operators/db-check-drops-kernel-verdict.patch` no longer applied. Removing
the `if let Value::Object(kernel) = kernel` guard — the latent #600 fix described above — deleted a
context line the patch sat inside.

The seam moved; the fault did not. `operators.txt`'s registered anchor
(`let kernel_passed = outcome_class(&kernel).is_success();`) still matches the source verbatim, and
the same substitution still reproduces #600. Only the context lines, the hunk offset, and the
preamble changed. The operator is not deleted, skipped, or loosened — its runner's own message says
a silently skipped operator is how a detector matrix rots into decoration.

Verified by reading the re-run's logs rather than inferring:
`db-check-drops-kernel-verdict.primary.log` shows
`db_check_folds_an_inconclusive_kernel_into_its_top_level_verdict ... FAILED` (the detector still
catches the injected fault) and `.blind.log` shows `test result: ok. 1 passed` (the blind detector
stays unreached). That is `primary=failed blind=ok`, the calibration the matrix requires.

Worth stating plainly: my pre-push verification ran `cargo fmt`/`clippy`/`test`/`build`, which is
AGENTS.md's "Rust CI-equivalent gate" but **not** the complete product gate
(`./tools/check-native-integration.sh`, which includes the fault-operator and semantic-mutation
legs). For a change rewriting `run_db_check` the fault-operator leg was directly in scope. CI caught
what I did not.
- `docs/LANGUAGE.md`'s "Use ordinary `fslc verify` when you want to inspect the generated kernel
  counterexample directly" documented the defect as intended behavior and is rewritten.

Closes #663. Related: #687, #689, #515, #641, #600, #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
