### PR TITLE
fix(domain): parenthesize each piece of a rendered can(...) expansion (#690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
-- Fixed a false green in `domain expand`/`domain testgen`/`domain scaffold`/
-  `check_domain`'s `can(Command)` rendering: `Context::normalize`
+- Fixed a false green in `domain expand`/`check_domain`'s `can(Command)`
+  rendering: `Context::normalize`
   (`rust/fsl-core/src/domain.rs`) joined a `decide`'s `requires` clauses and
   negated `rejects` conditions with literal `" and "` without
   parenthesizing each piece individually, so a piece containing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed a false green in `domain expand`/`domain testgen`/`domain scaffold`/
+  `check_domain`'s `can(Command)` rendering: `Context::normalize`
+  (`rust/fsl-core/src/domain.rs`) joined a `decide`'s `requires` clauses and
+  negated `rejects` conditions with literal `" and "` without
+  parenthesizing each piece individually, so a piece containing a
+  top-level `or` misgrouped once two or more pieces were present (`and`
+  binds tighter than `or` in FSL's grammar). This could invert a verifier
+  verdict between the directly-lowered typed model (`check`/`verify` on
+  domain source) and the rendered-then-reparsed kernel (`domain expand`'s
+  output): a `violated` invariant rendered as a tautology and reported
+  `verified`. Each piece is now individually parenthesized before joining
+  (#690, symptom 1 of 3; symptoms 2 and 3 remain open). Added
+  `rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl`
+  and `rust/fslc/tests/issue_690_can_precedence_false_green.rs` as the
+  reproducing fixture and verdict-agreement regression control, and moved
+  the fixture into `domain_render_agreement.rs`'s `VALID_DOMAIN_FIXTURES`;
+  `expressions_valid.fsl` remains in `KNOWN_DIVERGENT_DOMAIN_FIXTURES` for
+  the still-open name-shadowing symptom.
+
 - Added a standalone `site reference freshness` CI workflow
   (`.github/workflows/site-reference-freshness.yml`) that runs the
   pre-existing but previously unwired `tests/test_site_reference_snapshot.py`

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -300,16 +300,17 @@ tests, or external evidence.
 
 `domain` semantics has two independent lowerings that must stay in agreement:
 `lower_domain` (typed `KernelSpec`, used by `check`/`verify`) and
-`domain_kernel_source` (rendered `.fsl` text, used by `domain expand`/
-`check_domain`/`domain testgen`/`domain scaffold`).
+`domain_kernel_source` (rendered `.fsl` text, used by `domain expand` and
+by `check_domain` to validate renderability; only its hard-finding envelope
+includes the generated `kernel_source`).
 `rust/fsl-core/tests/domain_render_agreement.rs` projects both through
 `public_kernel_contract` for the full domain corpus and requires them to match
 except on source spans (#664). Building that gate found the two
 implementations already disagree: `Context::normalize`/`Context::default`
 (`domain.rs`) render text with `str::replace` and no syntax tree, so they
-cannot be scope- or precedence-aware the way `lower_domain`'s typed AST
-composition is, and one shape of that gap can invert a verified/violated
-verdict rather than merely change generated text.
+cannot be scope-aware the way `lower_domain`'s typed AST composition is. #690
+fixed the known `can(...)` precedence false green by parenthesizing each joined
+piece; its scope-aware substitution and generated-name symptoms remain open.
 `domain_render_agreement.rs`'s `KNOWN_DIVERGENT_DOMAIN_FIXTURES` pins the
 currently known instances as regression fixtures; #690 and #691 own
 resolving them.

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -332,12 +332,9 @@ impl<'a> Context<'a> {
                             "({})",
                             pieces
                                 .iter()
-                                .map(|piece| self.normalize(
-                                    piece,
-                                    Some(aggregate),
-                                    type_env,
-                                    None,
-                                    false
+                                .map(|piece| format!(
+                                    "({})",
+                                    self.normalize(piece, Some(aggregate), type_env, None, false)
                                 ))
                                 .collect::<Vec<_>>()
                                 .join(" and ")

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -121,6 +121,7 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
     "examples/domain/order_functional_ddd.fsl",
     "examples/domain/unsafe_irreversible_effect_without_idempotency.fsl",
     "rust/fslc/tests/fixtures/domain_canonical_enum.fsl",
+    "rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl",
     "rust/fslc/tests/fixtures/domain_legacy_enum_union.fsl",
     "rust/fslc/tests/fixtures/domain_origin_violation.fsl",
@@ -250,7 +251,11 @@ struct KnownDivergence {
 ///    rendered source.
 ///
 /// 3. `expressions_valid.fsl` both paths accept, but the projected
-///    contracts disagree at two independent points:
+///    contracts still disagree at one point (name-shadowing, #690 symptom
+///    2). A second point that used to disagree here -- `can(...)`
+///    operator-precedence misgrouping, #690 symptom 1 -- was fixed and is
+///    described below, after this list, rather than removed from the
+///    historical record:
 ///
 ///    - `command Approve { quantity: Quantity }` shares a name with the
 ///      aggregate's own `quantity` state field. Inside `evolve Approved`,
@@ -265,37 +270,38 @@ struct KnownDivergence {
 ///      that silently drops the incoming event payload. The same
 ///      mis-substitution reaches the `decide Approve` guard
 ///      `quantity >= 0`, which refers to the *command input* `quantity`,
-///      not the state field.
-///    - `invariant legacyImplication { status == Cancelled -> not can(Cancel) }`
-///      expands `can(Cancel)` against
-///      `decide Cancel { requires status == Draft or status == Approved rejects ... }`.
-///      `domain.rs`'s `can(...)` expansion (path B,
-///      `Context::normalize` around line 328) joins the requires/rejects
-///      pieces with literal `" and "` without individually parenthesizing
-///      each piece, so the rendered text reads
-///      `status == Draft or status == Approved and not (status == Cancelled)`
-///      -- `and` binds tighter than `or` in FSL's grammar, so this
-///      re-parses as `Draft or (Approved and not Cancelled)`, not the
-///      intended `(Draft or Approved) and not Cancelled` that
-///      `lower_domain`'s typed AST composition (path A) builds directly and
-///      therefore cannot get wrong the same way.
+///      not the state field. This needs a scope-aware substitution (design
+///      option B/C in #690) and is out of scope for the `can(...)` fix.
 ///
-///      In *this* fixture, `decide Cancel`'s pieces are over a
-///      single-valued enum and mutually exclusive, so the misgrouping only
-///      changes the JSON AST shape here, not the truth value -- this is
-///      the whole observable divergence this repository's corpus exposes
-///      for this bug. It is worse in general: the same misgrouping can flip
-///      a verdict once the pieces are over independent `Bool` state (e.g.
-///      `decide Open { requires a or b  requires c  emits Opened }` with
-///      `invariant aImpliesCanOpen { a => can(Open) }` renders the
-///      tautology `gate_a => (gate_a or gate_b and gate_c)` instead of the
-///      intended, sometimes-false `gate_a => ((gate_a or gate_b) and
-///      gate_c)`), so `fslc verify` returns `violated` on the checked model
-///      and `verified` on the rendered/re-parsed one for the identical
-///      domain spec -- a false green, the class AGENTS.md ranks above a
-///      crash. #690 owns that reproducing case; it is deliberately not
-///      added to this repository's corpus (doing so would change what this
-///      gate's own corpus-classification test enforces).
+///    Before #690's fix, this fixture's
+///    `invariant legacyImplication { status == Cancelled -> not can(Cancel) }`
+///    also disagreed at the projected `and`/`or` operator shape:
+///    `domain.rs`'s `can(...)` expansion (path B, `Context::normalize`
+///    around line 328) joined the requires/rejects pieces with literal
+///    `" and "` without individually parenthesizing each piece, so the
+///    rendered text read
+///    `status == Draft or status == Approved and not (status == Cancelled)`
+///    -- `and` binds tighter than `or` in FSL's grammar, so this re-parsed
+///    as `Draft or (Approved and not Cancelled)`, not the intended
+///    `(Draft or Approved) and not Cancelled` that `lower_domain`'s typed
+///    AST composition (path A) builds directly and therefore could not get
+///    wrong the same way. In *this* fixture, `decide Cancel`'s pieces are
+///    over a single-valued enum and mutually exclusive, so the misgrouping
+///    only changed the JSON AST shape here, not the truth value. It was
+///    worse in general: the same misgrouping could flip a verdict once the
+///    pieces are over independent `Bool` state -- see
+///    `can_expansion_precedence.fsl` in [`VALID_DOMAIN_FIXTURES`], which
+///    pins exactly that (`decide Open { requires a or b  requires c  emits
+///    Opened }` with `invariant aImpliesCanOpen { a => can(Open) }` used to
+///    render the tautology `gate_a => (gate_a or gate_b and gate_c)`
+///    instead of the intended, sometimes-false `gate_a => ((gate_a or
+///    gate_b) and gate_c)`, so `fslc verify` returned `violated` on the
+///    checked model and `verified` on the rendered/re-parsed one for the
+///    identical domain spec -- a false green, the class AGENTS.md ranks
+///    above a crash). #690's fix parenthesizes each piece individually
+///    before joining, which is why this fixture's `can(Cancel)` fingerprint
+///    is gone from [`KNOWN_DIVERGENT_DOMAIN_FIXTURES`] below while the
+///    `quantity`/`order_quantity` fingerprint remains.
 ///
 /// `known_divergent_domain_fixture_pins_the_open_finding` asserts each
 /// fixture's exact shape so an incidental change that makes the two agree --
@@ -319,10 +325,15 @@ const KNOWN_DIVERGENT_DOMAIN_FIXTURES: &[KnownDivergence] = &[
     KnownDivergence {
         fixture: "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
         shape: DivergenceShape::ContractsDisagree,
-        expected_contains: &[
-            "path A = \"quantity\", path B = \"order_quantity\"",
-            "operator: path A = \"and\", path B = \"or\"",
-        ],
+        // #690 symptom 1 (the `can(...)` operator-precedence misgrouping,
+        // previously pinned here as `"operator: path A = \"and\", path B =
+        // \"or\""`) is fixed: `Context::normalize` now parenthesizes each
+        // `requires`/`rejects` piece individually before joining, so this
+        // fixture's `can(Cancel)` projection no longer disagrees with path
+        // A. Only #690 symptom 2 remains here: the name-shadowing rewrite
+        // still needs a scope-aware substitution (design option B/C, still
+        // open), so `quantity`/`order_quantity` still disagrees.
+        expected_contains: &["path A = \"quantity\", path B = \"order_quantity\""],
         tracking_issue: "https://github.com/ymm-oss/fsl/issues/690",
     },
 ];

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7557,7 +7557,7 @@
       "requires order_status == OrderStatus_Draft and not (order_status == OrderStatus_Cancelled)",
       "requires order_status != OrderStatus_Cancelled and order_quantity >= 0",
       "order_audit.status = order_status",
-      "invariant Order_legacyImplication \"DOMAIN-INVARIANT: Order.legacyImplication\" { order_status == OrderStatus_Cancelled => not (order_status == OrderStatus_Draft or order_status == OrderStatus_Approved and not (order_status == OrderStatus_Cancelled)) }",
+      "invariant Order_legacyImplication \"DOMAIN-INVARIANT: Order.legacyImplication\" { order_status == OrderStatus_Cancelled => not ((order_status == OrderStatus_Draft or order_status == OrderStatus_Approved) and (not (order_status == OrderStatus_Cancelled))) }",
       "invariant Order_legacyDisjunction \"DOMAIN-INVARIANT: Order.legacyDisjunction\" { order_status == OrderStatus_Draft or order_status == OrderStatus_Approved or order_status == OrderStatus_Cancelled }",
       "invariant Order_finiteMembership \"DOMAIN-INVARIANT: Order.finiteMembership\" { (order_status == OrderStatus_Draft or order_status == OrderStatus_Approved or order_status == OrderStatus_Cancelled) }"
     ],

--- a/rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl
@@ -1,0 +1,35 @@
+domain CanExpansionPrecedence {
+  // SPDX-License-Identifier: Apache-2.0
+  aggregate Gate {
+    state {
+      a: Bool = false;
+      b: Bool = false;
+      c: Bool = false;
+    }
+
+    command Open {}
+    command SetA {}
+    command SetC {}
+
+    event Opened {}
+    event ASet {}
+    event CSet {}
+
+    decide SetA { emits ASet }
+    decide SetC { emits CSet }
+
+    decide Open {
+      requires a or b
+      requires c
+      emits Opened
+    }
+
+    evolve ASet { a = true }
+    evolve CSet { c = true }
+    evolve Opened { }
+
+    invariant aImpliesCanOpen {
+      a => can(Open)
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
 domain CanExpansionPrecedence {
-  // SPDX-License-Identifier: Apache-2.0
   aggregate Gate {
     state {
       a: Bool = false;

--- a/rust/fslc/tests/issue_690_can_precedence_false_green.rs
+++ b/rust/fslc/tests/issue_690_can_precedence_false_green.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Semantic negative control for #690 symptom 1: `Context::normalize`
+//! (`rust/fsl-core/src/domain.rs`) rendered a `can(Command)` expansion by
+//! joining each `requires`/`rejects` piece with literal `" and "` without
+//! individually parenthesizing each piece. Because `and` binds tighter
+//! than `or` in FSL's grammar, a `decide` with two or more pieces where one
+//! piece contains a top-level `or` misgrouped on the rendered/re-parsed
+//! path (`domain expand` / `domain testgen` / `domain scaffold` /
+//! `check_domain`) while the directly-lowered typed path (`check`/`verify`
+//! on the `.fsl` domain source) built the correct grouping directly.
+//!
+//! `rust/fsl-core/tests/domain_render_agreement.rs` pins that the two
+//! paths' *public Kernel contracts* agree (issue #664's structural gate).
+//! This file pins the property #690 is actually about: that the two paths
+//! reach the *same verifier verdict* on independent `Bool` state where the
+//! misgrouping is truth-value-observable, not just AST-shape-observable
+//! (`rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl`'s
+//! `can(Cancel)` is over a single-valued, mutually exclusive enum, so a
+//! misgrouping there cannot flip a verdict -- seeing this land in
+//! `rust/fslc/tests/` rather than folding it into `domain_render_agreement.rs`
+//! keeps the structural-contract-agreement gate and the
+//! verdict/false-green gate as two independently reviewable claims, per
+//! `rust/fsl-core/tests/domain_render_agreement.rs`'s own precedent of not
+//! calling `fslc verify` at all).
+//!
+//! Before the fix: path A (`verify` on the domain source) reported
+//! `violated`, path B (`verify` on `domain expand`'s rendered output)
+//! reported `verified` -- a false green, the class AGENTS.md ranks above a
+//! crash. The negative control (revert the one-line fix in
+//! `rust/fsl-core/src/domain.rs`) reproduces exactly that divergence; see
+//! the task report, not this file, for the reverted-fix transcript, since
+//! this file must keep pinning the *fixed* behavior on `main`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const FIXTURE: &str =
+    "rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl";
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn expanded_source() -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["domain", "expand", FIXTURE])
+        .current_dir(root())
+        .output()
+        .expect("run native fslc domain expand");
+    assert!(
+        output.status.success(),
+        "domain expand failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("utf8 rendered kernel source")
+}
+
+fn tempfile_dir() -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "fslc-issue-690-can-precedence-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&directory).expect("create scratch dir");
+    directory
+}
+
+/// The rendered `can(Open)` expansion must parenthesize each
+/// `requires`/`rejects` piece individually, not just wrap the whole joined
+/// list once. This is the direct textual assertion for the fix (each piece
+/// is now atomic wherever the substitution lands), independent of whether
+/// re-parsing happens to agree on this particular fixture.
+#[test]
+fn rendered_can_expansion_parenthesizes_each_piece() {
+    let rendered = expanded_source();
+    let invariant_line = rendered
+        .lines()
+        .find(|line| line.contains("aImpliesCanOpen"))
+        .unwrap_or_else(|| panic!("no aImpliesCanOpen invariant line in:\n{rendered}"));
+    assert!(
+        invariant_line.contains("((gate_a or gate_b) and (gate_c))"),
+        "expected each can(Open) piece individually parenthesized, got: {invariant_line}"
+    );
+}
+
+/// The headline false-green control: `verify` on the domain source
+/// (path A, the typed model `lower_domain` builds) and `verify` on
+/// `domain expand`'s rendered-then-reparsed output (path B) must report
+/// the same verdict on `aImpliesCanOpen`. Before #690's fix, path A
+/// reported `violated` and path B reported `verified` for this exact
+/// fixture -- the false green this test exists to prevent from coming
+/// back.
+#[test]
+fn verify_agrees_between_typed_model_and_rendered_kernel() {
+    let (verify_a, status_a) = run(&["verify", FIXTURE, "--depth", "6", "--no-cache"]);
+    assert_eq!(status_a, 1, "path A: {verify_a:#}");
+    assert_eq!(verify_a["result"], "violated", "path A: {verify_a:#}");
+    assert_eq!(
+        verify_a["invariant"], "aImpliesCanOpen",
+        "path A: {verify_a:#}"
+    );
+
+    let directory = tempfile_dir();
+    let expanded_path = directory.join("can_expansion_precedence.expanded.fsl");
+    std::fs::write(&expanded_path, expanded_source()).expect("write expanded kernel source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            expanded_path.to_str().expect("utf8 path"),
+            "--depth",
+            "6",
+            "--no-cache",
+        ])
+        .output()
+        .expect("run native fslc verify on expanded kernel");
+    let verify_b: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status_b = output.status.code().expect("exit status");
+
+    assert_eq!(status_b, 1, "path B: {verify_b:#}");
+    assert_eq!(verify_b["result"], "violated", "path B: {verify_b:#}");
+    assert_eq!(
+        status_a, status_b,
+        "path A/B exit codes disagree: {verify_a:#} vs {verify_b:#}"
+    );
+    assert_eq!(
+        verify_a["result"], verify_b["result"],
+        "path A/B verdicts disagree -- the #690 false green is back: {verify_a:#} vs {verify_b:#}"
+    );
+
+    std::fs::remove_file(&expanded_path).ok();
+}

--- a/rust/fslc/tests/issue_690_can_precedence_false_green.rs
+++ b/rust/fslc/tests/issue_690_can_precedence_false_green.rs
@@ -6,10 +6,10 @@
 //! joining each `requires`/`rejects` piece with literal `" and "` without
 //! individually parenthesizing each piece. Because `and` binds tighter
 //! than `or` in FSL's grammar, a `decide` with two or more pieces where one
-//! piece contains a top-level `or` misgrouped on the rendered/re-parsed
-//! path (`domain expand` / `domain testgen` / `domain scaffold` /
-//! `check_domain`) while the directly-lowered typed path (`check`/`verify`
-//! on the `.fsl` domain source) built the correct grouping directly.
+//! piece contains a top-level `or` misgrouped in the rendered source exposed
+//! by `domain expand` / `check_domain`. Re-parsing that source, as this test
+//! and the agreement gate do, then disagreed with the directly-lowered typed
+//! path (`check`/`verify` on the `.fsl` domain source).
 //!
 //! `rust/fsl-core/tests/domain_render_agreement.rs` pins that the two
 //! paths' *public Kernel contracts* agree (issue #664's structural gate).
@@ -148,6 +148,10 @@ fn verify_agrees_between_typed_model_and_rendered_kernel() {
     assert_eq!(status_b, 1, "path B: {verify_b:#}");
     assert_eq!(verify_b["result"], "violated", "path B: {verify_b:#}");
     assert_eq!(
+        verify_b["invariant"], verify_a["generated_name"],
+        "path B violated a different property: {verify_b:#}"
+    );
+    assert_eq!(
         status_a, status_b,
         "path A/B exit codes disagree: {verify_a:#} vs {verify_b:#}"
     );
@@ -157,4 +161,5 @@ fn verify_agrees_between_typed_model_and_rendered_kernel() {
     );
 
     std::fs::remove_file(&expanded_path).ok();
+    std::fs::remove_dir(&directory).ok();
 }


### PR DESCRIPTION
## Summary

- Correct `can(Command)` rendering so every normalized `requires`/`rejects` piece is parenthesized before conjunction.
- Preserve agreement between typed domain lowering and rendered-then-reparsed Kernel verification for the #690 false-green case.
- Tighten the regression evidence and correct accepted documentation after independent review.

Refs #690. Related: #664, #691, #640/#661.

## Changes

- Parenthesize each `can(...)` piece while retaining the outer grouping required under `not can(...)`.
- Register the truth-value-observable fixture in the two-path agreement corpus and retain only the still-open name-shadowing divergence.
- Assert that path B violates the generated form of the same `aImpliesCanOpen` property as path A.
- Correct renderer consumers to `domain expand` and `check_domain`; testgen/scaffold use the typed Public Kernel path.
- Update `docs/DESIGN-domain.md` to record the resolved precedence symptom and the remaining scope/generated-name and #691 divergences.
- Put the fixture SPDX header first and clean its temporary directory after the verdict test.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml -p fsl-core --test domain_render_agreement --locked` — 6 passed
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test issue_690_can_precedence_false_green --locked` — 2 passed
- Existing exact-head hosted checks before the review follow-up were green; new checks run for `b6fbb20`.
- Independent final re-review: no actionable findings.

The existing semantic-mutation job reports zero in-scope mutants for this renderer because `rust/.cargo/mutants.toml` excludes it. Calibration therefore remains the focused manual revert recorded by the regression test history, not a claim derived from that job.

## Risk / Review Notes

- This fixes #690 symptom 1 only. Scope-aware substitution and generated-name leakage remain open.
- #706 and #708 share `CHANGELOG.md`, `docs/DESIGN-domain.md`, and `rust/fsl-core/tests/domain_render_agreement.rs` review context. Merge #706 first, then rebase and retest #708 while preserving both fixture registrations, both changelog entries, #708's container-default controls, and #706's narrowed divergence fingerprint.
- No public schema, CLI flag, or migration changes.
