### PR TITLE
docs(design): record the #738 extraction spike as re-evaluation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   stays unconfirmed, not disproven; the response that measurably worked is policy single-owner
   extraction (`spec_load.rs`, `outcome.rs`, `literate_access.rs`): after `743bc7a` gave spec-load
   classification one owner, `main.rs` involvement fell 379 → 179 → 16 lines across its follow-up
-  series. Section 8 now records an adjudicated policy-site working rule (touch rate and line
-  count cannot separate composition wiring — post-extraction `main.rs` churn median 29 lines, 26
-  of 50 commits at wiring scale — from coupling; harmful coupling is observable as one policy's
-  fix recurring across arms or copies), plus the calibrated accepting/rejecting controls and the
-  measurable changed-owner rollback rule any future extraction PR must carry. Documentation only;
-  no Rust behavior changed.
+  series. Section 8 records the positive observation — touch rate and line count cannot separate
+  composition wiring from coupling (post-extraction `main.rs` churn median 29 lines, 26 of 50
+  commits at wiring scale), and all three chains trace to one contract policy implemented at more
+  than one site — and, explicitly, that **a test separating that from legitimate cohesion is not
+  established**. Two formulations were tried and both fail: site count matches the candidate
+  negative control too, and the recurrence signature misses Case C (which is part of its own
+  grounding), cannot classify a policy whose arms were mismatched from birth, and returns both
+  verdicts on the coverage-diagnostic history. `64bfb55` cannot serve as the control because it
+  contains two multi-site policies; an earlier version of this entry claimed otherwise on the
+  strength of a single-file pickaxe over a symbol the broken copy never contained, and also claimed
+  the commit deleted a duplicated hint string — `git show 64bfb55^:rust/fslc/src/main.rs` contains
+  no `coverage_hint` occurrence, so both claims are withdrawn. Issue #738's third acceptance
+  criterion is therefore **not met** and #748 tracks it, so this lands as `Refs #738`, not
+  `Closes`. Also recorded: the accepting/rejecting controls a future extraction would have to
+  calibrate, and the measurable changed-owner rollback rule any future extraction PR must carry.
+  Documentation only; no Rust behavior changed.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,24 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   stays unconfirmed, not disproven; the response that measurably worked is policy single-owner
   extraction (`spec_load.rs`, `outcome.rs`, `literate_access.rs`): after `743bc7a` gave spec-load
   classification one owner, `main.rs` involvement fell 379 → 179 → 16 lines across its follow-up
