### PR TITLE
ci: move the agent-configuration exemption in-job; land inert merge-group groundwork toward a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,18 @@ on:
   push:
     branches: [main]
   pull_request:
-    # No product-gate lane reads these surfaces. The paths that do read
-    # them keep their own unfiltered pre-merge coverage: `merge readiness /
-    # automation contracts` runs the `.claude/` environment contract test,
-    # and `release.yml` extracts notes from CHANGELOG.md at tag time and
-    # fails loudly on a malformed file. A pull request whose every changed
-    # file matches this list skips the product gate pre-merge; one file
-    # outside it restores the full run, and GitHub runs the workflow anyway
-    # when a diff is too large to evaluate. The post-merge `main` push,
-    # schedule, and dispatch triggers carry no filter, so every merged main
-    # state still receives the complete product evidence
-    # (docs/DESIGN-ci.md). Do not add `skills/**` or `docs/**`: those are
-    # coupled product surfaces (language reference, site freshness,
-    # literate doc-contract tests).
-    paths-ignore:
-      - ".claude/**"
-      - ".agents/**"
-      - "CLAUDE.md"
-      - "AGENTS.md"
-      - "CHANGELOG.md"
+    # The agent-configuration exemption formerly lived here as a
+    # `paths-ignore` list. It now lives in `tools/check-product-gate-scope.sh`,
+    # run as the first step of each heavy job below, so a skip is an
+    # in-job early exit that still reports a context instead of a
+    # workflow-level skip that reports none at all. See docs/DESIGN-ci.md,
+    # "Agent-configuration exemption" and "Merge queue (planned, not yet
+    # enabled)".
+  merge_group:
+    # Unfiltered: GitHub does not support `paths`/`paths-ignore` on
+    # `merge_group` (docs/DESIGN-ci.md), and only `main` will ever have a
+    # queue, so an unfiltered trigger is equivalent. Currently dormant --
+    # no merge queue exists on `main` yet, so this event never fires today.
   schedule:
     - cron: "17 18 * * *"
   workflow_dispatch:
@@ -36,12 +29,25 @@ on:
 permissions:
   contents: read
 
-# The Linux evidence — `rust workspace` and `WASM` — runs on every pull request.
-# It is where the tests live: 103 of the repository's 124 integration test files
-# sit in `fslc`, `fsl-tools`, `fsl-verifier` and `fsl-lsp`, none of which the
-# bounded `merge readiness` gate compiles or runs, and its `cargo check` carries
-# no `--all-targets`, so a type error or a failing assertion in any of them used
-# to reach main and surface only after the merge.
+# The Linux evidence — `rust workspace` and `WASM` — runs on every pull request
+# today. It is where the tests live: 103 of the repository's 124 integration
+# test files sit in `fslc`, `fsl-tools`, `fsl-verifier` and `fsl-lsp`, none of
+# which the bounded `merge readiness` gate compiles or runs, and its
+# `cargo check` carries no `--all-targets`, so a type error or a failing
+# assertion in any of them used to reach main and surface only after the
+# merge.
+#
+# The four heavy jobs (`rust-workspace`, `wasm`, `semantic-mutation`,
+# `fsl-logic`) also trigger on `merge_group`, which is where they are meant to
+# eventually run for real once a merge queue is configured on `main`: pull
+# requests would then report a cheap queue-entry stub instead, batches of
+# candidates would be validated together, and the pre-merge cost this file's
+# header used to describe would move to queue-entry time. That rollout has
+# two remaining, explicit, human-confirmed steps this PR does not take —
+# creating the `FSL_MERGE_QUEUE_CI` repository variable and adding a
+# `merge_queue` rule to the `main` ruleset — so today `pull_request` events
+# still run the complete evidence in full, exactly as before. See
+# docs/DESIGN-ci.md, "Merge queue (planned, not yet enabled)".
 #
 # Only the cross-platform matrix — `native Z3 4.16` on macOS and Windows — stays
 # post-merge under FSL_OPTIMISTIC_CI, reported by the post-merge CI reporter.
