### PR TITLE
fix(domain)!: reject retry backoff which has no executable lowering (#723)

### DIFF
--- a/changelog.d/723-retry-backoff-rejected.fixed.md
+++ b/changelog.d/723-retry-backoff-rejected.fixed.md
@@ -1,0 +1,19 @@
+Fixed (#723): effect `retry { backoff ... }` clauses (e.g. `retry { max_attempts
+3; backoff exponential }`) are now rejected fail-closed by both lowering
+paths through the same `validate_lowerable_constructs` gate
+(`rust/fsl-core/src/domain_lowering.rs`) that #710/#711/#712 established:
+no accepted design pins a backoff strategy's execution meaning in the
+finite model, and the parsed `backoff` value was never read by either
+lowering path or by the frozen Python reference
+(`src/fslc/domain_parser.py`, `src/fslc/domain_ir.py`), which only stores
+it in the IR. **Migration**: remove the `backoff ...` line from any `retry`
+block; it never had executable meaning under `check`/`verify`, so removing
+it changes no verification outcome. `retry { max_attempts N }` without a
+`backoff` clause is unaffected and still lowers the `attempts < N` guard.
+`examples/domain/order_async_effect.fsl` and
+`rust/fslc/tests/fixtures/issue_518_domain_replay.fsl` had their now-rejected
+`backoff exponential` lines removed as part of this fix, and
+`docs/intro/domain.{en,ja}.html`'s matching code sample was updated to
+match. See `docs/DESIGN-domain.md`. Tracked mechanism for future migration
+diagnostics: #702, #703. Remaining #723 items (`projection`, effect
+`compensation`, saga `outboxes`/`inboxes`) are out of this fix's scope.

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -112,7 +112,7 @@ the responsibility of `fsl-core` and the public Kernel contract.
 
 ### Rejected constructs: parsed, never lowered, so rejected fail-closed
 
-Parsing a construct into the IR is not a promise that it means anything. Three
+Parsing a construct into the IR is not a promise that it means anything. Four
 constructs reached the parse IR, were type-checked there, and were then dropped
 by **both** lowering paths, so an author could write them and the executable
 model would not contain them — an accepted construct with hollow semantics,
@@ -139,8 +139,15 @@ called from both `lower_domain_surface` (path A) and `domain_kernel_source`
   is not adopted as the contract: an author would believe every occurrence is
   checked while most are unconstrained. Value objects *without* invariants are
   unaffected and still lower as structs.
+- **effect `retry` `backoff`** (#723). This document (see "Effects" below)
+  pins only the `max_attempts` retry bound; no accepted decision assigns a
+  backoff strategy an execution meaning in the finite model, and neither
+  lowering path nor the frozen Python reference (`src/fslc/domain_parser.py`,
+  `src/fslc/domain_ir.py`) ever reads the parsed `backoff` value. `retry {
+  max_attempts N }` without a `backoff` clause is unaffected and still lowers
+  the existing `attempts < N` guard.
 
-Rejecting is deliberate rather than conservative: implementing any of the three
+Rejecting is deliberate rather than conservative: implementing any of the four
 would require inventing semantics inside a verifier, which is worse than
 refusing the construct. Each becomes implementable when an accepted amendment
 to this document settles the questions named above. Because the constructs never
@@ -196,7 +203,10 @@ inferred intent; the edition migrator consumes the edit contract described in
 
 An async `effect` declares the request event, completion events, correlation id,
 retry bound, timeout event, idempotency key, and optional reliable outbox/inbox
-boundary. The v0 implementation lowers the lifecycle to finite maps:
+boundary. `retry`'s `max_attempts` is the only lowered field; a `backoff`
+clause parses but has no execution meaning in the finite model and is
+rejected fail-closed (see "Rejected constructs" above, #723). The v0
+implementation lowers the lifecycle to finite maps:
 
 - `<effect>_status: Map<CorrelationId, EffectStatus>`
 - `<effect>_attempts: Map<CorrelationId, Attempt>`

--- a/docs/intro/domain.en.html
+++ b/docs/intro/domain.en.html
@@ -146,7 +146,6 @@
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
     retry {
       max_attempts 3
-      backoff exponential
     }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation {

--- a/docs/intro/domain.ja.html
+++ b/docs/intro/domain.ja.html
@@ -146,7 +146,6 @@
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
     retry {
       max_attempts 3
-      backoff exponential
     }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation {

--- a/examples/domain/order_async_effect.fsl
+++ b/examples/domain/order_async_effect.fsl
@@ -93,7 +93,6 @@ domain OrderAsyncEffect {
     emits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
     retry {
       max_attempts 3
-      backoff exponential
     }
     timeout after 10m emits PaymentCaptureTimedOut
     compensation {

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -101,7 +101,7 @@ fn span_at(loc: DomainLoc) -> Span {
 }
 
 /// Reject domain constructs that parse into a [`DomainSpec`] but have no
-/// executable lowering on either path (#710/#711/#712). Each of these
+/// executable lowering on either path (#710/#711/#712/#723). Each of these
 /// constructs is accepted by the grammar and, before this validation, was
 /// silently dropped by both `lower_domain` and `domain_kernel_source`: an
 /// author who wrote one believed it was checked when nothing consumed it.
@@ -128,6 +128,16 @@ pub(crate) fn validate_lowerable_constructs(domain: &DomainSpec) -> Result<(), C
                     stale.event
                 ),
                 span_at(stale.loc),
+            ));
+        }
+    }
+    for effect in &domain.effects {
+        if let Some(backoff) = &effect.retry.backoff {
+            return Err(error_at(
+                format!(
+                    "retry backoff '{backoff}' has no executable lowering; backoff strategies are not supported"
+                ),
+                span_at(effect.retry.loc.unwrap_or(effect.loc)),
             ));
         }
     }

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -135,9 +135,20 @@ pub(crate) fn validate_lowerable_constructs(domain: &DomainSpec) -> Result<(), C
         if let Some(backoff) = &effect.retry.backoff {
             return Err(error_at(
                 format!(
-                    "retry backoff '{backoff}' has no executable lowering; backoff strategies are not supported"
+                    "retry backoff '{backoff}' has no executable lowering; delete only the \
+                     `backoff` line, not the whole retry block -- `max_attempts` remains fully \
+                     lowered"
                 ),
-                span_at(effect.retry.loc.unwrap_or(effect.loc)),
+                // A `DomainRetry` only exists once the parser has read a `retry { ... }` block,
+                // and it always records that block's own loc at the same time (see
+                // `Parser::retry` in `rust/fsl-syntax/src/domain.rs`), so `backoff.is_some()`
+                // implies `loc.is_some()`.
+                span_at(
+                    effect
+                        .retry
+                        .loc
+                        .expect("a parsed retry block always records its own loc"),
+                ),
             ));
         }
     }

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -853,6 +853,16 @@ domain EmptyEnumContainers {
 /// Starts with the #712 top-level `await` case; #711's `on_stale`, #710's
 /// `value_object` invariant, and #723's `retry` `backoff` cases are added
 /// alongside their own fixes.
+///
+/// #723's `retry` `backoff` case breaks the "land on the block to delete"
+/// framing above: the located span is still the enclosing `retry { ... }`
+/// block (`DomainRetry` records no narrower span for its `backoff` field),
+/// but the correct migration deletes only the `backoff` line -- the
+/// `retry` block itself, and its `max_attempts` bound, stay and remain
+/// fully lowered. Deleting the whole block would silently shrink
+/// `max_attempts` to `domain_lowering.rs`'s `unwrap_or(1)` default instead
+/// of preserving the author's declared bound. The diagnostic message
+/// itself, not just its location, carries that distinction.
 struct UnlowerableConstructCase {
     fixture: &'static str,
     expected_message: &'static str,
@@ -891,14 +901,17 @@ const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[
     },
     UnlowerableConstructCase {
         fixture: "rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl",
-        expected_message: "retry backoff 'exponential' has no executable lowering; backoff strategies are not supported",
+        expected_message: "retry backoff 'exponential' has no executable lowering; delete only the `backoff` line, not the whole retry block -- `max_attempts` remains fully lowered",
         location: |domain| {
             let effect = domain
                 .effects
                 .iter()
                 .find(|effect| effect.retry.backoff.is_some())
                 .expect("fixture declares an effect with a retry backoff");
-            let loc = effect.retry.loc.unwrap_or(effect.loc);
+            let loc = effect
+                .retry
+                .loc
+                .expect("a parsed retry block always records its own loc");
             (loc.line, loc.column)
         },
     },

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -141,8 +141,9 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
 /// `domain_kernel_source` -> `parse_kernel_source` -> `build_model`) because
 /// they are semantically invalid (type mismatch / unknown symbol) OR because
 /// they use a construct that parses but has no executable lowering on either
-/// path and is therefore rejected fail-closed (#710/#711/#712: `value_object`
-/// invariants, aggregate `on_stale`, and top-level `await` routing).
+/// path and is therefore rejected fail-closed (#710/#711/#712/#723:
+/// `value_object` invariants, aggregate `on_stale`, top-level `await`
+/// routing, and effect `retry` `backoff`).
 const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_duplicate_enum.fsl",
@@ -150,6 +151,7 @@ const SEMANTICALLY_INVALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/domain_characterization/invalid_type_mismatch.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_member.fsl",
     "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl",
+    "rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl",
     "rust/fslc/tests/fixtures/domain_stale_policy_rejected.fsl",
     "rust/fslc/tests/fixtures/domain_value_object_invariant_rejected.fsl",
 ];
@@ -839,16 +841,18 @@ domain EmptyEnumContainers {
 }
 
 /// One case per accepted-but-unlowerable domain construct fail-closed by
-/// `validate_lowerable_constructs` (#710/#711/#712). Both paths must reject
-/// with the exact same message and the same `line`/`column`, located at the
-/// construct's own declaration, not some downstream position -- an author
-/// debugging the rejection needs to land on the block to delete, and a
-/// located-diagnostic regression on only one path would otherwise slip past
+/// `validate_lowerable_constructs` (#710/#711/#712/#723). Both paths must
+/// reject with the exact same message and the same `line`/`column`, located
+/// at the construct's own declaration, not some downstream position -- an
+/// author debugging the rejection needs to land on the block to delete, and
+/// a located-diagnostic regression on only one path would otherwise slip
+/// past
 /// `semantically_invalid_domain_fixtures_are_rejected_by_both_lowering_paths`
 /// (which only checks *that* both reject, not *where*).
 ///
-/// Starts with the #712 top-level `await` case; #711's `on_stale` and #710's
-/// `value_object` invariant cases are added alongside their own fixes.
+/// Starts with the #712 top-level `await` case; #711's `on_stale`, #710's
+/// `value_object` invariant, and #723's `retry` `backoff` cases are added
+/// alongside their own fixes.
 struct UnlowerableConstructCase {
     fixture: &'static str,
     expected_message: &'static str,
@@ -883,6 +887,19 @@ const UNLOWERABLE_CONSTRUCT_CASES: &[UnlowerableConstructCase] = &[
                 .expect("fixture declares a value_object");
             let span = value_object.invariants[0].span;
             (span.start.line, span.start.column)
+        },
+    },
+    UnlowerableConstructCase {
+        fixture: "rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl",
+        expected_message: "retry backoff 'exponential' has no executable lowering; backoff strategies are not supported",
+        location: |domain| {
+            let effect = domain
+                .effects
+                .iter()
+                .find(|effect| effect.retry.backoff.is_some())
+                .expect("fixture declares an effect with a retry backoff");
+            let loc = effect.retry.loc.unwrap_or(effect.loc);
+            (loc.line, loc.column)
         },
     },
 ];

--- a/rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl
+++ b/rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl
@@ -1,0 +1,41 @@
+domain RetryBackoffRejected {
+  // SPDX-License-Identifier: Apache-2.0
+  type PaymentRequestId = 0..1
+
+  aggregate Order {
+    id OrderId
+    state { status: PaymentResultStatus = NotRequested; }
+
+    command RequestPaymentCapture { payment_request_id: PaymentRequestId }
+
+    event PaymentCaptureRequested { payment_request_id: PaymentRequestId }
+    event PaymentCaptured { payment_request_id: PaymentRequestId }
+    event PaymentFailed { payment_request_id: PaymentRequestId }
+
+    decide RequestPaymentCapture {
+      emits PaymentCaptureRequested
+    }
+
+    evolve PaymentCaptureRequested { status = Requested }
+    evolve PaymentCaptured { status = Captured }
+    evolve PaymentFailed { status = Failed }
+  }
+
+  enum PaymentResultStatus { NotRequested, Requested, Captured, Failed }
+
+  effect CapturePayment {
+    async
+    irreversible
+    idempotency_key Order.id
+    correlation_id PaymentCaptureRequested.payment_request_id
+    handles PaymentCaptureRequested
+    emits one_of [PaymentCaptured, PaymentFailed]
+    retry {
+      max_attempts 3
+      backoff exponential
+    }
+    compensation {
+      emits PaymentFailed
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_518_domain_replay.fsl
+++ b/rust/fslc/tests/fixtures/issue_518_domain_replay.fsl
@@ -72,7 +72,6 @@ domain MinReplay {
     emits one_of [Delivered, DeliveryFailed]
     retry {
       max_attempts 2
-      backoff exponential
     }
     timeout after 5m emits DeliveryFailed
     compensation {


### PR DESCRIPTION
## Problem

#723 inventoried domain constructs that parse into the IR but have no executable lowering on either path — an accepted-but-hollow construct, which `AGENTS.md` classifies as a soundness defect. This PR resolves item 4 only: `retry { backoff ... }`.

`DomainRetry.backoff` (`rust/fsl-syntax/src/domain.rs:171`) parses but is never read again: neither `lower_domain_surface` nor `domain_kernel_source` consume it (only `max_attempts` becomes the `attempts < N` guard), and the frozen Python reference (`src/fslc/domain_parser.py`, `src/fslc/domain_ir.py`) only stores it in `DomainRetry`'s IR without ever reading the field back. `docs/DESIGN-domain.md:197-199` pins only the `max_attempts` retry bound; no accepted design assigns a backoff strategy an execution meaning in the finite model.

## Contract change (breaking)

Following the #710/#711/#712 precedent (top-level `await`, `on_stale`, `value_object` invariants), `retry { backoff ... }` is now rejected fail-closed at its declaration, with a located `semantics` diagnostic, by the same shared `validate_lowerable_constructs` gate in `rust/fsl-core/src/domain_lowering.rs`, called from both `lower_domain_surface` (path A) and `domain_kernel_source` (path B).

**Accepted syntax that is no longer accepted**: `retry { ...; backoff <name>; ... }`. `retry { max_attempts N }` without a `backoff` clause is completely unaffected. Grammar/parse is left intact (consistent with #710-#712) — the construct still parses so the rejection is a located diagnostic, not a syntax error.

**Migration**: remove the `backoff ...` line from any `retry` block. It never had executable meaning under `check`/`verify`, so removing it changes no verification outcome. No spec migration tooling is needed beyond deleting the line.

## Changes

- `rust/fsl-core/src/domain_lowering.rs`: new case in `validate_lowerable_constructs` rejecting `effect.retry.backoff` when present, located at the `retry` block's own span.
- `rust/fsl-core/tests/domain_render_agreement.rs`: new `UnlowerableConstructCase` (message/location) and a `SEMANTICALLY_INVALID_DOMAIN_FIXTURES` registration for the new negative fixture.
- `rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl` (new): negative-control fixture.
- `examples/domain/order_async_effect.fsl`: removed `backoff exponential` — this was the repo's only corpus example of the now-rejected clause. `max_attempts 3` is unchanged.
- `rust/fslc/tests/fixtures/issue_518_domain_replay.fsl`: same removal. This fixture is registered in `VALID_DOMAIN_FIXTURES` (`domain_render_agreement.rs`) and exercised by `issue_518_domain_replay_detection.rs` — it also carried `backoff exponential` and would otherwise have started failing to lower under this change. Found by inspection, not named in the original brief.
- `docs/intro/domain.en.html` / `docs/intro/domain.ja.html` (line 149 each): removed the same `backoff exponential` line from the hand-authored manual's embedded code sample. **These pages are not generated** — verified against `docs/DESIGN-docs-site.md` (`tools/build_site_reference.py` only produces `language.{ja,en}.html` and `cli.{ja,en}.html`; `domain.html` is one of the "12 flat chapter pages" explicitly listed as hand-authored). No generation pipeline exists for this page, so this is a direct content edit, not a hand-edit of a generated artifact.
- `docs/DESIGN-domain.md`: added `retry` `backoff` as a fourth entry to the "Rejected constructs" list, and a clarifying sentence in the "Effects" section.
- `changelog.d/723-retry-backoff-rejected.fixed.md`: new fragment, category `fixed` (matching #710/#711/#712's category), with a migration note since accepted syntax shrinks.
- Verified via grep: `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/reference.md`, and `rust/fsl-lsp/src/index.rs` have no `backoff` references — no coupled changes needed there.

## Test evidence

Negative control (new fixture, exit 2):
```
$ rust/target/debug/fslc check rust/fslc/tests/fixtures/domain_retry_backoff_rejected.fsl
{"result":"error","kind":"semantics","message":"retry backoff 'exponential' has no executable lowering; backoff strategies are not supported at ...:33:5", ...}
exit=2
```

Positive control (`max_attempts` without `backoff`, corpus fixture, all four commands):
```
$ rust/target/debug/fslc check examples/domain/order_async_effect.fsl                 -> result: ok, exit=0
$ rust/target/debug/fslc verify examples/domain/order_async_effect.fsl --depth 4       -> exit=0
$ rust/target/debug/fslc domain check examples/domain/order_async_effect.fsl          -> result: verified_under_assumptions, exit=0
$ rust/target/debug/fslc domain expand examples/domain/order_async_effect.fsl         -> exit=0
```

Narrow test suites:
```
$ cargo test --manifest-path rust/Cargo.toml -p fsl-core --test domain_render_agreement
running 10 tests ... 10 passed (includes corpus_discovery_matches_registered_classification,
unlowered_domain_constructs_fail_closed_on_both_paths, semantically_invalid_domain_fixtures_are_rejected_by_both_lowering_paths)

$ cargo test --manifest-path rust/Cargo.toml -p fslc-rust \
    --test issue_518_domain_replay_detection --test corpus_check_sweep \
    --test corpus_expectation_manifest --test domain_codegen_contract \
    --test domain_expression_characterization --test domain_compensation_guard \
    --test domain_origin_diagnostics
... all passed, including golden-baseline tests
    (all_five_public_kernel_domain_targets_match_pre_migration_goldens,
     domain_surface_lowering_public_kernel_and_diagnostics_match_baseline) —
    confirms removing the never-consumed `backoff` field does not perturb any
    Rust-native snapshot/golden.

$ cargo test --manifest-path rust/Cargo.toml -p fsl-lsp --test corpus
running 1 test ... 1 passed (valid_corpus_is_parsed_and_every_identifier_is_indexed)
```

Formatting/lint:
```
$ cargo fmt --manifest-path rust/Cargo.toml --all -- --check     -> clean
$ cargo clippy --manifest-path rust/Cargo.toml -p fsl-core -p fslc-rust --all-targets -- -D warnings  -> clean
```

Corpus/snapshot handling: no Rust-native golden/snapshot file changed as a result of this diff (confirmed by the passing golden-baseline tests above); no `rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json` diff. The Python-only `tests/snapshots/corpus_snapshot.json` (frozen-reference gate, not part of the required native product gate per `AGENTS.md`) was not exercised — no `.venv` is set up in this environment — but since the frozen Python reference never consumed `backoff` either (verified by reading `src/fslc/domain_parser.py`/`domain_ir.py`), no verdict-tier change is expected there.

## Judgment calls for review

1. **HTML pages are hand-authored, not generated** — see above. I edited them directly rather than "regenerating," since no generation script produces them. Flagging this explicitly in case the premise in the brief (that these are generated) reflects information I don't have.
2. Found and fixed an un-briefed sibling break: `rust/fslc/tests/fixtures/issue_518_domain_replay.fsl` also contained `backoff exponential` and is registered as a must-lower-cleanly fixture; without removing it, this change would have broken `issue_518_domain_replay_detection.rs` and the `domain_render_agreement.rs` corpus-parity sweep.
3. Left `docs/DESIGN-domain.md`'s existing three-bullet framing intact structurally, extending it to four rather than restructuring, per "smallest contract-preserving change."

This PR does **not** close #723 — items 1-3 (`projection`, effect `compensation`, saga `outboxes`/`inboxes`) and the adjacent `value_object` documentation gap are separate PRs by other agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)