### PR TITLE
fix(domain): render typed container defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `expressions_valid.fsl` remains in `KNOWN_DIVERGENT_DOMAIN_FIXTURES` for
   the still-open name-shadowing symptom.
 
+- Fixed `domain expand`/`domain testgen`/`domain scaffold` producing an
+  ill-typed `= 0` initializer for domain state fields whose accepted container
+  type had no explicit default. The rendered lowering path now dispatches
+  exhaustively over the structured type expression: `Option<T>` initializes to
+  `none`, `Set<T>` to `Set {}`, and top-level `Map<K, V>` to the same dense
+  per-key `forall` initializer as the typed lowering path. New corpus fixtures
+  keep all three variants in the checked two-path agreement gate. Both paths
+  now also share enum declaration validation, so an empty enum nested anywhere
+  in those containers fails at its declaration instead of producing invalid
+  text or panicking (#691).
+
 - Added a standalone `site reference freshness` CI workflow
   (`.github/workflows/site-reference-freshness.yml`) that runs the
   pre-existing but previously unwired `tests/test_site_reference_snapshot.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `expressions_valid.fsl` remains in `KNOWN_DIVERGENT_DOMAIN_FIXTURES` for
   the still-open name-shadowing symptom.
 
-- Fixed `domain expand`/`domain testgen`/`domain scaffold` producing an
+- Fixed `domain check`/`domain expand` producing an
   ill-typed `= 0` initializer for domain state fields whose accepted container
   type had no explicit default. The rendered lowering path now dispatches
   exhaustively over the structured type expression: `Option<T>` initializes to
@@ -33,7 +33,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   keep all three variants in the checked two-path agreement gate. Both paths
   now also share enum declaration validation, so an empty enum nested anywhere
   in those containers fails at its declaration instead of producing invalid
-  text or panicking (#691).
+  text or panicking. Renderer failures now retain their source location and
+  name-resolution classification in the CLI JSON envelope (#691).
 
 - Added a standalone `site reference freshness` CI workflow
   (`.github/workflows/site-reference-freshness.yml`) that runs the
@@ -84,7 +85,7 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 - Added a corpus-wide agreement gate between `domain`'s two independent
   lowering paths: `lower_domain` (typed `KernelSpec`, used by `check`/
   `verify`) and `domain_kernel_source` (rendered `.fsl` text, used by
-  `domain expand`/`check_domain`/`domain testgen`/`domain scaffold`).
+  `domain expand` and `check_domain`).
   `rust/fsl-core/tests/domain_render_agreement.rs` projects both paths
   through `public_kernel_contract` for every domain spec in `examples/` and
   `rust/fslc/tests/fixtures/` and diffs the two structurally, excluding only

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -313,7 +313,7 @@ fixed the known `can(...)` precedence false green by parenthesizing each joined
 piece; its scope-aware substitution and generated-name symptoms remain open.
 `domain_render_agreement.rs`'s `KNOWN_DIVERGENT_DOMAIN_FIXTURES` pins the
 currently known instances as regression fixtures; #690 owns the remaining
-`Context::normalize` scope/precedence gap. #691 (a separate root cause --
+`Context::normalize` scope and generated-name gaps. #691 (a separate root cause --
 `Context::default` had a catch-all arm reachable for every container type,
 not `Context::normalize`'s substitution-order problem) is fixed:
 `Context::default`/`Context::default_for_type` are now total over the
@@ -324,6 +324,9 @@ all three affected shapes (`Option`, `Set`, `Map`) are registered in
 `VALID_DOMAIN_FIXTURES`. Enum declaration validation is shared ahead of both
 paths, so a container cannot hide an empty or duplicate enum until rendered
 kernel parsing; rejection is anchored at the enum declaration.
+The CLI keeps the renderer's typed location and name-resolution classification
+when it constructs that rejection envelope; it does not recover either from the
+formatted message.
 
 ## Future Work
 

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -312,8 +312,18 @@ cannot be scope-aware the way `lower_domain`'s typed AST composition is. #690
 fixed the known `can(...)` precedence false green by parenthesizing each joined
 piece; its scope-aware substitution and generated-name symptoms remain open.
 `domain_render_agreement.rs`'s `KNOWN_DIVERGENT_DOMAIN_FIXTURES` pins the
-currently known instances as regression fixtures; #690 and #691 own
-resolving them.
+currently known instances as regression fixtures; #690 owns the remaining
+`Context::normalize` scope/precedence gap. #691 (a separate root cause --
+`Context::default` had a catch-all arm reachable for every container type,
+not `Context::normalize`'s substitution-order problem) is fixed:
+`Context::default`/`Context::default_for_type` are now total over the
+field's `SyntaxTypeExprKind` with no catch-all, `Option<T>`/`Set<T>` render
+`none`/`Set {}`, and a top-level `Map<K, V>` state field renders the same
+dense per-key `forall` init `lower_domain` already generated. Fixtures for
+all three affected shapes (`Option`, `Set`, `Map`) are registered in
+`VALID_DOMAIN_FIXTURES`. Enum declaration validation is shared ahead of both
+paths, so a container cannot hide an empty or duplicate enum until rendered
+kernel parsing; rejection is anchored at the enum declaration.
 
 ## Future Work
 

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use fsl_syntax::{
     DomainAggregate, DomainEffect, DomainEvolve, DomainField, DomainLoc, DomainSaga,
     DomainSagaStep, DomainSpec, DomainType, DomainTypeSourceForm, SourcePos, Span, SyntaxExpr,
-    SyntaxExprKind,
+    SyntaxExprKind, SyntaxTypeExpr, SyntaxTypeExprKind,
 };
 
 use crate::{
@@ -14,6 +14,38 @@ use crate::{
         domain_effect_owns_event, effect_outcome_member, validate_effect_outcome_roles,
     },
 };
+
+/// Mirrors `compose.rs`'s `error_at`: a rendering-time failure located at a
+/// span in the *original* `DomainSpec` source (this module runs before any
+/// text serialization, so these spans are real, unlike the ones inside the
+/// ephemeral kernel text `domain_kernel_source` produces).
+fn error_at(message: impl Into<String>, span: Span) -> CoreError {
+    CoreError {
+        message: message.into(),
+        line: span.start.line,
+        column: span.start.column,
+        origin: None,
+        name_resolution: false,
+    }
+}
+
+/// If `type_name` is a top-level `Map<K, V>` application, its key and value
+/// type expressions; `None` for every other shape (including a malformed
+/// `Map` arity, which falls through to [`Context::default_for_type`]'s
+/// generic "unsupported domain type constructor" rejection instead of being
+/// treated as a renderable Map here).
+fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &SyntaxTypeExpr)> {
+    match &type_name.kind {
+        SyntaxTypeExprKind::Apply {
+            constructor,
+            arguments,
+        } if constructor.text == "Map" => match arguments.as_slice() {
+            [key, value] => Some((key, value)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
 
 fn synthetic_num(value: i64, loc: DomainLoc) -> SyntaxExpr {
     let position = SourcePos {
@@ -265,35 +297,115 @@ impl<'a> Context<'a> {
             .map(|candidate| candidate.type_name.render_source())
     }
 
-    fn default(&self, field: &DomainField, type_env: &BTreeMap<String, String>) -> String {
+    /// The field-level default: an explicit `= expr` wins; otherwise falls
+    /// through to [`Self::default_for_type`]'s total dispatch on the field's
+    /// type. Mirrors `domain_lowering.rs`'s `Resolver::default_value`
+    /// (field-level, checks for an explicit default) versus
+    /// `Resolver::default_for_type` (type-level, total).
+    fn default(
+        &self,
+        field: &DomainField,
+        type_env: &BTreeMap<String, String>,
+    ) -> Result<String, CoreError> {
         if let Some(value) = &field.default {
-            return self.normalize(
+            return Ok(self.normalize(
                 &value.render_source(),
                 None,
                 type_env,
                 Some(&field.type_name),
                 true,
-            );
+            ));
         }
-        match field.type_name.as_str() {
-            "Bool" => "false".to_owned(),
-            "Int" => "0".to_owned(),
-            _ => match self.ty(&field.type_name) {
-                Some(ty) if ty.kind == "enum" => self.enum_value(&ty.name, &ty.members[0]),
-                Some(ty) if matches!(ty.kind.as_str(), "range" | "external") => ty
-                    .lo
-                    .as_ref()
-                    .map_or_else(|| "0".to_owned(), SyntaxExpr::render_source),
-                Some(ty) if ty.kind == "value_object" => format!(
-                    "{} {{ {} }}",
-                    ty.name,
-                    ty.fields
-                        .iter()
-                        .map(|field| format!("{}: {}", field.name, self.default(field, type_env)))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
-                _ => "0".to_owned(),
+        self.default_for_type(&field.type_name, field.span, type_env)
+    }
+
+    /// Total dispatch over `SyntaxTypeExprKind` -- the same two-variant AST
+    /// enum `domain_lowering.rs`'s `LogicalType` is itself derived from --
+    /// with no catch-all arm that can produce a value. An unrecognized
+    /// `SyntaxTypeExprKind::Apply` constructor reaches the final named arm,
+    /// which returns [`CoreError`] (the same "unsupported domain type
+    /// constructor" message `domain_lowering.rs`'s
+    /// `logical_type`/`surface_type` already use for the identical case), not
+    /// a silently rendered `"0"`.
+    fn default_for_type(
+        &self,
+        type_name: &SyntaxTypeExpr,
+        span: Span,
+        type_env: &BTreeMap<String, String>,
+    ) -> Result<String, CoreError> {
+        match &type_name.kind {
+            SyntaxTypeExprKind::Name(ident) => match ident.text.as_str() {
+                "Bool" => Ok("false".to_owned()),
+                "Int" => Ok("0".to_owned()),
+                other => match self.ty(other) {
+                    Some(ty) if ty.kind == "enum" => {
+                        let Some(member) = ty.members.first() else {
+                            return Err(error_at(
+                                format!("enum '{}' has no members", ty.name),
+                                span,
+                            ));
+                        };
+                        Ok(self.enum_value(&ty.name, member))
+                    }
+                    Some(ty) if matches!(ty.kind.as_str(), "range" | "external") => Ok(ty
+                        .lo
+                        .as_ref()
+                        .map_or_else(|| "0".to_owned(), SyntaxExpr::render_source)),
+                    Some(ty) if ty.kind == "value_object" => Ok(format!(
+                        "{} {{ {} }}",
+                        ty.name,
+                        ty.fields
+                            .iter()
+                            .map(|field| Ok(format!(
+                                "{}: {}",
+                                field.name,
+                                self.default(field, type_env)?
+                            )))
+                            .collect::<Result<Vec<_>, CoreError>>()?
+                            .join(", ")
+                    )),
+                    // Only "enum" | "range" | "external" | "value_object" are
+                    // ever constructed (fsl-syntax's domain parser and this
+                    // crate's own "external" backfill for referenced names
+                    // are the only producers); a fifth kind string reaching
+                    // here is unrecognized and must fail closed, not render
+                    // "0".
+                    Some(ty) => Err(error_at(
+                        format!("unsupported domain type kind '{}'", ty.kind),
+                        span,
+                    )),
+                    None => Err(error_at(format!("unknown domain type '{other}'"), span)),
+                },
+            },
+            SyntaxTypeExprKind::Apply {
+                constructor,
+                arguments,
+            } => match (constructor.text.as_str(), arguments.as_slice()) {
+                ("Option", [_]) => Ok("none".to_owned()),
+                ("Set", [_]) => Ok("Set {}".to_owned()),
+                // A bare `Map` default (no top-level state-field forall
+                // context) is always rejected, matching
+                // `domain_lowering.rs`'s `default_for_type` Map arm exactly:
+                // the only supported Map default is the per-key `forall`
+                // form `domain_kernel_source`'s state-field loop builds
+                // directly, before this function is ever called on the
+                // Map's own type.
+                ("Map", [_, _]) => Err(error_at(
+                    "Map state requires explicit initialization through supported semantics",
+                    span,
+                )),
+                // Includes `Seq` (out of scope: path A already rejects Seq
+                // domain state at `surface_type`, before any default is
+                // requested) and any unrecognized constructor/arity -- both
+                // fail closed here instead of falling through to "0".
+                (unsupported_constructor, unsupported_arguments) => Err(error_at(
+                    format!(
+                        "unsupported domain type constructor '{}'/{}",
+                        unsupported_constructor,
+                        unsupported_arguments.len()
+                    ),
+                    span,
+                )),
             },
         }
     }
@@ -729,11 +841,14 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
 ///
 /// # Errors
 ///
-/// Returns [`CoreError`] when an effect event has conflicting explicit outcome roles.
+/// Returns [`CoreError`] when a domain declaration cannot be rendered into a
+/// valid executable kernel, including invalid enums and conflicting explicit
+/// effect outcome roles.
 #[allow(clippy::too_many_lines)]
 pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
     validate_effect_outcome_roles(domain)?;
     let context = Context::new(domain);
+    crate::domain_lowering::validate_domain_enums(&context.types)?;
     let mut lines = vec![format!(
         "spec {} \"domain: generated from fsl-domain/fsl-effect\" {{",
         domain.name
@@ -807,10 +922,42 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
         for field in &aggregate.state {
             let name = Context::state_name(aggregate, &field.name);
             state.push(format!("    {name}: {},", field.type_name));
-            init.push(format!(
-                "    {name} = {}",
-                context.default(field, &environment)
-            ));
+            match map_key_value(&field.type_name) {
+                Some((key, value)) => {
+                    // Mirrors `domain_lowering.rs`'s `expand_domain`
+                    // (~line 2182): a top-level Map state field with no
+                    // explicit default lowers to a dense per-key `forall`
+                    // init, and an explicit whole-Map default is rejected
+                    // here rather than rendered, matching path A's
+                    // "whole-Map domain defaults are not supported".
+                    if field.default.is_some() {
+                        return Err(error_at(
+                            "whole-Map domain defaults are not supported",
+                            field.span,
+                        ));
+                    }
+                    let key_type = match &key.kind {
+                        SyntaxTypeExprKind::Name(ident) => ident.text.clone(),
+                        SyntaxTypeExprKind::Apply { .. } => {
+                            return Err(error_at(
+                                "map keys require a scalar or named type",
+                                field.span,
+                            ));
+                        }
+                    };
+                    let value_default =
+                        context.default_for_type(value, field.span, &environment)?;
+                    init.push(format!(
+                        "    forall k: {key_type} {{ {name}[k] = {value_default} }}"
+                    ));
+                }
+                None => {
+                    init.push(format!(
+                        "    {name} = {}",
+                        context.default(field, &environment)?
+                    ));
+                }
+            }
         }
     }
     let mut events = domain

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -9,22 +9,41 @@ use fsl_syntax::{
 };
 
 use crate::{
-    CoreError,
+    CoreError, LoweringStep, OriginChain, OriginId, OriginSite,
     domain_lowering::{
         domain_effect_owns_event, effect_outcome_member, validate_effect_outcome_roles,
     },
 };
 
-/// Mirrors `compose.rs`'s `error_at`: a rendering-time failure located at a
-/// span in the *original* `DomainSpec` source (this module runs before any
-/// text serialization, so these spans are real, unlike the ones inside the
-/// ephemeral kernel text `domain_kernel_source` produces).
+/// A rendering-time failure located at a span in the original `DomainSpec`.
+///
+/// This module runs before text serialization, so both the public location and
+/// the internal origin chain point at authored domain source rather than the
+/// ephemeral Kernel text produced by [`domain_kernel_source`].
 fn error_at(message: impl Into<String>, span: Span) -> CoreError {
     CoreError {
         message: message.into(),
         line: span.start.line,
         column: span.start.column,
-        origin: None,
+        origin: Some(Box::new(OriginChain {
+            id: OriginId(format!(
+                "domain:render-error:{}:{}",
+                span.start.offset, span.end.offset
+            )),
+            dialect: "domain".to_owned(),
+            primary: Some(OriginSite {
+                source_file: None,
+                span: Some(span),
+                dialect: "domain".to_owned(),
+                declaration_path: Vec::new(),
+            }),
+            secondary: Vec::new(),
+            lowering_steps: vec![LoweringStep {
+                kind: "render_domain_kernel_source".to_owned(),
+                detail: None,
+            }],
+            generated: false,
+        })),
         name_resolution: false,
     }
 }

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -71,6 +71,31 @@ fn error_at(message: impl Into<String>, span: Span) -> CoreError {
     }
 }
 
+pub(crate) fn validate_domain_enums(types: &[DomainType]) -> Result<(), CoreError> {
+    for ty in types {
+        if ty.kind != "enum" {
+            continue;
+        }
+        if ty.members.is_empty() {
+            return Err(error_at(
+                format!("enum '{}' has no members", ty.name),
+                ty.span,
+            ));
+        }
+        let mut seen = BTreeSet::new();
+        for (index, member) in ty.members.iter().enumerate() {
+            if !seen.insert(member) {
+                return Err(error_at(
+                    format!("duplicate enum member '{member}' in '{}'", ty.name),
+                    ty.member_spans.get(index).copied().unwrap_or(ty.span),
+                )
+                .into_name_resolution());
+            }
+        }
+    }
+    Ok(())
+}
+
 fn span_at(loc: DomainLoc) -> Span {
     loc.span()
 }
@@ -1854,27 +1879,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn validate_document_expressions(&self) -> Result<(), CoreError> {
-        for ty in &self.types {
-            if ty.kind != "enum" {
-                continue;
-            }
-            if ty.members.is_empty() {
-                return Err(error_at(
-                    format!("enum '{}' has no members", ty.name),
-                    ty.span,
-                ));
-            }
-            let mut seen = BTreeSet::new();
-            for (index, member) in ty.members.iter().enumerate() {
-                if !seen.insert(member) {
-                    return Err(error_at(
-                        format!("duplicate enum member '{member}' in '{}'", ty.name),
-                        ty.member_spans.get(index).copied().unwrap_or(ty.span),
-                    )
-                    .into_name_resolution());
-                }
-            }
-        }
+        validate_domain_enums(&self.types)?;
         for ty in &self.types {
             if ty.kind != "value_object" {
                 continue;

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -122,7 +122,9 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
     "examples/domain/unsafe_irreversible_effect_without_idempotency.fsl",
     "rust/fslc/tests/fixtures/domain_canonical_enum.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/can_expansion_precedence.fsl",
+    "rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl",
+    "rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl",
     "rust/fslc/tests/fixtures/domain_legacy_enum_union.fsl",
     "rust/fslc/tests/fixtures/domain_origin_violation.fsl",
     "rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl",
@@ -137,6 +139,7 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
 /// `domain_kernel_source` -> `parse_kernel_source` -> `build_model`) because
 /// they are semantically invalid (type mismatch / unknown symbol).
 const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
+    "rust/fslc/tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl",
@@ -161,6 +164,14 @@ enum DivergenceShape {
     PathARejects,
     /// The `domain_kernel_source` pipeline (path B) rejects; `lower_domain`
     /// (path A) accepts and produces a checked model.
+    ///
+    /// No [`KNOWN_DIVERGENT_DOMAIN_FIXTURES`] entry currently has this shape
+    /// (the sole example, `lvalues_surface.fsl` / #691, was fixed and moved
+    /// to [`VALID_DOMAIN_FIXTURES`]) -- kept for the next fixture that needs
+    /// it, since `known_divergent_domain_fixture_pins_the_open_finding` and
+    /// `assert_rejection_pinned` are already written generically over this
+    /// enum's full three-shape taxonomy.
+    #[allow(dead_code)]
     PathBRejects,
     /// Both paths accept and produce a checked model, but the two
     /// `public_kernel_contract` projections are not structurally equal.
@@ -197,19 +208,22 @@ struct KnownDivergence {
 /// a review transcript (AGENTS.md: "do not let the finding survive only in
 /// chat, a review transcript, or agent memory").
 ///
-/// **#690** <https://github.com/ymm-oss/fsl/issues/690> covers entries 1 and
-/// 3 below as one root cause: `domain.rs`'s `Context::normalize`
+/// **#690** <https://github.com/ymm-oss/fsl/issues/690> covers both entries
+/// below as one root cause: `domain.rs`'s `Context::normalize`
 /// (`rust/fsl-core/src/domain.rs:301`) is a chain of `str::replace` calls
 /// over rendered text with no syntax tree, so it cannot be scope-aware
-/// (entry 3's `quantity` shadowing) or precedence-aware (entry 3's
+/// (entry 2's `quantity` shadowing) or precedence-aware (entry 2's
 /// `can(...)` expansion) the way a typed AST composition can. Entry 1's
 /// generated-name leak is a symptom of the same string-level substitution
 /// having no notion of what is and is not a legal domain-level reference.
 ///
-/// **#691** <https://github.com/ymm-oss/fsl/issues/691> covers entry 2: a
-/// separate root cause, a missing match arm in `Context::default` rather
-/// than a substitution-order problem, and it fails loudly (a type error)
-/// rather than silently.
+/// **#691** <https://github.com/ymm-oss/fsl/issues/691> covered a third,
+/// now-resolved entry (`lvalues_surface.fsl`, a `Map<K, V>` domain state
+/// field with no explicit default): a missing match arm in
+/// `Context::default` rather than a substitution-order problem, fixed by
+/// making `Context::default`/`Context::default_for_type` total over
+/// `SyntaxTypeExprKind` with no catch-all arm. The two paths now agree on
+/// that fixture; it has moved to [`VALID_DOMAIN_FIXTURES`].
 ///
 /// 1. `ai_internal_name_misuse.fsl` writes the invariant
 ///    `status == Status_Draft`, directly naming the *generated*
@@ -231,26 +245,7 @@ struct KnownDivergence {
 ///    produced, so the rendered text parses and type-checks as an ordinary
 ///    valid kernel spec.
 ///
-/// 2. `lvalues_surface.fsl` declares `counts: Map<ItemId, Quantity>;` with
-///    no explicit default. `lower_domain` (path A,
-///    `rust/fsl-core/src/domain_lowering.rs` around line 2182) has an
-///    explicit `LogicalType::Map` case for aggregate state fields: it
-///    generates a `forall k: ItemId { inventory_counts[k] = 0 }` init
-///    statement, a well-typed dense-map default. `domain_kernel_source`'s
-///    `Context::default` (path B, `rust/fsl-core/src/domain.rs` around line
-///    268) has no `Map` case at all: `field.type_name.as_str()` is not
-///    `"Bool"`/`"Int"`, and `self.ty("Map<ItemId, Quantity>")` never matches
-///    a registered named type, so it falls through to the generic
-///    `_ => "0".to_owned()` default and renders `inventory_counts = 0` --
-///    which then fails `build_model` with
-///    `expression of type Int is not assignable to Map(...)`. This gap was
-///    previously invisible because the only existing coverage of this
-///    fixture's rendered text
-///    (`rust/fslc/tests/domain_expression_characterization.rs::generated_fragments`)
-///    greps for line substrings and never re-parses or type-checks the
-///    rendered source.
-///
-/// 3. `expressions_valid.fsl` both paths accept, but the projected
+/// 2. `expressions_valid.fsl` both paths accept, but the projected
 ///    contracts still disagree at one point (name-shadowing, #690 symptom
 ///    2). A second point that used to disagree here -- `can(...)`
 ///    operator-precedence misgrouping, #690 symptom 1 -- was fixed and is
@@ -315,12 +310,6 @@ const KNOWN_DIVERGENT_DOMAIN_FIXTURES: &[KnownDivergence] = &[
         shape: DivergenceShape::PathARejects,
         expected_contains: &["unknown domain symbol 'Status_Draft'"],
         tracking_issue: "https://github.com/ymm-oss/fsl/issues/690",
-    },
-    KnownDivergence {
-        fixture: "rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl",
-        shape: DivergenceShape::PathBRejects,
-        expected_contains: &["is not assignable to Map"],
-        tracking_issue: "https://github.com/ymm-oss/fsl/issues/691",
     },
     KnownDivergence {
         fixture: "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
@@ -662,7 +651,11 @@ fn run_path_b(domain: &DomainSpec) -> PipelineOutcome {
         Ok(source) => source,
         Err(error) => return PipelineOutcome::Rejected(error.to_string()),
     };
-    let kernel = match parse_kernel_source(&source, &FsResolver::new(".")) {
+    run_rendered_kernel(&source)
+}
+
+fn run_rendered_kernel(source: &str) -> PipelineOutcome {
+    let kernel = match parse_kernel_source(source, &FsResolver::new(".")) {
         Ok(kernel) => kernel,
         Err(error) => return PipelineOutcome::Rejected(error.to_string()),
     };
@@ -675,6 +668,89 @@ fn run_path_b(domain: &DomainSpec) -> PipelineOutcome {
 // ---------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------
+
+/// #691's rejecting controls: reintroducing the former `= 0` rendering for
+/// any accepted container default must be detected before an agreement claim
+/// can be made. Each case starts from the real path-B output, applies only the
+/// historical faulty initializer, and proves the checked kernel rejects it.
+#[test]
+fn container_default_zero_regressions_are_rejected() {
+    let root = repo_root();
+    let cases = [
+        (
+            "rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl",
+            "basket_picked = none",
+            "basket_picked = 0",
+        ),
+        (
+            "rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl",
+            "basket_seen = Set {}",
+            "basket_seen = 0",
+        ),
+        (
+            "rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl",
+            "forall k: ItemId { inventory_counts[k] = 0 }",
+            "inventory_counts = 0",
+        ),
+    ];
+
+    for (relative, accepted, faulty) in cases {
+        let source = fs::read_to_string(root.join(relative))
+            .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+        let domain = parse_domain_spec(&source).unwrap_or_else(|error| {
+            panic!("{relative}: expected a parseable domain document: {error}")
+        });
+        let rendered = domain_kernel_source(&domain)
+            .unwrap_or_else(|error| panic!("{relative}: render path B: {error}"));
+        assert!(
+            rendered.contains(accepted),
+            "{relative}: accepting control '{accepted}' is absent from path-B output"
+        );
+        let faulty_source = rendered.replacen(accepted, faulty, 1);
+        match run_rendered_kernel(&faulty_source) {
+            PipelineOutcome::Rejected(message) => assert!(
+                message.contains("is not assignable"),
+                "{relative}: faulty initializer '{faulty}' was rejected for an unexpected reason: {message}"
+            ),
+            PipelineOutcome::Checked(..) => {
+                panic!("{relative}: faulty initializer '{faulty}' produced a checked kernel")
+            }
+        }
+    }
+}
+
+/// Rejected declaration control for every affected container position. Empty
+/// enums are parseable surface ASTs but cannot produce an executable kernel;
+/// both paths must reject at the enum declaration before path B serializes
+/// invalid text, independent of whether the enum is direct, nested, a Map
+/// key, or a Map value.
+#[test]
+fn empty_enum_declarations_fail_closed_before_rendering() {
+    let source = r"
+domain EmptyEnumContainers {
+  enum Status {}
+  aggregate A {
+    state {
+      direct: Status;
+      optional: Option<Status>;
+      members: Set<Status>;
+      keyed: Map<Status, Bool>;
+      by_key: Map<Bool, Status>;
+    }
+  }
+}
+";
+
+    let domain = parse_domain_spec(source).expect("parse empty-enum domain");
+    let enum_span = domain.types[0].span;
+    let path_a = lower_domain(&domain).expect_err("typed path must reject empty enum");
+    let path_b = domain_kernel_source(&domain).expect_err("renderer must reject empty enum");
+    for (path, error) in [("path A", path_a), ("path B", path_b)] {
+        assert_eq!(error.message, "enum 'Status' has no members", "{path}");
+        assert_eq!(error.line, enum_span.start.line, "{path}");
+        assert_eq!(error.column, enum_span.start.column, "{path}");
+    }
+}
 
 #[test]
 fn syntax_invalid_domain_fixtures_fail_to_parse() {

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -10,8 +10,9 @@
 //!   typed [`fsl_core::KernelSpec`] directly. `check`/`verify` use this path.
 //! - path B: [`fsl_core::domain_kernel_source`] (`domain.rs`) renders the
 //!   same `DomainSpec` to `.fsl` **text**, which is then re-parsed with
-//!   [`fsl_core::parse_kernel_source`] into a `KernelSpec`. `domain expand`,
-//!   `domain testgen`, `domain scaffold`, and `check_domain` use this path.
+//!   [`fsl_core::parse_kernel_source`] into a `KernelSpec`. `domain expand`
+//!   and `check_domain` use the renderer in production; this gate additionally
+//!   re-parses its output so the comparison reaches a checked model.
 //!
 //! Before this file, no test checked that the two paths produce the same
 //! checked model for any spec, so a rule fixed on one side (e.g. PR #661)
@@ -139,6 +140,7 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
 /// `domain_kernel_source` -> `parse_kernel_source` -> `build_model`) because
 /// they are semantically invalid (type mismatch / unknown symbol).
 const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
+    "rust/fslc/tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl",
@@ -237,7 +239,7 @@ struct KnownDivergence {
 ///    `generated-enum-name-check-gap`, `misuse.internal_generated_name: 1`):
 ///    domain-level code must not reference compiler-generated names.
 ///    `domain_kernel_source` (path B -- what `domain expand` /
-///    `check_domain` / `domain testgen` / `domain scaffold` run) does not
+///    `check_domain` run) does not
 ///    reject it: its textual substitution only rewrites *bare* enum member
 ///    names it recognizes (`Draft` -> `Status_Draft`); the already-qualified
 ///    name the fixture writes is left untouched, and happens to be
@@ -716,6 +718,83 @@ fn container_default_zero_regressions_are_rejected() {
                 panic!("{relative}: faulty initializer '{faulty}' produced a checked kernel")
             }
         }
+    }
+}
+
+/// Rejecting controls for every fail-closed branch added by #691. These are
+/// intentionally separate cases: a single invalid fixture would stop at its
+/// first error and leave the later type-shape branches uncalibrated.
+#[test]
+fn unsupported_default_shapes_fail_closed_with_original_origins() {
+    let cases = [
+        (
+            "nested Map value",
+            "Map<Id, Map<Id, Id>>",
+            "",
+            "Map state requires explicit initialization through supported semantics",
+        ),
+        (
+            "Seq state",
+            "Seq<Id>",
+            "",
+            "unsupported domain type constructor 'Seq'/1",
+        ),
+        (
+            "unknown constructor",
+            "Bag<Id>",
+            "",
+            "unsupported domain type constructor 'Bag'/1",
+        ),
+        (
+            "malformed Map arity",
+            "Map<Id>",
+            "",
+            "unsupported domain type constructor 'Map'/1",
+        ),
+        (
+            "explicit whole-Map default",
+            "Map<Id, Id>",
+            " = 0",
+            "whole-Map domain defaults are not supported",
+        ),
+        (
+            "non-scalar Map key",
+            "Map<Option<Id>, Id>",
+            "",
+            "map keys require a scalar or named type",
+        ),
+    ];
+
+    for (label, type_name, explicit_default, expected) in cases {
+        let source = format!(
+            "domain InvalidDefaultShape {{\n  type Id = 0..1\n  aggregate A {{\n    state {{\n      value: {type_name}{explicit_default};\n    }}\n  }}\n}}\n"
+        );
+        let domain = parse_domain_spec(&source)
+            .unwrap_or_else(|error| panic!("{label}: expected parseable domain: {error}"));
+        let field_span = domain.aggregates[0].state[0].span;
+        let Err(error) = domain_kernel_source(&domain) else {
+            panic!("{label}: renderer unexpectedly accepted invalid shape");
+        };
+        assert_eq!(error.message, expected, "{label}");
+        assert_eq!(
+            (error.line, error.column),
+            (field_span.start.line, field_span.start.column),
+            "{label}"
+        );
+        let origin = error
+            .origin
+            .as_deref()
+            .unwrap_or_else(|| panic!("{label}: renderer discarded the domain origin"));
+        assert_eq!(
+            origin.primary.as_ref().and_then(|site| site.span),
+            Some(field_span),
+            "{label}"
+        );
+        assert_eq!(origin.lowering_steps.len(), 1, "{label}");
+        assert_eq!(
+            origin.lowering_steps[0].kind, "render_domain_kernel_source",
+            "{label}"
+        );
     }
 }
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6811,7 +6811,7 @@ fn run_domain_check(
     let result = match fsl_tools::check_domain(&domain, &fslc_rust::outcome::project_kernel(kernel))
     {
         Ok(result) => wrap_specialized(result),
-        Err(error) => (semantic_error_output(&error.to_string()), 2),
+        Err(error) => (core_error_output(&error), 2),
     };
     apply_domain_edition(result, path, path, edition)
 }
@@ -6830,7 +6830,7 @@ fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
     };
     let source = match fsl_tools::domain_kernel_source(&domain) {
         Ok(source) => source,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => return (core_error_output(&error), 2),
     };
     if let Some(output_path) = output_path
         && let Err(error) = std::fs::write(output_path, &source)
@@ -15817,6 +15817,18 @@ fn normalized_exit_status(output: &Value, reported_status: i32) -> i32 {
 
 fn semantic_error_output(message: &str) -> Value {
     fslc_rust::verification_output::render_semantic_error(envelope(), message, None, false)
+}
+
+/// Render a core frontend/lowering diagnostic without discarding its typed
+/// location or name-resolution classification at a command boundary.
+fn core_error_output(error: &fsl_core::CoreError) -> Value {
+    let diagnostic = SemanticDiagnostic::from_core_error(error);
+    fslc_rust::verification_output::render_semantic_error(
+        envelope(),
+        &diagnostic.message,
+        diagnostic.loc,
+        diagnostic.name_resolution,
+    )
 }
 
 /// Render a typed-model failure with the location the model recorded for the

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -76,6 +76,17 @@ impl SemanticDiagnostic {
         }
     }
 
+    /// A core-lowering failure, preserving both its lowering origin and the
+    /// frontend's name-resolution classification.
+    #[must_use]
+    pub fn from_core_error(error: &fsl_core::CoreError) -> Self {
+        Self {
+            message: error.to_string(),
+            loc: crate::verification_output::origin_loc(error.origin.as_deref()),
+            name_resolution: error.name_resolution,
+        }
+    }
+
     /// A typed-model failure, located by the span it recorded for itself or by
     /// its enclosing construct's lowering origin, and classified by whether it
     /// was resolving a name.
@@ -134,10 +145,7 @@ pub fn kernel_load_error(source: &str, error: &fsl_core::CoreError) -> SpecLoadE
     if error.message == "top-level document has not reached the kernel lowering gate" {
         return SpecLoadError::Semantic(SemanticDiagnostic::unlocated("spec has no state block"));
     }
-    SpecLoadError::Semantic(SemanticDiagnostic::located(
-        error.to_string(),
-        error.origin.as_deref(),
-    ))
+    SpecLoadError::Semantic(SemanticDiagnostic::from_core_error(error))
 }
 
 /// Render a classified spec-load failure into the public error envelope.

--- a/rust/fslc/tests/domain_origin_diagnostics.rs
+++ b/rust/fslc/tests/domain_origin_diagnostics.rs
@@ -17,6 +17,11 @@ fn fixture() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/domain_origin_violation.fsl")
 }
 
+fn empty_enum_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl")
+}
+
 fn run(arguments: &[String]) -> (Value, i32) {
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args(arguments)
@@ -30,6 +35,20 @@ fn run(arguments: &[String]) -> (Value, i32) {
         )
     });
     (value, output.status.code().expect("exit status"))
+}
+
+#[test]
+fn domain_expand_rejects_empty_enum_at_its_declaration() {
+    let path = empty_enum_fixture();
+    let (output, status) = run(&[
+        "domain".to_owned(),
+        "expand".to_owned(),
+        path.to_string_lossy().into_owned(),
+    ]);
+    assert_eq!(status, 2);
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "semantics");
+    assert_eq!(output["message"], "enum 'Status' has no members at 4:3");
 }
 
 #[test]

--- a/rust/fslc/tests/domain_origin_diagnostics.rs
+++ b/rust/fslc/tests/domain_origin_diagnostics.rs
@@ -22,6 +22,11 @@ fn empty_enum_fixture() -> PathBuf {
         .join("tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl")
 }
 
+fn duplicate_enum_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl")
+}
+
 fn run(arguments: &[String]) -> (Value, i32) {
     let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
         .args(arguments)
@@ -49,6 +54,46 @@ fn domain_expand_rejects_empty_enum_at_its_declaration() {
     assert_eq!(output["result"], "error");
     assert_eq!(output["kind"], "semantics");
     assert_eq!(output["message"], "enum 'Status' has no members at 4:3");
+    assert_eq!(output["loc"], serde_json::json!({"line": 4, "column": 3}));
+}
+
+#[test]
+fn domain_expand_preserves_duplicate_enum_name_classification_and_location() {
+    let path = duplicate_enum_fixture();
+    let (output, status) = run(&[
+        "domain".to_owned(),
+        "expand".to_owned(),
+        path.to_string_lossy().into_owned(),
+    ]);
+    assert_eq!(status, 2);
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "name");
+    assert_eq!(
+        output["message"],
+        "duplicate enum member 'Draft' in 'Status' at 4:24"
+    );
+    assert_eq!(output["loc"], serde_json::json!({"line": 4, "column": 24}));
+}
+
+#[test]
+fn domain_check_preserves_duplicate_enum_name_classification_and_location() {
+    let path = duplicate_enum_fixture();
+    let (output, status) = run(&[
+        "domain".to_owned(),
+        "check".to_owned(),
+        path.to_string_lossy().into_owned(),
+    ]);
+    assert_eq!(status, 2);
+    assert_eq!(output["result"], "error");
+    assert_eq!(output["kind"], "name");
+    assert_eq!(
+        output["message"],
+        format!(
+            "duplicate enum member 'Draft' in 'Status' at {}:4:24",
+            path.display()
+        )
+    );
+    assert_eq!(output["loc"], serde_json::json!({"line": 4, "column": 24}));
 }
 
 #[test]

--- a/rust/fslc/tests/fixtures/domain_characterization/README.md
+++ b/rust/fslc/tests/fixtures/domain_characterization/README.md
@@ -9,9 +9,21 @@ an intentional semantic or diagnostic change has been accepted and documented.
 - `expressions_valid.fsl` covers canonical logical operators and legacy `->`, bare
   enum members, finite membership, `can(Command)`, aggregate state references,
   scalar/field assignments, defaults, invariants, and stale-policy expressions.
-- `lvalues_surface.fsl` covers root, index, and field lvalue parsing. Its current
-  Map-state lowering limitation is intentionally characterized as a failure.
+- `lvalues_surface.fsl` covers root, index, and field lvalue parsing, including a
+  `Map<K, V>` domain state field with no explicit default (issue #691: fixed --
+  `Context::default_for_type` in `rust/fsl-core/src/domain.rs` is now total over
+  the field's `SyntaxTypeExprKind`, and the top-level state-field loop in
+  `domain_kernel_source` renders the same dense per-key `forall` init
+  `domain_lowering.rs`'s path A already generated).
+- `container_defaults_surface.fsl` covers `Option<T>`/`Set<T>` domain state
+  fields with no explicit default (issue #691's other two affected variants;
+  registered in `rust/fsl-core/tests/domain_render_agreement.rs`'s
+  `VALID_DOMAIN_FIXTURES` so the two lowering paths' agreement on this shape
+  stays gated, not just this corpus's own characterization).
 - `effect_saga_valid.fsl` covers expressions used by effect and saga lowering.
+- `invalid_empty_enum_containers.fsl` is the rejecting control that keeps empty
+  enum validation ahead of both typed lowering and rendered-kernel generation,
+  including direct, `Option`, `Set`, Map-key, and Map-value positions.
 - `on_stale` is captured in the surface projection only because current domain
   lowering omits it; this corpus records that gap without accepting it as the
   intended language contract.

--- a/rust/fslc/tests/fixtures/domain_characterization/README.md
+++ b/rust/fslc/tests/fixtures/domain_characterization/README.md
@@ -24,6 +24,9 @@ an intentional semantic or diagnostic change has been accepted and documented.
 - `invalid_empty_enum_containers.fsl` is the rejecting control that keeps empty
   enum validation ahead of both typed lowering and rendered-kernel generation,
   including direct, `Option`, `Set`, Map-key, and Map-value positions.
+- `invalid_duplicate_enum.fsl` keeps the repeated member's original location
+  and `name` diagnostic classification across both the `domain expand`
+  renderer boundary and the `domain check` load path.
 - `on_stale` is captured in the surface projection only because current domain
   lowering omits it; this corpus records that gap without accepting it as the
   intended language contract.

--- a/rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+domain DomainContainerDefaultsCharacterization {
+  type ItemId = 0..1
+
+  aggregate Basket {
+    id ItemId
+    state {
+      picked: Option<ItemId>;
+      seen: Set<ItemId>;
+    }
+    command Pick { item: ItemId }
+    event Picked { item: ItemId }
+    decide Pick { emits Picked }
+    evolve Picked {
+      picked = some(item)
+      seen = seen.add(item)
+    }
+    invariant pickedIsSeen { picked != none => seen.size() >= 1 }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+domain InvalidDuplicateEnum {
+  enum Status { Draft, Draft }
+
+  aggregate A {
+    state { status: Status; }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+domain InvalidEmptyEnumContainers {
+  enum Status {}
+
+  aggregate A {
+    state {
+      direct: Status;
+      optional: Option<Status>;
+      members: Set<Status>;
+      keyed: Map<Status, Bool>;
+      by_key: Map<Bool, Status>;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Render well-typed implicit defaults for accepted `Option<T>`, `Set<T>`, and top-level `Map<K, V>` domain state fields.
- Keep rendered Kernel source aligned with authoritative typed domain lowering and fail closed for unsupported shapes.
- Preserve typed source locations and `name`/`semantics` classification across both `domain expand` and `domain check` error paths.

Closes #691.

## Contract and implementation

- Replace the value-producing `0` fallback with total structured-type dispatch.
- Render `none`, `Set {}`, and dense per-key Map initialization as required by the typed Kernel contract.
- Share enum declaration validation between typed lowering and Kernel-source rendering.
- Attach authored-domain origins to renderer failures and retain `CoreError.name_resolution` in CLI load diagnostics.
- Add separate rejecting controls for nested Map values, Seq/unknown constructors, malformed arity, whole-Map defaults, invalid Map keys, empty enums, and duplicate enum members.
- Correct the accepted design and changelog to identify the actual renderer consumers.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml -p fsl-core --test domain_render_agreement --test domain_lowering --locked` (25 passed)
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test domain_origin_diagnostics --locked` (6 passed)
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test domain_expression_characterization --locked` (3 passed)
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test issue_484_parse_diagnostic_matrix --locked` (9 passed)
- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-core -p fslc-rust --all-targets --locked -- -D warnings`
- Independent review caught and verified fixes for renderer origin loss, CLI classification loss, missing rejecting controls, and incorrect consumer documentation; final re-review found no actionable findings.

`./tools/check-native-integration.sh` previously ran for more than one hour without an observed failure through the workspace suite, including the changed domain tests, corpus sweeps, parity checks, mutation controls, and typed agreement. It was stopped during final doc-test/tail stages, so this is **not** a completed local product-gate pass and has no successful final exit status. Hosted CI supplies the complete evidence.

## Risk and follow-up

- No public JSON schema, flag, or migration changes.
- Invalid empty or duplicate enum declarations now return exit code 2 with their authored location; duplicate members retain `kind:"name"` in both affected CLI paths.
- The implementation-local-optima audit classified duplicated semantic ownership between typed lowering and text rendering as a mixed externalization/time-delayed local optimum (11/15, C3). This PR is a bounded correctness fix, not the structural consolidation.
- Merge #706 first, then rebase and retest this PR while preserving both fixture registrations, both changelog entries, #706's narrowed precedence divergence, and this PR's container-default/diagnostic controls.
- #690 remains open for scope-aware substitution and generated-name leakage after #706 resolves its precedence false green.
