### PR TITLE
fix(ci): restate merge-group premise, repair dangling DESIGN-ci.md citation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,18 @@ on:
     # run as the first step of each heavy job below, so a skip is an
     # in-job early exit that still reports a context instead of a
     # workflow-level skip that reports none at all. See docs/DESIGN-ci.md,
-    # "Agent-configuration exemption" and "Merge queue (planned, not yet
-    # enabled)".
+    # "Agent-configuration exemption".
   merge_group:
     # Unfiltered: GitHub does not support `paths`/`paths-ignore` on
-    # `merge_group` (docs/DESIGN-ci.md), and only `main` will ever have a
-    # queue, so an unfiltered trigger is equivalent. Currently dormant --
-    # no merge queue exists on `main` yet, so this event never fires today.
+    # `merge_group`, and only `main` could ever have a queue, so an
+    # unfiltered trigger is equivalent. Dormant -- no merge queue exists on
+    # `main`. One was configured on this ruleset on 2026-08-05 and removed
+    # the same day: every merge here takes the admin-bypass path, so the
+    # queue never validated anything. Reviving it needs a human-review-policy
+    # change, not a CI change, so this trigger stays inert rather than
+    # removed. See docs/DESIGN-ci.md, "Required pre-merge contexts, and why
+    # the merge queue was rejected" and its "The merge queue was tried,
+    # measured against this repository's workflow, and rejected" subsection.
   schedule:
     - cron: "17 18 * * *"
   workflow_dispatch:
@@ -38,16 +43,18 @@ permissions:
 # merge.
 #
 # The four heavy jobs (`rust-workspace`, `wasm`, `semantic-mutation`,
-# `fsl-logic`) also trigger on `merge_group`, which is where they are meant to
-# eventually run for real once a merge queue is configured on `main`: pull
-# requests would then report a cheap queue-entry stub instead, batches of
-# candidates would be validated together, and the pre-merge cost this file's
-# header used to describe would move to queue-entry time. That rollout has
-# two remaining, explicit, human-confirmed steps this PR does not take —
-# creating the `FSL_MERGE_QUEUE_CI` repository variable and adding a
-# `merge_queue` rule to the `main` ruleset — so today `pull_request` events
-# still run the complete evidence in full, exactly as before. See
-# docs/DESIGN-ci.md, "Merge queue (planned, not yet enabled)".
+# `fsl-logic`) also trigger on `merge_group`, which stays inert: a merge
+# queue was tried on the `main` ruleset on 2026-08-05 and rejected the same
+# day, because an administrator's merge bypasses the queue entirely and the
+# ordinary enqueue path is unsatisfiable under this repository's
+# single-approver review policy. Reviving the queue would require changing
+# that human review policy, not this workflow, so the trigger and
+# `tools/check-product-gate-scope.sh`'s `queue-entry-stub` branch stay ready
+# rather than removed. `pull_request` events run the complete evidence in
+# full, exactly as before. See docs/DESIGN-ci.md, "Required pre-merge
+# contexts, and why the merge queue was rejected" and its "The merge queue
+# was tried, measured against this repository's workflow, and rejected"
+# subsection.
 #
 # Only the cross-platform matrix — `native Z3 4.16` on macOS and Windows — stays
 # post-merge under FSL_OPTIMISTIC_CI, reported by the post-merge CI reporter.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,12 @@ on:
     # "Agent-configuration exemption".
   merge_group:
     # Unfiltered: GitHub does not support `paths`/`paths-ignore` on
-    # `merge_group`, and only `main` could ever have a queue, so an
-    # unfiltered trigger is equivalent. Dormant -- no merge queue exists on
-    # `main`. One was configured on this ruleset on 2026-08-05 and removed
-    # the same day: every merge here takes the admin-bypass path, so the
-    # queue never validated anything. Reviving it needs a human-review-policy
+    # `merge_group` (docs/DESIGN-ci.md), and only `main` could ever have a
+    # queue, so an unfiltered trigger is equivalent. Dormant -- no merge
+    # queue exists on `main`. One was configured on the `main` ruleset on
+    # 2026-08-05 and removed the same day: every merge would have taken the
+    # admin-bypass path, so the queue would never have validated anything --
+    # measured, not predicted. Reviving it needs a human-review-policy
     # change, not a CI change, so this trigger stays inert rather than
     # removed. See docs/DESIGN-ci.md, "Required pre-merge contexts, and why
     # the merge queue was rejected" and its "The merge queue was tried,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#736): `.github/workflows/ci.yml` cited a `docs/DESIGN-ci.md` section,
