### PR TITLE
fix(domain): report implicit initial values for container-typed fields (#731)

### DIFF
--- a/changelog.d/731-container-domain-implicit-initial-value.fixed.md
+++ b/changelog.d/731-container-domain-implicit-initial-value.fixed.md
@@ -1,0 +1,21 @@
+Fixed (#731): `implicit_initial_value` now fires for every domain aggregate
+state field the renderer already gives an implicit default -- `Option<T>`
+(`none`), `Set<T>` (`Set {}`), a top-level `Map<K, V>` (the dense per-key
+`forall` init), and `value_object`-typed fields (their struct-literal
+default) -- not just the four scalar shapes (`Bool`, enum, range,
+external-placeholder). `rust/fslc/src/frontend_output.rs`'s warning now
+reads the selected value from `fsl_core::domain_type_default`, the same
+total dispatch `domain_kernel_source` already used
+(`rust/fsl-core/src/domain.rs`'s `Context::default_for_type`), instead of a
+second, non-exhaustive copy of the dispatch that silently excluded any type
+name containing `<`; a new `domain_expand`-vs-warning string-level parity
+check and container/`value_object` regression tests
+(`rust/fslc/tests/issue_250_initialization.rs`) cover the fix, alongside a
+negative control confirming an explicit default still suppresses the
+warning. A top-level `Map<K, V>` field (no whole-field initializer syntax
+exists) and a `Set<T>`/`value_object` field whose brace-literal default
+cannot yet round-trip through `fslc fmt` (issue #770, found and reproduced
+independently while implementing this fix) both still warn under `check`
+but omit the machine-applicable insertion and keep
+`edition_severity.next` at `warning` rather than `error`, since the next
+edition cannot yet demand an initializer it has no safe way to insert.

--- a/changelog.d/731-container-domain-implicit-initial-value.fixed.md
+++ b/changelog.d/731-container-domain-implicit-initial-value.fixed.md
@@ -1,21 +1,35 @@
 Fixed (#731): `implicit_initial_value` now fires for every domain aggregate
-state field the renderer already gives an implicit default -- `Option<T>`
-(`none`), `Set<T>` (`Set {}`), a top-level `Map<K, V>` (the dense per-key
-`forall` init), and `value_object`-typed fields (their struct-literal
-default) -- not just the four scalar shapes (`Bool`, enum, range,
+state field the renderer already gives an implicit default -- `Int` (`0`),
+`Option<T>` (`none`), `Set<T>` (`Set {}`), a top-level `Map<K, V>` (the dense
+per-key `forall` init), and `value_object`-typed fields (their struct-literal
+default) -- not just the original four scalar shapes (`Bool`, enum, range,
 external-placeholder). `rust/fslc/src/frontend_output.rs`'s warning now
 reads the selected value from `fsl_core::domain_type_default`, the same
 total dispatch `domain_kernel_source` already used
 (`rust/fsl-core/src/domain.rs`'s `Context::default_for_type`), instead of a
 second, non-exhaustive copy of the dispatch that silently excluded any type
-name containing `<`; a new `domain_expand`-vs-warning string-level parity
-check and container/`value_object` regression tests
-(`rust/fslc/tests/issue_250_initialization.rs`) cover the fix, alongside a
-negative control confirming an explicit default still suppresses the
-warning. A top-level `Map<K, V>` field (no whole-field initializer syntax
-exists) and a `Set<T>`/`value_object` field whose brace-literal default
-cannot yet round-trip through `fslc fmt` (issue #770, found and reproduced
-independently while implementing this fix) both still warn under `check`
-but omit the machine-applicable insertion and keep
-`edition_severity.next` at `warning` rather than `error`, since the next
-edition cannot yet demand an initializer it has no safe way to insert.
+name containing `<`. An enum default is rendered in domain-source form (the
+bare declared member, e.g. `Pending`) rather than `domain_kernel_source`'s
+kernel-scoped mangled identifier (`Status_Pending`); a `DefaultForm`
+threaded through `Context::default_for_type`/`default`/`normalize` selects
+the right form at every enum-rendering site, including a value_object's own
+explicit default field and an enum nested inside a value_object's struct
+literal or a top-level Map's per-key value, so nesting depth cannot bring
+the mangled form back. New regression tests
+(`rust/fslc/tests/issue_250_initialization.rs`) cover container/value_object
+coverage, `domain_expand`-vs-warning string-level parity, an explicit
+default still suppressing the warning, bare `Int` warning like every other
+scalar shape, and a nested enum inside a value_object/Map staying unmangled
+at any depth. A top-level `Map<K, V>` field (no whole-field initializer
+syntax exists at all) and a `Set<T>`/`value_object` field whose
+brace-literal default cannot yet round-trip through `fslc fmt`'s
+reformat-and-reparse pass (issue #770, found and reproduced independently
+while implementing this fix) both still warn under `check` but omit the
+machine-applicable insertion -- chosen by the field's type shape, not the
+rendered value's text -- and keep `edition_severity.next` at `warning`
+rather than `error`, since `migrate --write` is fail-closed (it would not
+write a corrupted file) but attempting that insertion would trip #770's
+reformat failure and fail migration for the whole file, dropping every
+other, otherwise-safe edit in it too. A "defect witness" test pins #770's
+`fslc fmt` symptom directly so a future fix to #770 turns it red instead of
+letting the withheld insertion silently outlive its reason.

--- a/changelog.d/731-container-domain-implicit-initial-value.fixed.md
+++ b/changelog.d/731-container-domain-implicit-initial-value.fixed.md
@@ -17,19 +17,28 @@ explicit default field and an enum nested inside a value_object's struct
 literal or a top-level Map's per-key value, so nesting depth cannot bring
 the mangled form back. New regression tests
 (`rust/fslc/tests/issue_250_initialization.rs`) cover container/value_object
-coverage, `domain_expand`-vs-warning string-level parity, an explicit
-default still suppressing the warning, bare `Int` warning like every other
-scalar shape, and a nested enum inside a value_object/Map staying unmangled
-at any depth. A top-level `Map<K, V>` field (no whole-field initializer
-syntax exists at all) and a `Set<T>`/`value_object` field whose
-brace-literal default cannot yet round-trip through `fslc fmt`'s
-reformat-and-reparse pass (issue #770, found and reproduced independently
-while implementing this fix) both still warn under `check` but omit the
-machine-applicable insertion -- chosen by the field's type shape, not the
-rendered value's text -- and keep `edition_severity.next` at `warning`
-rather than `error`, since `migrate --write` is fail-closed (it would not
-write a corrupted file) but attempting that insertion would trip #770's
-reformat failure and fail migration for the whole file, dropping every
-other, otherwise-safe edit in it too. A "defect witness" test pins #770's
-`fslc fmt` symptom directly so a future fix to #770 turns it red instead of
-letting the withheld insertion silently outlive its reason.
+coverage, an explicit default still suppressing the warning, bare `Int`
+warning like every other scalar shape, and a nested enum inside a
+value_object/Map staying bare (never `domain_kernel_source`'s mangled form)
+at any depth; a `domain_expand`-vs-warning string-level check confirms the
+selected value matches for every shape that renders identically in both
+domain-source and kernel form -- deliberately excluding enum-bearing values,
+where the warning's bare member and `domain_kernel_source`'s mangled
+identifier now intentionally differ. A top-level `Map<K, V>` field (no
+whole-field initializer syntax exists at all) and a `Set<T>`/`value_object`
+field whose brace-literal default cannot yet round-trip through `fslc
+fmt`'s reformat-and-reparse pass (issue #770, found and reproduced
+independently while implementing this fix) both still warn under `check`
+but omit the machine-applicable insertion -- chosen by an allowlist over
+the field's type shape (`Option` only; everything else, including any
+future brace-literal-rendering constructor, fails closed until reviewed),
+not the rendered value's text -- and keep `edition_severity.next` at
+`warning` rather than `error`, since `migrate --write` is fail-closed (it
+would not write a corrupted file) but attempting that insertion would trip
+#770's reformat failure and fail migration for the whole file, dropping
+every other, otherwise-safe edit in it too. A "defect witness" test pins
+#770's `fslc fmt` symptom directly so a future fix to #770 turns it red;
+its failure message also flags issue #785, a second pre-existing defect on
+the same `Context::normalize` enum-mangling guard (found independently
+during review, not reachable through this PR's own withheld insertion) that
+must be fixed before the `value_object` insertion can be safely re-enabled.

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -185,9 +185,17 @@ remain a separate traceability relation.
 
 Aggregate state fields retain their typed explicit initializer when present. In
 the current edition, an omitted initializer keeps the established lowering
-choice for Bool (`false`), enum (first declared member), range (lower bound), or
-external placeholder (`0`) and emits `implicit_initial_value`. The warning names
-the chosen value and reason and carries a byte insertion edit. This makes the
+choice -- Bool (`false`), Int (`0`), enum (first declared member, rendered
+bare as domain source itself would accept), range (lower bound), external
+placeholder (`0`), `Option<T>` (`none`), `Set<T>` (`Set {}`), `value_object`
+(its own default struct literal), or a top-level `Map<K, V>` (the dense
+per-key `forall` init) -- and emits `implicit_initial_value` for every one of
+these shapes (issue #731), not only the four scalar ones. The warning names
+the chosen value and reason and, where the value's shape allows a safe
+insertion, carries a byte insertion edit; a top-level `Map<K, V>` field (no
+whole-field initializer syntax exists) and a `Set<T>`/`value_object` field
+(blocked by a pre-existing formatter round-trip defect, issue #770) warn
+without one and keep next-edition severity at `warning`. This makes the
 existing behavior migratable without treating an arbitrary default as newly
 inferred intent; the edition migrator consumes the edit contract described in
 [`DESIGN-initialization.md`](DESIGN-initialization.md).

--- a/docs/DESIGN-initialization.md
+++ b/docs/DESIGN-initialization.md
@@ -45,15 +45,48 @@ the same way.
 
 The current edition preserves already-existing implicit values but reports the
 stable warning code `implicit_initial_value`. Each finding contains the field
-source span, selected value, selection reason, current/next severity, canonical
-replacement, and a machine-applicable byte insertion edit.
+source span, selected value, selection reason, and current/next severity.
+Where a machine-applicable insertion is safe to offer (see below), a finding
+additionally carries a canonical replacement and a byte insertion edit; a
+finding without one is still reported, just not auto-fixable yet.
 
-Domain aggregate fields warn when omission selects:
+Domain aggregate fields warn whenever an omitted initializer selects an
+implicit default -- every shape `fsl_core::domain_type_default` (the same
+total dispatch `fslc domain expand`'s renderer uses) can select one for, not
+a separately maintained scalar subset (issue #731):
 
-- `false` for `Bool`;
-- the first declared enum member;
-- the lower bound of a range;
-- `0` for an external placeholder without a declared lower bound.
+- `false` for `Bool`, `0` for `Int`;
+- the first declared enum member (rendered as domain source itself would
+  accept, e.g. `Pending`, never the generated kernel's mangled
+  `Status_Pending` -- including when the enum is nested inside a
+  `value_object`'s struct literal or a `Map`'s per-key value);
+- the lower bound of a range, or `0` for an external placeholder without a
+  declared lower bound;
+- `none` for `Option<T>`;
+- `Set {}` for `Set<T>`;
+- a `value_object`'s own default struct literal, built from this same
+  selection recursively over its fields;
+- for a top-level `Map<K, V>` field, the dense per-key
+  `forall k: K { field[k] = <V's default> }` init `fslc domain expand`
+  renders directly -- `<V's default>` recurses through this same selection,
+  and `field: Map<K, V> = expr;` is always rejected
+  ("whole-Map domain defaults are not supported"), so this is the *only*
+  supported `Map` default.
+
+Two of those shapes do not currently carry a machine-applicable insertion,
+and consequently keep next-edition severity at `warning` rather than `error`
+(`check --edition next`/`migrate --edition next` cannot yet demand an
+initializer they have no safe way to insert): a top-level `Map<K, V>` field,
+which has no whole-field initializer syntax at all, and a `Set<T>` or
+`value_object`-typed field, whose brace-literal default (`Set { ... }`,
+`Name { ... }`) is valid FSL that `check` accepts but that the lossless
+formatter cannot yet round-trip through a reformat-and-reparse pass
+(issue #770, a pre-existing formatter defect discovered while adding
+container-type coverage, independent of this migration contract). Reporting
+the finding without the insertion is deliberate: `migrate --write` is
+fail-closed and would not write a corrupted file, but attempting the edit
+would trip #770's reformat failure and fail migration for the whole file,
+dropping every other, otherwise-safe edit in it too.
 
 Requirements process fields warn only when a `number` field omits its initializer
 and therefore selects the declared `verify.values` lower bound. Requirements
@@ -61,13 +94,14 @@ and therefore selects the declared `verify.values` lower bound. Requirements
 a check-time error. This preserves the accepted requirements contract instead of
 inventing a new implicit value.
 
-The edit inserts ` = <selected value>` immediately after the field type. Applying
-it preserves surrounding comments/trivia and yields the value already selected by
-the current semantics. The lossless formatter and edition migrator consume this
-diagnostic contract. `fslc migrate --edition next` inserts the selected value
-only after comparing the checked before/after Public Kernel; `--write` applies
-it with the other validated file edits.
+Where an edit exists, it inserts ` = <selected value>` immediately after the
+field type. Applying it preserves surrounding comments/trivia and yields the
+value already selected by the current semantics. The lossless formatter and
+edition migrator consume this diagnostic contract. `fslc migrate --edition next`
+inserts the selected value only after comparing the checked before/after Public
+Kernel; `--write` applies it with the other validated file edits.
 
-The next edition severity is `error`; `check --edition next` requires the
-initializer to be explicit. The current edition continues to parse the omitted
-form and report its warning.
+The next edition severity is `error` for every insertable finding;
+`check --edition next` requires that initializer to be explicit. The current
+edition continues to parse every omitted form and report its warning,
+including the two shapes above with no insertion yet.

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -289,27 +289,33 @@ domain 宣言では、有限のバリアントに `enum Name { Member, ... }` �
 assurance/completeness を持つトップレベルの provenance グラフとして公開します。
 
 domain aggregate の状態フィールドが初期化子を省略した場合、現行エディションは
-確立された Bool `false`、enum 先頭メンバー、範囲下限、external-placeholder `0`、
-`value_object` の構造体リテラル、`Option<T>` の `none`、`Set<T>` の `Set {}`、
-トップレベルの `Map<K, V>` の密な per-key init
+確立された Bool `false`、Int `0`、enum 先頭メンバー(domain ソース自体が受理する
+bare な形で描画されます — `value_object` や `Map` の値としてどれだけ深く nested
+していても、`domain_kernel_source` の kernel 側 mangled 識別子には決してなりません)、
+範囲下限、external-placeholder `0`、`value_object` の構造体リテラル、`Option<T>` の
+`none`、`Set<T>` の `Set {}`、トップレベルの `Map<K, V>` の密な per-key init
 (`forall k: K { field[k] = <V の既定値> }`、`<V の既定値>` はこの同じ選択を再帰的に
 辿る)のいずれかの選択を維持し、これら**すべて**の形状について `implicit_initial_value`
 を出力します(#731)。この警告のカバー範囲は renderer の総当たり dispatch
-(`fsl_core::domain_type_default` — 警告と `domain_kernel_source` の双方が選択値を
-読み出す単一のオーナー)と一致しており、従来の4つのスカラー形状だけではありません。
-この警告には、選択された値、理由、current/next の深刻度、フィールドのスパン、そして
-機械適用可能な挿入が存在する場合は `suggestion`/`canonical_replacement` が含まれます。
-2つのフィールド形状ではこの挿入が省略され、それに伴い `edition_severity.next` は
-`error` ではなく `warning` のままになります(次のエディションは、安全に挿入する
-手段がない初期化子をまだ必須化できません): トップレベルの `Map<K, V>` フィールドには
-whole-field の既定値が一切なく(`field: Map<K, V> = expr;` は常に棄却されます、
-「whole-Map domain defaults are not supported」。サポートされる `Map` の既定値は
-per-key 形式のみだからです)、`Set<T>` または `value_object` 型フィールドの
-brace-literal な既定値(`Set { ... }`、`Name { ... }`)は、`fslc check` が明示的に
-書かれたものを受理するにもかかわらず、`fslc fmt`/`migrate --write` で現状
-round-trip できません(issue #770)。別の `Map` の値として nested された `Map` は
-別途棄却されます(「Map state requires explicit initialization through supported
-semantics」)。per-key init は `Map` 値型に対して選べる既定値を持たないからです。
+(`fsl_core::domain_type_default` — 警告と `domain_kernel_source` の双方が、選択値
+そのものと、その中の enum メンバーの綴り方を読み出す単一のオーナー)と一致しており、
+一部のスカラー形状だけではありません。この警告には、選択された値、理由、current/next
+の深刻度、フィールドのスパン、そして機械適用可能な挿入が存在する場合は
+`suggestion`/`canonical_replacement` が含まれます。2つのフィールド形状ではこの挿入が
+省略され、それに伴い `edition_severity.next` は `error` ではなく `warning` のままに
+なります(次のエディションは、安全に挿入する手段がない初期化子をまだ必須化できません):
+トップレベルの `Map<K, V>` フィールドには whole-field の既定値が一切なく
+(`field: Map<K, V> = expr;` は常に棄却されます、「whole-Map domain defaults are not
+supported」。サポートされる `Map` の既定値は per-key 形式のみだからです)、`Set<T>`
+または `value_object` 型フィールドの brace-literal な既定値(`Set { ... }`、
+`Name { ... }`)は、`fslc check` が明示的に書かれたものを受理するにもかかわらず、
+`fslc fmt` の reformat-and-reparse パスで現状 round-trip できません(issue #770)。
+`migrate --write` は fail-closed であり壊れたファイルを書き出すことはありませんが、
+挿入を提示すると #770 の reformat 失敗を誘発し、そのファイル全体の migration が
+失敗して、他の安全な編集まで一緒に失われます。別の `Map` の値として nested された
+`Map` は別途棄却されます(「Map state requires explicit initialization through
+supported semantics」)。per-key init は `Map` 値型に対して選べる既定値を持たないから
+です。
 
 安定した fsl-domain findings とネストされたカーネル結果(成功時は
 `verified_under_assumptions`)には `fslc domain check` を、aggregate/effect の

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -289,21 +289,27 @@ domain 宣言では、有限のバリアントに `enum Name { Member, ... }` �
 assurance/completeness を持つトップレベルの provenance グラフとして公開します。
 
 domain aggregate の状態フィールドが初期化子を省略した場合、現行エディションは
-確立された Bool `false`、enum 先頭メンバー、範囲下限、external-placeholder `0` の
-選択を維持し、`implicit_initial_value` を出力します。この警告には、選択された値、
-理由、current/next の深刻度、フィールドのスパン、機械適用可能な明示初期化子の挿入
-が含まれます。次のエディションでは初期化子の明示が必須になります。コンテナ型の
-フィールドにも暗黙の既定値があります — `Option<T>` は `none` を、`Set<T>` は
-`Set {}` を選び、トップレベルの `Map<K, V>` は密な per-key init
-(`forall k: K { field[k] = <V の既定値> }`)を選びます。`<V の既定値>` はこの同じ
-選択を再帰的に辿ります — ただし省略しても `implicit_initial_value` は
-**出力されません**。この警告のカバー範囲は上記の4つのスカラー形状で止まります。
-`Map` フィールドには、さらに2つの fail-closed ルールがあります: 明示の whole-`Map`
-既定値(`field: Map<K, V> = expr;`)は常に棄却されます(「whole-Map domain defaults
-are not supported」)。サポートされる `Map` の既定値は per-key 形式のみだからです。
-また、別の `Map` の値として nested された `Map` も棄却されます(「Map state requires
-explicit initialization through supported semantics」)。per-key init は `Map` 値型
-に対して選べる既定値を持たないからです。
+確立された Bool `false`、enum 先頭メンバー、範囲下限、external-placeholder `0`、
+`value_object` の構造体リテラル、`Option<T>` の `none`、`Set<T>` の `Set {}`、
+トップレベルの `Map<K, V>` の密な per-key init
+(`forall k: K { field[k] = <V の既定値> }`、`<V の既定値>` はこの同じ選択を再帰的に
+辿る)のいずれかの選択を維持し、これら**すべて**の形状について `implicit_initial_value`
+を出力します(#731)。この警告のカバー範囲は renderer の総当たり dispatch
+(`fsl_core::domain_type_default` — 警告と `domain_kernel_source` の双方が選択値を
+読み出す単一のオーナー)と一致しており、従来の4つのスカラー形状だけではありません。
+この警告には、選択された値、理由、current/next の深刻度、フィールドのスパン、そして
+機械適用可能な挿入が存在する場合は `suggestion`/`canonical_replacement` が含まれます。
+2つのフィールド形状ではこの挿入が省略され、それに伴い `edition_severity.next` は
+`error` ではなく `warning` のままになります(次のエディションは、安全に挿入する
+手段がない初期化子をまだ必須化できません): トップレベルの `Map<K, V>` フィールドには
+whole-field の既定値が一切なく(`field: Map<K, V> = expr;` は常に棄却されます、
+「whole-Map domain defaults are not supported」。サポートされる `Map` の既定値は
+per-key 形式のみだからです)、`Set<T>` または `value_object` 型フィールドの
+brace-literal な既定値(`Set { ... }`、`Name { ... }`)は、`fslc check` が明示的に
+書かれたものを受理するにもかかわらず、`fslc fmt`/`migrate --write` で現状
+round-trip できません(issue #770)。別の `Map` の値として nested された `Map` は
+別途棄却されます(「Map state requires explicit initialization through supported
+semantics」)。per-key init は `Map` 値型に対して選べる既定値を持たないからです。
 
 安定した fsl-domain findings とネストされたカーネル結果(成功時は
 `verified_under_assumptions`)には `fslc domain check` を、aggregate/effect の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -294,29 +294,36 @@ graph with portable source identities, exact byte/line coordinates,
 target bindings, source-node reverse lookup, and explicit assurance/completeness.
 
 When a domain aggregate state field omits its initializer, the current edition
-preserves the established Bool `false`, enum first-member, range lower-bound,
+preserves the established Bool `false`, Int `0`, enum first-member (rendered
+bare, as domain source itself would accept — never `domain_kernel_source`'s
+kernel-scoped mangled identifier, no matter how deeply the enum is nested
+inside a `value_object` or a `Map`'s value), range lower-bound,
 external-placeholder `0`, `value_object` struct-literal, `Option<T>` `none`,
 `Set<T>` `Set {}`, or top-level `Map<K, V>` dense per-key
 (`forall k: K { field[k] = <V's default> }`, where `<V's default>` recurses
 through this same selection) choice, and emits `implicit_initial_value` for
 every one of these shapes (#731) — the warning's coverage matches the
 renderer's total dispatch (`fsl_core::domain_type_default`, the single owner
-both the warning and `domain_kernel_source` read the selected value from), not
-just the four scalar forms. The warning contains the selected value, reason,
-current/next severity, field span, and — where a machine-applicable insertion
-exists — a `suggestion`/`canonical_replacement`. Two field shapes omit the
-insertion, and consequently keep `edition_severity.next` at `warning` rather
-than `error` (the next edition cannot yet demand an initializer it has no safe
-way to insert): a top-level `Map<K, V>` field has no whole-field default at
-all (`field: Map<K, V> = expr;` is always rejected,
-"whole-Map domain defaults are not supported", because the per-key form is the
-only supported `Map` default), and a `Set<T>` or `value_object`-typed field's
-brace-literal default (`Set { ... }`, `Name { ... }`) cannot currently be
-round-tripped by `fslc fmt`/`migrate --write` (issue #770) even though `fslc
-check` accepts it when written explicitly. A `Map` nested as another `Map`'s
-value is separately rejected ("Map state requires explicit initialization
-through supported semantics") because the per-key init has no default to
-select for a `Map` value type.
+both the warning and `domain_kernel_source` read the selected value, and how
+an enum member within it is spelled, from), not just a scalar subset. The
+warning contains the selected value, reason, current/next severity, field
+span, and — where a machine-applicable insertion exists — a
+`suggestion`/`canonical_replacement`. Two field shapes omit the insertion, and
+consequently keep `edition_severity.next` at `warning` rather than `error`
+(the next edition cannot yet demand an initializer it has no safe way to
+insert): a top-level `Map<K, V>` field has no whole-field default at all
+(`field: Map<K, V> = expr;` is always rejected, "whole-Map domain defaults are
+not supported", because the per-key form is the only supported `Map`
+default), and a `Set<T>` or `value_object`-typed field's brace-literal default
+(`Set { ... }`, `Name { ... }`) cannot currently be round-tripped by `fslc
+fmt`'s reformat-and-reparse pass (issue #770) even though `fslc check` accepts
+it when written explicitly; `migrate --write` is fail-closed and would not
+write a corrupted file, but offering the insertion would trip #770's reformat
+failure and fail migration for the whole file, dropping every other,
+otherwise-safe edit in it too. A `Map` nested as another `Map`'s value is
+separately rejected ("Map state requires explicit initialization through
+supported semantics") because the per-key init has no default to select for a
+`Map` value type.
 
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -294,23 +294,29 @@ graph with portable source identities, exact byte/line coordinates,
 target bindings, source-node reverse lookup, and explicit assurance/completeness.
 
 When a domain aggregate state field omits its initializer, the current edition
-preserves the established Bool `false`, enum first-member, range lower-bound, or
-external-placeholder `0` choice and emits `implicit_initial_value`. The warning
-contains the selected value, reason, current/next severity, field span, and a
-machine-applicable explicit-initializer insertion. The next edition requires the
-initializer to be explicit. Container-typed fields also get an implicit
-default — `Option<T>` selects `none`, `Set<T>` selects `Set {}`, and a
-top-level `Map<K, V>` selects a dense per-key init
-(`forall k: K { field[k] = <V's default> }`), where `<V's default>` recurses
-through this same selection — but omitting one does **not** emit
-`implicit_initial_value`; that warning's coverage stops at the four scalar
-shapes above. `Map` fields carry two additional fail-closed rules: an explicit
-whole-`Map` default (`field: Map<K, V> = expr;`) is always rejected
-("whole-Map domain defaults are not supported") because the per-key form is the
-only supported `Map` default, and a `Map` nested as another `Map`'s value is
-rejected too ("Map state requires explicit initialization through supported
-semantics") because the per-key init has no default to select for a `Map`
-value type.
+preserves the established Bool `false`, enum first-member, range lower-bound,
+external-placeholder `0`, `value_object` struct-literal, `Option<T>` `none`,
+`Set<T>` `Set {}`, or top-level `Map<K, V>` dense per-key
+(`forall k: K { field[k] = <V's default> }`, where `<V's default>` recurses
+through this same selection) choice, and emits `implicit_initial_value` for
+every one of these shapes (#731) — the warning's coverage matches the
+renderer's total dispatch (`fsl_core::domain_type_default`, the single owner
+both the warning and `domain_kernel_source` read the selected value from), not
+just the four scalar forms. The warning contains the selected value, reason,
+current/next severity, field span, and — where a machine-applicable insertion
+exists — a `suggestion`/`canonical_replacement`. Two field shapes omit the
+insertion, and consequently keep `edition_severity.next` at `warning` rather
+than `error` (the next edition cannot yet demand an initializer it has no safe
+way to insert): a top-level `Map<K, V>` field has no whole-field default at
+all (`field: Map<K, V> = expr;` is always rejected,
+"whole-Map domain defaults are not supported", because the per-key form is the
+only supported `Map` default), and a `Set<T>` or `value_object`-typed field's
+brace-literal default (`Set { ... }`, `Name { ... }`) cannot currently be
+round-tripped by `fslc fmt`/`migrate --write` (issue #770) even though `fslc
+check` accepts it when written explicitly. A `Map` nested as another `Map`'s
+value is separately rejected ("Map state requires explicit initialization
+through supported semantics") because the per-key init has no default to
+select for a `Map` value type.
 
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -326,23 +326,29 @@ unchanged. Opt-in Public Kernel v2 publishes the chain as a top-level provenance
 graph with portable source identities, exact byte/line coordinates,
 target bindings, source-node reverse lookup, and explicit assurance/completeness.</p>
 <p>When a domain aggregate state field omits its initializer, the current edition
-preserves the established Bool <code>false</code>, enum first-member, range lower-bound, or
-external-placeholder <code>0</code> choice and emits <code>implicit_initial_value</code>. The warning
-contains the selected value, reason, current/next severity, field span, and a
-machine-applicable explicit-initializer insertion. The next edition requires the
-initializer to be explicit. Container-typed fields also get an implicit
-default — <code>Option&lt;T&gt;</code> selects <code>none</code>, <code>Set&lt;T&gt;</code> selects <code>Set {}</code>, and a
-top-level <code>Map&lt;K, V&gt;</code> selects a dense per-key init
-(<code>forall k: K { field[k] = &lt;V's default&gt; }</code>), where <code>&lt;V's default&gt;</code> recurses
-through this same selection — but omitting one does <strong>not</strong> emit
-<code>implicit_initial_value</code>; that warning's coverage stops at the four scalar
-shapes above. <code>Map</code> fields carry two additional fail-closed rules: an explicit
-whole-<code>Map</code> default (<code>field: Map&lt;K, V&gt; = expr;</code>) is always rejected
-("whole-Map domain defaults are not supported") because the per-key form is the
-only supported <code>Map</code> default, and a <code>Map</code> nested as another <code>Map</code>'s value is
-rejected too ("Map state requires explicit initialization through supported
-semantics") because the per-key init has no default to select for a <code>Map</code>
-value type.</p>
+preserves the established Bool <code>false</code>, enum first-member, range lower-bound,
+external-placeholder <code>0</code>, <code>value_object</code> struct-literal, <code>Option&lt;T&gt;</code> <code>none</code>,
+<code>Set&lt;T&gt;</code> <code>Set {}</code>, or top-level <code>Map&lt;K, V&gt;</code> dense per-key
+(<code>forall k: K { field[k] = &lt;V's default&gt; }</code>, where <code>&lt;V's default&gt;</code> recurses
+through this same selection) choice, and emits <code>implicit_initial_value</code> for
+every one of these shapes (#731) — the warning's coverage matches the
+renderer's total dispatch (<code>fsl_core::domain_type_default</code>, the single owner
+both the warning and <code>domain_kernel_source</code> read the selected value from), not
+just the four scalar forms. The warning contains the selected value, reason,
+current/next severity, field span, and — where a machine-applicable insertion
+exists — a <code>suggestion</code>/<code>canonical_replacement</code>. Two field shapes omit the
+insertion, and consequently keep <code>edition_severity.next</code> at <code>warning</code> rather
+than <code>error</code> (the next edition cannot yet demand an initializer it has no safe
+way to insert): a top-level <code>Map&lt;K, V&gt;</code> field has no whole-field default at
+all (<code>field: Map&lt;K, V&gt; = expr;</code> is always rejected,
+"whole-Map domain defaults are not supported", because the per-key form is the
+only supported <code>Map</code> default), and a <code>Set&lt;T&gt;</code> or <code>value_object</code>-typed field's
+brace-literal default (<code>Set { ... }</code>, <code>Name { ... }</code>) cannot currently be
+round-tripped by <code>fslc fmt</code>/<code>migrate --write</code> (issue #770) even though <code>fslc
+check</code> accepts it when written explicitly. A <code>Map</code> nested as another <code>Map</code>'s
+value is separately rejected ("Map state requires explicit initialization
+through supported semantics") because the per-key init has no default to
+select for a <code>Map</code> value type.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -326,29 +326,36 @@ unchanged. Opt-in Public Kernel v2 publishes the chain as a top-level provenance
 graph with portable source identities, exact byte/line coordinates,
 target bindings, source-node reverse lookup, and explicit assurance/completeness.</p>
 <p>When a domain aggregate state field omits its initializer, the current edition
-preserves the established Bool <code>false</code>, enum first-member, range lower-bound,
+preserves the established Bool <code>false</code>, Int <code>0</code>, enum first-member (rendered
+bare, as domain source itself would accept — never <code>domain_kernel_source</code>'s
+kernel-scoped mangled identifier, no matter how deeply the enum is nested
+inside a <code>value_object</code> or a <code>Map</code>'s value), range lower-bound,
 external-placeholder <code>0</code>, <code>value_object</code> struct-literal, <code>Option&lt;T&gt;</code> <code>none</code>,
 <code>Set&lt;T&gt;</code> <code>Set {}</code>, or top-level <code>Map&lt;K, V&gt;</code> dense per-key
 (<code>forall k: K { field[k] = &lt;V's default&gt; }</code>, where <code>&lt;V's default&gt;</code> recurses
 through this same selection) choice, and emits <code>implicit_initial_value</code> for
 every one of these shapes (#731) — the warning's coverage matches the
 renderer's total dispatch (<code>fsl_core::domain_type_default</code>, the single owner
-both the warning and <code>domain_kernel_source</code> read the selected value from), not
-just the four scalar forms. The warning contains the selected value, reason,
-current/next severity, field span, and — where a machine-applicable insertion
-exists — a <code>suggestion</code>/<code>canonical_replacement</code>. Two field shapes omit the
-insertion, and consequently keep <code>edition_severity.next</code> at <code>warning</code> rather
-than <code>error</code> (the next edition cannot yet demand an initializer it has no safe
-way to insert): a top-level <code>Map&lt;K, V&gt;</code> field has no whole-field default at
-all (<code>field: Map&lt;K, V&gt; = expr;</code> is always rejected,
-"whole-Map domain defaults are not supported", because the per-key form is the
-only supported <code>Map</code> default), and a <code>Set&lt;T&gt;</code> or <code>value_object</code>-typed field's
-brace-literal default (<code>Set { ... }</code>, <code>Name { ... }</code>) cannot currently be
-round-tripped by <code>fslc fmt</code>/<code>migrate --write</code> (issue #770) even though <code>fslc
-check</code> accepts it when written explicitly. A <code>Map</code> nested as another <code>Map</code>'s
-value is separately rejected ("Map state requires explicit initialization
-through supported semantics") because the per-key init has no default to
-select for a <code>Map</code> value type.</p>
+both the warning and <code>domain_kernel_source</code> read the selected value, and how
+an enum member within it is spelled, from), not just a scalar subset. The
+warning contains the selected value, reason, current/next severity, field
+span, and — where a machine-applicable insertion exists — a
+<code>suggestion</code>/<code>canonical_replacement</code>. Two field shapes omit the insertion, and
+consequently keep <code>edition_severity.next</code> at <code>warning</code> rather than <code>error</code>
+(the next edition cannot yet demand an initializer it has no safe way to
+insert): a top-level <code>Map&lt;K, V&gt;</code> field has no whole-field default at all
+(<code>field: Map&lt;K, V&gt; = expr;</code> is always rejected, "whole-Map domain defaults are
+not supported", because the per-key form is the only supported <code>Map</code>
+default), and a <code>Set&lt;T&gt;</code> or <code>value_object</code>-typed field's brace-literal default
+(<code>Set { ... }</code>, <code>Name { ... }</code>) cannot currently be round-tripped by <code>fslc
+fmt</code>'s reformat-and-reparse pass (issue #770) even though <code>fslc check</code> accepts
+it when written explicitly; <code>migrate --write</code> is fail-closed and would not
+write a corrupted file, but offering the insertion would trip #770's reformat
+failure and fail migration for the whole file, dropping every other,
+otherwise-safe edit in it too. A <code>Map</code> nested as another <code>Map</code>'s value is
+separately rejected ("Map state requires explicit initialization through
+supported semantics") because the per-key init has no default to select for a
+<code>Map</code> value type.</p>
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -323,21 +323,27 @@ never-enabled action の警告として報告します。</p>
 バイト/行座標、ターゲットバインディング、ソースノードの逆引き、明示的な
 assurance/completeness を持つトップレベルの provenance グラフとして公開します。</p>
 <p>domain aggregate の状態フィールドが初期化子を省略した場合、現行エディションは
-確立された Bool <code>false</code>、enum 先頭メンバー、範囲下限、external-placeholder <code>0</code> の
-選択を維持し、<code>implicit_initial_value</code> を出力します。この警告には、選択された値、
-理由、current/next の深刻度、フィールドのスパン、機械適用可能な明示初期化子の挿入
-が含まれます。次のエディションでは初期化子の明示が必須になります。コンテナ型の
-フィールドにも暗黙の既定値があります — <code>Option&lt;T&gt;</code> は <code>none</code> を、<code>Set&lt;T&gt;</code> は
-<code>Set {}</code> を選び、トップレベルの <code>Map&lt;K, V&gt;</code> は密な per-key init
-(<code>forall k: K { field[k] = &lt;V の既定値&gt; }</code>)を選びます。<code>&lt;V の既定値&gt;</code> はこの同じ
-選択を再帰的に辿ります — ただし省略しても <code>implicit_initial_value</code> は
-<strong>出力されません</strong>。この警告のカバー範囲は上記の4つのスカラー形状で止まります。
-<code>Map</code> フィールドには、さらに2つの fail-closed ルールがあります: 明示の whole-<code>Map</code>
-既定値(<code>field: Map&lt;K, V&gt; = expr;</code>)は常に棄却されます(「whole-Map domain defaults
-are not supported」)。サポートされる <code>Map</code> の既定値は per-key 形式のみだからです。
-また、別の <code>Map</code> の値として nested された <code>Map</code> も棄却されます(「Map state requires
-explicit initialization through supported semantics」)。per-key init は <code>Map</code> 値型
-に対して選べる既定値を持たないからです。</p>
+確立された Bool <code>false</code>、enum 先頭メンバー、範囲下限、external-placeholder <code>0</code>、
+<code>value_object</code> の構造体リテラル、<code>Option&lt;T&gt;</code> の <code>none</code>、<code>Set&lt;T&gt;</code> の <code>Set {}</code>、
+トップレベルの <code>Map&lt;K, V&gt;</code> の密な per-key init
+(<code>forall k: K { field[k] = &lt;V の既定値&gt; }</code>、<code>&lt;V の既定値&gt;</code> はこの同じ選択を再帰的に
+辿る)のいずれかの選択を維持し、これら<strong>すべて</strong>の形状について <code>implicit_initial_value</code>
+を出力します(#731)。この警告のカバー範囲は renderer の総当たり dispatch
+(<code>fsl_core::domain_type_default</code> — 警告と <code>domain_kernel_source</code> の双方が選択値を
+読み出す単一のオーナー)と一致しており、従来の4つのスカラー形状だけではありません。
+この警告には、選択された値、理由、current/next の深刻度、フィールドのスパン、そして
+機械適用可能な挿入が存在する場合は <code>suggestion</code>/<code>canonical_replacement</code> が含まれます。
+2つのフィールド形状ではこの挿入が省略され、それに伴い <code>edition_severity.next</code> は
+<code>error</code> ではなく <code>warning</code> のままになります(次のエディションは、安全に挿入する
+手段がない初期化子をまだ必須化できません): トップレベルの <code>Map&lt;K, V&gt;</code> フィールドには
+whole-field の既定値が一切なく(<code>field: Map&lt;K, V&gt; = expr;</code> は常に棄却されます、
+「whole-Map domain defaults are not supported」。サポートされる <code>Map</code> の既定値は
+per-key 形式のみだからです)、<code>Set&lt;T&gt;</code> または <code>value_object</code> 型フィールドの
+brace-literal な既定値(<code>Set { ... }</code>、<code>Name { ... }</code>)は、<code>fslc check</code> が明示的に
+書かれたものを受理するにもかかわらず、<code>fslc fmt</code>/<code>migrate --write</code> で現状
+round-trip できません(issue #770)。別の <code>Map</code> の値として nested された <code>Map</code> は
+別途棄却されます(「Map state requires explicit initialization through supported
+semantics」)。per-key init は <code>Map</code> 値型に対して選べる既定値を持たないからです。</p>
 <p>安定した fsl-domain findings とネストされたカーネル結果(成功時は
 <code>verified_under_assumptions</code>)には <code>fslc domain check</code> を、aggregate/effect の
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -323,27 +323,33 @@ never-enabled action の警告として報告します。</p>
 バイト/行座標、ターゲットバインディング、ソースノードの逆引き、明示的な
 assurance/completeness を持つトップレベルの provenance グラフとして公開します。</p>
 <p>domain aggregate の状態フィールドが初期化子を省略した場合、現行エディションは
-確立された Bool <code>false</code>、enum 先頭メンバー、範囲下限、external-placeholder <code>0</code>、
-<code>value_object</code> の構造体リテラル、<code>Option&lt;T&gt;</code> の <code>none</code>、<code>Set&lt;T&gt;</code> の <code>Set {}</code>、
-トップレベルの <code>Map&lt;K, V&gt;</code> の密な per-key init
+確立された Bool <code>false</code>、Int <code>0</code>、enum 先頭メンバー(domain ソース自体が受理する
+bare な形で描画されます — <code>value_object</code> や <code>Map</code> の値としてどれだけ深く nested
+していても、<code>domain_kernel_source</code> の kernel 側 mangled 識別子には決してなりません)、
+範囲下限、external-placeholder <code>0</code>、<code>value_object</code> の構造体リテラル、<code>Option&lt;T&gt;</code> の
+<code>none</code>、<code>Set&lt;T&gt;</code> の <code>Set {}</code>、トップレベルの <code>Map&lt;K, V&gt;</code> の密な per-key init
 (<code>forall k: K { field[k] = &lt;V の既定値&gt; }</code>、<code>&lt;V の既定値&gt;</code> はこの同じ選択を再帰的に
 辿る)のいずれかの選択を維持し、これら<strong>すべて</strong>の形状について <code>implicit_initial_value</code>
 を出力します(#731)。この警告のカバー範囲は renderer の総当たり dispatch
-(<code>fsl_core::domain_type_default</code> — 警告と <code>domain_kernel_source</code> の双方が選択値を
-読み出す単一のオーナー)と一致しており、従来の4つのスカラー形状だけではありません。
-この警告には、選択された値、理由、current/next の深刻度、フィールドのスパン、そして
-機械適用可能な挿入が存在する場合は <code>suggestion</code>/<code>canonical_replacement</code> が含まれます。
-2つのフィールド形状ではこの挿入が省略され、それに伴い <code>edition_severity.next</code> は
-<code>error</code> ではなく <code>warning</code> のままになります(次のエディションは、安全に挿入する
-手段がない初期化子をまだ必須化できません): トップレベルの <code>Map&lt;K, V&gt;</code> フィールドには
-whole-field の既定値が一切なく(<code>field: Map&lt;K, V&gt; = expr;</code> は常に棄却されます、
-「whole-Map domain defaults are not supported」。サポートされる <code>Map</code> の既定値は
-per-key 形式のみだからです)、<code>Set&lt;T&gt;</code> または <code>value_object</code> 型フィールドの
-brace-literal な既定値(<code>Set { ... }</code>、<code>Name { ... }</code>)は、<code>fslc check</code> が明示的に
-書かれたものを受理するにもかかわらず、<code>fslc fmt</code>/<code>migrate --write</code> で現状
-round-trip できません(issue #770)。別の <code>Map</code> の値として nested された <code>Map</code> は
-別途棄却されます(「Map state requires explicit initialization through supported
-semantics」)。per-key init は <code>Map</code> 値型に対して選べる既定値を持たないからです。</p>
+(<code>fsl_core::domain_type_default</code> — 警告と <code>domain_kernel_source</code> の双方が、選択値
+そのものと、その中の enum メンバーの綴り方を読み出す単一のオーナー)と一致しており、
+一部のスカラー形状だけではありません。この警告には、選択された値、理由、current/next
+の深刻度、フィールドのスパン、そして機械適用可能な挿入が存在する場合は
+<code>suggestion</code>/<code>canonical_replacement</code> が含まれます。2つのフィールド形状ではこの挿入が
+省略され、それに伴い <code>edition_severity.next</code> は <code>error</code> ではなく <code>warning</code> のままに
+なります(次のエディションは、安全に挿入する手段がない初期化子をまだ必須化できません):
+トップレベルの <code>Map&lt;K, V&gt;</code> フィールドには whole-field の既定値が一切なく
+(<code>field: Map&lt;K, V&gt; = expr;</code> は常に棄却されます、「whole-Map domain defaults are not
+supported」。サポートされる <code>Map</code> の既定値は per-key 形式のみだからです)、<code>Set&lt;T&gt;</code>
+または <code>value_object</code> 型フィールドの brace-literal な既定値(<code>Set { ... }</code>、
+<code>Name { ... }</code>)は、<code>fslc check</code> が明示的に書かれたものを受理するにもかかわらず、
+<code>fslc fmt</code> の reformat-and-reparse パスで現状 round-trip できません(issue #770)。
+<code>migrate --write</code> は fail-closed であり壊れたファイルを書き出すことはありませんが、
+挿入を提示すると #770 の reformat 失敗を誘発し、そのファイル全体の migration が
+失敗して、他の安全な編集まで一緒に失われます。別の <code>Map</code> の値として nested された
+<code>Map</code> は別途棄却されます(「Map state requires explicit initialization through
+supported semantics」)。per-key init は <code>Map</code> 値型に対して選べる既定値を持たないから
+です。</p>
 <p>安定した fsl-domain findings とネストされたカーネル結果(成功時は
 <code>verified_under_assumptions</code>)には <code>fslc domain check</code> を、aggregate/effect の
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -53,13 +53,7 @@ fn error_at(message: impl Into<String>, span: Span) -> CoreError {
 /// `Map` arity, which falls through to [`Context::default_for_type`]'s
 /// generic "unsupported domain type constructor" rejection instead of being
 /// treated as a renderable Map here).
-///
-/// `pub` (issue #731): the `implicit_initial_value` warning needs the same
-/// top-level-`Map` classification `domain_kernel_source`'s state-field loop
-/// uses, so it can report the renderer's per-key value default instead of
-/// re-deriving what counts as a top-level `Map` shape.
-#[must_use]
-pub fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &SyntaxTypeExpr)> {
+fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &SyntaxTypeExpr)> {
     match &type_name.kind {
         SyntaxTypeExprKind::Apply {
             constructor,
@@ -72,33 +66,76 @@ pub fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &Sy
     }
 }
 
-/// The renderer's default value for `type_name` in `domain` -- the same
-/// total dispatch [`domain_kernel_source`] uses via `Context::default_for_type`
-/// to choose every field's implicit value, exposed so the
-/// `implicit_initial_value` warning (issue #731) reports the value this
-/// function -- the single owner -- selects, rather than a second hand-rolled
-/// copy of the dispatch that can silently drift from it (as the pre-#731
-/// warning did for every container type).
+/// [`domain_type_default`]'s result: either a single value a field's
+/// initializer would render as `= value`, or -- for a top-level `Map<K, V>`
+/// field only -- the dense per-key `forall` init [`domain_kernel_source`]'s
+/// state-field loop builds directly, since a bare `Map` has no single
+/// default value of its own.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DomainDefault {
+    /// A field initializer's right-hand side, e.g. `none`, `Set {}`, a bare
+    /// enum member, or a `value_object` struct literal.
+    Value(String),
+    /// The per-key value `field[k] = value` renders for every key, the only
+    /// supported default for a top-level `Map<K, V>` field
+    /// (`field: Map<K, V> = expr;` is always rejected).
+    MapPerKey(String),
+}
+
+/// The domain-*source* form of the renderer's default value for `type_name`
+/// in `domain` -- the same total dispatch [`domain_kernel_source`] uses via
+/// `Context::default_for_type` to choose every field's implicit value,
+/// exposed so the `implicit_initial_value` warning (issue #731) reports the
+/// value this function -- the single owner -- selects, rather than a second
+/// hand-rolled copy of the dispatch that can silently drift from it (as the
+/// pre-#731 warning did for every container type).
 ///
-/// A caller holding a top-level `Map<K, V>` field type calls [`map_key_value`]
-/// first and passes the value type `V` here instead: a bare `Map` has no
-/// single default value of its own (see the `Err` case below), only the
-/// per-key `forall` init `domain_kernel_source`'s state-field loop builds
-/// directly.
+/// "Domain-source form" matters for one case: an enum default renders as the
+/// bare member name a domain-source initializer would accept (`Pending`),
+/// not `domain_kernel_source`'s kernel-scoped mangled identifier
+/// (`Status_Pending`), and that bare form is threaded through recursion --
+/// into a `value_object`'s struct-literal fields and a `Map`'s per-key value
+/// -- so an enum default is never mangled no matter how deep it is nested
+/// (issue #731 review, M1: an earlier version of this fix special-cased only
+/// a field's own top-level enum type in the warning, which still mangled an
+/// enum nested inside a `value_object` or a `Map` value).
 ///
 /// # Errors
 ///
 /// Returns [`CoreError`] wherever `Context::default_for_type` does: an
 /// unknown domain type name, an enum with no members, or a type shape it
-/// fails closed on -- including a bare top-level `Map`, which is never a
-/// valid argument here (`"Map state requires explicit initialization
+/// fails closed on -- including a `Map` nested as another `Map`'s value,
+/// which is never renderable (`"Map state requires explicit initialization
 /// through supported semantics"`).
 pub fn domain_type_default(
     domain: &DomainSpec,
     type_name: &SyntaxTypeExpr,
     span: Span,
-) -> Result<String, CoreError> {
-    Context::new(domain).default_for_type(type_name, span, &BTreeMap::new())
+) -> Result<DomainDefault, CoreError> {
+    let context = Context::new(domain);
+    if let Some((_key, value)) = map_key_value(type_name) {
+        return context
+            .default_for_type(value, span, &BTreeMap::new(), DefaultForm::DomainSource)
+            .map(DomainDefault::MapPerKey);
+    }
+    context
+        .default_for_type(type_name, span, &BTreeMap::new(), DefaultForm::DomainSource)
+        .map(DomainDefault::Value)
+}
+
+/// Which identifier form [`Context::default_for_type`] renders an enum
+/// member's default as. Every other arm (`Bool`, `Int`, range/external,
+/// `Option`, `Set`, `Map`) renders identically in both forms; only the enum
+/// leaf differs, so this is threaded through rather than duplicating the
+/// whole dispatch per form (issue #731 review, M1).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DefaultForm {
+    /// `domain_kernel_source`'s own flat kernel namespace, where enum
+    /// members are mangled (`Enum_Member`) to avoid cross-enum collisions.
+    Kernel,
+    /// The syntax a domain-source field initializer itself accepts, where an
+    /// enum member is referenced by its bare declared name.
+    DomainSource,
 }
 
 fn synthetic_num(value: i64, loc: DomainLoc) -> SyntaxExpr {
@@ -360,6 +397,7 @@ impl<'a> Context<'a> {
         &self,
         field: &DomainField,
         type_env: &BTreeMap<String, String>,
+        form: DefaultForm,
     ) -> Result<String, CoreError> {
         if let Some(value) = &field.default {
             return Ok(self.normalize(
@@ -368,9 +406,10 @@ impl<'a> Context<'a> {
                 type_env,
                 Some(&field.type_name),
                 true,
+                form,
             ));
         }
-        self.default_for_type(&field.type_name, field.span, type_env)
+        self.default_for_type(&field.type_name, field.span, type_env, form)
     }
 
     /// Total dispatch over `SyntaxTypeExprKind` -- the same two-variant AST
@@ -380,12 +419,17 @@ impl<'a> Context<'a> {
     /// which returns [`CoreError`] (the same "unsupported domain type
     /// constructor" message `domain_lowering.rs`'s
     /// `logical_type`/`surface_type` already use for the identical case), not
-    /// a silently rendered `"0"`.
+    /// a silently rendered `"0"`. `form` selects only how the enum leaf
+    /// renders a selected member (see [`DefaultForm`]); every other arm is
+    /// identical in both forms and threads `form` through unchanged so a
+    /// nested enum -- inside a `value_object`'s fields or a `Map`'s value --
+    /// never mangles regardless of how deep it is (issue #731 review, M1).
     fn default_for_type(
         &self,
         type_name: &SyntaxTypeExpr,
         span: Span,
         type_env: &BTreeMap<String, String>,
+        form: DefaultForm,
     ) -> Result<String, CoreError> {
         match &type_name.kind {
             SyntaxTypeExprKind::Name(ident) => match ident.text.as_str() {
@@ -399,7 +443,10 @@ impl<'a> Context<'a> {
                                 span,
                             ));
                         };
-                        Ok(self.enum_value(&ty.name, member))
+                        Ok(match form {
+                            DefaultForm::Kernel => self.enum_value(&ty.name, member),
+                            DefaultForm::DomainSource => member.clone(),
+                        })
                     }
                     Some(ty) if matches!(ty.kind.as_str(), "range" | "external") => Ok(ty
                         .lo
@@ -413,7 +460,7 @@ impl<'a> Context<'a> {
                             .map(|field| Ok(format!(
                                 "{}: {}",
                                 field.name,
-                                self.default(field, type_env)?
+                                self.default(field, type_env, form)?
                             )))
                             .collect::<Result<Vec<_>, CoreError>>()?
                             .join(", ")
@@ -464,6 +511,19 @@ impl<'a> Context<'a> {
         }
     }
 
+    /// `form` governs only the `target_type`-driven bare-enum-member
+    /// mangling below: every kernel-text call site (guards, invariants,
+    /// evolve assignments) always passes [`DefaultForm::Kernel`], since
+    /// those render directly into `domain_kernel_source`'s output; only
+    /// [`Self::default`]'s explicit-default branch threads its caller's
+    /// `form` through, so a `value_object` field's own explicit enum
+    /// default (e.g. `status: OrderStatus = Draft;`) renders bare when the
+    /// whole struct literal is being computed in domain-source form (issue
+    /// #731 review, M1 follow-up: this is the second of two enum-mangling
+    /// sites -- [`Self::default_for_type`]'s own enum arm is the first --
+    /// that must both honor `form` for a nested `value_object` field's
+    /// explicit default to stay unmangled).
+    #[allow(clippy::too_many_lines)]
     fn normalize(
         &self,
         expression: &str,
@@ -471,6 +531,7 @@ impl<'a> Context<'a> {
         type_env: &BTreeMap<String, String>,
         target_type: Option<&str>,
         replace_state: bool,
+        form: DefaultForm,
     ) -> String {
         let mut output = compact(expression)
             .replace("&&", " and ")
@@ -500,7 +561,14 @@ impl<'a> Context<'a> {
                                 .iter()
                                 .map(|piece| format!(
                                     "({})",
-                                    self.normalize(piece, Some(aggregate), type_env, None, false)
+                                    self.normalize(
+                                        piece,
+                                        Some(aggregate),
+                                        type_env,
+                                        None,
+                                        false,
+                                        DefaultForm::Kernel,
+                                    )
                                 ))
                                 .collect::<Vec<_>>()
                                 .join(" and ")
@@ -549,7 +617,8 @@ impl<'a> Context<'a> {
                 output.replace_range(start..=end, &format!("({})", values.join(" or ")));
             }
         }
-        if let Some(target) = target_type
+        if form == DefaultForm::Kernel
+            && let Some(target) = target_type
             && self.ty(target).is_some_and(|ty| ty.kind == "enum")
             && output
                 .chars()
@@ -621,7 +690,8 @@ fn evolve_assignments(
                     Some(aggregate),
                     type_env,
                     None,
-                    true
+                    true,
+                    DefaultForm::Kernel,
                 )
             )
         })
@@ -643,6 +713,7 @@ fn evolve_assignments(
             type_env,
             state.get(root).copied(),
             true,
+            DefaultForm::Kernel,
         );
         format!("{target} = {expression}")
     }));
@@ -1004,8 +1075,12 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
                             ));
                         }
                     };
-                    let value_default =
-                        context.default_for_type(value, field.span, &environment)?;
+                    let value_default = context.default_for_type(
+                        value,
+                        field.span,
+                        &environment,
+                        DefaultForm::Kernel,
+                    )?;
                     init.push(format!(
                         "    forall k: {key_type} {{ {name}[k] = {value_default} }}"
                     ));
@@ -1013,7 +1088,7 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
                 None => {
                     init.push(format!(
                         "    {name} = {}",
-                        context.default(field, &environment)?
+                        context.default(field, &environment, DefaultForm::Kernel)?
                     ));
                 }
             }
@@ -1100,7 +1175,8 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
                         Some(aggregate),
                         &environment,
                         None,
-                        true
+                        true,
+                        DefaultForm::Kernel,
                     )
                 ));
             }
@@ -1112,7 +1188,8 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
                         Some(aggregate),
                         &environment,
                         None,
-                        true
+                        true,
+                        DefaultForm::Kernel,
                     )
                 ));
             }
@@ -1200,7 +1277,8 @@ pub fn domain_kernel_source(domain: &DomainSpec) -> Result<String, CoreError> {
                     Some(aggregate),
                     &environment,
                     None,
-                    true
+                    true,
+                    DefaultForm::Kernel,
                 )
             ));
         }

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -53,7 +53,13 @@ fn error_at(message: impl Into<String>, span: Span) -> CoreError {
 /// `Map` arity, which falls through to [`Context::default_for_type`]'s
 /// generic "unsupported domain type constructor" rejection instead of being
 /// treated as a renderable Map here).
-fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &SyntaxTypeExpr)> {
+///
+/// `pub` (issue #731): the `implicit_initial_value` warning needs the same
+/// top-level-`Map` classification `domain_kernel_source`'s state-field loop
+/// uses, so it can report the renderer's per-key value default instead of
+/// re-deriving what counts as a top-level `Map` shape.
+#[must_use]
+pub fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &SyntaxTypeExpr)> {
     match &type_name.kind {
         SyntaxTypeExprKind::Apply {
             constructor,
@@ -64,6 +70,35 @@ fn map_key_value(type_name: &SyntaxTypeExpr) -> Option<(&SyntaxTypeExpr, &Syntax
         },
         _ => None,
     }
+}
+
+/// The renderer's default value for `type_name` in `domain` -- the same
+/// total dispatch [`domain_kernel_source`] uses via `Context::default_for_type`
+/// to choose every field's implicit value, exposed so the
+/// `implicit_initial_value` warning (issue #731) reports the value this
+/// function -- the single owner -- selects, rather than a second hand-rolled
+/// copy of the dispatch that can silently drift from it (as the pre-#731
+/// warning did for every container type).
+///
+/// A caller holding a top-level `Map<K, V>` field type calls [`map_key_value`]
+/// first and passes the value type `V` here instead: a bare `Map` has no
+/// single default value of its own (see the `Err` case below), only the
+/// per-key `forall` init `domain_kernel_source`'s state-field loop builds
+/// directly.
+///
+/// # Errors
+///
+/// Returns [`CoreError`] wherever `Context::default_for_type` does: an
+/// unknown domain type name, an enum with no members, or a type shape it
+/// fails closed on -- including a bare top-level `Map`, which is never a
+/// valid argument here (`"Map state requires explicit initialization
+/// through supported semantics"`).
+pub fn domain_type_default(
+    domain: &DomainSpec,
+    type_name: &SyntaxTypeExpr,
+    span: Span,
+) -> Result<String, CoreError> {
+    Context::new(domain).default_for_type(type_name, span, &BTreeMap::new())
 }
 
 fn synthetic_num(value: i64, loc: DomainLoc) -> SyntaxExpr {

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use dialect::{
     governance_contract, lower_ai_component, lower_business, lower_db, lower_domain,
     lower_governance, lower_requirements, requirements_trace_contract,
 };
-pub use domain::{domain_kernel_source, domain_type_default, map_key_value};
+pub use domain::{DomainDefault, domain_kernel_source, domain_type_default};
 pub use domain_lowering::domain_effect_owns_event;
 pub use expr_text::{binder_text, expr_text, source_binder_text, source_expr_text};
 pub use model::{

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use dialect::{
     governance_contract, lower_ai_component, lower_business, lower_db, lower_domain,
     lower_governance, lower_requirements, requirements_trace_contract,
 };
-pub use domain::domain_kernel_source;
+pub use domain::{domain_kernel_source, domain_type_default, map_key_value};
 pub use domain_lowering::domain_effect_owns_event;
 pub use expr_text::{binder_text, expr_text, source_binder_text, source_expr_text};
 pub use model::{

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -282,18 +282,27 @@ fn omitted_domain_value(
 }
 
 /// Whether `type_name`'s domain-source default is safe to offer as a
-/// machine-applicable `= value` insertion: `false` exactly for the two
-/// brace-literal shapes issue #770 blocks (`Set<T>` and a `value_object`),
-/// `true` for every other shape [`fsl_core::domain_type_default`] can select
-/// a value for (`Map<K, V>` never reaches this function; its caller returns
-/// `insertable: false` unconditionally for the separate, structural reason
-/// that no whole-field `Map` initializer syntax exists at all).
+/// machine-applicable `= value` insertion. An **allowlist**, not a denylist
+/// (issue #731 review round 2, m2): `Apply` constructors are explicitly
+/// enumerated (`Option` insertable, everything else -- currently only
+/// `Set`, but also any future brace-literal-rendering constructor
+/// `fsl_core::domain_type_default` grows -- not), rather than excluding
+/// `Set` by name and defaulting every other constructor to `true`. A
+/// denylist here would silently start offering a machine-applicable
+/// insertion for a brace-literal default the day `fsl_core` supports one
+/// beyond `Set`/`value_object`, walking straight into the same #770 defect
+/// class without anyone deciding it was safe; failing closed on an unknown
+/// shape until it is explicitly reviewed is the fail-closed posture this
+/// repository's soundness rules require. `Map<K, V>` never reaches this
+/// function; its caller returns `insertable: false` unconditionally for the
+/// separate, structural reason that no whole-field `Map` initializer syntax
+/// exists at all.
 fn insertable_shape(
     domain: &fsl_syntax::DomainSpec,
     type_name: &fsl_syntax::SyntaxTypeExpr,
 ) -> bool {
     match &type_name.kind {
-        fsl_syntax::SyntaxTypeExprKind::Apply { constructor, .. } => constructor.text != "Set",
+        fsl_syntax::SyntaxTypeExprKind::Apply { constructor, .. } => constructor.text == "Option",
         fsl_syntax::SyntaxTypeExprKind::Name(ident) => !domain
             .types
             .iter()

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -170,71 +170,159 @@ pub fn implicit_initial_value_warnings(source: &str, source_file: &str) -> Vec<V
 }
 
 fn domain_implicit_warnings(path: &str, domain: &fsl_syntax::DomainSpec) -> Vec<Value> {
-    let declared = domain
-        .types
-        .iter()
-        .map(|ty| (ty.name.as_str(), ty))
-        .collect::<std::collections::BTreeMap<_, _>>();
     domain
         .aggregates
         .iter()
         .flat_map(|aggregate| {
             aggregate.state.iter().filter_map(|field| {
-                let type_name = field.type_name.render_source();
-                let selected = omitted_domain_value(&type_name, field.default.as_ref(), &declared)?;
+                let selected = omitted_domain_value(domain, field)?;
                 Some(implicit_initial_value_warning(
                     path,
                     &format!("{}.{}", aggregate.name, field.name.text),
                     field.span,
                     field.type_name.span.end.offset,
-                    &selected.0,
-                    &selected.1,
+                    &selected.value,
+                    &selected.reason,
+                    selected.insertable,
                 ))
             })
         })
         .collect()
 }
 
+/// A field's implicit default, as chosen by [`fsl_core::domain_type_default`]
+/// -- the same renderer dispatch `domain_kernel_source` uses -- plus whether
+/// an explicit `= value` initializer can be safely offered as a
+/// machine-applicable edit for this field's shape.
+struct SelectedDefault {
+    value: String,
+    reason: String,
+    /// `false` in two distinct cases, both explained in `reason`:
+    ///
+    /// - A top-level `Map<K, V>` field: an explicit whole-`Map` default is
+    ///   unconditionally rejected ("whole-Map domain defaults are not
+    ///   supported"), so no single-expression insertion exists at all.
+    /// - A brace-literal value (`Set { ... }`, a `value_object` struct
+    ///   literal): the syntax itself is valid and `fslc check` accepts it,
+    ///   but `fslc fmt`/`migrate --write`'s reformat-and-reparse step cannot
+    ///   currently round-trip an `Ident { ... }` literal after a domain
+    ///   field declaration (issue #770). Offering a machine-applicable
+    ///   insertion here would make `migrate --write` corrupt the file.
+    ///
+    /// `check` still reports the renderer's implicit choice in both cases;
+    /// `migrate --edition next` cannot yet demand an initializer it cannot
+    /// safely insert (see `docs/LANGUAGE.md`).
+    insertable: bool,
+}
+
+/// The value [`omitted_domain_value`]'s caller must warn about for `field`,
+/// or `None` when `field` already has an explicit default (nothing implicit
+/// to report) or the renderer itself cannot choose a default (an unknown
+/// type, an empty enum, etc. -- the full `check` pipeline reports that
+/// failure separately; a syntax-only warning pass degrades to silence rather
+/// than duplicating that diagnosis).
+///
+/// The selected *value* always comes from [`fsl_core::domain_type_default`],
+/// the renderer's own total dispatch (issue #731) -- this function never
+/// re-derives what a type's default value is, only classifies *why* for the
+/// warning's `reason` text and whether that value is safe to offer as a
+/// machine-applicable `= value` insertion.
 fn omitted_domain_value(
-    type_name: &str,
-    default: Option<&fsl_syntax::SyntaxExpr>,
-    declared: &std::collections::BTreeMap<&str, &fsl_syntax::DomainType>,
-) -> Option<(String, String)> {
-    if default.is_some() {
+    domain: &fsl_syntax::DomainSpec,
+    field: &fsl_syntax::DomainField,
+) -> Option<SelectedDefault> {
+    if field.default.is_some() {
         return None;
     }
-    if type_name == "Bool" {
-        return Some(("false".to_owned(), "Bool defaults to false".to_owned()));
-    }
+    let type_name = field.type_name.render_source();
     if type_name == "Int" {
         return None;
     }
-    if let Some(definition) = declared.get(type_name) {
-        return match definition.kind.as_str() {
-            "enum" => definition.members.first().map(|member| {
-                (
-                    member.clone(),
+    if let Some((_key, value_type)) = fsl_core::map_key_value(&field.type_name) {
+        // A top-level Map<K, V> has no defaultable value of its own: the
+        // renderer's only supported default is the dense per-key
+        // `forall k: K { field[k] = <V's default> }` init
+        // `domain_kernel_source`'s state-field loop builds directly, using
+        // this exact same `domain_type_default` call on `V`. Report that
+        // per-key value for informational parity with the renderer, but
+        // without a suggestion: no `= value` syntax for a whole Map field is
+        // ever accepted, so no insertion could be machine-applicable.
+        let value_default = fsl_core::domain_type_default(domain, value_type, field.span).ok()?;
+        return Some(SelectedDefault {
+            reason: format!(
+                "'{type_name}' has no whole-field default; each key implicitly defaults to '{value_default}' through the per-key forall init the renderer builds"
+            ),
+            value: value_default,
+            insertable: false,
+        });
+    }
+    let value = match domain.types.iter().find(|ty| ty.name == type_name) {
+        // `Context::default_for_type` selects this same first-declared
+        // member, but renders it as `domain_kernel_source`'s mangled
+        // `Enum_Member` kernel identifier -- correct for the generated
+        // kernel text, not parseable as a domain-source field initializer.
+        // Read the member domain source itself would accept from the same
+        // `DomainSpec.types` the renderer's dispatch reads, rather than
+        // asking that dispatch for a kernel-scoped answer to a
+        // domain-source question.
+        Some(ty) if ty.kind == "enum" => ty.members.first()?.clone(),
+        _ => fsl_core::domain_type_default(domain, &field.type_name, field.span).ok()?,
+    };
+    let reason = domain_default_reason(domain, &field.type_name, &type_name, &value);
+    // A brace-literal value (`Set {}`, a value_object struct literal) is
+    // valid FSL that `fslc check` accepts, but issue #770 tracks that
+    // `fslc fmt` cannot yet reparse its own reformatting of an
+    // `Ident { ... }` literal placed after a domain field declaration.
+    // Withhold the insertion rather than emit an edit `migrate --write`
+    // would use to produce an unparseable file.
+    let insertable = !value.contains('{');
+    Some(SelectedDefault {
+        value,
+        reason,
+        insertable,
+    })
+}
+
+/// Explanatory text for why [`fsl_core::domain_type_default`] selected
+/// `value` for `type_name` -- classification only, kept separate from value
+/// selection so a wording gap here can never make the *reported* value
+/// disagree with the renderer's.
+fn domain_default_reason(
+    domain: &fsl_syntax::DomainSpec,
+    type_name: &fsl_syntax::SyntaxTypeExpr,
+    type_name_text: &str,
+    value: &str,
+) -> String {
+    match &type_name.kind {
+        fsl_syntax::SyntaxTypeExprKind::Apply { constructor, .. } => {
+            match constructor.text.as_str() {
+                "Option" => format!("'{type_name_text}' defaults to none"),
+                "Set" => format!("'{type_name_text}' defaults to an empty set"),
+                _ => format!("'{type_name_text}' defaults to '{value}'"),
+            }
+        }
+        fsl_syntax::SyntaxTypeExprKind::Name(_) if type_name_text == "Bool" => {
+            "Bool defaults to false".to_owned()
+        }
+        fsl_syntax::SyntaxTypeExprKind::Name(_) => {
+            match domain.types.iter().find(|ty| ty.name == type_name_text) {
+                Some(ty) if ty.kind == "enum" => {
                     format!(
                         "the first declared member of enum '{}' is selected",
-                        definition.name
-                    ),
-                )
-            }),
-            "range" => definition.lo.as_ref().map(|lo| {
-                (
-                    lo.render_source(),
-                    format!("the lower bound of range '{}' is selected", definition.name),
-                )
-            }),
-            _ => None,
-        };
+                        ty.name
+                    )
+                }
+                Some(ty) if ty.kind == "range" => {
+                    format!("the lower bound of range '{}' is selected", ty.name)
+                }
+                Some(ty) if ty.kind == "value_object" => format!(
+                    "the default value_object literal for '{}' is selected",
+                    ty.name
+                ),
+                _ => format!("external placeholder type '{type_name_text}' defaults to '{value}'"),
+            }
+        }
     }
-    (!type_name.contains('<')).then(|| {
-        (
-            "0".to_owned(),
-            format!("external placeholder type '{type_name}' defaults to 0"),
-        )
-    })
 }
 
 fn requirements_implicit_warnings(
@@ -283,6 +371,7 @@ fn requirements_implicit_warnings(
                         "the lower bound of number '{}' is selected",
                         field.type_name.name
                     ),
+                    true,
                 ))
             })
         })
@@ -296,14 +385,23 @@ fn implicit_initial_value_warning(
     insertion_offset: usize,
     selected: &str,
     reason: &str,
+    insertable: bool,
 ) -> Value {
-    let replacement = format!(" = {selected}");
-    json!({
+    let next_severity = if insertable { "error" } else { "warning" };
+    let message = if insertable {
+        format!("field '{field}' implicitly selects {selected}; add an explicit initializer")
+    } else {
+        format!(
+            "field '{field}' implicitly selects {selected}; \
+             no machine-applicable initializer edit is offered for this field yet"
+        )
+    };
+    let mut warning = json!({
         "kind": "implicit_initial_value",
         "code": "implicit_initial_value",
         "severity": "warning",
-        "edition_severity": {"current": "warning", "next": "error"},
-        "message": format!("field '{field}' implicitly selects {selected}; add an explicit initializer"),
+        "edition_severity": {"current": "warning", "next": next_severity},
+        "message": message,
         "field": field,
         "selected_value": selected,
         "reason": reason,
@@ -314,12 +412,20 @@ fn implicit_initial_value_warning(
             "end_line": span.end.line,
             "end_column": span.end.column,
         },
-        "canonical_replacement": replacement,
-        "suggestion": {
-            "kind": "insert",
-            "replacement": replacement,
-            "span": {"start": insertion_offset, "end": insertion_offset},
-            "machine_applicable": true,
-        },
-    })
+    });
+    if insertable {
+        let replacement = format!(" = {selected}");
+        let object = warning.as_object_mut().expect("warning is a JSON object");
+        object.insert("canonical_replacement".to_owned(), json!(replacement));
+        object.insert(
+            "suggestion".to_owned(),
+            json!({
+                "kind": "insert",
+                "replacement": replacement,
+                "span": {"start": insertion_offset, "end": insertion_offset},
+                "machine_applicable": true,
+            }),
+        );
+    }
+    warning
 }

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -206,8 +206,11 @@ struct SelectedDefault {
     ///   literal): the syntax itself is valid and `fslc check` accepts it,
     ///   but `fslc fmt`/`migrate --write`'s reformat-and-reparse step cannot
     ///   currently round-trip an `Ident { ... }` literal after a domain
-    ///   field declaration (issue #770). Offering a machine-applicable
-    ///   insertion here would make `migrate --write` corrupt the file.
+    ///   field declaration (issue #770). `migrate --write` is fail-closed --
+    ///   it would not write a corrupted file -- but offering a
+    ///   machine-applicable insertion here would make that field's edit
+    ///   trip the #770 defect, failing `migrate` for the *whole* file and
+    ///   silently dropping every other, otherwise-safe edit in it.
     ///
     /// `check` still reports the renderer's implicit choice in both cases;
     /// `migrate --edition next` cannot yet demand an initializer it cannot
@@ -223,9 +226,13 @@ struct SelectedDefault {
 /// than duplicating that diagnosis).
 ///
 /// The selected *value* always comes from [`fsl_core::domain_type_default`],
-/// the renderer's own total dispatch (issue #731) -- this function never
-/// re-derives what a type's default value is, only classifies *why* for the
-/// warning's `reason` text and whether that value is safe to offer as a
+/// the renderer's own total dispatch, already rendered in domain-source form
+/// (issue #731 review, M1: no local enum bypass here or anywhere else --
+/// `fsl_core` is the single owner of *both* which value is selected and how
+/// an enum member within it is spelled, including when nested inside a
+/// `value_object` or a `Map`'s value) -- this function never re-derives what
+/// a type's default value is, only classifies *why* for the warning's
+/// `reason` text and whether that value is safe to offer as a
 /// machine-applicable `= value` insertion.
 fn omitted_domain_value(
     domain: &fsl_syntax::DomainSpec,
@@ -235,52 +242,63 @@ fn omitted_domain_value(
         return None;
     }
     let type_name = field.type_name.render_source();
-    if type_name == "Int" {
-        return None;
-    }
-    if let Some((_key, value_type)) = fsl_core::map_key_value(&field.type_name) {
+    match fsl_core::domain_type_default(domain, &field.type_name, field.span).ok()? {
         // A top-level Map<K, V> has no defaultable value of its own: the
         // renderer's only supported default is the dense per-key
         // `forall k: K { field[k] = <V's default> }` init
-        // `domain_kernel_source`'s state-field loop builds directly, using
-        // this exact same `domain_type_default` call on `V`. Report that
-        // per-key value for informational parity with the renderer, but
-        // without a suggestion: no `= value` syntax for a whole Map field is
-        // ever accepted, so no insertion could be machine-applicable.
-        let value_default = fsl_core::domain_type_default(domain, value_type, field.span).ok()?;
-        return Some(SelectedDefault {
+        // `domain_kernel_source`'s state-field loop builds directly. Report
+        // that per-key value for informational parity with the renderer,
+        // but without a suggestion: no `= value` syntax for a whole Map
+        // field is ever accepted, so no insertion could be
+        // machine-applicable.
+        fsl_core::DomainDefault::MapPerKey(value_default) => Some(SelectedDefault {
             reason: format!(
                 "'{type_name}' has no whole-field default; each key implicitly defaults to '{value_default}' through the per-key forall init the renderer builds"
             ),
             value: value_default,
             insertable: false,
-        });
+        }),
+        fsl_core::DomainDefault::Value(value) => {
+            let reason = domain_default_reason(domain, &field.type_name, &type_name, &value);
+            Some(SelectedDefault {
+                value,
+                reason,
+                // A brace-literal value (`Set {}`, a value_object struct
+                // literal) is valid FSL that `fslc check` accepts, but issue
+                // #770 tracks that `fslc fmt` cannot yet reparse its own
+                // reformatting of an `Ident { ... }` literal placed after a
+                // domain field declaration. `migrate --write` is fail-closed
+                // (it would not write a corrupted file), but an edit here
+                // would trip #770's reformat failure and fail `migrate` for
+                // the whole file, silently dropping every other edit in it
+                // too -- withhold the insertion instead. Driven by the
+                // field's *type shape* (issue #731 review, m4), not the
+                // rendered value's text, so it stays correct regardless of
+                // what that text happens to contain.
+                insertable: insertable_shape(domain, &field.type_name),
+            })
+        }
     }
-    let value = match domain.types.iter().find(|ty| ty.name == type_name) {
-        // `Context::default_for_type` selects this same first-declared
-        // member, but renders it as `domain_kernel_source`'s mangled
-        // `Enum_Member` kernel identifier -- correct for the generated
-        // kernel text, not parseable as a domain-source field initializer.
-        // Read the member domain source itself would accept from the same
-        // `DomainSpec.types` the renderer's dispatch reads, rather than
-        // asking that dispatch for a kernel-scoped answer to a
-        // domain-source question.
-        Some(ty) if ty.kind == "enum" => ty.members.first()?.clone(),
-        _ => fsl_core::domain_type_default(domain, &field.type_name, field.span).ok()?,
-    };
-    let reason = domain_default_reason(domain, &field.type_name, &type_name, &value);
-    // A brace-literal value (`Set {}`, a value_object struct literal) is
-    // valid FSL that `fslc check` accepts, but issue #770 tracks that
-    // `fslc fmt` cannot yet reparse its own reformatting of an
-    // `Ident { ... }` literal placed after a domain field declaration.
-    // Withhold the insertion rather than emit an edit `migrate --write`
-    // would use to produce an unparseable file.
-    let insertable = !value.contains('{');
-    Some(SelectedDefault {
-        value,
-        reason,
-        insertable,
-    })
+}
+
+/// Whether `type_name`'s domain-source default is safe to offer as a
+/// machine-applicable `= value` insertion: `false` exactly for the two
+/// brace-literal shapes issue #770 blocks (`Set<T>` and a `value_object`),
+/// `true` for every other shape [`fsl_core::domain_type_default`] can select
+/// a value for (`Map<K, V>` never reaches this function; its caller returns
+/// `insertable: false` unconditionally for the separate, structural reason
+/// that no whole-field `Map` initializer syntax exists at all).
+fn insertable_shape(
+    domain: &fsl_syntax::DomainSpec,
+    type_name: &fsl_syntax::SyntaxTypeExpr,
+) -> bool {
+    match &type_name.kind {
+        fsl_syntax::SyntaxTypeExprKind::Apply { constructor, .. } => constructor.text != "Set",
+        fsl_syntax::SyntaxTypeExprKind::Name(ident) => !domain
+            .types
+            .iter()
+            .any(|ty| ty.name == ident.text && ty.kind == "value_object"),
+    }
 }
 
 /// Explanatory text for why [`fsl_core::domain_type_default`] selected
@@ -304,6 +322,9 @@ fn domain_default_reason(
         fsl_syntax::SyntaxTypeExprKind::Name(_) if type_name_text == "Bool" => {
             "Bool defaults to false".to_owned()
         }
+        fsl_syntax::SyntaxTypeExprKind::Name(_) if type_name_text == "Int" => {
+            "Int defaults to 0".to_owned()
+        }
         fsl_syntax::SyntaxTypeExprKind::Name(_) => {
             match domain.types.iter().find(|ty| ty.name == type_name_text) {
                 Some(ty) if ty.kind == "enum" => {
@@ -319,7 +340,7 @@ fn domain_default_reason(
                     "the default value_object literal for '{}' is selected",
                     ty.name
                 ),
-                _ => format!("external placeholder type '{type_name_text}' defaults to '{value}'"),
+                _ => format!("external placeholder type '{type_name_text}' defaults to {value}"),
             }
         }
     }

--- a/rust/fslc/tests/issue_250_initialization.rs
+++ b/rust/fslc/tests/issue_250_initialization.rs
@@ -380,22 +380,16 @@ fn implicit_warnings(output: &Value) -> std::collections::BTreeMap<String, Value
 /// `fslc domain expand PATH` prints the generated kernel source as raw text
 /// (not JSON) whenever the command succeeds and no `--output` is given, so
 /// route through `--output` and read the written file back instead of
-/// reusing `run`'s JSON-only decoder.
+/// reusing `run`'s JSON-only decoder. `output` is a [`Fixture`] purely for
+/// its `Drop`-based cleanup (issue #731 review, n3): it reserves the temp
+/// path up front so the file is removed even if an `assert!` below panics,
+/// matching every other temp file in this suite instead of a bare
+/// `remove_file` that a panic would skip.
 fn domain_expand_source(path_text: &str) -> String {
-    let output_path = std::env::temp_dir().join(format!(
-        "fsl-issue-731-expand-{}-{}.fsl",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos()
-    ));
-    let output_path_text = output_path.to_str().expect("UTF-8 temporary path");
-    let (result, status) = run(&["domain", "expand", path_text, "--output", output_path_text]);
+    let output = Fixture::new("expand-output", "");
+    let (result, status) = run(&["domain", "expand", path_text, "--output", output.text()]);
     assert_eq!(status, 0, "{result}");
-    let source = std::fs::read_to_string(&output_path).expect("read expanded kernel source");
-    let _ = std::fs::remove_file(&output_path);
-    source
+    std::fs::read_to_string(&output.0).expect("read expanded kernel source")
 }
 
 /// Issue #731: `implicit_initial_value` must fire for container-typed domain
@@ -488,6 +482,164 @@ fn domain_map_and_value_object_fields_warn_without_a_next_edition_deadline() {
     let (next, next_status) = run(&["check", path_text, "--edition", "next"]);
     assert_eq!(next_status, 0, "{next}");
     assert_eq!(next["result"], "ok", "{next}");
+}
+
+/// Issue #731 review, M1: an enum nested one level below a field's own type
+/// -- inside a `value_object`'s struct literal, or as a top-level `Map`'s
+/// per-key value -- must still report the bare domain-source member name,
+/// not `domain_kernel_source`'s kernel-mangled `Enum_Member` identifier. An
+/// earlier version of this fix special-cased only a field's own top-level
+/// enum type in `frontend_output.rs`, which still mangled an enum nested one
+/// layer down; the fix now lives in `fsl_core::domain_type_default` itself
+/// (the single owner), so nesting depth cannot reintroduce the bug.
+#[test]
+fn domain_nested_enum_defaults_stay_bare_inside_value_object_and_map() {
+    let source = r"domain NestedEnumDefaults {
+  enum OrderStatus { Draft, Placed }
+  type ItemId = 0..1
+  value_object AuditStamp {
+    status: OrderStatus;
+    attempts: Int;
+  }
+  aggregate Order {
+    id ItemId
+    state {
+      audit: AuditStamp;
+      history: Map<ItemId, OrderStatus>;
+    }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+  }
+}
+";
+    let fixture = Fixture::new("nested-enum-defaults", source);
+    let path_text = fixture.text();
+    let (output, status) = run(&["check", path_text]);
+    assert_eq!(status, 0, "{output}");
+    let implicit = implicit_warnings(&output);
+
+    let audit = &implicit["Order.audit"];
+    assert_eq!(
+        audit["selected_value"], "AuditStamp { status: Draft, attempts: 0 }",
+        "{audit}"
+    );
+    assert!(
+        !audit["selected_value"]
+            .as_str()
+            .expect("audit value")
+            .contains("OrderStatus_"),
+        "{audit}"
+    );
+
+    let history = &implicit["Order.history"];
+    assert_eq!(history["selected_value"], "Draft", "{history}");
+    assert!(
+        !history["selected_value"]
+            .as_str()
+            .expect("history value")
+            .contains("OrderStatus_"),
+        "{history}"
+    );
+
+    // `AuditStamp { ... }` is itself a brace-literal value_object default
+    // (issue #770), so it must not be offered as a machine-applicable
+    // insertion regardless of the enum fix above.
+    assert!(audit.get("suggestion").is_none(), "{audit}");
+}
+
+/// Issue #731 review, M3: `Int` hit the exact defect class #731 fixed for
+/// containers -- the renderer (`Context::default_for_type`'s `"Int" => Ok("0")`
+/// arm) always selects `0` for an omitted `Int` field, but the warning
+/// carved `Int` out unconditionally. `0` contains no brace, so it is safe to
+/// offer as a machine-applicable insertion like every other scalar shape.
+#[test]
+fn domain_bare_int_fields_warn_like_every_other_scalar_shape() {
+    let source = r"domain BareIntDefault {
+  type ItemId = 0..1
+  aggregate Counter {
+    id ItemId
+    state {
+      raw: Int;
+      flag: Bool;
+    }
+    command Touch {}
+    event Touched {}
+    decide Touch { emits Touched }
+    evolve Touched {}
+  }
+}
+";
+    let fixture = Fixture::new("bare-int-default", source);
+    let path_text = fixture.text();
+    let (output, status) = run(&["check", path_text]);
+    assert_eq!(status, 0, "{output}");
+    let implicit = implicit_warnings(&output);
+    assert_eq!(
+        implicit.keys().collect::<Vec<_>>(),
+        vec!["Counter.flag", "Counter.raw"],
+        "{output}"
+    );
+    let raw = &implicit["Counter.raw"];
+    assert_eq!(raw["selected_value"], "0");
+    assert_eq!(raw["suggestion"]["machine_applicable"], true);
+    assert_eq!(raw["edition_severity"]["next"], "error");
+
+    let expanded = domain_expand_source(path_text);
+    assert!(expanded.contains("counter_raw = 0"), "{expanded}");
+}
+
+/// Issue #731 review, m2: a "defect witness" for #770, the pre-existing
+/// `fslc fmt` round-trip defect this PR discovered and withholds a
+/// machine-applicable insertion against for `Set<T>`/`value_object`
+/// defaults. This test does not exercise this PR's own code at all -- it
+/// pins #770's *symptom* directly. If #770 is ever fixed, this assertion
+/// starts failing, which is the intended signal to revisit
+/// `insertable_shape` in `frontend_output.rs` and re-enable the insertion
+/// these two shapes currently withhold, rather than #770's fix landing
+/// silently while the withholding logic here quietly outlives its reason.
+#[test]
+fn domain_brace_literal_defaults_still_fail_the_770_fmt_round_trip() {
+    for source in [
+        r"domain SetLiteralWitness {
+  type ItemId = 0..1
+  aggregate Basket {
+    id ItemId
+    state { seen: Set<ItemId> = Set {}; }
+    command Pick {}
+    event Picked {}
+    decide Pick { emits Picked }
+    evolve Picked {}
+  }
+}
+",
+        r"domain ValueObjectLiteralWitness {
+  type Quantity = 0..2
+  value_object Counter { value: Quantity = 0; }
+  aggregate Inventory {
+    id Quantity
+    state { counter: Counter = Counter { value: 0 }; }
+    command Adjust {}
+    event Adjusted {}
+    decide Adjust { emits Adjusted }
+    evolve Adjusted {}
+  }
+}
+",
+    ] {
+        let fixture = Fixture::new("770-witness", source);
+        let (output, status) = run(&["fmt", fixture.text(), "--check"]);
+        assert_eq!(
+            status, 2,
+            "issue #770 appears fixed -- {output}. If `fslc fmt` now round-trips \
+             this brace-literal default, re-enable the machine-applicable insertion \
+             `insertable_shape` withholds for it in \
+             rust/fslc/src/frontend_output.rs and update docs/LANGUAGE.md, \
+             docs/LANGUAGE.ja.md, and skills/fsl/reference.md accordingly."
+        );
+        assert_eq!(output["kind"], "parse", "{output}");
+    }
 }
 
 #[test]

--- a/rust/fslc/tests/issue_250_initialization.rs
+++ b/rust/fslc/tests/issue_250_initialization.rs
@@ -599,6 +599,25 @@ fn domain_bare_int_fields_warn_like_every_other_scalar_shape() {
 /// `insertable_shape` in `frontend_output.rs` and re-enable the insertion
 /// these two shapes currently withhold, rather than #770's fix landing
 /// silently while the withholding logic here quietly outlives its reason.
+///
+/// #770 fixed is necessary but not sufficient for that re-enable: issue
+/// #785 (found independently during this PR's second review round, and not
+/// reachable through this PR's own withheld insertion) is a second,
+/// pre-existing defect on the same `Context::normalize` enum-mangling guard
+/// this PR's `DefaultForm` fix touches for M1 -- an *explicit* brace-literal
+/// default containing an enum member (e.g. a hand-written
+/// `audit: AuditStamp = AuditStamp { status: Red, attempts: 0 };`) never
+/// gets that member mangled for the generated kernel, because the guard
+/// only fires for a bare alnum/underscore identifier, not a member embedded
+/// in a larger expression; the resulting kernel text fails
+/// `fslc check`. Re-enabling the `value_object` insertion once #770 is
+/// fixed but #785 is not would let `migrate --write` insert exactly that
+/// shape -- a `value_object` struct literal whose bare enum members
+/// `fsl_core::domain_type_default` rendered correctly for the *warning*
+/// stay unmangled the next time `domain_kernel_source` re-renders that now
+/// explicit default, producing a file `check` accepts today but whose
+/// generated kernel `check` rejects after the edit. Confirm #785 is fixed
+/// too before flipping `insertable_shape`'s `value_object` arm.
 #[test]
 fn domain_brace_literal_defaults_still_fail_the_770_fmt_round_trip() {
     for source in [
@@ -632,11 +651,18 @@ fn domain_brace_literal_defaults_still_fail_the_770_fmt_round_trip() {
         let (output, status) = run(&["fmt", fixture.text(), "--check"]);
         assert_eq!(
             status, 2,
-            "issue #770 appears fixed -- {output}. If `fslc fmt` now round-trips \
-             this brace-literal default, re-enable the machine-applicable insertion \
-             `insertable_shape` withholds for it in \
-             rust/fslc/src/frontend_output.rs and update docs/LANGUAGE.md, \
-             docs/LANGUAGE.ja.md, and skills/fsl/reference.md accordingly."
+            "issue #770 appears fixed -- {output}. Before re-enabling the \
+             machine-applicable insertion `insertable_shape` withholds for this \
+             shape in rust/fslc/src/frontend_output.rs, also confirm issue #785 \
+             is fixed (a second, pre-existing defect on the same \
+             `Context::normalize` enum-mangling guard in rust/fsl-core/src/domain.rs: \
+             an explicit brace-literal default containing an enum member never \
+             gets that member mangled for the generated kernel, so re-enabling \
+             only on #770's fix would let `migrate --write` insert a \
+             `value_object` default that `check` accepts today but whose \
+             generated kernel `check` rejects after the edit) -- then update \
+             docs/LANGUAGE.md, docs/LANGUAGE.ja.md, and skills/fsl/reference.md \
+             accordingly."
         );
         assert_eq!(output["kind"], "parse", "{output}");
     }

--- a/rust/fslc/tests/issue_250_initialization.rs
+++ b/rust/fslc/tests/issue_250_initialization.rs
@@ -357,6 +357,139 @@ fn domain_implicit_values_warn_with_selected_values_and_insertions() {
     }
 }
 
+fn characterization_fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("tests/fixtures/domain_characterization/{name}"))
+}
+
+fn implicit_warnings(output: &Value) -> std::collections::BTreeMap<String, Value> {
+    output["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .iter()
+        .filter(|warning| warning["code"] == "implicit_initial_value")
+        .map(|warning| {
+            (
+                warning["field"].as_str().expect("field").to_owned(),
+                warning.clone(),
+            )
+        })
+        .collect()
+}
+
+/// `fslc domain expand PATH` prints the generated kernel source as raw text
+/// (not JSON) whenever the command succeeds and no `--output` is given, so
+/// route through `--output` and read the written file back instead of
+/// reusing `run`'s JSON-only decoder.
+fn domain_expand_source(path_text: &str) -> String {
+    let output_path = std::env::temp_dir().join(format!(
+        "fsl-issue-731-expand-{}-{}.fsl",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos()
+    ));
+    let output_path_text = output_path.to_str().expect("UTF-8 temporary path");
+    let (result, status) = run(&["domain", "expand", path_text, "--output", output_path_text]);
+    assert_eq!(status, 0, "{result}");
+    let source = std::fs::read_to_string(&output_path).expect("read expanded kernel source");
+    let _ = std::fs::remove_file(&output_path);
+    source
+}
+
+/// Issue #731: `implicit_initial_value` must fire for container-typed domain
+/// state fields (`Option<T>`, `Set<T>`, a top-level `Map<K, V>`), not just
+/// the four scalar shapes, because `domain_kernel_source`'s renderer already
+/// gives every one of these an implicit default. The `selected_value` this
+/// warning reports must match `fslc domain expand`'s rendered default at the
+/// string level -- both must come from the same `fsl_core::domain_type_default`
+/// owner, not a second hand-rolled copy of the dispatch.
+#[test]
+fn domain_container_fields_warn_and_match_the_renderer_default() {
+    let path = characterization_fixture("container_defaults_surface.fsl");
+    let path_text = path.to_str().expect("UTF-8 path");
+    let (output, status) = run(&["check", path_text]);
+    assert_eq!(status, 0, "{output}");
+    let implicit = implicit_warnings(&output);
+    assert_eq!(
+        implicit.keys().collect::<Vec<_>>(),
+        vec!["Basket.picked", "Basket.seen"],
+        "{output}"
+    );
+
+    let picked = &implicit["Basket.picked"];
+    assert_eq!(picked["selected_value"], "none");
+    assert_eq!(picked["suggestion"]["machine_applicable"], true);
+    assert_eq!(picked["edition_severity"]["next"], "error");
+
+    let seen = &implicit["Basket.seen"];
+    assert_eq!(seen["selected_value"], "Set {}");
+    // No machine-applicable insertion for a brace-literal default (issue
+    // #770 tracks the `fslc fmt` round-trip defect this withholds against);
+    // `--edition next` cannot yet demand an initializer it cannot safely
+    // insert.
+    assert!(seen.get("suggestion").is_none(), "{seen}");
+    assert!(seen.get("canonical_replacement").is_none(), "{seen}");
+    assert_eq!(seen["edition_severity"]["next"], "warning");
+
+    let expanded = domain_expand_source(path_text);
+    let picked_value = picked["selected_value"].as_str().expect("picked value");
+    let seen_value = seen["selected_value"].as_str().expect("seen value");
+    assert!(
+        expanded.contains(&format!("basket_picked = {picked_value}")),
+        "{expanded}"
+    );
+    assert!(
+        expanded.contains(&format!("basket_seen = {seen_value}")),
+        "{expanded}"
+    );
+}
+
+/// Companion to the Option/Set case above: a top-level `Map<K, V>` field has
+/// no whole-field default at all (only the per-key `forall` init the
+/// renderer builds), and a `value_object`-typed field's struct-literal
+/// default hits the same #770 formatter round-trip gap `Set {}` does. Both
+/// must still warn under `check` and both must stay excluded from
+/// `--edition next` enforcement, since neither has a safe insertion to
+/// demand.
+#[test]
+fn domain_map_and_value_object_fields_warn_without_a_next_edition_deadline() {
+    let path = characterization_fixture("lvalues_surface.fsl");
+    let path_text = path.to_str().expect("UTF-8 path");
+    let (output, status) = run(&["check", path_text]);
+    assert_eq!(status, 0, "{output}");
+    let implicit = implicit_warnings(&output);
+    assert_eq!(
+        implicit.keys().collect::<Vec<_>>(),
+        vec!["Inventory.counter", "Inventory.counts"],
+        "{output}"
+    );
+    // `total: Quantity = 0;` has an explicit default and must not warn.
+    assert!(!implicit.contains_key("Inventory.total"), "{output}");
+
+    let counts = &implicit["Inventory.counts"];
+    assert_eq!(counts["selected_value"], "0");
+    assert!(counts.get("suggestion").is_none(), "{counts}");
+    assert_eq!(counts["edition_severity"]["next"], "warning");
+
+    let counter = &implicit["Inventory.counter"];
+    assert_eq!(counter["selected_value"], "Counter { value: 0 }");
+    assert!(counter.get("suggestion").is_none(), "{counter}");
+    assert_eq!(counter["edition_severity"]["next"], "warning");
+
+    let expanded = domain_expand_source(path_text);
+    assert!(expanded.contains("inventory_counts[k] = 0"), "{expanded}");
+    assert!(
+        expanded.contains("inventory_counter = Counter { value: 0 }"),
+        "{expanded}"
+    );
+
+    let (next, next_status) = run(&["check", path_text, "--edition", "next"]);
+    assert_eq!(next_status, 0, "{next}");
+    assert_eq!(next["result"], "ok", "{next}");
+}
+
 #[test]
 fn requirements_number_default_warning_edit_preserves_comment_and_verdict() {
     let source = r"requirements Amounts {

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -350,22 +350,29 @@ traceability relation, not origin identities. Public Kernel v1 remains
 byte-compatible and does not expose the internal chain; publication belongs to
 v2 (#256).
 
-Omitted domain aggregate initializers retain the current Bool `false`, enum
-first-member, range lower-bound, external-placeholder `0`, `value_object`
-struct-literal, `Option<T>` -> `none`, `Set<T>` -> `Set {}`, or top-level
-`Map<K, V>` -> dense per-key `forall k: K { field[k] = <value default> }`
-behavior, and every one of those shapes emits `implicit_initial_value`
-(#731) -- the warning's dispatch matches the renderer's total dispatch
-(`fsl_core::domain_type_default`). The warning carries the selected value,
-reason, edition severities, source span, and -- where a safe insertion
-exists -- a machine-applicable edit. A top-level `Map<K, V>` field (no
-whole-field default exists at all) and a `Set<T>`/`value_object` field whose
-brace-literal default cannot yet round-trip through `fslc fmt`
-(issue #770) omit the insertion and keep `edition_severity.next` at
-`warning`. An explicit whole-`Map` default and a `Map` nested as another
-`Map`'s value are both rejected ("whole-Map domain defaults are not
-supported" / "Map state requires explicit initialization through supported
-semantics").
+Omitted domain aggregate initializers retain the current Bool `false`, Int
+`0`, enum first-member (rendered bare, as domain source itself accepts, no
+matter how deeply the enum is nested inside a `value_object` or a `Map`
+value -- never `domain_kernel_source`'s kernel-mangled identifier), range
+lower-bound, external-placeholder `0`, `value_object` struct-literal,
+`Option<T>` -> `none`, `Set<T>` -> `Set {}`, or top-level `Map<K, V>` ->
+dense per-key `forall k: K { field[k] = <value default> }` behavior, and
+every one of those shapes emits `implicit_initial_value` (#731) -- the
+warning's dispatch matches the renderer's total dispatch
+(`fsl_core::domain_type_default`, the single owner of both the selected
+value and how any enum member within it is spelled). The warning carries the
+selected value, reason, edition severities, source span, and -- where a safe
+insertion exists -- a machine-applicable edit. A top-level `Map<K, V>` field
+(no whole-field default exists at all) and a `Set<T>`/`value_object` field
+whose brace-literal default cannot yet round-trip through `fslc fmt`'s
+reformat-and-reparse pass (issue #770) omit the insertion and keep
+`edition_severity.next` at `warning`: `migrate --write` is fail-closed and
+would not write a corrupted file, but offering the insertion would trip
+#770's reformat failure and fail migration for the whole file, dropping
+every other edit in it too. An explicit whole-`Map` default and a `Map`
+nested as another `Map`'s value are both rejected ("whole-Map domain
+defaults are not supported" / "Map state requires explicit initialization
+through supported semantics").
 
 AI hard-contract dialect (expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -351,15 +351,21 @@ byte-compatible and does not expose the internal chain; publication belongs to
 v2 (#256).
 
 Omitted domain aggregate initializers retain the current Bool `false`, enum
-first-member, range lower-bound, or external-placeholder `0` behavior while
-emitting `implicit_initial_value`. The warning carries the selected value,
-reason, edition severities, source span, and a machine-applicable insertion.
-Container-typed fields default too but do **not** trigger that warning:
-`Option<T>` -> `none`, `Set<T>` -> `Set {}`, top-level `Map<K, V>` -> dense
-per-key `forall k: K { field[k] = <value default> }`. An explicit whole-`Map`
-default and a `Map` nested as another `Map`'s value are both rejected
-("whole-Map domain defaults are not supported" / "Map state requires explicit
-initialization through supported semantics").
+first-member, range lower-bound, external-placeholder `0`, `value_object`
+struct-literal, `Option<T>` -> `none`, `Set<T>` -> `Set {}`, or top-level
+`Map<K, V>` -> dense per-key `forall k: K { field[k] = <value default> }`
+behavior, and every one of those shapes emits `implicit_initial_value`
+(#731) -- the warning's dispatch matches the renderer's total dispatch
+(`fsl_core::domain_type_default`). The warning carries the selected value,
+reason, edition severities, source span, and -- where a safe insertion
+exists -- a machine-applicable edit. A top-level `Map<K, V>` field (no
+whole-field default exists at all) and a `Set<T>`/`value_object` field whose
+brace-literal default cannot yet round-trip through `fslc fmt`
+(issue #770) omit the insertion and keep `edition_severity.next` at
+`warning`. An explicit whole-`Map` default and a `Map` nested as another
+`Map`'s value are both rejected ("whole-Map domain defaults are not
+supported" / "Map state requires explicit initialization through supported
+semantics").
 
 AI hard-contract dialect (expands to the same kernel for deterministic
 tool-boundary checks and reports stable fsl-ai findings for runtime replay):


### PR DESCRIPTION
## Problem

`domain` aggregate state fields that omit their initializer get an implicit
default from the renderer for **every** type — but `implicit_initial_value`
only warned about it for the four scalar shapes (`Bool`, enum, range,
external-placeholder). `omitted_domain_value`'s final arm
(`rust/fslc/src/frontend_output.rs`) explicitly excluded any type name
containing `<`:

```rust
(!type_name.contains('<')).then(|| {
    ("0".to_owned(), format!("external placeholder type '{type_name}' defaults to 0"))
})
```

Meanwhile `Context::default_for_type` (`rust/fsl-core/src/domain.rs`), used
by `domain_kernel_source` (and mirrored by `Resolver::default_for_type` in
`domain_lowering.rs`), has been a total dispatch since #691/#708:
`Option<T>` → `none`, `Set<T>` → `Set {}`, a top-level `Map<K, V>` → a dense
per-key `forall` init. So the renderer silently picked a default the
warning never told the author about.

## Contract change

`implicit_initial_value` now fires for every field shape the renderer gives
a default: `Option<T>`, `Set<T>`, a top-level `Map<K, V>`, and (a sibling
gap the same fix closes) `value_object`-typed fields — not just the four
scalar shapes.

**Single owner.** `rust/fslc/src/frontend_output.rs`'s warning now reads the
selected value from a new `fsl_core::domain_type_default` (wrapping the
existing `Context::default_for_type`) and `fsl_core::map_key_value`, instead
of re-deriving the dispatch as a third, non-exhaustive copy. The repo
already had two owners of this dispatch (`domain.rs`'s `Context` for kernel
text, `domain_lowering.rs`'s `Resolver` for typed exprs); the warning now
delegates to `domain.rs`'s, since it's the one `domain_kernel_source` (the
CLI-visible renderer `domain expand` shows) actually uses, so the warned
value and the rendered value are provably the same string, not two
independently-derived approximations of "the same" value. One exception:
for **enum** types, `Context::default_for_type` renders the kernel's
mangled `Enum_Member` identifier (correct for generated kernel text, not
parseable as a domain-source initializer), so the warning reads the bare
first-declared member directly from `DomainSpec.types` — the same AST field
both owners already read, not a re-derived selection rule.

**Two field shapes don't get a machine-applicable insertion**, and
consequently keep `edition_severity.next` at `warning` rather than `error`:

- A top-level `Map<K, V>` field has **no whole-field initializer syntax at
  all** — `field: Map<K, V> = expr;` is unconditionally rejected
  ("whole-Map domain defaults are not supported"); only the per-key form is
  supported.
- A `Set<T>` or `value_object`-typed field's brace-literal default
  (`Set { ... }`, `Name { ... }`) is valid FSL that `fslc check` accepts,
  but I found and reproduced a **separate, pre-existing** defect while
  testing this: `fslc fmt`/`migrate --write`'s reformat-and-reparse step
  cannot round-trip an `Ident { ... }` literal after a domain field
  declaration (confirmed independent of this change with hand-written
  fixtures, not migrator output — filed as **#770**). Marking these
  insertable as `true` would let `migrate --write` produce an unparseable
  file, so the insertion is withheld until #770 is fixed.

Both are documented in `docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md` /
`skills/fsl/reference.md` (regenerating `docs/intro/language.{en,ja}.html`
via `tools/build_site_reference.py`), replacing the #722 text that
documented the old (buggy) "containers never warn" behavior.

## Test evidence

```
$ cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- check \
    rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl
# picked (Option<ItemId>) -> implicit_initial_value, selected_value "none", machine_applicable:true, edition_severity.next:"error"
# seen (Set<ItemId>)       -> implicit_initial_value, selected_value "Set {}", no suggestion, edition_severity.next:"warning"

$ cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- check \
    rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl
# counts (Map<ItemId, Quantity>) -> implicit_initial_value, selected_value "0", no suggestion
# counter (Counter value_object) -> implicit_initial_value, selected_value "Counter { value: 0 }", no suggestion
# total (explicit `= 0`)         -> no warning (negative control)

$ cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- domain expand \
    rust/fslc/tests/fixtures/domain_characterization/container_defaults_surface.fsl
#   basket_picked = none
#   basket_seen = Set {}
$ cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- domain expand \
    rust/fslc/tests/fixtures/domain_characterization/lvalues_surface.fsl
#   forall k: ItemId { inventory_counts[k] = 0 }
#   inventory_counter = Counter { value: 0 }
```

The warning's `selected_value` matches `domain expand`'s rendered default at
the string level in every case above — the acceptance evidence requested in
the issue.

New regression tests in `rust/fslc/tests/issue_250_initialization.rs`:
`domain_container_fields_warn_and_match_the_renderer_default` and
`domain_map_and_value_object_fields_warn_without_a_next_edition_deadline`,
both asserting `selected_value`, presence/absence of `suggestion`,
`edition_severity.next`, string-level parity with `domain expand`, the
`--edition next` deferral for Map/Set/value_object, and a negative control
(`total: Quantity = 0;` does not warn). The existing scalar-only test
(`domain_implicit_values_warn_with_selected_values_and_insertions`) still
passes unchanged.

```
$ cargo test --manifest-path rust/Cargo.toml -p fslc-rust \
    --test issue_250_initialization --test edition_migrator \
    --test domain_expression_characterization --test domain_codegen_contract
# 3 + 3 + 21 + 12 = 39 passed; 0 failed

$ cargo fmt --manifest-path rust/Cargo.toml --all -- --check
# clean

$ cargo clippy --manifest-path rust/Cargo.toml -p fslc-rust -p fsl-core --all-targets -- -D warnings
# clean

$ bash tools/aggregate_changelog.sh check
# aggregate_changelog: check PASS

$ cargo build --manifest-path rust/Cargo.toml -p fsl-wasm
# builds clean (implicit_initial_value_warnings is also used by fsl-wasm's check/verify envelope)
```

Also ran the `fsl-core` domain suites (`domain_render_agreement`,
`domain_lowering`) unchanged/green, confirming the `fsl-core` API additions
(`domain_type_default`, `map_key_value` made `pub`) don't disturb existing
lowering/rendering agreement coverage.

## Follow-up filed

#770 tracks the `fslc fmt`/`format_source` brace-literal round-trip defect
this PR discovered and works around by withholding the affected insertion.
It's independent of #731's contract and should be revisited (re-enabling
the insertion for `Set<T>`/`value_object`) once fixed.

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)