### PR TITLE
fix(ci): stop pull requests from evicting main's caches, and break the semantic-mutation deadlock

### DIFF
--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Actions cache budget audit (issue #747). GitHub gives a repository 10 GiB of
+// Actions cache and evicts least-recently-used entries when it is exceeded.
+// Caches are also ref-scoped: a run can restore only its own ref's caches and
+// the default branch's, so a pull request's cache is worthless to a sibling
+// pull request while still counting against the shared limit.
+//
+// `ci.yml`'s four shared keys store about 6.9 GiB per ref, so two concurrent
+// pull requests exceeded the limit and evicted `main`'s caches. Every run then
+// built cold -- measured +8 to +16 min per shard -- and each cold run saved a
+// fresh ref-scoped copy, evicting more. `ci.yml` now restricts saving to
+// non-pull-request events, which is what this audit protects.
+//
+// This module is pure: it takes an already-fetched cache listing and returns
+// findings. The workflow does the fetching. That split is what makes the
+// rejecting fixtures in audit-cache-budget.test.mjs possible, and it is the
+// same shape as audit-ruleset-drift.mjs.
+
+export const GIB = 1024 ** 3;
+
+// GitHub's per-repository Actions cache allowance.
+export const CACHE_LIMIT_BYTES = 10 * GIB;
+
+// Fraction of the limit at which the budget is already too tight to be safe.
+// Not 100%: eviction begins when a *save* would exceed the limit, so a listing
+// sitting at 90% is one save away from evicting something load-bearing. The
+// observed failure had usage at 9.96 GiB, i.e. 99.6%.
+export const BUDGET_WARN_FRACTION = 0.85;
+
+// The shared keys `ci.yml` declares. A `refs/pull/*` entry for any of these
+// means the `save-if` guard regressed -- this is the calibrated rejecting
+// signal for the fix itself, not merely a hygiene check.
+export const CI_SHARED_KEYS = [
+  "rust-workspace",
+  "wasm",
+  "fsl-logic",
+  "semantic-mutation",
+];
+
+// Keys whose absence on the default branch makes every pull request build cold.
+// A subset of CI_SHARED_KEYS: these are the ones on the pre-merge critical path.
+export const REQUIRED_MAIN_KEYS = ["rust-workspace", "wasm", "fsl-logic"];
+
+function sharedKeyOf(key) {
+  // Swatinem/rust-cache composes `v0-rust-<shared-key>-<platform>-<hashes>`.
+  const match = /^v\d+-rust-(.+?)-(?:Linux|macOS|Windows)-/.exec(key ?? "");
+  return match ? match[1] : null;
+}
+
+function formatGiB(bytes) {
+  return `${(bytes / GIB).toFixed(2)} GiB`;
+}
+
+/**
+ * @param {{caches: Array<{key: string, ref: string, size_in_bytes: number}>,
+ *          usageBytes: number|null,
+ *          limitBytes?: number,
+ *          warnFraction?: number,
+ *          requiredMainKeys?: string[],
+ *          ciSharedKeys?: string[],
+ *          defaultBranchRef?: string}} input
+ * @returns {{findings: Array<{code: string, message: string}>, ok: boolean}}
+ */
+export function auditCacheBudget({
+  caches,
+  usageBytes,
+  limitBytes = CACHE_LIMIT_BYTES,
+  warnFraction = BUDGET_WARN_FRACTION,
+  requiredMainKeys = REQUIRED_MAIN_KEYS,
+  ciSharedKeys = CI_SHARED_KEYS,
+  defaultBranchRef = "refs/heads/main",
+}) {
+  const findings = [];
+
+  if (!Array.isArray(caches)) {
+    findings.push({
+      code: "listing-unreadable",
+      message:
+        "the cache listing is absent or not an array; an unreadable listing is never read as an empty (healthy) cache set",
+    });
+    return { findings, ok: false };
+  }
+
+  // 1. Budget headroom. Prefer the API's own usage figure when present; fall
+  //    back to summing the listing, which undercounts if it was paginated.
+  const summed = caches.reduce((total, entry) => total + (entry.size_in_bytes ?? 0), 0);
+  const effective = typeof usageBytes === "number" ? usageBytes : summed;
+  if (typeof usageBytes !== "number") {
+    findings.push({
+      code: "usage-unobserved",
+      message:
+        "the repository cache-usage endpoint returned no total; falling back to the sum of the listing, which undercounts when paginated. Absence of the total is not evidence of headroom.",
+    });
+  }
+  if (effective >= limitBytes * warnFraction) {
+    findings.push({
+      code: "budget-exhausted",
+      message: `cache usage is ${formatGiB(effective)} of a ${formatGiB(limitBytes)} limit (${Math.round(
+        (effective / limitBytes) * 100,
+      )}%), at or above the ${Math.round(warnFraction * 100)}% threshold. At this level a single save evicts a least-recently-used entry, and the default branch's caches are the ones every pull request depends on.`,
+    });
+  }
+
+  // 2. The default branch must hold every key on the pre-merge critical path.
+  const mainKeys = new Set(
+    caches
+      .filter((entry) => entry.ref === defaultBranchRef)
+      .map((entry) => sharedKeyOf(entry.key))
+      .filter(Boolean),
+  );
+  for (const key of requiredMainKeys) {
+    if (!mainKeys.has(key)) {
+      findings.push({
+        code: "main-cache-absent",
+        message: `no \`${defaultBranchRef}\` cache for shared key \`${key}\`. Actions caches are ref-scoped, so the default branch is the only cache every pull request can read; without it each pull request builds cold.`,
+      });
+    }
+  }
+
+  // 3. No pull-request-scoped cache for a `ci.yml` shared key. This is the
+  //    rejecting control for `save-if`: if the guard is removed, these reappear.
+  const ciKeys = new Set(ciSharedKeys);
+  for (const entry of caches) {
+    if (!/^refs\/pull\//.test(entry.ref ?? "")) continue;
+    const key = sharedKeyOf(entry.key);
+    if (key && ciKeys.has(key)) {
+      findings.push({
+        code: "pull-request-cache-present",
+        message: `\`${entry.ref}\` holds a cache for \`ci.yml\`'s shared key \`${key}\` (${formatGiB(
+          entry.size_in_bytes ?? 0,
+        )}). \`ci.yml\` restricts saving to non-pull-request events precisely so this cannot happen; its presence means that guard regressed.`,
+      });
+    }
+  }
+
+  return { findings, ok: findings.length === 0 };
+}
+
+export function formatReport({ findings, ok }) {
+  if (ok) return "cache budget audit: PASS -- budget within threshold, default-branch caches present, no pull-request-scoped ci.yml caches";
+  return [
+    `cache budget audit: FAIL -- ${findings.length} finding(s)`,
+    ...findings.map((finding) => `  ${finding.code}: ${finding.message}`),
+  ].join("\n");
+}

--- a/.github/scripts/audit-cache-budget.test.mjs
+++ b/.github/scripts/audit-cache-budget.test.mjs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Calibration suite for the Actions cache budget audit (issue #747).
+//
+// Every check has an accepting fixture and a rejecting fixture. The rejecting
+// fixtures are the point: a checker demonstrated only on healthy input is not
+// evidence it can detect the state it exists to detect. The
+// `pull-request-cache-present` case in particular is the rejecting control for
+// `ci.yml`'s `save-if` guard -- it reproduces the exact listing observed on
+// 2026-08-06, when two concurrent pull requests held 6.94 GiB and 4.25 GiB of
+// ref-scoped caches and `main` held no Rust build cache at all.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  auditCacheBudget,
+  formatReport,
+  CACHE_LIMIT_BYTES,
+  GIB,
+} from "./audit-cache-budget.mjs";
+
+const MAIN = "refs/heads/main";
+
+function cache(key, ref, gib) {
+  return { key, ref, size_in_bytes: Math.round(gib * GIB) };
+}
+
+function healthyListing() {
+  return [
+    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.495),
+    cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.352),
+    cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.369),
+    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.721),
+    cache("v0-rust-rust-compile-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/900/merge", 0.081),
+    cache("v0-rust-core-contracts-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/900/merge", 0.05),
+  ];
+}
+
+function usageOf(listing) {
+  return listing.reduce((total, entry) => total + entry.size_in_bytes, 0);
+}
+
+test("accepting: default-branch caches present, budget below threshold, no pull-request ci.yml caches", () => {
+  const caches = healthyListing();
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, true, formatReport(result));
+  assert.deepEqual(result.findings, []);
+});
+
+test("accepting: merge-readiness's own small keys may live on a pull-request ref", () => {
+  // `merge-readiness.yml` deliberately keeps saving from pull requests: its two
+  // keys total ~131 MiB and its lanes are the sub-minute fast path. Only
+  // `ci.yml`'s four shared keys are guarded, so these must not be flagged.
+  const caches = healthyListing();
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(
+    result.findings.some((finding) => finding.code === "pull-request-cache-present"),
+    false,
+  );
+});
+
+test("rejecting: a pull-request-scoped ci.yml cache means the save-if guard regressed", () => {
+  const caches = [
+    ...healthyListing(),
+    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 1.495),
+  ];
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const finding = result.findings.find((f) => f.code === "pull-request-cache-present");
+  assert.ok(finding, formatReport(result));
+  assert.match(finding.message, /refs\/pull\/745\/merge/);
+  assert.match(finding.message, /rust-workspace/);
+});
+
+test("rejecting: the 2026-08-06 listing that caused the outage", () => {
+  // Reproduced from `gh api repos/ymm-oss/fsl/actions/caches`: two pull requests
+  // holding every ci.yml key, and `main` holding only tool binaries.
+  const caches = [
+    cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 1.352),
+    cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 1.369),
+    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 1.495),
+    cache("v0-rust-core-contracts-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 0.05),
+    cache("v0-rust-rust-compile-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/745/merge", 0.081),
+    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf5", "refs/pull/743/merge", 2.721),
+    cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/743/merge", 1.352),
+    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/743/merge", 1.495),
+    cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/743/merge", 1.369),
+    cache("Linux-cargo-nextest-0.9.143", MAIN, 0.008),
+    cache("Linux-wasm-bindgen-cli-0.2.126", MAIN, 0.007),
+    cache("node-cache-Linux-x64-npm-541c2caf", MAIN, 0.011),
+  ];
+  const result = auditCacheBudget({ caches, usageBytes: Math.round(9.96 * GIB) });
+  assert.equal(result.ok, false);
+  const codes = result.findings.map((finding) => finding.code);
+  assert.ok(codes.includes("budget-exhausted"), formatReport(result));
+  // All three critical-path keys are missing from the default branch.
+  assert.equal(codes.filter((code) => code === "main-cache-absent").length, 3);
+  // Every ci.yml key on a pull-request ref is flagged: 3 + 4 across two refs.
+  assert.equal(codes.filter((code) => code === "pull-request-cache-present").length, 7);
+});
+
+test("rejecting: budget at or above the threshold, even with a healthy ref layout", () => {
+  const caches = healthyListing();
+  const result = auditCacheBudget({
+    caches,
+    usageBytes: Math.round(CACHE_LIMIT_BYTES * 0.85),
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.findings.some((finding) => finding.code === "budget-exhausted"));
+});
+
+test("accepting: budget just below the threshold does not fire", () => {
+  const caches = healthyListing();
+  const result = auditCacheBudget({
+    caches,
+    usageBytes: Math.round(CACHE_LIMIT_BYTES * 0.85) - 1,
+  });
+  assert.equal(
+    result.findings.some((finding) => finding.code === "budget-exhausted"),
+    false,
+    formatReport(result),
+  );
+});
+
+test("rejecting: a missing default-branch key is reported per key", () => {
+  const caches = healthyListing().filter(
+    (entry) => !entry.key.includes("-wasm-") || entry.ref !== MAIN,
+  );
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const missing = result.findings.filter((finding) => finding.code === "main-cache-absent");
+  assert.equal(missing.length, 1);
+  assert.match(missing[0].message, /`wasm`/);
+});
+
+test("rejecting: an absent usage total is never read as headroom", () => {
+  const caches = healthyListing();
+  const result = auditCacheBudget({ caches, usageBytes: null });
+  assert.equal(result.ok, false);
+  assert.ok(result.findings.some((finding) => finding.code === "usage-unobserved"));
+});
+
+test("rejecting: an unreadable listing fails closed rather than passing as empty", () => {
+  for (const caches of [undefined, null, "not-an-array"]) {
+    const result = auditCacheBudget({ caches, usageBytes: 0 });
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.findings.map((finding) => finding.code),
+      ["listing-unreadable"],
+    );
+  }
+});
+
+test("a key whose shared-key cannot be parsed is not silently attributed", () => {
+  const caches = [...healthyListing(), cache("some-unrelated-key", "refs/pull/1/merge", 1)];
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(
+    result.findings.some((finding) => finding.code === "pull-request-cache-present"),
+    false,
+  );
+});
+
+test("formatReport names every finding code", () => {
+  const result = auditCacheBudget({ caches: [], usageBytes: 0 });
+  const report = formatReport(result);
+  for (const finding of result.findings) {
+    assert.ok(report.includes(finding.code), `${finding.code} missing from report`);
+  }
+});