@@ -52,7 +58,7 @@ permissions:
 # Product gates for main pushes, schedules, manual runs, and production
 # promotions never honor that opt-out.
 concurrency:
-  group: product-gate-${{ github.event.pull_request.number || github.run_id }}
+  group: product-gate-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -62,16 +68,28 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
         with:
           components: clippy,rustfmt
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
 
       - name: Check Rust workspace
+        if: steps.scope.outputs.run == 'true'
         run: ./tools/check-native-integration.sh rust
 
   wasm:
@@ -80,16 +98,28 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
         with:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
 
       - uses: actions/setup-node@v4
+        if: steps.scope.outputs.run == 'true'
         with:
           node-version: "22"
           cache: npm
@@ -99,6 +129,7 @@ jobs:
 
       - name: Cache pinned wasm-bindgen CLI
         id: wasm-bindgen-cache
+        if: steps.scope.outputs.run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -108,17 +139,18 @@ jobs:
           key: ${{ runner.os }}-wasm-bindgen-cli-0.2.126
 
       - name: Install pinned wasm-bindgen CLI
-        if: steps.wasm-bindgen-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-bindgen-cache.outputs.cache-hit != 'true' && steps.scope.outputs.run == 'true'
         run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Check WASM integration
+        if: steps.scope.outputs.run == 'true'
         run: ./tools/check-native-integration.sh wasm
 
   rust-native-z3:
     name: native Z3 4.16 (${{ matrix.os }})
     if: >-
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'main' ||
+      (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+      github.base_ref == 'production' ||
       vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
@@ -171,7 +203,7 @@ jobs:
   # control matrix plus generic mutants intersecting their diff. Push,
   # schedule, and manual runs execute the complete accepted P2 pilot scope.
   semantic-mutation:
-    name: semantic mutation (${{ github.event_name == 'pull_request' && github.base_ref != 'production' && 'changed' || 'complete' }})
+    name: semantic mutation (${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'changed' || 'complete' }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -179,37 +211,47 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
+
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
 
       - name: Install pinned semantic mutation runner
+        if: steps.scope.outputs.run == 'true'
         run: cargo install cargo-mutants --version 27.1.0 --locked
 
-      - name: Build pull-request diff
-        if: github.event_name == 'pull_request' && github.base_ref != 'production'
+      - name: Build change diff
+        if: steps.scope.outputs.run == 'true' && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production'))
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         # cargo-mutants runs at rust/ and matches patch paths relative to that
         # workspace; --relative prevents a silent rust/ prefix mismatch.
         run: git diff --relative=rust --binary "$BASE_SHA...$HEAD_SHA" -- rust >"$RUNNER_TEMP/semantic-mutation.diff"
 
       - name: Calibrate changed implementation semantics
-        if: github.event_name == 'pull_request' && github.base_ref != 'production'
+        if: steps.scope.outputs.run == 'true' && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production'))
         env:
           FSL_MUTATION_DIFF: ${{ runner.temp }}/semantic-mutation.diff
-          FSL_MUTATION_BASE: ${{ github.event.pull_request.base.sha }}
+          FSL_MUTATION_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: ./tools/check-native-integration.sh semantic-mutation changed
 
       - name: Calibrate complete accepted implementation scope
-        if: github.event_name != 'pull_request' || github.base_ref == 'production'
+        if: steps.scope.outputs.run == 'true' && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.base_ref == 'production')
         run: ./tools/check-native-integration.sh semantic-mutation complete
 
       - name: Preserve mutation evidence
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: semantic-mutation-${{ github.run_id }}-${{ github.run_attempt }}
@@ -223,28 +265,39 @@ jobs:
   # incomplete and becomes complete only after every selected case and edge
   # executes, so a truncated shard cannot read green.
   fsl-logic:
-    name: FSL Logic Test (${{ github.event_name == 'pull_request' && github.base_ref != 'production' && 'pr' || 'scheduled' }})
+    name: FSL Logic Test (${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'pr' || 'scheduled' }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
 
       - name: Run bounded pull-request generation
-        if: github.event_name == 'pull_request' && github.base_ref != 'production'
+        if: steps.scope.outputs.run == 'true' && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production'))
         run: ./tools/check-native-integration.sh fsl-logic pr
 
       - name: Run scheduled-volume generation
-        if: github.event_name != 'pull_request' || github.base_ref == 'production'
+        if: steps.scope.outputs.run == 'true' && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.base_ref == 'production')
         run: ./tools/check-native-integration.sh fsl-logic scheduled
 
       - name: Preserve FSL Logic evidence
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: fsl-logic-${{ github.run_id }}-${{ github.run_attempt }}
@@ -257,8 +310,8 @@ jobs:
     if: >-
       always() &&
       (
-        github.event_name != 'pull_request' ||
-        github.base_ref != 'main' ||
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        github.base_ref == 'production' ||
         vars.FSL_OPTIMISTIC_CI != 'enabled'
       )
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Replaced `ci.yml`'s `paths-ignore`-based agent-configuration exemption with
+  `tools/check-product-gate-scope.sh`, run as the first step of each of the
+  four heavy product-gate jobs (`rust workspace`, `WASM`, `semantic
+  mutation`, `FSL Logic Test`). Same accepted exemption scope
+  (`.claude/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, `CHANGELOG.md`),
+  but a workflow-level path skip never emits its job's context at all — if
+  that context is ever made a required status check (issue #707) or needed
+  to satisfy merge-queue entry, the skip leaves it permanently `Expected`,
+  unfixable even by an admin merge (observed while merging PR #715); an
+  in-job diff-checked early exit cannot get stuck that way. `ci.yml` also
+  gains a currently dormant `merge_group` trigger and per-job scope checks
+  on those four jobs, as inert groundwork for a future merge-queue-gated CI
+  architecture — no live ruleset or repository-variable change ships with
+  this PR; see `docs/DESIGN-ci.md`'s new "Merge queue (planned, not yet
+  enabled)" section. The script's `selftest` subcommand is wired into
+  `merge readiness / automation contracts` as its accepting/rejecting
+  control.
+
 - Exempted agent-configuration-only pull requests (`.claude/**`, `.agents/**`,
   `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md`, whose coupled entry would
   otherwise defeat the exemption) from the pre-merge product gate via

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -94,37 +94,73 @@ parallel:
 - the deterministic finite-model agreement gate from `tools/check-native-integration.sh fsl-logic`
   (`FSL Logic Test`).
 
-**The first two carry no event condition and therefore also run on every pull request**, which is
-what makes the Linux evidence pre-merge. Only `native Z3 4.16` and the aggregate `product gate`
-context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into `main`.
+**The first two carry no event condition beyond scope evidence and therefore also run on every
+pull request today**, which is what makes the Linux evidence pre-merge. Only `native Z3 4.16` and
+the aggregate `product gate` context honour `FSL_OPTIMISTIC_CI` and skip on pull requests into
+`main`.
+
+All four heavy jobs (`rust workspace`, `WASM`, `semantic mutation`, `FSL Logic Test`) also trigger
+on the `merge_group` event. As of this writing that trigger is dormant — no merge queue is
+configured on `main`, so `merge_group` never fires — but once one exists, this is where these jobs
+are meant to execute for real, batched per queue entry. On `pull_request` events they still run
+in full today, because the `FSL_MERGE_QUEUE_CI` repository variable does not exist yet.
+Once that variable and a `merge_queue` ruleset rule are added (see "Merge queue (planned, not yet
+enabled)" below), pull-request pushes would report cheap queue-entry stubs from
+`tools/check-product-gate-scope.sh` instead of running the jobs in full. Until that rollout
+happens, treat this paragraph's first sentence — full evidence on every pull request — as the
+live contract, and the `merge_group` sentence as forward-looking infrastructure only.
 
 ### Agent-configuration exemption
 
-The `pull_request` trigger carries a `paths-ignore` list naming the agent-configuration surfaces
-plus the changelog: `.claude/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md`.
-`CHANGELOG.md` must be on the list for the exemption to fire at all — the coupled-change
-convention gives nearly every notable agent-configuration change a changelog entry.
+Each of the four heavy jobs runs `tools/check-product-gate-scope.sh` as its first step (named
+"Decide required evidence scope"), reads its `run`/`reason` output, and gates every later step on
+`steps.scope.outputs.run == 'true'`. This replaced a workflow-level `paths-ignore` list on
+`ci.yml`'s `pull_request` trigger that named the same five surfaces: `.claude/**`, `.agents/**`,
+`CLAUDE.md`, `AGENTS.md`, and `CHANGELOG.md` (exact root filenames, not prefixes —
+`CLAUDE.md.d/x` does not match). `CHANGELOG.md` stays on the list for the exemption to fire at
+all — the coupled-change convention gives nearly every notable agent-configuration change a
+changelog entry.
+
+The mechanism moved, not the accepted scope, for a concrete reason: a `paths-ignore`-skipped
+workflow never emits its job's context at all. If that context were ever made a required status
+check — issue #707 tracks exactly this gap — or ever needed to satisfy merge-queue entry, a
+workflow-level skip would leave it permanently `Expected`, unfixable even by an admin merge. This
+was independently observed while merging PR #715. An in-job early exit does not have that failure
+mode: the job always starts, checks out, computes the diff, and reports success either from the
+stub path or from real evidence. None of the four contexts are required status checks today —
+`merge readiness` remains the only one — so this is a latent-risk fix, not a response to an
+already-broken required check.
 
 No **product-gate lane** reads those files. The paths that do read them keep their own
 unfiltered pre-merge coverage: `merge readiness / automation contracts` executes the `.claude/`
 environment contract test from `tests/test_claude_environment.py`, and `release.yml` extracts
 release notes from `CHANGELOG.md` at tag time and fails loudly (`test -s`) on a malformed file.
-A pull request whose every changed file matches the list therefore skips the product gate
-pre-merge and merges on `merge readiness` (plus `site reference freshness`) alone.
+A pull request whose every changed file matches the list therefore still gets `run=false` from the
+scope script, each heavy job exits its remaining steps fast, and the pull request merges on
+`merge readiness` (plus `site reference freshness`) alone — exactly as under the retired
+`paths-ignore` list.
 
-The exemption is fail-closed three ways. A single changed file outside the list restores the full
-pre-merge run, and GitHub runs the workflow anyway when a diff is too large for path evaluation.
-The `main` push, schedule, and dispatch triggers carry no filter, so every merged `main` state
-still receives the complete product evidence, and a wrongly exempted defect surfaces through the
-existing post-merge reporting contract below instead of reaching `production`. And a pull request
-into `production` that matches the list is blocked rather than waved through: the production
-ruleset's required contexts (`rust workspace`, `WASM`, the `native Z3 4.16` matrix) simply never
-report, so the merge stays unsatisfiable — such a pull request should not exist, and the gate does
-not invent evidence for it.
+The exemption is fail-closed the same three ways as before, now enforced by the script rather than
+by GitHub's path evaluation. A single changed file outside the list restores the full pre-merge
+run. A missing base/head SHA, a failed `git diff`, or an event the script does not recognize all
+resolve to `run=true` — never to a stub. The `main` push, schedule, and dispatch triggers carry no
+exemption at all: `tools/check-product-gate-scope.sh` returns `run=true` unconditionally for
+those events, so every merged `main` state still receives the complete product evidence, and a
+wrongly exempted defect surfaces through the existing post-merge reporting contract below instead
+of reaching `production`. And a pull request into `production` that matches the list is blocked
+rather than waved through: the script's `production` branch always returns `run=true`, so the
+production ruleset's required contexts (`rust workspace`, `WASM`, the `native Z3 4.16` matrix)
+still report real evidence — such a pull request should not exist, and the gate does not invent a
+stub for it.
 
-Growing the list is a contract change to this decision, not a workflow tweak, and each candidate
-needs the same evidence sweep: name every path that reads it and show that path keeps unfiltered
-pre-merge or fail-loud coverage. `skills/**` and `docs/**` must never join it:
+The script's `selftest` subcommand is the executable accepting/rejecting control for its
+classifier (all-exempt, all-product, mixed, a filename-prefix near-miss, and fail-closed-on-empty
+cases), run by `merge readiness / automation contracts` on every pull request and merge-group
+event.
+
+Growing the exempt list is a contract change to this decision, not a script tweak, and each
+candidate needs the same evidence sweep: name every path that reads it and show that path keeps
+unfiltered pre-merge or fail-loud coverage. `skills/**` and `docs/**` must never join it:
 `skills/fsl/reference.md` moves with language features under the coupled-change contract,
 `docs/LANGUAGE*.md` feeds the site-reference freshness gate, and product-gate literate
 doc-contract tests read documentation files directly.
@@ -154,6 +190,41 @@ successful evidence; an accidentally skipped lane cannot make the workflow confi
 
 Product-gate runs for merged commits are not cancelled. Each merged state therefore retains its own
 portable evidence and failure attribution even when agents merge changes quickly.
+
+## Merge queue (planned, not yet enabled)
+
+**As of this writing, neither the ruleset rule nor the `FSL_MERGE_QUEUE_CI` variable described in
+this section exists.** This section documents infrastructure that this change lands in an inert
+state, not a live contract. Do not cite it as evidence that pull requests currently merge through
+a queue, or that the four heavy contexts are currently optional on `pull_request`.
+
+The target mechanism: once a GitHub merge queue is configured on `main`, `ci.yml`'s four heavy
+jobs (`rust workspace`, `WASM`, `semantic mutation (changed)`, `FSL Logic Test (pr)`) would execute
+for real on the `merge_group` event, validating each batched queue entry against current `main`
+instead of each pull request individually. A `pull_request` push would then report a cheap
+queue-entry stub for those same context names — `tools/check-product-gate-scope.sh` returns
+`run=false, reason=queue-entry-stub` for that case — deferring the real evidence to queue-entry
+time, the same way `native Z3 4.16` already defers to post-merge under `FSL_OPTIMISTIC_CI`.
+
+`ci.yml` already carries the (currently dormant) `merge_group` trigger and the scope-check
+plumbing this needs. What is missing is entirely on the GitHub configuration side, and enabling it
+is a separate, explicit, human-confirmed operational action — not something this or any other
+automated change performs. Issue #707 tracks the underlying required-status-check/ruleset gap
+this mechanism is meant to eventually close; this repository has already seen a design document
+assert ruleset enforcement that the live ruleset did not actually implement, and this section is
+written to not repeat that mistake.
+
+A future PR or operational change would need to, in order:
+
+1. Create the repository variable `FSL_MERGE_QUEUE_CI` (e.g. set to `enabled`).
+2. Add a `merge_queue` type rule to the `main` branch ruleset (id `19090811`), and add the four
+   heavy context names — `rust workspace`, `WASM`, `semantic mutation (changed)`, and
+   `FSL Logic Test (pr)` — to that rule's required status checks.
+
+Neither step is automated by this change, and completing only one of them without the other would
+leave the mechanism either invisible (variable set, no queue to batch into) or inert (queue rule
+added, but `FSL_MERGE_QUEUE_CI` unset, so `pull_request` pushes keep running full evidence as they
+do today).
 
 ## Failure reporting contract
 
@@ -219,3 +290,6 @@ discipline, which step 1 alone does not achieve.
 - Hiding platform failures with `continue-on-error`.
 - Trusting agent-authored verification claims in place of independent GitHub-hosted execution.
 - Changing FSL language, Kernel, CLI/JSON, LSP, Worker, or frozen Python compatibility behavior.
+- Enabling the GitHub merge queue or changing any live branch-protection ruleset — this PR lands
+  only the inert workflow/script mechanism; see the new "Merge queue (planned, not yet enabled)"
+  section.

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -39,6 +39,9 @@ check_automation() {
   # product behavior. These zero-argument contract tests use only the standard
   # library, so run them directly without adding pytest to the fail-fast lane.
   python3 -c 'from tests.test_codex_environment import test_semantic_findings_cannot_disappear_between_agents_and_checkpoint as codex_contract; from tests.test_claude_environment import test_semantic_findings_cannot_disappear_between_agents_and_checkpoint as claude_contract; codex_contract(); claude_contract()'
+  # Accepting/rejecting controls for the agent-configuration-exemption
+  # classifier that ci.yml's heavy jobs now run in-job (docs/DESIGN-ci.md).
+  ./tools/check-product-gate-scope.sh selftest
 }
 
 case "${1:-all}" in

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Decides whether a product-gate job needs to execute real evidence for the
+# current change. This replaces the workflow-level `paths-ignore`
+# agent-configuration exemption that `ci.yml`'s `pull_request` trigger used
+# to carry (see docs/DESIGN-ci.md, "Agent-configuration exemption"). A
+# workflow-level path skip never emits its job's context at all; if that
+# context is ever made a required status check, or ever needs to satisfy
+# merge-queue entry, an exempted pull request is stuck `Expected` forever --
+# unfixable even by an admin merge. This script instead lets the job start,
+# check out, diff, and exit fast, so its context always reports something.
+#
+# It also owns the (currently inert) `merge_group`/`FSL_MERGE_QUEUE_CI`
+# decision described in docs/DESIGN-ci.md's "Merge queue (planned, not yet
+# enabled)" section. Neither the repository variable nor the ruleset rule
+# exists yet, so the `queue-entry-stub` branch below is dead code in
+# production today -- it is implemented ahead of that rollout, not exercised
+# by it.
+#
+# Usage:
+#   ./tools/check-product-gate-scope.sh            # decide scope; prints
+#                                                   #   run=<bool>
+#                                                   #   reason=<token>
+#                                                   # to stdout, suitable for
+#                                                   # redirection into
+#                                                   # $GITHUB_OUTPUT
+#   ./tools/check-product-gate-scope.sh selftest    # exercise the classifier
+#                                                   # (accepting/rejecting
+#                                                   # controls)
+
+set -euo pipefail
+
+# Exempt paths: the five entries from the retired `paths-ignore` list.
+# `.claude/**` and `.agents/**` are directory prefixes; `CLAUDE.md`,
+# `AGENTS.md`, and `CHANGELOG.md` are exact repository-root filenames, not
+# prefixes -- "CLAUDE.md.d/x" must NOT match.
+is_exempt_path() {
+  case "$1" in
+    .claude/*|.agents/*) return 0 ;;
+    CLAUDE.md|AGENTS.md|CHANGELOG.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Reads a newline-separated path list on stdin and prints "exempt" when the
+# list is non-empty and every path matches is_exempt_path, otherwise prints
+# "product". An empty list is fail-closed to "product", never "exempt".
+classify_diff() {
+  local line total=0 exempt=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    total=$((total + 1))
+    if is_exempt_path "$line"; then
+      exempt=$((exempt + 1))
+    fi
+  done
+  if [ "$total" -gt 0 ] && [ "$total" -eq "$exempt" ]; then
+    echo exempt
+  else
+    echo product
+  fi
+}
+
+# Prints the two-line run=/reason= result and, on a stub (run=false), leaves
+# a one-line breadcrumb in the job summary so a skipped context is never
+# misread as product evidence.
+emit() {
+  local run="$1" reason="$2"
+  echo "run=$run"
+  echo "reason=$reason"
+  if [ "$run" = "false" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "early exit (\`$reason\`): evidence for this context is not required for this change; see docs/DESIGN-ci.md" >>"$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# Diff-based exemption shared by `pull_request` (once FSL_MERGE_QUEUE_CI is
+# not "enabled") and `merge_group` events -- the latter cannot be path-
+# filtered at the trigger level, so this in-job check is the only place the
+# exemption can apply once a merge queue exists. Fails closed to a full run
+# when either SHA is missing or the diff itself cannot be computed.
+diff_scope() {
+  if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+    emit true diff-unavailable-fail-closed
+    return
+  fi
+  local diff
+  if ! diff="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" 2>/dev/null)"; then
+    emit true diff-unavailable-fail-closed
+    return
+  fi
+  case "$(printf '%s\n' "$diff" | classify_diff)" in
+    exempt) emit false agent-configuration-exemption ;;
+    *) emit true product-paths-changed ;;
+  esac
+}
+
+decide() {
+  case "${GITHUB_EVENT_NAME:-}" in
+    pull_request)
+      if [ "${GITHUB_BASE_REF:-}" = "production" ]; then
+        # Never stub or skip promotion evidence.
+        emit true production-promotion-evidence
+      elif [ "${FSL_MERGE_QUEUE_CI:-}" = "enabled" ]; then
+        # Unreachable today: FSL_MERGE_QUEUE_CI does not exist yet. Correct
+        # ahead of time so enabling the variable is the only remaining step.
+        emit false queue-entry-stub
+      else
+        diff_scope
+      fi
+      ;;
+    merge_group)
+      diff_scope
+      ;;
+    push|schedule|workflow_dispatch)
+      emit true complete-evidence-event
+      ;;
+    *)
+      emit true unknown-event-fail-closed
+      ;;
+  esac
+}
+
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "check-product-gate-scope.sh selftest: FAIL ($desc): expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+  return 0
+}
+
+selftest() {
+  local failures=0
+
+  check "all-product-paths" product \
+    "$(printf 'src/main.rs\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+  check "mixed exempt + CHANGELOG.md" exempt \
+    "$(printf '.claude/skills/x/SKILL.md\nCHANGELOG.md\n' | classify_diff)" || failures=$((failures + 1))
+  check "mixed exempt + product" product \
+    "$(printf '.claude/skills/x/SKILL.md\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+  check "filename-prefix near-miss" product \
+    "$(printf 'CLAUDE.md.d/x\n' | classify_diff)" || failures=$((failures + 1))
+  check "empty input fail-closed" product \
+    "$(printf '' | classify_diff)" || failures=$((failures + 1))
+
+  if [ "$failures" -ne 0 ]; then
+    echo "check-product-gate-scope.sh selftest: $failures assertion(s) failed" >&2
+    exit 1
+  fi
+  echo "check-product-gate-scope.sh selftest: all assertions passed"
+}
+
+case "${1:-}" in
+  selftest)
+    selftest
+    ;;
+  "")
+    decide
+    ;;
+  *)
+    echo "usage: $0 [selftest]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Problem

Every PR pays the full pre-merge product gate (`rust workspace` ~12-18min, `WASM` ~6min, `semantic mutation`, `FSL Logic Test`) on every push. This is slow for iterative development even though runner minutes are free (public repo) — the cost is wall-clock latency, not billing.

The accepted mitigation, named but never implemented in `docs/DESIGN-ci.md`: "`merge-readiness.yml` already handles `merge_group`, so a merge queue can validate several candidates as one batch once `ci.yml` gains the same trigger." A full design for that migration was produced and reviewed (GitHub's merge-queue ruleset API shape independently verified against current docs). **This PR intentionally implements only the safe, inert first half of that design** — see scope below.

## Scope: mechanism now, ruleset flip later, deliberately split

Enabling a merge queue requires two live, hard-to-reverse, shared-infrastructure actions outside this PR's file diff: creating a `FSL_MERGE_QUEUE_CI` repository variable, and adding a `merge_queue` rule plus new required status checks to the `main` branch ruleset. This repository has already seen a design document (`docs/DESIGN-ci.md`'s "Safe rollout" section, per issue #707) assert ruleset enforcement that the live ruleset didn't actually implement. This PR is written not to repeat that: it ships the mechanism in an **explicitly inert state** and states plainly, in `docs/DESIGN-ci.md`'s new "Merge queue (planned, not yet enabled)" section, that neither the variable nor the ruleset rule exists yet. The live ruleset/variable change is left as a separate, explicit, human-confirmed follow-up.

## What changes

- **`tools/check-product-gate-scope.sh`** (new): replaces `ci.yml`'s `paths-ignore`-based agent-configuration exemption with an in-job diff check, run as the first step of each of the four heavy jobs (`rust-workspace`, `wasm`, `semantic-mutation`, `fsl-logic`). Same accepted exemption scope (`.claude/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, `CHANGELOG.md`). Motivation: a workflow-level path skip never emits its job's context at all — if that context is ever made a required status check (#707) or needs to satisfy merge-queue entry, the skip leaves it permanently `Expected`, unfixable even by `--admin` (observed firsthand while merging #715). An in-job early exit reports success either way.
- **`ci.yml`**: gains a currently-dormant `merge_group` trigger and the scope-check plumbing on the four heavy jobs; `rust-native-z3` and the `product-gate` aggregator's `if:` conditions are corrected to also exclude `merge_group` (otherwise they'd run/fail incorrectly once a queue exists); `semantic-mutation`/`fsl-logic`'s changed/complete tier logic includes `merge_group` in the changed tier.
- **`tools/check-merge-readiness.sh`**: wires `check-product-gate-scope.sh selftest` (accepting/rejecting/fail-closed controls) into the `automation` lane.
- **`docs/DESIGN-ci.md`**: updates the exemption section to describe the new mechanism, and adds "Merge queue (planned, not yet enabled)" stating the two precise future operator steps.
- **`CHANGELOG.md`**: `[Unreleased]` entry.

## Safety property this PR depends on

For an ordinary PR into `main` today, behavior is **functionally unchanged**: `FSL_MERGE_QUEUE_CI` doesn't exist, so the scope script always falls through to the same diff-based exemption `paths-ignore` used to express, and every heavy job runs in full exactly as before. The only observable difference: an agent-configuration-only PR now triggers `ci.yml` (four fast early-exits) instead of the workflow never starting at all — harmless, since none of those four contexts are required status checks yet.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK
- `bash -n tools/check-product-gate-scope.sh` → syntax OK
- `./tools/check-product-gate-scope.sh selftest` → all assertions passed (independently re-run, plus adversarial cases beyond the built-in selftest: missing SHAs, unknown event, a real multi-file commit diff — all resolved as expected)
- `./tools/check-merge-readiness.sh automation` → all 8 Node tests + Python contract tests + new selftest pass
- Manually traced the `if:` conditions for: ordinary main PR (unaffected), agent-config-only main PR (four fast stub successes, aggregator/native-Z3 unaffected — same skip as any ordinary main PR), a dormant `merge_group` event, and a push to `main` (unaffected)
- This PR itself is *not* agent-configuration-only (touches `.github/workflows/` and `docs/`), so it runs the full existing pre-merge gate.

## Follow-up (explicitly out of scope here, requires separate confirmation)

- Create the `FSL_MERGE_QUEUE_CI` repository variable.
- Add a `merge_queue` rule to the `main` ruleset (id `19090811`) and add the four heavy context names to its required status checks.
- Update issue #707 once the above lands, since it changes how #707's required-status-check gap gets closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)