### PR TITLE
docs(domain): enumerate container defaults for omitted domain initializers (#722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Documented (#722): the implicit domain aggregate initializer enumeration in
+  `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
+  covered only Bool `false`/enum first-member/range lower-bound/external-
+  placeholder `0`, omitting the container defaults `Context::default_for_type`
+  (`rust/fsl-core/src/domain.rs`) and its `domain_lowering.rs` counterpart
+  already select: `Option<T>` -> `none`, `Set<T>` -> `Set {}`, and a top-level
+  `Map<K, V>` -> dense per-key `forall k: K { field[k] = <value default> }`
+  (#691 / PR #708). Confirmed empirically with `fslc check` on
+  `rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl`
+  and `.../lvalues_surface.fsl` that `implicit_initial_value` does **not**
+  fire for these container shapes -- that warning's `omitted_domain_value`
+  (`rust/fslc/src/frontend_output.rs`) only ever recognizes the four scalar
+  shapes, a real (documented, not fixed) gap between the warning's coverage
+  and the renderer's total default dispatch. Also documented the two
+  `Map`-specific rejections: an explicit whole-`Map` default ("whole-Map
+  domain defaults are not supported") and a `Map` nested as another `Map`'s
+  value ("Map state requires explicit initialization through supported
+  semantics"). No Rust behavior changed. See `docs/DESIGN-domain.md`.
 - Fixed (#713): saga `compensation { when Trigger after After { ... } }` now
   lowers to a kernel action guarded by BOTH the trigger event flag and the
   `after` event flag on both lowering paths (`lower_saga_actions` in

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -292,7 +292,18 @@ domain aggregate の状態フィールドが初期化子を省略した場合、
 確立された Bool `false`、enum 先頭メンバー、範囲下限、external-placeholder `0` の
 選択を維持し、`implicit_initial_value` を出力します。この警告には、選択された値、
 理由、current/next の深刻度、フィールドのスパン、機械適用可能な明示初期化子の挿入
-が含まれます。次のエディションでは初期化子の明示が必須になります。
+が含まれます。次のエディションでは初期化子の明示が必須になります。コンテナ型の
+フィールドにも暗黙の既定値があります — `Option<T>` は `none` を、`Set<T>` は
+`Set {}` を選び、トップレベルの `Map<K, V>` は密な per-key init
+(`forall k: K { field[k] = <V の既定値> }`)を選びます。`<V の既定値>` はこの同じ
+選択を再帰的に辿ります — ただし省略しても `implicit_initial_value` は
+**出力されません**。この警告のカバー範囲は上記の4つのスカラー形状で止まります。
+`Map` フィールドには、さらに2つの fail-closed ルールがあります: 明示の whole-`Map`
+既定値(`field: Map<K, V> = expr;`)は常に棄却されます(「whole-Map domain defaults
+are not supported」)。サポートされる `Map` の既定値は per-key 形式のみだからです。
+また、別の `Map` の値として nested された `Map` も棄却されます(「Map state requires
+explicit initialization through supported semantics」)。per-key init は `Map` 値型
+に対して選べる既定値を持たないからです。
 
 安定した fsl-domain findings とネストされたカーネル結果(成功時は
 `verified_under_assumptions`)には `fslc domain check` を、aggregate/effect の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -298,7 +298,19 @@ preserves the established Bool `false`, enum first-member, range lower-bound, or
 external-placeholder `0` choice and emits `implicit_initial_value`. The warning
 contains the selected value, reason, current/next severity, field span, and a
 machine-applicable explicit-initializer insertion. The next edition requires the
-initializer to be explicit.
+initializer to be explicit. Container-typed fields also get an implicit
+default — `Option<T>` selects `none`, `Set<T>` selects `Set {}`, and a
+top-level `Map<K, V>` selects a dense per-key init
+(`forall k: K { field[k] = <V's default> }`), where `<V's default>` recurses
+through this same selection — but omitting one does **not** emit
+`implicit_initial_value`; that warning's coverage stops at the four scalar
+shapes above. `Map` fields carry two additional fail-closed rules: an explicit
+whole-`Map` default (`field: Map<K, V> = expr;`) is always rejected
+("whole-Map domain defaults are not supported") because the per-key form is the
+only supported `Map` default, and a `Map` nested as another `Map`'s value is
+rejected too ("Map state requires explicit initialization through supported
+semantics") because the per-key init has no default to select for a `Map`
+value type.
 
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -330,7 +330,19 @@ preserves the established Bool <code>false</code>, enum first-member, range lowe
 external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
 contains the selected value, reason, current/next severity, field span, and a
 machine-applicable explicit-initializer insertion. The next edition requires the
-initializer to be explicit.</p>
+initializer to be explicit. Container-typed fields also get an implicit
+default — <code>Option&lt;T&gt;</code> selects <code>none</code>, <code>Set&lt;T&gt;</code> selects <code>Set {}</code>, and a
+top-level <code>Map&lt;K, V&gt;</code> selects a dense per-key init
+(<code>forall k: K { field[k] = &lt;V's default&gt; }</code>), where <code>&lt;V's default&gt;</code> recurses
+through this same selection — but omitting one does <strong>not</strong> emit
+<code>implicit_initial_value</code>; that warning's coverage stops at the four scalar
+shapes above. <code>Map</code> fields carry two additional fail-closed rules: an explicit
+whole-<code>Map</code> default (<code>field: Map&lt;K, V&gt; = expr;</code>) is always rejected
+("whole-Map domain defaults are not supported") because the per-key form is the
+only supported <code>Map</code> default, and a <code>Map</code> nested as another <code>Map</code>'s value is
+rejected too ("Map state requires explicit initialization through supported
+semantics") because the per-key init has no default to select for a <code>Map</code>
+value type.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -326,7 +326,18 @@ assurance/completeness を持つトップレベルの provenance グラフとし
 確立された Bool <code>false</code>、enum 先頭メンバー、範囲下限、external-placeholder <code>0</code> の
 選択を維持し、<code>implicit_initial_value</code> を出力します。この警告には、選択された値、
 理由、current/next の深刻度、フィールドのスパン、機械適用可能な明示初期化子の挿入
-が含まれます。次のエディションでは初期化子の明示が必須になります。</p>
+が含まれます。次のエディションでは初期化子の明示が必須になります。コンテナ型の
+フィールドにも暗黙の既定値があります — <code>Option&lt;T&gt;</code> は <code>none</code> を、<code>Set&lt;T&gt;</code> は
+<code>Set {}</code> を選び、トップレベルの <code>Map&lt;K, V&gt;</code> は密な per-key init
+(<code>forall k: K { field[k] = &lt;V の既定値&gt; }</code>)を選びます。<code>&lt;V の既定値&gt;</code> はこの同じ
+選択を再帰的に辿ります — ただし省略しても <code>implicit_initial_value</code> は
+<strong>出力されません</strong>。この警告のカバー範囲は上記の4つのスカラー形状で止まります。
+<code>Map</code> フィールドには、さらに2つの fail-closed ルールがあります: 明示の whole-<code>Map</code>
+既定値(<code>field: Map&lt;K, V&gt; = expr;</code>)は常に棄却されます(「whole-Map domain defaults
+are not supported」)。サポートされる <code>Map</code> の既定値は per-key 形式のみだからです。
+また、別の <code>Map</code> の値として nested された <code>Map</code> も棄却されます(「Map state requires
+explicit initialization through supported semantics」)。per-key init は <code>Map</code> 値型
+に対して選べる既定値を持たないからです。</p>
 <p>安定した fsl-domain findings とネストされたカーネル結果(成功時は
 <code>verified_under_assumptions</code>)には <code>fslc domain check</code> を、aggregate/effect の
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -354,6 +354,12 @@ Omitted domain aggregate initializers retain the current Bool `false`, enum
 first-member, range lower-bound, or external-placeholder `0` behavior while
 emitting `implicit_initial_value`. The warning carries the selected value,
 reason, edition severities, source span, and a machine-applicable insertion.
+Container-typed fields default too but do **not** trigger that warning:
+`Option<T>` -> `none`, `Set<T>` -> `Set {}`, top-level `Map<K, V>` -> dense
+per-key `forall k: K { field[k] = <value default> }`. An explicit whole-`Map`
+default and a `Map` nested as another `Map`'s value are both rejected
+("whole-Map domain defaults are not supported" / "Map state requires explicit
+initialization through supported semantics").
 
 AI hard-contract dialect (expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):


### PR DESCRIPTION
## Problem

Three canonical surfaces enumerate the implicit initializer defaults for `domain` aggregate state fields as exactly four shapes — **Bool `false` / enum first-member / range lower-bound / external-placeholder `0`** — and omit the container types entirely:

- `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md` (section-aligned), and `skills/fsl/reference.md`.

But since #691 / PR #708 the renderer's dispatch is total: `Option<T>` selects `none`, `Set<T>` selects `Set {}`, and a top-level `Map<K, V>` selects a dense per-key init. A reader — human, or an agent consulting `skills/fsl/reference.md` — could not tell from the docs whether `picked: Option<ItemId>;` gets `none` or is an error, and could not know that writing an explicit `Map` default is refused.

Found during the coupled-change review of PR #708 and recorded in PR #715's body; this closes it.

## Ground truth, established from the implementation and confirmed with the built CLI

Not transcribed from the issue — read from both lowering paths and then observed:

| shape | selected default | source |
| --- | --- | --- |
| `Option<T>` | `none` | `domain.rs:403`, `domain_lowering.rs:1747` |
| `Set<T>` | `Set {}` | `domain.rs:404`, `domain_lowering.rs:1748` |
| top-level `Map<K, V>` | `forall k: K { field[k] = <V's default> }`, recursing through the same dispatch | `domain.rs:949-976`, `domain_lowering.rs:2225-2252` |
| explicit whole-`Map` default | **rejected** — "whole-Map domain defaults are not supported" | `domain.rs:957-962`, `domain_lowering.rs:2226-2231` |
| `Map` nested as a `Map` value | **rejected** — "Map state requires explicit initialization through supported semantics" | `domain.rs:412-415`, `domain_lowering.rs:1750-1755` |

Observed via `fslc domain expand`: `container_defaults_surface.fsl` renders `basket_picked = none` and `basket_seen = Set {}`; `lvalues_surface.fsl` renders `forall k: ItemId { inventory_counts[k] = 0 }`. Synthetic specs produced both rejection messages verbatim.

## The issue's open question, answered empirically — and it surfaced a real mismatch

The issue asked whether `implicit_initial_value` fires for container-typed fields. **It does not.** `omitted_domain_value` (`rust/fslc/src/frontend_output.rs:198-238`) ends with `(!type_name.contains('<')).then(...)`, so every container type is excluded. Observed: `fslc check` on both container fixtures yields no `implicit_initial_value` entry, while a `Bool` field with no default (positive control) does produce one.

So the warning's coverage stops at the four scalar shapes while the renderer's dispatch is total. This PR **documents that as the current fact** and does not change the emitter — a behavior change is out of a docs issue's scope. Filed as **#731** for the decision (widen the warning to containers, or record deliberately why containers are exempt from the next edition's explicit-initializer requirement). Either outcome will require these same three surfaces to follow.

## Change

All three surfaces now state the container defaults, the fact that omitting one does **not** emit `implicit_initial_value`, and both `Map` rejection rules — the last per the issue's acceptance criterion, documented inline rather than deferred because it sits directly adjacent to text a reader consulting container defaults is already reading. `docs/LANGUAGE.ja.md` mirrors the English paragraph in place; no `## ` heading was added.

Documentation only. No Rust, no `.fsl` corpus, no emitter change.

## Verification

- `python3 tools/build_site_reference.py` → exit 0; `docs/intro/language.{en,ja}.html` regenerated, never hand-edited, and **idempotent** — I re-ran it independently and got an empty diff.
- Section alignment (D7): 18 `## ` sections in each file, and I compared the heading lists **side by side** rather than trusting equal counts — indices 0–17 match in order and numbering.
- `python3 -m pytest tests/test_site_reference_snapshot.py -q` → 3 passed (the gate `site reference freshness` runs).
- I independently confirmed the emitter's `(!type_name.contains('<'))` exclusion at `frontend_output.rs:232` rather than accepting the claim.

## Related

- #722 (closed by this), #731 (the mismatch this surfaced), #691 / PR #708 (made the renderer's dispatch total), PR #715 (where the gap was first recorded)

Closes #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)