### PR TITLE
feat(skills): add the pr-review orchestration skill; exempt agent-config-only PRs from the pre-merge product gate

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: pr-review
+description: Independently review a pull request that resolves an issue. Reconstructs the issue contract from repository evidence, dispatches the specialized FSL reviewer agents in parallel, audits the diff for green-faking, reproduces verification claims, and delivers a severity-ranked verdict without merging.
+---
+
+# Review a pull request
+
+Orchestrate an independent review of a pull request, typically one authored by an agent to
+resolve an issue. This skill is the coordination layer; the per-dimension analysis belongs to
+the specialized read-only reviewer agents under `.claude/agents/`. Diagnose and report — do not
+push fixes onto the branch, and never merge (leave the PR open for human review).
+
+Inputs: a PR number or branch, and the linked issue. If no issue is linked, ask for the intended
+contract before reviewing.
+
+Lenses that apply to every phase:
+
+- Trust order per `AGENTS.md`: contracts and tests, then the Rust implementation, then frozen
+  Python behavior, then prose. The PR description and any implementer conversation are claims,
+  not evidence.
+- Suspect green. A confidently green false negative is more dangerous than a crash, so "the
+  checks pass" is never sufficient on its own.
+- Findings outside the diff still carry a reporting duty: an accepted construct with absent,
+  placeholder, or hollow semantics is a soundness defect wherever it is found.
+
+## Phase 0 — Reconstruct the contract
+
+1. Read the PR (`gh pr view`, `gh pr diff`), the linked issue, and any `docs/DESIGN-*.md` the
+   change touches or should have touched.
+2. Restate, from the issue and repository evidence only: the requested outcome, the affected
+   authority surface, the invariants at risk, and the verification the change needs.
+3. Note which CI lanes actually ran. `merge readiness` is a bounded fail-fast lane
+   (`docs/DESIGN-ci.md`), not product verification — record what remains unverified.
+
+## Phase 1 — Contract alignment
+
+Map the issue's acceptance criteria to the diff in both directions:
+
+- Required but missing: criteria with no corresponding change or test.
+- Present but not required: scope creep, speculative fallbacks, compatibility work no contract
+  calls for.
+
+Check authority placement: new behavior lives under `rust/`, not the frozen `src/fslc/`; design
+decisions are backed by an accepted design note; the change is the smallest contract-preserving
+one.
+
+## Phase 2 — Dispatch the specialized reviewers
+
+Select every applicable reviewer from the table and launch the selected ones in parallel. Each
+returns compact findings; do not re-run their file-level sweeps in the main thread.
+
+The reviewer agents have tight turn budgets and routinely exhaust them mid-exploration. In each
+dispatch prompt: point the agent at a checkout of the PR's tree (create one with
+`git worktree add <scratchpad>/prNNN <head-ref> --detach`; remove it after the review), state
+the base commit for diffing, enumerate the audit items, and instruct the agent to reserve budget
+for the final report — evidence gathered but never reported is wasted. If an agent still stops
+without a report, resume it with a "produce your final report now" message instead of
+re-launching it.
+
+| Diff touches | Reviewer agent |
+| --- | --- |
+| Grammar, lowering, CLI commands, public Kernel/JSON contracts, docs, corpus specs | `fsl-coupled-change-reviewer` |
+| `fsl-core`, `fsl-runtime`, `fsl-verifier`, `fsl-solver*`, refinement or dialect semantics | `fsl-soundness-reviewer` |
+| `.fsl` files under `specs/` or `examples/` | `fsl-vacuity-reviewer` |
+
+A language-feature change dispatches the coupled-change reviewer even when the diff looks
+complete — the coupled-change list (LSP index, `LANGUAGE.ja.md` alignment, dialect registry,
+changelog) is exactly what implementers forget.
+
+## Phase 3 — Green-faking audit
+
+On the diff itself, in the main thread, check for changes that make checks pass without
+honoring the contract:
+
+- A `.fsl` spec, property, or invariant weakened relative to the base branch.
+- Hand-edited generated snapshots, or snapshots regenerated without an intentional contract
+  change to justify the diff.
+- Growth in an allowlist, exclusion, or known-divergence list (`tests/dialect_registry.py`
+  entries, `KNOWN_DIVERGENT_*` fixtures, skip markers) presented as a fix.
+- Errors suppressed, downgraded, or swallowed instead of resolved.
+- Test assertions loosened, deleted, or rewritten to follow the new behavior without evidence
+  the new behavior is the contract.
+- New positive-path tests with no negative control — a test suite that cannot reject a known
+  contract-violating variant proves nothing about drift detection.
+- Weak assertions: each new test must verify through the strongest available oracle (re-parse,
+  type-check, `build_model`, exact message/location/exit code), not substring or line-presence
+  matching. Issue #691 survived characterization tests precisely because they matched substrings
+  without re-parsing the rendered output. Ask of every new test: would it have caught the bug it
+  claims to prevent?
+
+## Phase 4 — Reproduce verification claims
+
+Re-run the narrowest relevant tests and `fslc` commands yourself in the PR's worktree state and
+compare observed output with the PR body's claims. Do not accept a pass that was only planned,
+only claimed, or only observed in an earlier tree state. Delegate verbose or ambiguous failure
+output to `fsl-test-diagnostician` and keep exact commands, exit codes, and failing test names.
+
+## Phase 4b — Adversarial verification (soundness-critical PRs)
+
+When the central change touches verifier, lowering, or dialect semantics, reproduced green is
+still the implementer's chosen evidence. Add evidence the implementer did not choose:
+
+1. **Novel inputs.** Author 2–3 new `.fsl` fixtures that exercise edge shapes the PR's own tests
+   avoid (adjacent type constructors, generated names, boundary arities, nesting the fix does
+   not demonstrate). Run them through the strongest oracle on the PR tree — for two-path
+   surfaces, execute both paths and compare verdicts, not text. Prompt the authoring agent to
+   refute the PR's claim, not to confirm it. Keep these fixtures in the review packet; promote
+   any that find a divergence into the PR's regression suite as a requested change.
+2. **Live mutation of the negative control.** For the PR's central fix, revert or corrupt the
+   fixed arm in the scratch checkout and observe the claimed guard test actually fail. A
+   negative control verified only by reading is uncalibrated; one compile cycle buys executed
+   proof that the gate can detect the regression it pins. Restore the checkout afterwards.
+
+Skip this phase for doc, fixture-only, or tooling changes; say so explicitly in the verdict.
+
+## Phase 5 — Synthesize the verdict
+
+Rank findings by severity:
+
+1. Soundness defect (false-negative risk, hollow accepted semantics, broken
+   symbolic/concrete/BFS agreement).
+2. Contract violation or drift (public envelope, exit codes, accepted design notes).
+3. Coupled-change gap (missing docs, LSP index, registry, changelog, skill reference).
+4. Test-evidence gap (missing negative control or boundary case, unreproduced claim).
+5. Style and convention.
+
+Separately, record local-optimum escalation triggers without acting on them: the fix works by
+adding a compatibility layer or special-case branch; one semantic change fans out across many
+files; the same shape of fix recurs across recent PRs; an allowlist or exclusion list grows
+monotonically. Two or more recorded triggers on the same surface warrant a standalone
+local-optima audit outside any single PR review — note it, do not run it here.
+
+## Phase 6 — Deliver and persist
+
+1. Post the review with `gh pr review` (comment or request-changes; approve only when every
+   severity-1/2 finding is resolved or refuted). State what was reproduced, what was not, and
+   what remains unverified. Never merge.
+2. Every out-of-scope soundness finding must land as an issue URL or an explicit unresolved
+   follow-up in the task packet — never only in the review text or chat.
+3. Promote durable lessons (a recurring finding class, a missed coupled-change edge) to the
+   smallest authoritative surface: a test, a design note, or an agent rule.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -115,7 +115,12 @@ Skip this phase for doc, fixture-only, or tooling changes; say so explicitly in 
 
 ## Phase 5 — Synthesize the verdict
 
