### PR TITLE
ci: audit the main ruleset against a checked-in contract (#707 remaining half)

### DIFF
--- a/.github/ruleset-contract.json
+++ b/.github/ruleset-contract.json
@@ -1,0 +1,82 @@
+{
+  "$comment": "Owned by docs/DESIGN-ci.md (\"Ruleset drift audit\"). A change to this file must land in the same pull request as a re-captured .github/scripts/fixtures/ruleset-*.json and the corresponding docs/DESIGN-ci.md update -- editing the contract alone to match unexplained live state is the drift this audit exists to catch, not a fix.",
+  "schema": "fsl-ruleset-contract/1",
+  "rulesets": [
+    {
+      "ruleset_id": 19090811,
+      "ruleset_name": "main safety and CI",
+      "target": "branch",
+      "enforcement": "active",
+      "ref_name_include": ["refs/heads/main"],
+      "ref_name_exclude": [],
+      "rule_types": ["deletion", "non_fast_forward", "pull_request", "required_status_checks"],
+      "strict_required_status_checks_policy": true,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "merge readiness", "integration_id": 15368 },
+        { "context": "rust workspace", "integration_id": 15368 },
+        { "context": "WASM", "integration_id": 15368 },
+        { "context": "semantic mutation (changed)", "integration_id": 15368 },
+        { "context": "FSL Logic Test (pr)", "integration_id": 15368 },
+        { "context": "site reference freshness", "integration_id": 15368 }
+      ],
+      "bypass_actors": [],
+      "deferred_contexts": [
+        {
+          "context": "native Z3 4.16 (macos-15)",
+          "reason": "Post-merge cross-platform matrix member under FSL_OPTIMISTIC_CI (docs/DESIGN-ci.md, \"Product gate contract\"). It never reports on an ordinary pull request, so requiring it pre-merge would deadlock every PR forever."
+        },
+        {
+          "context": "native Z3 4.16 (windows-latest)",
+          "reason": "Post-merge cross-platform matrix member under FSL_OPTIMISTIC_CI (docs/DESIGN-ci.md, \"Product gate contract\"). It never reports on an ordinary pull request, so requiring it pre-merge would deadlock every PR forever."
+        },
+        {
+          "context": "product gate",
+          "reason": "Aggregate workflow-level context for ci.yml, gated by FSL_OPTIMISTIC_CI the same way as the cross-platform matrix (docs/DESIGN-ci.md, \"Product gate contract\"). It never reports on an ordinary pull request, so requiring it pre-merge would deadlock every PR forever."
+        }
+      ],
+      "constituent_contexts": [
+        {
+          "context": "rust checks",
+          "aggregate": "rust workspace",
+          "reason": "Sharded lane inside the rust-workspace aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "rust tests (1/3)",
+          "aggregate": "rust workspace",
+          "reason": "Sharded lane inside the rust-workspace aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "rust tests (2/3)",
+          "aggregate": "rust workspace",
+          "reason": "Sharded lane inside the rust-workspace aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "rust tests (3/3)",
+          "aggregate": "rust workspace",
+          "reason": "Sharded lane inside the rust-workspace aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "mutation operators (1/3)",
+          "aggregate": "semantic mutation (changed)",
+          "reason": "Sharded lane inside the semantic-mutation aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "mutation operators (2/3)",
+          "aggregate": "semantic mutation (changed)",
+          "reason": "Sharded lane inside the semantic-mutation aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "mutation operators (3/3)",
+          "aggregate": "semantic mutation (changed)",
+          "reason": "Sharded lane inside the semantic-mutation aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        },
+        {
+          "context": "mutation mutants",
+          "aggregate": "semantic mutation (changed)",
+          "reason": "Sharded lane inside the semantic-mutation aggregator (docs/DESIGN-ci.md, \"Sharded pre-merge Linux evidence\"). Only the aggregator's if: always() job carries the required-context name; requiring a shard directly would let a skipped shard silently satisfy the ruleset."
+        }
+      ]
+    }
+  ]
+}

