### PR TITLE
fix(cli): fail closed on literate Markdown input a command cannot read (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed literate Markdown FSL's diagnostic-quality gap: the 19 commands that
+  read a spec path but do not extract ` ```fsl ` fences from a `.md` input
+  (`lint`, `migrate`, `fmt`, `kernel`, `conformance`, `explain`, `mutate`,
+  `typestate`, `testgen`, `html`, `ledger`, `analyze`, `diff`, `refine`,
+  `replay`, `sweep`, and `document generate`/`claims`/`check`) used to hand
+  the raw Markdown to the parser and report the user's spec as a syntax
+  error at the position of the Markdown's own first non-fsl character
+  (`fmt` reported it under `kind:"format"` with no `diagnostic_code` at all).
+  They now fail closed with a dedicated `FSL-INPUT-LITERATE-UNSUPPORTED`
+  `kind:"usage"` diagnostic naming `check`/`verify`/`scenarios` as the
+  commands that do support literate input, with `loc` naming the input file
+  rather than a spec position. No exit code changed. The decision and
+  materialization are now owned by one function
+  (`fslc_rust::literate_access::literate_access`), driven by a total,
+  test-gated registry checked against `rust/fslc/cli-contract.json`'s real
+  command surface (#665).
+
 - Unified the nested `verify` kernel projection that `run_db_check` and
   `run_domain_check` each carried as an independent, hand-copied key list:
   `fslc_rust::outcome::{classify_kernel_key, project_kernel}` is now the

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1086,6 +1086,17 @@ fsl 以外のフェンス付きブロック(` ```python ` など)は無視され
 literate な `.md` はこの方法で `.fsl` ファイルを `use`/compose できますが、別の
 `.md` ファイルを compose のターゲットにすることはサポートされません。
 
+このフェンス抽出を行うのは `check`・`verify`・`scenarios` の 3 コマンドだけです。
+仕様パスを読み取る他のすべてのコマンド(`lint`・`migrate`・`fmt`・`kernel`・
+`conformance`・`explain`・`mutate`・`typestate`・`testgen`・`html`・`ledger`・
+`analyze`・`diff`・`refine`・`replay`・`sweep`、および
+`document generate`/`claims`/`check`)は、`.md` 入力を代わりに入力種別の誤りとして
+拒否します: `result: "error"`、`kind: "usage"`、
+`diagnostic_code: "FSL-INPUT-LITERATE-UNSUPPORTED"`、対応コマンドを挙げたメッセージ、
+そして仕様上の位置ではなく入力ファイル自体を指す `loc` です。これにより、非対応
+コマンドに渡された Markdown ドキュメントが、その Markdown 自身の最初の非 fsl 文字の
+位置にある仕様の構文エラーとして誤報されることを防ぎます。
+
 ## 8. 推奨ワークフロー: proved を標準にする
 
 1. spec を書く → `fslc check`(高速な構文/型のループ)

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1115,6 +1115,18 @@ resolve relative to the Markdown file's directory (same as for `.fsl` files);
 a literate `.md` may `use`/compose `.fsl` files this way, but using another
 `.md` file as a compose target is not supported.
 
