### PR TITLE
test(cli): make the literate doc-contract anchors line-ending independent

### DIFF
--- a/rust/fslc/tests/literate_docs_contract.rs
+++ b/rust/fslc/tests/literate_docs_contract.rs
@@ -17,6 +17,7 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use fslc_rust::literate_access::{LITERATE_REGISTRY, LITERATE_SUPPORTED_COMMANDS, LiterateSupport};
 
@@ -29,8 +30,29 @@ fn workspace_root() -> PathBuf {
 }
 
 fn read(relative: &str) -> String {
-    let path = workspace_root().join(relative);
-    std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {relative}: {error}"))
+    read_path(&workspace_root().join(relative))
+}
+
+/// The actual read path both `read()` and the composition regression below
+/// exercise: read whatever bytes are on disk, then normalize. Kept as its
+/// own function (rather than inlined in `read()`) so a test can point it at
+/// an arbitrary file -- a temporary CRLF fixture, not just a workspace path
+/// -- and observe the composed behavior instead of `normalize_line_endings`
+/// in isolation.
+fn read_path(path: &Path) -> String {
+    let source = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    normalize_line_endings(&source)
+}
+
+/// Normalize a checkout's line endings to `\n` before anchor matching. On a
+/// Windows checkout under `core.autocrlf`, `docs/LANGUAGE.md`,
+/// `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md` are read back with
+/// `\r\n`, so a multi-line anchor such as `"is not supported.\n\n"` never
+/// matches and `between()` panics with a missing-anchor error instead of
+/// comparing documented commands against the registry.
+fn normalize_line_endings(source: &str) -> String {
+    source.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 /// The registry's `Unsupported` command names, as a set.
@@ -226,6 +248,91 @@ fn command_names_expands_the_document_subcommand_chain() {
             "document claims".to_owned(),
             "document check".to_owned(),
         ]
+    );
+}
+
+/// The regression pinned to the anchor that actually broke: on Windows CI,
+/// `between()`'s search for `docs/LANGUAGE.md`'s `"is not supported.\n\n"`
+/// anchor failed against a `\r\n`-normalized checkout. Mirrors
+/// `implementation_mutation_manifest.rs`'s
+/// `multiline_anchor_matching_is_line_ending_independent`.
+///
+/// This alone is not a sufficient guard: it calls `normalize_line_endings`
+/// directly, so it proves the helper works in isolation but says nothing
+/// about whether `read()`/`read_path()` actually calls it -- deleting that
+/// one call site leaves this test green. `implementation_mutation_manifest.rs`
+/// has the same gap for the same reason. See
+/// `crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized` below
+/// for the composed guard that closes it; keep both, since this one is
+/// cheap and localizes a failure to the helper itself when the helper is
+/// what broke.
+#[test]
+fn multiline_anchor_matching_is_line_ending_independent() {
+    let anchor = "is not supported.\n\n";
+    let lf = format!("before\n{anchor}after");
+    let crlf = lf.replace('\n', "\r\n");
+    let cr = lf.replace('\n', "\r");
+
+    for source in [&lf, &crlf, &cr] {
+        assert_eq!(normalize_line_endings(source).matches(anchor).count(), 1);
+    }
+}
+
+/// A CRLF-encoded copy of a fixture file, cleaned up on drop. Mirrors
+/// `issue_260_leadsto_stagnation.rs`'s `Fixture`.
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-literate-docs-contract-{name}-{}-{nonce}.md",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write CRLF fixture");
+        Self(path)
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// The composed guard the helper-level test above cannot provide: write a
+/// CRLF copy of the real `docs/LANGUAGE.md` to a temp file, read it back
+/// through the actual production path (`read_path()`, the function `read()`
+/// delegates to), and confirm `between()` finds the anchor and returns the
+/// same slice as the LF original. Deleting the `normalize_line_endings`
+/// call inside `read_path()` makes this test fail -- and only this shape of
+/// test can observe that deletion, because it exercises the composition
+/// (disk read + normalization) rather than the normalization function
+/// called directly.
+#[test]
+fn crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized() {
+    let lf_original = read("docs/LANGUAGE.md");
+    let crlf_source = lf_original.replace('\n', "\r\n");
+    assert!(
+        crlf_source.contains("\r\n"),
+        "fixture must actually contain CRLF"
+    );
+    let fixture = Fixture::new("language-md", &crlf_source);
+
+    let read_back = read_path(&fixture.0);
+    assert_eq!(
+        read_back, lf_original,
+        "read_path() must normalize a CRLF checkout back to the LF content"
+    );
+
+    let start_anchor = "is not supported.\n\n";
+    let end_anchor = "are the only commands that extract fences";
+    assert_eq!(
+        between(&read_back, start_anchor, end_anchor),
+        between(&lf_original, start_anchor, end_anchor),
     );
 }
 