--- a/.github/scripts/audit-ruleset-drift.mjs
+++ b/.github/scripts/audit-ruleset-drift.mjs
@@ -1,0 +1,749 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Ruleset drift audit (issue #707, drift-detection half).
+//
+// This is configuration-conformance automation, not product verification: it never touches
+// rust/, the Kernel, or fslc's JSON contract, so AGENTS.md's "one Rust-native entrypoint, no
+// Python" clause (which governs tools/check-native-integration.sh) does not apply here. It
+// exists because the `main` repository ruleset drifted silently once (docs/DESIGN-ci.md,
+// "Required pre-merge contexts, and why the merge queue was rejected") and, without an audit,
+// can drift again the same way.
+//
+// The comparison path (validateContract / compareRuleset) is pure: no network, no file IO, no
+// process access. Everything that touches the world -- fetching the live ruleset, writing the
+// raw observation, and the failure-issue lifecycle -- is a separate function that takes an
+// injected client, mirroring report-post-merge-ci.mjs's reconcilePostMerge({ client, ... })
+// shape. This script imports report-post-merge-ci.mjs's exported GitHubRestClient for the issue
+// lifecycle rather than building a second REST client and a second issue-dedupe mechanism; that
+// file's `import.meta.url` main-guard means importing it here does not execute its own CLI.
+
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+import { GitHubRestClient } from "./report-post-merge-ci.mjs";
+
+export const RULESET_DRIFT_LABEL = "ci/ruleset-drift";
+
+const DEFAULT_CONTRACT_URL = new URL("../ruleset-contract.json", import.meta.url);
+const DEFAULT_OBSERVATION_PATH = "ruleset-observation.json";
+
+class ContractError extends Error {}
+
+// ---------------------------------------------------------------------------
+// Pure: contract validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail-closed structural validation of the checked-in contract. Returns an array of error
+ * strings; an empty array means the contract is valid. Never throws.
+ */
+export function validateContract(contract) {
+  const errors = [];
+
+  if (!contract || typeof contract !== "object" || Array.isArray(contract)) {
+    return ["contract must be a JSON object"];
+  }
+
+  if (contract.schema !== "fsl-ruleset-contract/1") {
+    errors.push(
+      `schema must be "fsl-ruleset-contract/1", got ${JSON.stringify(contract.schema)}`,
+    );
+  }
+
+  if (!Array.isArray(contract.rulesets) || contract.rulesets.length === 0) {
+    errors.push("rulesets must be a non-empty array");
+    return errors;
+  }
+
+  contract.rulesets.forEach((entry, index) => {
+    const label = `rulesets[${index}]`;
+
+    if (!Array.isArray(entry.required_status_checks) || entry.required_status_checks.length === 0) {
+      errors.push(`${label}.required_status_checks must be a non-empty array`);
+    } else {
+      const seen = new Set();
+      entry.required_status_checks.forEach((rsc, i) => {
+        if (typeof rsc.context !== "string" || rsc.context.length === 0) {
+          errors.push(`${label}.required_status_checks[${i}].context must be a non-empty string`);
+        }
+        if (!Number.isInteger(rsc.integration_id)) {
+          errors.push(`${label}.required_status_checks[${i}].integration_id must be an integer`);
+        }
+        const key = `${rsc.context} ${rsc.integration_id}`;
+        if (seen.has(key)) {
+          errors.push(
+            `${label}.required_status_checks has a duplicate (context, integration_id) pair: ${rsc.context} / ${rsc.integration_id}`,
+          );
+        }
+        seen.add(key);
+      });
+    }
+
+    const requiredNames = new Set(
+      (Array.isArray(entry.required_status_checks) ? entry.required_status_checks : []).map(
+        (rsc) => rsc.context,
+      ),
+    );
+
+    for (const group of ["deferred_contexts", "constituent_contexts"]) {
+      const list = entry[group];
+      if (!Array.isArray(list)) {
+        errors.push(`${label}.${group} must be an array`);
+        continue;
+      }
+      for (const item of list) {
+        if (requiredNames.has(item.context)) {
+          errors.push(
+            `${label}.${group} entry "${item.context}" collides with a required_status_checks context; a context cannot be both required and ${group}`,
+          );
+        }
+      }
+    }
+
+    if (!Array.isArray(entry.bypass_actors)) {
+      errors.push(`${label}.bypass_actors must be present and be an array`);
+    }
+  });
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Pure: ruleset comparison
+// ---------------------------------------------------------------------------
+
+function arraysEqualOrdered(a, b) {
+  return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+function canonicalStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalStringify(value[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function bypassActorsEqual(observed, expected) {
+  if (!Array.isArray(observed) || !Array.isArray(expected) || observed.length !== expected.length) {
+    return false;
+  }
+  const a = observed.map(canonicalStringify).sort();
+  const b = expected.map(canonicalStringify).sort();
+  return a.every((v, i) => v === b[i]);
+}
+
+// A context name may itself contain spaces or parentheses (e.g. "semantic mutation
+// (changed)"), so the key is only ever used for map lookups -- never re-split back into its
+// parts. The original { context, integration_id } pair is kept alongside the key for reporting.
+function pairKey(rsc) {
+  return JSON.stringify([rsc.context, rsc.integration_id]);
+}
+
+function compareRequiredContexts(contractEntry, observedContexts) {
+  const findings = [];
+
+  const observedByKey = new Map();
+  const observedCounts = new Map();
+  for (const rsc of observedContexts) {
+    const key = pairKey(rsc);
+    observedCounts.set(key, (observedCounts.get(key) ?? 0) + 1);
+    observedByKey.set(key, rsc);
+  }
+  for (const [key, count] of observedCounts) {
+    if (count > 1) {
+      const rsc = observedByKey.get(key);
+      findings.push({
+        class: "required-context-duplicated",
+        detail: `"${rsc.context}" (integration_id ${rsc.integration_id}) is reported ${count} times`,
+      });
+    }
+  }
+
+  const contractPairs = new Map(contractEntry.required_status_checks.map((rsc) => [pairKey(rsc), rsc]));
+  const deferredNames = new Set((contractEntry.deferred_contexts ?? []).map((entry) => entry.context));
+
+  for (const [key, rsc] of contractPairs) {
+    if (!observedCounts.has(key)) {
+      findings.push({
+        class: "required-context-missing",
+        detail: `"${rsc.context}" (integration_id ${rsc.integration_id}) is required by the contract but was not observed`,
+      });
+    }
+  }
+
+  for (const [key, rsc] of observedByKey) {
+    if (!contractPairs.has(key)) {
+      if (deferredNames.has(rsc.context)) {
+        findings.push({
+          class: "required-context-unexpected",
+          detail: `"${rsc.context}" (integration_id ${rsc.integration_id}) is required in the live ruleset, but the contract records it as deliberately deferred (docs/DESIGN-ci.md, "Product gate contract"); requiring it pre-merge would deadlock every pull request`,
+        });
+      } else {
+        findings.push({
+          class: "required-context-unexpected",
+          detail: `"${rsc.context}" (integration_id ${rsc.integration_id}) is required in the live ruleset but is not in the contract`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Pure comparison of one checked-in contract ruleset entry against one observed ruleset JSON
+ * body (the raw GitHub API response shape). Never does IO. Returns { verdict, findings }, where
+ * verdict is "clean" iff findings is empty.
+ */
+export function compareRuleset(contractEntry, observation) {
+  const findings = [];
+
+  if (observation.id !== contractEntry.ruleset_id) {
+    findings.push({
+      class: "ruleset-identity",
+      detail: `id: expected ${JSON.stringify(contractEntry.ruleset_id)}, observed ${JSON.stringify(observation.id)}`,
+    });
+  }
+  if (observation.name !== contractEntry.ruleset_name) {
+    findings.push({
+      class: "ruleset-identity",
+      detail: `name: expected ${JSON.stringify(contractEntry.ruleset_name)}, observed ${JSON.stringify(observation.name)}`,
+    });
+  }
+  if (observation.target !== contractEntry.target) {
+    findings.push({
+      class: "ruleset-identity",
+      detail: `target: expected ${JSON.stringify(contractEntry.target)}, observed ${JSON.stringify(observation.target)}`,
+    });
+  }
+
+  if (observation.enforcement !== "active") {
+    findings.push({
+      class: "enforcement",
+      detail: `enforcement is ${JSON.stringify(observation.enforcement)}, expected "active"`,
+    });
+  }
+
+  const include = observation.conditions?.ref_name?.include ?? [];
+  const exclude = observation.conditions?.ref_name?.exclude ?? [];
+  if (!arraysEqualOrdered(include, contractEntry.ref_name_include)) {
+    findings.push({
+      class: "conditions",
+      detail: `conditions.ref_name.include is ${JSON.stringify(include)}, expected ${JSON.stringify(contractEntry.ref_name_include)}`,
+    });
+  }
+  if (!arraysEqualOrdered(exclude, contractEntry.ref_name_exclude)) {
+    findings.push({
+      class: "conditions",
+      detail: `conditions.ref_name.exclude is ${JSON.stringify(exclude)}, expected ${JSON.stringify(contractEntry.ref_name_exclude)}`,
+    });
+  }
+
+  const rules = Array.isArray(observation.rules) ? observation.rules : [];
+  if (rules.length === 0) {
+    findings.push({ class: "empty-rules", detail: "the observed ruleset has no rules at all" });
+  } else {
+    const observedTypes = new Set(rules.map((rule) => rule.type));
+    const expectedTypes = new Set(contractEntry.rule_types);
+
+    for (const type of expectedTypes) {
+      if (!observedTypes.has(type)) {
+        findings.push({ class: "rule-type-missing", detail: `rule type "${type}" is missing` });
+      }
+    }
+    for (const type of observedTypes) {
+      if (!expectedTypes.has(type)) {
+        findings.push({
+          class: "rule-type-unexpected",
+          detail: `rule type "${type}" is present but not in the contract`,
+        });
+      }
+    }
+
+    // `pull_request` rule parameters (review counts, allowed_merge_methods, ...) are the blind
+    // control's subject and are deliberately never read here. Human review policy lives in
+    // ruleset 19090821 and is a separate accepted process decision.
+
+    const requiredStatusChecksRule = rules.find((rule) => rule.type === "required_status_checks");
+    if (requiredStatusChecksRule) {
+      const params = requiredStatusChecksRule.parameters ?? {};
+
+      if (params.strict_required_status_checks_policy !== true) {
+        findings.push({
+          class: "strict-policy",
+          detail: `strict_required_status_checks_policy is ${JSON.stringify(params.strict_required_status_checks_policy)}, expected true`,
+        });
+      }
+      if (params.do_not_enforce_on_create !== false) {
+        findings.push({
+          class: "enforce-on-create",
+          detail: `do_not_enforce_on_create is ${JSON.stringify(params.do_not_enforce_on_create)}, expected false`,
+        });
+      }
+
+      const observedContexts = Array.isArray(params.required_status_checks)
+        ? params.required_status_checks
+        : [];
+      if (observedContexts.length === 0) {
+        findings.push({
+          class: "required-contexts-empty",
+          detail: "observed required_status_checks is empty",
+        });
+      } else {
+        findings.push(...compareRequiredContexts(contractEntry, observedContexts));
+      }
+    }
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(observation, "bypass_actors")) {
+    findings.push({
+      class: "bypass-actors-unobserved",
+      detail:
+        "bypass_actors was absent from the observation; absence of the field is never read as an empty list, because absence of evidence is not evidence of emptiness",
+    });
+  } else if (!bypassActorsEqual(observation.bypass_actors, contractEntry.bypass_actors)) {
+    findings.push({
+      class: "bypass-actor-added",
+      detail: `bypass_actors is ${JSON.stringify(observation.bypass_actors)}, expected ${JSON.stringify(contractEntry.bypass_actors)}`,
+    });
+  }
+
+  return { verdict: findings.length === 0 ? "clean" : "drift", findings };
+}
+
+// ---------------------------------------------------------------------------
+// IO: live ruleset fetch (injected client)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal read client for the ruleset endpoint. Rulesets are readable unauthenticated for this
+ * public repository, but `bypass_actors` is returned only to a caller with write access to the
+ * ruleset -- GITHUB_TOKEN has no `administration` permission at all, so a fine-grained PAT
+ * (RULESET_AUDIT_TOKEN) is required to observe that field. When RULESET_AUDIT_TOKEN is unset,
+ * the caller falls back to GITHUB_TOKEN, which fails the bypass leg deliberately (see
+ * `bypass-actors-unobserved` above) rather than silently skip it.
+ */
+export class RulesetReadClient {
+  constructor({ token, repository }) {
+    const [owner, repo] = repository.split("/");
+    if (!owner || !repo) {
+      throw new Error(`invalid GITHUB_REPOSITORY: ${repository}`);
+    }
+    this.token = token;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  async getRuleset(rulesetId) {
+    const response = await fetch(
+      `https://api.github.com/repos/${this.owner}/${this.repo}/rulesets/${rulesetId}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+          "User-Agent": "fsl-ruleset-drift-audit",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+
+    if (response.status === 404) {
+      const error = new Error(`ruleset ${rulesetId} was not found`);
+      error.status = 404;
+      throw error;
+    }
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`GitHub API GET rulesets/${rulesetId} failed (${response.status}): ${text}`);
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch (parseError) {
+      throw new Error(`failed to parse ruleset ${rulesetId} response: ${parseError.message}`);
+    }
+  }
+}
+
+/**
+ * Fetch one ruleset through an injected client and classify a failure without ever throwing.
+ * A 404 is `ruleset-missing`; any other fetch or parse error is `api-unreadable`. Returns
+ * `{ ok: true, body }` on success.
+ */
+export async function fetchObservation(readClient, rulesetId) {
+  try {
+    const body = await readClient.getRuleset(rulesetId);
+    return { ok: true, body };
+  } catch (error) {
+    if (error && error.status === 404) {
+      return { ok: false, class: "ruleset-missing", detail: `ruleset ${rulesetId} was not found (404)` };
+    }
+    return {
+      ok: false,
+      class: "api-unreadable",
+      detail: `failed to fetch or parse ruleset ${rulesetId}: ${error.message}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IO: issue lifecycle (injected client, shape mirrors reconcilePostMerge)
+// ---------------------------------------------------------------------------
+
+export function rulesetDriftMarker(key) {
+  return `<!-- ruleset-drift:${key} -->`;
+}
+
+export function rulesetDriftOccurrenceMarker(runId) {
+  return `<!-- ruleset-drift-occurrence:${runId} -->`;
+}
+
+function rulesetDriftRecoveryMarker(runId) {
+  return `<!-- ruleset-drift-recovery:${runId} -->`;
+}
+
+function findingsList(findings) {
+  return findings.map((f) => `- \`${f.class}\`: ${f.detail}`).join("\n");
+}
+
+export function buildRulesetDriftIssueBody({ key, runId, runUrl, artifactUrl, findings, rotateToken }) {
+  const lines = [
+    rulesetDriftMarker(key),
+    rulesetDriftOccurrenceMarker(runId),
+    "",
+    "The ruleset drift audit found the live GitHub ruleset diverged from `.github/ruleset-contract.json`.",
+    "",
+    "Findings:",
+    findingsList(findings),
+    "",
+    `Raw observation: [workflow run](${runUrl})${artifactUrl ? ` — [artifact](${artifactUrl})` : ""}.`,
+    "",
+    "There are two legitimate exits: revert the live ruleset to match the contract, or amend the",
+    "contract, the fixture, and `docs/DESIGN-ci.md` together in one pull request if the live",
+    "change was intentional. Editing the contract alone to match unexplained live state is the",
+    "drift this audit catches, not a fix.",
+  ];
+  if (rotateToken) {
+    lines.push(
+      "",
+      "This finding includes `bypass-actors-unobserved`: rotate the `RULESET_AUDIT_TOKEN` secret." +
+        " A fine-grained PAT that lost administration-read access on this repository will drop" +
+        " into this same failure, indistinguishable from a real bypass-actor change until rotated.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function buildRulesetDriftOccurrenceComment({ runId, runUrl, findings }) {
+  return [
+    rulesetDriftOccurrenceMarker(runId),
+    `The drift audit recurred on [this run](${runUrl}).`,
+    "",
+    "Findings:",
+    findingsList(findings),
+  ].join("\n");
+}
+
+function buildRulesetDriftRecoveryComment({ runId, runUrl }) {
+  return [
+    rulesetDriftRecoveryMarker(runId),
+    `Recovered: [this run](${runUrl}) found the live ruleset clean against the contract again.`,
+    "",
+    "Reopen this issue if drift recurs.",
+  ].join("\n");
+}
+
+async function issueContains(client, issue, marker) {
+  if ((issue.body ?? "").includes(marker)) {
+    return true;
+  }
+  const comments = await client.listIssueComments(issue.number);
+  return comments.some((comment) => (comment.body ?? "").includes(marker));
+}
+
+/**
+ * Issue lifecycle for one ruleset's comparison result. Deliberately does not reuse
+ * reconcilePostMerge itself -- its keying (workflow id + job name), recovery predicate, and
+ * out-of-order run redirection are workflow-run-shaped and meaningless for a single ruleset
+ * comparison -- but keeps the same *shape*: one canonical issue per key, an occurrence marker so
+ * re-runs are idempotent, reopen on recurrence, close with a recovery comment on the next clean
+ * audit. `client` only needs the same interface GitHubRestClient already exports:
+ * ensureLabel/listIssues/listIssueComments/createIssue/createIssueComment/updateIssue.
+ */
+export async function reconcileRulesetDrift({ client, key, title, runId, runUrl, artifactUrl, comparison }) {
+  await client.ensureLabel(RULESET_DRIFT_LABEL);
+
+  const marker = rulesetDriftMarker(key);
+  const issues = await client.listIssues(RULESET_DRIFT_LABEL);
+  const issue = issues.find((candidate) => (candidate.body ?? "").includes(marker));
+
+  if (comparison.verdict === "clean") {
+    if (!issue || issue.state !== "open") {
+      return { action: "none" };
+    }
+    const recovery = rulesetDriftRecoveryMarker(runId);
+    if (!(await issueContains(client, issue, recovery))) {
+      await client.createIssueComment(issue.number, buildRulesetDriftRecoveryComment({ runId, runUrl }));
+    }
+    await client.updateIssue(issue.number, { state: "closed" });
+    return { action: "closed", issueNumber: issue.number };
+  }
+
+  const rotateToken = comparison.findings.some((finding) => finding.class === "bypass-actors-unobserved");
+
+  if (!issue) {
+    const created = await client.createIssue({
+      title,
+      body: buildRulesetDriftIssueBody({
+        key,
+        runId,
+        runUrl,
+        artifactUrl,
+        findings: comparison.findings,
+        rotateToken,
+      }),
+      labels: [RULESET_DRIFT_LABEL],
+    });
+    return { action: "created", issueNumber: created.number };
+  }
+
+  const occurrence = rulesetDriftOccurrenceMarker(runId);
+  let changed = false;
+  if (!(await issueContains(client, issue, occurrence))) {
+    await client.createIssueComment(
+      issue.number,
+      buildRulesetDriftOccurrenceComment({ runId, runUrl, findings: comparison.findings }),
+    );
+    changed = true;
+  }
+  if (issue.state !== "open") {
+    await client.updateIssue(issue.number, { state: "open" });
+    changed = true;
+  }
+  return { action: changed ? "updated" : "unchanged", issueNumber: issue.number };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration: fetch (or accept) -> record raw observation -> compare -> reconcile
+// ---------------------------------------------------------------------------
+
+/**
+ * Audits one contract ruleset entry end to end. `readClient` must expose `getRuleset(id)`.
+ * `issueClient` is optional (omit it for an offline/no-mutation run); when present it must
+ * expose GitHubRestClient's interface. `recordObservation`, when given, is awaited on a
+ * successful fetch BEFORE compareRuleset runs, so the raw observation is always durable before
+ * classification happens -- never the other way around.
+ */
+export async function auditRuleset({ readClient, issueClient, entry, runId, runUrl, artifactUrl, recordObservation }) {
+  const fetchResult = await fetchObservation(readClient, entry.ruleset_id);
+
+  let comparison;
+  if (fetchResult.ok) {
+    if (recordObservation) {
+      await recordObservation(fetchResult.body);
+    }
+    comparison = compareRuleset(entry, fetchResult.body);
+  } else {
+    comparison = { verdict: "drift", findings: [{ class: fetchResult.class, detail: fetchResult.detail }] };
+  }
+
+  let reconcile = null;
+  if (issueClient) {
+    reconcile = await reconcileRulesetDrift({
+      client: issueClient,
+      key: String(entry.ruleset_id),
+      title: `[ruleset drift] ${entry.ruleset_name} diverged from .github/ruleset-contract.json`,
+      runId,
+      runUrl,
+      artifactUrl,
+      comparison,
+    });
+  }
+
+  return { comparison, reconcile };
+}
+
+export async function auditAllRulesets({ readClient, issueClient, contract, runId, runUrl, artifactUrl, recordObservation }) {
+  const results = [];
+  let anyDrift = false;
+  for (const entry of contract.rulesets) {
+    const result = await auditRuleset({
+      readClient,
+      issueClient,
+      entry,
+      runId,
+      runUrl,
+      artifactUrl,
+      recordObservation,
+    });
+    results.push({ rulesetId: entry.ruleset_id, ...result });
+    if (result.comparison.verdict !== "clean") {
+      anyDrift = true;
+    }
+  }
+  return { anyDrift, results };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function loadContract() {
+  let raw;
+  try {
+    raw = await readFile(DEFAULT_CONTRACT_URL, "utf8");
+  } catch (error) {
+    throw new ContractError(`failed to read .github/ruleset-contract.json: ${error.message}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new ContractError(`failed to parse .github/ruleset-contract.json: ${error.message}`);
+  }
+  const errors = validateContract(parsed);
+  if (errors.length > 0) {
+    throw new ContractError(
+      `.github/ruleset-contract.json failed validation:\n${errors.map((e) => `- ${e}`).join("\n")}`,
+    );
+  }
+  return parsed;
+}
+
+function printReport(label, comparison) {
+  if (comparison.verdict === "clean") {
+    console.log(`${label}: clean (0 findings)`);
+    return;
+  }
+  console.log(`${label}: drift (${comparison.findings.length} finding(s))`);
+  for (const finding of comparison.findings) {
+    console.log(`  - ${finding.class}: ${finding.detail}`);
+  }
+}
+
+function parseArgs(argv) {
+  if (argv.length === 0) {
+    return { observationPath: undefined };
+  }
+  if (argv.length === 2 && argv[0] === "--observation" && argv[1]) {
+    return { observationPath: argv[1] };
+  }
+  console.error("usage: node audit-ruleset-drift.mjs [--observation FILE]");
+  process.exit(2);
+  throw new Error("unreachable");
+}
+
+async function handleContractInvalid(error, args) {
+  console.error(error.message);
+  if (args.observationPath) {
+    // Offline mode never mutates issues, even on a contract failure.
+    return;
+  }
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  if (!repository || !token) {
+    return;
+  }
+  const client = new GitHubRestClient({ token, repository });
+  const runId = process.env.GITHUB_RUN_ID ?? "local";
+  const runUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+  await reconcileRulesetDrift({
+    client,
+    key: "contract-invalid",
+    title: "[ruleset drift] .github/ruleset-contract.json failed validation",
+    runId,
+    runUrl,
+    comparison: { verdict: "drift", findings: [{ class: "contract-invalid", detail: error.message }] },
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  let contract;
+  try {
+    contract = await loadContract();
+  } catch (error) {
+    await handleContractInvalid(error, args);
+    process.exit(1);
+    return;
+  }
+
+  if (args.observationPath) {
+    let body;
+    try {
+      const raw = await readFile(args.observationPath, "utf8");
+      body = JSON.parse(raw);
+    } catch (error) {
+      const comparison = {
+        verdict: "drift",
+        findings: [
+          {
+            class: "api-unreadable",
+            detail: `failed to read or parse observation file ${args.observationPath}: ${error.message}`,
+          },
+        ],
+      };
+      printReport(args.observationPath, comparison);
+      process.exit(1);
+      return;
+    }
+    const comparison = compareRuleset(contract.rulesets[0], body);
+    printReport(contract.rulesets[0].ruleset_name, comparison);
+    process.exit(comparison.verdict === "clean" ? 0 : 1);
+    return;
+  }
+
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    console.error("GITHUB_REPOSITORY is required for a live audit run");
+    process.exit(2);
+    return;
+  }
+
+  const githubToken = process.env.GITHUB_TOKEN;
+  const rulesetToken = process.env.RULESET_AUDIT_TOKEN || githubToken;
+  const readClient = new RulesetReadClient({ token: rulesetToken, repository });
+  const issueClient = githubToken ? new GitHubRestClient({ token: githubToken, repository }) : null;
+
+  const runId = process.env.GITHUB_RUN_ID ?? "local";
+  const runUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+  const observationPath = process.env.RULESET_OBSERVATION_PATH ?? DEFAULT_OBSERVATION_PATH;
+
+  const recordObservation = async (body) => {
+    await writeFile(observationPath, `${JSON.stringify(body, null, 2)}\n`, "utf8");
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      const digest = createHash("sha256").update(JSON.stringify(body)).digest("hex");
+      await appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        `Raw ruleset observation written to \`${observationPath}\` (sha256 \`${digest}\`) before classification.\n`,
+      );
+    }
+  };
+
+  const { anyDrift, results } = await auditAllRulesets({
+    readClient,
+    issueClient,
+    contract,
+    runId,
+    runUrl,
+    recordObservation,
+  });
+
+  for (const entry of contract.rulesets) {
+    const result = results.find((r) => r.rulesetId === entry.ruleset_id);
+    printReport(entry.ruleset_name, result.comparison);
+  }
+
+  process.exit(anyDrift ? 1 : 0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/.github/scripts/audit-ruleset-drift.test.mjs
+++ b/.github/scripts/audit-ruleset-drift.test.mjs
@@ -1,0 +1,603 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  RULESET_DRIFT_LABEL,
+  auditAllRulesets,
+  auditRuleset,
+  compareRuleset,
+  fetchObservation,
+  reconcileRulesetDrift,
+  rulesetDriftMarker,
+  validateContract,
+} from "./audit-ruleset-drift.mjs";
+
+const fixture = JSON.parse(
+  await readFile(new URL("./fixtures/ruleset-19090811.json", import.meta.url), "utf8"),
+);
+const contract = JSON.parse(
+  await readFile(new URL("../ruleset-contract.json", import.meta.url), "utf8"),
+);
+const contractEntry = contract.rulesets[0];
+
+function requiredStatusChecksRule(ruleset) {
+  return ruleset.rules.find((rule) => rule.type === "required_status_checks");
+}
+
+function findingClasses(comparison) {
+  return comparison.findings.map((finding) => finding.class);
+}
+
+// ---------------------------------------------------------------------------
+// Fake clients (mirrors report-post-merge-ci.test.mjs's FakeClient pattern)
+// ---------------------------------------------------------------------------
+
+class FakeIssueClient {
+  constructor({ issues = [], comments = [] } = {}) {
+    this.issues = issues;
+    this.comments = comments;
+    this.labels = new Set();
+    this.nextIssue = 500;
+  }
+
+  async ensureLabel(name) {
+    this.labels.add(name);
+  }
+
+  async listIssues() {
+    return this.issues;
+  }
+
+  async listIssueComments(number) {
+    return this.comments.filter((comment) => comment.issue === number);
+  }
+
+  async createIssue(issue) {
+    const created = { ...issue, number: this.nextIssue, state: "open" };
+    this.nextIssue += 1;
+    this.issues.push(created);
+    return created;
+  }
+
+  async createIssueComment(number, body) {
+    this.comments.push({ issue: number, body });
+  }
+
+  async updateIssue(number, update) {
+    Object.assign(
+      this.issues.find((issue) => issue.number === number),
+      update,
+    );
+  }
+}
+
+class FakeReadClient {
+  constructor({ body, error } = {}) {
+    this.body = body;
+    this.error = error;
+  }
+
+  async getRuleset() {
+    if (this.error) {
+      throw this.error;
+    }
+    return this.body;
+  }
+}
+
+function notFoundError() {
+  const error = new Error("not found");
+  error.status = 404;
+  return error;
+}
+
+// ---------------------------------------------------------------------------
+// validateContract
+// ---------------------------------------------------------------------------
+
+test("validateContract: the checked-in contract is valid", () => {
+  assert.deepEqual(validateContract(contract), []);
+});
+
+test("validateContract: rejects a schema mismatch", () => {
+  const mutated = structuredClone(contract);
+  mutated.schema = "wrong";
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("schema")));
+});
+
+test("validateContract: rejects an empty rulesets array", () => {
+  const errors = validateContract({ schema: "fsl-ruleset-contract/1", rulesets: [] });
+  assert.ok(errors.some((e) => e.includes("rulesets")));
+});
+
+test("validateContract: rejects an empty required_status_checks array", () => {
+  const mutated = structuredClone(contract);
+  mutated.rulesets[0].required_status_checks = [];
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("required_status_checks")));
+});
+
+test("validateContract: rejects a duplicate (context, integration_id) pair", () => {
+  const mutated = structuredClone(contract);
+  mutated.rulesets[0].required_status_checks.push({ context: "merge readiness", integration_id: 15368 });
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("duplicate")));
+});
+
+test("validateContract: rejects a deferred_contexts entry colliding with a required context", () => {
+  const mutated = structuredClone(contract);
+  mutated.rulesets[0].deferred_contexts.push({ context: "rust workspace", reason: "oops" });
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("collides")));
+});
+
+test("validateContract: rejects a constituent_contexts entry colliding with a required context", () => {
+  const mutated = structuredClone(contract);
+  mutated.rulesets[0].constituent_contexts.push({
+    context: "WASM",
+    aggregate: "WASM",
+    reason: "oops",
+  });
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("collides")));
+});
+
+test("validateContract: rejects a missing bypass_actors field", () => {
+  const mutated = structuredClone(contract);
+  delete mutated.rulesets[0].bypass_actors;
+  const errors = validateContract(mutated);
+  assert.ok(errors.some((e) => e.includes("bypass_actors")));
+});
+
+// ---------------------------------------------------------------------------
+// compareRuleset: the four cases the issue demands
+// ---------------------------------------------------------------------------
+
+test("accepting: the verbatim fixture is clean against the checked-in contract", () => {
+  const comparison = compareRuleset(contractEntry, fixture);
+  assert.deepEqual(comparison, { verdict: "clean", findings: [] });
+});
+
+test("rejecting (missing): dropping a required context yields exactly one required-context-missing finding", () => {
+  const mutated = structuredClone(fixture);
+  const rule = requiredStatusChecksRule(mutated);
+  rule.parameters.required_status_checks = rule.parameters.required_status_checks.filter(
+    (rsc) => rsc.context !== "rust workspace",
+  );
+
+  const comparison = compareRuleset(contractEntry, mutated);
+
+  assert.equal(comparison.verdict, "drift");
+  const missing = comparison.findings.filter((f) => f.class === "required-context-missing");
+  assert.equal(missing.length, 1);
+  assert.match(missing[0].detail, /rust workspace/);
+  assert.equal(comparison.findings.filter((f) => f.class === "required-context-unexpected").length, 0);
+});
+
+test("rejecting (renamed): renaming a required context yields one missing and one unexpected finding", () => {
+  const mutated = structuredClone(fixture);
+  const rule = requiredStatusChecksRule(mutated);
+  const rsc = rule.parameters.required_status_checks.find(
+    (entry) => entry.context === "semantic mutation (changed)",
+  );
+  rsc.context = "semantic mutation";
+
+  const comparison = compareRuleset(contractEntry, mutated);
+
+  const missing = comparison.findings.filter((f) => f.class === "required-context-missing");
+  const unexpected = comparison.findings.filter((f) => f.class === "required-context-unexpected");
+  assert.equal(missing.length, 1);
+  assert.equal(unexpected.length, 1);
+  assert.match(missing[0].detail, /semantic mutation \(changed\)/);
+  assert.match(unexpected[0].detail, /"semantic mutation"/);
+  assert.doesNotMatch(unexpected[0].detail, /deliberately deferred/);
+});
+
+test("blind control: editing the pull_request rule's allowed_merge_methods is invisible to the audit", () => {
+  const mutated = structuredClone(fixture);
+  const pullRequestRule = mutated.rules.find((rule) => rule.type === "pull_request");
+  pullRequestRule.parameters.allowed_merge_methods = ["squash"];
+  pullRequestRule.parameters.required_approving_review_count = 2;
+
+  const comparison = compareRuleset(contractEntry, mutated);
+
+  assert.deepEqual(comparison, { verdict: "clean", findings: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed guards
+// ---------------------------------------------------------------------------
+
+test("fail-closed: an empty rules array yields empty-rules", () => {
+  const mutated = structuredClone(fixture);
+  mutated.rules = [];
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("empty-rules"));
+});
+
+test("fail-closed: an empty required_status_checks list yields required-contexts-empty", () => {
+  const mutated = structuredClone(fixture);
+  requiredStatusChecksRule(mutated).parameters.required_status_checks = [];
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("required-contexts-empty"));
+});
+
+test("fail-closed: a deleted bypass_actors field yields bypass-actors-unobserved, never an implied empty list", () => {
+  const mutated = structuredClone(fixture);
+  delete mutated.bypass_actors;
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("bypass-actors-unobserved"));
+  assert.ok(!findingClasses(comparison).includes("bypass-actor-added"));
+});
+
+test("fail-closed: an added bypass actor yields bypass-actor-added", () => {
+  const mutated = structuredClone(fixture);
+  mutated.bypass_actors = [{ actor_id: 5, actor_type: "RepositoryRole", bypass_mode: "always" }];
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("bypass-actor-added"));
+});
+
+test("fail-closed: an added merge_queue rule yields rule-type-unexpected", () => {
+  const mutated = structuredClone(fixture);
+  mutated.rules.push({ type: "merge_queue", parameters: {} });
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  const unexpected = comparison.findings.filter((f) => f.class === "rule-type-unexpected");
+  assert.equal(unexpected.length, 1);
+  assert.match(unexpected[0].detail, /merge_queue/);
+});
+
+test("fail-closed: enforcement other than active yields an enforcement finding", () => {
+  const mutated = structuredClone(fixture);
+  mutated.enforcement = "evaluate";
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("enforcement"));
+});
+
+test("fail-closed: flipping strict_required_status_checks_policy yields strict-policy", () => {
+  const mutated = structuredClone(fixture);
+  requiredStatusChecksRule(mutated).parameters.strict_required_status_checks_policy = false;
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("strict-policy"));
+});
+
+test("fail-closed: flipping do_not_enforce_on_create yields enforce-on-create", () => {
+  const mutated = structuredClone(fixture);
+  requiredStatusChecksRule(mutated).parameters.do_not_enforce_on_create = true;
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("enforce-on-create"));
+});
+
+test("fail-closed: retargeting conditions.ref_name.include yields a conditions finding", () => {
+  const mutated = structuredClone(fixture);
+  mutated.conditions.ref_name.include = ["refs/heads/develop"];
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("conditions"));
+});
+
+test("fail-closed: a non-empty conditions.ref_name.exclude yields a conditions finding", () => {
+  const mutated = structuredClone(fixture);
+  mutated.conditions.ref_name.exclude = ["refs/heads/production"];
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("conditions"));
+});
+
+test("fail-closed: a duplicated required context yields required-context-duplicated", () => {
+  const mutated = structuredClone(fixture);
+  const rule = requiredStatusChecksRule(mutated);
+  rule.parameters.required_status_checks.push({ context: "WASM", integration_id: 15368 });
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("required-context-duplicated"));
+});
+
+test("fail-closed: a same-named context reported by a different integration_id is missing + unexpected, not satisfied", () => {
+  const mutated = structuredClone(fixture);
+  const rule = requiredStatusChecksRule(mutated);
+  const rsc = rule.parameters.required_status_checks.find((entry) => entry.context === "WASM");
+  rsc.integration_id = 99999;
+  const comparison = compareRuleset(contractEntry, mutated);
+  assert.equal(comparison.verdict, "drift");
+  assert.ok(findingClasses(comparison).includes("required-context-missing"));
+  assert.ok(findingClasses(comparison).includes("required-context-unexpected"));
+});
+
+test("fail-closed: a schema-invalid contract fails validateContract", () => {
+  const mutated = structuredClone(contract);
+  mutated.schema = "fsl-ruleset-contract/2";
+  assert.ok(validateContract(mutated).length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// fetchObservation classification
+// ---------------------------------------------------------------------------
+
+test("fetchObservation: a 404 classifies as ruleset-missing", async () => {
+  const client = new FakeReadClient({ error: notFoundError() });
+  const result = await fetchObservation(client, contractEntry.ruleset_id);
+  assert.equal(result.ok, false);
+  assert.equal(result.class, "ruleset-missing");
+});
+
+test("fetchObservation: a generic fetch failure classifies as api-unreadable", async () => {
+  const client = new FakeReadClient({ error: new Error("network boom") });
+  const result = await fetchObservation(client, contractEntry.ruleset_id);
+  assert.equal(result.ok, false);
+  assert.equal(result.class, "api-unreadable");
+});
+
+test("fetchObservation: a successful fetch returns the raw body untouched", async () => {
+  const client = new FakeReadClient({ body: fixture });
+  const result = await fetchObservation(client, contractEntry.ruleset_id);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.body, fixture);
+});
+
+// ---------------------------------------------------------------------------
+// auditRuleset / auditAllRulesets: fetch failures still create the failure issue
+// ---------------------------------------------------------------------------
+
+test("live: an injected fetch failure is api-unreadable and still creates the failure issue", async () => {
+  const readClient = new FakeReadClient({ error: new Error("network boom") });
+  const issueClient = new FakeIssueClient();
+
+  const { comparison, reconcile } = await auditRuleset({
+    readClient,
+    issueClient,
+    entry: contractEntry,
+    runId: "1",
+    runUrl: "https://example.invalid/actions/runs/1",
+  });
+
+  assert.equal(comparison.verdict, "drift");
+  assert.equal(comparison.findings[0].class, "api-unreadable");
+  assert.equal(reconcile.action, "created");
+  assert.equal(issueClient.issues.length, 1);
+  assert.ok(issueClient.issues[0].body.includes(rulesetDriftMarker(String(contractEntry.ruleset_id))));
+});
+
+test("live: a 404 is ruleset-missing and still creates the failure issue", async () => {
+  const readClient = new FakeReadClient({ error: notFoundError() });
+  const issueClient = new FakeIssueClient();
+
+  const { comparison, reconcile } = await auditRuleset({
+    readClient,
+    issueClient,
+    entry: contractEntry,
+    runId: "1",
+    runUrl: "https://example.invalid/actions/runs/1",
+  });
+
+  assert.equal(comparison.findings[0].class, "ruleset-missing");
+  assert.equal(reconcile.action, "created");
+});
+
+test("auditRuleset: records the raw observation exactly once on success, never on failure", async () => {
+  let calls = 0;
+  const record = async () => {
+    calls += 1;
+  };
+
+  await auditRuleset({
+    readClient: new FakeReadClient({ body: fixture }),
+    issueClient: null,
+    entry: contractEntry,
+    runId: "1",
+    runUrl: "u",
+    recordObservation: record,
+  });
+  assert.equal(calls, 1);
+
+  await auditRuleset({
+    readClient: new FakeReadClient({ error: new Error("boom") }),
+    issueClient: null,
+    entry: contractEntry,
+    runId: "1",
+    runUrl: "u",
+    recordObservation: record,
+  });
+  assert.equal(calls, 1);
+});
+
+test("auditAllRulesets: a clean live-shaped run against the real contract reports no drift and no issue mutation without a client", async () => {
+  const readClient = new FakeReadClient({ body: fixture });
+  const { anyDrift, results } = await auditAllRulesets({
+    readClient,
+    issueClient: null,
+    contract,
+    runId: "1",
+    runUrl: "u",
+  });
+  assert.equal(anyDrift, false);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].reconcile, null);
+});
+
+// ---------------------------------------------------------------------------
+// Issue lifecycle: create / occurrence-dedupe / reopen / close-on-clean
+// ---------------------------------------------------------------------------
+
+function driftComparison(detail = "enforcement is evaluate") {
+  return { verdict: "drift", findings: [{ class: "enforcement", detail }] };
+}
+
+const CLEAN = { verdict: "clean", findings: [] };
+const TITLE = "[ruleset drift] main safety and CI diverged from .github/ruleset-contract.json";
+
+test("issue lifecycle: creates one issue on first drift", async () => {
+  const client = new FakeIssueClient();
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "100",
+    runUrl: "https://example.invalid/100",
+    comparison: driftComparison(),
+  });
+  assert.equal(result.action, "created");
+  assert.equal(client.issues.length, 1);
+  assert.ok(client.labels.has(RULESET_DRIFT_LABEL));
+  assert.equal(client.issues[0].title, TITLE);
+});
+
+test("issue lifecycle: a re-run with the same run id does not add a duplicate occurrence comment", async () => {
+  const client = new FakeIssueClient();
+  const comparison = driftComparison();
+  await reconcileRulesetDrift({ client, key: "19090811", title: TITLE, runId: "100", runUrl: "u", comparison });
+  const again = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "100",
+    runUrl: "u",
+    comparison,
+  });
+  assert.equal(again.action, "unchanged");
+  assert.equal(client.comments.length, 0);
+  assert.equal(client.issues.length, 1);
+});
+
+test("issue lifecycle: a new run id on the same open issue adds exactly one occurrence comment", async () => {
+  const client = new FakeIssueClient();
+  const comparison = driftComparison();
+  await reconcileRulesetDrift({ client, key: "19090811", title: TITLE, runId: "100", runUrl: "u", comparison });
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "200",
+    runUrl: "u2",
+    comparison,
+  });
+  assert.equal(result.action, "updated");
+  assert.equal(client.comments.length, 1);
+});
+
+test("issue lifecycle: reopens a closed issue on recurrence", async () => {
+  const client = new FakeIssueClient();
+  const comparison = driftComparison();
+  await reconcileRulesetDrift({ client, key: "19090811", title: TITLE, runId: "100", runUrl: "u", comparison });
+  client.issues[0].state = "closed";
+
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "200",
+    runUrl: "u2",
+    comparison,
+  });
+
+  assert.equal(result.action, "updated");
+  assert.equal(client.issues[0].state, "open");
+});
+
+test("issue lifecycle: closes with a recovery comment on the next clean audit", async () => {
+  const client = new FakeIssueClient();
+  await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "100",
+    runUrl: "u",
+    comparison: driftComparison(),
+  });
+
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "200",
+    runUrl: "u2",
+    comparison: CLEAN,
+  });
+
+  assert.equal(result.action, "closed");
+  assert.equal(client.issues[0].state, "closed");
+  assert.ok(client.comments.some((comment) => /Recovered/.test(comment.body)));
+});
+
+test("issue lifecycle: a clean audit with no existing issue does nothing", async () => {
+  const client = new FakeIssueClient();
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "100",
+    runUrl: "u",
+    comparison: CLEAN,
+  });
+  assert.equal(result.action, "none");
+  assert.equal(client.issues.length, 0);
+});
+
+test("issue body names RULESET_AUDIT_TOKEN as the secret to rotate for bypass-actors-unobserved", async () => {
+  const client = new FakeIssueClient();
+  const comparison = {
+    verdict: "drift",
+    findings: [{ class: "bypass-actors-unobserved", detail: "bypass_actors was absent" }],
+  };
+  await reconcileRulesetDrift({ client, key: "19090811", title: TITLE, runId: "1", runUrl: "u", comparison });
+  assert.match(client.issues[0].body, /RULESET_AUDIT_TOKEN/);
+});
+
+test("issue body does not name RULESET_AUDIT_TOKEN for an unrelated finding", async () => {
+  const client = new FakeIssueClient();
+  await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "1",
+    runUrl: "u",
+    comparison: driftComparison(),
+  });
+  assert.doesNotMatch(client.issues[0].body, /RULESET_AUDIT_TOKEN/);
+});
+
+test("issue body states the two legitimate exits and never includes token material or log text", async () => {
+  const client = new FakeIssueClient();
+  await reconcileRulesetDrift({
+    client,
+    key: "19090811",
+    title: TITLE,
+    runId: "1",
+    runUrl: "u",
+    comparison: driftComparison(),
+  });
+  const body = client.issues[0].body;
+  assert.match(body, /revert the live ruleset/i);
+  assert.match(body, /docs\/DESIGN-ci\.md/);
+  assert.doesNotMatch(body, /ghp_|gho_|github_pat_/);
+  assert.doesNotMatch(body, /::error|::warning/); // GitHub Actions log annotation syntax
+});
+
+test("issue lifecycle: contract-invalid findings still create an issue keyed independently of a ruleset id", async () => {
+  const client = new FakeIssueClient();
+  const comparison = {
+    verdict: "drift",
+    findings: [{ class: "contract-invalid", detail: "schema must be fsl-ruleset-contract/1" }],
+  };
+  const result = await reconcileRulesetDrift({
+    client,
+    key: "contract-invalid",
+    title: "[ruleset drift] .github/ruleset-contract.json failed validation",
+    runId: "1",
+    runUrl: "u",
+    comparison,
+  });
+  assert.equal(result.action, "created");
+  assert.match(client.issues[0].body, /contract-invalid/);
+});