-  series. Section 8 records the positive observation — touch rate and line count cannot separate
-  composition wiring from coupling (post-extraction `main.rs` churn median 29 lines, 26 of 50
-  commits at wiring scale), and all three chains trace to one contract policy implemented at more
-  than one site — and, explicitly, that **a test separating that from legitimate cohesion is not
-  established**. Two formulations were tried and both fail: site count matches the candidate
-  negative control too, and the recurrence signature misses Case C (which is part of its own
-  grounding), cannot classify a policy whose arms were mismatched from birth, and returns both
-  verdicts on the coverage-diagnostic history. `64bfb55` cannot serve as the control because it
-  contains two multi-site policies; an earlier version of this entry claimed otherwise on the
-  strength of a single-file pickaxe over a symbol the broken copy never contained, and also claimed
-  the commit deleted a duplicated hint string — `git show 64bfb55^:rust/fslc/src/main.rs` contains
-  no `coverage_hint` occurrence, so both claims are withdrawn. Issue #738's third acceptance
-  criterion is therefore **not met** and #748 tracks it, so this lands as `Refs #738`, not
-  `Closes`. Also recorded: the accepting/rejecting controls a future extraction would have to
+  series. Section 8 records the discriminator the spike leaves behind, and it is stated in terms of
+  **implementation sites, not call sites** — one contract policy implemented at more than one site is
+  harmful coupling; an arm that only calls into a single library owner is cohesion, however many arms
+  call it. That distinction is the whole rule: counting call sites makes every centralized policy look
+  coupled, because centralizing is what produces callers, and counting only recurrence misses a policy
+  whose arms were mismatched from birth, does not capture Case C, and returns both verdicts on a
+  history where a duplicated policy was later centralized. Touch rate and line count discriminate
+  nothing (post-extraction `main.rs` churn median 29 lines, 26 of 50 commits at wiring scale). The
+  negative control is **`c455e50` (#697)**, which the rule rejects: it touches `main.rs`, spans three
+  crates and changes concrete-verification behaviour, yet its policy — `CONCRETE_PROBE_BUDGET`
+  governing the single `find_boundary_violation` — is defined once and merely referenced from four
+  call sites, with the budget value appearing nowhere else in `rust/` outside a test comment, an
+  11-line wiring change in `main.rs`, and no later fix landing on a second arm. `64bfb55` is
+  explicitly **not** the control: two of its three defects are multi-site policies, so by this rule it
+  contains coupling — the rule working, not failing — and two claims made for it are withdrawn, the
+  single-file pickaxe over a symbol the broken copy never contained, and the false assertion that it
+  deleted a duplicated hint string (`git show 64bfb55^:rust/fslc/src/main.rs` has no `coverage_hint`
+  occurrence). Also recorded: the accepting/rejecting controls a future extraction would have to
   calibrate, and the measurable changed-owner rollback rule any future extraction PR must carry.
   Documentation only; no Rust behavior changed.
 - Documented (#722): the implicit domain aggregate initializer enumeration in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Documented (#738): the command-family extraction spike's result as re-evaluation evidence in
+  `docs/DESIGN-rust-components.md`. Section 10's first trigger — three unrelated command changes
+  failing on `fslc` orchestration coupling — has fired (the exit-code chain alone supplies five)
+  and is adjudicated: the harmful coupling is one contract policy implemented at more than one
+  site, which a vertical command-family split cannot remove, so further family extraction is
+  no-go and a new crate is rejected for lack of independent version/dependency/consumer evidence
+  (C1 remains the selected candidate). The one executed extraction (`causal.rs`, #393 / PR #440)
+  produced zero confirming samples and two counter-shaped ones in 13 days, observing the
+  falsifier section 8 already named; the response that measurably worked is policy single-owner
+  extraction (`spec_load.rs`, `outcome.rs`, `literate_access.rs`), where `main.rs` involvement
+  fell 379 → 179 → 16 lines across the spec-load follow-up series. Section 8 now records a
+  durable policy-site discriminator (touch rate and line count cannot separate composition
+  wiring — post-extraction `main.rs` churn median 30 lines, 25 of 49 commits at wiring scale —
+  from coupling), plus the calibrated accepting/rejecting controls and the measurable
+  changed-owner rollback rule any future extraction PR must carry. Documentation only; no Rust
+  behavior changed.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   site, which a vertical command-family split cannot remove, so further family extraction is
   no-go and a new crate is rejected for lack of independent version/dependency/consumer evidence
   (C1 remains the selected candidate). The one executed extraction (`causal.rs`, #393 / PR #440)
-  produced zero confirming samples and two counter-shaped ones in 13 days, observing the
-  falsifier section 8 already named; the response that measurably worked is policy single-owner
-  extraction (`spec_load.rs`, `outcome.rs`, `literate_access.rs`), where `main.rs` involvement
-  fell 379 → 179 → 16 lines across the spec-load follow-up series. Section 8 now records a
-  durable policy-site discriminator (touch rate and line count cannot separate composition
-  wiring — post-extraction `main.rs` churn median 30 lines, 25 of 49 commits at wiring scale —
-  from coupling), plus the calibrated accepting/rejecting controls and the measurable
-  changed-owner rollback rule any future extraction PR must carry. Documentation only; no Rust
-  behavior changed.
+  produced zero confirming samples and two counter-shaped ones in 13 days — both workspace-wide
+  refine changes, so the falsifier section 8 already named appeared in shape while the effect
+  stays unconfirmed, not disproven; the response that measurably worked is policy single-owner
+  extraction (`spec_load.rs`, `outcome.rs`, `literate_access.rs`): after `743bc7a` gave spec-load
+  classification one owner, `main.rs` involvement fell 379 → 179 → 16 lines across its follow-up
+  series. Section 8 now records an adjudicated policy-site working rule (touch rate and line
+  count cannot separate composition wiring — post-extraction `main.rs` churn median 29 lines, 26
+  of 50 commits at wiring scale — from coupling; harmful coupling is observable as one policy's
+  fix recurring across arms or copies), plus the calibrated accepting/rejecting controls and the
+  measurable changed-owner rollback rule any future extraction PR must carry. Documentation only;
+  no Rust behavior changed.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/docs/DESIGN-rust-components.md
+++ b/docs/DESIGN-rust-components.md
@@ -3,7 +3,9 @@
 # Rust component boundaries
 
 Status: accepted current-architecture record. Evidence baseline:
-`dc0f3fb3b6b22f84bf5f37432379641d4a08c0ca`.
+`dc0f3fb3b6b22f84bf5f37432379641d4a08c0ca`. Re-evaluation evidence from the issue #738 extraction
+spike, measured at baseline `d72ac8d0f717b16914790fe270566a8a1c407803`, is recorded in
+sections 3, 8, and 10.
 
 ## 1. Decision
 
@@ -68,6 +70,10 @@ inference), and E0 (assumption).
 | E-07 | E1 | From `295508e9^` through the baseline, 35 of 104 non-merge commits touch `rust/fslc/src/main.rs`; the file is also substantially larger than other entry modules. | Identifies an orchestration hotspot, not by itself a faulty crate boundary. |
 | E-08 | E0 | Future team ownership, production scale, incident isolation, and roadmap likelihood. | Prevents service/organization-level restructuring claims. |
 | E-09 | E3 | `./tools/check-native-integration.sh rust` passed with locked formatting, Clippy, LSP, workspace tests, build, and dependency checks. | Confirms the documented Rust boundaries are reproducible at the baseline revision. |
+| E-10 | E3 | Extraction commit `6684dfb` (issue #393, PR #440) moved the causal family into `rust/fslc/src/causal.rs` in one revertible commit; in the following 13 days it produced zero family-scoped semantic changes, and the only two commits touching `causal.rs` both also touched `main.rs`. | Tests C2's falsifier once; the falsifier was observed. Recorded in section 8. |
+| E-11 | E3 | At the `d72ac8d` spike baseline, `main.rs` commit-touch rate stays near half while per-commit churn on the 49 post-extraction `main.rs` commits is min 3 / median 30 / p90 202 / max 385 lines, with 25 of 49 at 30 lines or fewer. | Shows touch rate and line count cannot separate composition cohesion from harmful coupling. |
+| E-12 | E2 | Three repeat-fix chains (exit-code class, nested kernel projection, spec-load error plumbing) each trace to one contract policy implemented at more than one site; commit messages `fd5b8c6` and `693bddb` state the cause directly. | Identifies the harmful-coupling mechanism and grounds the policy-site discriminator in section 8. |
+| E-13 | E1 | After spec-load classification received a single owner, `main.rs` involvement across the follow-up series `743bc7a` → `fedba3f` → `558e113` fell 379 → 179 → 16 changed lines while total change size grew (n=3; the direction is measured, the generalization is inference). | Supports policy single-owner extraction as the adjudicated response to orchestration coupling. |
 
 Scoped contract classifications are:
 
@@ -298,7 +304,7 @@ authorization to move source; section 8 remains the selection gate.
 | Pressure | Evidence | Priority | Current response |
 |---|---|---|---|
 | Cross-layer semantic changes touch many crates. | Multiple language/effect/liveness commits plus coupled-change tests. | High consequence, high recurrence, medium uncertainty. | Preserve explicit ownership and agreement gates; do not hide required coupling behind a facade. |
-| Native command orchestration is concentrated in `fslc/src/main.rs`. | Responsibility inventory and the reproducible `295508e9^..dc0f3fb` non-merge history range. | Medium consequence and recurrence, medium uncertainty. | Record small in-crate extractions as C2 candidates requiring separate authorization and scenario evidence; line count does not authorize a crate split. |
+| Native command orchestration is concentrated in `fslc/src/main.rs`. | Responsibility inventory and the reproducible `295508e9^..dc0f3fb` non-merge history range. | Medium consequence and recurrence, medium uncertainty. | Record small in-crate extractions as C2 candidates requiring separate authorization and scenario evidence; line count does not authorize a crate split. The one executed extraction has since been measured, and the policy-site discriminator in section 8 now governs how this pressure is read. |
 | Browser backend behavior is opaque to Rust-only analysis. | JavaScript global bridge and absence of standalone Rust backend tests. | High consequence, medium recurrence. | Keep browser parity/cancellation as a required separate gate. |
 | Architecture authority text drifted after migration. | Migration-era Python statements contradicted the native integration contract. | Medium consequence, observed recurrence. | Consolidate this record and correct stale authority wording. |
 | Production-log replay lacks comprehensive coverage in the required Rust gate. | The native implementation is direct, while focused and broader cases are Python-driven tests excluded from the product gate. | High consequence, unknown recurrence. | Treat coverage as unknown; add Rust-native regression cases before changing mapped-log semantics. |
@@ -365,13 +371,138 @@ rejecting oracle, pre-PR audit, and independently revertible pull request.
   a new crate would add a version/dependency boundary without current consumer need.
 - Falsifier: replayed changes touch the same responsibilities after extraction or require broader
   fixtures than before.
-- Gate result: not tested. The hotspot evidence cannot distinguish legitimate composition cohesion
-  from harmful coupling, so implementation is not justified now.
+- Gate result: not tested at the original baseline. The hotspot evidence cannot distinguish
+  legitimate composition cohesion from harmful coupling, so implementation was not justified then.
+  One family extraction has since been executed and measured; the post-extraction evidence below
+  extends this analysis and confirms the falsifier.
+
+#### Post-extraction measurement (issue #738 spike)
+
+The falsifier above has now been tested once. The issue #738 spike measured the first executed
+family extraction — issue #393, landed by PR #440 as commit `6684dfb` "refactor(cli): extract
+causal command family" (2026-07-23) — against `origin/main` at
+`d72ac8d0f717b16914790fe270566a8a1c407803`. Issue #738 labels its options C0 keep / C1 in-crate
+family extraction / C2 new crate; both of its extraction options map into this candidate, whose
+first phase is the in-crate module and whose second is the crate.
+
+- The extraction moved the causal family into `rust/fslc/src/causal.rs` (+1468 lines) out of
+  `main.rs` (−1462) in a single revertible commit (6 files, +1567/−1466). (E2)
+- In the 13 days between the extraction and the spike baseline, causal-family-specific semantic
+  changes numbered zero, and `git log` on `rust/fslc/src/causal.rs` shows no mis-wiring fix
+  attributable to the extraction either. The only two non-extraction commits touching `causal.rs`
+  both also touched `main.rs`: `9fe427b` (`causal.rs` +10/−0, `main.rs` +81/−6) defines guard
+  helpers in `main.rs` that `causal.rs` calls back through `crate::`, and `cc1c318` (`causal.rs`
+  +2/−2, `main.rs` +46/−10). Before the extraction, the `9fe427b` change would have had one owner
+  instead of two — that counterfactual is inference, the two-owner edit is measured. This is the
+  falsifier stated above, observed. (E-10)
+- **New crate: rejected on measurement.** The independent version/dependency/consumer lifecycle
+  this candidate requires before a crate does not exist: one workspace version, no external
+  consumer, and `causal.rs` is a bin-only module (`mod causal;` in `main.rs`, absent from
+  `rust/fslc/src/lib.rs`) with no `fsl-wasm` or `fsl-lsp` consumer.
+- **Further family extraction: no-go.** The one executed instance produced zero confirming samples
+  and two counter-shaped ones in 13 days, and every measured harmful chain (Cases A–C below) is
+  cross-family policy duplication that a vertical family split cannot remove. The largest remaining
+  `run_*` families in `main.rs` at the spike baseline — domain 504 lines, document 425, mutate 403,
+  diff 397, approval 355, ai 324 — are all an order of magnitude below causal's pre-extraction
+  1,462 lines, and naming `domain` as the next candidate would be unsupported because Case B shows
+  its repeat-fix chain is policy duplication, not verticality.
+- **The response that measurably worked is policy single-owner extraction**, which the repository
+  is already executing: `rust/fslc/src/spec_load.rs` (`2fd555f`), `rust/fslc/src/outcome.rs`
+  (`fd5b8c6`, #537 C2 / #603), and `rust/fslc/src/literate_access.rs` (`95acd70`, #665), all
+  crate-public in `rust/fslc/src/lib.rs`, in contrast to the bin-only family module. After
+  spec-load classification received one owner, `main.rs` involvement across the follow-up series
+  `743bc7a` → `fedba3f` → `558e113` fell 379 → 179 → 16 changed lines while the total change kept
+  growing (763 lines across 7 files → 541 across 16 → 319 across 21). n=3: the direction is
+  measured, the generalization is inference. (E-13)
+- The 13-day observation window is short. The correct reading of the extraction's effect is
+  unconfirmed, not disproven; but the rollback rule below applied to that window yields no
+  confirmation, which is what makes a further extraction unjustified now. Review latency, rebase
+  count, and conflict-resolution time were not measured; they belong to issue #735.
+
+#### Policy-site discriminator for orchestration coupling
+
+The durable rule the spike leaves behind, for the next time `main.rs` size or touch rate is
+offered as evidence:
+
+> A contract rule implemented at more than one site is harmful coupling. A command arm that only
+> calls into a single library owner is legitimate composition cohesion.
+
+Harmful coupling is observable as any of: (1) one policy's fix splitting across two or more
+commits in different command arms; (2) one policy change forcing simultaneous edits to many arms;
+(3) a fix landing on only some of several copies; (4) a cross-cutting guard inserted into both
+`main.rs` and an extracted module. Three measured chains ground the rule, each caused by one
+contract policy implemented at more than one site, none by family verticality (E-12):
+
+- **Case A — exit-code class.** Five commands independently fixed the same fail-closed/exit-code
+  defect: `1bc5cf2` (mutate), `fbcb62d` (ledger, #599), `6933c7b` (ledger), `addc45f` (chain),
+  `169fc20` (ai). The terminal commit `fd5b8c6` states the cause: "the crate has 43 distinct
+  `result` values with no such definition".
+- **Case B — nested kernel projection.** `707523c` (#515) → `ed28f9a` (#641) → `db9a51a` (#619) →
+  `693bddb` (#663). `run_db_check` and `run_domain_check` each held a hand-copied projection key
+  list; `693bddb`'s message records that the #515 and #641 fixes "landed on the domain copy alone
+  because there was nowhere else to land them".
+- **Case C — spec-load error plumbing.** `743bc7a`: `load_kernel_model`'s String flattening
+  misclassified spec-load errors in 12 commands at once.
+
+Negative control that the rule discriminates rather than matching everything: `64bfb55`
+(scenarios) has its root cause in `rust/fsl-runtime/src/lib.rs`; its `main.rs` portion is that one
+command's own projection, and no repeat fix appeared in another arm. Domain-caused, not
+coupling-caused.
+
+Why the hotspot metrics cannot substitute for the rule: at the spike baseline `main.rs` is 16,052
+lines of the workspace's 167,241 Rust lines (`wc -l`, excluding `target/`), and its commit-touch
+rate is not decaying — 124 of 251 non-merge rust-touching commits since 2026-06-11 (49.4%), 53 of
+112 (47.3%) in the spike's final two weeks. Yet the per-commit churn distribution on the 49
+post-extraction commits touching `main.rs` is min 3 / median 30 / p90 202 / max 385 lines, and 25
+of 49 change 30 lines or fewer — wiring scale (E-11). A file can appear in half of all commits and
+still mostly receive legitimate composition wiring, so touch rate and line count cannot separate
+cohesion from coupling and neither authorizes an extraction. The 30-line wiring scale is the
+observed median, not a semantically derived threshold.
+
+#### Controls and rollback rule for a future extraction slice
+
+A future extraction pull request (this candidate's in-crate first phase) starts from these
+controls instead of re-deriving them. Each control must be calibrated — demonstrated to fail on
+the pre-extraction tree — because a green positive path alone is not evidence of detection power.
+
+1. **CLI JSON envelope.** Accepting: `rust/fslc/cli-contract.json` verified by
+   `rust/fslc/tests/native_integration.rs`, plus the family's existing CLI suite unmodified and
+   green. Rejecting: a tamper fixture that drops one key from the moved command's envelope golden
+   must fail. String assertions of the `rust/fslc/tests/causal_ownership.rs` kind cannot detect
+   envelope drift.
+2. **Exit codes.** Accepting: classification goes through `rust/fslc/src/outcome.rs`, including
+   its rule that unknown values classify as failure (`fd5b8c6`). Rejecting: a known fail-closed
+   fixture fed to the moved command must fail the test if exit 0 comes back — this detects
+   re-introduction of arm-local exit derivation, Case A's recurrence shape.
+3. **Diagnostics.** Accepting: the closed diagnostic classification in `DESIGN-v1.md` section 7.2
+   (`parse`/`name`/`type`/`semantics` carry `loc`). Rejecting: a syntax-error spec through the
+   moved command must fail unless `kind:"parse"` with a non-null `loc` comes back. This control
+   has caught real drift: `743bc7a` records the 12-command misclassification it would have
+   blocked.
+4. **Worker/LSP projection.** Accepting: the native/browser parity harness plus CLI/LSP diagnostic
+   identity. Rejecting: assert that the `unsupportedDocuments` registry in
+   `rust/fsl-wasm/test-browser.mjs` does not grow, closing the escape hatch of greening a broken
+   Worker projection by adding an exclusion; for a bin-only family, assert instead that its
+   reviewed-unsupported registration stays accurate.
+
+The rollback condition is measured, not judged. Define the changed-owner count of a change as the
+number of distinct owners — in-crate module files plus other crates — touched by its
+production-code diff, excluding `CHANGELOG.md`, documentation, and tests. After an extraction
+merges, measure the next three family-scoped changes and revert the extraction commit unless both
+hold: the median changed-owner count is below the pre-extraction family baseline, and at most one
+of the three touches `main.rs`, that one by ten or fewer wiring lines. Roll back immediately if
+any change inserts the same policy into both `main.rs` and the family module (the `9fe427b`
+shape). If six weeks pass without three family-scoped changes, record the effect as unconfirmed
+and treat further extraction as no-go — the causal extraction hit exactly this outcome, with zero
+family-scoped samples in 13 days.
 
 C1 does not robustly dominate C0 on change cost, but C0 fails the requested outcome. C2 has only a
 speculative maintainability benefit and higher verification/migration cost. Under a delivery-speed,
 correctness-risk, or flat-roadmap weighting, C1 remains the least-regret reversible choice. A future
-independent command team or repeated cross-command regression could make C2 preferable.
+independent command team or repeated cross-command regression could make C2 preferable. The
+cross-command regressions that did occur (Cases A–C above) were adjudicated in the issue #738 spike
+as policy duplication, answered by single-owner policy modules inside `fslc-rust` rather than by a
+C2 structural extraction.
 
 ## 9. Migration slice and fitness functions
 
@@ -402,7 +533,8 @@ adjudication still share one primary model and are not statistically independent
 
 Re-evaluate before the twelve-month horizon if:
 
-- three unrelated command changes fail because of `fslc` orchestration coupling;
+- three unrelated command changes fail because of `fslc` orchestration coupling
+  (fired and adjudicated; see below);
 - `fsl-tools` gains an independently versioned external consumer or incompatible dependency;
 - a production incident or SLO identifies a failure-isolation boundary absent from the crate graph;
 - LSP or Worker cannot reuse a shared diagnostic/result without importing inappropriate native
@@ -412,7 +544,18 @@ Re-evaluate before the twelve-month horizon if:
 - a normal-maintenance holdout shows materially different co-change behavior from the migration
   period.
 
+The first trigger has fired and been adjudicated (issue #738 spike). Case A in section 8 supplies
+five, not three, unrelated command changes that failed on the same `fslc` orchestration coupling.
+The adjudicated response is policy single-owner extraction inside `fslc-rust` — already executed
+as `spec_load.rs`, `outcome.rs`, and `literate_access.rs` — not the C2 structural extraction,
+because every measured failure chain was one contract policy implemented at more than one site,
+which a vertical family split cannot remove. C1 remains selected. This trigger is answered, not
+pending; it fires again only on a new coupling chain whose policy already has a single owner.
+
 The recommendation is falsified if a locally extracted command family demonstrably reduces the
 semantic responsibilities, contracts, and test environments touched by representative changes
-without weakening any hard gate. Until then, documentation and executable boundary checks have
-greater option value than a structural migration.
+without weakening any hard gate. That test has now been run once: the extracted causal family
+produced zero confirming samples and two counter-shaped ones in 13 days (section 8), so the
+recommendation stands on measured rather than merely untested ground. Documentation, executable
+boundary checks, and single-owner policy modules retain greater option value than a structural
+migration.

--- a/docs/DESIGN-rust-components.md
+++ b/docs/DESIGN-rust-components.md
@@ -74,6 +74,7 @@ inference), and E0 (assumption).
 | E-11 | E3 | At the `d72ac8d` spike baseline, `main.rs` commit-touch rate stays near half while per-commit churn on the 50 post-extraction `main.rs` commits (`6684dfb..d72ac8d`) is min 3 / median 29 / p90 202 / max 385 lines, with 26 of 50 at 30 lines or fewer. | Shows touch rate and line count cannot separate composition cohesion from harmful coupling. |
 | E-12 | E2 | Three repeat-fix chains (exit-code class, nested kernel projection, spec-load error plumbing) each trace to one contract policy implemented at more than one site; commit messages `fd5b8c6` and `693bddb` state the cause directly. | Identifies the harmful-coupling mechanism and grounds the policy-site discriminator in section 8. |
 | E-13 | E1 | `743bc7a` made `main.rs` the single owner of spec-load classification (typed `SpecLoadError`); across its follow-up series `743bc7a` → `fedba3f` → `558e113`, `main.rs` involvement fell 379 → 179 → 16 changed lines while total change size grew, and `2fd555f` later moved the owner into `rust/fslc/src/spec_load.rs` mid-series (n=3; the direction is measured, the generalization is inference). | Supports policy single-owner extraction as the adjudicated response to orchestration coupling. |
+| E-14 | E3 | `c455e50` (#697) changes the concrete probe's budget policy, which is defined once (`rust/fsl-runtime/src/lib.rs`'s `CONCRETE_PROBE_BUDGET`, governing the single `find_boundary_violation`) and referenced from four call sites across `fsl-wasm` and `fslc` with no reimplementation anywhere in `rust/`; its `main.rs` change is 11 lines of wiring, and the only later commit touching the budget (`74d7f3e`) adds a control rather than fixing a second arm. | The negative control the policy-site discriminator must reject: many call sites, one implementation site, read as cohesion. Establishes that the discriminator separates rather than matching everything. |
 
 Scoped contract classifications are:
 
@@ -453,44 +454,64 @@ first phase is the in-crate module and whose second is the crate.
 
 #### Policy-site discriminator for orchestration coupling
 
-What the spike leaves behind for the next time `main.rs` size or touch rate is offered as evidence,
-**and what it does not**. The positive observation is well grounded; the discriminator is not
-established, and this section says so rather than claiming a rule it cannot back.
+The rule the spike leaves behind, for the next time `main.rs` size or touch rate is offered as
+evidence. It is an adjudicated working rule graded by its evidence — three measured chains and one
+negative control that the rule rejects — not a definition:
 
-**Observed, in three measured chains (E-12):** each was caused by one contract policy implemented
-at more than one site, none by family verticality. Harmful coupling showed up as any of: (1) one
-policy's fix splitting across two or more commits in different command arms; (2) one policy change
-forcing simultaneous edits to many arms; (3) a fix landing on only some of several copies; (4) a
-cross-cutting guard inserted into both `main.rs` and an extracted module.
+> Harmful coupling is one contract policy **implemented** at more than one site. A command arm that
+> only calls into a single library owner of that policy is legitimate composition cohesion, however
+> many arms call it.
 
-**Not established: a test that separates this from legitimate composition cohesion.** Two
-formulations were tried and both fail, so neither is adopted here:
+**"Site" means implementation site, not call site.** That distinction is the whole rule, and getting
+it wrong is what made two earlier formulations fail. Counting call sites makes every centralized
+policy look coupled, because centralizing is exactly what produces many callers. Counting only
+recurrence — "a fix split across two or more commits in different arms" — misses a policy whose arms
+were mismatched from birth and never partially fixed, does not capture Case C at all, and returns
+both verdicts on a history where a duplicated policy was later centralized. Recurrence is a
+*symptom* of multi-site implementation, useful for reading a chain retrospectively; the site count is
+the property.
 
-- *Site count* — "one contract policy implemented at more than one site is harmful coupling." This
-  matches the three chains, but it also matches `64bfb55` below, which the same analysis wants to
-  classify as domain-caused. As a discriminator it accepts everything.
-- *Recurrence signature* — "harmful when a policy's fix splits across two or more commits in
-  different arms, or lands on only some copies." This excludes `64bfb55`, but it fails three ways.
-  It does not capture Case C, which is part of its own grounding: `743bc7a` fixed 12 commands in
-  one commit with no preceding partial fix, so the recurrence signature never appeared there
-  either. It cannot classify a policy whose arms were mismatched from birth and never partially
-  fixed — which is precisely `64bfb55`'s deadlock defect. And on the coverage-diagnostic history it
-  returns *both* verdicts: the fix split across `bf48338d` → `41dcfe12` → `64bfb55` while
-  `run_scenarios_mode`'s copy emitted the opposite diagnostic throughout (harmful by the first
-  clause), yet the repaired arm now only calls `verification_output::coverage_hint` (cohesion by
-  the second).
+Harmful coupling is observable as any of: (1) one policy's fix splitting across two or more commits
+in different command arms; (2) one policy change forcing simultaneous edits to many arms; (3) a fix
+landing on only some of several copies; (4) a cross-cutting guard inserted into both `main.rs` and an
+extracted module. Each is a consequence of the policy having more than one implementation site.
 
-So the recurrence signature is at best a **retrospective** marker: useful for reading a chain that
-has already recurred, not for authorizing or refusing an extraction in advance. Treat it that way.
+**Negative control: `c455e50` (issue #697), which this rule rejects.** It is in the population the
+rule is about — it touches `main.rs`, spans three crates, and changes behaviour on the concrete
+verification path — so a breadth-based reading would flag it. The rule does not, and the reason is
+checkable:
 
-A valid negative control would have to be a change that touches `main.rs` for genuinely
-single-owner reasons — a policy with one implementation site, wired into one arm, with the defect
-in a library — and be shown to be *rejected* by whatever rule is proposed. The spike did not find
-one, and `64bfb55` is not it. Until such a control exists, the classification of any individual
-change here is judgement, not measurement, and issue #738's third acceptance criterion
-("distinguish composition cohesion from harmful change coupling") is **not met**. This is recorded
-rather than resolved: issue #748 tracks establishing a discriminator, or recording that this axis
-cannot discriminate and that structural decisions must rest on other evidence.
+- The policy is the concrete probe's budget. It is **defined once**, at
+  `rust/fsl-runtime/src/lib.rs`'s `pub const CONCRETE_PROBE_BUDGET`, and the function it governs,
+  `find_boundary_violation`, likewise has exactly one implementation.
+- It has **four call sites** across three crates — `rust/fsl-wasm/src/lib.rs`, two in
+  `rust/fslc/src/main.rs`, and `rust/fslc/src/verification.rs` — and every one of them *references*
+  `fsl_runtime::CONCRETE_PROBE_BUDGET`. None reimplements it: the budget value appears nowhere else
+  in `rust/` outside a test comment.
+- The `main.rs` change is 11 lines of wiring: pass `&model` instead of `model.clone()`, pass the
+  budget, and destructure the new `BoundaryProbe` instead of an `Option` tuple. No policy logic.
+- No recurrence: after `c455e50` the only commit touching the budget is `74d7f3e`, which adds an
+  executable corpus-headroom control. No fix landed on a second arm, because there is no second
+  implementation to land on.
+
+So four arms call one owner and the rule reads cohesion — while Cases A, B and C each had the policy
+implemented per-arm and the rule reads coupling. That is the discrimination, and it is why issue
+#738's third acceptance criterion is met.
+
+**Why `64bfb55` is not the control.** An earlier version of this section offered it. It cannot serve:
+of the three defects it fixes, one is a verdict-promotion policy implemented in **two** arms —
+`run_scenarios_mode`'s early-return guard did not consult `deadlock_step`, so
+`scenarios --deadlock error` returned exit 0 where `verify --deadlock error` reported
+`violated`/`deadlock`/exit 1 — and another was fixed by making
+`verification_output::coverage_hint` `pub` and calling it, which is the single-owner move itself. By
+this rule `64bfb55` contains coupling, and that is the rule working, not failing. Its remaining
+defect, scenario semantics in `rust/fsl-runtime/src/lib.rs` (+43/−4), is genuinely domain-caused, but
+a commit that also fixes two multi-site policies cannot be a control for a rule about multi-site
+policies. Two claims from that version are withdrawn with it: the pickaxe
+`git log -S deadlock_step -- rust/fslc/src/main.rs` is scoped to one file and to a symbol the broken
+copy never contained, so it cannot detect a split by construction (widened to `rust/fslc/src/` it
+returns `41dcfe12` as well); and the assertion that the commit deleted a duplicated hint string is
+false — `git show 64bfb55^:rust/fslc/src/main.rs` contains no `coverage_hint` occurrence.
 
 The three chains that ground the positive observation (E-12):
 

--- a/docs/DESIGN-rust-components.md
+++ b/docs/DESIGN-rust-components.md
@@ -70,10 +70,10 @@ inference), and E0 (assumption).
 | E-07 | E1 | From `295508e9^` through the baseline, 35 of 104 non-merge commits touch `rust/fslc/src/main.rs`; the file is also substantially larger than other entry modules. | Identifies an orchestration hotspot, not by itself a faulty crate boundary. |
 | E-08 | E0 | Future team ownership, production scale, incident isolation, and roadmap likelihood. | Prevents service/organization-level restructuring claims. |
 | E-09 | E3 | `./tools/check-native-integration.sh rust` passed with locked formatting, Clippy, LSP, workspace tests, build, and dependency checks. | Confirms the documented Rust boundaries are reproducible at the baseline revision. |
-| E-10 | E3 | Extraction commit `6684dfb` (issue #393, PR #440) moved the causal family into `rust/fslc/src/causal.rs` in one revertible commit; in the following 13 days it produced zero family-scoped semantic changes, and the only two commits touching `causal.rs` both also touched `main.rs`. | Tests C2's falsifier once; the falsifier was observed. Recorded in section 8. |
-| E-11 | E3 | At the `d72ac8d` spike baseline, `main.rs` commit-touch rate stays near half while per-commit churn on the 49 post-extraction `main.rs` commits is min 3 / median 30 / p90 202 / max 385 lines, with 25 of 49 at 30 lines or fewer. | Shows touch rate and line count cannot separate composition cohesion from harmful coupling. |
+| E-10 | E3 | Extraction commit `6684dfb` (issue #393, PR #440) moved the causal family into `rust/fslc/src/causal.rs` in one revertible commit; in the following 13 days it produced zero family-scoped semantic changes, and the only two commits touching `causal.rs` — both workspace-wide refine changes, neither family-scoped — also touched `main.rs`. | Tests C2's falsifier once: its shape appeared, but on a population of two non-representative changes, so the effect is unconfirmed, not disproven. Recorded in section 8. |
+| E-11 | E3 | At the `d72ac8d` spike baseline, `main.rs` commit-touch rate stays near half while per-commit churn on the 50 post-extraction `main.rs` commits (`6684dfb..d72ac8d`) is min 3 / median 29 / p90 202 / max 385 lines, with 26 of 50 at 30 lines or fewer. | Shows touch rate and line count cannot separate composition cohesion from harmful coupling. |
 | E-12 | E2 | Three repeat-fix chains (exit-code class, nested kernel projection, spec-load error plumbing) each trace to one contract policy implemented at more than one site; commit messages `fd5b8c6` and `693bddb` state the cause directly. | Identifies the harmful-coupling mechanism and grounds the policy-site discriminator in section 8. |
-| E-13 | E1 | After spec-load classification received a single owner, `main.rs` involvement across the follow-up series `743bc7a` → `fedba3f` → `558e113` fell 379 → 179 → 16 changed lines while total change size grew (n=3; the direction is measured, the generalization is inference). | Supports policy single-owner extraction as the adjudicated response to orchestration coupling. |
+| E-13 | E1 | `743bc7a` made `main.rs` the single owner of spec-load classification (typed `SpecLoadError`); across its follow-up series `743bc7a` → `fedba3f` → `558e113`, `main.rs` involvement fell 379 → 179 → 16 changed lines while total change size grew, and `2fd555f` later moved the owner into `rust/fslc/src/spec_load.rs` mid-series (n=3; the direction is measured, the generalization is inference). | Supports policy single-owner extraction as the adjudicated response to orchestration coupling. |
 
 Scoped contract classifications are:
 
@@ -374,7 +374,9 @@ rejecting oracle, pre-PR audit, and independently revertible pull request.
 - Gate result: not tested at the original baseline. The hotspot evidence cannot distinguish
   legitimate composition cohesion from harmful coupling, so implementation was not justified then.
   One family extraction has since been executed and measured; the post-extraction evidence below
-  extends this analysis and confirms the falsifier.
+  extends this analysis, and the falsifier's shape appeared in both commits that touched the
+  extracted module — neither of them a family-scoped change, so the result reads as unconfirmed,
+  not disproven.
 
 #### Post-extraction measurement (issue #738 spike)
 
@@ -385,79 +387,132 @@ causal command family" (2026-07-23) — against `origin/main` at
 family extraction / C2 new crate; both of its extraction options map into this candidate, whose
 first phase is the in-crate module and whose second is the crate.
 
-- The extraction moved the causal family into `rust/fslc/src/causal.rs` (+1468 lines) out of
-  `main.rs` (−1462) in a single revertible commit (6 files, +1567/−1466). (E2)
+- The extraction moved the causal family — 1,452 contiguous lines and 13 functions, per the
+  accepted record in `docs/DESIGN-rust-component-internals.md` — into the new 1,468-line
+  `rust/fslc/src/causal.rs`, in a single revertible commit (6 files, +1567/−1466). Its `main.rs`
+  churn was +4/−1458 (`git show --numstat`), taking the file from 15,709 to 14,255 lines, a net
+  reduction of 1,454. (E-10)
 - In the 13 days between the extraction and the spike baseline, causal-family-specific semantic
   changes numbered zero, and `git log` on `rust/fslc/src/causal.rs` shows no mis-wiring fix
   attributable to the extraction either. The only two non-extraction commits touching `causal.rs`
   both also touched `main.rs`: `9fe427b` (`causal.rs` +10/−0, `main.rs` +81/−6) defines guard
   helpers in `main.rs` that `causal.rs` calls back through `crate::`, and `cc1c318` (`causal.rs`
   +2/−2, `main.rs` +46/−10). Before the extraction, the `9fe427b` change would have had one owner
-  instead of two — that counterfactual is inference, the two-owner edit is measured. This is the
-  falsifier stated above, observed. (E-10)
+  instead of two — that counterfactual is inference, the two-owner edit is measured. Both commits
+  are workspace-wide refine/enum-conversion changes (40 and 22 files respectively), not
+  representative family-scoped changes, so this is the falsifier's shape on a population of two
+  with no family-scoped sample: counter-shaped evidence, not a confirmed falsification. (E-10)
+- Issue #738's first acceptance criterion compares changed files, import breadth, fixtures, and
+  review surface around the extraction. Changed files and fixtures: the commit's
+  non-documentation surface is the two source files plus the family's own tests
+  (`rust/fslc/tests/causal_cli.rs` +47/−5, `rust/fslc/tests/causal_ownership.rs` +27/−0); no
+  shared fixture changed. Import breadth is the one axis the extraction clearly improved, worth
+  stating even under a no-go verdict: the family's coupling is now explicit and countable.
+  `main.rs` needs two symbols from the family (`mod causal;`,
+  `use causal::{causal_command, run_causal_check}`), while `causal.rs` reaches back into the
+  composition root with 12 reverse-direction symbols — ten through `use super::{…}` plus two
+  through `crate::`, the two added by `9fe427b` — and `main.rs` carries 14 top-level `use` lines
+  against `causal.rs`'s 4 (`grep -c '^use '`). The reverse-direction growth from ten symbols to
+  twelve is the same falsifier-shaped signal the rollback rule below watches. Review surface,
+  review latency, rebase count, and conflict-resolution time were not measured; that axis is
+  delegated to issue #735.
 - **New crate: rejected on measurement.** The independent version/dependency/consumer lifecycle
   this candidate requires before a crate does not exist: one workspace version, no external
   consumer, and `causal.rs` is a bin-only module (`mod causal;` in `main.rs`, absent from
   `rust/fslc/src/lib.rs`) with no `fsl-wasm` or `fsl-lsp` consumer.
 - **Further family extraction: no-go.** The one executed instance produced zero confirming samples
   and two counter-shaped ones in 13 days, and every measured harmful chain (Cases A–C below) is
-  cross-family policy duplication that a vertical family split cannot remove. The largest remaining
-  `run_*` families in `main.rs` at the spike baseline — domain 504 lines, document 425, mutate 403,
-  diff 397, approval 355, ai 324 — are all an order of magnitude below causal's pre-extraction
-  1,462 lines, and naming `domain` as the next candidate would be unsupported because Case B shows
-  its repeat-fix chain is policy duplication, not verticality.
+  cross-family policy duplication that a vertical family split cannot remove. The nine largest
+  remaining `run_*` families in `main.rs` at the spike baseline — domain 504 lines, document 425,
+  mutate 403, diff 397, approval 355, project 353, refine 351, analyze 328, ai 324 — are all well
+  below the causal family's pre-extraction 1,452 contiguous lines (`domain`, the largest, is
+  roughly a third of it), and naming `domain` as the next candidate would be unsupported because
+  Case B shows its repeat-fix chain is policy duplication, not verticality.
 - **The response that measurably worked is policy single-owner extraction**, which the repository
   is already executing: `rust/fslc/src/spec_load.rs` (`2fd555f`), `rust/fslc/src/outcome.rs`
   (`fd5b8c6`, #537 C2 / #603), and `rust/fslc/src/literate_access.rs` (`95acd70`, #665), all
-  crate-public in `rust/fslc/src/lib.rs`, in contrast to the bin-only family module. After
-  spec-load classification received one owner, `main.rs` involvement across the follow-up series
-  `743bc7a` → `fedba3f` → `558e113` fell 379 → 179 → 16 changed lines while the total change kept
-  growing (763 lines across 7 files → 541 across 16 → 319 across 21). n=3: the direction is
-  measured, the generalization is inference. (E-13)
+  crate-public in `rust/fslc/src/lib.rs`, in contrast to the bin-only family module. For
+  spec-load, the single owner arrived in two steps: `743bc7a` itself introduced the typed
+  `SpecLoadError` and `spec_load_error_output` with `main.rs` as the one owner, and `2fd555f`
+  later moved that owner into `rust/fslc/src/spec_load.rs`. Across the classification series that
+  starts with the owner-creating commit — `743bc7a` → `fedba3f` → `558e113` — `main.rs`
+  involvement fell 379 → 179 → 16 changed lines while the total change kept growing (763 lines
+  across 7 files → 541 across 16 → 319 across 21); the module move `2fd555f` (`main.rs` churn
+  125, dominated by the −121 relocation) sits between `fedba3f` and `558e113` and is not a point
+  in the series, because it relocates the owner rather than changing classification. n=3: the
+  direction is measured, the generalization is inference. (E-13) The single-owner move has now
+  recurred at least six times on this surface (`spec_load.rs`, `outcome.rs`, `literate_access.rs`,
+  `outcome::is_definitive_kernel_verdict`, `outcome::project_kernel`,
+  `verification_output::coverage_hint`); the recurrence measures how much contract policy still
+  lacked an owner, and `693bddb` records that `rust/fsl-tools/src/ai.rs`'s `kernel_projection`
+  remains a third copy that cannot call the single owner because the dependency direction is
+  `fslc-rust -> fsl-tools`; unifying it is tracked as issue #687.
 - The 13-day observation window is short. The correct reading of the extraction's effect is
   unconfirmed, not disproven; but the rollback rule below applied to that window yields no
-  confirmation, which is what makes a further extraction unjustified now. Review latency, rebase
-  count, and conflict-resolution time were not measured; they belong to issue #735.
+  confirmation, which is what makes a further extraction unjustified now.
 
 #### Policy-site discriminator for orchestration coupling
 
-The durable rule the spike leaves behind, for the next time `main.rs` size or touch rate is
-offered as evidence:
+The rule the spike leaves behind, for the next time `main.rs` size or touch rate is offered as
+evidence. It is an adjudicated working rule graded by its evidence — three measured chains and
+one calibrated negative control (E-12) — not a definition:
 
-> A contract rule implemented at more than one site is harmful coupling. A command arm that only
-> calls into a single library owner is legitimate composition cohesion.
+> Harmful coupling is observable when one contract policy's fix splits across two or more commits
+> in different command arms, or lands on only some of several copies while the others stay wrong.
+> A command arm that only calls into a single library owner is legitimate composition cohesion.
 
-Harmful coupling is observable as any of: (1) one policy's fix splitting across two or more
-commits in different command arms; (2) one policy change forcing simultaneous edits to many arms;
-(3) a fix landing on only some of several copies; (4) a cross-cutting guard inserted into both
-`main.rs` and an extracted module. Three measured chains ground the rule, each caused by one
-contract policy implemented at more than one site, none by family verticality (E-12):
+The underlying mechanism is one contract policy implemented at more than one site, but the site
+count alone cannot be the test, because a policy can sit at two sites and still be fixed once
+(`64bfb55` below). Harmful coupling is observable as any of: (1) one policy's fix splitting
+across two or more commits in different command arms; (2) one policy change forcing simultaneous
+edits to many arms; (3) a fix landing on only some of several copies; (4) a cross-cutting guard
+inserted into both `main.rs` and an extracted module. Three measured chains ground the rule, each
+caused by one contract policy implemented at more than one site, none by family verticality
+(E-12):
 
 - **Case A — exit-code class.** Five commands independently fixed the same fail-closed/exit-code
   defect: `1bc5cf2` (mutate), `fbcb62d` (ledger, #599), `6933c7b` (ledger), `addc45f` (chain),
   `169fc20` (ai). The terminal commit `fd5b8c6` states the cause: "the crate has 43 distinct
   `result` values with no such definition".
-- **Case B — nested kernel projection.** `707523c` (#515) → `ed28f9a` (#641) → `db9a51a` (#619) →
-  `693bddb` (#663). `run_db_check` and `run_domain_check` each held a hand-copied projection key
-  list; `693bddb`'s message records that the #515 and #641 fixes "landed on the domain copy alone
-  because there was nowhere else to land them".
+- **Case B — kernel-verdict fold rule, then nested kernel projection.** Two adjacent policies
+  duplicated across the same two arms, `run_db_check` and `run_domain_check`, in commit order
+  `707523c` (#515) → `db9a51a` (#612/#619) → `ed28f9a` (#641) → `693bddb` (#663). Fold rule:
+  `707523c` fixed the domain copy while `run_db_check`'s copy stayed wrong (it tested only
+  `== 2`), and `db9a51a` then gave the rule one owner, `outcome::is_definitive_kernel_verdict`.
+  Projection key list: `ed28f9a` again landed on the domain copy alone, and `693bddb` gave the
+  projection a single owner (`outcome::project_kernel`); its message records that the #515 and
+  #641 fixes "landed on the domain copy alone because there was nowhere else to land them". The
+  order matters: the fold rule already had its single owner two days before `ed28f9a`, and that
+  protected only the fold rule — single-owner-ising one policy does not protect an adjacent
+  policy duplicated in the same two functions.
 - **Case C — spec-load error plumbing.** `743bc7a`: `load_kernel_model`'s String flattening
   misclassified spec-load errors in 12 commands at once.
 
 Negative control that the rule discriminates rather than matching everything: `64bfb55`
-(scenarios) has its root cause in `rust/fsl-runtime/src/lib.rs`; its `main.rs` portion is that one
-command's own projection, and no repeat fix appeared in another arm. Domain-caused, not
-coupling-caused.
+(scenarios) fixed three defects at once, and one of them was a contract policy sitting at two
+sites — `run_scenarios_mode`'s early-return guard did not consult `deadlock_step`, so
+`scenarios --deadlock error` returned exit 0 where `verify --deadlock error` reported
+`violated`/`deadlock`/exit 1 for the same spec. A bare site-count rule would therefore match this
+commit and fail as a control. The operational rule excludes it correctly: all three defects were
+fixed in one commit, and no fix split across commits or landed on only some copies —
+`deadlock_step` appears in `main.rs` history only in `64bfb55` — while the commit even performed
+the single-owner move itself, making `verification_output::coverage_hint` `pub` and deleting a
+duplicated hint string. Its remaining root cause is scenario semantics in
+`rust/fsl-runtime/src/lib.rs` (+43/−4): domain-caused, fixed once, no recurrence signature.
 
 Why the hotspot metrics cannot substitute for the rule: at the spike baseline `main.rs` is 16,052
 lines of the workspace's 167,241 Rust lines (`wc -l`, excluding `target/`), and its commit-touch
-rate is not decaying — 124 of 251 non-merge rust-touching commits since 2026-06-11 (49.4%), 53 of
-112 (47.3%) in the spike's final two weeks. Yet the per-commit churn distribution on the 49
-post-extraction commits touching `main.rs` is min 3 / median 30 / p90 202 / max 385 lines, and 25
-of 49 change 30 lines or fewer — wiring scale (E-11). A file can appear in half of all commits and
-still mostly receive legitimate composition wiring, so touch rate and line count cannot separate
-cohesion from coupling and neither authorizes an extraction. The 30-line wiring scale is the
-observed median, not a semantically derived threshold.
+rate stays near half — 125 of 257 non-merge commits since `2026-06-11T00:00:00+09:00` under the
+pathspec `'rust/**/*.rs'` (48.6%), and 50 of 113 in the post-extraction range `6684dfb..d72ac8d`
+(44.2%). The pathspec and the explicit timestamp are part of the measurement: a broader pathspec
+such as `rust/` changes the denominator, and a bare `--since=2026-06-11` inherits the invoking
+clock's time of day. Yet the per-commit churn distribution on those 50 post-extraction `main.rs`
+commits is min 3 / median 29 / p90 202 / max 385 lines (added plus deleted per
+`git show --numstat`), and 26 of 50 change 30 lines or fewer — wiring scale (E-11). A file can
+appear in half of all commits and still mostly receive legitimate composition wiring, so touch
+rate and line count cannot separate cohesion from coupling and neither authorizes an extraction.
+The 30-lines-or-fewer wiring scale is an observed distribution feature (median 29), not a
+semantically derived threshold.
 
 #### Controls and rollback rule for a future extraction slice
 
@@ -475,8 +530,10 @@ the pre-extraction tree — because a green positive path alone is not evidence 
    fixture fed to the moved command must fail the test if exit 0 comes back — this detects
    re-introduction of arm-local exit derivation, Case A's recurrence shape.
 3. **Diagnostics.** Accepting: the closed diagnostic classification in `DESIGN-v1.md` section 7.2
-   (`parse`/`name`/`type`/`semantics` carry `loc`). Rejecting: a syntax-error spec through the
-   moved command must fail unless `kind:"parse"` with a non-null `loc` comes back. This control
+   (`parse`/`name`/`type`/`semantics` carry `loc`, with that section's one stated exception: a
+   `semantics` diagnostic that names no construct in the reported file omits `loc`). Rejecting:
+   a syntax-error spec through the moved command must fail unless `kind:"parse"` with a non-null
+   `loc` comes back. This control
    has caught real drift: `743bc7a` records the 12-command misclassification it would have
    blocked.
 4. **Worker/LSP projection.** Accepting: the native/browser parity harness plus CLI/LSP diagnostic
@@ -550,12 +607,17 @@ The adjudicated response is policy single-owner extraction inside `fslc-rust` �
 as `spec_load.rs`, `outcome.rs`, and `literate_access.rs` — not the C2 structural extraction,
 because every measured failure chain was one contract policy implemented at more than one site,
 which a vertical family split cannot remove. C1 remains selected. This trigger is answered, not
-pending; it fires again only on a new coupling chain whose policy already has a single owner.
+pending; it fires again only on a new coupling chain whose policy already has a single owner. The
+grain of that condition is the individual policy: Case B shows that giving the kernel-verdict
+fold rule one owner (`db9a51a`) did not protect the adjacent projection policy duplicated in the
+same two functions, which still required `ed28f9a` and `693bddb`. Single-owner-ising one policy
+answers the trigger for that policy alone.
 
 The recommendation is falsified if a locally extracted command family demonstrably reduces the
 semantic responsibilities, contracts, and test environments touched by representative changes
-without weakening any hard gate. That test has now been run once: the extracted causal family
-produced zero confirming samples and two counter-shaped ones in 13 days (section 8), so the
-recommendation stands on measured rather than merely untested ground. Documentation, executable
-boundary checks, and single-owner policy modules retain greater option value than a structural
-migration.
+without weakening any hard gate. That test has now been run once: in 13 days the extracted causal
+family produced zero confirming samples and two counter-shaped ones — both workspace-wide refine
+changes, neither a representative family-scoped change — so, as section 8 states, the
+extraction's effect remains unconfirmed, not disproven, and the falsification test is no longer
+untested but its one run is too small to confirm anything. Documentation, executable boundary
+checks, and single-owner policy modules retain greater option value than a structural migration.

--- a/docs/DESIGN-rust-components.md
+++ b/docs/DESIGN-rust-components.md
@@ -453,22 +453,46 @@ first phase is the in-crate module and whose second is the crate.
 
 #### Policy-site discriminator for orchestration coupling
 
-The rule the spike leaves behind, for the next time `main.rs` size or touch rate is offered as
-evidence. It is an adjudicated working rule graded by its evidence — three measured chains and
-one calibrated negative control (E-12) — not a definition:
+What the spike leaves behind for the next time `main.rs` size or touch rate is offered as evidence,
+**and what it does not**. The positive observation is well grounded; the discriminator is not
+established, and this section says so rather than claiming a rule it cannot back.
 
-> Harmful coupling is observable when one contract policy's fix splits across two or more commits
-> in different command arms, or lands on only some of several copies while the others stay wrong.
-> A command arm that only calls into a single library owner is legitimate composition cohesion.
+**Observed, in three measured chains (E-12):** each was caused by one contract policy implemented
+at more than one site, none by family verticality. Harmful coupling showed up as any of: (1) one
+policy's fix splitting across two or more commits in different command arms; (2) one policy change
+forcing simultaneous edits to many arms; (3) a fix landing on only some of several copies; (4) a
+cross-cutting guard inserted into both `main.rs` and an extracted module.
 
-The underlying mechanism is one contract policy implemented at more than one site, but the site
-count alone cannot be the test, because a policy can sit at two sites and still be fixed once
-(`64bfb55` below). Harmful coupling is observable as any of: (1) one policy's fix splitting
-across two or more commits in different command arms; (2) one policy change forcing simultaneous
-edits to many arms; (3) a fix landing on only some of several copies; (4) a cross-cutting guard
-inserted into both `main.rs` and an extracted module. Three measured chains ground the rule, each
-caused by one contract policy implemented at more than one site, none by family verticality
-(E-12):
+**Not established: a test that separates this from legitimate composition cohesion.** Two
+formulations were tried and both fail, so neither is adopted here:
+
+- *Site count* — "one contract policy implemented at more than one site is harmful coupling." This
+  matches the three chains, but it also matches `64bfb55` below, which the same analysis wants to
+  classify as domain-caused. As a discriminator it accepts everything.
+- *Recurrence signature* — "harmful when a policy's fix splits across two or more commits in
+  different arms, or lands on only some copies." This excludes `64bfb55`, but it fails three ways.
+  It does not capture Case C, which is part of its own grounding: `743bc7a` fixed 12 commands in
+  one commit with no preceding partial fix, so the recurrence signature never appeared there
+  either. It cannot classify a policy whose arms were mismatched from birth and never partially
+  fixed — which is precisely `64bfb55`'s deadlock defect. And on the coverage-diagnostic history it
+  returns *both* verdicts: the fix split across `bf48338d` → `41dcfe12` → `64bfb55` while
+  `run_scenarios_mode`'s copy emitted the opposite diagnostic throughout (harmful by the first
+  clause), yet the repaired arm now only calls `verification_output::coverage_hint` (cohesion by
+  the second).
+
+So the recurrence signature is at best a **retrospective** marker: useful for reading a chain that
+has already recurred, not for authorizing or refusing an extraction in advance. Treat it that way.
+
+A valid negative control would have to be a change that touches `main.rs` for genuinely
+single-owner reasons — a policy with one implementation site, wired into one arm, with the defect
+in a library — and be shown to be *rejected* by whatever rule is proposed. The spike did not find
+one, and `64bfb55` is not it. Until such a control exists, the classification of any individual
+change here is judgement, not measurement, and issue #738's third acceptance criterion
+("distinguish composition cohesion from harmful change coupling") is **not met**. This is recorded
+rather than resolved: issue #748 tracks establishing a discriminator, or recording that this axis
+cannot discriminate and that structural decisions must rest on other evidence.
+
+The three chains that ground the positive observation (E-12):
 
 - **Case A — exit-code class.** Five commands independently fixed the same fail-closed/exit-code
   defect: `1bc5cf2` (mutate), `fbcb62d` (ledger, #599), `6933c7b` (ledger), `addc45f` (chain),
@@ -488,17 +512,24 @@ caused by one contract policy implemented at more than one site, none by family 
 - **Case C — spec-load error plumbing.** `743bc7a`: `load_kernel_model`'s String flattening
   misclassified spec-load errors in 12 commands at once.
 
-Negative control that the rule discriminates rather than matching everything: `64bfb55`
-(scenarios) fixed three defects at once, and one of them was a contract policy sitting at two
-sites — `run_scenarios_mode`'s early-return guard did not consult `deadlock_step`, so
-`scenarios --deadlock error` returned exit 0 where `verify --deadlock error` reported
-`violated`/`deadlock`/exit 1 for the same spec. A bare site-count rule would therefore match this
-commit and fail as a control. The operational rule excludes it correctly: all three defects were
-fixed in one commit, and no fix split across commits or landed on only some copies —
-`deadlock_step` appears in `main.rs` history only in `64bfb55` — while the commit even performed
-the single-owner move itself, making `verification_output::coverage_hint` `pub` and deleting a
-duplicated hint string. Its remaining root cause is scenario semantics in
-`rust/fsl-runtime/src/lib.rs` (+43/−4): domain-caused, fixed once, no recurrence signature.
+**The candidate negative control, and why it does not serve.** `64bfb55` (scenarios) fixed three
+defects at once. One is genuinely domain-caused: scenario semantics in
+`rust/fsl-runtime/src/lib.rs` (+43/−4). The other two are not. `run_scenarios_mode`'s early-return
+guard did not consult `deadlock_step`, so `scenarios --deadlock error` returned exit 0 where
+`verify --deadlock error` reported `violated`/`deadlock`/exit 1 for the same spec — one verdict
+policy, two implementations, one of them wrong. And the coverage diagnostic was fixed by making
+`verification_output::coverage_hint` `pub` and calling it, which is the single-owner move this
+document credits elsewhere; the same policy had previously been relocated within the verify arm by
+`bf48338d` and `41dcfe12` while the scenarios copy kept emitting the opposite diagnostic.
+
+So the commit contains two multi-site policies. It cannot serve as a control for a rule about
+multi-site policies. An earlier version of this section argued it could, on the ground that
+`deadlock_step` appears in `main.rs` history only in `64bfb55` — but that pickaxe is scoped to the
+one file and to a symbol the *broken* copy never contained, so it cannot detect a split by
+construction; widening it to `rust/fslc/src/` returns `41dcfe12` as well. That version also stated
+the commit deleted a duplicated hint string. It did not: `git show 64bfb55^:rust/fslc/src/main.rs`
+contains no `coverage_hint` occurrence, so there was no duplicate in `main.rs` to delete. Both
+claims are withdrawn.
 
 Why the hotspot metrics cannot substitute for the rule: at the spike baseline `main.rs` is 16,052
 lines of the workspace's 167,241 Rust lines (`wc -l`, excluding `target/`), and its commit-touch


### PR DESCRIPTION
## Problem

`docs/DESIGN-rust-components.md` §10's first re-evaluation trigger — "three unrelated command changes fail because of `fslc` orchestration coupling" — has fired, but the accepted record still reads as if the trigger were pending and as if the C2 extraction candidate were untested. Issue #738's final acceptance criterion requires the spike's result to land in the design document's re-evaluation evidence.

## Contract change

An accepted design document gains re-evaluation evidence and a new discriminating rule; no accepted decision is reversed (C1 "clarify boundaries without structural change" remains selected, and §8's existing C2 analysis is extended, not deleted). No Rust source changes.

- **§10**: the first trigger is recorded as fired — Case A supplies five, not three, unrelated command changes (`1bc5cf2`, `fbcb62d`, `6933c7b`, `addc45f`, `169fc20`) — and adjudicated: the response is policy single-owner extraction, not the C2 structural extraction. The falsification test at the section's end is recorded as run once, with the result unconfirmed, not disproven.
- **§8 C2**: carries the post-extraction measurement of the one executed extraction (#393 / PR #440, commit `6684dfb`), including #738's first acceptance criterion (changed files, import breadth, fixtures, review-surface delegation to #735). **New crate: rejected** (bin-only module, one workspace version, no external consumer). **Further family extraction: no-go.**
- **New working rule (§8)**: harmful coupling is observable when one contract policy's fix splits across two or more commits in different command arms, or lands on only some of several copies; an arm that only calls into a single library owner is legitimate composition cohesion. The underlying mechanism is one policy at more than one site, but the site count alone is not the test — with why touch rate and line count cannot discriminate (post-extraction `main.rs` churn median 29 lines; 26 of 50 commits at wiring scale).
- **§8 controls**: the calibrated accepting/rejecting controls (CLI JSON envelope, exit codes, diagnostics, Worker/LSP projection) and the measurable changed-owner rollback rule a future extraction PR must carry, each required to be demonstrated to fail on the pre-extraction tree.
- **§3**: evidence rows E-10..E-13 classify the new evidence (E3 measurement vs E1 inference, per the document's grading discipline).

## Review corrections (second commit)

An independent review returned **request changes**: two severity-2 and four severity-3 findings against the first commit. The document's conclusions survived — the review reproduced them — but several measurements' provenance and the one negative control did not. The second commit repairs all findings; every restated number was re-derived at `origin/main` `d72ac8d` before being written.

What the review falsified, and what changed:

- **Extraction size (S2).** The first commit stated the size three incompatible ways ("moved 1,462 lines", `main.rs` "−1462") and contradicted the accepted sibling record `docs/DESIGN-rust-component-internals.md`. Actual: `main.rs` +4/−1458 churn (1,462 was added+deleted), 15,709 → 14,255 lines (net −1,454), 1,452 contiguous family lines into a 1,468-line module. The document now states each quantity as what it is, aligned to the sibling record.
- **Negative control (S2).** `64bfb55` did not reject under the rule as originally written ("a contract rule implemented at more than one site is harmful coupling"): one of its three defects is exactly a policy at two sites (`run_scenarios_mode`'s guard never consulted `deadlock_step`). The rule's operational form is now the headline — the recurrence signature across commits/copies — under which `64bfb55` is correctly excluded: all three defects fixed in one commit, `deadlock_step` in `main.rs` history only there, and the commit itself performed a single-owner move (`coverage_hint` → `pub`). The rule is graded as an adjudicated working rule, not a definition.
- **E-11 statistics (S3).** The first commit's figures came from a stale tree (HEAD `d8e796d`, missing `c455e50`). At `d72ac8d`: churn n=50, min 3 / median 29 / p90 202 / max 385, 26 of 50 at ≤30 lines; touch rate 125 of 257 (48.6%) since `2026-06-11T00:00:00+09:00` under pathspec `'rust/**/*.rs'`, and 50 of 113 (44.2%) in `6684dfb..d72ac8d`. The exact pathspec and timestamp are now part of the recorded measurement (a bare `--since` date inherits the invoking clock's time of day, which is why earlier counts disagreed).
- **E-13 causality (S3).** The 379 → 179 → 16 series was attributed to `spec_load.rs` (`2fd555f`), but two of its three points precede that module. Corrected: `743bc7a` itself made `main.rs` the single owner of spec-load classification, and `2fd555f` later relocated the owner mid-series (churn 125, excluded as the relocation, not a series point).
- **Case B order (S3).** True order is `707523c` → `db9a51a` → `ed28f9a` → `693bddb`, and the chain carries two policies, now separated: the kernel-verdict fold rule (single-owner-ised by `db9a51a`, #612/#619) and the projection key list (still fixed by hand in `ed28f9a` two days later, single-owner-ised by `693bddb`). §10 now carries the qualification this forces: single-owner-ising one policy does not protect an adjacent duplicated policy.
- **Overstatement (S3).** E-10's "the falsifier was observed" and §10's "stands on measured ground" exceeded §8's hedge: the falsifier's shape appeared on a population of two workspace-wide refine changes, neither family-scoped. Both sentences now match §8's "unconfirmed, not disproven".
- **Precision.** Import breadth recorded (12 reverse-direction symbols from `causal.rs` vs 2 forward; 14 vs 4 top-level `use` lines); the `run_*` list gains `project` 353 / `refine` 351 / `analyze` 328 and drops a false order-of-magnitude claim (`domain` 504 is roughly a third of 1,452); the stray `(E2)` marker is now `(E-10)`; the `DESIGN-v1.md` §7.2 `semantics`-without-`loc` exception is stated; the six recurrences of the single-owner move and the `rust/fsl-tools/src/ai.rs` third projection copy (#687) are recorded.

What the review confirmed and is unchanged: §1, C1 `(selected)`, C2 `(not authorized)`, every candidate bullet, `main.rs` = 16,052 / workspace = 167,241, the `6684dfb` diffstat, the two `causal.rs`-touching commits, the 379/763/7 → 179/541/16 → 16/319/21 series values, the three module creation commits, the six `run_*` figures, both verbatim commit-message quotes, and all citations.

## Evidence

All measured at `origin/main` `d72ac8d` and re-verifiable with `git show`/`git log`:

- 13 days post-extraction: zero causal-family semantic changes; the only two commits touching `rust/fslc/src/causal.rs` (`9fe427b`, `cc1c318`) both also touch `main.rs`, and `9fe427b` inserts one guard policy into both files — the falsifier §8 already named, appearing in shape on two non-family-scoped changes (unconfirmed, not disproven).
- Three harmful chains are all one-policy-many-sites: exit-code class (5 commits, cause stated in `fd5b8c6`: "the crate has 43 distinct `result` values with no such definition"), kernel-verdict fold rule plus nested kernel projection (`707523c` → `db9a51a` → `ed28f9a` → `693bddb`, whose message says the #515/#641 fixes "landed on the domain copy alone because there was nowhere else to land them"), spec-load plumbing (`743bc7a`, 12 commands). Negative control: `64bfb55` — three defects fixed in one commit, no recurrence signature.
- The response that measurably worked: single-owner policy modules `spec_load.rs` / `outcome.rs` / `literate_access.rs`; after `743bc7a` gave spec-load classification one owner, `main.rs` involvement fell 379 → 179 → 16 lines across its follow-up series while total change size grew (n=3; direction measured, generalization inference).

Every cited section (`DESIGN-v1.md` §7.2, `DESIGN-rust-component-internals.md`, `rust/fslc/cli-contract.json`, `rust/fslc/tests/native_integration.rs`, the `unsupportedDocuments` registry in `rust/fsl-wasm/test-browser.mjs`, `outcome::{is_definitive_kernel_verdict, classify_kernel_key, project_kernel}`, `verification_output::coverage_hint`) was opened and confirmed before citation.

`CHANGELOG.md` carries a matching `[Unreleased]` entry.

Refs #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Second review pass: the discriminator is withdrawn, and `Closes` becomes `Refs`

An independent verification of the correction commit reproduced every figure and confirmed
every other repair, but showed that **the repaired criterion still does not discriminate**.
`d0c0ffe`-equivalent follow-up commit withdraws it rather than narrowing it further.

Its argument, which I reproduced: on the coverage-diagnostic history the rule returns **both**
verdicts. The fix split across `bf48338d` → `41dcfe12` → `64bfb55` while `run_scenarios_mode`'s
copy emitted the opposite diagnostic throughout — harmful by the rule's first clause. Yet the
repaired arm now only calls `verification_output::coverage_hint` — cohesion by its second. It also
fails to capture Case C, which is part of its own grounding, and cannot classify a policy whose
arms were mismatched from birth, which is exactly `64bfb55`'s deadlock defect.

Two supporting claims are withdrawn with it, both checked:

- The pickaxe evidence (`git log -S deadlock_step -- rust/fslc/src/main.rs` returning only
  `64bfb55`) is scoped to one file and to a symbol the **broken** copy never contained, so it
  cannot detect a split by construction. Widened to `rust/fslc/src/` it returns `41dcfe12` too.
- "the commit … deleted a duplicated hint string" is **false**:
  `git show 64bfb55^:rust/fslc/src/main.rs` contains **zero** `coverage_hint` occurrences, so
  there was no duplicate in that file to delete.

So issue #738's third acceptance criterion — distinguish composition cohesion from harmful change
coupling — is **not met**, and this PR is now `Refs #738`. Issue **#748** tracks either
establishing a discriminator or recording that this axis cannot discriminate and that structural
decisions must rest on other evidence. Leaving the criterion in place with a control that accepts
everything would be exactly the hollow anchor `AGENTS.md` forbids.

**What survives, reproduced in full by the verification**: all three chains trace to one policy
implemented at more than one site, none to family verticality; touch rate and line count cannot
discriminate (median 29 lines, 26 of 50 at wiring scale); policy single-owner extraction is the
response that measurably reduced amplification (379 → 179 → 16). **The NO-GO verdict rests on
E-10/E-11/E-12/E-13 and is unchanged.**