+  `"Merge queue (planned, not yet enabled)"`, that does not exist and asserted the
+  opposite of the accepted decision — the design document records that a merge
+  queue was configured on the `main` ruleset on 2026-08-05 and rejected the same
+  day (`### The merge queue was tried, measured against this repository's
+  workflow, and rejected`), not merely planned. The `merge_group:` trigger
+  comment's "no merge queue exists on `main` **yet**" carried the same stale
+  implication. Both comments, plus the `pull_request:` trigger comment's
+  reference to the same dangling section, now cite the real heading
+  (`## Required pre-merge contexts, and why the merge queue was rejected` and
+  its subsection) and state the rejection accurately. Audited every other
+  `docs/DESIGN-ci.md` citation in `ci.yml`, `ruleset-drift-audit.yml`, and
+  `site-reference-freshness.yml`: all resolve to real headings. Comment/citation
+  fix only — no trigger, job, or required-context name changed; the parsed YAML
+  structure is unchanged before and after.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,28 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   carried the third instance of the same dangling citation and additionally
   described the inert `queue-entry-stub` branch as "implemented ahead of that
   rollout"; it now records that no rollout is pending and that reviving the queue
-  is a human-review-policy question, not a CI one. An independent verification
-  pass is what found that third site — the first sweep named only the two in
-  `ci.yml`. Audited every other `docs/DESIGN-ci.md` citation in `ci.yml`,
-  `ruleset-drift-audit.yml`, and `site-reference-freshness.yml`: all resolve to
-  real headings. Comment/citation fix only — no trigger, job, or required-context
-  name changed; the parsed YAML structure is unchanged before and after, and
-  `./tools/check-product-gate-scope.sh selftest` still passes.
+  is a human-review-policy question, not a CI one. The same file's
+  `FSL_MERGE_QUEUE_CI` branch comment said enabling the variable was "the only
+  remaining step", contradicting both the rejection record and the file's own
+  header eighty lines above; it now states that reaching that branch needs the
+  policy change first, and why enabling the variable alone would land changes
+  with no pre-merge Linux evidence. Four sites in total, of two different
+  signatures, each found by a different pass. Three quote the removed section
+  name; the first sweep found only two of those because the string is wrapped
+  across lines behind `#` prefixes and a single-line `git grep` matches one of
+  the three — the reliable detector strips the comment prefix before joining
+  lines (`sed 's/^[[:space:]]*#[[:space:]]*//' | tr '\n' ' ' | tr -s ' '`), and
+  swept over all 1,436 tracked files it leaves only the two `CHANGELOG.md`
+  entries that quote the string as history. The fourth site contains no section
+  name at all, so no citation detector could have found it; it was found by
+  reading the file, and it is the most consequential of the four because it
+  described a dangerous operation as one flag away. No mechanical check exists
+  for `docs/DESIGN-ci.md` heading citations, tracked as #742. Audited every
+  other `docs/DESIGN-ci.md` citation in
+  `ci.yml`, `ruleset-drift-audit.yml`, and `site-reference-freshness.yml`: all
+  resolve to real headings. Comment/citation fix only — no trigger, job, or
+  required-context name changed; the parsed YAML structure is unchanged before
+  and after, and `./tools/check-product-gate-scope.sh selftest` still passes.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   implication. Both comments, plus the `pull_request:` trigger comment's
   reference to the same dangling section, now cite the real heading
   (`## Required pre-merge contexts, and why the merge queue was rejected` and
-  its subsection) and state the rejection accurately. Audited every other
-  `docs/DESIGN-ci.md` citation in `ci.yml`, `ruleset-drift-audit.yml`, and
-  `site-reference-freshness.yml`: all resolve to real headings. Comment/citation
-  fix only — no trigger, job, or required-context name changed; the parsed YAML
-  structure is unchanged before and after.
+  its subsection) and state the rejection accurately. `tools/check-product-gate-scope.sh`
+  carried the third instance of the same dangling citation and additionally
+  described the inert `queue-entry-stub` branch as "implemented ahead of that
+  rollout"; it now records that no rollout is pending and that reviving the queue
+  is a human-review-policy question, not a CI one. An independent verification
+  pass is what found that third site — the first sweep named only the two in
+  `ci.yml`. Audited every other `docs/DESIGN-ci.md` citation in `ci.yml`,
+  `ruleset-drift-audit.yml`, and `site-reference-freshness.yml`: all resolve to
+  real headings. Comment/citation fix only — no trigger, job, or required-context
+  name changed; the parsed YAML structure is unchanged before and after, and
+  `./tools/check-product-gate-scope.sh selftest` still passes.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,32 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   remaining step", contradicting both the rejection record and the file's own
   header eighty lines above; it now states that reaching that branch needs the
   policy change first, and why enabling the variable alone would land changes