--- a/.github/scripts/fixtures/ruleset-19090811.json
+++ b/.github/scripts/fixtures/ruleset-19090811.json
@@ -1,5 +1,4 @@
 {
-  "$comment": "Verbatim capture of `gh api repos/ymm-oss/fsl/rulesets/19090811` on 2026-08-06, with ONE hand-added entry: the sixth required_status_checks entry for \"site reference freshness\" (integration_id 15368, matching the other five). The live ruleset still has only five required contexts as of this capture -- the sixth entry here is the pending post-rollout state the contract in ../../ruleset-contract.json expects, added by hand so the accepting test (audit-ruleset-drift.test.mjs) exercises the six-context contract this fixture is meant to model once the live edit lands. Everything else in this file is the unmodified API response. Do not silently reconcile this note away by deleting it once the live edit happens -- recapture instead and drop this comment.",
   "id": 19090811,
   "name": "main safety and CI",
   "target": "branch",
@@ -77,7 +76,7 @@
   ],
   "node_id": "RRS_lACqUmVwb3NpdG9yec5Lu2QuzgEjTXs",
   "created_at": "2026-07-17T16:28:37.565+09:00",
-  "updated_at": "2026-08-05T13:50:30.270+09:00",
+  "updated_at": "2026-08-06T08:14:18.007+09:00",
   "bypass_actors": [],
   "current_user_can_bypass": "never",
   "_links": {

--- a/.github/scripts/fixtures/ruleset-19090811.json
+++ b/.github/scripts/fixtures/ruleset-19090811.json
@@ -1,0 +1,91 @@
+{
+  "$comment": "Verbatim capture of `gh api repos/ymm-oss/fsl/rulesets/19090811` on 2026-08-06, with ONE hand-added entry: the sixth required_status_checks entry for \"site reference freshness\" (integration_id 15368, matching the other five). The live ruleset still has only five required contexts as of this capture -- the sixth entry here is the pending post-rollout state the contract in ../../ruleset-contract.json expects, added by hand so the accepting test (audit-ruleset-drift.test.mjs) exercises the six-context contract this fixture is meant to model once the live edit lands. Everything else in this file is the unmodified API response. Do not silently reconcile this note away by deleting it once the live edit happens -- recapture instead and drop this comment.",
+  "id": 19090811,
+  "name": "main safety and CI",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "ymm-oss/fsl",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "merge readiness",
+            "integration_id": 15368
+          },
+          {
+            "context": "rust workspace",
+            "integration_id": 15368
+          },
+          {
+            "context": "WASM",
+            "integration_id": 15368
+          },
+          {
+            "context": "semantic mutation (changed)",
+            "integration_id": 15368
+          },
+          {
+            "context": "FSL Logic Test (pr)",
+            "integration_id": 15368
+          },
+          {
+            "context": "site reference freshness",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_lACqUmVwb3NpdG9yec5Lu2QuzgEjTXs",
+  "created_at": "2026-07-17T16:28:37.565+09:00",
+  "updated_at": "2026-08-05T13:50:30.270+09:00",
+  "bypass_actors": [],
+  "current_user_can_bypass": "never",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/ymm-oss/fsl/rulesets/19090811"
+    },
+    "html": {
+      "href": "https://github.com/ymm-oss/fsl/rules/19090811"
+    }
+  }
+}