-Rank findings by severity:
+Build a claim ledger before writing the verdict: enumerate every verification claim made by the
+PR body and every claim the verdict itself is about to make, and classify each as verified by
+execution (command + observed output), verified by reading (file:line evidence), or unverified.
+The verdict must name its unverified residue explicitly — a claim the review neither executed
+nor read is an assumption, and certifying it is the reviewer's own green-faking. Rank the
+remainder by severity:
 
 1. Soundness defect (false-negative risk, hollow accepted semantics, broken
    symbolic/concrete/BFS agreement).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,25 @@ on:
   push:
     branches: [main]
   pull_request:
-    # Agent-configuration surfaces are not product inputs: no build, test,
-    # generator, or release path reads them. A pull request whose every
-    # changed file matches this list skips the product gate pre-merge; one
-    # file outside it restores the full run, and GitHub runs the workflow
-    # anyway when a diff is too large to evaluate. The post-merge `main`
-    # push, schedule, and dispatch triggers carry no filter, so every merged
-    # main state still receives the complete product evidence
+    # No product-gate lane reads these surfaces. The paths that do read
+    # them keep their own unfiltered pre-merge coverage: `merge readiness /
+    # automation contracts` runs the `.claude/` environment contract test,
+    # and `release.yml` extracts notes from CHANGELOG.md at tag time and
+    # fails loudly on a malformed file. A pull request whose every changed
+    # file matches this list skips the product gate pre-merge; one file
+    # outside it restores the full run, and GitHub runs the workflow anyway
+    # when a diff is too large to evaluate. The post-merge `main` push,
+    # schedule, and dispatch triggers carry no filter, so every merged main
+    # state still receives the complete product evidence
     # (docs/DESIGN-ci.md). Do not add `skills/**` or `docs/**`: those are
