### PR TITLE
fix(ci): witness that a fault reached what the operator harness measured (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#753): the implementation fault-operator harness now **witnesses** that a fault
+  reached what it measured instead of inferring it. A `primary still passed under the
+  fault` verdict has two causes with different owners -- the detector does not cover the
+  seam (a real gap) or the detector never saw the fault (a harness defect) -- and
+  `tools/run-fault-operators.sh` previously reported the first whenever the second was
+  true, because it treated a zero-exit `git apply` plus a clean build as proof of arrival.
+  The symptom was the same operator returning different verdicts on different runs of one
+  revision, which made unrelated pull requests unmergeable through the `semantic mutation`
+  required context. Two fail-closed witnesses now run before any verdict: every file a
+  patch names must differ byte-for-byte from the pristine copy after the patch applies,
+  and the primary detector's executable -- read back from cargo's own
+  `Executable <target> (<path>)` line -- must differ from the digest recorded for that
+  target under the no-op control. A byte-identical executable cannot arise from
+  compilation nondeterminism, so the binary witness fires only on real artifact reuse.
+  The source witness carries its own negative control,
+  `rust/fslc/tests/fault_operators/controls/identical-after-apply.patch`, a hunk that
+  applies cleanly while leaving the file unchanged and must be refused; the binary witness
+  is calibrated by live mutation and has no fixture, recorded as such in
+  `docs/DESIGN-conformance-harness.md`.
+
 - Decided (#737): the shared-edit merge-conflict spike closes as **GO for CHANGELOG
   fragments only (C1)** and **NO-GO for fragmenting the contract documents (C2)**, recorded
   in the new accepted `docs/DESIGN-changelog-fragments.md`. The load-bearing evidence is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+- Fixed (#753): `git apply` silently skips every file in a patch, and exits zero, when the
+  fault-operator scratch checkout is not its own git repository root -- git resolves the
+  scratch to the enclosing repository, where everything under it lives beneath `rust/target/`
+  and is git-ignored (`Skipped patch '<path>'.`, exit 0). The scratch then compiled
+  **unfaulted**, every detector passed because there was nothing to detect, and the harness
+  recorded that as a detector gap. `sync_scratch` guarded this with `[ -e "$scratch/.git" ]`,
+  which tests the wrong property: an empty or partial `.git` from a restored CI cache
+  satisfies it and suppresses the repair, which is why the failure appeared only in CI and
+  varied run to run. The guard now requires `git rev-parse --show-toplevel` inside the scratch
+  to equal the scratch, and `git apply --verbose` turns a `Skipped patch` line into a nonzero
+  status.
 - Fixed (#753): the implementation fault-operator harness now **witnesses** that a fault
   reached what it measured instead of inferring it. A `primary still passed under the
   fault` verdict has two causes with different owners -- the detector does not cover the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
   revision, which made unrelated pull requests unmergeable through the `semantic mutation`
   required context. Two fail-closed witnesses now run before any verdict: every file a
   patch names must differ byte-for-byte from the pristine copy after the patch applies,
-  and the primary detector's executable -- read back from cargo's own
-  `Executable <target> (<path>)` line -- must differ from the digest recorded for that
-  target under the no-op control. A byte-identical executable cannot arise from
-  compilation nondeterminism, so the binary witness fires only on real artifact reuse.
+  and, of the two artifacts a detector can execute -- the test harness binary, read back
+  from cargo's own `Executable <target> (<path>)` line, and the `fslc` executable a
+  detector may spawn via `env!("CARGO_BIN_EXE_fslc")` -- at least one must differ from the
+  digest recorded for it under the no-op control. Both are checked because an operator's
+  fault normally reaches exactly one: a patch under `rust/fslc/tests/**` changes the test
+  binary, a patch under `rust/fslc/src/**` changes `fslc`. A byte-identical pair cannot
+  arise from compilation nondeterminism, so the binary witness fires only on real artifact
+  reuse.
   The source witness carries its own negative control,
   `rust/fslc/tests/fault_operators/controls/identical-after-apply.patch`, a hunk that
   applies cleanly while leaving the file unchanged and must be refused; the binary witness

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -417,13 +417,26 @@ Two fail-closed witnesses now stand between the patch and the verdict, both in
 - **Source.** After the patch applies, every file it names must differ,
   byte-for-byte, from the pristine working-tree copy. `git apply` exiting zero says
   the patch was *accepted*, not that the bytes the compiler will read changed.
-- **Binary.** The primary detector's executable — read back from cargo's own
-  `Executable <target> (<path>)` line, so it is the binary that ran rather than an
-  inference about it — must differ from the digest recorded for the same target
-  under the no-op control, which is the one point in a run where the scratch is
-  known to carry no fault. A byte-identical executable is unambiguous: no
-  compilation nondeterminism can make a genuinely faulted binary equal an unfaulted
-  one, so this fires only on real artifact reuse, never on a flaky digest.
+- **Binary.** Of the two artifacts a detector can execute — the test harness
+  binary, read back from cargo's own `Executable <target> (<path>)` line so it is
+  the binary that ran rather than an inference about it, and the `fslc` executable
+  a detector may spawn through `env!("CARGO_BIN_EXE_fslc")` — at least one must
+  differ from the digest recorded for it under the no-op control, the one point in
+  a run where the scratch is known to carry no fault. A byte-identical pair is
+  unambiguous: no compilation nondeterminism can make a genuinely faulted artifact
+  equal an unfaulted one, so this fires only on real artifact reuse, never on a
+  flaky digest.
+
+  **Both artifacts, not just the test binary.** An operator's fault normally
+  reaches exactly one of them: a patch under `rust/fslc/tests/**`
+  (`shared-observer-lineage`) changes the test harness binary and leaves `fslc`
+  untouched, while a patch under `rust/fslc/src/**` (`failure-verdict-exits-zero`,
+  whose detector spawns the CLI) changes `fslc` and leaves the test binary
+  untouched. The first version of this witness hashed only the test binary and so
+  called the second shape a harness defect on every shard. It passed locally
+  because local rebuilds happened to produce differing test binaries anyway — a
+  vacuous green — and CI caught it. Requiring *both* to be unchanged before firing
+  is what makes the witness sound in both directions.
 
 Both witnesses report through the harness's own failure path and name the cause, so
 a harness defect can no longer be recorded as a detector gap.

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -399,6 +399,43 @@ seam it targeted moved, and someone must confirm the fault is still possible
 there and re-target the patch. Silently skipping a stale operator is how a
 detector matrix rots into decoration.
 
+### The fault must be witnessed, not inferred (#753)
+
+A `primary still passed under the fault` verdict has two possible causes, and they
+belong to different owners: the detector genuinely does not cover the seam (a real,
+reportable gap), or the detector never saw the fault at all (a defect in this
+harness). Until #753 the harness could not tell them apart. It inferred that the
+fault had arrived from two weaker facts — `git apply` exited zero, and the scratch
+compiled — and reported the first cause whenever the second was true. The
+observable symptom was the same operator returning different verdicts on different
+runs of the same revision, which made an unrelated pull request unmergeable through
+the `semantic mutation` required context.
+
+Two fail-closed witnesses now stand between the patch and the verdict, both in
+`tools/run-fault-operators.sh`:
+
+- **Source.** After the patch applies, every file it names must differ,
+  byte-for-byte, from the pristine working-tree copy. `git apply` exiting zero says
+  the patch was *accepted*, not that the bytes the compiler will read changed.
+- **Binary.** The primary detector's executable — read back from cargo's own
+  `Executable <target> (<path>)` line, so it is the binary that ran rather than an
+  inference about it — must differ from the digest recorded for the same target
+  under the no-op control, which is the one point in a run where the scratch is
+  known to carry no fault. A byte-identical executable is unambiguous: no
+  compilation nondeterminism can make a genuinely faulted binary equal an unfaulted
+  one, so this fires only on real artifact reuse, never on a flaky digest.
+
+Both witnesses report through the harness's own failure path and name the cause, so
+a harness defect can no longer be recorded as a detector gap.
+
+The source witness has its own negative control,
+`controls/identical-after-apply.patch`, alongside the stale-seam and no-op controls:
+a hunk that removes a line and adds the identical line back applies cleanly and
+leaves the file unchanged, and the harness requires the witness to refuse it. The
+binary witness has no fixture of its own — a fault that reaches the source but not
+the linked binary cannot be constructed on demand — and is calibrated by live
+mutation instead. That asymmetry is recorded here rather than left implicit.
+
 Rebuild cost keeps this out of the ordinary Rust workspace lane, but M13 makes
 it part of the dedicated semantic-mutation lanes on every pull request and
 product-gate run — round-robin sharded three ways across the

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -401,6 +401,42 @@ detector matrix rots into decoration.
 
 ### The fault must be witnessed, not inferred (#753)
 
+**Root cause.** `git apply` silently skips every file in a patch, and exits zero, when
+the scratch checkout is not its own repository root. Git then resolves the scratch to the
+*enclosing* repository, where every path under it lives beneath `rust/target/` and is
+git-ignored:
+
+```
+$ git -C "$scratch" apply --verbose shared-observer-lineage.patch
+Skipped patch 'rust/fslc/tests/support/self_conformance_mapping.rs'.
+Skipped patch 'rust/fslc/tests/triangulated/p1_compound_outcome.rs'.
+$ echo $?
+0
+```
+
+`apply_operator_patch` saw success, the scratch compiled **unfaulted**, the detector
+passed because there was nothing to detect, and the harness recorded that as "the primary
+detector still passed under the fault" — a detector gap, when the fault had never been
+applied at all.
+
+`sync_scratch` had guarded this with `[ -e "$scratch/.git" ]`, which tests the wrong
+property: *something existing* at that path is not *git resolving the scratch as its own
+root*. An empty or partial `.git` left behind by a restored CI cache satisfies `-e` and
+suppresses the `git init` that would have repaired it. That is why the failure appeared
+only in CI, never locally — where the scratch's `.git` persists between runs — and why the
+same revision returned different verdicts on different runs, depending on what the cache
+happened to carry. The guard now requires `git rev-parse --show-toplevel`, run inside the
+scratch, to equal the scratch itself, and rebuilds `.git` when it does not. `apply_patch`
+additionally runs `git apply --verbose` and turns a `Skipped patch` line into a nonzero
+status, so the silent-skip path cannot return success again through some other route.
+
+Reproduced and calibrated locally by breaking the marker exactly as the cache did — an
+empty `$scratch/.git` directory — and running the same shard both ways: under the previous
+`[ -e ]` guard the run fails with the source witness naming
+`rust/fslc/tests/support/self_conformance_mapping.rs`; under the repaired guard all six
+operators calibrate and the run exits 0.
+
+
 A `primary still passed under the fault` verdict has two possible causes, and they
 belong to different owners: the detector genuinely does not cover the seam (a real,
 reportable gap), or the detector never saw the fault at all (a defect in this

--- a/rust/fslc/tests/fault_operators/controls/identical-after-apply.patch
+++ b/rust/fslc/tests/fault_operators/controls/identical-after-apply.patch
@@ -1,0 +1,21 @@
+The negative control for the source witness (#753). It applies cleanly -- its
+hunk removes a line and adds the identical line back -- and leaves the file
+byte-for-byte unchanged, so `git apply` reports success while the compiler
+sees no fault at all. The harness requires `assert_fault_reached_source` to
+refuse it. If this control ever passes that witness, a `primary=ok` verdict is
+once again ambiguous between "the detector does not cover the seam" and "the
+detector never saw the fault", which is the confusion this witness exists to
+remove.
+
+Deliberately targets the same file as the other two controls, so all three
+share one seam and a future edit to `outcome.rs` moves them together.
+
+--- a/rust/fslc/src/outcome.rs
++++ b/rust/fslc/src/outcome.rs
+@@ -219,5 +219,5 @@
+         // success. Falling through to zero is exactly how #554 arose, and a
+         // poisoned verify-cache entry must not be readable as a pass either.
+         _ => OutcomeClass::Failure,
+-    }
++    }
+ }

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -199,7 +199,32 @@ sync_scratch() {
   # An infidelity like that makes a detector's verdict a property of the harness
   # rather than of the fault. `rsync --delete` leaves excluded paths alone, so
   # this survives the next sync.
-  [ -e "$scratch/.git" ] || git -C "$scratch" init --quiet
+  #
+  # Root cause of #753, and the reason this tests `rev-parse --show-toplevel`
+  # rather than `[ -e "$scratch/.git" ]` as it used to: *something existing* at
+  # that path is not the property this needs. When git resolves the scratch to
+  # the **enclosing** repository instead -- an empty or partial `.git` left by a
+  # restored CI cache satisfies `-e` and suppresses the `init` -- then every path
+  # in the scratch is under `rust/target/`, which the enclosing repository
+  # git-ignores, and `git apply` responds by *silently skipping every file and
+  # exiting zero*:
+  #
+  #     $ git -C "$scratch" apply --verbose shared-observer-lineage.patch
+  #     Skipped patch 'rust/fslc/tests/support/self_conformance_mapping.rs'.
+  #     Skipped patch 'rust/fslc/tests/triangulated/p1_compound_outcome.rs'.
+  #     $ echo $?
+  #     0
+  #
+  # `apply_operator_patch` sees success, the scratch compiles *unfaulted*, and
+  # every operator in the shard reports `primary=ok` -- read, correctly by the
+  # harness's own rules but wrongly in fact, as "the detector does not cover the
+  # seam". It reproduced only where the scratch's own `.git` was absent or
+  # unusable, which is why it appeared in CI and never locally, and why the same
+  # revision returned different verdicts on different runs.
+  if [ "$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null || true)" != "$(cd "$scratch" && pwd -P)" ]; then
+    rm -rf "$scratch/.git"
+    git -C "$scratch" init --quiet
+  fi
   # Second scratch-fidelity defect this harness has had to close (the .git
   # marker above was the first): a *faulted* build can outlive the fault.
   # `rsync -a` preserves the worktree's mtimes, and after an operator run the
@@ -242,9 +267,18 @@ sync_scratch() {
 # preamble each patch file carries. The scratch already has a repository of its
 # own -- `sync_scratch` gives it one so `portable_cli_source_path` cannot walk
 # out into the enclosing tree -- so `git -C` has a work tree to apply into.
+# `--verbose` is not decoration: `git apply` reports a file it declined to touch
+# as `Skipped patch '<path>'.` on stdout and still exits zero (#753), so without
+# it the one line that distinguishes "applied" from "silently did nothing" is
+# never written to the log. The skip is turned into a nonzero status here so
+# every caller -- including the stale-seam control, which must keep observing a
+# genuine refusal -- sees it as the failure it is.
 apply_patch() {
   local file="$1" log="$2" status=0
-  git -C "$scratch" apply --whitespace=nowarn "$file" >"$log" 2>&1 || status=$?
+  git -C "$scratch" apply --verbose --whitespace=nowarn "$file" >"$log" 2>&1 || status=$?
+  if [ "$status" -eq 0 ] && grep -q '^Skipped patch ' "$log"; then
+    status=1
+  fi
   return "$status"
 }
 

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -283,11 +283,20 @@ executable_from_build_log() {
 # in $detector_result. A detector that does not run at all is a loud failure,
 # never a pass: a renamed or deleted test must not read as green, and a
 # compile error must not be mistaken for the operator taking effect.
-# $detector_binary_hash carries the executed binary's digest back to the
-# caller, which is what lets run_operator prove the fault reached the thing it
-# measured instead of assuming it did (#753).
+# $detector_binary_hash and $detector_cli_hash carry the digests of the two
+# artifacts a detector can execute back to the caller, which is what lets
+# run_operator prove the fault reached the thing it measured instead of
+# assuming it did (#753). Both are needed because an operator's fault reaches
+# exactly one of them in the common case: a patch to `rust/fslc/tests/**`
+# (shared-observer-lineage) changes the test harness binary and leaves `fslc`
+# untouched, while a patch to `rust/fslc/src/**` (failure-verdict-exits-zero,
+# whose detector spawns `env!("CARGO_BIN_EXE_fslc")`) changes `fslc` and leaves
+# the test binary untouched. Hashing only the test binary called the second
+# shape a harness defect on every shard -- the first version of this witness
+# did exactly that, and CI caught it.
 detector_result=""
 detector_binary_hash=""
+detector_cli_hash=""
 run_detector() {
   local target="$1" name="$2" log="$3" status=0
   # `$target` is a cargo test-target selector ("--lib", "--test <name>") and
@@ -303,6 +312,12 @@ run_detector() {
   target '$target', so nothing here can prove which binary the detector ran.
   Full log: $log.build"
   detector_binary_hash="$(hash_file "$binary")"
+  # The `fslc` executable the detector may spawn instead of, or in addition to,
+  # exercising the library in-process. `cargo test` builds the package's bins so
+  # `CARGO_BIN_EXE_fslc` resolves, but prints no `Executable` line for them, so
+  # this one is named directly rather than read back.
+  detector_cli_hash=""
+  [ -f "$CARGO_TARGET_DIR/debug/fslc" ] && detector_cli_hash="$(hash_file "$CARGO_TARGET_DIR/debug/fslc")"
   # shellcheck disable=SC2086
   (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked -- --exact "$name") >"$log" 2>&1 || status=$?
   if ! grep -q -- "^test ${name} \.\.\. " "$log"; then
@@ -363,6 +378,7 @@ check_no_op_control() {
     # will be measured on. Recorded here, under the no-op control, because that
     # is the one point in the run where the scratch is known to carry no fault.
     no_op_primary_hashes[index]="$detector_binary_hash"
+    no_op_cli_hashes[index]="$detector_cli_hash"
     [ "$detector_result" = "ok" ] || fail "no-op control: primary detector
   '${primary_tests[$index]}' (operator ${names[$index]}) failed without any
   fault applied. Every cell in this matrix is meaningless until it passes.
@@ -378,6 +394,7 @@ check_no_op_control() {
 
 failures=()
 no_op_primary_hashes=()
+no_op_cli_hashes=()
 
 # Two fail-closed witnesses that the fault this run reports on actually reached
 # the thing it measured (#753). Without them the harness infers that from a
@@ -425,11 +442,13 @@ run_operator() {
 
   run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
     "$logs/$name.primary.log"
-  if [ "$detector_binary_hash" = "${no_op_primary_hashes[$index]}" ]; then
-    fail "operator '$name': the primary detector's binary is byte-identical to
-  the one built under the no-op control ($detector_binary_hash), so the fault
-  never reached the binary the verdict came from. This is a harness defect, not
-  a detector gap: do not record '$name' as uncalibrated on this evidence.
+  if [ "$detector_binary_hash" = "${no_op_primary_hashes[$index]}" ] \
+    && [ "$detector_cli_hash" = "${no_op_cli_hashes[$index]}" ]; then
+    fail "operator '$name': both artifacts its primary detector can execute are
+  byte-identical to the ones built under the no-op control (test binary
+  $detector_binary_hash, fslc ${detector_cli_hash:-absent}), so the fault
+  reached neither. This is a harness defect, not a detector gap: do not record
+  '$name' as uncalibrated on this evidence.
   Full log: $logs/$name.primary.log.build"
   fi
   local primary="$detector_result"

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -259,11 +259,35 @@ apply_operator_patch() {
   fi
 }
 
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# The path cargo linked for the target just built, read back from cargo's own
+# `--no-run` output rather than reconstructed from the target name: `cargo test
+# --no-run` prints one `Executable <target> (<path>)` line per selected target,
+# whether or not it relinked, so this is the binary the detector is about to
+# execute -- not an inference about it. CI colourizes cargo's output, so the
+# escapes come off first.
+executable_from_build_log() {
+  sed -e 's/'$'\x1b''\[[0-9;]*m//g' "$1" \
+    | sed -n 's/^ *Executable .*(\(.*\))$/\1/p' \
+    | tail -n 1
+}
+
 # Runs one named detector in the scratch checkout and reports "ok" or "failed"
 # in $detector_result. A detector that does not run at all is a loud failure,
 # never a pass: a renamed or deleted test must not read as green, and a
 # compile error must not be mistaken for the operator taking effect.
+# $detector_binary_hash carries the executed binary's digest back to the
+# caller, which is what lets run_operator prove the fault reached the thing it
+# measured instead of assuming it did (#753).
 detector_result=""
+detector_binary_hash=""
 run_detector() {
   local target="$1" name="$2" log="$3" status=0
   # `$target` is a cargo test-target selector ("--lib", "--test <name>") and
@@ -273,6 +297,12 @@ run_detector() {
     tail -40 "$log.build" >&2
     fail "the patched checkout does not compile (target: $target). Full log: $log.build"
   fi
+  local binary
+  binary="$(executable_from_build_log "$log.build")"
+  [ -n "$binary" ] && [ -f "$binary" ] || fail "cargo reported no executable for
+  target '$target', so nothing here can prove which binary the detector ran.
+  Full log: $log.build"
+  detector_binary_hash="$(hash_file "$binary")"
   # shellcheck disable=SC2086
   (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked -- --exact "$name") >"$log" 2>&1 || status=$?
   if ! grep -q -- "^test ${name} \.\.\. " "$log"; then
@@ -301,6 +331,26 @@ check_stale_seam_control() {
   echo "control stale-seam: refused, as required ($((SECONDS - started))s)"
 }
 
+# The source witness's own negative control (#753): a patch that applies
+# cleanly and changes nothing must be refused by assert_fault_reached_source.
+# Needs no build either, so it also runs before the expensive controls. The
+# subshell is load-bearing -- assert_fault_reached_source reports through
+# `fail`, which exits, and this control needs to observe that exit rather than
+# inherit it.
+check_source_witness_control() {
+  local started=$SECONDS control="$operators_dir/controls/identical-after-apply.patch"
+  sync_scratch
+  apply_operator_patch "$control" "$logs/identical-after-apply.apply.log"
+  if (assert_fault_reached_source "$control" "identical-after-apply") >/dev/null 2>&1; then
+    fail "the identical-after-apply control satisfied the source witness. A
+  patch that applies cleanly while leaving the bytes unchanged is now
+  indistinguishable from a real fault, so every 'primary still passed' verdict
+  below is ambiguous again between a detector gap and a fault that never
+  arrived."
+  fi
+  echo "control identical-after-apply: source witness refused it, as required ($((SECONDS - started))s)"
+}
+
 # Every named detector must be green under a patch that changes no behavior.
 check_no_op_control() {
   local started=$SECONDS index
@@ -309,6 +359,10 @@ check_no_op_control() {
   for index in "${assigned_indices[@]}"; do
     run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
       "$logs/no-op.${names[$index]}.primary.log"
+    # The unfaulted digest of the exact binary this operator's primary detector
+    # will be measured on. Recorded here, under the no-op control, because that
+    # is the one point in the run where the scratch is known to carry no fault.
+    no_op_primary_hashes[index]="$detector_binary_hash"
     [ "$detector_result" = "ok" ] || fail "no-op control: primary detector
   '${primary_tests[$index]}' (operator ${names[$index]}) failed without any
   fault applied. Every cell in this matrix is meaningless until it passes.
@@ -323,14 +377,61 @@ check_no_op_control() {
 }
 
 failures=()
+no_op_primary_hashes=()
+
+# Two fail-closed witnesses that the fault this run reports on actually reached
+# the thing it measured (#753). Without them the harness infers that from a
+# clean `git apply` and a clean build, and a `primary=ok` verdict is then
+# ambiguous between the two things it must never conflate: a detector that
+# genuinely does not cover the seam (a real, reportable defect) and a detector
+# that never saw the fault at all (a harness defect reported as the former).
+# That ambiguity is exactly what made the same operator return different
+# verdicts on different runs of the same revision.
+#
+# Witness 1, source: every file the patch names must differ from the pristine
+# working-tree copy once the patch is applied. `git apply` exiting zero is not
+# that evidence -- it says the patch was accepted, not that the bytes under
+# the compiler changed.
+#
+# Witness 2, binary: the primary detector's executable must differ from the
+# digest recorded for the same target under the no-op control. A fault that
+# reaches the source but not the linked binary produces a byte-identical
+# executable, which is unambiguous: no compilation nondeterminism can make a
+# genuinely faulted binary equal the unfaulted one, so this only ever fires on
+# a real reuse, never on a flaky digest.
+assert_fault_reached_source() {
+  local file="$1" name="$2" patched seen=0
+  while IFS= read -r patched; do
+    [ -n "$patched" ] || continue
+    seen=$((seen + 1))
+    [ -f "$scratch/$patched" ] || fail "operator '$name': $patched is missing
+  from the scratch after its patch applied."
+    if cmp -s "$root/$patched" "$scratch/$patched"; then
+      fail "operator '$name': $patched in the scratch is byte-identical to the
+  working tree after \`git apply\` reported success, so the fault never reached
+  the source the detector is about to be built from. Any verdict below would be
+  a property of the harness, not of the fault."
+    fi
+  done < <(sed -n 's/^+++ b\///p' "$file" | sort -u)
+  [ "$seen" -gt 0 ] || fail "operator '$name': its patch names no files, so
+  there is nothing to verify reached the scratch."
+}
 
 run_operator() {
   local index="$1" name="${names[$1]}" started=$SECONDS
   sync_scratch
   apply_operator_patch "${patch_files[$index]}" "$logs/$name.apply.log"
+  assert_fault_reached_source "${patch_files[$index]}" "$name"
 
   run_detector "${primary_targets[$index]}" "${primary_tests[$index]}" \
     "$logs/$name.primary.log"
+  if [ "$detector_binary_hash" = "${no_op_primary_hashes[$index]}" ]; then
+    fail "operator '$name': the primary detector's binary is byte-identical to
+  the one built under the no-op control ($detector_binary_hash), so the fault
+  never reached the binary the verdict came from. This is a harness defect, not
+  a detector gap: do not record '$name' as uncalibrated on this evidence.
+  Full log: $logs/$name.primary.log.build"
+  fi
   local primary="$detector_result"
   run_detector "${blind_targets[$index]}" "${blind_tests[$index]}" \
     "$logs/$name.blind.log"
@@ -354,6 +455,7 @@ run_operator() {
 read_table
 assign_shard
 check_stale_seam_control
+check_source_witness_control
 check_no_op_control
 
 for index in "${assigned_indices[@]}"; do


### PR DESCRIPTION
## Problem

`tools/run-fault-operators.sh` reports `primary still passed under the fault` for two causes that
belong to different owners:

1. the detector genuinely does not cover the seam — a real, reportable gap;
2. the detector never saw the fault at all — a defect in this harness.

It could not tell them apart. It inferred that the fault had arrived from two weaker facts — `git
apply` exited zero, and the scratch compiled — and reported cause 1 whenever cause 2 was true.

The observable symptom is #753's title: the same operator returns different verdicts on different
runs of the same revision. Because `semantic mutation (changed)` is a required status context and
aggregates the operator shards, this makes unrelated pull requests unmergeable (#755, and currently
#759).

## Evidence that the ambiguity is real, not theoretical

`shared-observer-lineage`'s primary detector,
`every_registered_claim_has_raw_independent_executable_evidence`, resolves to
`check_observers`' comparison of two `&'static str` values (`rust/fslc/tests/triangulated/claim.rs`).
No I/O, no environment input. A correctly built faulted binary **cannot** pass it.

Yet CI recorded `primary=ok`, with the harness's own uploaded logs showing the patch applied cleanly
(empty `shared-observer-lineage.apply.log`) and a full six-crate, 24s rebuild
(`shared-observer-lineage.primary.log.build`). Meanwhile, run locally:

| tree | scratch | verdict |
|---|---|---|
| `main` @ `bcb0a4d` | cold | `primary=failed blind=ok` — correct |
| `main` @ `bcb0a4d`, immediately again | warm | `primary=failed blind=ok` — correct |
| `feat/737-changelog-fragments` head | cold | `primary=failed blind=ok` — correct |
| same head, CI, two attempts | — | `primary=ok` — wrong |
| `main` @ `bcb0a4d`, CI run 31135753393 | — | `primary=ok` — wrong |

So the wrong verdict is not a property of any tree, and the harness recorded a defect in itself as a
defect in a detector. Full differential table in
[#753](https://github.com/ymm-oss/fsl/issues/753#issuecomment-5223994654).

**This pull request does not claim to have found the root cause.** It removes the harness's ability
to confuse the two causes, and makes the next occurrence name itself.

## Contract change

Two fail-closed witnesses run between the patch and the verdict:

- **Source witness.** After the patch applies, every file it names must differ byte-for-byte from the
  pristine working-tree copy. A zero exit from `git apply` says the patch was *accepted*, not that
  the bytes the compiler reads changed.
- **Binary witness.** The primary detector's executable — read back from cargo's own
  `Executable <target> (<path>)` line, so it is the binary that ran rather than an inference about it
  — must differ from the digest recorded for that target under the no-op control, the one point in a
  run where the scratch is known to carry no fault. A byte-identical executable is unambiguous: no
  compilation nondeterminism can make a genuinely faulted binary equal an unfaulted one, so this
  fires only on real artifact reuse, never on a flaky digest.

Neither witness changes any operator's verdict semantics. Nothing is skipped, waived, or allowlisted.

## Test evidence

`./tools/run-fault-operators.sh --shard 2/3`, this branch:

```
control stale-seam: refused, as required (0s)
control identical-after-apply: source witness refused it, as required (0s)
control no-op: all 6 operators' detectors green (111s)
operator failure-verdict-exits-zero: primary=failed blind=ok (6s)
operator shared-observer-lineage: primary=failed blind=ok (6s)
operator p2-backend-error-as-success: primary=failed blind=ok (6s)
operator p2-action-omission: primary=failed blind=ok (7s)
operator p2-violation-name-substitution: primary=failed blind=ok (8s)
operator business-precedence-omission: primary=failed blind=ok (7s)
fault-operators: 6 operators calibrated (152s total)
exit=0
```

No operator regresses, and the new control fires.

**Live mutation of the binary witness** — substituting the no-op digest at operator time, i.e.
simulating a binary the fault never reached:

```
fault-operators: operator 'failure-verdict-exits-zero': the primary detector's binary is
  byte-identical to the one built under the no-op control (d8c05da9...), so the fault never
  reached the binary the verdict came from. This is a harness defect, not a detector gap
exit=1
```

`shellcheck` and `bash -n` clean.

## Negative controls

The source witness has one: the new `rust/fslc/tests/fault_operators/controls/identical-after-apply.patch`
removes a line and adds the identical line back, so it applies cleanly and leaves the file unchanged;
the harness requires the witness to refuse it, in the same style as the stale-seam control.

The binary witness has **no fixture** — a fault that reaches the source but not the linked binary
cannot be constructed on demand — and is calibrated by the live mutation above. That asymmetry is
recorded in `docs/DESIGN-conformance-harness.md`, not left implicit.

## What this does not do

It does not explain why CI produced a wrong verdict where every local run produces the right one. It
makes the next CI run answer that: if both witnesses pass and the verdict is still `primary=ok`, the
fault reached source *and* binary and the cause is in the detector's own environment sensitivity,
which is #754's territory, not artifact reuse. If either witness fires, it names the cause directly.

Refs #753, #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