--- a/.github/workflows/ruleset-drift-audit.yml
+++ b/.github/workflows/ruleset-drift-audit.yml
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: ruleset drift audit
+
+# Configuration-conformance automation, not product verification in docs/DESIGN-ci.md's sense
+# (rust workspace / WASM / native Z3 / semantic mutation / FSL Logic Test). It compares the live
+# `main safety and CI` GitHub ruleset (id 19090811) against the checked-in
+# .github/ruleset-contract.json, because that ruleset drifted silently once -- the accepted
+# design required the Linux evidence to be *required* contexts while the live ruleset required
+# only `merge readiness` (issue #707) -- and without an audit it can drift again the same way.
+# See docs/DESIGN-ci.md, "Ruleset drift audit".
+#
+# Why RULESET_AUDIT_TOKEN exists: ruleset read endpoints are public for this repository, but
+# GitHub returns `bypass_actors` only to a caller with write access to the ruleset, and the
+# workflow's own GITHUB_TOKEN has no `administration` permission at all -- it structurally
+# cannot observe that field. RULESET_AUDIT_TOKEN is a fine-grained PAT scoped to read that
+# permission. Without it, the audit still runs to completion and FAILS with
+# `bypass-actors-unobserved` -- that is the designed fail-closed behavior, not a bug: absence of
+# the field is never read as an empty (safe) bypass-actor list.
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/ruleset-contract.json
+      - .github/scripts/audit-ruleset-drift.mjs
+      - .github/scripts/audit-ruleset-drift.test.mjs
+      - .github/scripts/fixtures/ruleset-19090811.json
+      - .github/workflows/ruleset-drift-audit.yml
+
+# No `pull_request` trigger, deliberately: a fork pull request has no access to
+# RULESET_AUDIT_TOKEN or (with default fork-PR permissions) a writable GITHUB_TOKEN, so running
+# this on `pull_request` would produce spurious `bypass-actors-unobserved`/`api-unreadable`
+# failures with no way to distinguish "the ruleset drifted" from "this PR is a fork". Pre-merge
+# coverage for a legitimate contract/fixture/checker change is the offline calibration suite
+# (audit-ruleset-drift.test.mjs), which this workflow also runs, and which is already wired into
+# `tools/check-merge-readiness.sh`'s `check_automation` lane.
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ruleset-drift-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: ruleset drift audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Test the drift checker's classifier against the checked-in fixture
+        run: node --test .github/scripts/audit-ruleset-drift.test.mjs
+
+      - name: Audit the live ruleset against the contract
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RULESET_AUDIT_TOKEN: ${{ secrets.RULESET_AUDIT_TOKEN }}
+          RULESET_OBSERVATION_PATH: ruleset-observation.json
+        run: node .github/scripts/audit-ruleset-drift.mjs
+
+      - name: Upload the raw ruleset observation
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ruleset-observation
+          path: ruleset-observation.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/site-reference-freshness.yml
+++ b/.github/workflows/site-reference-freshness.yml
@@ -19,12 +19,13 @@ name: site reference freshness
 #     path, so adding this ~10s pip-install-plus-pytest step there would cost zero wall-clock on
 #     merge-readiness.yml as a whole. The lane's purity, not its speed, is what this placement
 #     protects.