-  with no pre-merge Linux evidence. Four sites in total, of two different
-  signatures, each found by a different pass. Three quote the removed section
-  name; the first sweep found only two of those because the string is wrapped
-  across lines behind `#` prefixes and a single-line `git grep` matches one of
-  the three — the reliable detector strips the comment prefix before joining
-  lines (`sed 's/^[[:space:]]*#[[:space:]]*//' | tr '\n' ' ' | tr -s ' '`), and
-  swept over all 1,436 tracked files it leaves only the two `CHANGELOG.md`
-  entries that quote the string as history. The fourth site contains no section
-  name at all, so no citation detector could have found it; it was found by
-  reading the file, and it is the most consequential of the four because it
-  described a dangerous operation as one flag away. No mechanical check exists
-  for `docs/DESIGN-ci.md` heading citations, tracked as #742. Audited every
-  other `docs/DESIGN-ci.md` citation in
+  with no pre-merge Linux evidence. `tools/check-product-gate-scope.sh`'s
+  `diff_scope` comment said the in-job check is "the only place the exemption can
+  apply **once** a merge queue exists", presupposing one will; it now says
+  "if a merge queue ever existed" and states that none does. And
+  `docs/DESIGN-ci.md` itself — the authority the other five sites cite —
+  recommended a merge queue as a mitigation "worth using ... once `ci.yml` gains
+  the same trigger", while its own `## Non-goals` lists running a queue as a
+  non-goal; `ci.yml` had already gained that trigger, so the paragraph read as an
+  available next step. It is corrected rather than deleted, so the sequence stays
+  legible.
+
+  **Seven sites across three files, of two signatures, found over four passes** —
+  not one clean sweep. Three quote the removed section name; four state a stale
+  premise without naming any section. The section-name sites are findable
+  mechanically, but only with a comment-prefix-aware detector: the string wraps
+  across lines behind `#` prefixes, so a single-line `git grep` matches one of the
+  three. The reliable form is
+  `sed 's/^[[:space:]]*#[[:space:]]*//' | tr '\n' ' ' | tr -s ' '`; calibrated
+  against the pre-repair tree it finds all three, and over all 1,436 tracked files
+  here it leaves only the two `CHANGELOG.md` entries that quote the string as
+  history. **The four stale-premise sites are not findable that way at all** — they
+  contain no section name — and they include both the most dangerous one (an
+  operation the #717 canary proved unsafe, described as one flag away) and the one
+  inside the accepted decision record. #742 tracks mechanising the citation check;
+  it must also cover this second signature, or the recurrence continues. Audited
+  every other `docs/DESIGN-ci.md` citation in
   `ci.yml`, `ruleset-drift-audit.yml`, and `site-reference-freshness.yml`: all
   resolve to real headings. Comment/citation fix only — no trigger, job, or
   required-context name changed; the parsed YAML structure is unchanged before

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -38,11 +38,20 @@ Measured on the batch that motivated this revision:
 
 The cost is stated plainly: a pull request into `main` now waits for `rust workspace`, measured at
 18m17s on a cold cache and around twelve minutes warm, rather than forty seconds. Because a branch
-that falls behind `main` must re-run its checks, a serial chain of rebases pays that repeatedly. Two
-mitigations already exist and are worth using before the cost is treated as inherent: independent
-changes can share one pull request with one commit per topic, and `merge-readiness.yml` already
-handles `merge_group`, so a merge queue can validate several candidates as one batch once `ci.yml`
-gains the same trigger.
+that falls behind `main` must re-run its checks, a serial chain of rebases pays that repeatedly. One
+mitigation exists and is worth using before the cost is treated as inherent: independent changes can
+share one pull request with one commit per topic.
+
+A merge queue would be the other, batching several candidates into one validation, and both
+`merge-readiness.yml` and `ci.yml` carry a `merge_group` trigger for exactly that. **It is not an
+available mitigation.** The queue itself was configured on the `main` ruleset on 2026-08-05 and
+removed the same day; both triggers are inert and enabling one changes nothing, because no
+`merge_group` event fires without a queue. Reviving it is a human-review-policy decision, not a CI
+one — see "Required pre-merge contexts, and why the merge queue was rejected" below, and the
+"Non-goals" entry that follows from it. This paragraph previously recommended the queue as a
+mitigation "once `ci.yml` gains the same trigger"; `ci.yml` gained it, the queue was then measured
+and rejected, and the recommendation was left behind. It is corrected here rather than deleted so the
+sequence stays legible.
 
 ## Merge readiness contract
 

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -12,11 +12,15 @@
 # check out, diff, and exit fast, so its context always reports something.
 #
 # It also owns the (currently inert) `merge_group`/`FSL_MERGE_QUEUE_CI`
-# decision described in docs/DESIGN-ci.md's "Merge queue (planned, not yet
-# enabled)" section. Neither the repository variable nor the ruleset rule
-# exists yet, so the `queue-entry-stub` branch below is dead code in
-# production today -- it is implemented ahead of that rollout, not exercised
-# by it.
+# decision described in docs/DESIGN-ci.md, "The merge queue was tried,
+# measured against this repository's workflow, and rejected". A merge queue
+# was configured on the `main` ruleset on 2026-08-05 and removed the same
+# day: an admin merge bypasses the queue entirely, and the ordinary
+# `enqueuePullRequest` path is unsatisfiable under the single-approver review
+# policy. Neither the repository variable nor a `merge_queue` ruleset rule
+# exists, so the `queue-entry-stub` branch below never runs in production.
+# It is kept because it is harmless and ready if that *human-review-policy*
+# question is ever answered differently -- not because a rollout is pending.
 #
 # Usage:
 #   ./tools/check-product-gate-scope.sh            # decide scope; prints

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -106,8 +106,13 @@ decide() {
         # Never stub or skip promotion evidence.
         emit true production-promotion-evidence
       elif [ "${FSL_MERGE_QUEUE_CI:-}" = "enabled" ]; then
-        # Unreachable today: FSL_MERGE_QUEUE_CI does not exist yet. Correct
-        # ahead of time so enabling the variable is the only remaining step.
+        # Unreachable: neither the `FSL_MERGE_QUEUE_CI` variable nor a
+        # `merge_queue` ruleset rule exists, and the queue was tried and
+        # rejected (see the header comment). Enabling the variable is
+        # therefore NOT "the only remaining step" -- doing so while no
+        # `merge_group` run replaces these stubs would land changes on `main`
+        # with no pre-merge Linux evidence at all. Reaching this branch
+        # requires the human-review-policy change first.
         emit false queue-entry-stub
       else
         diff_scope

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -78,11 +78,13 @@ emit() {
   fi
 }
 
-# Diff-based exemption shared by `pull_request` (once FSL_MERGE_QUEUE_CI is
+# Diff-based exemption shared by `pull_request` (when FSL_MERGE_QUEUE_CI is
 # not "enabled") and `merge_group` events -- the latter cannot be path-
-# filtered at the trigger level, so this in-job check is the only place the
-# exemption can apply once a merge queue exists. Fails closed to a full run
-# when either SHA is missing or the diff itself cannot be computed.
+# filtered at the trigger level, so this in-job check would be the only place
+# the exemption could apply if a merge queue ever existed. None does, and the
+# queue was rejected rather than deferred: see the header comment. Fails
+# closed to a full run when either SHA is missing or the diff itself cannot be
+# computed.
 diff_scope() {
   if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
     emit true diff-unavailable-fail-closed


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` line 50 cited `docs/DESIGN-ci.md, "Merge queue (planned, not yet enabled)"` — a section that does not exist in that document, and one that asserts the opposite of the accepted decision: `docs/DESIGN-ci.md` records that a merge queue *was* configured on the `main` ruleset on 2026-08-05 and rejected the same day (`### The merge queue was tried, measured against this repository's workflow, and rejected`, under `## Required pre-merge contexts, and why the merge queue was rejected`), not merely "planned, not yet enabled".

A second, related staleness lived in the same file: the `merge_group:` trigger comment said the event "never fires today" because no queue exists on `main` "**yet**" — the word "yet" implies a queue is still planned, which contradicts the design document's rejection.

## What changed

This is a comment/citation-only change. No workflow behavior changed:

- `pull_request:` trigger comment: dropped the dangling `"Merge queue (planned, not yet enabled)"` citation (the comment's content is about the agent-configuration exemption only).
- `merge_group:` trigger comment: restated to say a queue was tried and rejected on 2026-08-05, that reviving it needs a human-review-policy change (not a CI change), and cited the real heading.
- The large comment above the `jobs:` block describing why the four heavy jobs also trigger on `merge_group`: restated the same way, replacing the stale "two remaining, explicit, human-confirmed steps this PR does not take" framing (which implied the queue was one variable + one ruleset rule away from working) with the actual rejection rationale (admin-bypass path; single-approver review policy makes the ordinary enqueue path unsatisfiable).
- Audited every other `docs/DESIGN-ci.md` citation in `ci.yml` (`grep -n 'DESIGN-ci.md' .github/workflows/ci.yml`): the two references to `"Sharded pre-merge Linux evidence"` (job-splitting comments) both resolve to the real `### Sharded pre-merge Linux evidence` heading — no change needed there.
- Checked every other workflow file under `.github/workflows/` for `docs/DESIGN-ci.md` citations (`grep -rn 'DESIGN-ci.md' .github/workflows/`): `ruleset-drift-audit.yml`'s `"Ruleset drift audit"` and `site-reference-freshness.yml`'s `"Product gate contract"` and `"Ruleset drift audit"` citations all resolve to real headings. No changes needed in either file.

No trigger was added or removed, no job was renamed, and no required-status-check context name was altered.

## Verification

- `grep -n '^##* ' docs/DESIGN-ci.md` to enumerate real headings, confirming the new citations resolve.
- `python3 -c "import yaml,sys; [yaml.safe_load(open(p)) for p in sys.argv[1:]]" .github/workflows/*.yml` — all eight workflow files parse (PyYAML is available in this environment).
- Additionally confirmed the parsed YAML structure of `ci.yml` is identical before and after the edit (`yaml.safe_load` on `git show HEAD~1:.github/workflows/ci.yml` vs. the working tree file compares equal), proving this is a comment-only change with no structural/behavioral effect.

Refs #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: the sweep was incomplete

An independent verification pass over the claim behind this PR found a **third**
occurrence of the same dangling citation that the first sweep missed:
`tools/check-product-gate-scope.sh:15`. That file went further than the workflow
comments — it described the inert `queue-entry-stub` branch as "implemented ahead
of that rollout", which asserts a pending rollout the accepted decision
explicitly rules out.

`0496ff3` repairs it. Verification for that commit:

- `bash -n tools/check-product-gate-scope.sh` — clean
- `./tools/check-product-gate-scope.sh selftest` — `all assertions passed`
- `git grep -n 'planned, not yet enabled'` — now matches only the `CHANGELOG.md`
  entry that quotes the removed string

So the full set of repaired sites is three: `.github/workflows/ci.yml` (two) and
`tools/check-product-gate-scope.sh` (one). No behavior, trigger, job name, or
required-context name changed in either commit.


---

## Second follow-up: a fourth site, and the reason the sweeps kept missing them

An independent review pass over this PR found a **fourth** site:
`tools/check-product-gate-scope.sh`'s `FSL_MERGE_QUEUE_CI` branch said enabling the
variable was "the only remaining step". That is worse than a broken link — it
contradicted both the accepted decision and the same file's own header eighty lines
above, and it made the exact operation the canary PR (#717) proved dangerous look
like it was one flag away.

`4d9afd2` fixes it.

**Why the earlier passes missed sites — two different reasons, not one.** Three of
the four sites quote the removed section name, and the first sweep found two of
those: the string is wrapped across lines behind `#` comment prefixes, so a
single-line `git grep 'planned, not yet enabled'` matches **one of the three**. The
reliable form strips the prefix before joining lines:

```sh
sed 's/^[[:space:]]*#[[:space:]]*//' | tr '\n' ' ' | tr -s ' '
```

Swept all 1,436 tracked files with that detector on this branch: the only remaining
matches are two `CHANGELOG.md` entries that quote the string as history, which is
correct — `CHANGELOG.md` records what was true when written and is not rewritten.

The fourth site is a different signature entirely: it contains **no section name**,
so no citation detector could have found it. A review pass found it by reading the
file. It is also the most consequential of the four, because it described an
operation the canary proved dangerous as one flag away.

**Final tally: four active sites repaired** — `.github/workflows/ci.yml` (two) and
`tools/check-product-gate-scope.sh` (two). Verification for `4d9afd2`: `bash -n`
clean, `./tools/check-product-gate-scope.sh selftest` reports all assertions passed.

**The recurrence itself is now tracked.** One defect class surfaced four times
across a rename commit, two sweeps and a review, because nothing mechanically checks
`docs/DESIGN-*.md` heading citations. Filed as #742, including the requirement that
the lint be calibrated against the post-rename tree where all four sites were
stale — a lint that is only green on the fixed tree is not evidence it can detect
drift.

