### PR TITLE
fix(domain): bind four accepted-but-hollow constructs to semantics or fail closed (#710, #711, #712, #713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   (issue #662, `docs/DESIGN-saga-history.md`). No spec migration is required:
   an existing `compensation` block's syntax and semantics are unchanged
   (only its guard strength, previously unsound). See `docs/DESIGN-domain.md`.
+- Fixed (#712): top-level `await` blocks (e.g.
+  `await PaymentResult { waits_for one_of [...] on X -> Y }`) are now
+  rejected fail-closed by both lowering paths through a new
+  `validate_lowerable_constructs` gate (`rust/fsl-core/src/domain_lowering.rs`,
+  called from both `lower_domain_surface` and `domain_kernel_source`):
+  `DomainAwait` was consumed by nothing outside the parser, and cross-
+  aggregate routing proofs remain explicit Future Work in
+  `docs/DESIGN-domain.md`. **Migration**: remove the top-level
+  `await { ... }` block and use a saga step's `awaits` instead; the
+  top-level form never had executable meaning under `check`/`verify`, so
+  removing it changes no verification outcome.
+  `examples/domain/order_async_effect.fsl` had its now-rejected `await
+  PaymentResult` block removed as part of this fix (its `projection
+  OrderObservedState` block is unaffected and out of this fix's scope). See
+  `docs/DESIGN-domain.md`. Tracked mechanism for future migration
+  diagnostics: #702, #703.
 - Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
   from a measured 38m15s (`semantic mutation (changed)`, run 30968645971) to a
   measured **20.7 min** (run 30989320577, all lanes green) — 1.85x, ~17.5 min

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   had executable meaning under `check`/`verify`, so removing it changes no
   verification outcome. See `docs/DESIGN-domain.md`. Tracked mechanism for
   future migration diagnostics: #702, #703.
+- Fixed (#710): `value_object` invariants (e.g.
+  `value_object AuditStamp { ... invariant nonNegative { attempts >= 0 } }`)
+  are now rejected fail-closed by both lowering paths through the same
+  `validate_lowerable_constructs` gate. No accepted design pins a
+  `value_object` instance set, and the frozen Python reference only emits
+  direct-state-field instances while skipping `Option<VO>`/`Set<VO>`/
+  `Map<_,VO>`/command-input/event-field/nested-VO positions -- adopting that
+  partial coverage in the verifier would leave most instances unconstrained
+  while an author believes every instance is checked. **Migration**: remove
+  the `invariant { ... }` block from any `value_object`; it never had
+  executable meaning under `check`/`verify`, so removing it changes no
+  verification outcome. `value_object` field defaults without invariants
+  remain fully supported. See `docs/DESIGN-domain.md`. Tracked mechanism for
+  future migration diagnostics: #702, #703.
 - Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
   from a measured 38m15s (`semantic mutation (changed)`, run 30968645971) to a
   measured **20.7 min** (run 30989320577, all lanes green) — 1.85x, ~17.5 min

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   OrderObservedState` block is unaffected and out of this fix's scope). See
   `docs/DESIGN-domain.md`. Tracked mechanism for future migration
   diagnostics: #702, #703.
+- Fixed (#711): aggregate `on_stale` policies (e.g.
+  `on_stale Approved when ... { emits ApprovalRejected }`) are now rejected
+  fail-closed by both lowering paths through the same
+  `validate_lowerable_constructs` gate: nothing in `docs/DESIGN-domain.md`
+  pins `on_stale` semantics, and the finding it references
+  (`late_completion_without_stale_policy`) is itself unimplemented in native
+  Rust (#724). **Migration**: remove the `on_stale { ... }` block; it never
+  had executable meaning under `check`/`verify`, so removing it changes no
+  verification outcome. See `docs/DESIGN-domain.md`. Tracked mechanism for
+  future migration diagnostics: #702, #703.
 - Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
   from a measured 38m15s (`semantic mutation (changed)`, run 30968645971) to a
   measured **20.7 min** (run 30989320577, all lanes green) — 1.85x, ~17.5 min

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#713): saga `compensation { when Trigger after After { ... } }` now
+  lowers to a kernel action guarded by BOTH the trigger event flag and the
+  `after` event flag on both lowering paths (`lower_saga_actions` in
+  `rust/fsl-core/src/domain_lowering.rs` and `render_saga_actions` in
+  `rust/fsl-core/src/domain.rs`); previously only the trigger flag was
+  required, so a compensation could fire on a trace that never observed its
+  `after` event. Because generated `event_*` flags are one-hot per
+  transition, a compensation whose trigger and after events differ (the
+  common shape, e.g. `examples/domain/order_fulfillment_saga.fsl`) is now
+  structurally disabled and surfaces as a `fslc verify` never-enabled action
+  warning instead of silently accepting the bad trace; this is the accepted
+  interim state pending the correlation-indexed saga history follow-up
+  (issue #662, `docs/DESIGN-saga-history.md`). No spec migration is required:
+  an existing `compensation` block's syntax and semantics are unchanged
+  (only its guard strength, previously unsound). See `docs/DESIGN-domain.md`.
 - Sharded the two heaviest pre-merge product-gate jobs to cut PR wall clock
   from a measured 38m15s (`semantic mutation (changed)`, run 30968645971) to a
   measured **20.7 min** (run 30989320577, all lanes green) — 1.85x, ~17.5 min

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -110,6 +110,44 @@ not cross the parse boundary as strings. This parse IR deliberately does not
 perform domain name or type resolution. Checked and lowered expressions remain
 the responsibility of `fsl-core` and the public Kernel contract.
 
+### Rejected constructs: parsed, never lowered, so rejected fail-closed
+
+Parsing a construct into the IR is not a promise that it means anything. Three
+constructs reached the parse IR, were type-checked there, and were then dropped
+by **both** lowering paths, so an author could write them and the executable
+model would not contain them — an accepted construct with hollow semantics,
+which `AGENTS.md` classifies as a soundness defect. They are now rejected at
+their declaration, with a located `semantics` diagnostic, by the shared
+`validate_lowerable_constructs` in `rust/fsl-core/src/domain_lowering.rs`,
+called from both `lower_domain_surface` (path A) and `domain_kernel_source`
+(path B) so neither path can accept what the other rejects:
+
+- **top-level `await` routing** (#712). No accepted decision assigns routing a
+  meaning; this document accepts only its grammar (see the Parse IR boundary
+  above), and cross-aggregate routing proofs are Future Work. A saga step's
+  `awaits` is a different construct and remains fully lowered.
+- **aggregate `on_stale`** (#711). Nothing pins the stale-completion semantics.
+  For this to become implementable, an accepted decision must define the stale
+  predicate's evaluation point, the generated action and guard, and the
+  interaction with the effect-completion single-writer rule below.
+- **`value_object` invariants** (#710). What is undecided here is the *instance
+  set*, not the predicate: whether the constraint attaches to direct aggregate
+  state fields only, or also to occurrences inside `Option<T>`/`Set<T>`/
+  `Map<_, T>`, to command parameters and event fields, to nested value objects,
+  and whether a value object's own field defaults must satisfy it. The frozen
+  Python reference emits only the direct-state-field instances, which is why it
+  is not adopted as the contract: an author would believe every occurrence is
+  checked while most are unconstrained. Value objects *without* invariants are
+  unaffected and still lower as structs.
+
+Rejecting is deliberate rather than conservative: implementing any of the three
+would require inventing semantics inside a verifier, which is worse than
+refusing the construct. Each becomes implementable when an accepted amendment
+to this document settles the questions named above. Because the constructs never
+had executable meaning, removing such a block from an existing spec changes no
+verification outcome — see `CHANGELOG.md` for the migration note, and #702/#703
+for the general strictness-migration mechanism.
+
 Domain-only finite membership is represented structurally. Accepted legacy
 spellings retain their source spelling while recording the canonical operator:
 `||` is `or`, and logical `->` is `=>`. Structural `->` in declarations such

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -70,6 +70,11 @@ Each aggregate becomes kernel state and actions:
 - saga step -> kernel action guarded by `starts_on`, `requires`, or awaited
   event flags
 - saga compensation -> kernel action guarded by trigger/after event flags
+  (#713: both lowering paths, `lower_saga_actions` in `domain_lowering.rs` and
+  `render_saga_actions` in `domain.rs`, emit a `requires` for the trigger
+  event flag AND a separate `requires` for the `after_event` flag, in that
+  order; before #713 only the trigger flag was required, so a compensation
+  could fire on a trace that never observed its `after_event`)
 
 Domain enum members are namespaced during lowering (`OrderStatus_Pending`) so
 two domain enums can both contain `Pending`. Domain expressions stay in the
@@ -288,6 +293,20 @@ history is checked through replay evidence rather than treated as an unbounded
 kernel proof. Outcome events owned by an effect are observed only through that
 effect's correlation-guarded completion action, so the modeled lifecycle retains
 completion-requires-request without a weaker saga observation writer.
+
+Because generated `event_<Event>` flags are a one-hot, one-step observation
+(see `docs/DESIGN-saga-history.md`), a compensation's dual trigger/after guard
+is only satisfiable by a single transition that emits both events. When the
+trigger and after events differ — the typical shape, e.g.
+`examples/domain/order_fulfillment_saga.fsl`'s
+`when PaymentFailed after InventoryReserved` — the compensation action is
+structurally disabled under the current one-hot flag scheme, and `fslc
+verify` surfaces it as a "never enabled" action warning rather than silently
+passing. This is the accepted interim boundary
+(`docs/DESIGN-saga-history.md`'s "Implementation boundary" section): the
+warning is valid evidence of the known gap and must not be suppressed or
+replaced by sticky global flags until the correlation-indexed saga history
+follow-up (issue #662) lands.
 
 ## Guarantee Boundary
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -247,6 +247,17 @@ aggregate 内で解決され、そのコマンドの `requires` 節の連言と�
 なります。未知のシンボル、aggregate をまたぐコマンド、型の不一致、未対応の呼び出し
 は、元の domain 式の位置で報告されます。
 
+saga の `compensation { when Trigger after After { emits ... } }` ブロックは、
+トリガーイベントフラグと `after` イベントフラグの**両方**でガードされたカーネル
+action へ lowering されます。つまり compensation は、両方のイベントが観測されて
+初めて発火します。生成されるイベントフラグは 1 遷移につき 1 つだけ立つ one-hot な
+観測なので、この二重ガードは単一の `decide` が両方のイベントを同一遷移で emit する
+場合にしか充足できません。トリガーイベントと after イベントが異なる一般的なケース
+(例えば、先の成功の後で起きた失敗によってトリガーされる compensation)は、現在の
+one-hot フラグ方式のもとでは構造的に無効化されており、`fslc verify` はこれを、
+after イベントを一度も観測していないトレースを黙って受理するのではなく、
+never-enabled action の警告として報告します。
+
 effect は `success_event`、`failure_event`、`timeout_event` により、完了イベントへ
 明示的な outcome role を割り当てられます。これらの宣言が分類の正規契約であり、
 イベント名に `fail`、`cancel`、`timeout` が含まれていても、それぞれ `Succeeded`、

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -248,6 +248,18 @@ the negation of each rejection condition. Unknown symbols, cross-aggregate
 commands, type mismatches, and unsupported calls are reported at the original
 domain expression.
 
+A saga `compensation { when Trigger after After { emits ... } }` block lowers
+to a kernel action guarded by BOTH the trigger event flag and the `after`
+event flag, so the compensation only fires once both events have been
+observed. Because generated event flags are a one-hot, one-step observation,
+this dual guard is satisfiable only when a single `decide` emits both events
+in the same transition; the common case where the trigger and after events
+differ (for example, a compensation triggered by a later failure after an
+earlier success) is structurally disabled under the current flag scheme, and
+`fslc verify` reports the disabled compensation action as a never-enabled
+action warning rather than silently accepting a trace that never observed the
+`after` event.
+
 An effect can assign completion events explicit outcome roles with
 `success_event`, `failure_event`, and `timeout_event`. These declarations are the
 authoritative classification: they lower to `Succeeded`, `Failed`, and `TimedOut`

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -284,6 +284,17 @@ aggregate and becomes the conjunction of the command's <code>requires</code> cla
 the negation of each rejection condition. Unknown symbols, cross-aggregate
 commands, type mismatches, and unsupported calls are reported at the original
 domain expression.</p>
+<p>A saga <code>compensation { when Trigger after After { emits ... } }</code> block lowers
+to a kernel action guarded by BOTH the trigger event flag and the <code>after</code>
+event flag, so the compensation only fires once both events have been
+observed. Because generated event flags are a one-hot, one-step observation,
+this dual guard is satisfiable only when a single <code>decide</code> emits both events
+in the same transition; the common case where the trigger and after events
+differ (for example, a compensation triggered by a later failure after an
+earlier success) is structurally disabled under the current flag scheme, and
+<code>fslc verify</code> reports the disabled compensation action as a never-enabled
+action warning rather than silently accepting a trace that never observed the
+<code>after</code> event.</p>
 <p>An effect can assign completion events explicit outcome roles with
 <code>success_event</code>, <code>failure_event</code>, and <code>timeout_event</code>. These declarations are the
 authoritative classification: they lower to <code>Succeeded</code>, <code>Failed</code>, and <code>TimedOut</code>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -285,6 +285,16 @@ lowering します。domain の enum メンバーは lowering 時に名前空間
 aggregate 内で解決され、そのコマンドの <code>requires</code> 節の連言と、各拒否条件の否定に
 なります。未知のシンボル、aggregate をまたぐコマンド、型の不一致、未対応の呼び出し
 は、元の domain 式の位置で報告されます。</p>
+<p>saga の <code>compensation { when Trigger after After { emits ... } }</code> ブロックは、
+トリガーイベントフラグと <code>after</code> イベントフラグの<strong>両方</strong>でガードされたカーネル
+action へ lowering されます。つまり compensation は、両方のイベントが観測されて
+初めて発火します。生成されるイベントフラグは 1 遷移につき 1 つだけ立つ one-hot な
+観測なので、この二重ガードは単一の <code>decide</code> が両方のイベントを同一遷移で emit する
+場合にしか充足できません。トリガーイベントと after イベントが異なる一般的なケース
+(例えば、先の成功の後で起きた失敗によってトリガーされる compensation)は、現在の
+one-hot フラグ方式のもとでは構造的に無効化されており、<code>fslc verify</code> はこれを、
+after イベントを一度も観測していないトレースを黙って受理するのではなく、
+never-enabled action の警告として報告します。</p>
 <p>effect は <code>success_event</code>、<code>failure_event</code>、<code>timeout_event</code> により、完了イベントへ
 明示的な outcome role を割り当てられます。これらの宣言が分類の正規契約であり、
 イベント名に <code>fail</code>、<code>cancel</code>、<code>timeout</code> が含まれていても、それぞれ <code>Succeeded</code>、

--- a/examples/domain/order_async_effect.fsl
+++ b/examples/domain/order_async_effect.fsl
@@ -101,13 +101,6 @@ domain OrderAsyncEffect {
     }
   }
 
-  await PaymentResult {
-    waits_for one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
-    on PaymentCaptured -> PaymentCaptured
-    on PaymentFailed -> PaymentFailed
-    on PaymentCaptureTimedOut -> PaymentCaptureTimedOut
-  }
-
   projection OrderObservedState {
     from Order
     fields [status, payment_status]

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -870,6 +870,7 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
 #[allow(clippy::too_many_lines)]
 pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
     validate_effect_outcome_roles(domain)?;
+    crate::domain_lowering::validate_lowerable_constructs(domain)?;
     let context = Context::new(domain);
     crate::domain_lowering::validate_domain_enums(&context.types)?;
     let mut lines = vec![format!(

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -846,6 +846,10 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
             "  requires {}",
             Context::event_flag(&compensation.trigger_event)
         ));
+        lines.push(format!(
+            "  requires {}",
+            Context::event_flag(&compensation.after_event)
+        ));
         lines.extend(
             event_assignments(context.domain, &compensation.emits)
                 .into_iter()

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -120,6 +120,17 @@ pub(crate) fn validate_lowerable_constructs(domain: &DomainSpec) -> Result<(), C
             span_at(awaited.loc),
         ));
     }
+    for aggregate in &domain.aggregates {
+        if let Some(stale) = aggregate.stale_policies.first() {
+            return Err(error_at(
+                format!(
+                    "on_stale '{}' has no executable lowering; stale policies are not supported",
+                    stale.event
+                ),
+                span_at(stale.loc),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -1941,13 +1952,6 @@ impl<'a> Resolver<'a> {
                         )?;
                     }
                 }
-            }
-            for stale in &aggregate.stale_policies {
-                self.event(&stale.event, stale.loc)?;
-                for emitted in &stale.emits {
-                    self.event(emitted, stale.loc)?;
-                }
-                self.resolve_bool(&stale.condition, &state_scope, Some(aggregate))?;
             }
             for evolve in &aggregate.evolves {
                 let (_, event) = self.event(&evolve.event, evolve.loc)?;

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -2758,10 +2758,10 @@ fn lower_saga_actions(
             resolver.event(&compensation.trigger_event, compensation.loc)?;
             resolver.event(&compensation.after_event, compensation.loc)?;
             let span = span_at(compensation.loc);
-            let mut action_items = vec![ActionItem::Requires(
-                Expr::Var(event_flag(&compensation.trigger_event)),
-                span,
-            )];
+            let mut action_items = vec![
+                ActionItem::Requires(Expr::Var(event_flag(&compensation.trigger_event)), span),
+                ActionItem::Requires(Expr::Var(event_flag(&compensation.after_event)), span),
+            ];
             action_items.extend(
                 resolver
                     .event_assignments(&compensation.emits, span)?

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -131,6 +131,19 @@ pub(crate) fn validate_lowerable_constructs(domain: &DomainSpec) -> Result<(), C
             ));
         }
     }
+    for ty in &domain.types {
+        if ty.kind == "value_object"
+            && let Some(invariant) = ty.invariants.first()
+        {
+            return Err(error_at(
+                format!(
+                    "value_object invariant '{}.{}' has no executable lowering; value-object invariants are not supported",
+                    ty.name, invariant.name.text
+                ),
+                invariant.span,
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -1925,9 +1938,6 @@ impl<'a> Resolver<'a> {
                     let _ =
                         self.resolve_expr(default, Some(&expected), &scope, None, &mut Vec::new())?;
                 }
-            }
-            for invariant in &ty.invariants {
-                self.resolve_bool(&invariant.expr, &scope, None)?;
             }
         }
         for aggregate in &self.domain.aggregates {

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -100,6 +100,29 @@ fn span_at(loc: DomainLoc) -> Span {
     loc.span()
 }
 
+/// Reject domain constructs that parse into a [`DomainSpec`] but have no
+/// executable lowering on either path (#710/#711/#712). Each of these
+/// constructs is accepted by the grammar and, before this validation, was
+/// silently dropped by both `lower_domain` and `domain_kernel_source`: an
+/// author who wrote one believed it was checked when nothing consumed it.
+/// Fail closed instead of inventing semantics no accepted design pins.
+///
+/// This walks the raw parsed [`DomainSpec`], not a resolver context: these
+/// are `semantics`-class diagnostics (an accepted-but-unlowerable construct),
+/// not name-resolution failures.
+pub(crate) fn validate_lowerable_constructs(domain: &DomainSpec) -> Result<(), CoreError> {
+    if let Some(awaited) = domain.awaits.first() {
+        return Err(error_at(
+            format!(
+                "top-level await '{}' has no executable lowering; use a saga step's awaits",
+                awaited.name
+            ),
+            span_at(awaited.loc),
+        ));
+    }
+    Ok(())
+}
+
 fn safe(name: &str) -> String {
     let mut value = name
         .chars()
@@ -2069,6 +2092,7 @@ pub(crate) fn lower_domain_surface(
     domain: &DomainSpec,
 ) -> Result<(SurfaceSpec, OriginRegistry), CoreError> {
     validate_effect_outcome_roles(domain)?;
+    validate_lowerable_constructs(domain)?;
     let resolver = Resolver::new(domain);
     resolver.validate_document_expressions()?;
     let mut items = Vec::new();

--- a/rust/fsl-core/tests/domain_lowering.rs
+++ b/rust/fsl-core/tests/domain_lowering.rs
@@ -268,10 +268,15 @@ domain InvalidValueObject {
 
 ",
     );
+    // Since #710 the invariant is rejected for having no executable lowering
+    // before its expression is ever resolved, so the fail-closed diagnostic
+    // preempts the unknown-symbol one. Unknown symbols in value-object
+    // positions that *are* still lowered stay covered by `unused_default`
+    // below (field defaults) and by the effect-path case at the end.
     assert!(
         value_object
             .message
-            .contains("unknown domain symbol 'missing'")
+            .contains("value_object invariant 'Counter.bad' has no executable lowering")
     );
 
     let unused_default = lowering_error(
@@ -309,7 +314,14 @@ domain InvalidStale {
 }
 ",
     );
-    assert!(stale.message.contains("unknown domain symbol 'missing'"));
+    // Since #711, as with the value-object invariant above, the stale policy is
+    // rejected for having no executable lowering before its condition is
+    // resolved.
+    assert!(
+        stale
+            .message
+            .contains("on_stale 'Touched' has no executable lowering")
+    );
 
     let idempotency = lowering_error(
         r"

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -139,8 +139,12 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
 /// Domain specs that parse into a [`DomainSpec`] but must be rejected by
 /// both lowering pipelines (path A at `lower_domain`, path B somewhere in
 /// `domain_kernel_source` -> `parse_kernel_source` -> `build_model`) because
-/// they are semantically invalid (type mismatch / unknown symbol).
+/// they are semantically invalid (type mismatch / unknown symbol) OR because
+/// they use a construct that parses but has no executable lowering on either
+/// path and is therefore rejected fail-closed (#710/#711/#712: `value_object`
+/// invariants, aggregate `on_stale`, and top-level `await` routing).
 const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
+    "rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_empty_enum_containers.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl",
@@ -829,6 +833,61 @@ domain EmptyEnumContainers {
         assert_eq!(error.message, "enum 'Status' has no members", "{path}");
         assert_eq!(error.line, enum_span.start.line, "{path}");
         assert_eq!(error.column, enum_span.start.column, "{path}");
+    }
+}
+
+/// One case per accepted-but-unlowerable domain construct fail-closed by
+/// `validate_lowerable_constructs` (#710/#711/#712). Both paths must reject
+/// with the exact same message and the same `line`/`column`, located at the
+/// construct's own declaration, not some downstream position -- an author
+/// debugging the rejection needs to land on the block to delete, and a
+/// located-diagnostic regression on only one path would otherwise slip past
+/// `semantically_invalid_domain_fixtures_are_rejected_by_both_lowering_paths`
+/// (which only checks *that* both reject, not *where*).
+///
+/// Starts with the #712 top-level `await` case; #711's `on_stale` and #710's
+/// `value_object` invariant cases are added alongside their own fixes.
+struct UnlowerableConstructCase {
+    fixture: &'static str,
+    expected_message: &'static str,
+    location: fn(&DomainSpec) -> (u32, u32),
+}
+
+const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[UnlowerableConstructCase {
+    fixture: "rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl",
+    expected_message: "top-level await 'PaymentResult' has no executable lowering; use a saga step's awaits",
+    location: |domain| {
+        let loc = domain.awaits[0].loc;
+        (loc.line, loc.column)
+    },
+}];
+
+#[test]
+fn unlowered_domain_constructs_fail_closed_on_both_paths() {
+    let root = repo_root();
+    for case in UNLOWERABLE_CONSTRUCT_CASES {
+        let source = fs::read_to_string(root.join(case.fixture))
+            .unwrap_or_else(|error| panic!("read {}: {error}", case.fixture));
+        let domain = parse_domain_spec(&source).unwrap_or_else(|error| {
+            panic!(
+                "{}: expected a parseable domain document: {error}",
+                case.fixture
+            )
+        });
+        let (expected_line, expected_column) = (case.location)(&domain);
+        let path_a =
+            lower_domain(&domain).expect_err("path A must reject an unlowerable construct");
+        let path_b =
+            domain_kernel_source(&domain).expect_err("path B must reject an unlowerable construct");
+        for (path, error) in [("path A", path_a), ("path B", path_b)] {
+            assert_eq!(
+                error.message, case.expected_message,
+                "{}: {path}",
+                case.fixture
+            );
+            assert_eq!(error.line, expected_line, "{}: {path}", case.fixture);
+            assert_eq!(error.column, expected_column, "{}: {path}", case.fixture);
+        }
     }
 }
 

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -150,6 +150,7 @@ const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl",
+    "rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl",
 ];
 
 /// Domain specs that fail at the single shared surface parser
@@ -853,14 +854,24 @@ struct UnlowerableConstructCase {
     location: fn(&DomainSpec) -> (u32, u32),
 }
 
-const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[UnlowerableConstructCase {
-    fixture: "rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl",
-    expected_message: "top-level await 'PaymentResult' has no executable lowering; use a saga step's awaits",
-    location: |domain| {
-        let loc = domain.awaits[0].loc;
-        (loc.line, loc.column)
+const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[
+    UnlowerableConstructCase {
+        fixture: "rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl",
+        expected_message: "top-level await 'PaymentResult' has no executable lowering; use a saga step's awaits",
+        location: |domain| {
+            let loc = domain.awaits[0].loc;
+            (loc.line, loc.column)
+        },
     },
-}];
+    UnlowerableConstructCase {
+        fixture: "rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl",
+        expected_message: "on_stale 'Approved' has no executable lowering; stale policies are not supported",
+        location: |domain| {
+            let loc = domain.aggregates[0].stale_policies[0].loc;
+            (loc.line, loc.column)
+        },
+    },
+];
 
 #[test]
 fn unlowered_domain_constructs_fail_closed_on_both_paths() {

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -128,6 +128,7 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl",
     "rust/fslc/tests/fixtures/domain_legacy_enum_union.fsl",
     "rust/fslc/tests/fixtures/domain_origin_violation.fsl",
+    "rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl",
     "rust/fslc/tests/fixtures/issue_515_domain_broken_invariant.fsl",
     "rust/fslc/tests/fixtures/issue_515_domain_clean_invariant.fsl",
     "rust/fslc/tests/fixtures/issue_518_domain_replay.fsl",

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -151,6 +151,7 @@ const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl",
     "rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl",
+    "rust/fslc/tests/fixtures/domain_value_object_invariant_rejected.fsl",
 ];
 
 /// Domain specs that fail at the single shared surface parser
@@ -869,6 +870,19 @@ const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[
         location: |domain| {
             let loc = domain.aggregates[0].stale_policies[0].loc;
             (loc.line, loc.column)
+        },
+    },
+    UnlowerableConstructCase {
+        fixture: "rust/fslc/tests/fixtures/domain_value_object_invariant_rejected.fsl",
+        expected_message: "value_object invariant 'AuditStamp.nonNegative' has no executable lowering; value-object invariants are not supported",
+        location: |domain| {
+            let value_object = domain
+                .types
+                .iter()
+                .find(|ty| ty.kind == "value_object")
+                .expect("fixture declares a value_object");
+            let span = value_object.invariants[0].span;
+            (span.start.line, span.start.column)
         },
     },
 ];

--- a/rust/fslc/tests/domain_compensation_guard.rs
+++ b/rust/fslc/tests/domain_compensation_guard.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! #713: saga compensation must guard on BOTH the trigger event flag and the
+//! `after_event` flag (`docs/DESIGN-domain.md:72` — "saga compensation ->
+//! kernel action guarded by trigger/after event flags"). Before this fix,
+//! both lowering paths (`lower_saga_actions` in `domain_lowering.rs` and
+//! `render_saga_actions` in `domain.rs`) only required the trigger flag, so a
+//! compensation action could fire on a trace that never observed the
+//! `after_event` it is supposed to be gated on.
+//!
+//! `rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl` is
+//! built so a single `decide` can emit both the trigger and after events in
+//! one transition (`emits TriggerHappened, AfterHappened`), which is the only
+//! way to satisfy a dual-flag guard given the one-hot `event_*` flag scheme
+//! (`domain_lowering.rs`, `generated `event_*` flags are one-hot per
+//! transition`). That makes the fixture's compensation actually reachable,
+//! so control 2 below is non-vacuous, not merely "never fires either way".
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fsl_core::{FsResolver, build_model, domain_kernel_source, lower_domain, parse_kernel_source};
+use fsl_runtime::Monitor;
+use fsl_syntax::{DomainSpec, SurfaceDocument, parse_surface_document};
+use serde_json::Value;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust/ directory")
+        .parent()
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn fixture_source() -> String {
+    std::fs::read_to_string(
+        repo_root().join("rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl"),
+    )
+    .expect("read dual-guard fixture")
+}
+
+fn fixture_domain() -> DomainSpec {
+    match parse_surface_document(&fixture_source()).expect("parse dual-guard fixture") {
+        SurfaceDocument::Domain(domain) => domain,
+        _ => panic!("expected a domain document"),
+    }
+}
+
+const OBSERVE_TRIGGER: &str = "saga_compensate_both_observe_trigger_happened";
+const TRIGGER_ACTION: &str = "order_trigger";
+const COMPENSATE_ACTION: &str =
+    "saga_compensate_both_compensate_trigger_happened_after_after_happened";
+
+/// Control 1 (rejecting, mandated by #713): a trace that observes ONLY the
+/// trigger event, then attempts the compensation action, must be rejected on
+/// a guard failure because the `after_event` flag is still false. Reverting
+/// the dual-guard fix (leaving only the trigger `requires`) makes the Monitor
+/// accept this trace.
+#[test]
+fn compensation_rejects_when_only_trigger_event_was_observed() {
+    let domain = fixture_domain();
+    let kernel = lower_domain(&domain).expect("lower dual-guard fixture (path A)");
+    let model = build_model(kernel).expect("build dual-guard model (path A)");
+    let mut monitor = Monitor::new(model).expect("initialize monitor");
+
+    let observed = monitor
+        .attempt(OBSERVE_TRIGGER, &std::collections::BTreeMap::new())
+        .expect("observe trigger action must not error");
+    assert!(
+        observed.violation.is_none(),
+        "observing the trigger event alone must not violate anything: {:?}",
+        observed.violation
+    );
+
+    let compensated = monitor
+        .attempt(COMPENSATE_ACTION, &std::collections::BTreeMap::new())
+        .expect("attempting the compensation action must not error");
+    let violation = compensated
+        .violation
+        .as_ref()
+        .expect("compensation must be rejected when the after_event was never observed");
+    assert_eq!(violation.kind, "requires_failed");
+}
+
+/// Control 2 (accepting, non-vacuity): a trace that fires the dual-emit
+/// `decide` (setting both event flags in a single transition), then attempts
+/// the compensation action, must be accepted, and the post-state must show
+/// the compensation's own emitted event flag true. This proves the dual
+/// guard is satisfiable, not structurally disabled by construction.
+#[test]
+fn compensation_accepts_when_both_events_were_observed_in_one_transition() {
+    let domain = fixture_domain();
+    let kernel = lower_domain(&domain).expect("lower dual-guard fixture (path A)");
+    let model = build_model(kernel).expect("build dual-guard model (path A)");
+    let mut monitor = Monitor::new(model).expect("initialize monitor");
+
+    let triggered = monitor
+        .attempt(TRIGGER_ACTION, &std::collections::BTreeMap::new())
+        .expect("trigger action must not error");
+    assert!(
+        triggered.violation.is_none(),
+        "the dual-emit decide must not violate anything: {:?}",
+        triggered.violation
+    );
+
+    let compensated = monitor
+        .attempt(COMPENSATE_ACTION, &std::collections::BTreeMap::new())
+        .expect("attempting the compensation action must not error");
+    assert!(
+        compensated.violation.is_none(),
+        "compensation must be accepted once both events were observed: {:?}",
+        compensated.violation
+    );
+    assert_eq!(
+        compensated.state.get("event_Released"),
+        Some(&fsl_core::FslValue::Bool(true)),
+        "the compensation's own emitted event flag must be set post-state"
+    );
+}
+
+/// Control 3 (path-B textual control with calibration, the #708 pattern):
+/// the rendered kernel text for the compensation action block must contain
+/// BOTH `requires` lines. Then, to prove the control actually detects the
+/// historical fault (not merely passes), the after-event `requires` line is
+/// mechanically stripped out of the rendered text, the weakened text is
+/// re-parsed and built into a model, and the SAME rejecting trace from
+/// control 1 is replayed against it -- the weakened model must ACCEPT the
+/// bad trace, reproducing the pre-fix defect.
+#[test]
+fn rendered_kernel_source_carries_both_requires_and_calibration_detects_their_absence() {
+    let domain = fixture_domain();
+    let source = domain_kernel_source(&domain).expect("render dual-guard fixture (path B)");
+
+    let block_start = source
+        .find(&format!("action {COMPENSATE_ACTION}("))
+        .unwrap_or_else(|| panic!("rendered kernel is missing action {COMPENSATE_ACTION}"));
+    let block_end = source[block_start..]
+        .find('}')
+        .map(|offset| block_start + offset)
+        .expect("compensation action block must close");
+    let block = &source[block_start..block_end];
+
+    assert!(
+        block.contains("requires event_TriggerHappened"),
+        "compensation action block is missing the trigger requires: {block}"
+    );
+    assert!(
+        block.contains("requires event_AfterHappened"),
+        "compensation action block is missing the after requires: {block}"
+    );
+
+    // Calibration: mechanically remove the after-event requires line and
+    // prove the weakened model reproduces the pre-fix, historically-real
+    // false accept.
+    let after_requires_line = block
+        .lines()
+        .find(|line| line.trim() == "requires event_AfterHappened")
+        .expect("locate the exact after-event requires line to strip");
+    let weakened_source = source.replacen(after_requires_line, "", 1);
+    assert_ne!(
+        weakened_source, source,
+        "the replacen calibration step must actually remove a line"
+    );
+
+    let weakened_kernel = parse_kernel_source(&weakened_source, &FsResolver::new("."))
+        .expect("parse weakened kernel source");
+    let weakened_model = build_model(weakened_kernel).expect("build weakened model");
+    let mut weakened_monitor = Monitor::new(weakened_model).expect("initialize weakened monitor");
+
+    let observed = weakened_monitor
+        .attempt(OBSERVE_TRIGGER, &std::collections::BTreeMap::new())
+        .expect("observe trigger action must not error on weakened model");
+    assert!(observed.violation.is_none());
+
+    let compensated = weakened_monitor
+        .attempt(COMPENSATE_ACTION, &std::collections::BTreeMap::new())
+        .expect("attempting compensation must not error on weakened model");
+    assert!(
+        compensated.violation.is_none(),
+        "calibration failed: the weakened (trigger-only-guarded) model must \
+         reproduce the pre-fix false accept, but it still rejected: {:?}",
+        compensated.violation
+    );
+}
+
+fn run_cli(args: &[&str]) -> (i32, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .current_dir(repo_root())
+        .args(args)
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse CLI JSON for {args:?}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (output.status.code().expect("fslc exit code"), value)
+}
+
+/// Control 4 (interim-evidence control): `verify`ing the corpus saga whose
+/// trigger and after events differ
+/// (`examples/domain/order_fulfillment_saga.fsl`: `when PaymentFailed after
+/// InventoryReserved`) must still reach the same verdict class, but its
+/// warnings must now include the never-enabled warning naming the
+/// compensation action -- because under one-hot `event_*` flags, a
+/// trigger != `after_event` compensation is structurally disabled by the dual
+/// guard (accepted interim state, `docs/DESIGN-saga-history.md:60-62`).
+/// Reverting the fix removes this warning.
+#[test]
+fn order_fulfillment_saga_verify_surfaces_never_enabled_compensation_warning() {
+    let (exit_code, output) = run_cli(&[
+        "verify",
+        "examples/domain/order_fulfillment_saga.fsl",
+        "--depth",
+        "3",
+    ]);
+    assert_eq!(exit_code, 0, "verify exit code: {output}");
+    assert_eq!(output["result"], "verified", "verify verdict: {output}");
+
+    let warnings = output["warnings"]
+        .as_array()
+        .expect("verify output carries a warnings array");
+    let messages = warnings
+        .iter()
+        .map(|warning| warning["message"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+    let expected_action =
+        "saga_order_fulfillment_compensate_payment_failed_after_inventory_reserved";
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains(expected_action) && message.contains("never enabled")),
+        "expected a never-enabled warning naming '{expected_action}', got: {messages:?}"
+    );
+}

--- a/rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl
+++ b/rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl
@@ -1,0 +1,31 @@
+domain AwaitRoutingRejected {
+  // SPDX-License-Identifier: Apache-2.0
+  type PaymentRequestId = 0..1
+
+  aggregate Order {
+    id OrderId
+    state { status: PaymentResultStatus = NotRequested; }
+
+    command RequestPaymentCapture { payment_request_id: PaymentRequestId }
+
+    event PaymentCaptureRequested { payment_request_id: PaymentRequestId }
+    event PaymentCaptured { payment_request_id: PaymentRequestId }
+    event PaymentFailed { payment_request_id: PaymentRequestId }
+
+    decide RequestPaymentCapture {
+      emits PaymentCaptureRequested
+    }
+
+    evolve PaymentCaptureRequested { status = Requested }
+    evolve PaymentCaptured { status = Captured }
+    evolve PaymentFailed { status = Failed }
+  }
+
+  enum PaymentResultStatus { NotRequested, Requested, Captured, Failed }
+
+  await PaymentResult {
+    waits_for one_of [PaymentCaptured, PaymentFailed]
+    on PaymentCaptured -> PaymentCaptured
+    on PaymentFailed -> PaymentFailed
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_characterization/README.md
+++ b/rust/fslc/tests/fixtures/domain_characterization/README.md
@@ -36,6 +36,16 @@ an intentional semantic or diagnostic change has been accepted and documented.
   recorded omission. `expressions_valid.fsl` keeps a commented-out `on_stale`
   block (same line count, so later constructs' spans do not shift) as a record
   that the construct used to be silently accepted here.
+- `value_object` invariants (e.g. `expressions_valid.fsl`'s former
+  `AuditStamp.nonNegative`) are, since #710, likewise rejected fail-closed by
+  `validate_lowerable_constructs` before either lowering path runs
+  (`domain_value_object_invariant_rejected.fsl` in
+  `SEMANTICALLY_INVALID_DOMAIN_FIXTURES`): the frozen Python reference only
+  emits direct-state-field VO instances and skips `Option<VO>`/`Set<VO>`/
+  `Map<_,VO>`/command-input/event-field/nested-VO positions, so adopting it
+  would leave most instances unconstrained while an author believes they are
+  checked. `value_object` field defaults (without invariants) remain fully
+  supported, as `lvalues_surface.fsl` (in `VALID_DOMAIN_FIXTURES`) shows.
 - `expressions_valid.fsl` records accepted legacy `||` and `->` normalization;
   `legacy_logical_parse_error.fsl` records the current lexer rejection of `&&`.
   The later typed-expression migration must make any change explicit.

--- a/rust/fslc/tests/fixtures/domain_characterization/README.md
+++ b/rust/fslc/tests/fixtures/domain_characterization/README.md
@@ -27,9 +27,15 @@ an intentional semantic or diagnostic change has been accepted and documented.
 - `invalid_duplicate_enum.fsl` keeps the repeated member's original location
   and `name` diagnostic classification across both the `domain expand`
   renderer boundary and the `domain check` load path.
-- `on_stale` is captured in the surface projection only because current domain
-  lowering omits it; this corpus records that gap without accepting it as the
-  intended language contract.
+- `on_stale` is captured in the surface projection for parser/AST fidelity, but
+  since #711 it is rejected fail-closed by `validate_lowerable_constructs`
+  before either lowering path runs (`domain_stale_policy_rejected.fsl` in
+  `rust/fsl-core/tests/domain_render_agreement.rs`'s
+  `SEMANTICALLY_INVALID_DOMAIN_FIXTURES`): no accepted design pins `on_stale`
+  semantics, so this is now an accepted, intentional rejection rather than a
+  recorded omission. `expressions_valid.fsl` keeps a commented-out `on_stale`
+  block (same line count, so later constructs' spans do not shift) as a record
+  that the construct used to be silently accepted here.
 - `expressions_valid.fsl` records accepted legacy `||` and `->` normalization;
   `legacy_logical_parse_error.fsl` records the current lexer rejection of `&&`.
   The later typed-expression migration must make any change explicit.

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -308,19 +308,7 @@
               }
             }
           ],
-          "stale_policies": [
-            {
-              "event": "Approved",
-              "condition": "status == Approved and previous_status != Cancelled",
-              "emits": [
-                "ApprovalRejected"
-              ],
-              "loc": {
-                "line": 69,
-                "column": 5
-              }
-            }
-          ],
+          "stale_policies": [],
           "loc": {
             "line": 15,
             "column": 3

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -78,16 +78,7 @@
               }
             }
           ],
-          "invariants": [
-            {
-              "name": "nonNegative",
-              "expr": "attempts >= 0",
-              "loc": {
-                "line": 12,
-                "column": 5
-              }
-            }
-          ],
+          "invariants": [],
           "loc": {
             "line": 9,
             "column": 3
@@ -7648,18 +7639,18 @@
                   "name": "Cancel",
                   "generated_name": "order_cancel",
                   "origin": {
-                    "identity": "domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5",
+                    "identity": "domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5",
                     "dialect": "domain",
                     "primary": {
                       "source_file": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
                       "span": {
                         "start": {
-                          "offset": 1003,
+                          "offset": 1044,
                           "line": 46,
                           "column": 5
                         },
                         "end": {
-                          "offset": 1009,
+                          "offset": 1050,
                           "line": 46,
                           "column": 11
                         }
@@ -7678,12 +7669,12 @@
                         "source_file": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
                         "span": {
                           "start": {
-                            "offset": 604,
+                            "offset": 645,
                             "line": 28,
                             "column": 5
                           },
                           "end": {
-                            "offset": 611,
+                            "offset": 652,
                             "line": 28,
                             "column": 12
                           }

--- a/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
@@ -9,7 +9,7 @@ domain DomainExpressionCharacterization {
   value_object AuditStamp {
     status: OrderStatus = Draft;
     attempts: Quantity = 0;
-    invariant nonNegative { attempts >= 0 }
+    // invariant nonNegative rejected fail-closed since #710 (docs/DESIGN-domain.md)
   }
 
   aggregate Order {

--- a/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
+++ b/rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl
@@ -66,9 +66,9 @@ domain DomainExpressionCharacterization {
       previous_status = status
     }
 
-    on_stale Approved when status == Approved and previous_status != Cancelled {
-      emits ApprovalRejected
-    }
+    // on_stale rejected fail-closed since #711 (docs/DESIGN-domain.md)
+    //
+    //
 
     invariant canonicalImplication {
       status == Approved => previous_status == Draft or previous_status == Approved

--- a/rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl
+++ b/rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl
@@ -1,0 +1,40 @@
+domain SagaCompensationDualGuard {
+  // SPDX-License-Identifier: Apache-2.0
+  implementation_profile functional_ddd
+
+  type OrderId = 0..1
+
+  aggregate Order {
+    id OrderId
+    state {
+      triggered: Bool = false;
+      after_happened: Bool = false;
+      released: Bool = false;
+    }
+
+    command Trigger {}
+
+    event TriggerHappened {}
+    event AfterHappened {}
+    event Released {}
+
+    decide Trigger {
+      requires not triggered
+      emits TriggerHappened, AfterHappened
+    }
+
+    evolve TriggerHappened { triggered = true }
+    evolve AfterHappened { after_happened = true }
+    evolve Released { released = true }
+  }
+
+  saga CompensateBoth {
+    starts_on TriggerHappened
+
+    compensation {
+      when TriggerHappened after AfterHappened {
+        emits Released
+      }
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl
+++ b/rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl
@@ -1,0 +1,34 @@
+domain StalePolicyRejected {
+  // SPDX-License-Identifier: Apache-2.0
+  type Status = Draft | Approved | Cancelled
+
+  aggregate Order {
+    state {
+      status: Status = Draft;
+      previous_status: Status = Draft;
+    }
+
+    command Approve {}
+
+    event Approved {}
+    event ApprovalRejected {}
+
+    decide Approve {
+      requires status == Draft
+      emits Approved
+    }
+
+    evolve Approved {
+      previous_status = status
+      status = Approved
+    }
+
+    evolve ApprovalRejected {
+      previous_status = status
+    }
+
+    on_stale Approved when status == Approved and previous_status != Cancelled {
+      emits ApprovalRejected
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/domain_value_object_invariant_rejected.fsl
+++ b/rust/fslc/tests/fixtures/domain_value_object_invariant_rejected.fsl
@@ -1,0 +1,31 @@
+domain ValueObjectInvariantRejected {
+  // SPDX-License-Identifier: Apache-2.0
+  type Quantity = 0..2
+  type Status = Draft | Approved
+
+  value_object AuditStamp {
+    status: Status = Draft;
+    attempts: Quantity = 0;
+    invariant nonNegative { attempts >= 0 }
+  }
+
+  aggregate Order {
+    state {
+      status: Status = Draft;
+      audit: AuditStamp;
+    }
+
+    command Approve {}
+    event Approved {}
+
+    decide Approve {
+      requires status == Draft
+      emits Approved
+    }
+
+    evolve Approved {
+      status = Approved
+      audit.status = status
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/kernel_origin.v2.json
+++ b/rust/fslc/tests/fixtures/kernel_origin.v2.json
@@ -5502,7 +5502,7 @@
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5511,8 +5511,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5534,8 +5534,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5559,11 +5559,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5572,8 +5572,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5595,8 +5595,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5620,11 +5620,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5633,8 +5633,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5656,8 +5656,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5681,11 +5681,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5694,8 +5694,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5717,8 +5717,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5742,11 +5742,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5755,8 +5755,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5778,8 +5778,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5803,11 +5803,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5816,8 +5816,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5839,8 +5839,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5864,11 +5864,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5877,8 +5877,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5900,8 +5900,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5925,11 +5925,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5938,8 +5938,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5961,8 +5961,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5986,11 +5986,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5999,8 +5999,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6022,8 +6022,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6047,11 +6047,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6060,8 +6060,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6083,8 +6083,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6108,11 +6108,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6121,8 +6121,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6144,8 +6144,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6169,11 +6169,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6182,8 +6182,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1640,
-            "byte_end": 1717,
+            "byte_start": 1610,
+            "byte_end": 1687,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6205,8 +6205,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1601,
-              "byte_end": 1723,
+              "byte_start": 1571,
+              "byte_end": 1693,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6230,11 +6230,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6243,8 +6243,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6266,8 +6266,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6295,11 +6295,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6308,8 +6308,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6331,8 +6331,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6360,11 +6360,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6373,8 +6373,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6396,8 +6396,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6425,11 +6425,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6438,8 +6438,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6461,8 +6461,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6490,11 +6490,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6503,8 +6503,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6526,8 +6526,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6555,11 +6555,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6568,8 +6568,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6591,8 +6591,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6620,11 +6620,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6633,8 +6633,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6656,8 +6656,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6685,11 +6685,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6698,8 +6698,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6721,8 +6721,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6750,11 +6750,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6763,8 +6763,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6786,8 +6786,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6815,11 +6815,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6828,8 +6828,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6851,8 +6851,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6880,11 +6880,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6893,8 +6893,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6916,8 +6916,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6945,11 +6945,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6958,8 +6958,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1958,
-            "byte_end": 1996,
+            "byte_start": 1928,
+            "byte_end": 1966,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6981,8 +6981,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1923,
-              "byte_end": 2002,
+              "byte_start": 1893,
+              "byte_end": 1972,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -7010,11 +7010,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7023,8 +7023,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7046,8 +7046,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7075,11 +7075,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7088,8 +7088,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7111,8 +7111,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7140,11 +7140,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7153,8 +7153,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7176,8 +7176,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7205,11 +7205,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7218,8 +7218,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7241,8 +7241,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7270,11 +7270,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7283,8 +7283,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7306,8 +7306,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7335,11 +7335,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7348,8 +7348,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7371,8 +7371,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7400,11 +7400,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7413,8 +7413,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7436,8 +7436,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7465,11 +7465,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7478,8 +7478,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7501,8 +7501,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7530,11 +7530,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7543,8 +7543,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7566,8 +7566,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7595,11 +7595,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7608,8 +7608,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7631,8 +7631,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7660,11 +7660,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7673,8 +7673,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7696,8 +7696,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7725,11 +7725,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7738,8 +7738,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1851,
-            "byte_end": 1911,
+            "byte_start": 1821,
+            "byte_end": 1881,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7761,8 +7761,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1815,
-              "byte_end": 1917,
+              "byte_start": 1785,
+              "byte_end": 1887,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7790,11 +7790,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7803,8 +7803,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7826,8 +7826,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7859,11 +7859,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7872,8 +7872,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7895,8 +7895,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7928,11 +7928,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7941,8 +7941,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7964,8 +7964,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7997,11 +7997,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8010,8 +8010,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8033,8 +8033,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8066,11 +8066,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8079,8 +8079,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8102,8 +8102,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8135,11 +8135,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8148,8 +8148,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8171,8 +8171,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8204,11 +8204,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8217,8 +8217,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8240,8 +8240,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8273,11 +8273,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8286,8 +8286,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8309,8 +8309,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8342,11 +8342,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8355,8 +8355,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8378,8 +8378,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8411,11 +8411,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8424,8 +8424,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8447,8 +8447,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8480,11 +8480,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8493,8 +8493,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8516,8 +8516,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8549,11 +8549,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8562,8 +8562,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8585,8 +8585,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8618,11 +8618,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8631,8 +8631,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8654,8 +8654,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8687,11 +8687,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8700,8 +8700,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8723,8 +8723,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8756,11 +8756,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8769,8 +8769,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8792,8 +8792,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8825,11 +8825,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8838,8 +8838,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8861,8 +8861,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8894,11 +8894,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8907,8 +8907,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8930,8 +8930,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8963,11 +8963,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8976,8 +8976,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1765,
-            "byte_end": 1803,
+            "byte_start": 1735,
+            "byte_end": 1773,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8999,8 +8999,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1729,
-              "byte_end": 1809,
+              "byte_start": 1699,
+              "byte_end": 1779,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -9032,7 +9032,7 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
       },
       {
         "kind": "source_chain",
@@ -10013,325 +10013,325 @@
       {
         "target": "property:invariant:Order_canonicalImplication",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0"
         ]
       },
       {
@@ -10542,7 +10542,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1640:1717:74:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7",
         "targets": [
           "property:invariant:Order_canonicalImplication",
           "property:invariant:Order_canonicalImplication:expr:root",
@@ -10559,7 +10559,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1958:1996:86:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7",
         "targets": [
           "property:invariant:Order_finiteMembership",
           "property:invariant:Order_finiteMembership:expr:root",
@@ -10576,7 +10576,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1851:1911:82:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7",
         "targets": [
           "property:invariant:Order_legacyDisjunction",
           "property:invariant:Order_legacyDisjunction:expr:root",
@@ -10593,7 +10593,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1765:1803:78:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7",
         "targets": [
           "property:invariant:Order_legacyImplication",
           "property:invariant:Order_legacyImplication:expr:root",

--- a/rust/fslc/tests/fixtures/kernel_origin.v2.json
+++ b/rust/fslc/tests/fixtures/kernel_origin.v2.json
@@ -3024,7 +3024,7 @@
     "origins": [
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3033,8 +3033,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3064,11 +3064,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3077,8 +3077,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3108,11 +3108,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3121,8 +3121,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3152,11 +3152,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3165,8 +3165,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3196,11 +3196,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3209,8 +3209,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3240,11 +3240,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3253,8 +3253,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3284,11 +3284,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3297,8 +3297,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3328,11 +3328,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3341,8 +3341,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3372,11 +3372,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3385,8 +3385,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 939,
-            "byte_end": 970,
+            "byte_start": 980,
+            "byte_end": 1011,
             "line": 42,
             "column": 29,
             "end_line": 42,
@@ -3416,11 +3416,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3429,8 +3429,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3456,11 +3456,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3469,8 +3469,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3496,11 +3496,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3509,8 +3509,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3536,11 +3536,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3549,8 +3549,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3576,11 +3576,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3589,8 +3589,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3616,11 +3616,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3629,8 +3629,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3656,11 +3656,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3669,8 +3669,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3696,11 +3696,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3709,8 +3709,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3736,11 +3736,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3749,8 +3749,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 812,
-            "byte_end": 857,
+            "byte_start": 853,
+            "byte_end": 898,
             "line": 40,
             "column": 16,
             "end_line": 40,
@@ -3776,11 +3776,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3789,8 +3789,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -3816,11 +3816,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3829,8 +3829,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -3856,11 +3856,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3869,8 +3869,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -3896,11 +3896,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3909,8 +3909,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -3936,11 +3936,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3949,8 +3949,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -3976,11 +3976,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -3989,8 +3989,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -4016,11 +4016,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4029,8 +4029,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -4056,11 +4056,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4069,8 +4069,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 873,
-            "byte_end": 910,
+            "byte_start": 914,
+            "byte_end": 951,
             "line": 41,
             "column": 16,
             "end_line": 41,
@@ -4096,11 +4096,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4109,8 +4109,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 780,
-            "byte_end": 786,
+            "byte_start": 821,
+            "byte_end": 827,
             "line": 39,
             "column": 5,
             "end_line": 39,
@@ -4132,8 +4132,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 551,
-              "byte_end": 558,
+              "byte_start": 592,
+              "byte_end": 599,
               "line": 25,
               "column": 5,
               "end_line": 25,
@@ -4157,11 +4157,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:0:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:0:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4170,8 +4170,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 780,
-            "byte_end": 786,
+            "byte_start": 821,
+            "byte_end": 827,
             "line": 39,
             "column": 5,
             "end_line": 39,
@@ -4193,8 +4193,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 551,
-              "byte_end": 558,
+              "byte_start": 592,
+              "byte_end": 599,
               "line": 25,
               "column": 5,
               "end_line": 25,
@@ -4218,11 +4218,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:1:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:1:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4231,8 +4231,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 780,
-            "byte_end": 786,
+            "byte_start": 821,
+            "byte_end": 827,
             "line": 39,
             "column": 5,
             "end_line": 39,
@@ -4254,8 +4254,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 551,
-              "byte_end": 558,
+              "byte_start": 592,
+              "byte_end": 599,
               "line": 25,
               "column": 5,
               "end_line": 25,
@@ -4279,11 +4279,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:2:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:2:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4292,8 +4292,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 780,
-            "byte_end": 786,
+            "byte_start": 821,
+            "byte_end": 827,
             "line": 39,
             "column": 5,
             "end_line": 39,
@@ -4315,8 +4315,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 551,
-              "byte_end": 558,
+              "byte_start": 592,
+              "byte_end": 599,
               "line": 25,
               "column": 5,
               "end_line": 25,
@@ -4340,11 +4340,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4353,8 +4353,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1108,
-            "byte_end": 1127,
+            "byte_start": 1149,
+            "byte_end": 1168,
             "line": 48,
             "column": 37,
             "end_line": 48,
@@ -4380,11 +4380,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4393,8 +4393,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1108,
-            "byte_end": 1127,
+            "byte_start": 1149,
+            "byte_end": 1168,
             "line": 48,
             "column": 37,
             "end_line": 48,
@@ -4420,11 +4420,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4433,8 +4433,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1108,
-            "byte_end": 1127,
+            "byte_start": 1149,
+            "byte_end": 1168,
             "line": 48,
             "column": 37,
             "end_line": 48,
@@ -4460,11 +4460,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4473,8 +4473,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1108,
-            "byte_end": 1127,
+            "byte_start": 1149,
+            "byte_end": 1168,
             "line": 48,
             "column": 37,
             "end_line": 48,
@@ -4500,11 +4500,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4513,8 +4513,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1108,
-            "byte_end": 1127,
+            "byte_start": 1149,
+            "byte_end": 1168,
             "line": 48,
             "column": 37,
             "end_line": 48,
@@ -4540,11 +4540,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4553,8 +4553,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4580,11 +4580,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4593,8 +4593,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4620,11 +4620,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4633,8 +4633,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4660,11 +4660,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4673,8 +4673,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4700,11 +4700,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4713,8 +4713,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4740,11 +4740,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4753,8 +4753,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4780,11 +4780,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4793,8 +4793,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4820,11 +4820,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4833,8 +4833,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1034,
-            "byte_end": 1071,
+            "byte_start": 1075,
+            "byte_end": 1112,
             "line": 47,
             "column": 16,
             "end_line": 47,
@@ -4860,11 +4860,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4873,8 +4873,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1003,
-            "byte_end": 1009,
+            "byte_start": 1044,
+            "byte_end": 1050,
             "line": 46,
             "column": 5,
             "end_line": 46,
@@ -4896,8 +4896,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 604,
-              "byte_end": 611,
+              "byte_start": 645,
+              "byte_end": 652,
               "line": 28,
               "column": 5,
               "end_line": 28,
@@ -4921,11 +4921,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:0:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:0:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4934,8 +4934,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1003,
-            "byte_end": 1009,
+            "byte_start": 1044,
+            "byte_end": 1050,
             "line": 46,
             "column": 5,
             "end_line": 46,
@@ -4957,8 +4957,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 604,
-              "byte_end": 611,
+              "byte_start": 645,
+              "byte_end": 652,
               "line": 28,
               "column": 5,
               "end_line": 28,
@@ -4982,11 +4982,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:1:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:1:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -4995,8 +4995,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1003,
-            "byte_end": 1009,
+            "byte_start": 1044,
+            "byte_end": 1050,
             "line": 46,
             "column": 5,
             "end_line": 46,
@@ -5018,8 +5018,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 604,
-              "byte_end": 611,
+              "byte_start": 645,
+              "byte_end": 652,
               "line": 28,
               "column": 5,
               "end_line": 28,
@@ -5043,11 +5043,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:2:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:2:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5056,8 +5056,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1003,
-            "byte_end": 1009,
+            "byte_start": 1044,
+            "byte_end": 1050,
             "line": 46,
             "column": 5,
             "end_line": 46,
@@ -5079,8 +5079,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 604,
-              "byte_end": 611,
+              "byte_start": 645,
+              "byte_end": 652,
               "line": 28,
               "column": 5,
               "end_line": 28,
@@ -5104,11 +5104,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1271:1292:56:7@action:order_approve:statement:5:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1312:1333:56:7@action:order_approve:statement:5:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5117,8 +5117,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1271,
-            "byte_end": 1292,
+            "byte_start": 1312,
+            "byte_end": 1333,
             "line": 56,
             "column": 7,
             "end_line": 56,
@@ -5143,11 +5143,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1271:1292:56:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1312:1333:56:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1216:1240:54:7@action:order_approve:statement:3:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1257:1281:54:7@action:order_approve:statement:3:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5156,8 +5156,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1216,
-            "byte_end": 1240,
+            "byte_start": 1257,
+            "byte_end": 1281,
             "line": 54,
             "column": 7,
             "end_line": 54,
@@ -5182,11 +5182,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1216:1240:54:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1257:1281:54:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1299:1318:57:7@action:order_approve:statement:6:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1340:1359:57:7@action:order_approve:statement:6:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5195,8 +5195,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1299,
-            "byte_end": 1318,
+            "byte_start": 1340,
+            "byte_end": 1359,
             "line": 57,
             "column": 7,
             "end_line": 57,
@@ -5221,11 +5221,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1299:1318:57:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1340:1359:57:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5234,8 +5234,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1194,
-            "byte_end": 1209,
+            "byte_start": 1235,
+            "byte_end": 1250,
             "line": 53,
             "column": 16,
             "end_line": 53,
@@ -5261,11 +5261,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5274,8 +5274,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1194,
-            "byte_end": 1209,
+            "byte_start": 1235,
+            "byte_end": 1250,
             "line": 53,
             "column": 16,
             "end_line": 53,
@@ -5301,11 +5301,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5314,8 +5314,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1194,
-            "byte_end": 1209,
+            "byte_start": 1235,
+            "byte_end": 1250,
             "line": 53,
             "column": 16,
             "end_line": 53,
@@ -5341,11 +5341,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5354,8 +5354,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1194,
-            "byte_end": 1209,
+            "byte_start": 1235,
+            "byte_end": 1250,
             "line": 53,
             "column": 16,
             "end_line": 53,
@@ -5381,11 +5381,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1247:1264:55:7@action:order_approve:statement:4:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1288:1305:55:7@action:order_approve:statement:4:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5394,8 +5394,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1247,
-            "byte_end": 1264,
+            "byte_start": 1288,
+            "byte_end": 1305,
             "line": 55,
             "column": 7,
             "end_line": 55,
@@ -5420,11 +5420,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1247:1264:55:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1288:1305:55:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1355:1379:61:7@action:order_cancel:statement:3:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1396:1420:61:7@action:order_cancel:statement:3:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5433,8 +5433,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1355,
-            "byte_end": 1379,
+            "byte_start": 1396,
+            "byte_end": 1420,
             "line": 61,
             "column": 7,
             "end_line": 61,
@@ -5459,11 +5459,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1355:1379:61:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1396:1420:61:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1386:1404:62:7@action:order_cancel:statement:4:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1427:1445:62:7@action:order_cancel:statement:4:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -5472,8 +5472,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1386,
-            "byte_end": 1404,
+            "byte_start": 1427,
+            "byte_end": 1445,
             "line": 62,
             "column": 7,
             "end_line": 62,
@@ -5498,11 +5498,11 @@
         ],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1386:1404:62:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1427:1445:62:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5511,8 +5511,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5534,8 +5534,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5559,11 +5559,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5572,8 +5572,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5595,8 +5595,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5620,11 +5620,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5633,8 +5633,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5656,8 +5656,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5681,11 +5681,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5694,8 +5694,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5717,8 +5717,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5742,11 +5742,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5755,8 +5755,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5778,8 +5778,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5803,11 +5803,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5816,8 +5816,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5839,8 +5839,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5864,11 +5864,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5877,8 +5877,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5900,8 +5900,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5925,11 +5925,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5938,8 +5938,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -5961,8 +5961,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -5986,11 +5986,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -5999,8 +5999,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6022,8 +6022,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6047,11 +6047,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6060,8 +6060,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6083,8 +6083,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6108,11 +6108,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6121,8 +6121,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6144,8 +6144,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6169,11 +6169,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6182,8 +6182,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1610,
-            "byte_end": 1687,
+            "byte_start": 1651,
+            "byte_end": 1728,
             "line": 74,
             "column": 7,
             "end_line": 74,
@@ -6205,8 +6205,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1571,
-              "byte_end": 1693,
+              "byte_start": 1612,
+              "byte_end": 1734,
               "line": 73,
               "column": 5,
               "end_line": 75,
@@ -6230,11 +6230,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6243,8 +6243,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6266,8 +6266,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6295,11 +6295,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6308,8 +6308,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6331,8 +6331,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6360,11 +6360,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6373,8 +6373,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6396,8 +6396,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6425,11 +6425,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6438,8 +6438,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6461,8 +6461,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6490,11 +6490,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6503,8 +6503,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6526,8 +6526,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6555,11 +6555,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6568,8 +6568,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6591,8 +6591,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6620,11 +6620,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6633,8 +6633,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6656,8 +6656,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6685,11 +6685,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6698,8 +6698,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6721,8 +6721,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6750,11 +6750,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6763,8 +6763,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6786,8 +6786,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6815,11 +6815,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6828,8 +6828,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6851,8 +6851,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6880,11 +6880,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6893,8 +6893,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6916,8 +6916,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -6945,11 +6945,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -6958,8 +6958,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1928,
-            "byte_end": 1966,
+            "byte_start": 1969,
+            "byte_end": 2007,
             "line": 86,
             "column": 7,
             "end_line": 86,
@@ -6981,8 +6981,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1893,
-              "byte_end": 1972,
+              "byte_start": 1934,
+              "byte_end": 2013,
               "line": 85,
               "column": 5,
               "end_line": 87,
@@ -7010,11 +7010,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7023,8 +7023,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7046,8 +7046,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7075,11 +7075,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7088,8 +7088,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7111,8 +7111,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7140,11 +7140,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7153,8 +7153,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7176,8 +7176,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7205,11 +7205,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7218,8 +7218,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7241,8 +7241,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7270,11 +7270,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7283,8 +7283,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7306,8 +7306,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7335,11 +7335,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7348,8 +7348,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7371,8 +7371,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7400,11 +7400,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7413,8 +7413,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7436,8 +7436,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7465,11 +7465,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7478,8 +7478,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7501,8 +7501,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7530,11 +7530,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7543,8 +7543,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7566,8 +7566,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7595,11 +7595,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7608,8 +7608,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7631,8 +7631,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7660,11 +7660,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7673,8 +7673,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7696,8 +7696,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7725,11 +7725,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7738,8 +7738,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1821,
-            "byte_end": 1881,
+            "byte_start": 1862,
+            "byte_end": 1922,
             "line": 82,
             "column": 7,
             "end_line": 82,
@@ -7761,8 +7761,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1785,
-              "byte_end": 1887,
+              "byte_start": 1826,
+              "byte_end": 1928,
               "line": 81,
               "column": 5,
               "end_line": 83,
@@ -7790,11 +7790,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7803,8 +7803,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7826,8 +7826,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7859,11 +7859,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7872,8 +7872,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7895,8 +7895,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7928,11 +7928,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -7941,8 +7941,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -7964,8 +7964,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -7997,11 +7997,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8010,8 +8010,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8033,8 +8033,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8066,11 +8066,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8079,8 +8079,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8102,8 +8102,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8135,11 +8135,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8148,8 +8148,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8171,8 +8171,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8204,11 +8204,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8217,8 +8217,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8240,8 +8240,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8273,11 +8273,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8286,8 +8286,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8309,8 +8309,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8342,11 +8342,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8355,8 +8355,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8378,8 +8378,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8411,11 +8411,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8424,8 +8424,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8447,8 +8447,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8480,11 +8480,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8493,8 +8493,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8516,8 +8516,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8549,11 +8549,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8562,8 +8562,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8585,8 +8585,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8618,11 +8618,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8631,8 +8631,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8654,8 +8654,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8687,11 +8687,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8700,8 +8700,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8723,8 +8723,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8756,11 +8756,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8769,8 +8769,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8792,8 +8792,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8825,11 +8825,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8838,8 +8838,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8861,8 +8861,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8894,11 +8894,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8907,8 +8907,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8930,8 +8930,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -8963,11 +8963,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -8976,8 +8976,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 1735,
-            "byte_end": 1773,
+            "byte_start": 1776,
+            "byte_end": 1814,
             "line": 78,
             "column": 7,
             "end_line": 78,
@@ -8999,8 +8999,8 @@
               "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
             },
             "span": {
-              "byte_start": 1699,
-              "byte_end": 1779,
+              "byte_start": 1740,
+              "byte_end": 1820,
               "line": 77,
               "column": 5,
               "end_line": 79,
@@ -9032,11 +9032,11 @@
         ],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7@init:3:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7@init:3:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -9045,8 +9045,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 521,
-            "byte_end": 539,
+            "byte_start": 562,
+            "byte_end": 580,
             "line": 22,
             "column": 7,
             "end_line": 22,
@@ -9065,11 +9065,11 @@
         "lowering_steps": [],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7@state:order_audit:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7@state:order_audit:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -9078,8 +9078,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 521,
-            "byte_end": 539,
+            "byte_start": 562,
+            "byte_end": 580,
             "line": 22,
             "column": 7,
             "end_line": 22,
@@ -9098,11 +9098,11 @@
         "lowering_steps": [],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7@init:1:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7@init:1:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -9111,8 +9111,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 447,
-            "byte_end": 484,
+            "byte_start": 488,
+            "byte_end": 525,
             "line": 20,
             "column": 7,
             "end_line": 20,
@@ -9131,11 +9131,11 @@
         "lowering_steps": [],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7@state:order_previous_status:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7@state:order_previous_status:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -9144,8 +9144,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 447,
-            "byte_end": 484,
+            "byte_start": 488,
+            "byte_end": 525,
             "line": 20,
             "column": 7,
             "end_line": 20,
@@ -9164,11 +9164,11 @@
         "lowering_steps": [],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7@init:2:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7@init:2:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -9177,8 +9177,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 491,
-            "byte_end": 514,
+            "byte_start": 532,
+            "byte_end": 555,
             "line": 21,
             "column": 7,
             "end_line": 21,
@@ -9197,11 +9197,11 @@
         "lowering_steps": [],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7@state:order_quantity:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7@state:order_quantity:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -9210,8 +9210,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 491,
-            "byte_end": 514,
+            "byte_start": 532,
+            "byte_end": 555,
             "line": 21,
             "column": 7,
             "end_line": 21,
@@ -9230,11 +9230,11 @@
         "lowering_steps": [],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7@init:0:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7@init:0:0",
         "dialect": "domain",
         "assurance": "generated_from_source",
         "primary": {
@@ -9243,8 +9243,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 412,
-            "byte_end": 440,
+            "byte_start": 453,
+            "byte_end": 481,
             "line": 19,
             "column": 7,
             "end_line": 19,
@@ -9263,11 +9263,11 @@
         "lowering_steps": [],
         "generated": true,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7"
       },
       {
         "kind": "source_chain",
-        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7@state:order_status:0",
+        "id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7@state:order_status:0",
         "dialect": "domain",
         "assurance": "source_backed",
         "primary": {
@@ -9276,8 +9276,8 @@
             "value": "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl"
           },
           "span": {
-            "byte_start": 412,
-            "byte_end": 440,
+            "byte_start": 453,
+            "byte_end": 481,
             "line": 19,
             "column": 7,
             "end_line": 19,
@@ -9296,7 +9296,7 @@
         "lowering_steps": [],
         "generated": false,
         "extensions": {},
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7"
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7"
       },
       {
         "kind": "source_chain",
@@ -9623,343 +9623,343 @@
       {
         "target": "action:order_approve",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:right:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16@action:order_approve:guard:0:expr:root:expr:right:expr:operand:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:1:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16@action:order_approve:guard:1:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:left:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29@action:order_approve:guard:2:expr:root:expr:operand:expr:right:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:guard:3",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:0"
         ]
       },
       {
         "target": "action:order_approve:guard:3:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:0"
         ]
       },
       {
         "target": "action:order_approve:guard:3:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:expr:left:0"
         ]
       },
       {
         "target": "action:order_approve:guard:3:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16@action:order_approve:guard:3:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16@action:order_approve:guard:3:expr:root:expr:right:0"
         ]
       },
       {
         "target": "action:order_approve:statement:0",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:0:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:0:0"
         ]
       },
       {
         "target": "action:order_approve:statement:1",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:1:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:1:0"
         ]
       },
       {
         "target": "action:order_approve:statement:2",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5@action:order_approve:statement:2:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5@action:order_approve:statement:2:0"
         ]
       },
       {
         "target": "action:order_approve:statement:3",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1216:1240:54:7@action:order_approve:statement:3:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1257:1281:54:7@action:order_approve:statement:3:0"
         ]
       },
       {
         "target": "action:order_approve:statement:4",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1247:1264:55:7@action:order_approve:statement:4:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1288:1305:55:7@action:order_approve:statement:4:0"
         ]
       },
       {
         "target": "action:order_approve:statement:5",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1271:1292:56:7@action:order_approve:statement:5:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1312:1333:56:7@action:order_approve:statement:5:0"
         ]
       },
       {
         "target": "action:order_approve:statement:6",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1299:1318:57:7@action:order_approve:statement:6:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1340:1359:57:7@action:order_approve:statement:6:0"
         ]
       },
       {
         "target": "action:order_cancel",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:0:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16@action:order_cancel:guard:0:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:1",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:1:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:1:expr:root:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:1:expr:root:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "action:order_cancel:guard:1:expr:root:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37@action:order_cancel:guard:1:expr:root:expr:operand:expr:right:0"
         ]
       },
       {
         "target": "action:order_cancel:statement:0",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:0:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:0:0"
         ]
       },
       {
         "target": "action:order_cancel:statement:1",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:1:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:1:0"
         ]
       },
       {
         "target": "action:order_cancel:statement:2",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5@action:order_cancel:statement:2:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5@action:order_cancel:statement:2:0"
         ]
       },
       {
         "target": "action:order_cancel:statement:3",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1355:1379:61:7@action:order_cancel:statement:3:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1396:1420:61:7@action:order_cancel:statement:3:0"
         ]
       },
       {
         "target": "action:order_cancel:statement:4",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1386:1404:62:7@action:order_cancel:statement:4:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1427:1445:62:7@action:order_cancel:statement:4:0"
         ]
       },
       {
@@ -9971,25 +9971,25 @@
       {
         "target": "init:0",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7@init:0:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7@init:0:0"
         ]
       },
       {
         "target": "init:1",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7@init:1:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7@init:1:0"
         ]
       },
       {
         "target": "init:2",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7@init:2:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7@init:2:0"
         ]
       },
       {
         "target": "init:3",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7@init:3:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7@init:3:0"
         ]
       },
       {
@@ -10013,325 +10013,325 @@
       {
         "target": "property:invariant:Order_canonicalImplication",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7@property:invariant:Order_canonicalImplication:expr:root:expr:right:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7@property:invariant:Order_finiteMembership:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7@property:invariant:Order_legacyDisjunction:expr:root:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:left:expr:right:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:left:0"
         ]
       },
       {
         "target": "property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7@property:invariant:Order_legacyImplication:expr:root:expr:right:expr:operand:expr:right:expr:operand:expr:right:0"
         ]
       },
       {
@@ -10361,25 +10361,25 @@
       {
         "target": "state:order_audit",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7@state:order_audit:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7@state:order_audit:0"
         ]
       },
       {
         "target": "state:order_previous_status",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7@state:order_previous_status:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7@state:order_previous_status:0"
         ]
       },
       {
         "target": "state:order_quantity",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7@state:order_quantity:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7@state:order_quantity:0"
         ]
       },
       {
         "target": "state:order_status",
         "origin_ids": [
-          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7@state:order_status:0"
+          "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7@state:order_status:0"
         ]
       },
       {
@@ -10415,7 +10415,7 @@
     ],
     "reverse_index": [
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:939:970:42:29",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/reject/NotDraft:980:1011:42:29",
         "targets": [
           "action:order_approve:guard:2",
           "action:order_approve:guard:2:expr:root",
@@ -10429,7 +10429,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:812:857:40:16",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/0:853:898:40:16",
         "targets": [
           "action:order_approve:guard:0",
           "action:order_approve:guard:0:expr:root",
@@ -10443,7 +10443,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:873:910:41:16",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve/requires/1:914:951:41:16",
         "targets": [
           "action:order_approve:guard:1",
           "action:order_approve:guard:1:expr:root",
@@ -10456,7 +10456,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:780:786:39:5",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Approve:821:827:39:5",
         "targets": [
           "action:order_approve",
           "action:order_approve:statement:0",
@@ -10465,7 +10465,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1108:1127:48:37",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/reject/AlreadyCancelled:1149:1168:48:37",
         "targets": [
           "action:order_cancel:guard:1",
           "action:order_cancel:guard:1:expr:root",
@@ -10475,7 +10475,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1034:1071:47:16",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel/requires/0:1075:1112:47:16",
         "targets": [
           "action:order_cancel:guard:0",
           "action:order_cancel:guard:0:expr:root",
@@ -10488,7 +10488,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1003:1009:46:5",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/decide/Cancel:1044:1050:46:5",
         "targets": [
           "action:order_cancel",
           "action:order_cancel:statement:0",
@@ -10497,25 +10497,25 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1271:1292:56:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/audit.status:1312:1333:56:7",
         "targets": [
           "action:order_approve:statement:5"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1216:1240:54:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/previous_status:1257:1281:54:7",
         "targets": [
           "action:order_approve:statement:3"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1299:1318:57:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/quantity:1340:1359:57:7",
         "targets": [
           "action:order_approve:statement:6"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1194:1209:53:16",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/requires/0:1235:1250:53:16",
         "targets": [
           "action:order_approve:guard:3",
           "action:order_approve:guard:3:expr:root",
@@ -10524,25 +10524,25 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1247:1264:55:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Approved/status:1288:1305:55:7",
         "targets": [
           "action:order_approve:statement:4"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1355:1379:61:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/previous_status:1396:1420:61:7",
         "targets": [
           "action:order_cancel:statement:3"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1386:1404:62:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/evolve/Cancelled/status:1427:1445:62:7",
         "targets": [
           "action:order_cancel:statement:4"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1610:1687:74:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/canonicalImplication:1651:1728:74:7",
         "targets": [
           "property:invariant:Order_canonicalImplication",
           "property:invariant:Order_canonicalImplication:expr:root",
@@ -10559,7 +10559,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1928:1966:86:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/finiteMembership:1969:2007:86:7",
         "targets": [
           "property:invariant:Order_finiteMembership",
           "property:invariant:Order_finiteMembership:expr:root",
@@ -10576,7 +10576,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1821:1881:82:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyDisjunction:1862:1922:82:7",
         "targets": [
           "property:invariant:Order_legacyDisjunction",
           "property:invariant:Order_legacyDisjunction:expr:root",
@@ -10593,7 +10593,7 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1735:1773:78:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/invariant/legacyImplication:1776:1814:78:7",
         "targets": [
           "property:invariant:Order_legacyImplication",
           "property:invariant:Order_legacyImplication:expr:root",
@@ -10616,28 +10616,28 @@
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:521:539:22:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/audit:562:580:22:7",
         "targets": [
           "init:3",
           "state:order_audit"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:447:484:20:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/previous_status:488:525:20:7",
         "targets": [
           "init:1",
           "state:order_previous_status"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:491:514:21:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/quantity:532:555:21:7",
         "targets": [
           "init:2",
           "state:order_quantity"
         ]
       },
       {
-        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:412:440:19:7",
+        "source_node_id": "source:repository_path:rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl#domain:DomainExpressionCharacterization/aggregate/Order/state/status:453:481:19:7",
         "targets": [
           "init:0",
           "state:order_status"

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -319,6 +319,11 @@ exactly-once semantics.
 The accepted #662 design keeps `event_*` flags one-hot/current-step and will add
 a dedicated `Map<Correlation,SagaPhase>` in a follow-up; do not make global
 event flags sticky or treat one effect's status map as a general saga history.
+A saga `compensation { when Trigger after After { ... } }` block is guarded by
+BOTH event flags (#713); because flags are one-hot, a compensation whose
+trigger and after events differ is structurally disabled today and surfaces
+as a `fslc verify` never-enabled action warning — do not suppress that
+warning or weaken the guard to make it disappear.
 Native domain generation is grounded in Public Kernel v1. A closed
 `domain-scaffold-metadata.v1` companion retains source grouping/spelling that
 lowering cannot publish. Versions, dialect, duplicate Kernel members, and


### PR DESCRIPTION
## Problem

Four `domain` constructs found by #709's semantic-drift pilot were **accepted and then meant nothing** in the executable model. Per `AGENTS.md`, "an accepted construct with absent, placeholder, or hollow semantics is a soundness defect" — the author believes a constraint is checked, the verifier never checks it, and nothing fails. All four are milestone M10 / `track:A`.

## Decisions: three fail closed, one implemented

The governing rule is that each accepted variant must bind to **executable semantics or an explicit fail-closed diagnostic**. Which one depends on whether an accepted design actually pins the meaning — inventing semantics inside a verifier is worse than rejecting the construct.

| Issue | Construct | Decision | Why |
|---|---|---|---|
| **#713** | saga compensation `after_event` | **implement** | `docs/DESIGN-domain.md:72` pins it: "saga compensation -> kernel action guarded by trigger/**after** event flags" (plural). Both lowerings already resolved `after_event` for the action name and observed set but guarded only on the trigger, so compensation was enabled on traces that never observed the after event. Emitting the second guard executes the accepted contract. |
| **#712** | top-level `await` | **fail closed** | `DomainAwait` is consumed by nothing outside the parser — not either lowering, `domain analyze`, `check_domain`, scaffold metadata, or any finding. `docs/DESIGN-domain.md:110-112` accepts only the *grammar*; cross-aggregate routing proofs are explicit Future Work (:334-335). |
| **#711** | aggregate `on_stale` | **fail closed** | Nothing pins the semantics. `docs/DESIGN-domain.md` mentions stale policies only as parse IR (:104) and as the name of a finding (`late_completion_without_stale_policy`, :211) that **is not implemented in native Rust at all** — filed as #724. |
| **#710** | `value_object` invariants | **fail closed** | No accepted design pins the *instance set*. The frozen Python (`src/fslc/domain_expand.py:783-830`) emits only direct-state-field instances and skips `Option<VO>` / `Set<VO>` / `Map<_,VO>` / command inputs / event fields / nested VOs, so adopting it would leave most instances unconstrained while the author believes they are checked — a false-assurance shape. `value_object` is not documented in `docs/LANGUAGE.md` at all. |

For each fail-close, the `[Unreleased]` entry records what a future accepted decision would have to settle for the construct to become implementable.

### The #713 consequence that must not be "fixed"

Generated `event_*` flags are one-hot per transition, so requiring both flags is satisfiable only by a transition emitting both events. For a trigger≠after compensation (e.g. `examples/domain/order_fulfillment_saga.fsl`) the action becomes **structurally disabled**, and `verify` now emits its never-enabled warning naming `saga_order_fulfillment_compensate_payment_failed_after_inventory_reserved`. That is the accepted interim state, verified at `docs/DESIGN-saga-history.md:60-62`: *"Until that follow-up lands, `domain check` warnings for structurally disabled saga actions remain valid evidence. They must not be suppressed or replaced by sticky global flags."* The dual guard makes the kernel claim strictly less than before, never more. Do not add sticky flags to re-enable it; the real fix is the correlation-indexed saga history follow-up (#679).

## Change, by commit

1. `92a7014` **#713** — both paths emit `requires event_<after>` alongside `requires event_<trigger>` (`lower_saga_actions` in `domain_lowering.rs`, `render_saga_actions` in `domain.rs`). New dual-emit fixture in `VALID_DOMAIN_FIXTURES` + `rust/fslc/tests/domain_compensation_guard.rs` with four controls. `docs/DESIGN-domain.md`, `docs/LANGUAGE.md` + `docs/LANGUAGE.ja.md` (saga `compensation` was undocumented despite being accepted corpus), `skills/fsl/reference.md`.
2. `58311c9` **#712** — new shared `validate_lowerable_constructs` in `domain_lowering.rs`, called from **both** `lower_domain_surface` and `domain_kernel_source` (the `validate_domain_enums` precedent). Dead `await PaymentResult` block removed from `examples/domain/order_async_effect.fsl`. Rejecting fixture + located-diagnostic test.
3. `062f1aa` **#711** — stale arm added; now-unreachable stale resolution removed; `expressions_valid.fsl`'s `on_stale` block replaced by a same-line-count comment so downstream spans don't shift.
4. `49e0e37` **#710** — VO-invariant arm (using the invariant's own declaration `span`); now-unreachable VO invariant resolution removed, field-default validation kept.

One PR with one commit per topic, as `docs/DESIGN-ci.md:43` sanctions: the four cannot be developed independently (commits 2–4 grow the same validator and call sites, 3–4 edit the same fixture/baseline/golden, all four touch the agreement registries), and four PRs would be ~80 min of CI plus serial-rebase churn for no review benefit.

**Correction.** An earlier version of this description claimed each commit was self-contained and green on its own. Review falsified that: commits 3 and 4 each broke an assertion in `rust/fsl-core/tests/domain_lowering.rs`, so the head commit was red on first push. `d8e796d` repairs it. The intermediate commits were not rebuilt after that repair and are therefore **not** independently green; only the head is. See the review-findings section below.

## Verification — independent of the implementing agent

**Both paths reject identically** (the invariant whose violation produced #690/#691). Ran path A (`check`) and path B (`domain expand`) on all three rejecting fixtures myself:

| fixture | both paths |
|---|---|
| `domain_await_routing_rejected` | `error/semantics … @26:3` — identical |
| `domain_stale_policy_rejected` | `error/semantics … @30:5` — identical |
| `domain_value_object_invariant_rejected` | `error/semantics … @9:5` — identical |

**Live mutation of the negative controls** (not merely reading them):
- Deleted path B's `validate_lowerable_constructs` call → `semantically_invalid_domain_fixtures_are_rejected_by_both_lowering_paths` **and** `unlowered_domain_constructs_fail_closed_on_both_paths` both failed, the former naming the fixture and quoting *"one path only rejecting is itself a finding, not something to normalize away"*. Restored.
- Deleted path A's after-flag `Requires` → `compensation_rejects_when_only_trigger_event_was_observed` **and** `order_fulfillment_saga_verify_surfaces_never_enabled_compensation_warning` both failed. Restored.

**The regenerated golden is offsets-only.** `rust/fslc/tests/fixtures/kernel_origin.v2.json` moved because the fixture edits change byte lengths. Proved mechanically rather than trusted: across all 741 changed lines the `line:column` multiset is identical, and across the 141 `source_node_id` strings **every differing token is numeric** (88 distinct, all byte offsets) — no identifier, coordinate, or content change. Regenerated via `FSLC_KERNEL_V2_UPDATE=1`, not hand-edited.

**Other checks I re-ran:** `domain_render_agreement` 10 passed; `domain_compensation_guard` 4 passed; `domain_expression_characterization` 3 passed; `cargo fmt --check` clean. `expressions_valid.fsl` still holds its **#690 pin** in `KNOWN_DIVERGENT_DOMAIN_FIXTURES` (`DivergenceShape::ContractsDisagree`). `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` both have 18 `## ` sections (D7 alignment).

The implementing agent additionally ran `cargo clippy --workspace --all-targets -- -D warnings` (clean), the full `fslc-rust` suite per commit, `./tools/check-native-integration.sh rust-checks`, and `tools/build_site_reference.py` (zero diff). The wasm leg was deliberately not run — `fsl-wasm` is untouched and that leg hangs locally.

## What independent review found, and what changed

Two review passes ran against `49e0e37` (a soundness/coupled-change/vacuity sweep, and an evidence-classification pass). They found four real defects. Two were fixed in `d8e796d`; two are filed.

**Fixed — `rust/fsl-core/tests/domain_lowering.rs` was red.** `validates_non_executable_domain_expression_positions` asserted the unknown-symbol diagnostic for a `value_object` invariant *and* for an `on_stale` condition; the fail-closed rejection now preempts both, because the expressions are never resolved. Reproduced in CI (`rust tests (1/3)` and `merge readiness / core contracts`) and locally. Both assertions now expect the fail-closed message; unknown-symbol coverage survives in the same test on a value-object field default and an effect idempotency path, which are still lowered. **This test sits in `fsl-core`, outside the three suites the implementation verified — a verification-coverage hole, and the fail-close having missed a coupled consumer is precisely the class of defect this PR exists to remove.**

**Fixed — the rejection boundary had no design authority.** The `[Unreleased]` entries and two fixture comments all ended "See `docs/DESIGN-domain.md`", but that document had received only #713 material, so every pointer dangled. `docs/DESIGN-domain.md` now carries a `### Rejected constructs` section recording, per construct, why nothing pins its semantics and what a future accepted amendment must settle — for #710, that the open question is the *instance set* rather than the predicate, and why the frozen Python's partial per-state-field emission is not adopted as the contract.

**Filed — #726: `fslc domain analyze` bypasses the guard.** It parses only and never lowers, so all three rejected constructs still return `result:"analyzed"`, exit 0, while being absent from the projection. Not a false-green verdict (no verification verdict is produced), but the same spec is now rejected by `check` and accepted by `analyze`. The reviewer enumerated every other raw-`DomainSpec` consumer — `compose`, the wasm Worker, `domain check`, `domain expand`, `domain generate`, `domain replay` — and `analyze` was the only unguarded one.

**Filed — #727: no mutation evidence channel exists for domain specs.** `fslc mutate` rejects domain-dialect files on this branch *and* on `main`, so the vacuity reviewer could not compute a base-vs-PR kill-rate at all — the low-kill-rate heuristic is inapplicable here rather than passed. Pre-existing, not caused by this PR.

**Recorded on #724.** This PR's #711 entry states that `late_completion_without_stale_policy` is unimplemented natively, while `docs/DESIGN-domain.md:216` still lists it under implemented finding kinds; and the frozen Python's remediation hint (`src/fslc/domain_expand.py:919`) still tells authors to add an `on_stale` block that the native verifier now rejects.

**Vacuity finding accepted as interim, not fixed here.** `examples/domain/order_fulfillment_saga.fsl`'s only compensation goes from `covered: true` on `main` to never-enabled under the dual guard. It is disclosed, not silent — both `verify` (depths 3 and 8, and induction) and `domain check` name the action — but the verdict stays `verified`/`proved` and `--vacuity error` does not escalate it, so nothing fails on it. That is the interim state `docs/DESIGN-saga-history.md:60-62` accepts pending #679; the reviewer's suggestion to make never-enabled actions escalatable belongs with that follow-up rather than here.

**Claims in this description that review could not corroborate**, stated so a reader does not over-trust them: the manual both-path rejection runs, the two live-mutation experiments, and the `FSLC_KERNEL_V2_UPDATE=1` regeneration are author-process claims that left no artifact. The offsets-only golden proof *was* independently reproduced (−741/+741 lines, identical `line:column` multiset, 88 distinct differing tokens all numeric), which rules out a content-changing hand edit — the part `AGENTS.md` actually bans.

### Review outcome

The review completed at head `d8e796d` with an **approve** verdict. Its adversarial pass authored four new probe fixtures — a value_object invariant reachable only through `Option<VO>` and `Map<_,VO>` state, one on a wholly unused type, a `trigger == after` compensation, and a compensation whose two events are emitted by disjoint transitions — and **found no divergence between the two lowering paths** in any of them, so none needed promotion into the regression suite. It also ran live mutations different from the author's: deleting only the `on_stale` arm of the validator (caught, naming the fixture), and dropping the *trigger* `requires` while keeping the after one on path A (caught by the corpus agreement test and by the never-enabled warning control).

Two residual observations, neither blocking:

- **The four compensation controls are not four independent oracles.** A trigger-side revert passes controls 1–3 and is caught only by control 4 and `valid_domain_corpus_lowering_and_rendering_agree`; an after-side revert is caught by 1–3. Net coverage has no hole, but control 4 must not be treated as redundant. Recorded in #728.
- **Local-optimum trigger, second occurrence on this surface.** This is the third fix of the shape "shared validator called from both lowering paths" (`validate_effect_outcome_roles`, `validate_domain_enums`, now `validate_lowerable_constructs`), and every domain semantic change fans out across both paths plus two goldens plus the characterization baseline plus the agreement registries (#690, #691, #708, this PR). The path-B text renderer versus path-A typed lowering duplication is the underlying cost; PR #708 already recorded a local-optima audit of it at 11/15, C3. Not acted on here.

Also filed from the review: **#728** — `verify` detects a never-enabled action but no exit code moves, even under `--vacuity error`, so the interim state this PR creates in `order_fulfillment_saga.fsl` is disclosed yet ungated and could outlive #679 unnoticed.

## Migration

Three previously-accepted constructs now fail closed, which is semantic-strictness tightening. Each `[Unreleased]` entry states the author action plainly: **remove the block — the construct had no executable meaning, so removing it changes no verification outcome.** #702 (migration notes required for strictness tightening) and #703 (a migration diagnostic for rejected idioms) track the general mechanism; neither is implemented here.

## Coupled change

`rust/fsl-lsp/src/index.rs` — no change needed: no new declaration, binder, or reference form; the grammar is untouched and these are existing constructs now rejected later in the pipeline. `tests/dialect_registry.py` — no change: no new top-level construct or corpus directory. Both confirmed by empty diffs.

## Out of scope, filed rather than folded in

Inventorying the domain sum types surfaced more of the same class. Recorded as issues per `AGENTS.md` rather than silently expanding this PR:

- **#723** — `DomainProjection` is fully hollow (and has an accepted-corpus instance at `order_async_effect.fsl:111-114`, deliberately left untouched by commit 2); effect `compensation { emits … }` is inert and the generated `Compensated` status member has no writer; `DomainSaga.outboxes`/`inboxes`; `DomainRetry.backoff`.
- **#724** — `docs/DESIGN-domain.md:202-219` lists five finding kinds as implemented that exist only in the frozen Python. Directly relevant to #711: the "remedy" finding for a missing stale policy does not exist natively.
- **#722** — the implicit-initializer enumeration in `docs/LANGUAGE.md` / `LANGUAGE.ja.md` / `skills/fsl/reference.md` omits the container defaults.

Closes #710, closes #711, closes #712, closes #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