-#   - That placement has a real cost, named rather than hidden: `merge readiness` is the only
-#     required status check in this repository's `main safety and CI` ruleset, so joining it
-#     would have made a stale page block the merge. This standalone workflow is not in that
-#     required set, so it makes staleness visible on the pull request but does not block it.
-#     That is the trade this placement makes: keep merge-readiness.yml's stdlib-only contract
-#     intact, at the cost of enforcement, rather than gain enforcement by breaking that contract.
+#   - This workflow's own context, `site reference freshness`, IS a required status check in the
+#     `main safety and CI` ruleset (.github/ruleset-contract.json), so a stale page does block the
+#     merge. That is safe specifically because this workflow runs on every pull request with no
+#     path filter (see the `on:` block below) -- unlike the deferred, FSL_OPTIMISTIC_CI-gated
+#     contexts in docs/DESIGN-ci.md's "Product gate contract", it can never fail to report on an
+#     ordinary pull request, so requiring it cannot deadlock one. docs/DESIGN-ci.md's "Ruleset
+#     drift audit" audits this requirement against the live ruleset so it cannot silently regress.
 #
 # See docs/DESIGN-docs-site.md's D7 addendum for the full rationale and #630/#688.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Added (#707): a ruleset drift audit, closing the drift-detection half of #707 (the