-    # coupled product surfaces (language reference, site freshness).
+    # coupled product surfaces (language reference, site freshness,
+    # literate doc-contract tests).
     paths-ignore:
       - ".claude/**"
       - ".agents/**"
       - "CLAUDE.md"
       - "AGENTS.md"
+      - "CHANGELOG.md"
   schedule:
     - cron: "17 18 * * *"
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Agent-configuration surfaces are not product inputs: no build, test,
+    # generator, or release path reads them. A pull request whose every
+    # changed file matches this list skips the product gate pre-merge; one
+    # file outside it restores the full run, and GitHub runs the workflow
+    # anyway when a diff is too large to evaluate. The post-merge `main`
+    # push, schedule, and dispatch triggers carry no filter, so every merged
+    # main state still receives the complete product evidence
+    # (docs/DESIGN-ci.md). Do not add `skills/**` or `docs/**`: those are
+    # coupled product surfaces (language reference, site freshness).
+    paths-ignore:
+      - ".claude/**"
+      - ".agents/**"
+      - "CLAUDE.md"
+      - "AGENTS.md"
   schedule:
     - cron: "17 18 * * *"
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Exempted agent-configuration-only pull requests (`.claude/**`, `.agents/**`,
+  `CLAUDE.md`, `AGENTS.md`) from the pre-merge product gate via `paths-ignore`
+  on `ci.yml`'s `pull_request` trigger. One changed file outside the list
+  restores the full run, and the unfiltered `main` push trigger still gives
+  every merged state the complete product evidence; `docs/DESIGN-ci.md`
+  records the exemption contract and why `skills/**` and `docs/**` must never
+  join the list.
+
 - Added the `pr-review` agent skill (`.claude/skills/pr-review/SKILL.md`), a
   two-layer review orchestrator for pull requests that resolve issues: the
   skill reconstructs the issue contract from repository evidence, dispatches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Added the `pr-review` agent skill (`.claude/skills/pr-review/SKILL.md`), a
+  two-layer review orchestrator for pull requests that resolve issues: the
+  skill reconstructs the issue contract from repository evidence, dispatches
+  the specialized read-only reviewer agents (`fsl-coupled-change-reviewer`,
+  `fsl-soundness-reviewer`, `fsl-vacuity-reviewer`, with
+  `fsl-test-diagnostician` for failure triage) in parallel, audits the diff
+  for green-faking (weakened specs, hand-edited snapshots, allowlist growth,
+  loosened tests, missing negative controls, substring-strength assertions),
+  reproduces the PR's verification claims, adversarially verifies
+  soundness-critical changes with reviewer-authored fixtures and a live
+  mutation of the claimed negative control, and delivers a severity-ranked
+  verdict without merging. `CLAUDE.md`'s verification checklist now points
+  to it.
+
 - Fixed a false green in `domain expand`/`check_domain`'s `can(Command)`
   rendering: `Context::normalize`
   (`rust/fsl-core/src/domain.rs`) joined a `decide`'s `requires` clauses and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 - Exempted agent-configuration-only pull requests (`.claude/**`, `.agents/**`,
-  `CLAUDE.md`, `AGENTS.md`) from the pre-merge product gate via `paths-ignore`
-  on `ci.yml`'s `pull_request` trigger. One changed file outside the list
-  restores the full run, and the unfiltered `main` push trigger still gives
-  every merged state the complete product evidence; `docs/DESIGN-ci.md`
-  records the exemption contract and why `skills/**` and `docs/**` must never
-  join the list.
+  `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md`, whose coupled entry would
+  otherwise defeat the exemption) from the pre-merge product gate via
+  `paths-ignore` on `ci.yml`'s `pull_request` trigger. No product-gate lane
+  reads those files; the paths that do (`merge readiness / automation
+  contracts` runs the `.claude/` environment contract test, `release.yml`
+  reads the changelog at tag time) keep unfiltered coverage. One changed
+  file outside the list restores the full run, and the unfiltered `main`
+  push trigger still gives every merged state the complete product
+  evidence; `docs/DESIGN-ci.md` records the exemption contract and why
+  `skills/**` and `docs/**` must never join the list.
 
 - Added the `pr-review` agent skill (`.claude/skills/pr-review/SKILL.md`), a
   two-layer review orchestrator for pull requests that resolve issues: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   `fsl-test-diagnostician` for failure triage) in parallel, audits the diff
   for green-faking (weakened specs, hand-edited snapshots, allowlist growth,
   loosened tests, missing negative controls, substring-strength assertions),