+`check`, `verify`, and `scenarios` are the only commands that extract fences
+this way. Every other command that reads a spec path (`lint`, `migrate`,
+`fmt`, `kernel`, `conformance`, `explain`, `mutate`, `typestate`, `testgen`,
+`html`, `ledger`, `analyze`, `diff`, `refine`, `replay`, `sweep`, and
+`document generate`/`claims`/`check`) rejects a `.md` input as an input-kind
+error instead: `result: "error"`, `kind: "usage"`,
+`diagnostic_code: "FSL-INPUT-LITERATE-UNSUPPORTED"`, a message naming the
+commands that do support literate input, and a `loc` that names the input
+file rather than a spec position. This keeps a Markdown document passed to an
+unsupported command from being misreported as a spec syntax error at the
+position of the Markdown's own first non-fsl character.
+
 ## 8. Recommended workflow: make proved the standard
 
 1. Write the spec → `fslc check` (the fast syntax/type loop)

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1193,7 +1193,18 @@ spec Cart {
 Non-fsl fenced blocks (<code>```python</code>, etc.) are ignored. <code>use</code>/compose paths
 resolve relative to the Markdown file's directory (same as for <code>.fsl</code> files);
 a literate <code>.md</code> may <code>use</code>/compose <code>.fsl</code> files this way, but using another
-<code>.md</code> file as a compose target is not supported.</p></div></details>
+<code>.md</code> file as a compose target is not supported.</p>
+<p><code>check</code>, <code>verify</code>, and <code>scenarios</code> are the only commands that extract fences
+this way. Every other command that reads a spec path (<code>lint</code>, <code>migrate</code>,
+<code>fmt</code>, <code>kernel</code>, <code>conformance</code>, <code>explain</code>, <code>mutate</code>, <code>typestate</code>, <code>testgen</code>,
+<code>html</code>, <code>ledger</code>, <code>analyze</code>, <code>diff</code>, <code>refine</code>, <code>replay</code>, <code>sweep</code>, and
+<code>document generate</code>/<code>claims</code>/<code>check</code>) rejects a <code>.md</code> input as an input-kind
+error instead: <code>result: "error"</code>, <code>kind: "usage"</code>,
+<code>diagnostic_code: "FSL-INPUT-LITERATE-UNSUPPORTED"</code>, a message naming the
+commands that do support literate input, and a <code>loc</code> that names the input
+file rather than a spec position. This keeps a Markdown document passed to an
+unsupported command from being misreported as a spec syntax error at the
+position of the Markdown's own first non-fsl character.</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. Recommended workflow: make proved the standard<span class="tree-blurb"> — The recommended BMC-to-induction workflow toward proved.</span></summary><div class="tree-body"><ol>
 <li>Write the spec → <code>fslc check</code> (the fast syntax/type loop)</li>
 <li><code>fslc verify --depth 8</code> → if violated, fix using the trace.

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1165,7 +1165,17 @@ spec Cart {
 fsl 以外のフェンス付きブロック(<code>```python</code> など)は無視されます。<code>use</code>/compose の
 パスは(<code>.fsl</code> ファイルと同様に)Markdown ファイルのディレクトリを基準に解決されます。
 literate な <code>.md</code> はこの方法で <code>.fsl</code> ファイルを <code>use</code>/compose できますが、別の
-<code>.md</code> ファイルを compose のターゲットにすることはサポートされません。</p></div></details>
+<code>.md</code> ファイルを compose のターゲットにすることはサポートされません。</p>
+<p>このフェンス抽出を行うのは <code>check</code>・<code>verify</code>・<code>scenarios</code> の 3 コマンドだけです。
+仕様パスを読み取る他のすべてのコマンド(<code>lint</code>・<code>migrate</code>・<code>fmt</code>・<code>kernel</code>・
+<code>conformance</code>・<code>explain</code>・<code>mutate</code>・<code>typestate</code>・<code>testgen</code>・<code>html</code>・<code>ledger</code>・
+<code>analyze</code>・<code>diff</code>・<code>refine</code>・<code>replay</code>・<code>sweep</code>、および
+<code>document generate</code>/<code>claims</code>/<code>check</code>)は、<code>.md</code> 入力を代わりに入力種別の誤りとして
+拒否します: <code>result: "error"</code>、<code>kind: "usage"</code>、
+<code>diagnostic_code: "FSL-INPUT-LITERATE-UNSUPPORTED"</code>、対応コマンドを挙げたメッセージ、
+そして仕様上の位置ではなく入力ファイル自体を指す <code>loc</code> です。これにより、非対応
+コマンドに渡された Markdown ドキュメントが、その Markdown 自身の最初の非 fsl 文字の
+位置にある仕様の構文エラーとして誤報されることを防ぎます。</p></div></details>
 <details id="8-recommended-workflow-make-proved-the-standard"><summary>8. 推奨ワークフロー: proved を標準にする<span class="tree-blurb"> — BMC から帰納法へ、proved を標準にする推奨ワークフロー。</span></summary><div class="tree-body"><ol>
 <li>spec を書く → <code>fslc check</code>(高速な構文/型のループ)</li>
 <li><code>fslc verify --depth 8</code> → violated ならトレースを使って直す。

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -7,6 +7,14 @@ use serde_json::{Value, json};
 
 pub mod coverage;
 pub mod frontend_output;
+// The single owner of "does this command accept literate Markdown input"
+// (issue #665). Declared on the library side for the same reason `outcome`
+// is: integration tests under `tests/` link the library, not the binary, and
+// need to gate the registry against `cli-contract.json` directly. Native-CLI
+// filesystem materialization is not meaningful to `fsl-lsp`/`fsl-wasm`, which
+// depend on this crate with `default-features = false`.
+#[cfg(feature = "native-cli")]
+pub mod literate_access;
 pub mod migration;
 pub mod origin_coverage;
 // The one definition of the success/failure classes (issue #537 C2). It is

--- a/rust/fslc/src/literate_access.rs
+++ b/rust/fslc/src/literate_access.rs
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The single owner of "does this command accept literate Markdown (`.md`)
+//! input" (issue #665).
+//!
+//! Literate Markdown FSL (#193) extracts ```` ```fsl ```` fences from a `.md`
+//! file so `check`/`verify`/`scenarios` can verify the fenced code as an
+//! ordinary spec. Every other command that reads a spec path used to hand the
+//! raw Markdown straight to the surface parser, which reported the user's
+//! spec as having a *syntax error* at the position of the first character
+//! the parser could not make sense of -- typically `1:2`, the `!` of the
+//! Markdown file's own `<!--` comment. The diagnostic was truthful about the
+//! exit code (2, the spec-error class) but not about the cause: the command
+//! does not understand the input's *kind*, not the spec's syntax.
+//!
+//! [`materialize_literate`] used to live in `main.rs` with exactly two call
+//! sites (`check`, and the shared `verify`/`scenarios` arm). A third command
+//! would have reached the surface parser unfixed by simply not knowing this
+//! function existed -- a helper called from N arms is not ownership, because
+//! arm N+1 is written without it. [`literate_access`] is now the one
+//! function every arm that reads a spec path calls immediately after
+//! resolving its command key: it materializes for [`LiterateSupport::Supported`]
+//! commands exactly as before, and fails closed with
+//! [`LITERATE_UNSUPPORTED_CODE`] for [`LiterateSupport::Unsupported`] ones
+//! instead of ever reaching the parser. [`LITERATE_REGISTRY`] is the
+//! enumeration that *is* the registry (following `outcome::outcome_class`'s
+//! idiom): [`literate_support`] returns `None` for a key nobody classified,
+//! and `literate_registry_is_total_over_the_cli_surface` below fails the
+//! build the moment a spec-path-taking leaf command in
+//! `rust/fslc/cli-contract.json` is neither registered nor explicitly
+//! excluded with a reason.
+//!
+//! # Scope boundary
+//!
+//! This registry's domain is commands whose spec argument reaches the
+//! *shared kernel frontend* (`fsl_syntax`'s surface parser, by way of
+//! `spec_load::kernel_load_error`/`surface_parse_failure`) the same way
+//! `check`/`verify`/`scenarios` do. [`LITERATE_EXCLUDED`] lists every other
+//! leaf command that reads at least one positional path
+//! (`rust/fslc/cli-contract.json`'s notion of "takes a spec-shaped
+//! argument") together with why it is out of this registry's scope, so the
+//! totality test can still be total over the *real* CLI surface without
+//! this module silently claiming ownership of a command it does not
+//! actually gate:
+//!
+//! - `chain`'s positional is a project manifest (`fsl-project.toml`); a
+//!   `.md` there fails TOML parsing, never the FSL frontend (measured:
+//!   `fslc chain examples/literate/toggle.md` reports `kind:"parse"` with
+//!   message `"invalid TOML at line 1..."`, not the Markdown-as-spec lie
+//!   this issue is about). It is not "a command that takes a spec path" in
+//!   this issue's sense.
+//! - `approval create`/`check`/`diff`'s shared positional's *meaning*
+//!   depends on `--kind`: with `--kind requirements_document` it binds
+//!   against a rendered document, which is legitimately `.md`-shaped
+//!   already. Rejecting `.md` there unconditionally would be a regression,
+//!   not a fix, so approval is left to a dedicated follow-up that can
+//!   thread `--kind` through the decision.
+//! - `db`/`compat check`/`ai`/`causal`/`domain`'s dialect-specific spec
+//!   arguments hit **the same defect**, not a different one: measured
+//!   against `examples/literate/toggle.md`, `db check`/`domain check`/
+//!   `ai check`/`compat check` all report `kind:"semantics"`,
+//!   `"unexpected character '!' at examples/literate/toggle.md:1:2"` --
+//!   the same false spec position, exit 2 -- and `causal check` reports
+//!   `kind:"parse"`, `"unexpected character '!'"` with a `"diagnostic"` key
+//!   instead of `"diagnostic_code"`. Only the `kind` label (and, for
+//!   `causal`, the field name) differs from what `check` used to report
+//!   before this fix. Excluding them from this change is a scope decision,
+//!   not a claim that their symptom is different: issue #665's measured
+//!   table has 17 rows and none of these five commands is in it. Tracked as
+//!   issue #694 (with the measurements above), which also needs to decide
+//!   whether these five get `FSL-INPUT-LITERATE-UNSUPPORTED` or a
+//!   dialect-appropriate variant, since none of them shares `check`'s
+//!   `command()`-arm shape that this module's registry keys on.
+//!
+//! Implementing literate support for every command is issue #666, and is
+//! deliberately not attempted here: [`LiterateSupport::Unsupported`] commands
+//! stay unsupported after this change, and become unreachable code only once
+//! #666 (or a future decision) reclassifies them -- this module does not
+//! depend on that ordering.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+/// A `.md` input materialized into a process-owned `.fsl` sibling. Dropping
+/// it removes the sibling file.
+///
+/// Each CLI process owns its own materialization; the original Markdown path
+/// is used separately as the stable verify-cache identity, so physical
+/// isolation does not trade away cache hits across invocations.
+pub struct LiterateState {
+    pub path: PathBuf,
+}
+
+impl Drop for LiterateState {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Extract literate Markdown FSL's ```` ```fsl ```` fences from `path` into a
+/// temporary `.fsl` sibling, when `path`'s extension is `.md`.
+///
+/// Returns `Ok(None)` when `path` is not a `.md` path at all, so callers use
+/// `path` unchanged in that case.
+///
+/// # Errors
+///
+/// Returns a message when `path` cannot be read or contains no ```` ```fsl ````
+/// fenced code blocks.
+pub fn materialize_literate(path: &Path) -> Result<Option<LiterateState>, String> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) != Some("md") {
+        return Ok(None);
+    }
+    let raw =
+        std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let blanked = fsl_syntax::extract_literate_fsl(&raw).ok_or_else(|| {
+        format!(
+            "{}: Markdown file does not contain any ```fsl fenced code blocks",
+            path.display()
+        )
+    })?;
+    let stem = path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("literate");
+    let materialized = literate_materialization_path(path, stem, std::process::id());
+    std::fs::write(&materialized, &blanked).map_err(|error| error.to_string())?;
+    Ok(Some(LiterateState { path: materialized }))
+}
+
+fn literate_materialization_path(path: &Path, stem: &str, process_id: u32) -> PathBuf {
+    path.with_file_name(format!(".{stem}.literate-{process_id}.fsl"))
+}
+
+/// Whether a registered command extracts ```` ```fsl ```` fences from a `.md`
+/// input, or fails closed instead of handing raw Markdown to the parser.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiterateSupport {
+    /// Materializes the `.md` input exactly as `check` does.
+    Supported,
+    /// Fails closed with [`LITERATE_UNSUPPORTED_CODE`] naming the commands
+    /// that do support it, instead of reaching the surface parser.
+    Unsupported,
+}
+
+/// The command keys [`LiterateSupport::Supported`] classifies -- named once
+/// so the registry and the unsupported-command diagnostic's message cannot
+/// drift apart from each other.
+pub const LITERATE_SUPPORTED_COMMANDS: &[&str] = &["check", "verify", "scenarios"];
+
+/// The total registry of command keys whose spec argument reaches the shared
+/// kernel frontend through `main.rs`'s top-level `command()` dispatch, its
+/// `fmt_command()` sibling, or `document_command`'s shared `path` prelude --
+/// the same textual seam `materialize_literate`'s original two call sites
+/// (`check`, and the combined `verify`/`scenarios` arm) already sat in.
+///
+/// A nested command's key is its space-joined path (`"document generate"`),
+/// matching `rust/fslc/cli-contract.json`'s own leaf-path convention so the
+/// totality test below can compare directly against it.
+pub const LITERATE_REGISTRY: &[(&str, LiterateSupport)] = &[
+    ("check", LiterateSupport::Supported),
+    ("verify", LiterateSupport::Supported),
+    ("scenarios", LiterateSupport::Supported),
+    ("lint", LiterateSupport::Unsupported),
+    ("migrate", LiterateSupport::Unsupported),
+    ("kernel", LiterateSupport::Unsupported),
+    ("conformance", LiterateSupport::Unsupported),
+    ("explain", LiterateSupport::Unsupported),
+    ("mutate", LiterateSupport::Unsupported),
+    ("typestate", LiterateSupport::Unsupported),
+    ("testgen", LiterateSupport::Unsupported),
+    ("html", LiterateSupport::Unsupported),
+    ("ledger", LiterateSupport::Unsupported),
+    ("analyze", LiterateSupport::Unsupported),
+    ("diff", LiterateSupport::Unsupported),
+    ("refine", LiterateSupport::Unsupported),
+    ("replay", LiterateSupport::Unsupported),
+    ("sweep", LiterateSupport::Unsupported),
+    ("fmt", LiterateSupport::Unsupported),
+    ("document generate", LiterateSupport::Unsupported),
+    ("document claims", LiterateSupport::Unsupported),
+    ("document check", LiterateSupport::Unsupported),
+];
+
+/// Leaf commands in `rust/fslc/cli-contract.json` that read at least one
+/// positional path argument but are outside [`LITERATE_REGISTRY`]'s scope,
+/// paired with why (see this module's "Scope boundary" section). Kept
+/// alongside the registry, rather than only in prose, so
+/// `literate_registry_is_total_over_the_cli_surface` can assert every
+/// spec-shaped leaf command is *accounted for* -- registered or knowingly
+/// excluded -- even though only the registered half is behaviorally fixed by
+/// this change.
+pub const LITERATE_EXCLUDED: &[(&str, &str)] = &[
+    (
+        "chain",
+        "positional is a project manifest (TOML), not a spec; a .md there fails TOML parsing, never the FSL frontend",
+    ),
+    (
+        "approval create",
+        "shared positional's meaning depends on --kind; --kind requirements_document legitimately binds a rendered .md document",
+    ),
+    (
+        "approval check",
+        "shared positional's meaning depends on --kind; --kind requirements_document legitimately binds a rendered .md document",
+    ),
+    (
+        "approval diff",
+        "shared positional's meaning depends on --kind; --kind requirements_document legitimately binds a rendered .md document",
+    ),
+    (
+        "db check",
+        "measured: same defect as the commands this issue fixes -- kind:\"semantics\", \
+         \"unexpected character '!' at examples/literate/toggle.md:1:2\", exit 2, same false \
+         spec position. Only the kind label differs. Excluded as #665's measured scope (17 \
+         rows, none of them this command); tracked as #694",
+    ),
+    (
+        "db import",
+        "same dialect family as \"db check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "db observe",
+        "same dialect family as \"db check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "compat check",
+        "delegates to the same db-check path; see \"db check\" (measured). Tracked as #694",
+    ),
+    (
+        "ai check",
+        "measured: same defect as the commands this issue fixes -- kind:\"semantics\", \
+         \"unexpected character '!' at examples/literate/toggle.md:1:2\", exit 2, same false \
+         spec position. Only the kind label differs. Excluded as #665's measured scope (17 \
+         rows, none of them this command); tracked as #694",
+    ),
+    (
+        "ai replay",
+        "same dialect family as \"ai check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "ai eval",
+        "same dialect family as \"ai check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "ai regress",
+        "same dialect family as \"ai check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "ai drift",
+        "same dialect family as \"ai check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "ai compat",
+        "same dialect family as \"ai check\" (measured); presumed same shape, not independently \
+         measured. Tracked as #694",
+    ),
+    (
+        "causal analyze",
+        "same dialect family as \"causal check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "causal check",
+        "measured: same defect as the commands this issue fixes -- kind:\"parse\", \
+         \"unexpected character '!'\", exit 2, same false spec position, but rendered with a \
+         \"diagnostic\" key instead of \"diagnostic_code\". Excluded as #665's measured scope \
+         (17 rows, none of them this command); tracked as #694",
+    ),
+    (
+        "causal diff",
+        "same dialect family as \"causal check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "causal ledger",
+        "same dialect family as \"causal check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "causal observe-expectations",
+        "same dialect family as \"causal check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "causal verify-expectations",
+        "same dialect family as \"causal check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "domain analyze",
+        "same dialect family as \"domain check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "domain check",
+        "measured: same defect as the commands this issue fixes -- kind:\"semantics\", \
+         \"unexpected character '!' at examples/literate/toggle.md:1:2\", exit 2, same false \
+         spec position. Only the kind label differs. Excluded as #665's measured scope (17 \
+         rows, none of them this command); tracked as #694",
+    ),
+    (
+        "domain expand",
+        "same dialect family as \"domain check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "domain generate",
+        "domain's own codegen command (distinct from \"document generate\"); same dialect \
+         family as \"domain check\" (measured), presumed same kind:\"semantics\" shape. Tracked \
+         as #694",
+    ),
+    (
+        "domain replay",
+        "same dialect family as \"domain check\" (measured); presumed same shape, not \
+         independently measured. Tracked as #694",
+    ),
+    (
+        "domain testgen",
+        "domain's own testgen command (distinct from the top-level \"testgen\"); same dialect \
+         family as \"domain check\" (measured), presumed same kind:\"semantics\" shape. Tracked \
+         as #694",
+    ),
+];
+
+/// The diagnostic code an [`LiterateSupport::Unsupported`] command reports
+/// instead of `FSL-PARSE`.
+///
+/// Deliberately not routed through `fsl_syntax::ParseError::coded`: a
+/// `ParseError` means "the spec is malformed", which is exactly the false
+/// claim this diagnostic replaces. It is rendered directly into the JSON
+/// envelope by [`literate_unsupported_output`] instead.
+pub const LITERATE_UNSUPPORTED_CODE: &str = "FSL-INPUT-LITERATE-UNSUPPORTED";
+
+/// Classify `command_key` against [`LITERATE_REGISTRY`]. `None` means the key
+/// is not registered at all -- either it does not read a spec path through
+/// this shared decision point, or (the case the totality test below exists
+/// to catch) it does and nobody has classified it yet.
+#[must_use]
+pub fn literate_support(command_key: &str) -> Option<LiterateSupport> {
+    LITERATE_REGISTRY
+        .iter()
+        .find(|(key, _)| *key == command_key)
+        .map(|(_, support)| *support)
+}
+
+/// Render the `FSL-INPUT-LITERATE-UNSUPPORTED` envelope for `command_key`
+/// receiving `.md` input it does not support.
+///
+/// `kind` is `"usage"` (issue #665 design constraint 3): the caller invoked a
+/// real command with an input kind it does not handle, which is exactly what
+/// `"usage"` already means elsewhere, and it already exits 2 -- reusing it
+/// keeps this change from touching the exit-code contract at all. `loc`
+/// deliberately never carries a spec line/column: it names the input file
+/// only, so a repair agent is not pointed at a spec position that does not
+/// exist.
+#[must_use]
+pub fn literate_unsupported_output(command_key: &str, path: &Path) -> Value {
+    let supported = LITERATE_SUPPORTED_COMMANDS.join(", ");
+    json!({
+        "fsl": "1.0",
+        "result": "error",
+        "kind": "usage",
+        "message": format!(
+            "fslc {command_key} does not support literate Markdown input; only {supported} \
+             extract ```fsl fenced code from a .md file -- pass '{}' to one of those, or \
+             extract the fenced code into a .fsl file first",
+            path.display(),
+        ),
+        "diagnostic_code": LITERATE_UNSUPPORTED_CODE,
+        "loc": {"file": path.to_string_lossy()},
+    })
+}
+
+/// The single call every arm that reads a spec path makes immediately after
+/// resolving `command_key`, in place of calling [`materialize_literate`]
+/// directly.
+///
+/// Returns `Ok(None)` when `display_path` is not literate input at all (any
+/// extension other than `.md`) -- callers use `display_path` unchanged, as
+/// `check` and `verify`/`scenarios` already did before this function
+/// existed. A supported command's `.md` input still materializes exactly as
+/// before; an unsupported one's fails closed with the envelope
+/// [`literate_unsupported_output`] renders, ready to return directly as the
+/// command's own `(Value, i32)` result.
+///
+/// `command_key` must be present in [`LITERATE_REGISTRY`]; this is enforced
+/// at test time (`literate_registry_is_total_over_the_cli_surface`), not at
+/// runtime, per issue #665 design constraint 5 -- an unregistered key reaches
+/// this function only if a future edit adds a new call site without
+/// registering it, and the fallback below reports that as an internal
+/// inconsistency rather than a spec verdict, exactly as
+/// `outcome::outcome_class`'s unregistered-value arm does for `result`.
+///
+/// # Errors
+///
+/// Returns the `(Value, i32)` envelope and exit code the caller should
+/// return verbatim: an IO failure materializing a supported command's input,
+/// or the unsupported-command diagnostic.
+pub fn literate_access(
+    command_key: &str,
+    display_path: &Path,
+) -> Result<Option<LiterateState>, (Value, i32)> {
+    if display_path.extension().and_then(std::ffi::OsStr::to_str) != Some("md") {
+        return Ok(None);
+    }
+    match literate_support(command_key) {
+        Some(LiterateSupport::Supported) => materialize_literate(display_path).map_err(|message| {
+            (
+                json!({"fsl":"1.0","result":"error","kind":"io","message":message}),
+                2,
+            )
+        }),
+        Some(LiterateSupport::Unsupported) => {
+            Err((literate_unsupported_output(command_key, display_path), 2))
+        }
+        None => Err((
+            json!({
+                "fsl": "1.0",
+                "result": "error",
+                "kind": "internal",
+                "message": format!(
+                    "command '{command_key}' is not registered in the literate-input registry"
+                ),
+            }),
+            3,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LITERATE_EXCLUDED, LITERATE_REGISTRY, LITERATE_SUPPORTED_COMMANDS, LiterateSupport,
+        literate_materialization_path, literate_support,
+    };
+    use serde_json::Value;
+
+    #[test]
+    fn literate_materialization_paths_are_process_owned() {
+        let source = std::path::Path::new("spec.md");
+        assert_ne!(
+            literate_materialization_path(source, "spec", 41),
+            literate_materialization_path(source, "spec", 42)
+        );
+    }
+
+    /// Recover every leaf command path in the embedded CLI contract that
+    /// reads at least one positional argument -- the contract's own notion
+    /// of "takes a spec-shaped path". `native_cli_help_matches_the_embedded_contract_at_every_command_path`
+    /// (`rust/fslc/tests/native_integration.rs`) keeps this file honest
+    /// against the live `--help` tree, which is what makes it a real CLI
+    /// surface to gate against rather than a second hand-written list.
+    fn leaf_positional_commands(node: &Value, path: &mut Vec<String>, out: &mut Vec<String>) {
+        let commands = node.get("commands").and_then(Value::as_array);
+        match commands {
+            Some(commands) if !commands.is_empty() => {
+                for command in commands {
+                    let Some(name) = command
+                        .get("path")
+                        .and_then(Value::as_array)
+                        .and_then(|segments| segments.last())
+                        .and_then(Value::as_str)
+                    else {
+                        continue;
+                    };
+                    path.push(name.to_owned());
+                    leaf_positional_commands(command, path, out);
+                    path.pop();
+                }
+            }
+            _ => {
+                let has_positional =
+                    node.get("actions")
+                        .and_then(Value::as_array)
+                        .is_some_and(|actions| {
+                            actions
+                                .iter()
+                                .any(|action| action.get("positional") == Some(&Value::Bool(true)))
+                        });
+                if has_positional && !path.is_empty() {
+                    out.push(path.join(" "));
+                }
+            }
+        }
+    }
+
+    fn cli_surface_spec_path_commands() -> Vec<String> {
+        let contract: Value = serde_json::from_str(include_str!("../cli-contract.json"))
+            .expect("valid embedded CLI contract");
+        let mut leaves = Vec::new();
+        leaf_positional_commands(&contract["root"], &mut Vec::new(), &mut leaves);
+        leaves
+    }
+
+    /// Design constraint 2 (issue #665): the registry must be total and
+    /// gated. Every leaf command in the real CLI surface that reads a
+    /// spec-shaped positional is either registered (`LITERATE_REGISTRY`) or
+    /// explicitly excluded with a reason (`LITERATE_EXCLUDED`) -- never
+    /// neither. A command added to `command()`/`fmt_command()`/
+    /// `document_command()` without updating either list fails this test
+    /// instead of silently reaching the surface parser unfixed, which is the
+    /// #689/#563 blind spot this issue's design explicitly avoids
+    /// reproducing.
+    #[test]
+    fn literate_registry_is_total_over_the_cli_surface() {
+        let unaccounted = cli_surface_spec_path_commands()
+            .into_iter()
+            .filter(|command| {
+                !LITERATE_REGISTRY.iter().any(|(key, _)| *key == command)
+                    && !LITERATE_EXCLUDED.iter().any(|(key, _)| *key == command)
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            unaccounted.is_empty(),
+            "commands with a spec-shaped positional argument are neither in \
+             LITERATE_REGISTRY nor LITERATE_EXCLUDED: {unaccounted:?} -- classify each in \
+             rust/fslc/src/literate_access.rs"
+        );
+    }
+
+    /// The two lists must not overlap: a command claimed as both registered
+    /// and knowingly-excluded is a self-contradiction the totality test
+    /// above would not catch on its own.
+    #[test]
+    fn no_command_is_both_registered_and_excluded() {
+        for (key, _) in LITERATE_REGISTRY {
+            assert!(
+                !LITERATE_EXCLUDED
+                    .iter()
+                    .any(|(excluded, _)| excluded == key),
+                "'{key}' is in both LITERATE_REGISTRY and LITERATE_EXCLUDED"
+            );
+        }
+    }
+
+    /// An unregistered key classifies as `None`, never as a silent pass
+    /// through to either behavior -- the same "unregistered is not a
+    /// default" shape `outcome::outcome_class`'s `_ => Failure` arm fixes for
+    /// `result` values (#554).
+    #[test]
+    fn an_unregistered_command_key_is_unclassified() {
+        assert_eq!(literate_support("a_command_nobody_registered"), None);
+        assert_eq!(literate_support(""), None);
+    }
+
+    /// [`LiterateSupport::Supported`] in the registry and
+    /// [`LITERATE_SUPPORTED_COMMANDS`] must name exactly the same set, or the
+    /// unsupported-command diagnostic's message could advertise a command
+    /// the registry does not actually mark supported (or omit one it does).
+    #[test]
+    fn supported_commands_constant_matches_the_registry() {
+        let mut from_registry = LITERATE_REGISTRY
+            .iter()
+            .filter(|(_, support)| *support == LiterateSupport::Supported)
+            .map(|(key, _)| *key)
+            .collect::<Vec<_>>();
+        from_registry.sort_unstable();
+        let mut from_constant = LITERATE_SUPPORTED_COMMANDS.to_vec();
+        from_constant.sort_unstable();
+        assert_eq!(from_registry, from_constant);
+    }
+
+    /// `document generate`/`document claims`/`document check` share one
+    /// `path` read in `document_command` before it dispatches on subcommand
+    /// (`main.rs`), so all three must classify identically or that shared
+    /// call site cannot single-source its decision.
+    #[test]
+    fn document_subcommands_classify_uniformly() {
+        for key in ["document generate", "document claims", "document check"] {
+            assert_eq!(
+                literate_support(key),
+                Some(LiterateSupport::Unsupported),
+                "{key}"
+            );
+        }
+    }
+}

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -13,6 +13,7 @@ use fsl_core::{
     ParamDef, TraceStep, TypeDef, TypeRef, insert_requirement_metadata, model_warnings,
     requirement_metadata,
 };
+use fslc_rust::literate_access::literate_access;
 use fslc_rust::outcome::{OutcomeClass, outcome_class};
 use fslc_rust::spec_load::{
     SemanticDiagnostic, SpecLoadError, kernel_load_error, surface_parse_failure,
@@ -42,44 +43,6 @@ const DEFAULT_EXPLICIT_BUDGET: usize = 1_000_000;
 /// evaluates a different mutant set and reports a different kill rate
 /// (issue #524).
 const DEFAULT_MAX_MUTANTS: usize = 200;
-
-struct LiterateState {
-    path: PathBuf,
-}
-
-impl Drop for LiterateState {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
-fn materialize_literate(path: &Path) -> Result<Option<LiterateState>, String> {
-    if path.extension().and_then(std::ffi::OsStr::to_str) != Some("md") {
-        return Ok(None);
-    }
-    let raw =
-        std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
-    let blanked = fsl_syntax::extract_literate_fsl(&raw).ok_or_else(|| {
-        format!(
-            "{}: Markdown file does not contain any ```fsl fenced code blocks",
-            path.display()
-        )
-    })?;
-    let stem = path
-        .file_stem()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or("literate");
-    // Each CLI process owns its materialization. The original Markdown path is
-    // passed separately as the stable verify-cache identity, so physical
-    // isolation does not trade away cache hits across invocations.
-    let materialized = literate_materialization_path(path, stem, std::process::id());
-    std::fs::write(&materialized, &blanked).map_err(|error| error.to_string())?;
-    Ok(Some(LiterateState { path: materialized }))
-}
-
-fn literate_materialization_path(path: &Path, stem: &str, process_id: u32) -> PathBuf {
-    path.with_file_name(format!(".{stem}.literate-{process_id}.fsl"))
-}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ScopeBounds {
@@ -428,6 +391,9 @@ fn run_fmt(options: &FmtOptions) -> (FmtCliOutput, i32) {
     let mut files = Vec::new();
     let mut any_changed = false;
     for path in &options.paths {
+        if let Err((output, status)) = literate_access("fmt", path) {
+            return (FmtCliOutput::Json(output), status);
+        }
         let source = match read_fmt_source(path) {
             Ok(source) => source,
             Err(error) => return (FmtCliOutput::Json(error_output("io", &error)), 2),
@@ -1077,7 +1043,10 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| "usage: fslc check SPEC [options]".to_owned())?,
             );
-            let literate_guard = materialize_literate(&display_path)?;
+            let literate_guard = match literate_access("check", &display_path) {
+                Ok(guard) => guard,
+                Err(early_return) => return Ok(early_return),
+            };
             let path = literate_guard
                 .as_ref()
                 .map_or(&display_path, |state| &state.path);
@@ -1120,10 +1089,20 @@ fn command() -> Result<(Value, i32), String> {
         }
         "lint" => {
             let options = parse_migration_options(args, false)?;
+            for path in &options.paths {
+                if let Err(early_return) = literate_access("lint", path) {
+                    return Ok(early_return);
+                }
+            }
             Ok(run_lint(&options))
         }
         "migrate" => {
             let options = parse_migration_options(args, true)?;
+            for path in &options.paths {
+                if let Err(early_return) = literate_access("migrate", path) {
+                    return Ok(early_return);
+                }
+            }
             Ok(run_migrate(&options))
         }
         "kernel" => {
@@ -1149,6 +1128,9 @@ fn command() -> Result<(Value, i32), String> {
             }
             let path =
                 path.ok_or_else(|| "usage: fslc kernel SPEC [--kernel-version MAJOR]".to_owned())?;
+            if let Err(early_return) = literate_access("kernel", &path) {
+                return Ok(early_return);
+            }
             Ok(run_kernel_contract(&path, version))
         }
         "conformance" => {
@@ -1181,6 +1163,9 @@ fn command() -> Result<(Value, i32), String> {
             let path = path.ok_or_else(|| {
                 "usage: fslc conformance SPEC [--depth N] [--kernel-version MAJOR]".to_owned()
             })?;
+            if let Err(early_return) = literate_access("conformance", &path) {
+                return Ok(early_return);
+            }
             Ok(run_conformance(&path, depth, version))
         }
         "approval" => approval_command(args),
@@ -1216,6 +1201,9 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| format!("fslc {command} requires a spec"))?,
             );
+            if let Err(early_return) = literate_access(&command, &path) {
+                return Ok(early_return);
+            }
             let mut depth = 8_usize;
             let mut readable = false;
             let mut max_mutants = DEFAULT_MAX_MUTANTS;
@@ -1287,6 +1275,9 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| format!("fslc {command} requires a spec"))?,
             );
+            if let Err(early_return) = literate_access(&command, &path) {
+                return Ok(early_return);
+            }
             let mut depth = 8_usize;
             let mut output = None;
             let mut target = "pytest".to_owned();
@@ -1420,6 +1411,11 @@ fn command() -> Result<(Value, i32), String> {
                     _ => return Err(format!("unknown analyze option '{option}'")),
                 }
             }
+            for path in &paths {
+                if let Err(early_return) = literate_access("analyze", path) {
+                    return Ok(early_return);
+                }
+            }
             let result = if paths.len() != 1 || paths[0].is_dir() {
                 run_analyze_batch(
                     &paths,
@@ -1486,6 +1482,11 @@ fn command() -> Result<(Value, i32), String> {
                     }
                     _ if !option.starts_with('-') => paths.push(PathBuf::from(option)),
                     _ => return Err(format!("unknown diff option '{option}'")),
+                }
+            }
+            for path in &paths {
+                if let Err(early_return) = literate_access("diff", path) {
+                    return Ok(early_return);
                 }
             }
             if let Some(range) = git_range {
@@ -1569,6 +1570,11 @@ fn command() -> Result<(Value, i32), String> {
                     _ => rest.push(PathBuf::from(option)),
                 }
             }
+            for candidate in [&path, &abstraction, &mapping].into_iter().chain(&rest) {
+                if let Err(early_return) = literate_access("refine", candidate) {
+                    return Ok(early_return);
+                }
+            }
             if rest.is_empty() {
                 Ok(run_refine(&path, &abstraction, &mapping, depth))
             } else if rest.len() % 2 != 0 {
@@ -1594,6 +1600,9 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| "usage: fslc replay SPEC --trace TRACE.json".to_owned())?,
             );
+            if let Err(early_return) = literate_access("replay", &path) {
+                return Ok(early_return);
+            }
             let mut trace = None;
             let mut from_log = None;
             let mut mapping = None;
@@ -1651,6 +1660,9 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| "usage: fslc sweep SPEC [options]".to_owned())?,
             );