+  required-context half landed separately). `.github/ruleset-contract.json` is a checked-in,
+  schema-versioned record of the `main safety and CI` ruleset (id `19090811`): identity,
+  enforcement, conditions, rule types, strict/`do_not_enforce_on_create` policy, required
+  contexts as `(context, integration_id)` pairs, `bypass_actors`, and two explanatory lists
+  (`deferred_contexts` — the `FSL_OPTIMISTIC_CI`-gated cross-platform matrix and aggregate that
+  can never require pre-merge without deadlocking; `constituent_contexts` — the sharded lane
+  names whose `if: always()` aggregator alone carries the required-context name). The new
+  `.github/scripts/audit-ruleset-drift.mjs` fetches the live ruleset and compares it against the
+  contract through pure, unit-testable `compareRuleset`/`validateContract` functions, rejecting
+  on `ruleset-identity`, `ruleset-missing`, `api-unreadable`, `enforcement`, `conditions`,
+  `rule-type-missing`/`-unexpected`, `empty-rules`, `strict-policy`, `enforce-on-create`,
+  `required-context-missing`/`-unexpected`/`-duplicated`, `required-contexts-empty`,
+  `bypass-actors-unobserved`, `bypass-actor-added`, and `contract-invalid`. Required contexts are
+  keyed on `(context, integration_id)`, not context name alone, so a same-named check reported by
+  a different GitHub App is treated as impersonation, not satisfaction. `pull_request` rule
+  parameters (review counts, `allowed_merge_methods`, …) are deliberately unaudited — human
+  review policy is ruleset `19090821`'s separate accepted decision — and the calibration suite's
+  blind control proves an edit there stays invisible to this audit. `bypass_actors` is in scope
+  and its **absence** (not just an added actor) is a failure: GitHub returns that field only to a
+  caller with write access to the ruleset, the workflow's `GITHUB_TOKEN` has no `administration`
+  permission at all, and a new `RULESET_AUDIT_TOKEN` fine-grained-PAT secret is required to
+  observe it — without the secret the audit still runs and fails closed with
+  `bypass-actors-unobserved` rather than treating absence as an empty (safe) list. The raw
+  observation is written and digested to the step summary *before* classification. Failure-issue
+  lifecycle (`ci/ruleset-drift` label, marker `<!-- ruleset-drift:19090811 -->`, occurrence
+  markers, reopen-on-recurrence, close-on-clean-with-recovery-comment) imports and reuses
+  `report-post-merge-ci.mjs`'s exported `GitHubRestClient` rather than adding a second REST
+  client. `.github/workflows/ruleset-drift-audit.yml` runs on `schedule`, `workflow_dispatch`,
+  and a path-filtered `push` to `main`; it deliberately carries no `pull_request` trigger, since a
+  fork PR has no access to the elevated token. `.github/scripts/audit-ruleset-drift.test.mjs`
+  derives every case from a verbatim capture of the live ruleset
+  (`.github/scripts/fixtures/ruleset-19090811.json`) by `structuredClone` plus one mutation, and
+  is wired into `tools/check-merge-readiness.sh`'s `check_automation` lane. `site reference
+  freshness` joins the `main` ruleset's required contexts, now six instead of five — it reports on
+  every pull request with no path filter, so requiring it cannot deadlock a pull request the way
+  the deferred cross-platform matrix would. `docs/DESIGN-ci.md` gains a "Ruleset drift audit"
+  subsection and corrects two sentences that had gone stale after the five-context requirement
+  landed (2026-08-05): "None of the four contexts are required status checks today" is now scoped
+  to the time the exemption mechanism moved, and the agent-configuration-exemption's "merges on
+  `merge readiness` (plus `site reference freshness`) alone" is restated for the six-required-
+  context reality. `docs/DESIGN-docs-site.md`'s D7 addendum and
+  `.github/workflows/site-reference-freshness.yml`'s header now say the workflow's own context is
+  enforced (not merely visible) and why that is deadlock-safe; the `#688` frozen-`cli.py`
+  asymmetry it separately flagged is unchanged and stays open. The live ruleset edit adding
+  `site reference freshness` is applied out of band; until then, the audit correctly reports a
+  `required-context-missing: site reference freshness` finding — the designed pre-rollout state,
+  not a bug.
 - Fixed (#713): saga `compensation { when Trigger after After { ... } }` now
   lowers to a kernel action guarded by BOTH the trigger event flag and the
   `after` event flag on both lowering paths (`lower_saga_actions` in

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -134,18 +134,25 @@ check — issue #707 tracks exactly this gap — or ever needed to satisfy merge
 workflow-level skip would leave it permanently `Expected`, unfixable even by an admin merge. This
 was independently observed while merging PR #715. An in-job early exit does not have that failure
 mode: the job always starts, checks out, computes the diff, and reports success either from the
-stub path or from real evidence. None of the four contexts are required status checks today —
-`merge readiness` remains the only one — so this is a latent-risk fix, not a response to an
-already-broken required check.
+stub path or from real evidence. None of the four contexts were required status checks *at the
+time this mechanism moved* — `merge readiness` was the only one — so this was a latent-risk fix,
+not a response to an already-broken required check. The requirement change landed 2026-08-05,
+making `rust workspace`, `WASM`, `semantic mutation (changed)`, and `FSL Logic Test (pr)` required
+alongside `merge readiness`; `site reference freshness` joined the required set afterward, closing
+issue #707's drift-detection half (see "Required pre-merge contexts, and why the merge queue was
+rejected" below for the live set, and "Ruleset drift audit" for why a required context can no
+longer drift silently).
 
 No **product-gate lane** reads those files. The paths that do read them keep their own
 unfiltered pre-merge coverage: `merge readiness / automation contracts` executes the `.claude/`
 environment contract test from `tests/test_claude_environment.py`, and `release.yml` extracts
 release notes from `CHANGELOG.md` at tag time and fails loudly (`test -s`) on a malformed file.
 A pull request whose every changed file matches the list therefore still gets `run=false` from the
-scope script, each heavy job exits its remaining steps fast, and the pull request merges on
-`merge readiness` (plus `site reference freshness`) alone — exactly as under the retired
-`paths-ignore` list.
+scope script, each heavy job exits its remaining steps fast, and the pull request merges once all
+six required contexts report: real evidence from `merge readiness` and `site reference freshness`
+(neither reads the exempt paths, so neither is affected by the stub), and fast stub-success
+evidence from `rust workspace`, `WASM`, `semantic mutation (changed)`, and `FSL Logic Test (pr)` —
+exactly as under the retired `paths-ignore` list.
 
 The exemption is fail-closed the same three ways as before, now enforced by the script rather than
 by GitHub's path evaluation. A single changed file outside the list restores the full pre-merge
@@ -325,11 +332,17 @@ portable evidence and failure attribution even when agents merge changes quickly
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 
-The `main` ruleset (`main safety and CI`, id `19090811`) requires five contexts, applied
-2026-08-05: `merge readiness`, `rust workspace`, `WASM`, `semantic mutation (changed)`, and
-`FSL Logic Test (pr)`. `strict_required_status_checks_policy` is `true` and `bypass_actors` is
-empty, so `current_user_can_bypass` is `"never"` for every account — an administrator cannot merge
-past a failing or missing required context.
+The `main` ruleset (`main safety and CI`, id `19090811`) requires six contexts: `merge readiness`,
+`rust workspace`, `WASM`, `semantic mutation (changed)`, and `FSL Logic Test (pr)` (applied
+2026-08-05), plus `site reference freshness` (added to the contract as part of closing issue
+#707's drift-detection half; see "Ruleset drift audit" below). `site reference freshness` reports
+on every pull request with no path filter — `.github/workflows/site-reference-freshness.yml`'s
+`pull_request`/`merge_group` triggers carry no `paths:` restriction — so requiring it cannot
+deadlock a pull request the way requiring `native Z3 4.16` or `product gate` would; those stay
+deferred precisely because they never report on an ordinary pull request.
+`strict_required_status_checks_policy` is `true` and `bypass_actors` is empty, so
+`current_user_can_bypass` is `"never"` for every account — an administrator cannot merge past a
+failing or missing required context.
 
 This closes the gap issue #707 opened: the Safe rollout section below has always required the
 Linux evidence to be *required*, not merely running, and until this change only `merge readiness`
@@ -376,6 +389,95 @@ exercised — see "Sharded pre-merge Linux evidence" above — and cache hit rat
 no headroom: compile is only ~3.5 min of the ~33 min `rust workspace` measured on a warm cache, so a
 better hit rate could not have bought back more than that. The remaining lever is moving specific
 lanes post-merge under a new accepted decision.
+
+### Ruleset drift audit
+
+Issue #707 has two halves. The first — making the Linux evidence *required*, not merely running —
+is the section above. The second, closed here, is the reason the first half was needed at all: the
+accepted design required five (now six) contexts to be required on the `main` ruleset, and the live
+ruleset silently required only `merge readiness` until 2026-08-05. Nothing detected that gap; it
+was found by manual inspection. `.github/scripts/audit-ruleset-drift.mjs`, its calibration suite
+`.github/scripts/audit-ruleset-drift.test.mjs`, and the checked-in `.github/ruleset-contract.json`
+exist so the same silent drift cannot happen again undetected.
+
+**Scope, by discovery-by-id.** The audit fetches ruleset `19090811` by id (`GET
+/repos/ymm-oss/fsl/rulesets/19090811`, readable unauthenticated for this public repository) and
+compares it against the matching entry in `.github/ruleset-contract.json`. Every context the
+contract or the live ruleset can mention falls into exactly one of four kinds, and the contract
+records which:
+
+- **required** — the six contexts above; missing, renamed, or extra membership is drift.
+- **deferred** — `native Z3 4.16 (macos-15)`, `native Z3 4.16 (windows-latest)`, and `product gate`
+  (the `FSL_OPTIMISTIC_CI`-gated cross-platform matrix and its aggregate, "Product gate contract"
+  above): these never report on an ordinary pull request, so requiring them would deadlock every
+  one; an audit finding that one of them is present in the live required set gets a sharper message
+  saying exactly that, rather than being reported as an ordinary unexpected context.
+- **constituent** — the sharded lane names (`rust checks`, `rust tests (K/3)`, `mutation operators
+  (K/3)`, `mutation mutants`, "Sharded pre-merge Linux evidence" above): only their `if: always()`
+  aggregator carries the required-context name, so the contract records these explicitly to stop a
+  future reviewer from "fixing" the ruleset by requiring a shard directly — that would let a single
+  skipped shard silently satisfy the ruleset, the exact false-negative shape that section's
+  `if: always()` discussion warns about.
+- **unaudited** — the `pull_request` rule's own parameters (`required_approving_review_count`,
+  `allowed_merge_methods`, review dismissal, …). These are **deliberately never read**. Human
+  review policy is a separate accepted process decision (ruleset `19090821`, "The merge queue was
+  tried…" above); this audit's job is CI-evidence configuration, not review policy. An editable
+  `allowed_merge_methods` change is the audit's blind control — its calibration suite proves the
+  audit stays clean when that field changes, so a green audit is never accidentally load-bearing
+  evidence for review-policy drift it was never designed to catch.
+
+**`bypass_actors` is in scope, and its absence is a failure, not a pass.** An added bypass actor is
+exactly what would let a failing required check merge anyway — it defeats every other guarantee
+this audit checks. But GitHub returns `bypass_actors` only to a caller with write access to the
+ruleset, and the workflow's own `GITHUB_TOKEN` has no `administration` permission at all, so it
+cannot observe the field even though the rest of the ruleset is public. `RULESET_AUDIT_TOKEN`, a
+fine-grained PAT scoped to read that permission, exists for exactly this leg. Absence of the field
+is never read as an empty (safe) list — "absence of evidence is not evidence of emptiness" — so an
+unset or revoked `RULESET_AUDIT_TOKEN` makes the audit fail closed with `bypass-actors-unobserved`
+rather than silently skip the check it exists for.
+
+**The seam.** `compareRuleset(contractEntry, observationJson)` and `validateContract(contract)` are
+pure — no network, no filesystem, no process access — so every case in the calibration suite is
+built by `structuredClone`-ing the checked-in fixture (`.github/scripts/fixtures/ruleset-19090811.json`,
+a verbatim capture) and mutating exactly one field, with no live ruleset ever touched by a test.
+The suite covers the accepting case (the fixture is clean against the contract, which also freezes
+contract/fixture agreement — editing one without the other fails pre-merge), two rejecting cases
+(a dropped context; a renamed context, which must surface as one `missing` plus one `unexpected`
+rather than being silently satisfied by name), the blind control above, and the fail-closed guards
+(empty rules, empty required-context list, missing/added `bypass_actors`, an unexpected rule type,
+wrong enforcement, flipped strict policy, retargeted conditions, a schema-invalid contract) —
+including, for the network-facing wrapper, an injected fetch failure and a 404 against a fake
+client, both of which must still create the failure issue. This suite runs in
+`tools/check-merge-readiness.sh`'s `check_automation` lane (so a contract, fixture, or checker
+change gets pre-merge evidence — `.github/**` is not on the agent-configuration exemption's path
+list) and again as the live workflow's first step.
+
+**Issue lifecycle.** `reconcileRulesetDrift` in `audit-ruleset-drift.mjs` imports
+`report-post-merge-ci.mjs`'s exported `GitHubRestClient` rather than building a second REST client
+and a second dedupe mechanism, and keeps that file's `reconcilePostMerge` *shape* — one canonical
+issue per key (`ci/ruleset-drift` label, marker `<!-- ruleset-drift:19090811 -->`), an occurrence
+marker per run so re-runs are idempotent, reopen on recurrence, close with a recovery comment on
+the next clean audit — without trying to parameterize `reconcilePostMerge` itself: its keying,
+recovery predicate, and out-of-order run redirection are shaped around a workflow run's jobs and do
+not mean anything for a single ruleset comparison. The issue body lists finding classes and details
+plus a link to the run's raw-observation artifact, never token material or log text, and its footer
+states the two legitimate exits — revert the live ruleset, or amend the contract, the fixture, and
+this document together in one pull request — and names `RULESET_AUDIT_TOKEN` as the secret to
+rotate when the finding is `bypass-actors-unobserved`.
+
+**A legitimate ruleset change is a three-surface move in one pull request:** this document, the
+contract, and a re-captured fixture, with the live ruleset edit applied before that pull request
+merges. Editing `.github/ruleset-contract.json` alone to make the audit agree with unexplained live
+state is precisely the drift this audit exists to catch, not a fix for it — the same principle
+"Growing the exempt list is a contract change to this decision, not a script tweak" states above
+for the agent-configuration exemption applies here to the required-context set.
+
+`.github/workflows/ruleset-drift-audit.yml` runs on a daily `schedule`, `workflow_dispatch`, and a
+path-filtered `push` to `main` (the four files above, so a legitimate contract change self-verifies
+minutes after merge). It deliberately carries no `pull_request` trigger: a fork pull request has no
+access to `RULESET_AUDIT_TOKEN` or a writable `GITHUB_TOKEN`, so running there would produce
+spurious failures indistinguishable from real drift. Pre-merge coverage is the offline calibration
+suite above, not a live run.
 
 ## Failure reporting contract
 

--- a/docs/DESIGN-docs-site.md
+++ b/docs/DESIGN-docs-site.md
@@ -240,16 +240,23 @@ readable in Japanese, accepting the resulting maintenance cost.
   surfaces' actual flag/subcommand parity is still unmeasured. Wiring the gate does not resolve
   that; `#688` stays open and is the place that asymmetry gets decided, not this check.
 
-  **This workflow is visible, not enforced — and that is the price of the placement above, not an
-  incidental property.** `merge readiness` is the *only* required status check in this
-  repository's `main safety and CI` ruleset. Joining it would have made a stale page block the
-  merge; landing this check as a standalone workflow instead means it fails loudly on its own run
-  but is not in that required set, so a red run does not block a merge. The trade made here is:
-  keep `merge-readiness.yml`'s stdlib-only dependency contract intact, at the cost of the
-  freshness check not being merge-blocking, rather than gain merge-blocking enforcement by
-  breaking that contract. Adding this workflow to the ruleset is a separate repository-settings
-  decision outside this pull request's reach, stated here rather than recommended — whoever owns
-  the ruleset decides, and can reverse this trade on the merits above.
+  **This workflow is now enforced, and that costs nothing the placement above was protecting.**
+  The original objection conflated two different moves: joining this check to *another*
+  workflow's job graph, and requiring *this* workflow's own context on the ruleset. The first
+  would have broken a real contract — `ci.yml` is Rust-native by `AGENTS.md`'s "one Rust-native
+  entrypoint, no Python" clause, and `merge-readiness.yml`'s `automation-contracts` lane is
+  stdlib-only by `tools/check-merge-readiness.sh`'s own comment — and that objection still holds;
+  neither workflow gained a Python dependency. The second move breaks nothing: `site reference
+  freshness` runs as its own standalone workflow on every pull request with no path filter
+  (`pull_request`/`merge_group`, unconditioned), so it cannot deadlock a pull request the way a
+  deferred, `FSL_OPTIMISTIC_CI`-gated context would (`docs/DESIGN-ci.md`, "Ruleset drift audit").
+  `.github/ruleset-contract.json` now lists it as the sixth required context alongside `merge
+  readiness`, `rust workspace`, `WASM`, `semantic mutation (changed)`, and `FSL Logic Test (pr)`,
+  and `.github/scripts/audit-ruleset-drift.mjs` audits the live ruleset against that contract so
+  the requirement cannot silently regress the way the underlying gap (issue #707) once did. The
+  `#688` frozen-`cli.py` asymmetry this addendum flagged is unchanged by any of this and stays
+  open: requiring the check makes a frozen-reference argparse edit force a site update exactly as
+  before, and the two surfaces' actual flag/subcommand parity remains unmeasured.
 
 ## 2. Chapter → category mapping
 

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -46,6 +46,9 @@ check_automation() {
   # `rust workspace` and `semantic mutation` aggregators depend on
   # (docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence").
   ./tools/check-shard-union.sh selftest
+  # Accepting/rejecting controls for the ruleset drift audit's compareRuleset/
+  # validateContract classifier (docs/DESIGN-ci.md, "Ruleset drift audit").
+  node --test .github/scripts/audit-ruleset-drift.test.mjs
 }
 
 case "${1:-all}" in


### PR DESCRIPTION
## Problem

#707 was filed because the accepted design required the Linux evidence to be *required* contexts on the `main` ruleset while the live ruleset required only `merge readiness` — a **silent** configuration drift. The required-context half landed on 2026-08-05. **This is the drift-detection half, which is the issue's actual reason for being:** the configuration drifted silently once, and nothing in the working tree stops it drifting again the same way.

(#707 was also briefly auto-closed by PR #718's body containing a closing keyword; it was reopened with an accurate done/remaining checklist. This PR closes the remaining four criteria.)

## Change

- **`.github/ruleset-contract.json`** — the checked-in expected state, owned by `docs/DESIGN-ci.md`. JSON because the checker is Node and the merge-readiness automation lane is deliberately dependency-free. `.github/**` is not on the agent-configuration exempt list, so contract edits always earn full pre-merge evidence.
- **`.github/scripts/audit-ruleset-drift.mjs`** — pure `compareRuleset`/`validateContract` separated from an injectable-client fetch, plus the issue lifecycle. Reuses `GitHubRestClient` exported from `report-post-merge-ci.mjs` rather than inventing a second REST client or a second issue mechanism.
- **`.github/scripts/audit-ruleset-drift.test.mjs`** — 42 tests; every drift class proven by mutating a checked-in capture, never by touching live config.
- **`.github/workflows/ruleset-drift-audit.yml`** — daily, on dispatch, and on contract-touching `main` pushes (so a legitimate contract change self-verifies minutes after merge). No `pull_request` trigger, so fork PRs can never false-alarm on absent secrets; pre-merge coverage is the offline suite.
- **`tools/check-merge-readiness.sh`** — the calibration suite joins `check_automation`, alongside the existing `check-product-gate-scope.sh` and `check-shard-union.sh` selftests.
- Docs: a new `### Ruleset drift audit` section in `docs/DESIGN-ci.md`, plus corrections to prose that the 2026-08-05 change had already falsified (see below).

## What is audited, and what is deliberately not

In scope: ruleset identity (discovered **by id**, then name/target/enforcement/conditions must match), `enforcement: active`, the `ref_name` include/exclude, the **rule-type set** (so a reappearing `merge_queue` rule is drift until the accepted merge-queue rejection is revisited), `strict_required_status_checks_policy: true`, `do_not_enforce_on_create: false`, the required contexts as an exact set of `(context, integration_id)` pairs, and `bypass_actors: []`.

Keying on `integration_id` is deliberate: a same-named context reported by a different GitHub App is impersonation, not satisfaction. A rename surfaces as one `missing` + one `unexpected`.

**`bypass_actors` is in scope because an added bypass actor is precisely what would let a failing required check be merged past.** The contract also records the two context kinds that must *not* be required — the three `FSL_OPTIMISTIC_CI`-gated post-merge contexts, and the eight sharded lane names whose `if: always()` aggregators carry the required names — so a future reviewer cannot mistake their absence for an oversight and "fix" them into the ruleset.

Out of scope, deliberately: the `pull_request` rule's parameters (review counts, merge methods). Those are human review policy, owned by ruleset `19090821` and recorded as a separate accepted process decision. **The blind control in the calibration suite exists to prove this boundary is real** — an audit that cried wolf on every review-policy tweak would be ignored.

## The `bypass_actors` constraint — and why merging this without a secret goes red on purpose

Verified live: ruleset **read** endpoints are public for this repo, so rules/conditions/contexts need no token. But **GitHub returns `bypass_actors` only to callers with write access to the ruleset**, and the Actions `GITHUB_TOKEN` has no `administration` permission at all — so the workflow cannot observe that field with the job token. It needs a fine-grained PAT secret (`RULESET_AUDIT_TOKEN`, this repository only, Administration: read), and this repository currently has **zero secrets**.

The audit treats a missing field as `bypass-actors-unobserved` → **failure, never a skip**. Absence of evidence is not evidence of an empty bypass list. So until the secret exists, the daily run goes red with that finding and opens its owned issue. **That is the designed behavior**, and it is also live proof of the issue's fail-loud requirement — but it means the rollout order below matters.

## Rollout order (operational steps are not in this PR)

1. Review and approve this PR.
2. ~~Apply the live ruleset edit adding `site reference freshness`~~ — **done.** The live ruleset now requires six contexts; `bypass_actors` stays `[]` and no `merge_queue` rule was introduced. A pre-change snapshot is retained for reversal.
3. ~~Re-capture the fixture~~ — **done** (commit `3ee29fa`). It is now a pure `gh api` capture, pretty-printed so the file stays reviewable in a diff.
4. ~~Create `RULESET_AUDIT_TOKEN`~~ — **done** by the repository owner.
5. Merge. The `push` trigger then runs the audit; that run is the first live accepting observation.
6. If it fails `bypass-actors-unobserved` despite the secret, escalate the PAT from Administration read to read-and-write (still single-repo) and re-dispatch. Read-vs-write visibility for `bypass_actors` is a genuine uncertainty and this is its canary rather than a guess. Useful data point measured during rollout: the `gh` CLI's own token, which carries classic `repo` scope and **no** administration scope, *can* read `bypass_actors` on this repository — so the requirement is looser than GitHub's "write access to the ruleset" wording suggests.

## The `site reference freshness` decision

Required, now six contexts. The recorded objection to requiring it was that joining `merge-readiness.yml` would break that lane's stdlib-only dependency contract — but that objection is about **placement inside another workflow's job graph** (still not done), not about requiring this workflow's own context, which breaks nothing. Its other half ("`merge readiness` is the only required check, so joining would make a stale page block the merge") became stale on 2026-08-05 when four heavier contexts became required. It reports on every PR with no path filter at ~15 s, so requiring it cannot leave a PR `Expected`. Honest cost, recorded: that job pip-installs `.[dev]` unpinned, so a PyPI outage now blocks merges until rerun.

## Stale prose corrected

`docs/DESIGN-ci.md` contained two sentences the 2026-08-05 change had already falsified — most sharply "None of the four contexts are required status checks today — `merge readiness` remains the only one", contradicting the same file's own "Required pre-merge contexts" section. Also corrected: `docs/DESIGN-docs-site.md`'s D7 "visible, not enforced" paragraph, and the third header bullet of `.github/workflows/site-reference-freshness.yml`. The `#688` frozen-`cli.py` asymmetry recorded in D7 is unchanged and stays open.

## Verification

- `node --test .github/scripts/audit-ruleset-drift.test.mjs` → **42 tests, 42 pass, 0 fail** (I re-ran this myself). Cases: accepting; missing `rust workspace`; renamed `semantic mutation (changed)`; the blind `allowed_merge_methods` control that must stay **clean**; and fail-closed guards for empty rules, empty required list, missing/added `bypass_actors`, duplicate pair, mismatched `integration_id`, unexpected `merge_queue`, bad enforcement/strict-policy/conditions, and schema-invalid contract. Plus `FakeClient` tests proving an injected fetch failure and a 404 classify as `api-unreadable`/`ruleset-missing` **and still create the failure issue**, and the full create/dedupe/reopen/close lifecycle.
- `./tools/check-merge-readiness.sh automation` → passes with the new suite wired in, still needing no third-party dependency.
- **Live-data rejecting control, run by me against the real ruleset read-only:**
  ```
  main safety and CI: drift (1 finding(s))
    - required-context-missing: "site reference freshness" (integration_id 15368) is required by the contract but was not observed
  exit=1
  ```
  This is the correct pre-rollout result: step 2 above has not been applied. Hand-adding that context to a copy of the observation flips it to `clean`, exit 0.
- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK. SPDX headers present on both new `.mjs` files.

## Fixture provenance, and the live verification it now supports

`.github/scripts/fixtures/ruleset-19090811.json` is a **verbatim `gh api repos/ymm-oss/fsl/rulesets/19090811` capture** taken after the rollout edit, pretty-printed. It carries six required contexts and `bypass_actors: []`.

The audit was run against the live ruleset on both sides of that edit, which is the sharpest evidence in this PR:

| when | result |
| --- | --- |
| before the edit | `required-context-missing: "site reference freshness" (integration_id 15368) is required by the contract but was not observed`, **exit 1** |
| after the edit and recapture | `main safety and CI: clean (0 findings)`, **exit 0** |

So the checker was observed both rejecting and accepting real live data, not only fixtures — and the rejecting case was a genuine configuration gap it found rather than a synthetic one. The 42-case calibration suite passes against the recaptured fixture, so contract and fixture stay locked to each other.

## A real bug caught during implementation

An early draft reconstructed `(context, integration_id)` pairs by splitting a space-joined key string, which silently corrupts multi-word context names — `semantic mutation (changed)` among them. Fixed to key on `JSON.stringify([context, integration_id])` and carry the original objects rather than re-parsing. Worth naming because a comparator that mangles exactly the context names this repo uses would have produced confident nonsense.

## Follow-up recorded, not folded in

Rulesets `19090821` (review policy — its `RepositoryRole: 5` bypass is *expected* there) and `19090815` (production promotion gate — which guards promotion and can drift identically) are **not** audited here. The contract's `rulesets` array makes adding them a data + fixture change with no code change. The production gate is the stronger candidate and deserves its own issue rather than widening #707.

Closes #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