-  reproduces the PR's verification claims, adversarially verifies
+  reproduces the PR's verification claims into an explicit claim ledger
+  (executed / read / unverified), adversarially verifies
   soundness-critical changes with reviewer-authored fixtures and a live
   mutation of the claimed negative control, and delivers a severity-ranked
   verdict without merging. `CLAUDE.md`'s verification checklist now points

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@
 2. Inspect the diff and exercise the changed contract with positive, negative, and boundary evidence.
 3. Run broader Rust, compatibility, or browser gates in proportion to the affected surface.
 4. Use the specialized FSL reviewers after semantics, coupled language files, or specs change.
-5. Before ending or compacting substantial work, run `/checkpoint` and preserve exact test outcomes.
+5. To review a pull request that resolves an issue, use `/pr-review`; it orchestrates the
+   specialized reviewers and never merges.
+6. Before ending or compacting substantial work, run `/checkpoint` and preserve exact test outcomes.
 
 ## Context management
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -100,10 +100,17 @@ context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into `main`.
 
 ### Agent-configuration exemption
 
-The `pull_request` trigger carries a `paths-ignore` list naming the agent-configuration surfaces:
-`.claude/**`, `.agents/**`, `CLAUDE.md`, and `AGENTS.md`. No build, test, generator, or release
-path reads those files, so a pull request whose every changed file matches the list skips the
-product gate pre-merge and merges on `merge readiness` (plus `site reference freshness`) alone.
+The `pull_request` trigger carries a `paths-ignore` list naming the agent-configuration surfaces
+plus the changelog: `.claude/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md`.
+`CHANGELOG.md` must be on the list for the exemption to fire at all — the coupled-change
+convention gives nearly every notable agent-configuration change a changelog entry.
+
+No **product-gate lane** reads those files. The paths that do read them keep their own
+unfiltered pre-merge coverage: `merge readiness / automation contracts` executes the `.claude/`
+environment contract test from `tests/test_claude_environment.py`, and `release.yml` extracts
+release notes from `CHANGELOG.md` at tag time and fails loudly (`test -s`) on a malformed file.
+A pull request whose every changed file matches the list therefore skips the product gate
+pre-merge and merges on `merge readiness` (plus `site reference freshness`) alone.
 
 The exemption is fail-closed three ways. A single changed file outside the list restores the full
 pre-merge run, and GitHub runs the workflow anyway when a diff is too large for path evaluation.
@@ -115,9 +122,12 @@ ruleset's required contexts (`rust workspace`, `WASM`, the `native Z3 4.16` matr
 report, so the merge stays unsatisfiable — such a pull request should not exist, and the gate does
 not invent evidence for it.
 
-Growing the list is a contract change to this decision, not a workflow tweak. `skills/**` and
-`docs/**` must never join it: `skills/fsl/reference.md` moves with language features under the
-coupled-change contract, and `docs/LANGUAGE*.md` feeds the site-reference freshness gate.
+Growing the list is a contract change to this decision, not a workflow tweak, and each candidate
+needs the same evidence sweep: name every path that reads it and show that path keeps unfiltered
+pre-merge or fail-loud coverage. `skills/**` and `docs/**` must never join it:
+`skills/fsl/reference.md` moves with language features under the coupled-change contract,
+`docs/LANGUAGE*.md` feeds the site-reference freshness gate, and product-gate literate
+doc-contract tests read documentation files directly.
 
 `semantic mutation` is required on pull requests and every product-gate event. Ordinary pull
 requests run all curated controls plus generic mutants intersecting the recorded base-to-head diff;

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -98,6 +98,27 @@ parallel:
 what makes the Linux evidence pre-merge. Only `native Z3 4.16` and the aggregate `product gate`
 context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into `main`.
 