+            if let Err(early_return) = literate_access("sweep", &path) {
+                return Ok(early_return);
+            }
             let mut depth = "0..8".to_owned();
             let mut deadlock = "warn".to_owned();
             let mut engine = "bmc".to_owned();
@@ -1740,7 +1752,10 @@ fn command() -> Result<(Value, i32), String> {
                 args.next()
                     .ok_or_else(|| format!("usage: fslc {command} SPEC [options]"))?,
             );
-            let literate_guard = materialize_literate(&display_path)?;
+            let literate_guard = match literate_access(&command, &display_path) {
+                Ok(guard) => guard,
+                Err(early_return) => return Ok(early_return),
+            };
             let path = literate_guard
                 .as_ref()
                 .map_or(&display_path, |state| &state.path);
@@ -1959,6 +1974,16 @@ fn document_command(mut args: impl Iterator<Item = String>) -> Result<(Value, i3
         args.next()
             .ok_or_else(|| format!("fslc document {subcommand} requires a spec"))?,
     );
+    // Only the three known subcommands are registered
+    // (`literate_access.rs`'s `LITERATE_REGISTRY`); an unrecognized
+    // subcommand must still fall through to this match's own `_` arm and its
+    // `kind:"usage"` diagnostic rather than the registry's "unregistered
+    // command" internal-error fallback.
+    if matches!(subcommand.as_str(), "generate" | "claims" | "check")
+        && let Err(early_return) = literate_access(&format!("document {subcommand}"), &path)
+    {
+        return Ok(early_return);
+    }
     match subcommand.as_str() {
         "generate" => {
             let mut locale = fsl_tools::Locale::Ja;
@@ -15978,15 +16003,6 @@ mod exit_status_tests {
         assert_eq!(
             normalized_exit_status(&error_output("semantics", "bad spec"), 2),
             2
-        );
-    }
-
-    #[test]
-    fn literate_materialization_paths_are_process_owned() {
-        let source = Path::new("spec.md");
-        assert_ne!(
-            literate_materialization_path(source, "spec", 41),
-            literate_materialization_path(source, "spec", 42)
         );
     }
 

--- a/rust/fslc/tests/literate_docs_contract.rs
+++ b/rust/fslc/tests/literate_docs_contract.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Documentation-consistency regression for issue #665's literate-input
+//! registry, in the style of `mutation_docs_contract.rs` (issue #338):
+//! extract the command names each document claims from its own prose and
+//! assert the set equals `fslc_rust::literate_access::LITERATE_REGISTRY`'s
+//! `Unsupported`/`Supported` halves, rather than trusting that three
+//! hand-written copies of the same 19+3 names stay in sync with the
+//! registry and with each other.
+//!
+//! Before this test the enumeration in `docs/LANGUAGE.md`,
+//! `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md` was accurate but
+//! *ungated*: registering a 20th `Unsupported` command in
+//! `rust/fslc/src/literate_access.rs` would leave all three documents
+//! silently stale, with nothing to fail. This is the gate.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use fslc_rust::literate_access::{LITERATE_REGISTRY, LITERATE_SUPPORTED_COMMANDS, LiterateSupport};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    let path = workspace_root().join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {relative}: {error}"))
+}
+
+/// The registry's `Unsupported` command names, as a set.
+fn registry_unsupported() -> BTreeSet<String> {
+    LITERATE_REGISTRY
+        .iter()
+        .filter(|(_, support)| *support == LiterateSupport::Unsupported)
+        .map(|(key, _)| (*key).to_owned())
+        .collect()
+}
+
+/// The registry's `Supported` command names, as a set.
+fn registry_supported() -> BTreeSet<String> {
+    LITERATE_SUPPORTED_COMMANDS
+        .iter()
+        .map(|&key| key.to_owned())
+        .collect()
+}
+
+/// Slice `text` between the end of `start_anchor` and the start of
+/// `end_anchor`, panicking with the anchor that went missing rather than
+/// silently returning an empty or wrong slice -- a doc rewrite that drops or
+/// rewords an anchor must fail loudly here, not produce a false pass.
+fn between<'a>(text: &'a str, start_anchor: &str, end_anchor: &str) -> &'a str {
+    let start = text
+        .find(start_anchor)
+        .unwrap_or_else(|| panic!("missing start anchor {start_anchor:?}"))
+        + start_anchor.len();
+    let rest = &text[start..];
+    let end = rest
+        .find(end_anchor)
+        .unwrap_or_else(|| panic!("missing end anchor {end_anchor:?} after {start_anchor:?}"));
+    &rest[..end]
+}
+
+/// The text strictly inside the first balanced `(...)` pair that starts
+/// after `anchor`.
+fn parenthesized_after<'a>(text: &'a str, anchor: &str) -> &'a str {
+    let after_anchor = text
+        .find(anchor)
+        .unwrap_or_else(|| panic!("missing anchor {anchor:?}"))
+        + anchor.len();
+    let rest = &text[after_anchor..];
+    let open = rest
+        .find('(')
+        .unwrap_or_else(|| panic!("expected '(' after anchor {anchor:?}"));
+    let mut depth = 0_i32;
+    for (offset, character) in rest[open..].char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &rest[open + 1..open + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced parentheses after anchor {anchor:?}");
+}
+
+/// Extract command names from backtick-quoted tokens in `list_text`.
+///
+/// Handles two shapes this prose uses: a bare single-word token (`` `lint` ``)
+/// and a compound-command chain written as `` `document generate`/`claims`/`check` ``,
+/// where only the first token spells the group's prefix and the rest are
+/// joined by a literal `/` with no surrounding space. A token is also
+/// stripped of a leading `"fslc "` (`skills/fsl/reference.md` spells the
+/// supported three as `` `fslc check` `` etc.) before either rule applies.
+fn command_names(list_text: &str) -> Vec<String> {
+    let mut spans = Vec::new();
+    let mut search_from = 0;
+    while let Some(relative_start) = list_text[search_from..].find('`') {
+        let start = search_from + relative_start;
+        let Some(relative_end) = list_text[start + 1..].find('`') else {
+            break;
+        };
+        let end = start + 1 + relative_end;
+        spans.push((start, end));
+        search_from = end + 1;
+    }
+
+    let mut names = Vec::new();
+    let mut carry: Option<String> = None;
+    for (index, &(start, end)) in spans.iter().enumerate() {
+        let raw = &list_text[start + 1..end];
+        let content = raw.strip_prefix("fslc ").unwrap_or(raw);
+        let joiner = if index == 0 {
+            ""
+        } else {
+            &list_text[spans[index - 1].1 + 1..start]
+        };
+        if content.contains(' ') {
+            names.push(content.to_owned());
+            carry = content.split(' ').next().map(str::to_owned);
+        } else if joiner.trim() == "/" && carry.is_some() {
+            names.push(format!(
+                "{} {content}",
+                carry.as_ref().expect("checked Some")
+            ));
+        } else {
+            names.push(content.to_owned());
+            carry = None;
+        }
+    }
+    names
+}
+
+struct DocAnchors {
+    relative: &'static str,
+    supported_start: &'static str,
+    supported_end: &'static str,
+    unsupported_anchor: &'static str,
+}
+
+const DOCS: &[DocAnchors] = &[
+    DocAnchors {
+        relative: "docs/LANGUAGE.md",
+        supported_start: "is not supported.\n\n",
+        supported_end: "are the only commands that extract fences",
+        unsupported_anchor: "Every other command that reads a spec path ",
+    },
+    DocAnchors {
+        relative: "docs/LANGUAGE.ja.md",
+        supported_start: "サポートされません。\n\n",
+        supported_end: "の 3 コマンドだけです",
+        unsupported_anchor: "仕様パスを読み取る他のすべてのコマンド",
+    },
+    DocAnchors {
+        relative: "skills/fsl/reference.md",
+        supported_start: "**Literate Markdown FSL.** ",
+        supported_end: "\naccept `.md` files containing",
+        unsupported_anchor: "Every other spec-reading command ",
+    },
+];
+
+/// Each document's `Unsupported` enumeration must equal
+/// `LITERATE_REGISTRY`'s `Unsupported` half exactly -- no name missing, none
+/// extra, regardless of which document is checked or which command was
+/// registered most recently.
+#[test]
+fn documented_unsupported_commands_match_the_registry() {
+    let expected = registry_unsupported();
+    for doc in DOCS {
+        let text = read(doc.relative);
+        let list_text = parenthesized_after(&text, doc.unsupported_anchor);
+        let documented: BTreeSet<String> = command_names(list_text).into_iter().collect();
+
+        let missing: Vec<_> = expected.difference(&documented).collect();
+        let extra: Vec<_> = documented.difference(&expected).collect();
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "{} is stale against LITERATE_REGISTRY: missing {missing:?}, extra {extra:?}",
+            doc.relative
+        );
+    }
+}
+
+/// Each document's `Supported` list must equal `LITERATE_SUPPORTED_COMMANDS`
+/// exactly.
+#[test]
+fn documented_supported_commands_match_the_registry() {
+    let expected = registry_supported();
+    for doc in DOCS {
+        let text = read(doc.relative);
+        let list_text = between(&text, doc.supported_start, doc.supported_end);
+        let documented: BTreeSet<String> = command_names(list_text).into_iter().collect();
+
+        let missing: Vec<_> = expected.difference(&documented).collect();
+        let extra: Vec<_> = documented.difference(&expected).collect();
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "{} is stale against LITERATE_SUPPORTED_COMMANDS: missing {missing:?}, extra {extra:?}",
+            doc.relative
+        );
+    }
+}
+
+/// Pin the extractor itself against a literal fixture, independent of the
+/// registry, so a change to `command_names`'s parsing rules that breaks the
+/// `document generate`/`claims`/`check` chain is caught here rather than
+/// only as a confusing failure in the two tests above.
+#[test]
+fn command_names_expands_the_document_subcommand_chain() {
+    let text = "`lint`, `migrate`, and\n`document generate`/`claims`/`check` remain";
+    assert_eq!(
+        command_names(text),
+        vec![
+            "lint".to_owned(),
+            "migrate".to_owned(),
+            "document generate".to_owned(),
+            "document claims".to_owned(),
+            "document check".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn command_names_strips_an_fslc_prefix() {
+    assert_eq!(
+        command_names("`fslc check`, `fslc verify`, and `fslc scenarios`"),
+        vec![
+            "check".to_owned(),
+            "verify".to_owned(),
+            "scenarios".to_owned()
+        ]
+    );
+}

--- a/rust/fslc/tests/literate_markdown.rs
+++ b/rust/fslc/tests/literate_markdown.rs
@@ -437,3 +437,211 @@ example only
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// --- Issue #665: unsupported commands fail closed as an input-kind error --
+
+/// The Markdown fixture the issue itself reproduced against
+/// (`examples/literate/toggle.md`), not the `tests/fixtures` copy used above.
+fn examples_literate_toggle() -> String {
+    repository_root()
+        .join("examples/literate/toggle.md")
+        .to_str()
+        .expect("UTF-8 path")
+        .to_owned()
+}
+
+/// `command_key`'s space-joined pieces, followed by `doc` as its positional
+/// spec argument(s). `refine` alone needs three positionals (`IMPL ABS
+/// MAPPING`) before its own arm ever reaches the literate-input decision, so
+/// it repeats `doc` three times; every other registered command's decision
+/// point sits before any other required argument.
+fn minimal_arguments<'a>(command_key: &'a str, doc: &'a str) -> Vec<&'a str> {
+    let mut arguments: Vec<&str> = command_key.split(' ').collect();
+    if command_key == "refine" {
+        arguments.extend([doc, doc, doc]);
+    } else {
+        arguments.push(doc);
+    }
+    arguments
+}
+
+/// Positive: the registry's `Supported` commands still accept
+/// `examples/literate/toggle.md` unchanged. Exercises
+/// [`fslc_rust::literate_access::LITERATE_SUPPORTED_COMMANDS`] directly so a
+/// command added to that list without a matching case here is at least
+/// asserted not to error, even before a dedicated test is written for it.
+#[test]
+fn registry_supported_commands_still_accept_the_measured_repro_file() {
+    let doc = examples_literate_toggle();
+    for &command in fslc_rust::literate_access::LITERATE_SUPPORTED_COMMANDS {
+        let (output, status) = match command {
+            "verify" => run_cli(&["verify", &doc, "--depth", "4", "--no-cache"]),
+            "scenarios" => run_cli(&["scenarios", &doc, "--depth", "4"]),
+            _ => run_cli(&[command, &doc]),
+        };
+        assert_eq!(status, 0, "{command}: {output:#}");
+        assert_ne!(
+            output["result"], "error",
+            "{command} should still accept literate input: {output:#}"
+        );
+    }
+}
+
+/// Negative control per unsupported command, driven entirely from
+/// [`fslc_rust::literate_access::LITERATE_REGISTRY`] rather than a
+/// hand-copied command list (issue #665 design constraint 2): a command
+/// newly registered as `Unsupported` is covered by this test the moment it
+/// is added, with no test-file edit required.
+///
+/// Also the test that "the lie must not come back": the message must never
+/// contain the Markdown's own `1:2` position, and the diagnostic code must
+/// never be `FSL-PARSE` -- the two symptoms the issue reported before this
+/// fix. This is what fails if a future change re-routes an unsupported
+/// command back into the surface parser.
+#[test]
+fn every_unsupported_registry_command_fails_closed_as_an_input_kind_error() {
+    use fslc_rust::literate_access::{LITERATE_REGISTRY, LiterateSupport};
+
+    let doc = examples_literate_toggle();
+    let mut exercised = 0;
+    for (command_key, support) in LITERATE_REGISTRY {
+        if *support != LiterateSupport::Unsupported {
+            continue;
+        }
+        exercised += 1;
+        let arguments = minimal_arguments(command_key, &doc);
+        let (output, status) = run_cli(&arguments);
+
+        assert_eq!(
+            status, 2,
+            "{command_key}: exit code must not move: {output:#}"
+        );
+        assert_eq!(output["result"], "error", "{command_key}: {output:#}");
+        assert_eq!(
+            output["diagnostic_code"], "FSL-INPUT-LITERATE-UNSUPPORTED",
+            "{command_key}: {output:#}"
+        );
+        assert_ne!(
+            output["kind"], "parse",
+            "{command_key}: kind must not be parse: {output:#}"
+        );
+        assert_ne!(
+            output["kind"], "format",
+            "{command_key}: kind must not be format: {output:#}"
+        );
+        let message = output["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{command_key} missing message: {output:#}"));
+        for supported in fslc_rust::literate_access::LITERATE_SUPPORTED_COMMANDS {
+            assert!(
+                message.contains(*supported),
+                "{command_key}: message should name '{supported}': {message}"
+            );
+        }
+        // loc identifies the input file, never a spec position.
+        assert!(
+            output["loc"].get("line").is_none() && output["loc"].get("column").is_none(),
+            "{command_key}: loc must not carry a spec line/column: {output:#}"
+        );
+        assert_eq!(
+            output["loc"]["file"], doc,
+            "{command_key}: loc should name the input file: {output:#}"
+        );
+        // The lie must not come back.
+        assert!(
+            !message.contains("1:2"),
+            "{command_key}: the Markdown-as-syntax-error lie returned: {message}"
+        );
+        assert_ne!(
+            output["diagnostic_code"], "FSL-PARSE",
+            "{command_key}: {output:#}"
+        );
+    }
+    assert!(
+        exercised >= 19,
+        "expected at least the 19 commands issue #665 classified Unsupported, got {exercised}"
+    );
+}
+
+/// Over-firing control: an ordinary `.fsl` spec must be unaffected on every
+/// registered command, including the `Supported` ones -- the guard keys on
+/// the input's extension, not on which command is running.
+#[test]
+fn ordinary_fsl_input_is_unaffected_on_every_registered_command() {
+    use fslc_rust::literate_access::LITERATE_REGISTRY;
+
+    let dir = std::env::temp_dir().join(format!("fslc-literate-overfire-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let plain = dir.join("toggle.fsl");
+    std::fs::write(
+        &plain,
+        "\
+spec Toggle {
+  state { active: Bool }
+  init  { active = false }
+  action toggle() {
+    active = not active
+  }
+  invariant AlwaysBool {
+    active or not active
+  }
+}
+",
+    )
+    .expect("write plain fsl fixture");
+    let plain_str = plain.to_str().expect("UTF-8 path").to_owned();
+
+    // `testgen`/`html`/`ledger`/`document generate` print their generated
+    // artifact raw to stdout on success instead of the JSON envelope
+    // (`main.rs`'s `raw_delivery_allowed` bypass) -- redirect to a file with
+    // `-o` so a *successful* run here still parses as JSON like every other
+    // command's.
+    let redirect = dir.join("out.txt");
+    let redirect_str = redirect.to_str().expect("UTF-8 path");
+
+    for (command_key, _) in LITERATE_REGISTRY {
+        let mut arguments = minimal_arguments(command_key, &plain_str);
+        if matches!(
+            *command_key,
+            "testgen" | "html" | "ledger" | "document generate"
+        ) {
+            arguments.extend(["-o", redirect_str]);
+        }
+        // `fmt` prints the raw formatted source on success unless `--check`
+        // asks for the JSON envelope instead (same reason as the `-o`
+        // redirects above).
+        if *command_key == "fmt" {
+            arguments.push("--check");
+        }
+        let (output, _status) = run_cli(&arguments);
+        assert_ne!(
+            output["diagnostic_code"], "FSL-INPUT-LITERATE-UNSUPPORTED",
+            "{command_key}: the literate guard must not fire on a .fsl input: {output:#}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Unregistered-command gate (issue #665 design constraint 2): a command key
+/// nobody classified must fail closed as an internal inconsistency rather
+/// than silently falling through to either behavior. The registry's own
+/// totality gate (`literate_registry_is_total_over_the_cli_surface` in
+/// `rust/fslc/src/literate_access.rs`) is what actually keeps every real CLI
+/// command classified; this test pins the *fallback* that function's
+/// enumeration exists to make unreachable in production.
+#[test]
+fn an_unregistered_command_key_fails_closed_not_silently() {
+    use fslc_rust::literate_access::literate_access;
+
+    let doc = PathBuf::from(examples_literate_toggle());
+    let Err((output, status)) = literate_access("a_command_nobody_registered", &doc) else {
+        panic!("an unregistered command key must not resolve to Ok");
+    };
+    assert_eq!(status, 3, "{output:#}");
+    assert_eq!(output["kind"], "internal", "{output:#}");
+    assert_ne!(
+        output["result"], "ok",
+        "an internal inconsistency must never read as a pass: {output:#}"
+    );
+}

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -1076,7 +1076,13 @@ Multiple fsl blocks form one compilation unit (split definitions across
 sections). Files without fsl fences are rejected; non-fsl fences
 (` ```python ` etc.) are ignored. A literate `.md` may `use`/compose `.fsl`
 files relative to its own directory; using another `.md` as a compose target
-is not supported.
+is not supported. Every other spec-reading command (`lint`, `migrate`, `fmt`,
+`kernel`, `conformance`, `explain`, `mutate`, `typestate`, `testgen`, `html`,
+`ledger`, `analyze`, `diff`, `refine`, `replay`, `sweep`,
+`document generate`/`claims`/`check`) rejects `.md` input as an input-kind
+error (`kind:"usage"`, `diagnostic_code:"FSL-INPUT-LITERATE-UNSUPPORTED"`,
+`loc` naming the input file, not a spec position) instead of handing it to
+the parser (issue #665).
 
 `diff` uses bidirectional bounded refinement for behavior changes, implication
 between the OLD/NEW user-invariant conjunctions, and replay of OLD `forbidden`


### PR DESCRIPTION
## Problem

Literate Markdown FSL (#193) extracts ```` ```fsl ```` fences from a `.md` file. Only `check`,
`verify`, and `scenarios` did it. Every other spec-reading command handed the raw `.md` to the
surface parser and reported **the user's spec as having a syntax error at 1:2** — which is the `!` of
the Markdown's own `<!-- SPDX-License-Identifier: Apache-2.0 -->`.

Measured before this change:

```
fslc check  examples/literate/toggle.md   ->  exit 0
fslc mutate examples/literate/toggle.md   ->  exit 2  kind:"parse"  FSL-PARSE
                                               "unexpected character '!' at 1:2"
```

Exit 2 was already the spec-error class, so this is **not** a false green. What was broken is the
truthfulness of the diagnostic and the contract symmetry between sibling commands. `fmt` classified
the same cause differently again (`kind:"format"`, `diagnostic_code: null`), and
`docs/LANGUAGE.md:723` mentioned `.md` only for `check` — implementation silence was the contract.

## Contract changes

`fslc_rust::literate_access` owns the decision. `materialize_literate` and `LiterateState` move
there from `main.rs`, joined by `literate_access`, which either materializes or fails closed
according to `LITERATE_REGISTRY`. Every arm of `command()`, `run_fmt`, and `document_command`'s
shared prelude obtains its path through it — 22 call sites — rather than repeating a three-line
prologue that fourteen arms simply never had. It lives in the lib under the same `native-cli` gate as
`outcome.rs`, so the tests defer to the production registry instead of copying it (#577's shape).

An unsupported command returns:

```json
{
  "result": "error",
  "kind": "usage",
  "message": "fslc mutate does not support literate Markdown input; only check, verify, scenarios
              extract ```fsl fenced code from a .md file -- pass '...' to one of those, or extract
              the fenced code into a .fsl file first",
  "diagnostic_code": "FSL-INPUT-LITERATE-UNSUPPORTED",
  "loc": { "file": "examples/literate/toggle.md" }
}
```

`kind:"usage"` is an existing vocabulary entry that already means "you invoked this wrong" and
already exits 2, so **no exit code moves** and no new `kind` needs an exit-code mapping. `loc`
carries only the file — never a spec line and column. The envelope is built as JSON directly, never
through `fsl_syntax::ParseError::coded`, because a `ParseError` asserts the spec is malformed, which
is exactly the lie being removed.

Full literate support for every command is #666 and deliberately not attempted here; this closes on
the diagnostic alone and does not depend on that ordering.

## Both lists are gated, because an ungated one is this repository's recurring blind spot

`literate_registry_is_total_over_the_cli_surface` walks `rust/fslc/cli-contract.json` and fails when
a leaf command taking a positional path is in neither `LITERATE_REGISTRY` nor `LITERATE_EXCLUDED`.
So command #20 cannot be silently forgotten — it must be classified.

The command enumeration also appears in three documents, and `literate_docs_contract.rs` gates all
three against the registry in `mutation_docs_contract.rs`'s style (issue #338 is the precedent for
gating documentation claims against code). Without it, registering a twentieth command would leave
`docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md` stale in silence — which is
the shape #689 documents.

## The exclusion reasons are measured, and one of them corrects my own first draft

`LITERATE_EXCLUDED` records why each remaining command is out of scope:

- `chain` — the positional is a TOML project manifest. Measured: `invalid TOML at line 1: expected
  key = value`. A `.md` never reaches the FSL frontend. Genuinely a different thing.
- `approval create/check/diff` — the positional's meaning depends on `--kind`, and
  `--kind requirements_document` **legitimately** binds a rendered `.md`. A blanket guard here would
  break correct input.
- The dialect commands are **the same defect, not a different one**. Measured:

```
db check      exit=2  kind="semantics"  "unexpected character '!' at examples/literate/toggle.md:1:2"
domain check  exit=2  kind="semantics"  (same)
ai check      exit=2  kind="semantics"  (same)
compat check  exit=2  kind="semantics"  (same)
causal check  exit=2  kind="parse"      "unexpected character '!'"
```

Same message, same false spec position; only the `kind` label differs. An earlier draft of this
change described them as "a different pre-existing gap", which the measurement does not support — and
a wrong reason in an exclusion list is worse than no reason, because it stops the next reader from
looking. They are excluded because #665's measured table has 17 rows and none of these five are in
it, and they are tracked as **#694** with the measurements above.

## Evidence

Negative controls **calibrated by reintroducing each defect**, not assumed (AGENTS.md: a green
positive path alone does not establish that the anchor can detect drift):

- Dropping the `literate_access` call from the `kernel` arm fails
  `every_unsupported_registry_command_fails_closed_as_an_input_kind_error` with
  `left: "FSL-PARSE" / right: "FSL-INPUT-LITERATE-UNSUPPORTED"` and the reverted
  `"unexpected character '!' at 1:2"` envelope.
- Removing `("mutate", Unsupported)` from the registry fails the totality test naming `mutate`; the
  built binary then returns `kind:"internal"`, exit 3 — fail-closed, never a silent pass.
- Removing one command name from `docs/LANGUAGE.md` fails the doc gate with
  `docs/LANGUAGE.md is stale against LITERATE_REGISTRY: missing ["html"], extra []`.

Verified across all 19 unsupported commands: exit 2, `kind:"usage"`,
`FSL-INPUT-LITERATE-UNSUPPORTED`, no spec position in `loc`.

```
cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked
    --test literate_markdown        16 passed
    --test literate_docs_contract    4 passed
cargo test --manifest-path rust/Cargo.toml --workspace --locked             exit 0
    1367 tests across 190 test binaries, 0 failed
cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
                                                                           exit 0
cargo fmt --manifest-path rust/Cargo.toml --all -- --check                 exit 0
python3 -m pytest tests/test_site_reference_snapshot.py                    3 passed
./tools/check-native-integration.sh fault-operators                        exit 0
    control stale-seam: refused, as required
    control no-op: all 17 operators' detectors green
    all 17 operators: primary=failed blind=ok
```

The fault-operator leg is included deliberately: PR #692 failed CI because a fault-operator patch's
seam moved under a `main.rs` change, and this PR rewrites 22 `main.rs` call sites. It is now part of
the pre-merge check rather than something CI discovers.

## Notes for review

- `docs/intro/language.{en,ja}.html` is regenerated because `docs/LANGUAGE.md` changed and
  `tests/test_site_reference_snapshot.py` requires it. Of the 39 changed lines in `language.en.html`,
  13 are this change's; the other 26 are pre-existing drift from earlier `Seq` partial-operation and
  `vacuous_deadline` doc edits that were never regenerated. PR #692 carries the same drift as a
  separate commit, so whichever lands second will need a regeneration to resolve that file.
- The scope boundary — 19 registered, the rest excluded — is the judgement call. `diff`/`refine`/
  `replay` are in because they show the same `FSL-PARSE` symptom; the dialect commands are out
  because #665 measured 17 rows and #694 now owns them.
- The totality guarantee is bounded by `cli-contract.json`'s completeness. That file is checked
  against live `--help` for every path it lists, and `native_integration.rs` pins its leaf count at
  50, but nothing compares the dispatch arms *to* the contract, so a command added to dispatch and
  not to the contract would be invisible to both. I measured zero such commands today.

Closes #665. Related: #694, #666, #689, #338, #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