--- a/rust/fslc/tests/literate_docs_contract.rs
+++ b/rust/fslc/tests/literate_docs_contract.rs
@@ -29,18 +29,16 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn read(relative: &str) -> String {
-    read_path(&workspace_root().join(relative))
-}
-
-/// The actual read path both `read()` and the composition regression below
-/// exercise: read whatever bytes are on disk, then normalize. Kept as its
-/// own function (rather than inlined in `read()`) so a test can point it at
-/// an arbitrary file -- a temporary CRLF fixture, not just a workspace path
-/// -- and observe the composed behavior instead of `normalize_line_endings`
-/// in isolation.
-fn read_path(path: &Path) -> String {
-    let source = std::fs::read_to_string(path)
+/// Read a workspace-relative document or an absolute regression fixture
+/// through the single entrypoint used by every contract assertion.
+fn read(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace_root().join(path)
+    };
+    let source = std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
     normalize_line_endings(&source)
 }
@@ -259,8 +257,9 @@ fn command_names_expands_the_document_subcommand_chain() {
 ///
 /// This alone is not a sufficient guard: it calls `normalize_line_endings`
 /// directly, so it proves the helper works in isolation but says nothing
-/// about whether `read()`/`read_path()` actually calls it -- deleting that
-/// one call site leaves this test green. `implementation_mutation_manifest.rs`
+/// about whether the contract's `read()` entrypoint actually calls it --
+/// deleting that one call site leaves this test green.
+/// `implementation_mutation_manifest.rs`
 /// has the same gap for the same reason. See
 /// `crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized` below
 /// for the composed guard that closes it; keep both, since this one is
@@ -305,13 +304,12 @@ impl Drop for Fixture {
 
 /// The composed guard the helper-level test above cannot provide: write a
 /// CRLF copy of the real `docs/LANGUAGE.md` to a temp file, read it back
-/// through the actual production path (`read_path()`, the function `read()`
-/// delegates to), and confirm `between()` finds the anchor and returns the
-/// same slice as the LF original. Deleting the `normalize_line_endings`
-/// call inside `read_path()` makes this test fail -- and only this shape of
-/// test can observe that deletion, because it exercises the composition
-/// (disk read + normalization) rather than the normalization function
-/// called directly.
+/// through the same `read()` entrypoint as every documentation contract, and
+/// confirm `between()` finds the anchor and returns the same slice as the LF
+/// original. Deleting the `normalize_line_endings` call inside `read()` makes
+/// this test fail -- and only this shape of test can observe that deletion,
+/// because it exercises the composition (disk read + normalization) rather
+/// than the normalization function called directly.
 #[test]
 fn crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized() {
     let lf_original = read("docs/LANGUAGE.md");
@@ -322,10 +320,10 @@ fn crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized() {
     );
     let fixture = Fixture::new("language-md", &crlf_source);
 
-    let read_back = read_path(&fixture.0);
+    let read_back = read(&fixture.0);
     assert_eq!(
         read_back, lf_original,
-        "read_path() must normalize a CRLF checkout back to the LF content"
+        "read() must normalize a CRLF checkout back to the LF content"
     );
 
     let start_anchor = "is not supported.\n\n";


### PR DESCRIPTION
## Summary

- Normalize documentation line endings before literate contract anchor matching.
- Route both repository documents and the synthetic CRLF fixture through the same top-level `read()` entrypoint.
- Prevent a call-site regression from remaining green on LF-only CI.

Refs #665. Related: #685, #617.

## Changes

- `read()` now accepts workspace-relative documents and absolute temporary fixtures.
- Removed the lower-level `read_path()` escape hatch that let the composed regression bypass the contract entrypoint.
- Kept the helper-level LF/CRLF/CR test and the real-document composition test as separate diagnostics.

No product behavior, documentation content, registry, schema, or CLI contract changes.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test literate_docs_contract --locked` — 6 passed
- Negative control: replacing `normalize_line_endings(&source)` in `read()` with `source` makes `crlf_checkout_of_a_real_doc_reaches_the_anchor_matcher_normalized` fail; restoring it returns all 6 tests to green.
- Independent re-review: no actionable findings.

## Risk / Review Notes

- PR-head Windows/macOS jobs remain deferred by optimistic CI. The synthetic CRLF fixture reproduces the line-ending boundary on any platform; the post-merge product gate remains the platform confirmation.
- The change is test-only and reversible.