+### Agent-configuration exemption
+
+The `pull_request` trigger carries a `paths-ignore` list naming the agent-configuration surfaces:
+`.claude/**`, `.agents/**`, `CLAUDE.md`, and `AGENTS.md`. No build, test, generator, or release
+path reads those files, so a pull request whose every changed file matches the list skips the
+product gate pre-merge and merges on `merge readiness` (plus `site reference freshness`) alone.
+
+The exemption is fail-closed three ways. A single changed file outside the list restores the full
+pre-merge run, and GitHub runs the workflow anyway when a diff is too large for path evaluation.
+The `main` push, schedule, and dispatch triggers carry no filter, so every merged `main` state
+still receives the complete product evidence, and a wrongly exempted defect surfaces through the
+existing post-merge reporting contract below instead of reaching `production`. And a pull request
+into `production` that matches the list is blocked rather than waved through: the production
+ruleset's required contexts (`rust workspace`, `WASM`, the `native Z3 4.16` matrix) simply never
+report, so the merge stays unsatisfiable — such a pull request should not exist, and the gate does
+not invent evidence for it.
+
+Growing the list is a contract change to this decision, not a workflow tweak. `skills/**` and
+`docs/**` must never join it: `skills/fsl/reference.md` moves with language features under the
+coupled-change contract, and `docs/LANGUAGE*.md` feeds the site-reference freshness gate.
+
 `semantic mutation` is required on pull requests and every product-gate event. Ordinary pull
 requests run all curated controls plus generic mutants intersecting the recorded base-to-head diff;
 pushes, schedules, manual runs, and pull requests targeting `production` run the complete accepted


### PR DESCRIPTION
## Problem

Reviewing an agent-authored PR that resolves an issue had no repository procedure: the specialized read-only reviewers (`fsl-coupled-change-reviewer`, `fsl-soundness-reviewer`, `fsl-vacuity-reviewer`, `fsl-test-diagnostician`) existed, but nothing defined when to dispatch them, what the main thread itself must audit, or what a verdict must contain. Separately, a PR that changes only agent-configuration surfaces (like this one's first commit) paid the full ~12–18 min pre-merge Linux product gate for files no build, test, generator, or release path reads.

## Contract change

- **New `.claude/skills/pr-review/SKILL.md`** — a two-layer review orchestrator: the skill reconstructs the issue contract from repository evidence (Phase 0–1), dispatches the applicable specialized reviewers in parallel (Phase 2), audits the diff for green-faking including substring-strength assertions (Phase 3), reproduces the PR's verification claims (Phase 4), adversarially verifies soundness-critical changes with reviewer-authored fixtures and a live mutation of the claimed negative control (Phase 4b), builds an explicit claim ledger — executed / read / unverified — before a severity-ranked verdict (Phase 5), and posts without merging while forcing out-of-scope soundness findings into issues (Phase 6). `CLAUDE.md`'s verification checklist now points to it.
- **`ci.yml` `pull_request` trigger gains `paths-ignore`** for `.claude/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md` (whose coupled entry would otherwise defeat the exemption on nearly every qualifying PR). No product-gate lane reads those files; the paths that do keep unfiltered coverage — `merge readiness / automation contracts` executes the `.claude/` environment contract test, and `release.yml` reads the changelog at tag time and fails loudly on a malformed file. Fail-closed: one changed file outside the list restores the full run; oversized diffs run anyway; the unfiltered `main` push trigger still gives every merged state the complete product evidence with post-merge reporting; an exempted PR into `production` is blocked by its required contexts never reporting. `docs/DESIGN-ci.md` records the exemption as part of the accepted CI decision, requires a reader-evidence sweep for any future list growth, and states why `skills/**` and `docs/**` must never join.

## Test evidence

- The skill was validated by a full dry run against open PR #708: contract reconstruction from issue #691, parallel dispatch of the soundness and coupled-change reviewers, green-faking audit, and reproduction of the PR's narrowest claims on its tree (`domain_render_agreement` + `domain_lowering` 25 passed; `domain_origin_diagnostics` 6 passed — both matching the PR body exactly). The dry run's failure modes (reviewer turn exhaustion, unreproduced clippy/fmt claims carried silently into the verdict) are folded back into Phase 2 dispatch guidance and the Phase 5 claim ledger.
- `ci.yml` parses (`yaml.safe_load`). This PR itself touches `.github/workflows/` and `docs/`, so it runs the full pre-merge product gate — the exemption does not apply to the change that introduces it.

## Documentation

- `docs/DESIGN-ci.md`: new “Agent-configuration exemption” subsection under the product gate contract.
- `CHANGELOG.md`: entries for both changes under `[Unreleased]`.

## Follow-up (not in this PR)

- Pre-existing docs gap found during the dry run: the implicit-default enumerations at `docs/LANGUAGE.md:284` and `skills/fsl/reference.md:348` omit the container defaults (`none`, `Set {}`, dense per-key Map) that the typed lowering already applies. Needs an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
