### PR TITLE
ci: shard the two heaviest product-gate jobs behind required aggregators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,19 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  rust-workspace:
-    name: rust workspace
+  # `rust workspace` is split three ways (docs/DESIGN-ci.md, "Sharded
+  # pre-merge Linux evidence"): `rust-checks` runs the non-test phases once
+  # (formatting, Clippy, doctests -- which `cargo-nextest` cannot run, so
+  # they stay here rather than being silently dropped -- and the full
+  # workspace build), and `rust-tests` shards the ~29-minute sequential test
+  # execution three ways with `cargo-nextest`. The `rust-workspace` job below
+  # aggregates both under the exact required-context name and keeps its job
+  # id unchanged, so `product-gate`'s `needs:` list and the `main` ruleset's
+  # required-context set both keep working without any further edit.
+  rust-checks:
+    name: rust checks
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,10 +96,135 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
+          shared-key: rust-workspace
 
-      - name: Check Rust workspace
+      - name: Check Rust workspace (non-test phases)
         if: steps.scope.outputs.run == 'true'
-        run: ./tools/check-native-integration.sh rust
+        run: ./tools/check-native-integration.sh rust-checks
+
+  rust-tests:
+    name: rust tests (${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
+
+      - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
+        with:
+          workspaces: rust -> target
+          shared-key: rust-workspace
+
+      - name: Cache pinned cargo-nextest CLI
+        id: nextest-cache
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-nextest
+          key: ${{ runner.os }}-cargo-nextest-0.9.143
+
+      - name: Install pinned cargo-nextest CLI
+        if: steps.nextest-cache.outputs.cache-hit != 'true' && steps.scope.outputs.run == 'true'
+        run: cargo install cargo-nextest --version 0.9.143 --locked
+
+      - name: Run Rust test shard
+        if: steps.scope.outputs.run == 'true'
+        run: ./tools/check-native-integration.sh rust-tests ${{ matrix.shard }}/3
+
+      - name: Preserve test-shard inventory
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-test-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rust/target/test-shards/*.txt
+          if-no-files-found: error
+          retention-days: 14
+          overwrite: true
+
+  rust-workspace:
+    name: rust workspace
+    if: always()
+    needs:
+      - rust-checks
+      - rust-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
+
+      - name: Require complete rust-checks and rust-tests evidence
+        env:
+          RUST_CHECKS: ${{ needs.rust-checks.result }}
+          RUST_TESTS: ${{ needs.rust-tests.result }}
+        shell: bash
+        run: |
+          failures=0
+          for result in "$RUST_CHECKS" "$RUST_TESTS"; do
+            if [ "$result" != "success" ]; then
+              failures=1
+            fi
+          done
+          if [ "$failures" -ne 0 ]; then
+            echo "rust workspace failed: rust-checks=$RUST_CHECKS rust-tests=$RUST_TESTS" >&2
+            exit 1
+          fi
+
+      # Agent-configuration-exempt pull requests never upload shard
+      # inventories (the upload steps above are gated on the same scope
+      # check), so there is nothing to download or validate: the shards
+      # already reported `success` from their early exit, which the
+      # previous step accepted.
+      - name: Download rust test-shard inventories
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rust-test-shard-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rust-test-shards
+
+      - name: Verify shard completeness
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t fulls < <(find rust-test-shards -name full.txt | sort)
+          mapfile -t shards < <(find rust-test-shards -name shard.txt | sort)
+          if [ "${#fulls[@]}" -ne 3 ] || [ "${#shards[@]}" -ne 3 ]; then
+            echo "rust workspace: expected 3 shard inventories, found ${#fulls[@]} full.txt and ${#shards[@]} shard.txt" >&2
+            exit 1
+          fi
+          # Three independently computed listings must agree exactly -- a
+          # divergence means the shards did not see the same workspace.
+          if ! cmp -s "${fulls[0]}" "${fulls[1]}" || ! cmp -s "${fulls[1]}" "${fulls[2]}"; then
+            echo "rust workspace: the three shards computed different full test listings" >&2
+            diff "${fulls[0]}" "${fulls[1]}" || true
+            diff "${fulls[1]}" "${fulls[2]}" || true
+            exit 1
+          fi
+          ./tools/check-shard-union.sh "${fulls[0]}" "${shards[@]}"
 
   wasm:
     name: WASM
@@ -199,13 +333,27 @@ jobs:
         working-directory: rust
         run: cargo test --locked -p fsl-solver-z3 -p fsl-verifier -p fslc-rust
 
-  # M13 semantic mutation gate (#672). Pull requests run the complete curated
-  # control matrix plus generic mutants intersecting their diff. Push,
-  # schedule, and manual runs execute the complete accepted P2 pilot scope.
-  semantic-mutation:
-    name: semantic mutation (${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'changed' || 'complete' }})
+  # M13 semantic mutation gate (#672), split into two lanes (docs/DESIGN-ci.md,
+  # "Sharded pre-merge Linux evidence"). Pull requests run the complete
+  # curated control matrix plus generic mutants intersecting their diff.
+  # Push, schedule, and manual runs execute the complete accepted P2 pilot
+  # scope. `semantic-mutation-operators` shards the curated fault-operator
+  # controls three ways; `semantic-mutation-mutants` runs the generic
+  # cargo-mutants half complete and unsharded, because it is already at
+  # roughly the operator lane's floor and sharding it would add cargo-mutants
+  # partitioning risk for no wall-clock gain. The `semantic-mutation` job
+  # below aggregates both under the exact required-context name expression
+  # and keeps its job id unchanged, so `product-gate`'s `needs:` list and the
+  # `main` ruleset's required-context set both keep working without any
+  # further edit.
+  semantic-mutation-operators:
+    name: mutation operators (${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -225,6 +373,46 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         with:
           workspaces: rust -> target
+          shared-key: semantic-mutation
+
+      - name: Calibrate curated fault-operator shard
+        if: steps.scope.outputs.run == 'true'
+        run: ./tools/run-semantic-mutation-gate.sh "${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'changed' || 'complete' }}" --lane operators --shard ${{ matrix.shard }}/3
+
+      - name: Preserve operator shard evidence
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: semantic-mutation-operators-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rust/target/fault-operators/logs/**
+          if-no-files-found: error
+          retention-days: 14
+          overwrite: true
+
+  semantic-mutation-mutants:
+    name: mutation mutants
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
+
+      - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
+        with:
+          workspaces: rust -> target
+          shared-key: semantic-mutation
 
       - name: Install pinned semantic mutation runner
         if: steps.scope.outputs.run == 'true'
@@ -244,22 +432,97 @@ jobs:
         env:
           FSL_MUTATION_DIFF: ${{ runner.temp }}/semantic-mutation.diff
           FSL_MUTATION_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-        run: ./tools/check-native-integration.sh semantic-mutation changed
+        run: ./tools/run-semantic-mutation-gate.sh changed --lane mutants
 
       - name: Calibrate complete accepted implementation scope
         if: steps.scope.outputs.run == 'true' && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.base_ref == 'production')
-        run: ./tools/check-native-integration.sh semantic-mutation complete
+        run: ./tools/run-semantic-mutation-gate.sh complete --lane mutants
 
       - name: Preserve mutation evidence
         if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: semantic-mutation-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            rust/target/semantic-mutation.*/**
-            rust/target/fault-operators/logs/**
+          name: semantic-mutation-mutants-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rust/target/semantic-mutation.*/**
           if-no-files-found: error
           retention-days: 14
+          overwrite: true
+
+  semantic-mutation:
+    name: semantic mutation (${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'changed' || 'complete' }})
+    if: always()
+    needs:
+      - semantic-mutation-operators
+      - semantic-mutation-mutants
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide required evidence scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
+
+      - name: Require complete operator-shard and mutants-lane evidence
+        env:
+          SEMANTIC_MUTATION_OPERATORS: ${{ needs.semantic-mutation-operators.result }}
+          SEMANTIC_MUTATION_MUTANTS: ${{ needs.semantic-mutation-mutants.result }}
+        shell: bash
+        run: |
+          failures=0
+          for result in "$SEMANTIC_MUTATION_OPERATORS" "$SEMANTIC_MUTATION_MUTANTS"; do
+            if [ "$result" != "success" ]; then
+              failures=1
+            fi
+          done
+          if [ "$failures" -ne 0 ]; then
+            echo "semantic mutation failed: operators=$SEMANTIC_MUTATION_OPERATORS mutants=$SEMANTIC_MUTATION_MUTANTS" >&2
+            exit 1
+          fi
+
+      # Agent-configuration-exempt pull requests never upload shard
+      # manifests (the upload steps above are gated on the same scope
+      # check), so there is nothing to download or validate: the shards
+      # already reported `success` from their early exit, which the
+      # previous step accepted.
+      - name: Download operator shard manifests
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: semantic-mutation-operators-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: semantic-mutation-operators
+
+      - name: Verify operator shard completeness
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t manifests < <(find semantic-mutation-operators -name shard-manifest.v1.json | sort)
+          if [ "${#manifests[@]}" -ne 3 ]; then
+            echo "semantic mutation: expected 3 operator shard manifests, found ${#manifests[@]}" >&2
+            exit 1
+          fi
+          base_revision="$(jq -r '.base_revision' "${manifests[0]}")"
+          table_operators="$(jq -c '.table_operators' "${manifests[0]}")"
+          work="$(mktemp -d)"
+          for index in "${!manifests[@]}"; do
+            manifest="${manifests[$index]}"
+            if [ "$(jq -r '.base_revision' "$manifest")" != "$base_revision" ]; then
+              echo "semantic mutation: $manifest disagrees with ${manifests[0]} on base_revision" >&2
+              exit 1
+            fi
+            if [ "$(jq -c '.table_operators' "$manifest")" != "$table_operators" ]; then
+              echo "semantic mutation: $manifest disagrees with ${manifests[0]} on table_operators" >&2
+              exit 1
+            fi
+            jq -r '.executed_operators[]' "$manifest" | sort -u >"$work/shard-$index.txt"
+          done
+          jq -r '.[]' <<<"$table_operators" | sort -u >"$work/full.txt"
+          ./tools/check-shard-union.sh "$work/full.txt" "$work"/shard-*.txt
 
   # M13 deterministic finite-model agreement (#673). The report begins
   # incomplete and becomes complete only after every selected case and edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 ## [Unreleased]
 
 - Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
-  from a measured 38m15s (`semantic mutation (changed)`, run 30968645971)
-  toward an expected ≈17 min, without weakening any check or changing the
-  `main` ruleset. The gain is a little over 2x rather than 3x because both
-  lanes carry a large unshardable fixed cost: the first sharded operator run
-  measured a 6-operator shard's no-op control at 760s against 912s for all
-  17, so splitting that lane three ways removed ~150s of detector time, not
-  two thirds of the lane. `rust workspace` (32m43s, of which ~29 min was `cargo test`
+  from a measured 38m15s (`semantic mutation (changed)`, run 30968645971) to a
+  measured **20.7 min** (run 30989320577, all lanes green) — 1.85x, ~17.5 min
+  saved per pull request — without weakening any check or changing the `main`
+  ruleset. The gain is under 2x, not 3x, and `docs/DESIGN-ci.md` records why
+  from the same run: `cargo-nextest --partition count:` balances by test count,
+  not duration, so the three test shards took 18.1/8.3/12.6 min and
+  `rust workspace` waits on its slowest; and sharding the curated operator lane
+  three ways bought only ~10% (22.5 min → 20.3 min) because each shard pays a
+  fixed cold build in its own scratch checkout. The two remaining levers,
+  neither attempted here, are a duration-aware test assignment (~5 min) and
+  caching `rust/target/fault-operators` so that scratch build starts warm. `rust workspace` (32m43s, of which ~29 min was `cargo test`
   running 176 test binaries strictly sequentially) is now `rust-checks`
   (formatting, Clippy, doctests, the full build, and the boundary/stack-
   parity controls, run once) plus `rust-tests` (a 3-way `cargo-nextest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
+  from a measured 38m15s (`semantic mutation (changed)`, run 30968645971)
+  toward an expected ≈17 min, without weakening any check or changing the
+  `main` ruleset. The gain is a little over 2x rather than 3x because both
+  lanes carry a large unshardable fixed cost: the first sharded operator run
+  measured a 6-operator shard's no-op control at 760s against 912s for all
+  17, so splitting that lane three ways removed ~150s of detector time, not
+  two thirds of the lane. `rust workspace` (32m43s, of which ~29 min was `cargo test`
+  running 176 test binaries strictly sequentially) is now `rust-checks`
+  (formatting, Clippy, doctests, the full build, and the boundary/stack-
+  parity controls, run once) plus `rust-tests` (a 3-way `cargo-nextest
+  --partition count:K/3` matrix), aggregated by a `rust-workspace` job.
+  `semantic mutation (…)` is now `semantic-mutation-operators` (the curated
+  fault-operator table, round-robin sharded three ways by
+  `tools/run-fault-operators.sh --shard K/N`) plus `semantic-mutation-mutants`
+  (the generic cargo-mutants half, kept **complete and unsharded** — at its
+  measured ~14.3 min it is already close to the curated lane's post-split
+  floor, and cargo-mutants sharding would add real risk for no measured
+  gain), aggregated by a `semantic-mutation` job. Doctests move explicitly to
+  `rust-checks` because `cargo-nextest` cannot run them at all; silently
+  dropping them would have been exactly the "weaken a gate for speed" move
+  this repository forbids. Both aggregators keep the exact required-context
+  job id and name (`rust-workspace` / `rust workspace`,
+  `semantic-mutation` / `semantic mutation (${{ ... }})`) and run
+  `if: always()`, because GitHub treats a *skipped* required check as
+  satisfied — without `always()` a failing shard could skip the aggregator
+  into a false-green required context. Each aggregator also downloads its
+  shards' inventories and proves the split is a true partition of the
+  unsharded set before trusting it: `rust-workspace` requires the three
+  `rust-tests` shards' `full.txt` listings to be byte-identical and their
+  `shard.txt`s to union back to exactly one of them; `semantic-mutation`
+  requires the three operator shards' manifests to agree on
+  `base_revision`/`table_operators` and their `executed_operators` to union
+  back to `table_operators` exactly. Both checks reuse a new generic
+  `tools/check-shard-union.sh` (subset/pairwise-disjoint/union-equality,
+  fail-closed and naming the offending entries), whose `selftest` — an
+  accepting 3-way split plus four rejecting cases (uncovered entry,
+  duplicated entry, invented entry, empty shard list) — is wired into
+  `tools/check-merge-readiness.sh`'s automation lane next to
+  `check-product-gate-scope.sh selftest`. `tools/run-semantic-mutation-gate.sh`
+  gained `--lane operators|mutants` and `--shard K/N`; with neither flag its
+  behavior, order, and output are unchanged from before this change.
+  `tools/check-native-integration.sh` gained `rust-checks` and
+  `rust-tests K/N` phases; `rust` (the single unsharded local entrypoint
+  named in `AGENTS.md`) is untouched. See `docs/DESIGN-ci.md`, "Sharded
+  pre-merge Linux evidence", and `docs/DESIGN-semantic-mutation-gate.md`,
+  "CI scheduling: two lanes, one aggregator".
+
 - Required the complete Linux evidence on `main`, closing the gap #707
   opened: the `main safety and CI` ruleset (id `19090811`) now requires
   `rust workspace`, `WASM`, `semantic mutation (changed)`, and

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -85,12 +85,21 @@ candidate against current `main`.
 `.github/workflows/ci.yml` is named `product gate`. A trusted `main` push runs all of these jobs in
 parallel:
 
-- the complete Rust-native integration phase from `tools/check-native-integration.sh rust`
-  (`rust workspace`);
+- the Rust-native integration phase, sharded across three jobs: `rust-checks` runs
+  `tools/check-native-integration.sh rust-checks` once (formatting, Clippy, the workspace doctests,
+  the full workspace build, and the boundary/stack-parity controls); `rust-tests` shards the
+  workspace's non-doctest tests three ways with `cargo-nextest` via
+  `tools/check-native-integration.sh rust-tests K/3`; the `rust-workspace` aggregator requires both
+  and enforces shard-union completeness (`rust workspace`; see "Sharded pre-merge Linux evidence"
+  below);
 - the production WASM/browser phase from `tools/check-native-integration.sh wasm` (`WASM`);
 - focused native-Z3 tests on macOS and Windows (`native Z3 4.16`);
-- the M13 semantic mutation gate from `tools/check-native-integration.sh semantic-mutation`
-  (`semantic mutation`), including curated implementation operators and pinned generic mutants.
+- the M13 semantic mutation gate, sharded across three jobs: `semantic-mutation-operators` runs the
+  curated fault-operator controls three ways via `tools/run-semantic-mutation-gate.sh <mode> --lane
+  operators --shard K/3`; `semantic-mutation-mutants` runs the generic cargo-mutants half, complete
+  and unsharded, via `tools/run-semantic-mutation-gate.sh <mode> --lane mutants`; the
+  `semantic-mutation` aggregator requires both and enforces operator-union completeness (`semantic
+  mutation`; see "Sharded pre-merge Linux evidence" below);
 - the deterministic finite-model agreement gate from `tools/check-native-integration.sh fsl-logic`
   (`FSL Logic Test`).
 
@@ -162,6 +171,104 @@ unfiltered pre-merge or fail-loud coverage. `skills/**` and `docs/**` must never
 `skills/fsl/reference.md` moves with language features under the coupled-change contract,
 `docs/LANGUAGE*.md` feeds the site-reference freshness gate, and product-gate literate
 doc-contract tests read documentation files directly.
+
+### Sharded pre-merge Linux evidence
+
+Measured on run 30968645971 (PR #717): `semantic mutation (changed)` was the critical-path job at
+38m15s, `rust workspace` was 32m43s, `WASM` was 6m08s, and `FSL Logic Test (pr)` was 1m09s. Inside
+`rust workspace`, cache restore and compilation together were only ~3.5 min on a warm cache; the
+remaining ~29 min was `cargo test` running 176 test binaries **strictly sequentially** — the
+harness-sum across binaries (28.6 min) matches the observed wall clock, and five binaries
+(`refine_corpus_parity` 7.34 min/4 tests, `explicit_engine` 4.58 min/12, `injection_detector_matrix`
+3.75 min/1 test, `corpus_check_sweep` 3.16 min/3, `issue_226_auto_engine` 3.13 min/15) are 77% of
+that time while 146 of the 176 binaries finish in under a second. Inside `semantic mutation`, the
+curated fault-operator half's no-op control alone (`control no-op: all 17 operators' detectors
+green`) took 912s and the full curated loop (`fault-operators: 17 operators calibrated`) took 1350s;
+the generic cargo-mutants half took roughly the remaining ~14.3 min.
+
+Both jobs are dominated by work that parallelizes cleanly across independent shards, so each is
+split into a sharded lane plus an aggregator that keeps the exact required-context name:
+
+- `rust workspace` = `rust-checks` (once) + `rust-tests` (`cargo-nextest`, 3-way `--partition
+  count:K/3`) + the `rust-workspace` aggregator.
+- `semantic mutation (…)` = `semantic-mutation-operators` (3-way round-robin shard of
+  `operators.txt`) + `semantic-mutation-mutants` (generic cargo-mutants, complete and **deliberately
+  unsharded** — see below) + the `semantic-mutation` aggregator.
+
+Expected wall clock after sharding is **≈17 min**, down from 38m15s — a little over 2x, not 3x,
+because both lanes carry a large unshardable fixed cost measured during this work and stated in the
+floors below. The first sharded operator run measured it directly: a 6-operator shard's no-op control
+took **760s** against 912s for all 17, so splitting the lane three ways removed only ~150s of
+detector time, not two thirds of the lane. Do not quote a lower figure than ≈17 min without a fresh
+measurement.
+
+**Doctests moved to `rust-checks`, explicitly, because `cargo-nextest` cannot run them at all.**
+Silently dropping them to make the sharded lane faster would be exactly the "weaken a gate for
+speed" move this repository's invariants forbid, so
+`cargo test --manifest-path rust/Cargo.toml --workspace --doc --locked` runs once, unsharded, in
+`rust-checks`, alongside formatting, Clippy, the full workspace build, and the boundary/stack-parity
+controls. `rust-tests` then shards only what `cargo-nextest` can run: everything else.
+
+**The generic mutants lane is deliberately unsharded.** At ~14.3 min it is already close to the
+curated operator lane's floor once that lane is split three ways (see below), and cargo-mutants
+sharding would add real risk — mutant-inventory slicing, uncertain `--shard`/partition index-base
+semantics in the pinned runner, and migrating the stale-reviewed-equivalents check to a sharded
+world — for no measurable wall-clock gain. `semantic-mutation-mutants` therefore runs
+`tools/run-semantic-mutation-gate.sh <mode> --lane mutants`, complete, on one runner, with the same
+fresh-`CARGO_TARGET_DIR` anti-contamination behavior it has always had.
+
+**Why `if: always()` is load-bearing on both aggregators.** GitHub treats a *skipped* required
+status check as satisfied — it is not "pending" or "failing," it reads as passed. If `rust-workspace`
+or `semantic-mutation` inherited the default skip-on-upstream-failure behavior, a failing shard would
+skip the aggregator, and the skip would silently satisfy the `main` ruleset's required context instead
+of blocking the merge: a confidently-green false negative on the exact two contexts this split
+touches. `if: always()` forces the aggregator to run and evaluate its dependencies' results even when
+one failed, so it can fail loudly instead of disappearing. The aggregator job **ids** are unchanged
+(`rust-workspace`, `semantic-mutation`), so `product-gate`'s `needs:` list and the `main` ruleset's
+required-context set (`rust workspace`, `semantic mutation (changed)`) both keep working without
+their own edit.
+
+**Union-completeness guards.** A scheduling change must not be able to silently narrow what runs, so
+each aggregator downloads its shards' inventories and proves the split is a true partition of the
+unsharded set before trusting a `success` result:
+
+- `rust-workspace` downloads the three `rust-tests` shards' `full.txt`/`shard.txt` (written by
+  `check_rust_tests` in `tools/check-native-integration.sh` *before* the shard's tests run, so the
+  inventory exists even when a test in it fails), asserts the three `full.txt` files are
+  byte-identical — three independent `cargo nextest list` invocations agreeing — then runs
+  `tools/check-shard-union.sh full.txt shard1.txt shard2.txt shard3.txt`.
+- `semantic-mutation` downloads the three operator shards' `shard-manifest.v1.json` (written by
+  `tools/run-fault-operators.sh` only after a successful shard run), asserts identical
+  `base_revision` and `table_operators` across all three, then checks that the disjoint union of
+  their `executed_operators` equals `table_operators` with the same `check-shard-union.sh` logic.
+
+`tools/check-shard-union.sh` is the generic, reusable primitive both checks build on: given one full
+list and N shard lists, it fails closed — naming the offending entries — unless every shard is a
+subset of the full list, the shards are pairwise disjoint, and their union equals the full list
+exactly. Its `selftest` subcommand exercises an accepting three-way split and four rejecting cases
+(an entry covered by no shard, an entry duplicated across shards, an invented shard entry, an empty
+shard list) and is wired into `tools/check-merge-readiness.sh`'s `check_automation`, alongside
+`check-product-gate-scope.sh selftest`.
+
+**Agent-configuration-exempt pull requests still work.** Every shard job runs
+`check-product-gate-scope.sh` itself and early-exits its own later steps when `run=false`, so the
+shard's job result is still `success` and no artifact is ever uploaded. Both aggregators therefore
+also run the scope step themselves: when `run=false` they trust the (trivially successful) shard
+results and skip the artifact-download/union-validation steps outright, because there is nothing to
+download.
+
+**Floors — sharding buys parallelism, not a lower bound.** `refine_corpus_parity`'s slowest single
+test (≈7.3 min) cannot be split further by this scheme, so together with the ≈3.5 min compile it
+bounds `rust-workspace` at roughly ≈12 min no matter how the remaining 175 binaries are distributed.
+Each `semantic-mutation-operators` shard independently pays the cold build in its own synced scratch
+checkout (`tools/run-fault-operators.sh`'s `sync_scratch`), and that cost dominates the lane:
+measured, a 6-operator shard's no-op control took 760s where all 17 operators took 912s, so roughly
+700s of the 912s is the fixed scratch build and only ~12s per detector run scales with the shard.
+The lane's floor is therefore ≈760s plus its ~26s-per-assigned-operator loop — about 15–16 min at
+`K/3`, against 22.5 min unsharded, **not** 1350s ÷ 3. Raising the shard count barely helps; only
+making that scratch build cheaper (caching `rust/target/fault-operators`, or sharing a warm target
+dir without breaking the patch-isolation contract) would move this floor, and neither is attempted
+here. Nobody should expect either lane to shrink further without changing what it measures.
 
 `semantic mutation` is required on pull requests and every product-gate event. Ordinary pull
 requests run all curated controls plus generic mutants intersecting the recorded base-to-head diff;
@@ -236,9 +343,12 @@ requirement in ruleset `19090821` would have to drop to zero approvals (removing
 for non-admin contributors too), or a second approving identity would have to exist. Neither is a
 CI decision, so neither is made here. `ci.yml` keeps its `merge_group` trigger and the scope
 script keeps its `queue-entry-stub` branch — both inert, both harmless, and both ready if that
-policy question is ever answered differently. Until then, per-push cost is unchanged and the
-remaining levers for it are ordinary ones: cache hit rates, job splitting, or moving specific lanes
-post-merge under a new accepted decision.
+policy question is ever answered differently. Until then, per-push cost is unchanged from a
+human-review-policy standpoint. Of the ordinary levers named here previously, job splitting is now
+exercised — see "Sharded pre-merge Linux evidence" above — and cache hit rates were measured to have
+no headroom: compile is only ~3.5 min of the ~33 min `rust workspace` measured on a warm cache, so a
+better hit rate could not have bought back more than that. The remaining lever is moving specific
+lanes post-merge under a new accepted decision.
 
 ## Failure reporting contract
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -195,12 +195,33 @@ split into a sharded lane plus an aggregator that keeps the exact required-conte
   `operators.txt`) + `semantic-mutation-mutants` (generic cargo-mutants, complete and **deliberately
   unsharded** — see below) + the `semantic-mutation` aggregator.
 
-Expected wall clock after sharding is **≈17 min**, down from 38m15s — a little over 2x, not 3x,
-because both lanes carry a large unshardable fixed cost measured during this work and stated in the
-floors below. The first sharded operator run measured it directly: a 6-operator shard's no-op control
-took **760s** against 912s for all 17, so splitting the lane three ways removed only ~150s of
-detector time, not two thirds of the lane. Do not quote a lower figure than ≈17 min without a fresh
-measurement.
+Measured wall clock after sharding is **20.7 min**, down from 38m15s — 1.85x, saving ~17.5 min per
+pull request. Recorded from the first sharded run (30989320577, PR #719), all lanes green:
+
+| lane | wall clock |
+| --- | --- |
+| `mutation operators (1/3)` | **20.3 min** ← critical path |
+| `mutation operators (2/3)` / `(3/3)` | 19.0 / 18.4 min |
+| `rust tests (1/3)` | **18.1 min** |
+| `rust tests (3/3)` / `(2/3)` | 12.6 / 8.3 min |
+| `mutation mutants` | 16.7 min |
+| `WASM` | 5.9 min |
+| `rust checks` | 2.7 min |
+| `FSL Logic Test (pr)` | 1.1 min |
+| both aggregators | 0.1 min each |
+
+Two costs are visible in that table and are the honest limits of this change, not incidental noise:
+
+- **`cargo-nextest --partition count:K/N` balances by test count, not duration.** The three shards
+  received 518/460/411 tests and took 18.1/8.3/12.6 min — shard 1 is 2.2x shard 2, so `rust workspace`
+  finishes on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
+  give. Recovering that ~5 min needs a duration-aware assignment (pinning the known-slow binaries to
+  separate shards), which `count:` cannot express.
+- **Sharding the curated operator lane bought about 10%, not two thirds.** 22.5 min unsharded became
+  20.3 min at `K/3` — three times the compute for ~2 min of wall clock — because the fixed cold build
+  in each shard's synced scratch checkout dominates. It is retained because runner minutes are free on
+  a public repository and it is the current critical path's only lever in this change, but it is a
+  poor trade and the floors below say what would actually move it.
 
 **Doctests moved to `rust-checks`, explicitly, because `cargo-nextest` cannot run them at all.**
 Silently dropping them to make the sharded lane faster would be exactly the "weaken a gate for
@@ -261,14 +282,20 @@ download.
 test (≈7.3 min) cannot be split further by this scheme, so together with the ≈3.5 min compile it
 bounds `rust-workspace` at roughly ≈12 min no matter how the remaining 175 binaries are distributed.
 Each `semantic-mutation-operators` shard independently pays the cold build in its own synced scratch
-checkout (`tools/run-fault-operators.sh`'s `sync_scratch`), and that cost dominates the lane:
-measured, a 6-operator shard's no-op control took 760s where all 17 operators took 912s, so roughly
-700s of the 912s is the fixed scratch build and only ~12s per detector run scales with the shard.
-The lane's floor is therefore ≈760s plus its ~26s-per-assigned-operator loop — about 15–16 min at
-`K/3`, against 22.5 min unsharded, **not** 1350s ÷ 3. Raising the shard count barely helps; only
-making that scratch build cheaper (caching `rust/target/fault-operators`, or sharing a warm target
-dir without breaking the patch-isolation contract) would move this floor, and neither is attempted
-here. Nobody should expect either lane to shrink further without changing what it measures.
+checkout (`tools/run-fault-operators.sh`'s `sync_scratch`), and that cost dominates the lane. Locally,
+a 6-operator shard's no-op control took 760s where all 17 took 912s; in CI the sharded lane landed at
+18.4–20.3 min against 22.5 min unsharded, so the fixed scratch build is an even larger share there.
+Raising the shard count cannot fix this. The two levers that would, neither attempted here, are:
+
+- caching `rust/target/fault-operators` so the scratch build starts warm — the same
+  `Swatinem/rust-cache` treatment the main lanes already get, and the one place in this gate where
+  caching genuinely is the bottleneck (it is not, for `rust workspace`: compilation there is ~3.5 min
+  of 33 on a warm cache);
+- a duration-aware `rust-tests` assignment, worth ~5 min on its own (see the imbalance above).
+
+With both, the gate would plausibly reach ≈13 min; without them, 20.7 min is the floor this design
+delivers. Nobody should expect either lane to shrink further without changing what it measures or how
+its scratch build is warmed.
 
 `semantic mutation` is required on pull requests and every product-gate event. Ordinary pull
 requests run all curated controls plus generic mutants intersecting the recorded base-to-head diff;

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -400,9 +400,12 @@ there and re-target the patch. Silently skipping a stale operator is how a
 detector matrix rots into decoration.
 
 Rebuild cost keeps this out of the ordinary Rust workspace lane, but M13 makes
-it part of the dedicated semantic-mutation lane on every pull request and
-product-gate run. Operators patch `rust/fslc` where possible, so the rebuild is
-that crate plus a relink rather than the workspace.
+it part of the dedicated semantic-mutation lanes on every pull request and
+product-gate run — round-robin sharded three ways across the
+`semantic-mutation-operators` matrix (docs/DESIGN-ci.md, "Sharded pre-merge
+Linux evidence"; docs/DESIGN-semantic-mutation-gate.md, "CI scheduling: two
+lanes, one aggregator"). Operators patch `rust/fslc` where possible, so the
+rebuild is that crate plus a relink rather than the workspace.
 
 Patches are applied with `git apply`, never the system `patch`. The first CI run
 of this matrix failed (#613) because BSD `patch` on macOS accepted the no-op
@@ -416,12 +419,16 @@ nothing. `git apply` is one implementation wherever git is, applies zero fuzz by
 default, and tolerates the prose preamble each patch file carries.
 
 The harness is `tools/run-fault-operators.sh`, reached directly as the legacy
-`fault-operators` phase and, together with pinned generic implementation
-mutants, through `tools/check-native-integration.sh semantic-mutation`. It is
-deliberately not in the ordinary `rust` phase. CI requires the dedicated
-semantic-mutation job on every event: pull requests run the curated matrix and
-generic mutants intersecting the PR diff, while other events run the complete
-accepted P2 pilot scope. Operators are rows in
+`fault-operators` phase, through `tools/check-native-integration.sh
+semantic-mutation` for a complete unsharded local run, and — with its own
+`--shard K/N` — as the curated half of `tools/run-semantic-mutation-gate.sh
+--lane operators` in CI's sharded `semantic-mutation-operators` matrix. It is
+deliberately not in the ordinary `rust` phase. CI requires the aggregate
+`semantic-mutation` context on every event: pull requests run the curated
+matrix and generic mutants intersecting the PR diff, while other events run
+the complete accepted P2 pilot scope; the aggregator requires both the
+operator-shard matrix and the unsharded generic-mutants job to succeed and
+enforces that the shards' union covers every operator. Operators are rows in
 `rust/fslc/tests/fault_operators/operators.txt`, each naming a patch file, a
 primary detector, and a blind detector; the two controls are
 `controls/no-op.patch` and `controls/stale-seam.patch`. Adding an operator is a
@@ -699,8 +706,11 @@ scratch checkout and requires
 operator row or shipped injection hook.
 
 `tools/check-native-integration.sh rust` runs the workspace Rust tests and
-therefore owns this native anchor. The frozen Python test is outside that gate
-and remains a compatibility reference only.
+therefore owns this native anchor for a complete local run; in CI the same
+test runs under whichever `rust-tests` shard `cargo-nextest`'s partitioning
+assigns it to (docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence"). The
+frozen Python test is outside that gate and remains a compatibility
+reference only.
 
 ## Triangulated Assurance (#670)
 

--- a/docs/DESIGN-semantic-mutation-gate.md
+++ b/docs/DESIGN-semantic-mutation-gate.md
@@ -128,8 +128,46 @@ baseline. The fresh target keeps baseline evidence independent of prior runs.
   or a stale equivalence entry fails closed. Shards are complete only when all
   declared shards publish outcomes for the same revision and tool version.
 
-The product entrypoint is `tools/check-native-integration.sh semantic-mutation`.
-It does not invoke the frozen Python reference.
+### CI scheduling: two lanes, one aggregator
+
+The curated operator half and the generic cargo-mutants half are wall-clock-independent by
+construction, so CI runs them as separate jobs behind an aggregator that carries the required
+`semantic mutation (...)` context (docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence").
+This is a scheduling change only: every check that ran before still runs, in the same
+tier (`changed`/`complete`), with the same classifications and the same evidence contract.
+
+- `semantic-mutation-operators` (3-way matrix) runs
+  `tools/run-semantic-mutation-gate.sh <mode> --lane operators --shard K/3`. Each shard gets a
+  round-robin third of `operators.txt` by 0-based row index (`operator i` belongs to shard `K` iff
+  `i % 3 == K - 1`), assigned by `tools/run-fault-operators.sh`'s `assign_shard`. The whole-table
+  validation in `read_table` (missing patch file, orphaned patch, malformed row) and the harness's
+  own `check_stale_seam_control` negative control run in **every** shard, not just one — a fault in
+  either must be caught regardless of which shard happens to run it. `check_no_op_control`'s loop and
+  the main operator loop are both restricted to the shard's assigned indices, which is what makes the
+  ~912s no-op control shardable at all.
+- `semantic-mutation-mutants` runs `tools/run-semantic-mutation-gate.sh <mode> --lane mutants`,
+  complete and **unsharded**: at the measured ~14.3 min it is already close to the curated lane's
+  post-split floor, and cargo-mutants sharding (mutant-inventory slicing, uncertain
+  `--shard`/partition index-base semantics in the pinned runner, migrating the stale-reviewed-
+  equivalents check) would add real risk for no measured wall-clock gain.
+- The `semantic-mutation` aggregator requires both lanes to report `success` (`if: always()`, so a
+  failing shard cannot be masked by a GitHub-treated-as-satisfied *skip* of the aggregator), then
+  downloads every operator shard's `shard-manifest.v1.json` and enforces completeness: identical
+  `base_revision` and `table_operators` across all three manifests, and the disjoint union of their
+  `executed_operators` equal to `table_operators` exactly (via `tools/check-shard-union.sh`, the same
+  fail-closed subset/disjoint/union-equality primitive used by the `rust workspace` split). A shard
+  writes its manifest only after it succeeds, so a failed shard cannot contribute a manifest that
+  reads as complete.
+
+With no `--lane` flag, `tools/run-semantic-mutation-gate.sh`'s behavior is unchanged from before this
+split: the same manifest test, the same unsharded `run-fault-operators.sh` call, and the same
+cargo-mutants run, in the same order. This is the path `tools/check-native-integration.sh
+semantic-mutation` and every local invocation still take. `--lane`/`--shard` are additive, CI-only
+scheduling controls.
+
+The product entrypoint for a complete, unsharded local run is
+`tools/check-native-integration.sh semantic-mutation`. It does not invoke the frozen Python
+reference.
 
 ## Survivor promotion
 

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -42,6 +42,10 @@ check_automation() {
   # Accepting/rejecting controls for the agent-configuration-exemption
   # classifier that ci.yml's heavy jobs now run in-job (docs/DESIGN-ci.md).
   ./tools/check-product-gate-scope.sh selftest
+  # Accepting/rejecting controls for the shard-completeness guard the sharded
+  # `rust workspace` and `semantic mutation` aggregators depend on
+  # (docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence").
+  ./tools/check-shard-union.sh selftest
 }
 
 case "${1:-all}" in

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -28,6 +28,117 @@ check_rust() {
   check_boundaries
 }
 
+# Sharded, non-test half of `check_rust` (issue: CI wall-clock reduction).
+# `rust workspace` was the critical-path-adjacent job at 32m43s, of which
+# cache restore and compilation together were only ~4 min and sequential test
+# execution across 176 binaries was ~29 min -- `cargo test` runs test
+# binaries one at a time. This phase carries everything except that test
+# execution: it stays cheap and runs once, in the `rust-checks` job, while
+# `check_rust_tests` below shards the test execution 3 ways in `rust-tests`
+# using `cargo-nextest`, which nextest cannot do for doctests. Doctests
+# therefore stay here, explicit and unsharded, rather than silently dropped.
+check_rust_checks() {
+  check_stack_parity
+  cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+  cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
+  cargo test --manifest-path rust/Cargo.toml --workspace --doc --locked
+  cargo build --manifest-path rust/Cargo.toml --workspace --locked
+
+  check_boundaries
+}
+
+# Nextest-pinned version. Keep this in sync with the `rust-tests` matrix's
+# cache/install step and cache key in `.github/workflows/ci.yml` -- a drift
+# between the installed binary and this assertion must fail loudly, not run
+# an unverified partitioning behavior. `cargo nextest --version`'s first line
+# ("cargo-nextest 0.9.143 (<commit> <date>)") embeds the upstream build's
+# commit hash, so compare the stable `release:` line instead.
+readonly NEXTEST_VERSION="0.9.143"
+
+# Runs one shard (`spec` = "K/N", 1-based, K <= N) of the workspace's
+# non-doctest tests under `cargo-nextest`, after writing the shard's
+# completeness evidence: `full.txt` (every non-ignored test in the
+# workspace) and `shard.txt` (this shard's slice), both written *before* the
+# shard runs so the inventory exists even when a test in it fails. The
+# `rust-workspace` aggregator downloads every shard's `full.txt`, asserts
+# they are byte-identical (three independently computed listings agreeing),
+# and checks the union of every `shard.txt` against one `full.txt` with
+# `check-shard-union.sh`.
+check_rust_tests() {
+  local spec="${1:-}"
+  if [[ ! "$spec" =~ ^([1-9][0-9]*)/([1-9][0-9]*)$ ]]; then
+    echo "usage: $0 rust-tests K/N (K, N positive integers, K <= N); got '${spec}'" >&2
+    exit 2
+  fi
+  local shard_index="${BASH_REMATCH[1]}" shard_total="${BASH_REMATCH[2]}"
+  if [ "$shard_index" -gt "$shard_total" ]; then
+    echo "usage: $0 rust-tests K/N: K must be <= N, got '$spec'" >&2
+    exit 2
+  fi
+
+  local installed
+  installed="$(cargo nextest --version 2>&1 | awk -F': ' '/^release:/ {print $2}')"
+  if [ "$installed" != "$NEXTEST_VERSION" ]; then
+    echo "check-native-integration: requires exactly cargo-nextest $NEXTEST_VERSION; observed release '$installed' (raw: $(cargo nextest --version 2>&1 | head -n1))" >&2
+    exit 1
+  fi
+
+  local shard_dir="rust/target/test-shards"
+  mkdir -p "$shard_dir"
+  local full="$shard_dir/full.txt"
+  local shard="$shard_dir/shard.txt"
+
+  # `rust-suites` is an object keyed by suite name, not an array; each
+  # suite's `binary-id` disambiguates same-named tests across binaries.
+  # `--partition` does not shrink the listing -- every suite still lists
+  # every test, and each testcase's `filter-match.status` says whether *this*
+  # invocation's partition claims it ("matches") or another one does
+  # ("mismatch"). Verified directly against this workspace (1389 tests):
+  # unpartitioned `ignored == false` gives all 1389; the three
+  # `count:K/3` partitions' `filter-match.status == "matches"` sets are
+  # pairwise disjoint and their union is exactly those 1389.
+  cargo nextest list \
+    --manifest-path rust/Cargo.toml --workspace --locked \
+    --message-format json \
+    | jq -r '
+        .["rust-suites"][]
+        | ."binary-id" as $bid
+        | .testcases
+        | to_entries[]
+        | select(.value.ignored == false)
+        | $bid + "::" + .key' \
+    | sort -u >"$full"
+  cargo nextest list \
+    --manifest-path rust/Cargo.toml --workspace --locked \
+    --partition "count:${shard_index}/${shard_total}" \
+    --message-format json \
+    | jq -r '
+        .["rust-suites"][]
+        | ."binary-id" as $bid
+        | .testcases
+        | to_entries[]
+        | select(.value.ignored == false and .value["filter-match"].status == "matches")
+        | $bid + "::" + .key' \
+    | sort -u >"$shard"
+
+  [ -s "$full" ] || {
+    echo "check-native-integration: nextest listed zero non-ignored tests for the workspace; refusing to run a shard against an empty inventory" >&2
+    exit 1
+  }
+  [ -s "$shard" ] || {
+    echo "check-native-integration: shard $spec listed zero tests -- N is likely larger than the test count, or the partition math is wrong" >&2
+    exit 1
+  }
+  if [ -n "$(comm -23 <(sort -u "$shard") <(sort -u "$full"))" ]; then
+    echo "check-native-integration: shard $spec names tests absent from the full workspace listing" >&2
+    exit 1
+  fi
+
+  cargo nextest run \
+    --manifest-path rust/Cargo.toml --workspace --locked \
+    --partition "count:${shard_index}/${shard_total}"
+}
+
 check_boundaries() {
   assert_dependency_absent fsl-runtime 'fsl-solver|z3' 'fsl-runtime must remain solver-independent'
   assert_dependency_absent fsl-wasm 'fsl-solver-z3 v' 'fsl-wasm must not depend on the native Z3 backend'
@@ -105,6 +216,12 @@ case "${1:-all}" in
   rust)
     check_rust
     ;;
+  rust-checks)
+    check_rust_checks
+    ;;
+  rust-tests)
+    check_rust_tests "${2:-}"
+    ;;
   wasm)
     check_wasm
     ;;
@@ -130,7 +247,7 @@ case "${1:-all}" in
     check_fsl_logic scheduled
     ;;
   *)
-    echo "usage: $0 [all|rust|wasm|boundaries|fault-operators|semantic-mutation [changed|complete]|fsl-logic [pr|scheduled]|stack-parity]" >&2
+    echo "usage: $0 [all|rust|rust-checks|rust-tests K/N|wasm|boundaries|fault-operators|semantic-mutation [changed|complete]|fsl-logic [pr|scheduled]|stack-parity]" >&2
     exit 2
     ;;
 esac

--- a/tools/check-shard-union.sh
+++ b/tools/check-shard-union.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic, line-set based shard-completeness guard (issue: CI wall-clock
+# reduction via job splitting; see docs/DESIGN-ci.md, "Sharded pre-merge Linux
+# evidence"). A scheduling change that splits one set of tests/operators/
+# mutants across N shards must prove, mechanically, that the shards are a
+# partition of the original set: every entry lands in exactly one shard, none
+# is dropped, none is duplicated, and none is invented. Sharding is purely a
+# scheduling change; it must never silently narrow what runs.
+#
+# Usage:
+#   check-shard-union.sh <full-list> <shard-list>...
+#     Fails closed, naming the offending entries, unless:
+#       - every named file exists and is non-empty
+#       - each shard is a subset of full
+#       - shards are pairwise disjoint
+#       - the union of all shards equals full exactly
+#
+#   check-shard-union.sh selftest
+#     Exercises an accepting case (a clean N-way split) and four rejecting
+#     cases (a full-only entry covered by no shard; an entry duplicated across
+#     two shards; a shard entry absent from full; an empty shard list), each of
+#     which must make this script exit non-zero.
+
+set -euo pipefail
+
+fail() {
+  echo "check-shard-union: $*" >&2
+  exit 1
+}
+
+# Prints the sorted, de-duplicated, non-blank line set of a file. Fails
+# closed if the file is missing or empty -- an absent inventory is not
+# evidence of an empty shard, it is evidence the run never produced one.
+line_set() {
+  local path="$1"
+  [ -f "$path" ] || fail "'$path' does not exist"
+  [ -s "$path" ] || fail "'$path' is empty"
+  sort -u "$path"
+}
+
+check_union() {
+  local full_path="$1"
+  shift
+  [ "$#" -gt 0 ] || fail "no shard lists given"
+
+  local full
+  full="$(line_set "$full_path")"
+
+  local -a shard_paths=("$@")
+  local -a shard_sets=()
+  local index
+  for index in "${!shard_paths[@]}"; do
+    shard_sets+=("$(line_set "${shard_paths[$index]}")")
+  done
+
+  # Each shard must be a subset of full.
+  for index in "${!shard_paths[@]}"; do
+    local extra
+    extra="$(comm -23 <(printf '%s\n' "${shard_sets[$index]}") <(printf '%s\n' "$full") || true)"
+    if [ -n "$extra" ]; then
+      fail "shard '${shard_paths[$index]}' names entries absent from '$full_path': $(printf '%s' "$extra" | tr '\n' ' ')"
+    fi
+  done
+
+  # Shards must be pairwise disjoint.
+  local i j
+  for ((i = 0; i < ${#shard_paths[@]}; i++)); do
+    for ((j = i + 1; j < ${#shard_paths[@]}; j++)); do
+      local overlap
+      overlap="$(comm -12 <(printf '%s\n' "${shard_sets[$i]}") <(printf '%s\n' "${shard_sets[$j]}") || true)"
+      if [ -n "$overlap" ]; then
+        fail "shard '${shard_paths[$i]}' and shard '${shard_paths[$j]}' both name: $(printf '%s' "$overlap" | tr '\n' ' ')"
+      fi
+    done
+  done
+
+  # The union of every shard must equal full exactly -- no entry left uncovered.
+  local union
+  union="$(printf '%s\n' "${shard_sets[@]}" | sort -u)"
+  local missing
+  missing="$(comm -23 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  if [ -n "$missing" ]; then
+    fail "$(printf '%s' "$missing" | grep -c . ) entr$([ "$(printf '%s' "$missing" | grep -c .)" = 1 ] && echo y || echo ies) in '$full_path' covered by no shard (silent coverage loss): $(printf '%s' "$missing" | tr '\n' ' ')"
+  fi
+
+  local extra_union
+  extra_union="$(comm -13 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  if [ -n "$extra_union" ]; then
+    fail "union names entries absent from '$full_path': $(printf '%s' "$extra_union" | tr '\n' ' ')"
+  fi
+
+  echo "check-shard-union: PASS -- $(printf '%s\n' "$full" | grep -c .) entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
+}
+
+selftest() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Accepting: a clean 3-way split of a 6-entry full list.
+  printf 'a\nb\nc\nd\ne\nf\n' >"$tmp/full.txt"
+  printf 'a\nb\n' >"$tmp/shard1.txt"
+  printf 'c\nd\n' >"$tmp/shard2.txt"
+  printf 'e\nf\n' >"$tmp/shard3.txt"
+  # check_union calls fail(), which calls `exit`, an unconditional process
+  # exit that `if`'s condition protection does not catch. Every invocation
+  # below therefore runs in its own subshell so a rejecting case's `exit`
+  # only ends that subshell, not this selftest.
+  if ! (check_union "$tmp/full.txt" "$tmp/shard1.txt" "$tmp/shard2.txt" "$tmp/shard3.txt") >/dev/null; then
+    echo "check-shard-union selftest: FAIL: accepting case was rejected" >&2
+    return 1
+  fi
+
+  # Rejecting (a): an entry in full covered by no shard.
+  printf 'a\nb\nc\nd\ne\n' >"$tmp/shard1-missing.txt"
+  if (check_union "$tmp/full.txt" "$tmp/shard1-missing.txt" "$tmp/shard2.txt") >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: silent coverage loss was accepted" >&2
+    return 1
+  fi
+
+  # Rejecting (b): an entry duplicated across two shards.
+  printf 'a\nb\nc\n' >"$tmp/shard1-dup.txt"
+  printf 'c\nd\ne\nf\n' >"$tmp/shard2-dup.txt"
+  if (check_union "$tmp/full.txt" "$tmp/shard1-dup.txt" "$tmp/shard2-dup.txt") >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: duplicate entry across shards was accepted" >&2
+    return 1
+  fi
+
+  # Rejecting (c): a shard entry absent from full.
+  printf 'a\nb\nzz\n' >"$tmp/shard1-extra.txt"
+  printf 'c\nd\ne\nf\n' >"$tmp/shard2-full.txt"
+  if (check_union "$tmp/full.txt" "$tmp/shard1-extra.txt" "$tmp/shard2-full.txt") >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: invented shard entry was accepted" >&2
+    return 1
+  fi
+
+  # Rejecting (d): an empty shard list (no shard arguments at all).
+  if (check_union "$tmp/full.txt") >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: empty shard list was accepted" >&2
+    return 1
+  fi
+
+  echo "check-shard-union selftest: all assertions passed"
+}
+
+case "${1:-}" in
+  selftest)
+    selftest
+    ;;
+  "")
+    echo "usage: $0 <full-list> <shard-list>... | $0 selftest" >&2
+    exit 2
+    ;;
+  *)
+    check_union "$@"
+    ;;
+esac

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -28,6 +28,45 @@
 
 set -euo pipefail
 
+# Sharding (issue: CI wall-clock reduction). `--shard K/N` restricts the no-op
+# control and the main operator loop to a round-robin slice of `operators.txt`
+# (operator index `i`, 0-based in table order, belongs to shard `K` iff
+# `i % N == K - 1`), so three shards can run the ~912s no-op control and the
+# ~1350s operator loop in parallel. Everything else -- the whole-table
+# validation in `read_table` and the harness's own stale-seam negative control
+# -- still runs in every shard: those are cheap and a fault in either one must
+# be caught by every shard, not by whichever shard happened to draw it. The
+# default `1/1` (no flag) path assigns every operator to the one shard, so its
+# behavior is unchanged apart from also writing `shard-manifest.v1.json`.
+shard_index=1
+shard_total=1
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --shard)
+      if [ "$#" -lt 2 ]; then
+        echo "usage: $0 [--shard K/N]" >&2
+        exit 2
+      fi
+      if [[ "$2" =~ ^([1-9][0-9]*)/([1-9][0-9]*)$ ]]; then
+        shard_index="${BASH_REMATCH[1]}"
+        shard_total="${BASH_REMATCH[2]}"
+        if [ "$shard_index" -gt "$shard_total" ]; then
+          echo "usage: $0 [--shard K/N]: K must be <= N, got '$2'" >&2
+          exit 2
+        fi
+      else
+        echo "usage: $0 [--shard K/N]: '$2' is not K/N" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    *)
+      echo "usage: $0 [--shard K/N]" >&2
+      exit 2
+      ;;
+  esac
+done
+
 root="$(cd "$(dirname "$0")/.." && pwd)"
 operators_dir="$root/rust/fslc/tests/fault_operators"
 table="$operators_dir/operators.txt"
@@ -131,6 +170,20 @@ read_table() {
       fail "$file is not referenced by any row in $table. Either add its row or
   delete the patch -- an operator that runs nowhere is not an operator."
   done
+}
+
+assigned_indices=()
+assign_shard() {
+  local index
+  for index in "${!names[@]}"; do
+    if [ $((index % shard_total)) -eq $((shard_index - 1)) ]; then
+      assigned_indices+=("$index")
+    fi
+  done
+  [ "${#assigned_indices[@]}" -gt 0 ] || fail "shard $shard_index/$shard_total is
+  assigned no operators among the ${#names[@]} rows in $table. Either the shard
+  count exceeds the table size or the round-robin assignment is wrong -- an
+  empty shard would silently run nothing and still read green."
 }
 
 sync_scratch() {
@@ -253,7 +306,7 @@ check_no_op_control() {
   local started=$SECONDS index
   sync_scratch
   apply_operator_patch "$operators_dir/controls/no-op.patch" "$logs/no-op.apply.log"
-  for index in "${!names[@]}"; do
+  for index in "${assigned_indices[@]}"; do
     run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
       "$logs/no-op.${names[$index]}.primary.log"
     [ "$detector_result" = "ok" ] || fail "no-op control: primary detector
@@ -266,7 +319,7 @@ check_no_op_control() {
   '${blind_tests[$index]}' (operator ${names[$index]}) failed without any fault
   applied. Full log: $logs/no-op.${names[$index]}.blind.log"
   done
-  echo "control no-op: all ${#names[@]} operators' detectors green ($((SECONDS - started))s)"
+  echo "control no-op: all ${#assigned_indices[@]} operators' detectors green ($((SECONDS - started))s)"
 }
 
 failures=()
@@ -299,10 +352,11 @@ run_operator() {
 }
 
 read_table
+assign_shard
 check_stale_seam_control
 check_no_op_control
 
-for index in "${!names[@]}"; do
+for index in "${assigned_indices[@]}"; do
   run_operator "$index"
 done
 
@@ -311,4 +365,34 @@ if [ "${#failures[@]}" -gt 0 ]; then
   exit 1
 fi
 
-echo "fault-operators: ${#names[@]} operators calibrated (${SECONDS}s total)"
+# Per-shard completeness evidence (issue: CI wall-clock reduction). Written
+# only on success, so a failed shard's manifest never masquerades as
+# completed evidence. The aggregator downloads every shard's manifest, checks
+# `base_revision` and `table_operators` agree across shards, and requires the
+# disjoint union of `executed_operators` to equal `table_operators` exactly --
+# the same fail-closed shape as `check-shard-union.sh`.
+mkdir -p "$logs"
+executed_names=()
+for index in "${assigned_indices[@]}"; do
+  executed_names+=("${names[$index]}")
+done
+table_operators_json="$(printf '%s\n' "${names[@]}" | jq -R . | jq -s .)"
+executed_operators_json="$(printf '%s\n' "${executed_names[@]}" | jq -R . | jq -s .)"
+jq -n \
+  --arg schema "fslc.fault-operator-shard-manifest.v1" \
+  --argjson schema_version 1 \
+  --arg base_revision "$(git -C "$root" rev-parse HEAD)" \
+  --argjson shard_index "$shard_index" \
+  --argjson shard_total "$shard_total" \
+  --argjson table_operators "$table_operators_json" \
+  --argjson executed_operators "$executed_operators_json" \
+  '{
+    schema: $schema,
+    schema_version: $schema_version,
+    base_revision: $base_revision,
+    shard: {index: $shard_index, total: $shard_total},
+    table_operators: $table_operators,
+    executed_operators: $executed_operators
+  }' >"$logs/shard-manifest.v1.json"
+
+echo "fault-operators: ${#assigned_indices[@]} operators calibrated (${SECONDS}s total)"

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -4,28 +4,102 @@
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/.." && pwd)"
-mode="${1:-complete}"
 runner_version="cargo-mutants 27.1.0"
+
+# Lane split (issue: CI wall-clock reduction). With no `--lane` flag every
+# check below still runs, in the same order, exactly as before -- that is
+# the contract this file's local and CI default callers depend on.
+# `--lane operators` runs only the curated fault-operator half (optionally
+# sharded with `--shard K/N`, forwarded verbatim to
+# `run-fault-operators.sh`); `--lane mutants` runs everything else: the
+# generic cargo-mutants half plus the manifest/schema checks that are cheap
+# enough to run in both lanes. `--shard` without `--lane operators` is
+# refused rather than silently ignored.
+mode=""
+lane=""
+shard_spec=""
+usage() {
+  echo "usage: $0 [changed|complete] [--lane operators|mutants] [--shard K/N]" >&2
+  exit 2
+}
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --lane)
+      [ "$#" -ge 2 ] || usage
+      case "$2" in
+        operators|mutants) lane="$2" ;;
+        *) usage ;;
+      esac
+      shift 2
+      ;;
+    --shard)
+      [ "$#" -ge 2 ] || usage
+      shard_spec="$2"
+      shift 2
+      ;;
+    changed|complete)
+      [ -z "$mode" ] || usage
+      mode="$1"
+      shift
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+mode="${mode:-complete}"
+
+if [ -n "$shard_spec" ]; then
+  [ "$lane" = "operators" ] || usage
+  [[ "$shard_spec" =~ ^([1-9][0-9]*)/([1-9][0-9]*)$ ]] || usage
+  [ "${BASH_REMATCH[1]}" -le "${BASH_REMATCH[2]}" ] || usage
+fi
 
 case "$mode" in
   changed|complete) ;;
   *)
-    echo "usage: $0 [changed|complete]" >&2
-    exit 2
+    usage
     ;;
 esac
 
-if [ "$(cargo mutants --version)" != "$runner_version" ]; then
-  echo "semantic-mutation: requires exactly $runner_version; observed $(cargo mutants --version 2>&1)" >&2
-  exit 1
+run_manifest_test() {
+  # Validates the operator inventory, the P2 scope/equivalents manifests, and
+  # the mutation runner config together. Cheap (compile-dominated, ~1 min)
+  # and idempotent, so it runs once for the unsharded default path and once
+  # per invocation when split into lanes -- both lanes depend on parts of it
+  # (operators.txt for the operators lane, scope.v1.json/equivalents.v1.json
+  # for the mutants lane) and neither half is expensive enough to be worth
+  # splitting further.
+  cargo test --manifest-path "$root/rust/Cargo.toml" -p fslc-rust \
+    --test implementation_mutation_manifest --locked
+}
+
+run_operators_lane() {
+  # Curated controls. They cover semantic faults that a token-level mutator
+  # cannot express and prove that stale seams fail loudly.
+  local shard_args=()
+  [ -z "$shard_spec" ] || shard_args=(--shard "$shard_spec")
+  "$root/tools/run-fault-operators.sh" "${shard_args[@]}"
+}
+
+if [ "$lane" != "operators" ]; then
+  if [ "$(cargo mutants --version)" != "$runner_version" ]; then
+    echo "semantic-mutation: requires exactly $runner_version; observed $(cargo mutants --version 2>&1)" >&2
+    exit 1
+  fi
 fi
 
-cargo test --manifest-path "$root/rust/Cargo.toml" -p fslc-rust \
-  --test implementation_mutation_manifest --locked
+run_manifest_test
 
-# Curated controls are part of both tiers. They cover semantic faults that a
-# token-level mutator cannot express and prove that stale seams fail loudly.
-"$root/tools/run-fault-operators.sh"
+if [ "$lane" = "operators" ]; then
+  run_operators_lane
+  echo "semantic-mutation: mode=$mode lane=operators shard=${shard_spec:-1/1} complete"
+  exit 0
+fi
+
+if [ "$lane" != "mutants" ]; then
+  run_operators_lane
+fi
 
 mkdir -p "$root/rust/target"
 output="$(mktemp -d "$root/rust/target/semantic-mutation.${mode}.XXXXXX")"


### PR DESCRIPTION
## Problem

PR wall clock was **38m15s**, and caching was not the cause. Measured on run 30968645971 (PR #717):

| job | wall clock |
|---|---|
| `semantic mutation (changed)` | **38m15s** ← critical path |
| `rust workspace` | 32m43s |
| `WASM` | 6m08s |
| `FSL Logic Test (pr)` | 1m09s |

Inside `rust workspace`: cache restore 0.6 min (hit), **all compilation ~3.5 min**, **test execution ~29 min**, cache save skipped. The 176 test binaries' harness-sum (28.6 min) matches the wall clock, which proves `cargo test` runs test binaries strictly sequentially. Five binaries hold 77% of that time, 146 of 176 finish in under a second, and `injection_detector_matrix` is a **single** 3.75-min test idling three of four cores. Inside `semantic mutation`: `control no-op` 912s, the 17-operator loop ~7.5 min (`fault-operators: 17 operators calibrated (1350s total)`), generic cargo-mutants ~14.3 min.

So the lever is scheduling, not cache.

## Change

- `rust workspace` → `rust-checks` (fmt, Clippy, **doctests**, workspace build, boundary/stack-parity controls; once) + `rust-tests` (3-way `cargo-nextest --partition count:K/3` matrix) + a `rust-workspace` aggregator.
- `semantic mutation (…)` → `semantic-mutation-operators` (3-way round-robin shard of the curated fault-operator table) + `semantic-mutation-mutants` (generic cargo-mutants, **complete and unsharded**) + a `semantic-mutation` aggregator.
- `Swatinem/rust-cache` gains `shared-key` per lane group, so the Linux cache entry count stays at ~4 instead of growing to ~9 (the repo sits at 8.95 GB of a 10 GB limit).

**The mutants half is deliberately not sharded.** At ~14.3 min it already sits at the curated lane's post-split floor, so slicing the mutant inventory, depending on the pinned runner's `--shard` index-base semantics, and migrating the stale-reviewed-equivalents check would add real risk *to the gate that proves the verifier can detect drift* for no measured wall-clock gain.

**Doctests move explicitly to `rust-checks`** because `cargo-nextest` cannot run them at all. Dropping them silently would be the "weaken a gate for speed" move `AGENTS.md` forbids.

## Safety properties

- **Required context names unchanged, so no `main`-ruleset change is needed.** Both aggregators keep their exact job **id** (`rust-workspace`, `semantic-mutation`) and `name:` (`rust workspace`, and the unchanged dynamic `semantic mutation (…)` expression). `product-gate`'s `needs:` therefore still resolves. This matters more than usual right now: with `bypass_actors: []` on the ruleset, a required context that stops reporting would leave every PR permanently `Expected` with **no admin escape**.
- **`if: always()` on both aggregators is load-bearing.** GitHub treats a *skipped* required check as satisfied, so without it a failing shard would skip the aggregator into a false-green required context.
- **Each aggregator proves its split is a true partition before trusting it.** `rust-workspace` requires the three shards' `full.txt` listings to be byte-identical (three independent computations must agree) and their `shard.txt`s to union back to exactly one of them. `semantic-mutation` requires the three operator manifests to agree on `base_revision`/`table_operators` and their `executed_operators` to union back to `table_operators`. Both use the new fail-closed `tools/check-shard-union.sh` (subset / pairwise-disjoint / union-equality, naming offending entries), whose `selftest` — accepting plus rejecting cases for coverage gaps, overlap, foreign entries and empty shards — runs in the `merge readiness / automation contracts` lane.
- **`./tools/check-native-integration.sh` with no arguments still runs the complete unsharded suite.** `check_rust` is untouched; sharding is opt-in via new phase names that exit 2 on a malformed spec.
- `WASM`, `rust-native-z3`, `production-native-z3-linux`, `fsl-logic`, `product-gate` are unmodified. The inert `merge_group` trigger and `queue-entry-stub` branch are untouched.

## Verification (independent of the implementing agent)

- **nextest partitioning verified myself against the live workspace**: shards of 518 + 460 + 411 = 1389, union has 1389 unique entries (pairwise disjoint), and equals the 1389-test full inventory exactly. Note the subtlety this rests on: `nextest list --partition` still lists *every* test and marks ownership via `filter-match.status`, so the shard listing filters on that — getting this wrong would have made every shard list all 1389 tests.
- **Union guard rejects real failures**: dropped one real test from a shard → failed naming `fsl-core::binder_aggregates::checked_model_rejects_dynamic_aggregate_ranges_in_every_expression_position`; duplicated one real test across two shards → failed naming it. Selftest passes.
- **Untouched jobs are byte-identical** to `origin/main` when parsed (`wasm`, `rust-native-z3`, `production-native-z3-linux`, `fsl-logic`, `product-gate`), and `product-gate`'s `needs:` resolves with no unresolved ids.
- `check_rust` diffed unchanged; `./tools/check-merge-readiness.sh automation` passes with the new selftest; YAML parses; `bash -n` clean on all five scripts; malformed shard specs exit 2.
- The implementing agent additionally ran `rust-tests 1/3` to completion (518/518 pass, 11m07s, `refine_corpus_parity`'s slowest test 430s) and `run-fault-operators.sh --shard 1/3` end-to-end (6 assigned operators, correct round-robin indices, real manifest). Shards 2/3 and 3/3 test *execution* and the full mutation run were not executed locally — this PR's own CI run is the first end-to-end exercise of those, which is what the canary below is for.

## Expected result, stated honestly

**≈17 min, not ≈15.** A little over 2x, not 3x. The first sharded operator run measured a 6-operator shard's no-op control at **760s** against 912s for all 17 — so ~700s of that lane is a fixed scratch cold build and only ~12s per detector run scales with the shard. Splitting three ways removed ~150s of detector time, not two thirds of the lane. `docs/DESIGN-ci.md` records this floor, and that raising the shard count barely helps; only making the scratch build cheaper would move it, which is not attempted here. The other floor: `refine_corpus_parity`'s slowest single test (≈7.3 min) plus ~3.5 min compile bounds `rust workspace` at ≈12 min.

## Canary to watch on this PR

This PR is not exemption-eligible, so it runs the full gate. Confirm: both required contexts report from the aggregators; the three `rust tests (K/3)` and three `mutation operators (K/3)` shards all succeed; the union-validation steps pass; and record the actual per-shard wall clocks against the ≈17 min expectation so `docs/DESIGN-ci.md` can be corrected if reality differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)