### PR TITLE
perf(ci): pin the five slowest test binaries to distinct pre-merge shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,25 +22,25 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   cases (including a whole-binary-dropped fixture) wired into the existing `merge readiness /
   automation contracts` lane. `.github/workflows/ci.yml` is unchanged — the required `rust workspace`
   context, its `if: always()` aggregator, and the shard-union contract all keep their exact shape.
-  **Measured on run 31076668077 and the first form did not deliver**: shards took 15.5 / 14.6 / 8.75 min
-  against a 15.6 / 5.0 / 8.7 baseline — the spread improved 3.1x → 1.77x but the aggregator's critical
-  path moved about 0.1 min. Three measured causes, each of which changed the design. The cost model was
-  wrong: a shard's pinned phase costs its *slowest single test*, not the sum of its binaries' sequential
-  times (7m40s / 4m27s / 4m36s against 458.8s / 266.6s / 275.6s — agreement to the second), because
-  nextest runs tests concurrently inside a shard. The two `cargo nextest run` invocations are serial, so
-  shard wall clock is pinned + leftover + a fixed ≈1m50s, and the leftover phases spread 5.3x — worse
-  than the pinned phases' 1.72x, i.e. the duration-blindness moved rather than went away. And the
-  pinning file was stale before it merged: `fslc-rust::issue_697_all_properties_memory`, whose 371.8s
-  test is the workspace's slowest after `refine_corpus_parity`, arrived with this branch's own base
-  (the #739 merge) and was unpinned, which is what took shard 2 from 5.0 to 14.6 min. The assignment now
-  pins eight binaries chosen by slowest-single-test, removing 2,061s of sequential work from the
-  duration-blind leftover, and `docs/DESIGN-ci.md` **withdraws the ≈13 min projection**: the floor for
-  whichever shard holds `refine_corpus_parity`'s indivisible 458.8s test is ≈9.5 min, and getting below
-  that needs either splitting that test or running the two phases concurrently. The new assignment's
-  own gain is again expected rather than measured; the next `product gate` run on this branch is what
-  confirms it. Issue #720 Finding 2
-  (warming the fault-operator scratch build, and a possible revert of that lane's sharding) is
-  untouched and #720 stays open for it.
+  **Measured, and the second form delivers**: the slowest shard — the only quantity
+  `rust workspace` waits on — fell from **15.6 min to 12.2 min** and the spread from 3.1x to 1.17x
+  (warm-cache runs 31076668077 and 31081427765 attempt 2; shard wall clocks 12.2 / 10.85 / 10.46 min,
+  clean shard union on both). The first form delivered ~0.1 min and this entry previously said so;
+  two measured defects explain the gap. The cost model was wrong twice: packing by each binary's
+  sequential total, then by its slowest single test, which underestimates a shard holding several
+  long binaries by 52%. The model that fits all three shards is
+  `1.11 × max(slowest single test, sequential sum / 3)` — error −0.2% / +12.7% / +0.1%, the outlier
+  being the shard holding `issue_697_all_properties_memory`, which is memory-bound by construction
+  (`CONCRETE_PROBE_BUDGET`, #697) and so overlaps less than the model assumes. Adding a pin is
+  therefore **not** free. And the pinning file was stale before the first form merged:
+  `issue_697_all_properties_memory`, whose 371.8s test is the workspace's second slowest, arrived with
+  the #739 merge and was unpinned, putting that test in shard 2's count partition — which is what took
+  shard 2 from 5.0 to 14.6 min. The assignment now pins eight binaries by
+  `max(slowest, sum/3)`, which also cut the duration-blind leftover's spread from 5.3x to **1.75x**
+  (phases 75.4s / 43.0s / 63.9s). Remaining floor ≈10.4 min: `refine_corpus_parity`'s indivisible
+  458.8s test plus a measured ≈113s of fixed cost per shard, so going materially lower needs that test
+  split or the two phases run concurrently rather than serially. Every comparison here is warm-cache;
+  an eviction-induced cold build adds 6–12 min per shard and is tracked as #747.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,23 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   cases (including a whole-binary-dropped fixture) wired into the existing `merge readiness /
   automation contracts` lane. `.github/workflows/ci.yml` is unchanged — the required `rust workspace`
   context, its `if: always()` aggregator, and the shard-union contract all keep their exact shape.
-  Expected gain ~5 min off `rust workspace`'s current ≈18 min slowest shard (docs/DESIGN-ci.md); not
-  yet measured — that needs a pull-request run of this change against `ci.yml`. Issue #720 Finding 2
+  **Measured on run 31076668077 and the first form did not deliver**: shards took 15.5 / 14.6 / 8.75 min
+  against a 15.6 / 5.0 / 8.7 baseline — the spread improved 3.1x → 1.77x but the aggregator's critical
+  path moved about 0.1 min. Three measured causes, each of which changed the design. The cost model was
+  wrong: a shard's pinned phase costs its *slowest single test*, not the sum of its binaries' sequential
+  times (7m40s / 4m27s / 4m36s against 458.8s / 266.6s / 275.6s — agreement to the second), because
+  nextest runs tests concurrently inside a shard. The two `cargo nextest run` invocations are serial, so
+  shard wall clock is pinned + leftover + a fixed ≈1m50s, and the leftover phases spread 5.3x — worse
+  than the pinned phases' 1.72x, i.e. the duration-blindness moved rather than went away. And the
+  pinning file was stale before it merged: `fslc-rust::issue_697_all_properties_memory`, whose 371.8s
+  test is the workspace's slowest after `refine_corpus_parity`, arrived with this branch's own base
+  (the #739 merge) and was unpinned, which is what took shard 2 from 5.0 to 14.6 min. The assignment now
+  pins eight binaries chosen by slowest-single-test, removing 2,061s of sequential work from the
+  duration-blind leftover, and `docs/DESIGN-ci.md` **withdraws the ≈13 min projection**: the floor for
+  whichever shard holds `refine_corpus_parity`'s indivisible 458.8s test is ≈9.5 min, and getting below
+  that needs either splitting that test or running the two phases concurrently. The new assignment's
+  own gain is again expected rather than measured; the next `product gate` run on this branch is what
+  confirms it. Issue #720 Finding 2
   (warming the fault-operator scratch build, and a possible revert of that lane's sharding) is
   untouched and #720 stays open for it.
 - Documented (#722): the implicit domain aggregate initializer enumeration in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#720 Finding 1): `rust-tests`' `cargo-nextest --partition count:K/3` balanced pre-merge
+  shards by test count, not wall clock, so five binaries holding ~77% of the suite's sequential time
+  (`refine_corpus_parity`, `explicit_engine`, `injection_detector_matrix`, `corpus_check_sweep`,
+  `issue_226_auto_engine`) could land unevenly across shards — measured spreads of 2.2x and 3.1x
+  between the fastest and slowest shard. `check_rust_tests` in `tools/check-native-integration.sh` now
+  pins those five binaries to specific shards via a checked-in
+  `tools/rust-test-shard-groups.txt` and `cargo nextest`'s `binary_id(=…)` filterset, unpartitioned,
+  while every other test still goes through the original count-partition, scoped to exclude every
+  pinned binary. Coverage cannot silently drop: an unlisted binary simply falls into the
+  count-partitioned leftover as before, and `tools/check-shard-union.sh`'s existing full.txt/shard.txt
+  guard needed no shape change to keep validating the result. Added `check-shard-union.sh
+  check-groups`, a narrower guard that fails closed if the grouping file pins a binary-id the live
+  workspace no longer has or pins one binary to two shards, plus new accepting/rejecting `selftest`
+  cases (including a whole-binary-dropped fixture) wired into the existing `merge readiness /
+  automation contracts` lane. `.github/workflows/ci.yml` is unchanged — the required `rust workspace`
+  context, its `if: always()` aggregator, and the shard-union contract all keep their exact shape.
+  Expected gain ~5 min off `rust workspace`'s current ≈18 min slowest shard (docs/DESIGN-ci.md); not
+  yet measured — that needs a pull-request run of this change against `ci.yml`. Issue #720 Finding 2
+  (warming the fault-operator scratch build, and a possible revert of that lane's sharding) is
+  untouched and #720 stays open for it.
 - Documented (#722): the implicit domain aggregate initializer enumeration in
   `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, and `skills/fsl/reference.md`
   covered only Bool `false`/enum first-member/range lower-bound/external-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   shards by test count, not wall clock, so five binaries holding ~77% of the suite's sequential time
   (`refine_corpus_parity`, `explicit_engine`, `injection_detector_matrix`, `corpus_check_sweep`,
   `issue_226_auto_engine`) could land unevenly across shards — measured spreads of 2.2x and 3.1x
-  between the fastest and slowest shard. `check_rust_tests` in `tools/check-native-integration.sh` now
+  between the fastest and slowest shard on two runs of the same commit, now both
+  recorded in `docs/DESIGN-ci.md` (previously only the 2.2x run was). `check_rust_tests` in `tools/check-native-integration.sh` now
   pins those five binaries to specific shards via a checked-in
   `tools/rust-test-shard-groups.txt` and `cargo nextest`'s `binary_id(=…)` filterset, unpartitioned,
   while every other test still goes through the original count-partition, scoped to exclude every

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -222,8 +222,9 @@ incidental noise:
 
 - **`cargo-nextest --partition count:K/N` balances by test count, not duration.** The three shards
   received 518/460/411 tests and took 18.1/8.3/12.6 min — shard 1 is 2.2x shard 2, so `rust workspace`
-  finished on its slowest shard at ≈18 min. A duration-balanced split was expected to give ≈13 min;
-  it did not — see "Duration-aware `rust-tests` shard pinning" below for the measurement and why. A rerun of the same commit gave 15.6/5.0/8.7 min, a **3.1x** spread: the skew is not a fixed
+  finished on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
+  give — which it now does, measured: see "Duration-aware `rust-tests` shard pinning" below. A
+  rerun of the same commit gave 15.6/5.0/8.7 min, a **3.1x** spread: the skew is not a fixed
   property of the split but varies run to run, which is what makes an explicit assignment worth more
   than a better hash. Issue #720 Finding 1 addressed this — see "Duration-aware `rust-tests` shard
   pinning" below —
@@ -317,16 +318,15 @@ Raising the shard count cannot fix this. Two levers would move it further:
   changes a different mechanism (`tools/run-fault-operators.sh`'s scratch checkout) with its own
   patch-isolation contract, and because #720 asks that a possible revert of the operator sharding be
   evaluated in the same change once this lands, which needs its own review;
-- a duration-aware `rust-tests` assignment. **Landed, and its first form did not deliver** — issue
-  #720 Finding 1; see "Duration-aware `rust-tests` shard pinning" below for the measurement that
-  refuted the ~5 min estimate and what changed in response.
+- a duration-aware `rust-tests` assignment, worth **3.4 min measured**. **Landed** — issue #720
+  Finding 1. Its first form delivered about 0.1 min and its second delivers 3.4; see
+  "Duration-aware `rust-tests` shard pinning" below for both measurements and what changed between
+  them.
 
-The ≈13 min figure this section previously projected for `rust workspace` is **withdrawn as a
-prediction**. It was derived from the wrong cost model, and the first measured run of duration-aware
-pinning moved the aggregator's critical path by about 0.1 min. What replaces it: the slowest shard
-cannot go below ≈9.5 min (the indivisible 458.8s test plus the ≈1m50s fixed cost) while
-`refine_corpus_parity` holds a single test that long, and every minute between there and the measured
-15.5 min is leftover-phase work whose distribution is still count-based. Finding 2 remains 20.3 min at best until it lands; nobody should
+With Finding 1 landed, `rust workspace`'s slowest shard is **12.2 min measured**, against ≈15.6 before
+it and the ≈13 min this section projected. The remaining floor is ≈10.4 min — the indivisible 458.8s
+test plus the measured ≈113s of fixed cost — so most of what is left is that one test. Finding 2
+remains 20.3 min at best until it lands; nobody should
 expect either lane to shrink further without changing what it measures or how its scratch build is
 warmed.
 
@@ -356,54 +356,63 @@ land in the same shard, or unevenly across shards, by chance. `check_rust_tests`
    run used the five-binary assignment; the pin list has since changed but the mechanism has not, so
    the next `product gate` run re-proves the union for the current list.
 
-**The first form of this change was measured and did not deliver.** Run 31076668077 on the pull
-request that introduced it:
+**Measured, in two forms.** The first form did not deliver; the second does. All figures below
+are warm-cache runs, which matters: an eviction-induced cold build adds 6-12 min per shard and
+makes any comparison across cache states meaningless (see issue #747).
 
 | | shard 1 | shard 2 | shard 3 | slowest | spread |
 |---|---|---|---|---|---|
 | baseline run 1 | 18.1 | 8.3 | 12.6 | **18.1** | 2.2x |
 | baseline run 2 | 15.6 | 5.0 | 8.7 | **15.6** | 3.1x |
-| first pinning form | 15.5 | 14.6 | 8.75 | **15.5** | **1.77x** |
+| first form, 5 pins (run 31076668077) | 15.5 | 14.6 | 8.75 | **15.5** | 1.77x |
+| second form, 8 pins (run 31081427765 attempt 2) | **12.2** | **10.85** | **10.46** | **12.2** | **1.17x** |
 
-Spread improved from 3.1x to 1.77x, and the aggregator's critical path — which is the only quantity
-`rust workspace` actually waits on — moved by about **0.1 min against the nearer baseline**. Three
-measured facts explain it, and each changed the design:
+The slowest shard — the only quantity `rust workspace` waits on — fell from 15.6 min to
+**12.2 min**, and the spread from 3.1x to 1.17x. `tools/check-shard-union.sh` reported a clean
+union on that run.
 
-**The cost model was wrong.** Decomposed from job-step timestamps, each shard's pinned phase took
-7m40s / 4m27s / 4m36s against slowest individual tests of 458.8s / 266.6s / 275.6s — agreement to the
-second. nextest runs tests concurrently inside a shard, so **a shard's pinned phase costs about its
-slowest single test, not the sum of its binaries' sequential times.** The first assignment packed by
-that sum and overestimated shards 2 and 3 by roughly 40%. Two consequences: adding a pin to a shard
-that already holds a slower test is nearly free, and every pin removes its binary's whole sequential
-duration from the leftover.
+**The first form failed for two measurable reasons, both since fixed.**
 
-**The two phases are serial.** Shard wall clock is `pinned + leftover + fixed`, with fixed cost
-measured at ≈1m50s. The leftover phases took 5m16s / 7m31s / 1m25s — a **5.3x spread, worse than the
-pinned phases' 1.72x**. The duration-blindness this change set out to remove was displaced into the
-leftover rather than eliminated, because the leftover is still `count:K/N`.
+*The cost model was wrong, twice over.* The original assignment packed by the sum of each
+binary's sequential minutes. Corrected to the slowest single test, it then underestimated a shard
+holding several long binaries by 52%. The model that fits all three shards is
+**`1.11 × max(slowest single test, sequential sum / 3)`**:
 
-**The pinning file was stale before it merged.** `fslc-rust::issue_697_all_properties_memory`
-(slowest test 371.8s) arrived with the #697 fix in pull request #739 and was not pinned, so its test
-went into shard 2's count-partitioned leftover. That single test is what took shard 2 from 5.0 min to
-14.6 min. `fslc-rust::explain_cli` was also unpinned — although under the corrected model its slowest
-test is only 69.5s, so it matters for the 439.7s it puts in the leftover, not as a shard occupant.
+| shard | pinned sum | slowest | model | actual | error |
+|---|---|---|---|---|---|
+| 1 | 683.4s | 458.8s | 509s | 508.1s | −0.2% |
+| 2 | 922.3s | 371.8s | 413s | 465.2s | +12.7% |
+| 3 | 1130.4s | 275.6s | 418s | 418.5s | +0.1% |
 
-**Decision on the leftover skew.** Pinning is currently the only lever against it, because every pin
-takes its binary's sequential time out of the count partition. The assignment therefore pins eight
-binaries rather than five, removing 2,061s of sequential work from the leftover. Making the leftover
-itself duration-aware is *not* attempted here: `--partition count:` has no duration input, so it would
-mean replacing the partition with a second checked-in assignment covering every test binary, which
-trades a small maintained file for a large one. If the pinning form below still leaves a leftover
-spread above roughly 2x, that trade is the next thing to evaluate, and it should be its own change.
+Neither term alone works, so adding a pin is **not** free: it raises the sum, and once `sum/3`
+exceeds the slowest test the phase grows with each addition. Shard 2 is the one outlier at +12.7%,
+and the reason is specific: `issue_697_all_properties_memory` is memory-bound by construction
+(`CONCRETE_PROBE_BUDGET`, issue #697), so its tests contend for memory rather than CPU and overlap
+less than the model assumes. Treat +15% as the planning margin for whichever shard holds it.
 
-**What is reachable.** Not ≈13 min on the strength of pinning alone, and that projection is withdrawn.
-`refine_corpus_parity`'s 458.8s single test is indivisible under this scheme, so whichever shard holds
-it pays 7.65 min plus its leftover share plus ≈1m50s fixed — an absolute floor of **≈9.5 min** for that
-shard even with an empty leftover. Going below that needs one of: splitting that test (and
-`issue_697_all_properties_memory`'s 371.8s one), or running the pinned and leftover phases
-concurrently instead of serially. Neither is attempted here; both are larger changes than a scheduling
-tweak, and the second would need care because the two phases currently write one `shard.txt` between
-them.
+*The pinning file was stale before the first form merged.*
+`fslc-rust::issue_697_all_properties_memory`, whose 371.8s test is the workspace's second slowest,
+arrived with the #739 merge for issue #697 and was not pinned. Its test landed in shard 2's count
+partition, which is exactly what took shard 2 from 5.0 min to 14.6 min.
+
+**The leftover skew is reduced, not removed.** Pinning is the only lever currently available
+against it, because every pin takes its binary's whole sequential duration out of the
+count-partitioned remainder. The second form's leftover phases are 75.4s / 43.0s / 63.9s — a
+**1.75x spread, down from 5.3x**. Making the leftover itself duration-aware is not attempted:
+`--partition count:` takes no duration input, so it would mean a checked-in assignment covering
+every test binary, trading a small maintained file for a large one. At 1.75x that trade is not
+currently worth making; if the spread returns above roughly 2x, it is the next thing to evaluate,
+as its own change.
+
+**Where the floor is.** `refine_corpus_parity`'s 458.8s single test is indivisible under this
+scheme, and each shard pays a constant ≈113s of checkout, toolchain and build (measured, all three
+shards). So whichever shard holds that test cannot go below about **10.4 min** even with an empty
+leftover, and the measured 12.2 min is within two minutes of that. The ≈13 min this document
+projected earlier for `rust workspace` **is met, measured at 12.2 min** — it was unreachable with
+the wrong pinning, not unreachable in principle. Going materially below 10 min needs one of:
+splitting that test (and `issue_697_all_properties_memory`'s 371.8s one), or running the pinned and
+leftover phases concurrently instead of serially. Neither is attempted here; the second would need
+care because the two phases currently write one `shard.txt` between them.
 
 **Coverage cannot silently drop, by construction, independent of this file's accuracy.** A binary this
 file does not name is not "unhandled" — it simply is not pinned to anyone, so it falls into the

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -223,7 +223,10 @@ incidental noise:
 - **`cargo-nextest --partition count:K/N` balances by test count, not duration.** The three shards
   received 518/460/411 tests and took 18.1/8.3/12.6 min — shard 1 is 2.2x shard 2, so `rust workspace`
   finished on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
-  give. Issue #720 Finding 1 addressed this — see "Duration-aware `rust-tests` shard pinning" below —
+  give. A rerun of the same commit gave 15.6/5.0/8.7 min, a **3.1x** spread: the skew is not a fixed
+  property of the split but varies run to run, which is what makes an explicit assignment worth more
+  than a better hash. Issue #720 Finding 1 addressed this — see "Duration-aware `rust-tests` shard
+  pinning" below —
   by pinning the known-slow binaries to distinct shards explicitly, which `count:` alone cannot
   express.
 - **Sharding the curated operator lane bought about 10%, not two thirds.** 22.5 min unsharded became
@@ -275,9 +278,13 @@ unsharded set before trusting a `success` result:
 `tools/check-shard-union.sh` is the generic, reusable primitive both checks build on: given one full
 list and N shard lists, it fails closed — naming the offending entries — unless every shard is a
 subset of the full list, the shards are pairwise disjoint, and their union equals the full list
-exactly. Its `selftest` subcommand exercises an accepting three-way split and four rejecting cases
-(an entry covered by no shard, an entry duplicated across shards, an invented shard entry, an empty
-shard list) and is wired into `tools/check-merge-readiness.sh`'s `check_automation`, alongside
+exactly. It has a second mode, `check-groups`, described under "Duration-aware `rust-tests` shard
+pinning" below. Its `selftest` subcommand exercises the union form's accepting three-way split and
+five rejecting cases (an entry covered by no shard, an entry duplicated across shards, an invented
+shard entry, an empty shard list, and an entire binary's tests dropped from every shard), plus
+`check-groups`'s accepting case and two rejecting cases (a pin naming a binary-id the live workspace
+no longer has, and one binary pinned to two shards). It is wired into
+`tools/check-merge-readiness.sh`'s `check_automation`, alongside
 `check-product-gate-scope.sh selftest`.
 
 **Agent-configuration-exempt pull requests still work.** Every shard job runs
@@ -315,7 +322,11 @@ that run is what would confirm it. Finding 2 remains 20.3 min at best until it l
 expect either lane to shrink further without changing what it measures or how its scratch build is
 warmed.
 
-### Duration-aware `rust-tests` shard pinning (issue #720 Finding 1)
+### Duration-aware `rust-tests` shard pinning
+
+Issue #720 Finding 1. No other heading in this document carries a parenthetical issue tag, and three
+citations of this section elsewhere in the file quoted the heading without one, so the tag lives here
+in the body instead.
 
 `cargo-nextest --partition count:K/N` assigns tests to shards by count, with no notion of how long
 each test takes, so five binaries holding ~77% of the suite's sequential wall clock
@@ -348,9 +359,24 @@ ordinary count-partitioned leftover exactly as before. A new test binary landing
 it; only duration balance, not coverage, depends on the file being current. Coverage is still proven
 the same way as before this change: `check_rust_tests` writes `full.txt` (unfiltered) and `shard.txt`
 (this shard's union of pinned + leftover) exactly as it always has, and `rust-workspace`'s aggregator
-still runs the unmodified `tools/check-shard-union.sh full.txt shard1.txt shard2.txt shard3.txt` against
-them — the shape those files take did not change, so that guard needed no changes to keep validating
-the new mechanism.
+still runs `tools/check-shard-union.sh full.txt shard1.txt shard2.txt shard3.txt` against them with
+that invocation's behaviour unchanged — the script gained a `check-groups` mode and a fifth rejecting
+selftest case, but the union form itself was not touched, and the shape of the files it consumes did
+not change, so that guard keeps validating the new mechanism without alteration.
+
+**When to update `tools/rust-test-shard-groups.txt`.** Coverage never depends on it, but two cases do
+require an edit, and neither is discoverable from the file alone:
+
+- **Renaming or removing a pinned binary hard-fails every shard.** `check-groups` runs before the
+  partition and rejects a pin whose binary-id is absent from the live `cargo nextest list` output, so
+  `rust workspace` goes red until the pin is updated. That is deliberate — a silently stale pin would
+  degrade balance invisibly — but it means a rename is a two-file change: the test binary and this
+  file. The failure message names the file and the offending id.
+- **Adding a binary slower than roughly three minutes.** Below that, the count partition absorbs it
+  without materially skewing a shard. Above it, pin the binary to whichever shard currently carries
+  the least pinned time (the per-shard totals are in the list above), because one such binary is
+  enough to make its shard the aggregator's critical path. Adding a pin is a single data edit and no
+  code change, the same shape as adding a row to `rust/fslc/tests/fault_operators/operators.txt`.
 
 What *is* new is a second, narrower guard: `tools/check-shard-union.sh check-groups
 tools/rust-test-shard-groups.txt <live-binary-ids> <shard-total>`, run once per shard before any

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -222,8 +222,8 @@ incidental noise:
 
 - **`cargo-nextest --partition count:K/N` balances by test count, not duration.** The three shards
   received 518/460/411 tests and took 18.1/8.3/12.6 min — shard 1 is 2.2x shard 2, so `rust workspace`
-  finished on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
-  give. A rerun of the same commit gave 15.6/5.0/8.7 min, a **3.1x** spread: the skew is not a fixed
+  finished on its slowest shard at ≈18 min. A duration-balanced split was expected to give ≈13 min;
+  it did not — see "Duration-aware `rust-tests` shard pinning" below for the measurement and why. A rerun of the same commit gave 15.6/5.0/8.7 min, a **3.1x** spread: the skew is not a fixed
   property of the split but varies run to run, which is what makes an explicit assignment worth more
   than a better hash. Issue #720 Finding 1 addressed this — see "Duration-aware `rust-tests` shard
   pinning" below —
@@ -295,8 +295,15 @@ results and skip the artifact-download/union-validation steps outright, because 
 download.
 
 **Floors — sharding buys parallelism, not a lower bound.** `refine_corpus_parity`'s slowest single
-test (≈7.3 min) cannot be split further by this scheme, so together with the ≈3.5 min compile it
-bounds `rust-workspace` at roughly ≈12 min no matter how the remaining 175 binaries are distributed.
+test is an indivisible 458.8s (7.65 min) under this scheme. A `rust-tests` shard's wall clock is
+`pinned phase + leftover phase + fixed cost`, because the two `cargo nextest run` invocations execute
+**serially** inside the shard — so the floor for whichever shard holds that test is 7.65 min plus
+its share of the leftover plus the fixed ≈1m50s of checkout, toolchain and build. An earlier version
+of this paragraph put the floor at ≈12 min "no matter how the remaining 175 binaries are distributed",
+adding a ≈3.5 min compile to the 7.3 min test. Both parts were wrong: the fixed cost is ≈1m50s, not
+3.5 min, and the leftover term was missing entirely — leftover distribution is exactly what run
+31076668077's shard 2 lost nine minutes to. See "Duration-aware `rust-tests` shard pinning" below for
+the measured decomposition and what the floor actually is.
 Each `semantic-mutation-operators` shard independently pays the cold build in its own synced scratch
 checkout (`tools/run-fault-operators.sh`'s `sync_scratch`), and that cost dominates the lane. Locally,
 a 6-operator shard's no-op control took 760s where all 17 took 912s; in CI the sharded lane landed at
@@ -310,47 +317,93 @@ Raising the shard count cannot fix this. Two levers would move it further:
   changes a different mechanism (`tools/run-fault-operators.sh`'s scratch checkout) with its own
   patch-isolation contract, and because #720 asks that a possible revert of the operator sharding be
   evaluated in the same change once this lands, which needs its own review;
-- a duration-aware `rust-tests` assignment, worth ~5 min on its own (see the imbalance above).
-  **Landed** — issue #720 Finding 1; see "Duration-aware `rust-tests` shard pinning" below.
+- a duration-aware `rust-tests` assignment. **Landed, and its first form did not deliver** — issue
+  #720 Finding 1; see "Duration-aware `rust-tests` shard pinning" below for the measurement that
+  refuted the ~5 min estimate and what changed in response.
 
-With both, the gate would plausibly reach ≈13 min; with only Finding 1, the expected floor is
-`rust-workspace` at roughly ≈13 min (unchanged from the estimate above: `refine_corpus_parity`'s
-single ≈7.3 min test plus ≈3.5 min compile) rather than the ≈18 min its slowest count-balanced shard
-measured before. That is an *expected* gain from the shard-composition arithmetic below, not a
-measured one — only a pull-request run of this change against `ci.yml` measures real wall clock, and
-that run is what would confirm it. Finding 2 remains 20.3 min at best until it lands; nobody should
+The ≈13 min figure this section previously projected for `rust workspace` is **withdrawn as a
+prediction**. It was derived from the wrong cost model, and the first measured run of duration-aware
+pinning moved the aggregator's critical path by about 0.1 min. What replaces it: the slowest shard
+cannot go below ≈9.5 min (the indivisible 458.8s test plus the ≈1m50s fixed cost) while
+`refine_corpus_parity` holds a single test that long, and every minute between there and the measured
+15.5 min is leftover-phase work whose distribution is still count-based. Finding 2 remains 20.3 min at best until it lands; nobody should
 expect either lane to shrink further without changing what it measures or how its scratch build is
 warmed.
 
 ### Duration-aware `rust-tests` shard pinning
 
-Issue #720 Finding 1. No other heading in this document carries a parenthetical issue tag, and three
-citations of this section elsewhere in the file quoted the heading without one, so the tag lives here
-in the body instead.
+Issue #720 Finding 1. No other heading in this document carries a parenthetical issue tag, and the
+four citations of this section elsewhere in the file quote the heading without one, so the tag lives
+here in the body instead.
 
 `cargo-nextest --partition count:K/N` assigns tests to shards by count, with no notion of how long
-each test takes, so five binaries holding ~77% of the suite's sequential wall clock
-(`refine_corpus_parity` ~7.34 min/4 tests, `explicit_engine` ~4.58 min/12, `injection_detector_matrix`
-~3.75 min/1 test, `corpus_check_sweep` ~3.16 min/3, `issue_226_auto_engine` ~3.13 min/15 — all five
-confirmed still present against this workspace, with test counts matching exactly) could land in the
-same shard, or unevenly across shards, by chance. `check_rust_tests` in
+each test takes, so the handful of binaries holding most of the suite's sequential wall clock could
+land in the same shard, or unevenly across shards, by chance. `check_rust_tests` in
 `tools/check-native-integration.sh` replaces the single `--partition` invocation with two, unioned:
 
 1. `tools/rust-test-shard-groups.txt`, a checked-in text file pinning specific binary-ids to specific
-   shards (`<shard> <binary-id>`, comments with `#`), read once per shard invocation. The binaries
-   above are bin-packed onto the three shards by their measured minutes (shard 1: `refine_corpus_parity`
-   alone, ~7.34 min; shard 2: `explicit_engine` + `corpus_check_sweep`, ~7.74 min; shard 3:
-   `injection_detector_matrix` + `issue_226_auto_engine`, ~6.88 min), then each shard's pinned binaries
-   run through `cargo nextest run -E 'binary_id(=…) or binary_id(=…) …'` — the exact-match `=`
-   name-matcher (`cargo nextest help filterset`) — unpartitioned, so a pinned binary is never split
-   across shards or forced to share a shard with another pin by count-hash chance.
+   shards (`<shard> <binary-id>`, comments with `#`), read once per shard invocation. Each shard's
+   pinned binaries run through `cargo nextest run -E 'binary_id(=…) or binary_id(=…) …'` — the
+   exact-match `=` name-matcher (`cargo nextest help filterset`) — unpartitioned, so a pinned binary is
+   never split across shards or forced to share a shard with another pin by count-hash chance. The
+   assignment and the measurements behind it live in that file; the cost model it uses is below.
 2. Every test *not* in any pinned binary still goes through the original `--partition count:K/N`,
    scoped by `-E 'not binary_id(=…) and not binary_id(=…) …'` excluding every pinned binary (not just
    this shard's), so a pinned binary's tests are never double-counted into another shard's leftover
-   share. Verified directly against this workspace (1418 non-ignored tests, 35 of them pinned): the
-   three leftover partitions receive 518/457/408 tests, are pairwise disjoint, and their union is
-   exactly the 1383 non-pinned tests; folding the 4/15/16 pinned tests back in gives 522/472/424 per
-   shard, pairwise disjoint, unioning to exactly the full 1418.
+   share. Proven end to end by run 31076668077's aggregator, whose guard reported
+   `check-shard-union: PASS -- 1419 entries, 3 shard(s), union matches exactly`, with the three shard
+   logs showing 4+519, 15+457 and 16+408 tests — 1419, matching the unfiltered inventory exactly. That
+   run used the five-binary assignment; the pin list has since changed but the mechanism has not, so
+   the next `product gate` run re-proves the union for the current list.
+
+**The first form of this change was measured and did not deliver.** Run 31076668077 on the pull
+request that introduced it:
+
+| | shard 1 | shard 2 | shard 3 | slowest | spread |
+|---|---|---|---|---|---|
+| baseline run 1 | 18.1 | 8.3 | 12.6 | **18.1** | 2.2x |
+| baseline run 2 | 15.6 | 5.0 | 8.7 | **15.6** | 3.1x |
+| first pinning form | 15.5 | 14.6 | 8.75 | **15.5** | **1.77x** |
+
+Spread improved from 3.1x to 1.77x, and the aggregator's critical path — which is the only quantity
+`rust workspace` actually waits on — moved by about **0.1 min against the nearer baseline**. Three
+measured facts explain it, and each changed the design:
+
+**The cost model was wrong.** Decomposed from job-step timestamps, each shard's pinned phase took
+7m40s / 4m27s / 4m36s against slowest individual tests of 458.8s / 266.6s / 275.6s — agreement to the
+second. nextest runs tests concurrently inside a shard, so **a shard's pinned phase costs about its
+slowest single test, not the sum of its binaries' sequential times.** The first assignment packed by
+that sum and overestimated shards 2 and 3 by roughly 40%. Two consequences: adding a pin to a shard
+that already holds a slower test is nearly free, and every pin removes its binary's whole sequential
+duration from the leftover.
+
+**The two phases are serial.** Shard wall clock is `pinned + leftover + fixed`, with fixed cost
+measured at ≈1m50s. The leftover phases took 5m16s / 7m31s / 1m25s — a **5.3x spread, worse than the
+pinned phases' 1.72x**. The duration-blindness this change set out to remove was displaced into the
+leftover rather than eliminated, because the leftover is still `count:K/N`.
+
+**The pinning file was stale before it merged.** `fslc-rust::issue_697_all_properties_memory`
+(slowest test 371.8s) arrived with the #697 fix in pull request #739 and was not pinned, so its test
+went into shard 2's count-partitioned leftover. That single test is what took shard 2 from 5.0 min to
+14.6 min. `fslc-rust::explain_cli` was also unpinned — although under the corrected model its slowest
+test is only 69.5s, so it matters for the 439.7s it puts in the leftover, not as a shard occupant.
+
+**Decision on the leftover skew.** Pinning is currently the only lever against it, because every pin
+takes its binary's sequential time out of the count partition. The assignment therefore pins eight
+binaries rather than five, removing 2,061s of sequential work from the leftover. Making the leftover
+itself duration-aware is *not* attempted here: `--partition count:` has no duration input, so it would
+mean replacing the partition with a second checked-in assignment covering every test binary, which
+trades a small maintained file for a large one. If the pinning form below still leaves a leftover
+spread above roughly 2x, that trade is the next thing to evaluate, and it should be its own change.
+
+**What is reachable.** Not ≈13 min on the strength of pinning alone, and that projection is withdrawn.
+`refine_corpus_parity`'s 458.8s single test is indivisible under this scheme, so whichever shard holds
+it pays 7.65 min plus its leftover share plus ≈1m50s fixed — an absolute floor of **≈9.5 min** for that
+shard even with an empty leftover. Going below that needs one of: splitting that test (and
+`issue_697_all_properties_memory`'s 371.8s one), or running the pinned and leftover phases
+concurrently instead of serially. Neither is attempted here; both are larger changes than a scheduling
+tweak, and the second would need care because the two phases currently write one `shard.txt` between
+them.
 
 **Coverage cannot silently drop, by construction, independent of this file's accuracy.** A binary this
 file does not name is not "unhandled" — it simply is not pinned to anyone, so it falls into the
@@ -360,23 +413,28 @@ it; only duration balance, not coverage, depends on the file being current. Cove
 the same way as before this change: `check_rust_tests` writes `full.txt` (unfiltered) and `shard.txt`
 (this shard's union of pinned + leftover) exactly as it always has, and `rust-workspace`'s aggregator
 still runs `tools/check-shard-union.sh full.txt shard1.txt shard2.txt shard3.txt` against them with
-that invocation's behaviour unchanged — the script gained a `check-groups` mode and a fifth rejecting
-selftest case, but the union form itself was not touched, and the shape of the files it consumes did
+that invocation's behaviour unchanged — the script gained a `check-groups` mode, a fifth rejecting
+selftest case for the union form, and four rejecting plus two accepting cases for `check-groups`, but
+the union form itself was not touched, and the shape of the files it consumes did
 not change, so that guard keeps validating the new mechanism without alteration.
 
 **When to update `tools/rust-test-shard-groups.txt`.** Coverage never depends on it, but two cases do
 require an edit, and neither is discoverable from the file alone:
 
-- **Renaming or removing a pinned binary hard-fails every shard.** `check-groups` runs before the
-  partition and rejects a pin whose binary-id is absent from the live `cargo nextest list` output, so
+- **Renaming or removing a pinned binary hard-fails every shard.** `check-groups` runs after the one
+  unfiltered `cargo nextest list` (which supplies both `full.txt` and the live binary set) and before
+  the partition, and rejects a pin whose binary-id is absent from that live set, so
   `rust workspace` goes red until the pin is updated. That is deliberate — a silently stale pin would
   degrade balance invisibly — but it means a rename is a two-file change: the test binary and this
   file. The failure message names the file and the offending id.
-- **Adding a binary slower than roughly three minutes.** Below that, the count partition absorbs it
-  without materially skewing a shard. Above it, pin the binary to whichever shard currently carries
-  the least pinned time (the per-shard totals are in the list above), because one such binary is
-  enough to make its shard the aggregator's critical path. Adding a pin is a single data edit and no
-  code change, the same shape as adding a row to `rust/fslc/tests/fault_operators/operators.txt`.
+- **Adding a binary whose slowest single test exceeds roughly a minute.** The quantity that matters
+  is the slowest *individual* test, not the binary's sequential total — see the cost model above. If
+  that test is slower than every test already pinned to some shard, pin it to the shard with the
+  smallest current maximum, because it will become that shard's pinned-phase cost. If it is faster
+  than an existing pin's slowest test, pinning it is nearly free on that shard and still worth doing:
+  it takes the binary's whole sequential time out of the duration-blind leftover. Adding a pin is a
+  single data edit and no code change, the same shape as adding a row to
+  `rust/fslc/tests/fault_operators/operators.txt`.
 
 What *is* new is a second, narrower guard: `tools/check-shard-union.sh check-groups
 tools/rust-test-shard-groups.txt <live-binary-ids> <shard-total>`, run once per shard before any

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -196,8 +196,8 @@ the generic cargo-mutants half took roughly the remaining ~14.3 min.
 Both jobs are dominated by work that parallelizes cleanly across independent shards, so each is
 split into a sharded lane plus an aggregator that keeps the exact required-context name:
 
-- `rust workspace` = `rust-checks` (once) + `rust-tests` (`cargo-nextest`, 3-way `--partition
-  count:K/3`) + the `rust-workspace` aggregator.
+- `rust workspace` = `rust-checks` (once) + `rust-tests` (`cargo-nextest`, 3-way, duration-aware —
+  see "Duration-aware `rust-tests` shard pinning" below) + the `rust-workspace` aggregator.
 - `semantic mutation (…)` = `semantic-mutation-operators` (3-way round-robin shard of
   `operators.txt`) + `semantic-mutation-mutants` (generic cargo-mutants, complete and **deliberately
   unsharded** — see below) + the `semantic-mutation` aggregator.
@@ -217,13 +217,15 @@ pull request. Recorded from the first sharded run (30989320577, PR #719), all la
 | `FSL Logic Test (pr)` | 1.1 min |
 | both aggregators | 0.1 min each |
 
-Two costs are visible in that table and are the honest limits of this change, not incidental noise:
+Two costs were visible in that table and were the honest limits of that first change, not
+incidental noise:
 
 - **`cargo-nextest --partition count:K/N` balances by test count, not duration.** The three shards
   received 518/460/411 tests and took 18.1/8.3/12.6 min — shard 1 is 2.2x shard 2, so `rust workspace`
-  finishes on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
-  give. Recovering that ~5 min needs a duration-aware assignment (pinning the known-slow binaries to
-  separate shards), which `count:` cannot express.
+  finished on its slowest shard at ≈18 min rather than the ≈13 min a duration-balanced split would
+  give. Issue #720 Finding 1 addressed this — see "Duration-aware `rust-tests` shard pinning" below —
+  by pinning the known-slow binaries to distinct shards explicitly, which `count:` alone cannot
+  express.
 - **Sharding the curated operator lane bought about 10%, not two thirds.** 22.5 min unsharded became
   20.3 min at `K/3` — three times the compute for ~2 min of wall clock — because the fixed cold build
   in each shard's synced scratch checkout dominates. It is retained because runner minutes are free on
@@ -292,17 +294,74 @@ Each `semantic-mutation-operators` shard independently pays the cold build in it
 checkout (`tools/run-fault-operators.sh`'s `sync_scratch`), and that cost dominates the lane. Locally,
 a 6-operator shard's no-op control took 760s where all 17 took 912s; in CI the sharded lane landed at
 18.4–20.3 min against 22.5 min unsharded, so the fixed scratch build is an even larger share there.
-Raising the shard count cannot fix this. The two levers that would, neither attempted here, are:
+Raising the shard count cannot fix this. Two levers would move it further:
 
 - caching `rust/target/fault-operators` so the scratch build starts warm — the same
   `Swatinem/rust-cache` treatment the main lanes already get, and the one place in this gate where
   caching genuinely is the bottleneck (it is not, for `rust workspace`: compilation there is ~3.5 min
-  of 33 on a warm cache);
+  of 33 on a warm cache). **Not attempted** — issue #720 Finding 2, tracked separately because it
+  changes a different mechanism (`tools/run-fault-operators.sh`'s scratch checkout) with its own
+  patch-isolation contract, and because #720 asks that a possible revert of the operator sharding be
+  evaluated in the same change once this lands, which needs its own review;
 - a duration-aware `rust-tests` assignment, worth ~5 min on its own (see the imbalance above).
+  **Landed** — issue #720 Finding 1; see "Duration-aware `rust-tests` shard pinning" below.
 
-With both, the gate would plausibly reach ≈13 min; without them, 20.7 min is the floor this design
-delivers. Nobody should expect either lane to shrink further without changing what it measures or how
-its scratch build is warmed.
+With both, the gate would plausibly reach ≈13 min; with only Finding 1, the expected floor is
+`rust-workspace` at roughly ≈13 min (unchanged from the estimate above: `refine_corpus_parity`'s
+single ≈7.3 min test plus ≈3.5 min compile) rather than the ≈18 min its slowest count-balanced shard
+measured before. That is an *expected* gain from the shard-composition arithmetic below, not a
+measured one — only a pull-request run of this change against `ci.yml` measures real wall clock, and
+that run is what would confirm it. Finding 2 remains 20.3 min at best until it lands; nobody should
+expect either lane to shrink further without changing what it measures or how its scratch build is
+warmed.
+
+### Duration-aware `rust-tests` shard pinning (issue #720 Finding 1)
+
+`cargo-nextest --partition count:K/N` assigns tests to shards by count, with no notion of how long
+each test takes, so five binaries holding ~77% of the suite's sequential wall clock
+(`refine_corpus_parity` ~7.34 min/4 tests, `explicit_engine` ~4.58 min/12, `injection_detector_matrix`
+~3.75 min/1 test, `corpus_check_sweep` ~3.16 min/3, `issue_226_auto_engine` ~3.13 min/15 — all five
+confirmed still present against this workspace, with test counts matching exactly) could land in the
+same shard, or unevenly across shards, by chance. `check_rust_tests` in
+`tools/check-native-integration.sh` replaces the single `--partition` invocation with two, unioned:
+
+1. `tools/rust-test-shard-groups.txt`, a checked-in text file pinning specific binary-ids to specific
+   shards (`<shard> <binary-id>`, comments with `#`), read once per shard invocation. The binaries
+   above are bin-packed onto the three shards by their measured minutes (shard 1: `refine_corpus_parity`
+   alone, ~7.34 min; shard 2: `explicit_engine` + `corpus_check_sweep`, ~7.74 min; shard 3:
+   `injection_detector_matrix` + `issue_226_auto_engine`, ~6.88 min), then each shard's pinned binaries
+   run through `cargo nextest run -E 'binary_id(=…) or binary_id(=…) …'` — the exact-match `=`
+   name-matcher (`cargo nextest help filterset`) — unpartitioned, so a pinned binary is never split
+   across shards or forced to share a shard with another pin by count-hash chance.
+2. Every test *not* in any pinned binary still goes through the original `--partition count:K/N`,
+   scoped by `-E 'not binary_id(=…) and not binary_id(=…) …'` excluding every pinned binary (not just
+   this shard's), so a pinned binary's tests are never double-counted into another shard's leftover
+   share. Verified directly against this workspace (1418 non-ignored tests, 35 of them pinned): the
+   three leftover partitions receive 518/457/408 tests, are pairwise disjoint, and their union is
+   exactly the 1383 non-pinned tests; folding the 4/15/16 pinned tests back in gives 522/472/424 per
+   shard, pairwise disjoint, unioning to exactly the full 1418.
+
+**Coverage cannot silently drop, by construction, independent of this file's accuracy.** A binary this
+file does not name is not "unhandled" — it simply is not pinned to anyone, so it falls into the
+ordinary count-partitioned leftover exactly as before. A new test binary landing with nobody updating
+`tools/rust-test-shard-groups.txt` therefore still runs, in whichever shard the count partition puts
+it; only duration balance, not coverage, depends on the file being current. Coverage is still proven
+the same way as before this change: `check_rust_tests` writes `full.txt` (unfiltered) and `shard.txt`
+(this shard's union of pinned + leftover) exactly as it always has, and `rust-workspace`'s aggregator
+still runs the unmodified `tools/check-shard-union.sh full.txt shard1.txt shard2.txt shard3.txt` against
+them — the shape those files take did not change, so that guard needed no changes to keep validating
+the new mechanism.
+
+What *is* new is a second, narrower guard: `tools/check-shard-union.sh check-groups
+tools/rust-test-shard-groups.txt <live-binary-ids> <shard-total>`, run once per shard before any
+listing or partition happens. It fails closed if the grouping file names a binary-id the live
+workspace's `cargo nextest list` no longer reports (a stale pin surviving a rename or removal) or pins
+the same binary-id to more than one shard. Its `selftest` cases (in `tools/check-shard-union.sh`,
+wired into `merge readiness / automation contracts` alongside the pre-existing shard-union selftest)
+cover an accepting config, an unknown pinned binary-id, and a duplicate pin; a further rejecting case
+added to the pre-existing `check_union` selftest proves that guard catches an entire binary's tests
+(not just one stray entry) dropped from every shard, since that is the failure shape a whole-binary
+pin actually risks.
 
 `semantic mutation` is required on pull requests and every product-gate event. Ordinary pull
 requests run all curated controls plus generic mutants intersecting the recorded base-to-head diff;

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -148,7 +148,12 @@ check_rust_tests() {
 
   local -a pinned_here=() pinned_all=()
   local line
-  while IFS= read -r line; do
+  # `|| [ -n "$line" ]` keeps a final line with no trailing newline. Without it
+  # this loop and `check-shard-union.sh check-groups` -- which has always had the
+  # guard -- disagree about the same file: the guard would accept a pin that this
+  # loop silently drops. Coverage stays correct either way (a dropped pin falls
+  # into the count partition), but two parsers of one file must not differ.
+  while IFS= read -r line || [ -n "$line" ]; do
     local trimmed="${line%%#*}"
     trimmed="$(printf '%s' "$trimmed" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [ -z "$trimmed" ] && continue

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -55,6 +55,21 @@ check_rust_checks() {
 # commit hash, so compare the stable `release:` line instead.
 readonly NEXTEST_VERSION="0.9.143"
 
+# Duration-aware pinning file for `rust-tests` (issue #720 Finding 1;
+# docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence"). `--partition
+# count:K/N` balances by test *count*, not wall clock: five binaries hold
+# ~77% of this suite's sequential time while most of the other ~170 finish
+# in under a second, so a pure count split puts wildly different amounts of
+# work per shard. Each non-comment, non-blank line is "<shard> <binary-id>",
+# 1-based shard index <= the shard total in use; it pins that whole binary's
+# tests to that shard, unpartitioned. A binary this file does not name is
+# not pinned to anyone, so it always falls into the leftover count-partition
+# below -- coverage never depends on this file staying current, only
+# duration balance does. `check-shard-union.sh check-groups` fails closed if
+# a pin names a binary the live workspace no longer has (stale rename or
+# removal) or pins one binary to more than one shard.
+readonly RUST_TEST_SHARD_GROUPS="tools/rust-test-shard-groups.txt"
+
 # Runs one shard (`spec` = "K/N", 1-based, K <= N) of the workspace's
 # non-doctest tests under `cargo-nextest`, after writing the shard's
 # completeness evidence: `full.txt` (every non-ignored test in the
@@ -64,6 +79,16 @@ readonly NEXTEST_VERSION="0.9.143"
 # they are byte-identical (three independently computed listings agreeing),
 # and checks the union of every `shard.txt` against one `full.txt` with
 # `check-shard-union.sh`.
+#
+# The shard itself is the union of two independently computed slices, run in
+# two separate `cargo nextest` invocations:
+#   - `RUST_TEST_SHARD_GROUPS`'s explicit pins for this shard, run whole
+#     (no partition -- the point is to keep a known-slow binary from being
+#     split across shards or landing next to another slow one by chance);
+#   - every test *not* in any pinned binary, still balanced by
+#     `--partition count:K/N` exactly as before. Excluding every pinned
+#     binary (not just this shard's) from that partition is what stops a
+#     pinned binary from being double-counted into another shard's share.
 check_rust_tests() {
   local spec="${1:-}"
   if [[ ! "$spec" =~ ^([1-9][0-9]*)/([1-9][0-9]*)$ ]]; then
@@ -87,29 +112,95 @@ check_rust_tests() {
   mkdir -p "$shard_dir"
   local full="$shard_dir/full.txt"
   local shard="$shard_dir/shard.txt"
+  local known="$shard_dir/known-binaries.txt"
 
   # `rust-suites` is an object keyed by suite name, not an array; each
-  # suite's `binary-id` disambiguates same-named tests across binaries.
-  # `--partition` does not shrink the listing -- every suite still lists
-  # every test, and each testcase's `filter-match.status` says whether *this*
-  # invocation's partition claims it ("matches") or another one does
-  # ("mismatch"). Verified directly against this workspace (1389 tests):
-  # unpartitioned `ignored == false` gives all 1389; the three
-  # `count:K/3` partitions' `filter-match.status == "matches"` sets are
-  # pairwise disjoint and their union is exactly those 1389.
-  cargo nextest list \
+  # suite's `binary-id` disambiguates same-named tests across binaries. One
+  # unfiltered listing serves both `full.txt` (unchanged contract with
+  # `rust-workspace`'s aggregator) and the live binary-id set `check-groups`
+  # validates the pinning file against, so validating the grouping costs no
+  # extra listing pass. Verified directly against this workspace (1418
+  # non-ignored tests as of issue #720's Finding 1 fix, up from 1389 when
+  # #719 wrote this comment; the count drifts as tests are added, which is
+  # exactly why `full.txt` is computed fresh here rather than hardcoded).
+  local full_json
+  full_json="$(cargo nextest list \
     --manifest-path rust/Cargo.toml --workspace --locked \
-    --message-format json \
-    | jq -r '
-        .["rust-suites"][]
-        | ."binary-id" as $bid
-        | .testcases
-        | to_entries[]
-        | select(.value.ignored == false)
-        | $bid + "::" + .key' \
+    --message-format json)"
+  printf '%s' "$full_json" | jq -r '
+      .["rust-suites"][]
+      | ."binary-id" as $bid
+      | .testcases
+      | to_entries[]
+      | select(.value.ignored == false)
+      | $bid + "::" + .key' \
     | sort -u >"$full"
+  printf '%s' "$full_json" | jq -r '.["rust-suites"][] | ."binary-id"' \
+    | sort -u >"$known"
+
+  [ -s "$full" ] || {
+    echo "check-native-integration: nextest listed zero non-ignored tests for the workspace; refusing to run a shard against an empty inventory" >&2
+    exit 1
+  }
+
+  ./tools/check-shard-union.sh check-groups "$RUST_TEST_SHARD_GROUPS" "$known" "$shard_total"
+
+  local -a pinned_here=() pinned_all=()
+  local line
+  while IFS= read -r line; do
+    local trimmed="${line%%#*}"
+    trimmed="$(printf '%s' "$trimmed" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$trimmed" ] && continue
+    local idx bin
+    read -r idx bin <<<"$trimmed"
+    pinned_all+=("$bin")
+    [ "$idx" = "$shard_index" ] && pinned_here+=("$bin")
+  done <"$RUST_TEST_SHARD_GROUPS"
+
+  # `binary_id(=name)` is nextest's exact-match filterset predicate (`cargo
+  # nextest help filterset`). `pinned_expr` selects this shard's pinned
+  # binaries whole; `leftover_expr` excludes every pinned binary (any shard)
+  # from the count-partitioned remainder, so a pin can never land in two
+  # shards at once via the fallback path.
+  local pinned_expr="" leftover_expr="all()" bin
+  if [ "${#pinned_here[@]}" -gt 0 ]; then
+    for bin in "${pinned_here[@]}"; do
+      if [ -z "$pinned_expr" ]; then
+        pinned_expr="binary_id(=$bin)"
+      else
+        pinned_expr="$pinned_expr or binary_id(=$bin)"
+      fi
+    done
+  fi
+  if [ "${#pinned_all[@]}" -gt 0 ]; then
+    leftover_expr=""
+    for bin in "${pinned_all[@]}"; do
+      if [ -z "$leftover_expr" ]; then
+        leftover_expr="not binary_id(=$bin)"
+      else
+        leftover_expr="$leftover_expr and not binary_id(=$bin)"
+      fi
+    done
+  fi
+
+  : >"$shard"
+  if [ -n "$pinned_expr" ]; then
+    cargo nextest list \
+      --manifest-path rust/Cargo.toml --workspace --locked \
+      -E "$pinned_expr" \
+      --message-format json \
+      | jq -r '
+          .["rust-suites"][]
+          | ."binary-id" as $bid
+          | .testcases
+          | to_entries[]
+          | select(.value.ignored == false)
+          | $bid + "::" + .key' \
+      >>"$shard"
+  fi
   cargo nextest list \
     --manifest-path rust/Cargo.toml --workspace --locked \
+    -E "$leftover_expr" \
     --partition "count:${shard_index}/${shard_total}" \
     --message-format json \
     | jq -r '
@@ -119,12 +210,9 @@ check_rust_tests() {
         | to_entries[]
         | select(.value.ignored == false and .value["filter-match"].status == "matches")
         | $bid + "::" + .key' \
-    | sort -u >"$shard"
+    >>"$shard"
+  sort -u -o "$shard" "$shard"
 
-  [ -s "$full" ] || {
-    echo "check-native-integration: nextest listed zero non-ignored tests for the workspace; refusing to run a shard against an empty inventory" >&2
-    exit 1
-  }
   [ -s "$shard" ] || {
     echo "check-native-integration: shard $spec listed zero tests -- N is likely larger than the test count, or the partition math is wrong" >&2
     exit 1
@@ -134,8 +222,14 @@ check_rust_tests() {
     exit 1
   fi
 
+  if [ -n "$pinned_expr" ]; then
+    cargo nextest run \
+      --manifest-path rust/Cargo.toml --workspace --locked \
+      -E "$pinned_expr"
+  fi
   cargo nextest run \
     --manifest-path rust/Cargo.toml --workspace --locked \
+    -E "$leftover_expr" \
     --partition "count:${shard_index}/${shard_total}"
 }
 

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -56,7 +56,8 @@ check_rust_checks() {
 readonly NEXTEST_VERSION="0.9.143"
 
 # Duration-aware pinning file for `rust-tests` (issue #720 Finding 1;
-# docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence"). `--partition
+# docs/DESIGN-ci.md, "Duration-aware `rust-tests` shard pinning" -- the sibling
+# section of "Sharded pre-merge Linux evidence", not a part of it). `--partition
 # count:K/N` balances by test *count*, not wall clock: five binaries hold
 # ~77% of this suite's sequential time while most of the other ~170 finish
 # in under a second, so a pure count split puts wildly different amounts of

--- a/tools/check-shard-union.sh
+++ b/tools/check-shard-union.sh
@@ -38,9 +38,12 @@
 #     N-way split) and five rejecting cases (a full-only entry covered by no
 #     shard; an entry duplicated across two shards; a shard entry absent from
 #     full; an empty shard list; an entire binary's tests dropped from every
-#     shard), plus check-groups's accepting case and two rejecting cases (an
-#     unknown pinned binary-id; a binary-id pinned to two shards) -- each
-#     rejecting case must make this script exit non-zero.
+#     shard), plus check-groups's two accepting cases (a clean pinning, and a
+#     final line with no trailing newline -- the shape `check_rust_tests` in
+#     tools/check-native-integration.sh must agree with) and four rejecting
+#     cases (an unknown pinned binary-id; a binary-id pinned to two shards; a
+#     shard index above the shard total; a malformed line, in three shapes) --
+#     each rejecting case must make this script exit non-zero.
 
 set -euo pipefail
 
@@ -238,6 +241,37 @@ selftest() {
   printf '1 binA\n2 binA\n' >"$tmp/groups-dup.txt"
   if (check_groups "$tmp/groups-dup.txt" "$tmp/known.txt" 3) >/dev/null 2>&1; then
     echo "check-shard-union selftest: FAIL: a binary-id pinned to two shards was accepted" >&2
+    return 1
+  fi
+
+  # check-groups rejecting (c): a shard index above the shard total. This bound
+  # is stated as a guarantee in docs/DESIGN-ci.md, so it needs an executable
+  # control -- otherwise deleting the check passes every gate.
+  printf '1 binA\n4 binB\n' >"$tmp/groups-range.txt"
+  if (check_groups "$tmp/groups-range.txt" "$tmp/known.txt" 3) >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: a shard index above the total was accepted" >&2
+    return 1
+  fi
+
+  # check-groups rejecting (d): a malformed line. Three shapes, each of which
+  # would otherwise reach the runner as a pin with an empty binary-id or an
+  # empty index: no index, index only, non-numeric index.
+  local malformed
+  for malformed in 'binA' '1' 'x binA'; do
+    printf '%s\n' "$malformed" >"$tmp/groups-malformed.txt"
+    if (check_groups "$tmp/groups-malformed.txt" "$tmp/known.txt" 3) >/dev/null 2>&1; then
+      echo "check-shard-union selftest: FAIL: a malformed groups line was accepted: '$malformed'" >&2
+      return 1
+    fi
+  done
+
+  # check-groups accepting: a final line with no trailing newline is still a pin.
+  # `check_rust_tests` in tools/check-native-integration.sh parses the same file,
+  # and the two must not disagree about it.
+  printf '1 binA\n2 binB' >"$tmp/groups-nonewline.txt"
+  if ! (check_groups "$tmp/groups-nonewline.txt" "$tmp/known.txt" 3) \
+      | grep -q 'pins 2 binary'; then
+    echo "check-shard-union selftest: FAIL: a groups file with no trailing newline lost its last pin" >&2
     return 1
   fi
 

--- a/tools/check-shard-union.sh
+++ b/tools/check-shard-union.sh
@@ -17,11 +17,30 @@
 #       - shards are pairwise disjoint
 #       - the union of all shards equals full exactly
 #
+#   check-shard-union.sh check-groups <groups-file> <known-binaries-file> <shard-total>
+#     Validates a checked-in duration-aware binary->shard pinning file (e.g.
+#     tools/rust-test-shard-groups.txt) against the live set of binary IDs
+#     cargo-nextest actually reports, and against itself. Fails closed unless:
+#       - every pinned binary-id is present in <known-binaries-file> (a
+#         pinned name absent from the live set means the grouping went stale
+#         after a rename/removal and nobody updated it)
+#       - no binary-id is pinned to more than one shard
+#       - every shard index is a positive integer <= <shard-total>
+#     A binary *not* named in the groups file is not an error here -- the
+#     caller's fallback count-partition covers it automatically, so this
+#     check only protects against a wrong pin, never against an unpinned
+#     (i.e. uncovered) binary; final coverage is still proven end to end by
+#     the <full-list>/<shard-list> form above, which check_rust_tests also
+#     runs against the resulting shard.
+#
 #   check-shard-union.sh selftest
-#     Exercises an accepting case (a clean N-way split) and four rejecting
-#     cases (a full-only entry covered by no shard; an entry duplicated across
-#     two shards; a shard entry absent from full; an empty shard list), each of
-#     which must make this script exit non-zero.
+#     Exercises the <full-list>/<shard-list> form's accepting case (a clean
+#     N-way split) and five rejecting cases (a full-only entry covered by no
+#     shard; an entry duplicated across two shards; a shard entry absent from
+#     full; an empty shard list; an entire binary's tests dropped from every
+#     shard), plus check-groups's accepting case and two rejecting cases (an
+#     unknown pinned binary-id; a binary-id pinned to two shards) -- each
+#     rejecting case must make this script exit non-zero.
 
 set -euo pipefail
 
@@ -94,6 +113,50 @@ check_union() {
   echo "check-shard-union: PASS -- $(printf '%s\n' "$full" | grep -c .) entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
 }
 
+# See the "check-groups" usage block above. Format: non-comment, non-blank
+# lines are "<shard> <binary-id>", 1-based shard index <= shard_total.
+check_groups() {
+  local groups_path="$1" known_path="$2" shard_total="$3"
+  [ -f "$groups_path" ] || fail "'$groups_path' does not exist"
+  [ -f "$known_path" ] || fail "'$known_path' does not exist"
+  [[ "$shard_total" =~ ^[1-9][0-9]*$ ]] || fail "shard total must be a positive integer, got '$shard_total'"
+
+  local known
+  known="$(sort -u "$known_path")"
+
+  local -a seen_binaries=()
+  local line_no=0 line
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$((line_no + 1))
+    local trimmed="${line%%#*}"
+    trimmed="$(printf '%s' "$trimmed" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$trimmed" ] && continue
+
+    local shard_idx binary_id
+    read -r shard_idx binary_id <<<"$trimmed"
+    if [[ ! "$shard_idx" =~ ^[1-9][0-9]*$ ]] || [ -z "${binary_id:-}" ]; then
+      fail "'$groups_path' line $line_no is malformed (want '<shard> <binary-id>'): $line"
+    fi
+    if [ "$shard_idx" -gt "$shard_total" ]; then
+      fail "'$groups_path' line $line_no pins '$binary_id' to shard $shard_idx, but shard_total is $shard_total"
+    fi
+    if ! grep -qxF "$binary_id" <<<"$known"; then
+      fail "'$groups_path' names an unknown binary-id '$binary_id' (line $line_no) -- absent from the live cargo-nextest binary set; the binary was renamed or removed and this grouping went stale"
+    fi
+    if [ "${#seen_binaries[@]}" -gt 0 ]; then
+      local prior
+      for prior in "${seen_binaries[@]}"; do
+        if [ "$prior" = "$binary_id" ]; then
+          fail "'$groups_path' pins binary-id '$binary_id' more than once (line $line_no)"
+        fi
+      done
+    fi
+    seen_binaries+=("$binary_id")
+  done <"$groups_path"
+
+  echo "check-shard-union: PASS -- '$groups_path' pins ${#seen_binaries[@]} binary(s), all known, none duplicated"
+}
+
 selftest() {
   local tmp
   tmp="$(mktemp -d)"
@@ -142,6 +205,42 @@ selftest() {
     return 1
   fi
 
+  # Rejecting (e): an entire binary's tests dropped from every shard, not
+  # just one stray entry. A duration-aware grouping pins whole binaries, so
+  # its most likely failure mode is losing every entry belonging to one
+  # binary at once; this proves check_union catches that shape, not only a
+  # single missing line.
+  printf 'binW::t1\nbinW::t2\nbinX::t1\nbinX::t2\nbinY::t1\n' >"$tmp/full-bin.txt"
+  printf 'binW::t1\nbinW::t2\n' >"$tmp/shard1-bin.txt"
+  printf 'binY::t1\n' >"$tmp/shard2-bin.txt"
+  if (check_union "$tmp/full-bin.txt" "$tmp/shard1-bin.txt" "$tmp/shard2-bin.txt") >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: an entire binary dropped from every shard was accepted" >&2
+    return 1
+  fi
+
+  # check-groups accepting: every pinned binary-id is known, none duplicated.
+  printf 'binA\nbinB\nbinC\n' >"$tmp/known.txt"
+  printf '1 binA\n2 binB\n' >"$tmp/groups.txt"
+  if ! (check_groups "$tmp/groups.txt" "$tmp/known.txt" 3) >/dev/null; then
+    echo "check-shard-union selftest: FAIL: an accepting group config was rejected" >&2
+    return 1
+  fi
+
+  # check-groups rejecting (a): a pinned binary-id absent from the live
+  # binary set -- the grouping went stale after a rename/removal.
+  printf '1 binA\n2 binZZZ\n' >"$tmp/groups-unknown.txt"
+  if (check_groups "$tmp/groups-unknown.txt" "$tmp/known.txt" 3) >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: an unknown pinned binary-id was accepted" >&2
+    return 1
+  fi
+
+  # check-groups rejecting (b): the same binary-id pinned to two shards.
+  printf '1 binA\n2 binA\n' >"$tmp/groups-dup.txt"
+  if (check_groups "$tmp/groups-dup.txt" "$tmp/known.txt" 3) >/dev/null 2>&1; then
+    echo "check-shard-union selftest: FAIL: a binary-id pinned to two shards was accepted" >&2
+    return 1
+  fi
+
   echo "check-shard-union selftest: all assertions passed"
 }
 
@@ -149,8 +248,16 @@ case "${1:-}" in
   selftest)
     selftest
     ;;
+  check-groups)
+    shift
+    [ "$#" -eq 3 ] || {
+      echo "usage: $0 check-groups <groups-file> <known-binaries-file> <shard-total>" >&2
+      exit 2
+    }
+    check_groups "$@"
+    ;;
   "")
-    echo "usage: $0 <full-list> <shard-list>... | $0 selftest" >&2
+    echo "usage: $0 <full-list> <shard-list>... | $0 check-groups <groups-file> <known-binaries-file> <shard-total> | $0 selftest" >&2
     exit 2
     ;;
   *)

--- a/tools/rust-test-shard-groups.txt
+++ b/tools/rust-test-shard-groups.txt
@@ -1,9 +1,10 @@
 # Duration-aware pinning for `rust-tests` shards (issue #720 Finding 1;
 # docs/DESIGN-ci.md, "Duration-aware `rust-tests` shard pinning", which also
-# records when this file must be edited). Each non-comment,
-# non-blank line is "<shard> <binary-id>", 1-based shard index <= the shard
-# total cargo-nextest is invoked with (3 in .github/workflows/ci.yml today).
-# A pinned binary's tests all run in that shard, unpartitioned.
+# records the cost model, the reachable floor, and when this file must be
+# edited). Each non-comment, non-blank line is "<shard> <binary-id>", 1-based
+# shard index <= the shard total cargo-nextest is invoked with (3 in
+# .github/workflows/ci.yml today). A pinned binary's tests all run in that
+# shard, unpartitioned.
 #
 # `binary-id` is cargo-nextest's own identifier (`cargo nextest list
 # --message-format json`, the `binary-id` field; see `cargo nextest help
@@ -18,18 +19,56 @@
 # depends on this file being current -- only duration balance does. What
 # does depend on this file: `tools/check-shard-union.sh check-groups` fails
 # closed if a pin below names a binary the live workspace no longer has
-# (rename/removal) or pins one binary to more than one shard.
+# (rename/removal), pins one binary to more than one shard, uses a shard index
+# above the total, or is malformed.
 #
-# Measured per-binary wall clock (run 30989320577 / rerun, docs/DESIGN-ci.md):
-# refine_corpus_parity ~7.34 min (4 tests), explicit_engine ~4.58 min
-# (12 tests), injection_detector_matrix ~3.75 min (1 test),
-# corpus_check_sweep ~3.16 min (3 tests), issue_226_auto_engine ~3.13 min
-# (15 tests) -- together ~77% of the suite's sequential time while most of
-# the remaining ~190 binaries finish in under a second. Bin-packed across 3
-# shards: shard 1 ~7.34 min, shard 2 ~7.74 min, shard 3 ~6.88 min, each then
-# also taking its share of the count-partitioned leftover.
+# THE COST MODEL IS THE LONGEST SINGLE TEST, NOT THE SUM.
+# nextest runs tests concurrently inside a shard, so a shard's pinned phase
+# costs about its slowest individual test -- measured to the second on all
+# three shards of run 31076668077, where the pinned phases took 7m40s / 4m27s /
+# 4m36s against slowest tests of 458.8s / 266.6s / 275.6s. Packing by the sum
+# of per-binary sequential minutes (which this file did in its first version)
+# overestimated shards 2 and 3 by roughly 40% and balanced the wrong quantity.
+#
+# Two consequences follow, and they are why the list below is longer than the
+# first version's:
+#   - Adding a pin to a shard that already holds a slower test is close to
+#     free, because the shard's phase cost does not move.
+#   - Every pin removes its binary's whole sequential duration from the
+#     count-partitioned leftover, which is duration-blind. On run 31076668077
+#     the leftover phases were 5m16s / 7m31s / 1m25s -- a 5.3x spread, worse
+#     than the pinned phases' 1.72x. Pinning is therefore the only lever
+#     currently available against leftover skew as well.
+#
+# Measured slowest-single-test per binary, run 31076668077 (this pull request's
+# own CI run; per-test `PASS [ Ns]` lines from the three `rust tests (K/3)`
+# job logs). Sequential total and test count in brackets:
+#   refine_corpus_parity                458.8s  [458.9s total,  4 tests]
+#   issue_697_all_properties_memory     371.8s  [655.6s total,  4 tests]
+#   injection_detector_matrix           275.6s  [275.6s total,  1 test]
+#   explicit_engine                     266.6s  [266.7s total,  4 tests]
+#   issue_226_auto_engine               205.9s  [338.4s total,  6 tests]
+#   corpus_check_sweep                  192.5s  [224.5s total,  2 tests]
+#   issue_697_corpus_probe_budget        76.7s  [ 76.7s total,  1 test]
+#   explain_cli                          69.5s  [439.7s total, 13 tests]
+# Nothing else exceeds 62s. Note `explain_cli`: 439.7s sequential but only 69.5s
+# slowest test, so under the corrected model it is not a heavy shard occupant --
+# it is pinned only to take its 439.7s out of the leftover.
+#
+# `issue_697_all_properties_memory` did not exist when the first version of this
+# file was written; it arrived with the #697 fix (pull request #739) and, being
+# unpinned, put its 371.8s test into shard 2's count-partitioned leftover. That
+# single test is what took shard 2 from 5.0 min to 14.6 min.
+#
+# Projected pinned-phase cost with the assignment below: 458.8s / 371.8s / 275.6s
+# = 7.6 / 6.2 / 4.6 min, and 2,061s of sequential work removed from the
+# leftover. Projected, not measured -- the next `product gate` run on this
+# branch is what confirms it.
 1 fslc-rust::refine_corpus_parity
+1 fslc-rust::corpus_check_sweep
+2 fslc-rust::issue_697_all_properties_memory
 2 fslc-rust::explicit_engine
-2 fslc-rust::corpus_check_sweep
 3 fslc-rust::injection_detector_matrix
 3 fslc-rust::issue_226_auto_engine
+3 fslc-rust::explain_cli
+3 fslc-rust::issue_697_corpus_probe_budget

--- a/tools/rust-test-shard-groups.txt
+++ b/tools/rust-test-shard-groups.txt
@@ -1,0 +1,34 @@
+# Duration-aware pinning for `rust-tests` shards (issue #720 Finding 1;
+# docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence"). Each non-comment,
+# non-blank line is "<shard> <binary-id>", 1-based shard index <= the shard
+# total cargo-nextest is invoked with (3 in .github/workflows/ci.yml today).
+# A pinned binary's tests all run in that shard, unpartitioned.
+#
+# `binary-id` is cargo-nextest's own identifier (`cargo nextest list
+# --message-format json`, the `binary-id` field; see `cargo nextest help
+# filterset`'s binary_id() predicate) -- typically `<package>::<binary-name>`,
+# disambiguating same-named test files across crates (this workspace has two
+# `explicit_engine.rs` files, in `fslc` and `fsl-runtime`; only the `fslc`
+# one is pinned here).
+#
+# A binary NOT named here is not dropped: `check_rust_tests` in
+# tools/check-native-integration.sh falls every unpinned binary back to
+# cargo-nextest's ordinary `--partition count:K/N` split. Coverage never
+# depends on this file being current -- only duration balance does. What
+# does depend on this file: `tools/check-shard-union.sh check-groups` fails
+# closed if a pin below names a binary the live workspace no longer has
+# (rename/removal) or pins one binary to more than one shard.
+#
+# Measured per-binary wall clock (run 30989320577 / rerun, docs/DESIGN-ci.md):
+# refine_corpus_parity ~7.34 min (4 tests), explicit_engine ~4.58 min
+# (12 tests), injection_detector_matrix ~3.75 min (1 test),
+# corpus_check_sweep ~3.16 min (3 tests), issue_226_auto_engine ~3.13 min
+# (15 tests) -- together ~77% of the suite's sequential time while most of
+# the remaining ~190 binaries finish in under a second. Bin-packed across 3
+# shards: shard 1 ~7.34 min, shard 2 ~7.74 min, shard 3 ~6.88 min, each then
+# also taking its share of the count-partitioned leftover.
+1 fslc-rust::refine_corpus_parity
+2 fslc-rust::explicit_engine
+2 fslc-rust::corpus_check_sweep
+3 fslc-rust::injection_detector_matrix
+3 fslc-rust::issue_226_auto_engine

--- a/tools/rust-test-shard-groups.txt
+++ b/tools/rust-test-shard-groups.txt
@@ -22,23 +22,34 @@
 # (rename/removal), pins one binary to more than one shard, uses a shard index
 # above the total, or is malformed.
 #
-# THE COST MODEL IS THE LONGEST SINGLE TEST, NOT THE SUM.
-# nextest runs tests concurrently inside a shard, so a shard's pinned phase
-# costs about its slowest individual test -- measured to the second on all
-# three shards of run 31076668077, where the pinned phases took 7m40s / 4m27s /
-# 4m36s against slowest tests of 458.8s / 266.6s / 275.6s. Packing by the sum
-# of per-binary sequential minutes (which this file did in its first version)
-# overestimated shards 2 and 3 by roughly 40% and balanced the wrong quantity.
+# THE COST MODEL IS max(SLOWEST SINGLE TEST, SEQUENTIAL SUM / 3).
+# nextest runs tests concurrently inside a shard, but the concurrency is finite.
+# Measured against all three shards of run 31081427765 attempt 2 (warm cache),
+# the pinned phase costs about 1.11 * max(slowest single test, sequential sum / 3):
 #
-# Two consequences follow, and they are why the list below is longer than the
-# first version's:
-#   - Adding a pin to a shard that already holds a slower test is close to
-#     free, because the shard's phase cost does not move.
-#   - Every pin removes its binary's whole sequential duration from the
-#     count-partitioned leftover, which is duration-blind. On run 31076668077
-#     the leftover phases were 5m16s / 7m31s / 1m25s -- a 5.3x spread, worse
-#     than the pinned phases' 1.72x. Pinning is therefore the only lever
-#     currently available against leftover skew as well.
+#   shard  pinned sum  slowest  model  actual   error
+#     1        683.4s   458.8s   509s   508.1s   -0.2%
+#     2        922.3s   371.8s   413s   465.2s  +12.7%
+#     3       1130.4s   275.6s   418s   418.5s   +0.1%
+#
+# Neither term alone works. Using only the slowest test underestimates shard 3 by
+# 52%; using only the sum overestimates shard 1. Shard 2's excess is the one
+# outlier: `issue_697_all_properties_memory` is memory-bound by construction (see
+# `CONCRETE_PROBE_BUDGET`, issue #697), so its tests contend for memory rather
+# than CPU and do not overlap as freely as the model assumes. Treat +15% as the
+# planning margin for a shard holding it.
+#
+# Two consequences, and the second is why this list is longer than five entries:
+#   - Adding a pin is NOT free. It raises the shard's sequential sum, and once
+#     sum/3 exceeds the slowest test the phase grows with every addition.
+#   - Every pin still removes its binary's whole sequential duration from the
+#     count-partitioned leftover, which is duration-blind. Measured on the same
+#     run, the leftover phases fell to 75.4s / 43.0s / 63.9s -- a 1.75x spread,
+#     down from 5.3x under the five-binary assignment.
+# Balance the two: keep max(slowest, sum/3) even across shards, and prefer
+# pinning a binary whose sequential total is large relative to its slowest test
+# (`explain_cli`: 439.7s over 13 tests, slowest 69.5s) because it drains the
+# leftover cheaply.
 #
 # Measured slowest-single-test per binary, run 31076668077 (this pull request's
 # own CI run; per-test `PASS [ Ns]` lines from the three `rust tests (K/3)`
@@ -51,19 +62,25 @@
 #   corpus_check_sweep                  192.5s  [224.5s total,  2 tests]
 #   issue_697_corpus_probe_budget        76.7s  [ 76.7s total,  1 test]
 #   explain_cli                          69.5s  [439.7s total, 13 tests]
-# Nothing else exceeds 62s. Note `explain_cli`: 439.7s sequential but only 69.5s
-# slowest test, so under the corrected model it is not a heavy shard occupant --
-# it is pinned only to take its 439.7s out of the leftover.
+# Nothing else exceeds 62s. `explain_cli` is the instructive case: 439.7s sequential
+# but only a 69.5s slowest test. It is pinned to drain that 439.7s from the
+# duration-blind leftover, and the trade is not free -- it raises shard 3's sum from
+# 690.7s to 1130.4s, which is what moves that shard's model term from max(275.6, 230)
+# to sum/3 = 376.8 and costs it about 112s of pinned phase. It pays because the
+# leftover is count-partitioned across all three shards, so the 439.7s it removes is
+# spread over every shard while the 112s lands on one.
 #
 # `issue_697_all_properties_memory` did not exist when the first version of this
 # file was written; it arrived with the #697 fix (pull request #739) and, being
 # unpinned, put its 371.8s test into shard 2's count-partitioned leftover. That
 # single test is what took shard 2 from 5.0 min to 14.6 min.
 #
-# Projected pinned-phase cost with the assignment below: 458.8s / 371.8s / 275.6s
-# = 7.6 / 6.2 / 4.6 min, and 2,061s of sequential work removed from the
-# leftover. Projected, not measured -- the next `product gate` run on this
-# branch is what confirms it.
+# MEASURED with the assignment below, run 31081427765 attempt 2, warm cache:
+# pinned phases 508.1s / 465.2s / 418.5s, leftover 75.4s / 43.0s / 63.9s, a
+# constant ~113s of setup and build per shard, giving shard wall clocks of
+# 12.2 / 10.85 / 10.46 min. The slowest shard -- which is what `rust workspace`
+# waits on -- fell from 15.6 min to 12.2 min, and the spread from 3.1x to 1.17x.
+# `tools/check-shard-union.sh` reported a clean union on that run.
 1 fslc-rust::refine_corpus_parity
 1 fslc-rust::corpus_check_sweep
 2 fslc-rust::issue_697_all_properties_memory

--- a/tools/rust-test-shard-groups.txt
+++ b/tools/rust-test-shard-groups.txt
@@ -1,5 +1,6 @@
 # Duration-aware pinning for `rust-tests` shards (issue #720 Finding 1;
-# docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence"). Each non-comment,
+# docs/DESIGN-ci.md, "Duration-aware `rust-tests` shard pinning", which also
+# records when this file must be edited). Each non-comment,
 # non-blank line is "<shard> <binary-id>", 1-based shard index <= the shard
 # total cargo-nextest is invoked with (3 in .github/workflows/ci.yml today).
 # A pinned binary's tests all run in that shard, unpartitioned.


### PR DESCRIPTION
## Problem

`rust-tests` sharded with `cargo-nextest --partition count:K/3`, which balances by
test **count**, not wall clock. Five binaries hold about 77% of the suite's
sequential time while most of the rest finish in under a second, so `count:` cannot
express the shape of the work. Measured shard spreads were **2.2x and 3.1x**, and
`rust workspace` waits on its slowest shard — about 18 minutes where a
duration-balanced split would give 10–13.

Issue #720, Finding 1.

## Mechanism

A checked-in pinning file, `tools/rust-test-shard-groups.txt`, maps the known-slow
binaries to shard indices. `check_rust_tests` selects this shard's pinned binaries
whole via nextest's exact-match `binary_id(=…)` filterset, and runs every remaining
test through the original count-partition **scoped to exclude every pinned binary**,
not just this shard's — so a pin can never be counted into a second shard's share.

Bin-packed across three shards the pinned work comes to roughly 7.34 / 7.74 / 6.88
minutes, each shard then also taking its share of the count-partitioned leftover.

## Why a hand-maintained grouping file is safe here

**Coverage does not depend on the file being current.** A binary the file does not
name is not dropped — it falls into the count-partitioned leftover exactly as before.
A stale grouping costs duration balance and nothing else. That is the property that
makes this design acceptable rather than a silent-under-coverage risk.

## Constraints preserved, and how each was verified

| Constraint | How verified | Result |
|---|---|---|
| Required contexts `rust workspace` / `semantic mutation (changed)` keep reporting under the same names | `.github/workflows/ci.yml` is **not modified** by this PR (`git diff --name-only`) | unchanged |
| `if: always()` on the aggregators is intact | same — no workflow change | unchanged |
| No test dropped, ignored, deferred, or duplicated | the existing `check-shard-union.sh` full.txt/shard.txt union check needed **no shape change** and still proves end to end that the shards partition the live test set; `full.txt` is recomputed from an unfiltered `cargo nextest list` every run | guard unchanged and still binding |
| A stale grouping cannot silently under-cover | by construction (unpinned → count-partition fallback), plus new `check-groups` rejecting a pin whose binary-id the live workspace no longer has | fail-closed |
| Union guards keep failing closed, with accepting **and** rejecting selftests in `merge readiness / automation contracts` | `./tools/check-shard-union.sh selftest` → `all assertions passed` | pass |
| `./tools/check-native-integration.sh` with no arguments still runs the complete unsharded suite, doctests included | the unsharded `cargo test --workspace` path and the `--doc` invocation are untouched; only the `rust-tests K/N` subcommand changed | unchanged |
| Empty inventory must not silently pass | the shard refuses to run when `cargo nextest list` reports zero non-ignored tests | fail-closed |

New fail-closed guard `check-shard-union.sh check-groups` rejects: a pin naming a
binary-id absent from the live nextest binary set (rename or removal left the
grouping stale), a binary pinned to two shards, and a shard index outside the total.
`selftest` gains its accepting case, two rejecting cases for it, and a rejecting case
for **an entire binary's tests dropped from every shard** — the most likely failure
mode once whole binaries are pinned, which the previous fixture set did not cover.

## What is not measured

The expected gain is about **5 minutes** off the current ~18-minute slowest shard.
That is an expectation, **not a measurement**. Confirming it needs a pull-request run
of this change through `ci.yml` — which is this pull request; compare the three
`rust tests (K/3)` durations here against the 15.6 / 5.0 / 8.7 minute spread recorded
in `docs/DESIGN-ci.md`.

## Scope

Finding 2 of #720 (warming the fault-operator scratch build, and evaluating a revert
of that lane's sharding) is **untouched**. It is a different mechanism with a
patch-isolation contract to preserve, and #720's own constraints ask for
independently revertible changes. #720 stays open for it.

`Refs #720`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review corrections — the first form was measured and it did not deliver

An independent review measured this pull request's own CI run (31076668077). **Read this
section before the expectation above it.**

| | shard 1 | shard 2 | shard 3 | slowest | spread |
|---|---|---|---|---|---|
| baseline run 2 | 15.6 | 5.0 | 8.7 | **15.6** | 3.1x |
| first pinning form | 15.5 | 14.6 | 8.75 | **15.5** | **1.77x** |

The spread improved. The aggregator's critical path — the only quantity `rust workspace`
waits on — moved about **0.1 min**. The ~5 min estimate is refuted.

### Why, all measured

**The cost model was wrong.** Pinned phases took 7m40s / 4m27s / 4m36s against slowest
individual tests of 458.8s / 266.6s / 275.6s — agreement to the second. nextest runs tests
concurrently inside a shard, so **a shard's pinned phase costs its slowest single test, not
the sum of its binaries' sequential times.** The first assignment packed by that sum and
overestimated shards 2 and 3 by ~40%.

**The two phases are serial**, so shard wall clock is pinned + leftover + fixed (~1m50s,
not the 3.5 min the design document assumed). Leftover phases spread **5.3x** — worse than
the pinned phases' 1.72x. The duration-blindness was displaced, not removed.

**The pinning file was stale before merge.** `fslc-rust::issue_697_all_properties_memory`
(371.8s slowest test) arrived with this branch's own base — the #739 merge — and was
unpinned, so its test went into shard 2's count partition. That is what took shard 2 from
5.0 to 14.6 min. This shipped violating the pinning rule the same commit wrote down.

### What changed in response

- **Assignment re-derived by slowest single test**, now eight pins rather than five,
  removing 2,061s of sequential work from the duration-blind leftover. Because phase cost
  is a maximum rather than a sum, pinning to a shard that already holds something slower
  is nearly free — which makes pinning the only lever currently available against leftover
  skew. `explain_cli` is pinned for that reason alone (439.7s sequential, 69.5s slowest
  test, so not a heavy occupant under the corrected model). One correction to the review
  here: it recommended pinning `explain_cli` on its sequential total, which is the quantity
  its own finding shows is wrong.
- **The ≈13 min projection is withdrawn** from `docs/DESIGN-ci.md`. The floor for whichever
  shard holds `refine_corpus_parity`'s indivisible 458.8s test is **≈9.5 min**; below that
  needs splitting that test or running the two phases concurrently, both larger than a
  scheduling change. Recording the reachable floor is a better outcome than restating a
  target.
- **Leftover skew decision stated explicitly**: not made duration-aware here, because
  `--partition count:` has no duration input and replacing it would mean a checked-in
  assignment covering every binary. If the spread stays above ~2x after this form, that is
  the next change to evaluate, on its own.
- **Parser asymmetry fixed.** `check-shard-union.sh check-groups` tolerated a missing final
  newline; `check_rust_tests`'s pin loop did not, so the guard accepted a pin the runner
  dropped. Coverage was never at risk — a dropped pin falls into the count partition — but
  one file must not have two readings.
- **Two missing negative controls added**: a shard index above the total, and a malformed
  line in three shapes, plus an accepting case for the missing trailing newline. Both
  rejections already worked but nothing pinned them, so deleting either check would have
  passed every gate — and the shard-index bound is stated as a guarantee in the design
  document. Each was executed directly: all six rejecting inputs return non-zero, the
  accepting pair returns zero.
- **Documentation precision**: `check-groups` runs after the one unfiltered
  `cargo nextest list` and before the partition, not "before any listing"; its fail-closed
  conditions are four, not two; per-binary measurements now cite run 31076668077 rather
  than the run that supplied only the per-shard table; this section is cited four times,
  not three.

### Not in question

The review proved the partition correct four independent ways, including from the CI
aggregator (`check-shard-union: PASS -- 1419 entries, 3 shard(s), union matches exactly`)
and the shard logs (`4+519, 15+457, 16+408 = 1419`). `binary_id(=…)` is exact — an
unqualified `binary_id(=explicit_engine)` is a nextest parse error, not a silent mismatch.
Rename, empty inventory and all-pinned all fail closed. `bash -n` and `shellcheck 0.11.0`
clean. `.github/workflows/ci.yml` untouched; all six required contexts report and pass.
**There is no path by which a test silently stops running.**

The new assignment's gain is again *expected, not measured*. The next `product gate` run on
this branch is what confirms it, and its `rust tests (K/3)` durations are the number to
read.


---

## Finding 1 は達成: 最遅シャード 15.6 → 12.2分(warm 実測)

第1形態が要件未達だった原因を2つ直し、run 31081427765 attempt 2(warm、`rust-cache` 復元 24〜25秒)で測り直した。

| | shard 1 | shard 2 | shard 3 | 最遅 | 偏り |
|---|---|---|---|---|---|
| ベースライン実行1 | 18.1 | 8.3 | 12.6 | **18.1** | 2.2x |
| ベースライン実行2 | 15.6 | 5.0 | 8.7 | **15.6** | 3.1x |
| 第1形態(5 pin) | 15.5 | 14.6 | 8.75 | **15.5** | 1.77x |
| **第2形態(8 pin)** | **12.2** | **10.85** | **10.46** | **12.2** | **1.17x** |

**最遅シャードは 15.6 → 12.2分(3.4分・22%)、偏りは 3.1x → 1.17x。** `rust workspace` は clean union を報告した。本 issue が期待した「約5分」には届かないが、`docs/DESIGN-ci.md` が projection していた **≈13分は達成**している。

## 直した欠陥は2つ

**1. コストモデルが二重に誤っていた。** 最初は「バイナリ別逐次合計」で packing し、次に「単体最長テスト」に直した。後者も誤りで、長時間バイナリを複数持つシャードを **52% 過小評価**する(shard 3 予測 275.6s に対し実測 418.5s)。nextest のシャード内並列度は有限である。3シャードすべてに適合するモデルは:

```
pin フェーズ ≈ 1.11 × max(単体最長テスト, 逐次合計 ÷ 3)
```

| shard | 逐次合計 | 単体最長 | モデル | 実測 | 誤差 |
|---|---|---|---|---|---|
| 1 | 683.4s | 458.8s | 509s | 508.1s | −0.2% |
| 2 | 922.3s | 371.8s | 413s | 465.2s | +12.7% |
| 3 | 1130.4s | 275.6s | 418s | 418.5s | +0.1% |

どちらの項も単独では成立しない。**帰結として pin の追加は無料ではない** — `sum/3` が単体最長を超えると追加ごとに pin フェーズが伸びる。第2コミットは逆を主張していたので訂正した。shard 2 の +12.7% は `issue_697_all_properties_memory` を持つシャードで、`CONCRETE_PROBE_BUDGET`(#697)によりメモリ律速のため想定より重ならない。同シャードには +15% を計画余裕として見る。

**2. pinning ファイルが第1形態のマージ前から陳腐化していた。** `fslc-rust::issue_697_all_properties_memory`(単体最長 371.8s、ワークスペース2番目)は #697 修正(PR #739)で到来し未 pin だったため、その単体テストが shard 2 の count 分割に落ちた。これが shard 2 を 5.0 → 14.6分に押し上げた直接原因である。

## leftover の偏りも改善した

pin は leftover から逐次時間を丸ごと抜くので、現状これが偏りへの唯一のレバーである。leftover フェーズは **75.4 / 43.0 / 63.9秒 = 偏り 1.75x**(第1形態では 5.3x)。`explain_cli` が示唆的な例で、逐次 439.7秒だが単体最長 69.5秒 — pin すると shard 3 の pin フェーズは約112秒増えるが、count 分割された leftover から 439.7秒が3シャードに分散して消える。

leftover 自体を duration 対応にはしない。`--partition count:` は duration を受け取らないので、全バイナリを網羅する割り当てファイルが必要になり、小さな保守ファイルを大きなものに置き換える取引になる。1.75x では見合わない。約2x を超えて戻るなら、それを次のレバーとして別変更で評価する。

## 残る床

`refine_corpus_parity` の単体 458.8秒テストは本方式では分割不能で、各シャードは実測 約113秒の固定費(checkout・toolchain・build)を払う。したがってそのテストを持つシャードは leftover が空でも **約10.4分**を下回れない。実測 12.2分はその2分以内である。**10分を有意に下回るには、そのテスト(および `issue_697_all_properties_memory` の 371.8秒テスト)を分割するか、pin と leftover フェーズを逐次ではなく並行実行する必要がある。** どちらも scheduling 変更より大きく、後者は現在2つのフェーズが1つの `shard.txt` を共有して書くため注意が必要である。

## 全数値は warm である

これは load-bearing な限定条件である。Actions キャッシュ追い出しによるコールドビルドはシャードあたり **6〜12分**を加算し、同一コミットの attempt 1 は 27.88 / 20.81 / 20.61分だった。キャッシュ状態を跨いだ比較は無意味になる。原因(並行2 PR で 10 GiB 上限を超え、`main` に Rust ビルドキャッシュが無い)は **#747** で追跡している。

Finding 2(fault-operator scratch build の warm 化)は未着手のまま。
