### PR TITLE
docs(ci): record the live merge-queue ruleset state (canary 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Enabled a GitHub merge queue on `main`: the `main safety and CI` ruleset
+  (id `19090811`) now carries an active `merge_queue` rule and requires
+  `rust workspace`, `WASM`, `semantic mutation (changed)`, and
+  `FSL Logic Test (pr)` alongside the existing `merge readiness` context. A
+  pull request can now be enqueued via "Merge when ready" once all five
+  contexts pass on the pull request; the queue re-validates a `merge_group`
+  run before merging. This does **not** yet reduce per-push cost — the
+  `FSL_MERGE_QUEUE_CI` repository variable that activates
+  `tools/check-product-gate-scope.sh`'s queue-entry-stub path is still unset,
+  so the four heavy jobs keep running in full on every pull-request push
+  until that variable is created. The ruleset also gained a `User`
+  bypass-actor entry (repository admin, pull-request-scoped) as an
+  operator escape hatch: the prior ruleset had zero bypass actors, so a
+  queue malfunction would have had no direct-merge recovery path short of
+  reverting the ruleset itself. See `docs/DESIGN-ci.md`'s "Merge queue
+  (ruleset live, per-push cost not yet reduced)" section.
+
 - Replaced `ci.yml`'s `paths-ignore`-based agent-configuration exemption with
   `tools/check-product-gate-scope.sh`, run as the first step of each of the
   four heavy product-gate jobs (`rust workspace`, `WASM`, `semantic

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -191,40 +191,58 @@ successful evidence; an accidentally skipped lane cannot make the workflow confi
 Product-gate runs for merged commits are not cancelled. Each merged state therefore retains its own
 portable evidence and failure attribution even when agents merge changes quickly.
 
-## Merge queue (planned, not yet enabled)
+## Merge queue (ruleset live, per-push cost not yet reduced)
 
-**As of this writing, neither the ruleset rule nor the `FSL_MERGE_QUEUE_CI` variable described in
-this section exists.** This section documents infrastructure that this change lands in an inert
-state, not a live contract. Do not cite it as evidence that pull requests currently merge through
-a queue, or that the four heavy contexts are currently optional on `pull_request`.
+**As of this writing, the `main` ruleset (id `19090811`) carries an active `merge_queue` rule and
+five required status checks — `merge readiness`, `rust workspace`, `WASM`,
+`semantic mutation (changed)`, and `FSL Logic Test (pr)` — applied 2026-08-05. The
+`FSL_MERGE_QUEUE_CI` repository variable does not exist yet.** Concretely, this means: a pull
+request into `main` can now be added to the queue once all five contexts pass on the pull request
+itself, and the queue will re-validate a `merge_group` run before merging — but because
+`FSL_MERGE_QUEUE_CI` is unset, `tools/check-product-gate-scope.sh` still returns `run=true` for
+ordinary pull requests, so the four heavy jobs still run in full on every push, exactly as before
+this section's rollout began. Nothing here changes today's per-push cost yet; it changes what
+happens once a pull request author clicks "Merge when ready" — that action now enqueues into a
+real, ruleset-configured queue rather than merging immediately once required checks pass on the
+branch. Do not cite this ruleset state as evidence that per-push evidence has become cheap; that
+is what step 2 below still needs to do.
 
-The target mechanism: once a GitHub merge queue is configured on `main`, `ci.yml`'s four heavy
-jobs (`rust workspace`, `WASM`, `semantic mutation (changed)`, `FSL Logic Test (pr)`) would execute
-for real on the `merge_group` event, validating each batched queue entry against current `main`
-instead of each pull request individually. A `pull_request` push would then report a cheap
-queue-entry stub for those same context names — `tools/check-product-gate-scope.sh` returns
+The target mechanism, once step 2 completes: `ci.yml`'s four heavy jobs would execute for real on
+the `merge_group` event, validating each batched queue entry against current `main` instead of
+each pull request individually. A `pull_request` push would then report a cheap queue-entry stub
+for those same context names — `tools/check-product-gate-scope.sh` returns
 `run=false, reason=queue-entry-stub` for that case — deferring the real evidence to queue-entry
 time, the same way `native Z3 4.16` already defers to post-merge under `FSL_OPTIMISTIC_CI`.
 
-`ci.yml` already carries the (currently dormant) `merge_group` trigger and the scope-check
-plumbing this needs. What is missing is entirely on the GitHub configuration side, and enabling it
-is a separate, explicit, human-confirmed operational action — not something this or any other
-automated change performs. Issue #707 tracks the underlying required-status-check/ruleset gap
-this mechanism is meant to eventually close; this repository has already seen a design document
-assert ruleset enforcement that the live ruleset did not actually implement, and this section is
-written to not repeat that mistake.
+`ci.yml` already carries the `merge_group` trigger and the scope-check plumbing this needs, and
+the ruleset now enforces the target required-context set — but until step 2 completes, every
+pull-request run is real evidence, not a stub, so nothing merges on unvalidated stand-ins. Issue
+#707 tracks the underlying required-status-check/ruleset gap this mechanism is meant to close;
+this repository has already seen a design document assert ruleset enforcement that the live
+ruleset did not actually implement, and this section is written to not repeat that mistake by
+naming exactly which half is live.
 
-A future PR or operational change would need to, in order:
+The ruleset's `merge_queue` rule enforcement has one operator escape hatch: `bypass_actors`
+carries a single `User` entry (repository admin, `bypass_mode: "pull_request"`), added because the
+ruleset's prior `bypass_actors` list was empty and `current_user_can_bypass` was `"never"` for
+every account — including admins — which was independently confirmed while merging #715 (`--admin`
+could not override an `Expected` required context). Without this entry, a queue malfunction (an
+undocumented `merge_group` branch-filter behavior, a `check_response_timeout_minutes` too low for
+a slow batch, or any other queue-side failure) would have no direct-merge recovery path short of
+reverting this ruleset change via the API. `OrganizationAdmin` was tried first and rejected: this
+repository's admin operates at the repository role, not the organization-owner role, so that actor
+type resolved to nobody, confirmed by `current_user_can_bypass` staying `"never"` after applying
+it. `bypass_mode` is scoped to `"pull_request"` rather than `"always"`, so this bypass cannot be
+used to push directly to `main` outside a pull request.
+
+A future PR or operational change would still need to:
 
 1. Create the repository variable `FSL_MERGE_QUEUE_CI` (e.g. set to `enabled`).
-2. Add a `merge_queue` type rule to the `main` branch ruleset (id `19090811`), and add the four
-   heavy context names — `rust workspace`, `WASM`, `semantic mutation (changed)`, and
-   `FSL Logic Test (pr)` — to that rule's required status checks.
 
-Neither step is automated by this change, and completing only one of them without the other would
-leave the mechanism either invisible (variable set, no queue to batch into) or inert (queue rule
-added, but `FSL_MERGE_QUEUE_CI` unset, so `pull_request` pushes keep running full evidence as they
-do today).
+Completing this step is what activates the queue-entry-stub path described above. Until then, the
+ruleset changes recorded here are enforcement of the *target* required-context set without yet
+changing per-push cost — the queue exists and gates merges, but every pull request still earns its
+five green checks the expensive way.
 
 ## Failure reporting contract
 


### PR DESCRIPTION
## What this is

Canary 1 of the merge-queue rollout described in #716's follow-up plan. The \`main\` ruleset (id \`19090811\`) was just updated live: an active \`merge_queue\` rule was added, and \`rust workspace\`, \`WASM\`, \`semantic mutation (changed)\`, and \`FSL Logic Test (pr)\` joined \`merge readiness\` as required status checks. \`FSL_MERGE_QUEUE_CI\` is intentionally still unset, so this PR should behave exactly like any ordinary pull request today (all five contexts run for real, no stubs) — it exists to prove the ruleset change works before that variable is created.

## Change

Updates \`docs/DESIGN-ci.md\`'s "Merge queue" section (renamed from "planned, not yet enabled" to "ruleset live, per-push cost not yet reduced") to name precisely which half of the rollout is live vs. still pending, and records the ruleset's new \`bypass_actors\` entry (a \`User\`/repository-admin, pull-request-scoped) added as an operator escape hatch — the prior ruleset had zero bypass actors, so a queue malfunction would have had no direct-merge recovery path. Also documents that \`OrganizationAdmin\` was tried first and silently resolved to nobody, since this repo's admin holds the repository role, not the organization-owner role.

## What this PR verifies

1. All five required contexts (\`merge readiness\`, \`rust workspace\`, \`WASM\`, \`semantic mutation (changed)\`, \`FSL Logic Test (pr)\`) report on a real pull request under the new ruleset.
2. This PR is not agent-configuration-exempt (touches \`docs/\` and \`CHANGELOG.md\` together — the changelog entry alone wouldn't be exempt-safe since \`docs/DESIGN-ci.md\` isn't on the exemption list), so \`tools/check-product-gate-scope.sh\` should resolve \`run=true\` for all four heavy jobs, exactly like pre-ruleset behavior.
3. Once checks pass, "Merge when ready" should enqueue this PR into the new queue and produce a \`merge_group\` event — this is the first real exercise of \`merge-readiness.yml\`'s and \`ci.yml\`'s (previously dormant) \`merge_group\` triggers, including the undocumented branch-filter behavior flagged during design.

If the merge-group run doesn't fire \`merge readiness\` as expected, the documented fallback is dropping \`branches: [main]\` from that workflow's \`merge_group\` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)