--- a/.github/scripts/run-cache-budget-audit.mjs
+++ b/.github/scripts/run-cache-budget-audit.mjs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fetches the live Actions cache listing and runs the pure audit in
+// audit-cache-budget.mjs (issue #747). Kept separate from the audit itself so
+// the audit can be calibrated offline against rejecting fixtures; this file
+// holds only the network access and the process exit.
+//
+// Needs a token with `actions: read`. The workflow's own GITHUB_TOKEN has it,
+// so unlike the ruleset audit this needs no PAT.
+
+import { auditCacheBudget, formatReport } from "./audit-cache-budget.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+
+if (!token || !repo) {
+  console.error(
+    "cache budget audit: GITHUB_TOKEN and GITHUB_REPOSITORY are required; refusing to report a healthy budget without observing one",
+  );
+  process.exit(1);
+}
+
+async function api(path) {
+  const response = await fetch(`https://api.github.com/repos/${repo}${path}`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GET ${path} -> ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+let caches;
+let usageBytes = null;
+try {
+  // 100 is the maximum page size. A repository at the 10 GiB limit holds far
+  // fewer entries than that, and `usageBytes` below comes from the API's own
+  // total, so a truncated listing cannot understate the budget finding.
+  const listing = await api("/actions/caches?per_page=100");
+  caches = listing.actions_caches;
+  const usage = await api("/actions/cache/usage");
+  if (typeof usage.active_caches_size_in_bytes === "number") {
+    usageBytes = usage.active_caches_size_in_bytes;
+  }
+} catch (error) {
+  // An unreadable API is not evidence of a healthy cache budget.
+  console.error(`cache budget audit: FAIL -- api-unreadable: ${error.message}`);
+  process.exit(1);
+}
+
+const result = auditCacheBudget({ caches, usageBytes });
+console.log(formatReport(result));
+process.exit(result.ok ? 0 : 1);

--- a/.github/workflows/cache-budget-audit.yml
+++ b/.github/workflows/cache-budget-audit.yml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: cache budget audit
+
+# Configuration-conformance automation, not product verification in
+# docs/DESIGN-ci.md's sense (rust workspace / WASM / native Z3 / semantic
+# mutation / FSL Logic Test). It checks the live Actions cache state against the
+# budget contract, because that state silently degraded once: two concurrent
+# pull requests filled the repository's 10 GiB allowance with ref-scoped caches,
+# evicted `main`'s, and every run afterwards built cold -- measured +8 to +16 min
+# per shard, with each cold run saving a fresh ref-scoped copy and evicting more.
+# See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+#
+# Unlike the ruleset audit this needs no PAT: the cache endpoints are readable
+# with the workflow's own GITHUB_TOKEN and `actions: read`.
+#
+# Not a required status check. It reports on the shared cache state, which any
+# pull request's own runs can change after that pull request's checks have
+# passed, so gating a merge on it would be gating on something outside the
+# change under review. Pre-merge coverage for a change to the checker itself is
+# the offline calibration suite, which `tools/check-merge-readiness.sh`'s
+# `check_automation` lane runs on every pull request.
+
+on:
+  schedule:
+    - cron: "43 3 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/audit-cache-budget.mjs
+      - .github/scripts/audit-cache-budget.test.mjs
+      - .github/scripts/run-cache-budget-audit.mjs
+      - .github/workflows/cache-budget-audit.yml
+      - .github/workflows/ci.yml
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: cache-budget-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: audit Actions cache budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      # The calibration suite runs first: an audit whose own rejecting fixtures
+      # no longer fail is not evidence about the live state.
+      - name: Calibrate the audit
+        run: node --test .github/scripts/audit-cache-budget.test.mjs
+
+      - name: Audit the live cache budget
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/run-cache-budget-audit.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: rust-workspace
 
@@ -136,6 +145,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: rust-workspace
 
@@ -258,6 +276,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - uses: actions/setup-node@v4
@@ -308,6 +335,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - name: Test pinned native solver and BMC crates
@@ -335,6 +371,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - name: Test pinned native solver and BMC crates
@@ -380,6 +425,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: semantic-mutation
 
@@ -419,6 +473,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: semantic-mutation
 
@@ -557,6 +620,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
+          # Saving is restricted to non-pull-request events. A pull request's cache is
+          # readable only by that same pull request -- Actions caches are ref-scoped, so
+          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
+          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
+          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
+          # which every run built cold: measured +8 to +16 min per shard. Only `main`
+          # saves now, and every pull request can read `main` because it is the default
+          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - name: Run bounded pull-request generation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
   semantic-mutation-operators:
     name: mutation operators (${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -436,6 +436,13 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: semantic-mutation
+          # Save even when the job fails. Without this the lane cannot recover from a
+          # cold start: a cold scratch build exceeds the job budget, the job is
+          # cancelled, `rust-cache` skips saving, and the next run is cold again. The
+          # cache can then only be created by a run that succeeds, and a run can only
+          # succeed once the cache exists. Measured on `main` and on three pull
+          # requests; see docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          cache-on-failure: true
 
       - name: Calibrate curated fault-operator shard
         if: steps.scope.outputs.run == 'true'
@@ -454,7 +461,7 @@ jobs:
   semantic-mutation-mutants:
     name: mutation mutants
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -484,6 +491,13 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: semantic-mutation
+          # Save even when the job fails. Without this the lane cannot recover from a
+          # cold start: a cold scratch build exceeds the job budget, the job is
+          # cancelled, `rust-cache` skips saving, and the next run is cold again. The
+          # cache can then only be created by a run that succeeds, and a run can only
+          # succeed once the cache exists. Measured on `main` and on three pull
+          # requests; see docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          cache-on-failure: true
 
       - name: Install pinned semantic mutation runner
         if: steps.scope.outputs.run == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   qualifies this repository's earlier finding that cache hit rates have no headroom — true **on a
   warm cache**, which is the premise concurrency breaks. #720's Finding 2 adds a cache and therefore
   depends on this budget holding first.
+  Eviction started the problem; `cache-on-failure: false` made it unrecoverable. The
+  `semantic mutation` lane fell into a closed loop: a cold scratch build exceeds the job budget, the
+  job is cancelled, `rust-cache` skips saving from a failed job, and the next run is cold again — so
+  the cache could only be created by a run that succeeds while a run could only succeed once the cache
+  existed. Both semantic-mutation cache steps now carry `cache-on-failure: true`, and both budgets are
+  raised past a measured cold run: `mutation operators` 30 → 50 min (warm 18.0–19.5, cancelled at 30.2
+  cold) and `mutation mutants` 60 → 90 min (warm 17.2–34.2, cancelled at ~61 cold). Raised rather than
+  narrowed, for the reason this repository already gives for the promotion-only native-Z3 job: a gate
+  that runs out of wall clock reports a failure it did not observe. This is the most likely explanation
+  for `main`'s standing #721 and #678, whose cancellations sit exactly at the old budgets; whether they
+  clear once this lands is the test of that reading.
 - Fixed (#736): `.github/workflows/ci.yml` cited a `docs/DESIGN-ci.md` section,
   `"Merge queue (planned, not yet enabled)"`, that does not exist and asserted the
   opposite of the accepted decision — the design document records that a merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#747): two concurrent pull requests exhausted the repository's 10 GiB Actions cache
+  allowance and evicted `main`'s Rust build caches, after which every run built cold. Actions caches
+  are ref-scoped — a pull request's cache is readable only by that same pull request — while
+  `ci.yml`'s four shared keys store about 6.9 GiB per ref (`semantic-mutation` 2.72 GiB,
+  `rust-workspace` 1.50, `fsl-logic` 1.37, `wasm` 1.35), so two pull requests exceed the limit on
+  their own. Measured on 2026-08-06: usage 9.96 GiB across 12 entries, every large cache on a
+  `refs/pull/*` ref, and `refs/heads/main` holding only 26 MiB of tool binaries — while a `main` push
+  four hours earlier had restored a cache in 25–50 s, so one had existed and been evicted. The cost
+  is measured too: two runs of the same commit on the same branch gave 27.88 / 20.81 / 20.61 min cold
+  against 12.2 / 10.85 / 10.46 warm, i.e. **+8 to +16 min per shard**, independently on each of `rust
+  workspace`'s three shards, `WASM`, `FSL Logic Test` and `semantic mutation` — and each cold run
+  saved a fresh ref-scoped copy, evicting more. Every `Swatinem/rust-cache` step in `ci.yml` now
+  carries `save-if: ${{ github.event_name != 'pull_request' }}`; pull requests still restore, because
+  `main` is the default branch and readable from every ref. `merge-readiness.yml` is deliberately
+  unchanged — its two keys total ~131 MiB and its lanes are the sub-minute fast path. New
+  `.github/scripts/audit-cache-budget.mjs` fails closed on usage at or above 85% of the limit, on a
+  missing `refs/heads/main` cache for a critical-path shared key, and — the rejecting control for the
+  `save-if` guard itself — on any pull-request-scoped cache for one of `ci.yml`'s shared keys, which
+  can only appear if that guard is removed; an unreadable listing or absent usage total also fail
+  closed rather than reading as headroom. `.github/workflows/cache-budget-audit.yml` runs it on a
+  schedule, on dispatch, and on `main` pushes touching it or `ci.yml`; it is not a required context
+  because the shared cache state can change after a pull request's checks pass. The 11-case
+  calibration suite, including a fixture reproducing the 2026-08-06 listing verbatim, is wired into
+  `tools/check-merge-readiness.sh`'s `check_automation` lane. No job, trigger, or required-context
+  name changed: the parsed `ci.yml` differs from `main` only inside its cache steps. This also
+  qualifies this repository's earlier finding that cache hit rates have no headroom — true **on a
+  warm cache**, which is the premise concurrency breaks. #720's Finding 2 adds a cache and therefore
+  depends on this budget holding first.
 - Fixed (#736): `.github/workflows/ci.yml` cited a `docs/DESIGN-ci.md` section,
   `"Merge queue (planned, not yet enabled)"`, that does not exist and asserted the
   opposite of the accepted decision — the design document records that a merge

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -381,6 +381,32 @@ no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a 
 remains true warm, and it is exactly the premise that fails under concurrency: the question is not
 how much a better hit rate buys, but whether a hit happens at all.
 
+**Eviction started this; `cache-on-failure: false` made it unrecoverable.** The
+`semantic mutation` lane fell into a closed loop, measured on `main` and on three pull requests:
+
+1. a cold scratch build exceeds the job's budget, so the job is cancelled;
+2. `Swatinem/rust-cache` does not save from a failed job (`cache-on-failure` defaults to false),
+   so nothing is written;
+3. the next run is cold again.
+
+**The cache can then only be created by a run that succeeds, and a run can only succeed once the
+cache exists.** Measured budgets against measured durations:
+
+| job | budget before | warm | cold | budget now |
+|---|---|---|---|---|
+| `mutation operators (K/3)` | 30 min | 18.0–19.5 min | **>30** (cancelled at 30.2) | **50 min** |
+| `mutation mutants` | 60 min | 17.2–34.2 min | **>60** (cancelled at ~61) | **90 min** |
+
+Both semantic-mutation cache steps now carry `cache-on-failure: true`, so a cold run that runs out
+of budget still leaves a warm cache behind, and both budgets are raised past a measured cold run.
+Raised rather than narrowed, for the reason this document already gives for the promotion-only
+native-Z3 job: a gate that runs out of wall clock reports a failure it did not observe.
+
+This is also the most likely explanation for `main`'s standing post-merge failures #721
+(`mutation mutants`) and #678 (`semantic mutation (complete)`), whose cancellations sit exactly at
+the old budgets. Whether they clear once this lands is the test of that reading, and #747's
+acceptance criteria record it as such.
+
 **The control.** `.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched cache
 listing; `.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch,
 and on `main` pushes that touch it or `ci.yml`. It fails closed on three states: usage at or above

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -339,6 +339,66 @@ successful evidence; an accidentally skipped lane cannot make the workflow confi
 Product-gate runs for merged commits are not cancelled. Each merged state therefore retains its own
 portable evidence and failure attribution even when agents merge changes quickly.
 
+### Actions cache budget
+
+GitHub gives a repository **10 GiB** of Actions cache and evicts least-recently-used entries once
+that is exceeded. Caches are also **ref-scoped**: a run restores only its own ref's caches and the
+default branch's, so a pull request's cache is worthless to a sibling pull request while still
+counting against the shared limit.
+
+`ci.yml` declares four shared keys, measured: `semantic-mutation` 2.72 GiB, `rust-workspace`
+1.50 GiB, `fsl-logic` 1.37 GiB, `wasm` 1.35 GiB — about **6.9 GiB per ref**. Two concurrent pull
+requests therefore exceed the limit on their own, and on 2026-08-06 they did: usage stood at
+9.96 GiB across 12 entries, every large cache belonged to `refs/pull/743/merge` or
+`refs/pull/745/merge`, and `refs/heads/main` held only three tool binaries totalling 26 MiB — no
+Rust build cache at all. A `main` push four hours earlier had restored one in 25–50 s, so it had
+existed and been evicted.
+
+The consequence is measured, not inferred. Two runs of the same commit on the same branch:
+
+| | shard 1 | shard 2 | shard 3 | `rust-cache` restore |
+|---|---|---|---|---|
+| cold | 27.88 | 20.81 | 20.61 | 0–1 s (miss) |
+| warm | 12.2 | 10.85 | 10.46 | 24–25 s (hit) |
+
+**+8 to +16 min per shard**, independently on each of `rust workspace`'s three shards, `WASM`,
+`FSL Logic Test` and `semantic mutation`. And it is self-reinforcing: each cold run saves a fresh
+ref-scoped copy, which evicts more. `main` can heal — a miss there does save — but the pressure
+from concurrent pull requests outran the healing.
+
+**Decision: only non-pull-request events save.** Every `Swatinem/rust-cache` step in `ci.yml`
+carries `save-if: ${{ github.event_name != 'pull_request' }}`. Pull requests still *restore*,
+because `main` is the default branch and therefore readable from every ref. What a pull request
+gives up is a warm second run of itself; what it gains is that `main`'s caches stay resident, which
+is the only cache any pull request could ever share.
+
+`merge-readiness.yml` is deliberately **not** changed. Its two keys total about 131 MiB, they are not
+the pressure, and its lanes are the sub-minute fast path — making them cold would defeat the reason
+that workflow exists.
+
+This also qualifies a claim made elsewhere in this document. Cache hit rates were measured to have
+no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a warm cache**. That
+remains true warm, and it is exactly the premise that fails under concurrency: the question is not
+how much a better hit rate buys, but whether a hit happens at all.
+
+**The control.** `.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched cache
+listing; `.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch,
+and on `main` pushes that touch it or `ci.yml`. It fails closed on three states: usage at or above
+85% of the limit, a missing `refs/heads/main` cache for any critical-path shared key, and — the
+rejecting control for the `save-if` guard itself — **any pull-request-scoped cache for one of
+`ci.yml`'s shared keys**, which can only appear if that guard is removed. An unreadable listing or
+an absent usage total fail closed too; neither is read as headroom.
+
+`.github/scripts/audit-cache-budget.test.mjs` calibrates all of it offline, including a fixture that
+reproduces the 2026-08-06 listing verbatim and must fail. `tools/check-merge-readiness.sh`'s
+`check_automation` lane runs that suite on every pull request, so a change to the checker is covered
+pre-merge even though the live audit deliberately is not a required context: the shared cache state
+can change after a pull request's own checks pass, so gating a merge on it would gate on something
+outside the change under review.
+
+Issue #747 records the incident. Issue #720's Finding 2 — warming the fault-operator scratch build —
+**adds** a cache and therefore depends on this budget holding first.
+
 ## Required pre-merge contexts, and why the merge queue was rejected
 
 The `main` ruleset (`main safety and CI`, id `19090811`) requires six contexts: `merge readiness`,

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -49,6 +49,11 @@ check_automation() {
   # Accepting/rejecting controls for the ruleset drift audit's compareRuleset/
   # validateContract classifier (docs/DESIGN-ci.md, "Ruleset drift audit").
   node --test .github/scripts/audit-ruleset-drift.test.mjs
+  # Accepting/rejecting controls for the Actions cache budget audit, including
+  # the rejecting fixture for `ci.yml`'s `save-if` guard: a pull-request-scoped
+  # cache for one of its shared keys must fail the audit, so removing that guard
+  # cannot pass silently (docs/DESIGN-ci.md, "Actions cache budget").
+  node --test .github/scripts/audit-cache-budget.test.mjs
 }
 
 case "${1:-all}" in


### PR DESCRIPTION
## Problem

Two concurrent pull requests exhausted the repository's **10 GiB** Actions cache allowance and evicted `main`'s Rust build caches. Then `cache-on-failure: false` made it unrecoverable, and the `semantic mutation` lane deadlocked.

Actions caches are **ref-scoped**: a run restores only its own ref's caches and the default branch's, so a pull request's cache is worthless to a sibling pull request while still counting against the shared limit. `ci.yml`'s four shared keys store about **6.9 GiB per ref** — `semantic-mutation` 2.72 GiB, `rust-workspace` 1.50, `fsl-logic` 1.37, `wasm` 1.35 — so two pull requests exceed the limit on their own.

Measured 2026-08-06: usage **9.96 GiB across 12 entries**, every large cache on a `refs/pull/*` ref, `refs/heads/main` holding only 26 MiB of tool binaries. A `main` push four hours earlier had restored one in 25–50 s, so it had existed and been evicted.

### The deadlock

```
1. a cold scratch build exceeds the job's budget  → the job is cancelled
2. rust-cache does not save from a failed job     → nothing is written
3. the next run is cold again                     → back to 1
```

**The cache could only be created by a run that succeeds, and a run could only succeed once the cache existed.**

| job | budget was | warm | cold | budget now |
|---|---|---|---|---|
| `mutation operators (K/3)` | 30 min | 18.0–19.5 | **>30** (cancelled at 30.2) | **50 min** |
| `mutation mutants` | 60 min | 17.2–34.2 | **>60** (cancelled at ~61) | **90 min** |

### Cost of a cold run, measured

Two runs of the same commit on the same branch:

| | shard 1 | shard 2 | shard 3 | `rust-cache` restore |
|---|---|---|---|---|
| cold | 27.88 | 20.81 | 20.61 | 0–1 s (miss) |
| warm | 12.2 | 10.85 | 10.46 | 24–25 s (hit) |

**+8 to +16 min per shard**, independently on each of `rust workspace`'s three shards, `WASM`, `FSL Logic Test` and `semantic mutation`.

## The change

- **`save-if: ${{ github.event_name != 'pull_request' }}`** on all 8 `Swatinem/rust-cache` steps in `ci.yml`. Pull requests still *restore*, because `main` is the default branch and readable from every ref. A pull request gives up a warm second run of itself; it gains that `main`'s caches stay resident — the only cache any pull request could ever share.
- **`cache-on-failure: true`** on both semantic-mutation cache steps, so a cold run that runs out of budget still leaves a warm cache behind.
- **Budgets raised past a measured cold run**: operators 30 → 50, mutants 60 → 90. Raised rather than narrowed, for the reason this document already gives for the promotion-only native-Z3 job: *a gate that runs out of wall clock reports a failure it did not observe.*
- **`merge-readiness.yml` is deliberately unchanged**: its two keys total ~131 MiB, they are not the pressure, and its lanes are the sub-minute fast path that making them cold would defeat.

## The control, calibrated against the failure it exists to detect

`.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched listing and fails closed on:

1. usage at or above **85%** of the limit;
2. a missing `refs/heads/main` cache for a critical-path shared key;
3. **any pull-request-scoped cache for one of `ci.yml`'s shared keys** — the rejecting control for the `save-if` guard itself, which can only appear if that guard is removed.

An unreadable listing or an absent usage total also fail closed; neither is read as headroom.

`.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch, and on `main` pushes touching it or `ci.yml`. Deliberately **not** a required context: the shared cache state can change after a pull request's own checks pass, so gating a merge on it would gate on something outside the change under review. Pre-merge coverage for a change to the checker is the offline calibration suite, wired into `tools/check-merge-readiness.sh`'s `check_automation` lane.

## Verification

- **11/11 calibration cases pass**, including a fixture that reproduces the 2026-08-06 listing verbatim and must fail.
- Run against the **live API** the audit reported **10 findings and exit 1** — it detects the state as it stood.
- `tools/check-merge-readiness.sh automation` passes; all 9 workflow files parse; `bash -n` and `shellcheck 0.11.0` clean.
- **No required context moved**: job ids and job names are byte-identical to `main`; the only structural differences are the two `timeout-minutes` values and the cache steps.

## Why this must merge before the other open pull requests

`semantic mutation (changed)` is a required context and `19090811` has `bypass_actors: []`, so **an admin cannot merge past it**. While the cache is evicted, a cold `mutation operators` shard exceeds 30 minutes and the aggregate fails — so #743, #744 and #745 cannot pass the gate either. This pull request's own run uses the raised budgets and `cache-on-failure: true`, so it can complete cold and repopulate the cache, after which the others go warm.

## Also recorded, not asserted

`main`'s standing post-merge failures **#721** (`mutation mutants`) and **#678** (`semantic mutation (complete)`) have cancellations sitting exactly at the old budgets, so this is the most likely explanation for them. Whether they clear once this lands is the test of that reading; #747's acceptance criteria record it as such.

`Closes #747` — `Refs #720, #721, #678`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
