### PR TITLE
fix(runtime): drop per-node model clones from the three lanes issue #730 enumerates (#730)

### DIFF
--- a/changelog.d/730-drop-per-node-model-clones.fixed.md
+++ b/changelog.d/730-drop-per-node-model-clones.fixed.md
@@ -1,0 +1,19 @@
+Fixed issue #730: `fsl-runtime`'s `bfs` (the solver-free agreement oracle),
+`first_self_violation` (`check_refinement`'s self-consistency precondition),
+and `verify_explicit_selected` each held a `Monitor` -- and therefore the
+whole `KernelModel` by value -- per queued/frontier node, so exploring `n`
+states cloned the model `n` times; `first_self_violation` additionally
+cloned its whole accumulated `Vec<TraceStep>` per node, worse than
+`find_boundary_violation` before issue #697's fix. Measured directly on the
+`LabelCoreRepro` reproducer (release build, depth 3, 16,290 states): `bfs`'s
+peak memory footprint dropped from ~946 MB to ~236 MB with the state count
+unchanged. All three now carry only a `State` (plus a scratch `Monitor`
+re-pointed at each popped state, `find_boundary_violation`'s established
+pattern) and reconstruct a trace from parent links only when one is
+actually needed. `first_self_violation`'s multi-root case (issue #493:
+nondeterministic init) is handled by `trace::reconstruct_trace` discovering
+each state's actual root by walking parent links to whichever parentless
+state the chain terminates at, rather than assuming a single passed-in
+initial state. No public contract changed: verdicts, JSON envelopes, and
+state counts are identical before and after on the reproducer and on the
+`specs`/`examples` corpus.

--- a/rust/fsl-runtime/src/bin/fsl-explicit.rs
+++ b/rust/fsl-runtime/src/bin/fsl-explicit.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! A minimal driver for [`fsl_runtime::verify_explicit`], the same shape as
+//! `fsl-bfs`. Exists so a memory-ceiling regression test can exercise the
+//! explicit-state lane's own `(State, usize)`/`BTreeSet<State>` frontier in
+//! isolation, without the `fslc verify` CLI's Z3-backed vacuity checks
+//! (which run regardless of `--engine` and would fold solver memory into
+//! the measurement, `fsl-runtime` itself never links a solver at all --
+//! see `rust-verifier.md`'s dependency-direction rule).
+
+use std::fs;
+
+use serde_json::json;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: fsl-explicit SPEC [DEPTH] [MAX_STATES]");
+    let depth = args
+        .next()
+        .map_or(Ok(4_usize), |value| value.parse::<usize>())
+        .expect("depth must be a non-negative integer");
+    let max_states = args
+        .next()
+        .map_or(Ok(1_000_000_usize), |value| value.parse::<usize>())
+        .expect("max_states must be a positive integer");
+    let result = fs::read_to_string(&path)
+        .map_err(|error| error.to_string())
+        .and_then(|source| {
+            let base = std::path::Path::new(&path)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
+            let resolver = fsl_core::FsResolver::new(base);
+            fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| error.to_string())
+        })
+        .and_then(|kernel| fsl_core::build_model(kernel).map_err(|error| error.to_string()))
+        .and_then(|model| {
+            fsl_runtime::verify_explicit(model, depth, max_states)
+                .map_err(|error| error.to_string())
+        });
+    match result {
+        Ok(result) => println!(
+            "{}",
+            serde_json::to_string(&json!({
+                "spec": result.spec,
+                "depth": result.depth,
+                "depth_reached": result.depth_reached,
+                "states_explored": result.states_explored,
+                "max_frontier_width": result.max_frontier_width,
+                "closure": result.closure,
+                "budget_exceeded": result.budget_exceeded,
+                "violation": result.violation.as_ref().map(|violation| json!({
+                    "kind": violation.violation.kind,
+                    "name": violation.violation.name,
+                    "step": violation.violation.step,
+                })),
+                "deadlock_step": result.deadlock_step,
+                "action_coverage": result.action_coverage,
+            }))
+            .expect("serialize explicit-engine result")
+        ),
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(2);
+        }
+    }
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -116,10 +116,16 @@ pub fn verify_explicit_selected(
         return Err(runtime_error(reason));
     }
 
-    let initial = Monitor::new(model)?;
-    let initial_state = initial.state.clone();
+    // The frontier carries `State` only, not `Monitor` -- a full `Monitor`
+    // clone per child, on top of a `BTreeMap<State, Monitor>` frontier
+    // holding one whole `KernelModel` per live state, duplicated the model
+    // at both layers (issue #730). `scratch` is re-pointed at each state
+    // instead; `parents` (already used for trace reconstruction) is the
+    // only per-state bookkeeping kept.
+    let mut scratch = Monitor::new(model)?;
+    let initial_state = scratch.state.clone();
     let mut result = ExplicitResult {
-        spec: initial.model.name.clone(),
+        spec: scratch.model.name.clone(),
         depth,
         depth_reached: 0,
         states_explored: 1,
@@ -127,7 +133,7 @@ pub fn verify_explicit_selected(
         closure: false,
         budget_exceeded: false,
         violation: None,
-        reachables: initial
+        reachables: scratch
             .model
             .reachables
             .iter()
@@ -135,34 +141,34 @@ pub fn verify_explicit_selected(
             .collect(),
         deadlock_step: None,
         deadlock_trace: None,
-        action_coverage: initial
+        action_coverage: scratch
             .model
             .actions
             .iter()
             .map(|action| (action.name.clone(), false))
             .collect(),
     };
-    let mut frontier = BTreeMap::from([(initial_state.clone(), initial)]);
-    let mut seen = BTreeSet::from([initial_state.clone()]);
+    let mut frontier = BTreeSet::from([initial_state.clone()]);
+    let mut seen = BTreeSet::from([initial_state]);
     let mut parents = BTreeMap::<State, ParentLink>::new();
 
     for level in 0..=depth {
         result.depth_reached = level;
         result.max_frontier_width = result.max_frontier_width.max(frontier.len());
 
-        for monitor in frontier.values() {
-            if let Some(violation) = monitor.current_violation_selected(checked_bounds)? {
+        for state in &frontier {
+            scratch.state = state.clone();
+            scratch.step = level;
+            if let Some(violation) = scratch.current_violation_selected(checked_bounds)? {
                 result.violation = Some(ExplicitViolation {
-                    trace: reconstruct_trace(&initial_state, &monitor.state, &parents),
+                    trace: reconstruct_trace(state, &parents),
                     violation,
                 });
                 return Ok(result);
             }
-            if let Some(violation) =
-                record_reachables(monitor, level, &initial_state, &parents, &mut result)?
-            {
+            if let Some(violation) = record_reachables(&scratch, level, &parents, &mut result)? {
                 result.violation = Some(ExplicitViolation {
-                    trace: reconstruct_trace(&initial_state, &monitor.state, &parents),
+                    trace: reconstruct_trace(state, &parents),
                     violation,
                 });
                 return Ok(result);
@@ -170,17 +176,19 @@ pub fn verify_explicit_selected(
         }
 
         let mut enabled_by_state = BTreeMap::new();
-        for (state, monitor) in &frontier {
-            let enabled = monitor.enabled()?;
+        for state in &frontier {
+            scratch.state = state.clone();
+            scratch.step = level;
+            let enabled = scratch.enabled()?;
             for instance in &enabled {
                 result.action_coverage.insert(instance.action.clone(), true);
             }
             if enabled.is_empty() && result.deadlock_step.is_none() {
-                let terminal = match terminal_holds(monitor) {
+                let terminal = match terminal_holds(&scratch) {
                     Ok(value) => value,
                     Err(error) if super::is_partial_operation_error(&error.message) => {
                         result.violation = Some(ExplicitViolation {
-                            trace: reconstruct_trace(&initial_state, state, &parents),
+                            trace: reconstruct_trace(state, &parents),
                             violation: Violation {
                                 kind: "partial_op".to_owned(),
                                 name: "_partial_property_terminal".to_owned(),
@@ -193,8 +201,7 @@ pub fn verify_explicit_selected(
                 };
                 if !terminal {
                     result.deadlock_step = Some(level);
-                    result.deadlock_trace =
-                        Some(reconstruct_trace(&initial_state, state, &parents));
+                    result.deadlock_trace = Some(reconstruct_trace(state, &parents));
                 }
             }
             enabled_by_state.insert(state.clone(), enabled);
@@ -204,22 +211,24 @@ pub fn verify_explicit_selected(
             break;
         }
 
-        let mut next = BTreeMap::new();
-        for (state, monitor) in &frontier {
+        let mut next = BTreeSet::new();
+        for state in &frontier {
             for instance in &enabled_by_state[state] {
-                let mut child = monitor.clone();
-                let stepped = child.step_selected(instance, checked_bounds)?;
+                scratch.state = state.clone();
+                scratch.step = level;
+                let stepped = scratch.step_selected(instance, checked_bounds)?;
                 if let Some(violation) = stepped.violation {
                     // The Monitor rolls back on violation (`state` is the pre-step
                     // state); the trace must show the attempted post-state.
                     let after = stepped.attempted_state.as_ref().unwrap_or(&stepped.state);
-                    let mut trace = reconstruct_trace(&initial_state, state, &parents);
+                    let mut trace = reconstruct_trace(state, &parents);
                     trace.push(edge_trace_step(level + 1, state, instance, after));
                     result.depth_reached = level + 1;
                     result.violation = Some(ExplicitViolation { violation, trace });
                     return Ok(result);
                 }
-                if seen.contains(&child.state) {
+                let child_state = scratch.state.clone();
+                if seen.contains(&child_state) {
                     continue;
                 }
                 if seen.len() >= max_states {
@@ -227,7 +236,6 @@ pub fn verify_explicit_selected(
                     result.budget_exceeded = true;
                     return Ok(result);
                 }
-                let child_state = child.state.clone();
                 seen.insert(child_state.clone());
                 parents.insert(
                     child_state.clone(),
@@ -239,7 +247,7 @@ pub fn verify_explicit_selected(
                         },
                     },
                 );
-                next.insert(child_state, child);
+                next.insert(child_state);
             }
         }
         result.states_explored = seen.len();
@@ -275,7 +283,6 @@ fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
 fn record_reachables(
     monitor: &Monitor,
     level: usize,
-    initial_state: &State,
     parents: &BTreeMap<State, ParentLink>,
     result: &mut ExplicitResult,
 ) -> Result<Option<Violation>, RuntimeError> {
@@ -307,7 +314,7 @@ fn record_reachables(
                         property.name.clone(),
                         Some(ExplicitReachableWitness {
                             step: level,
-                            trace: reconstruct_trace(initial_state, &monitor.state, parents),
+                            trace: reconstruct_trace(&monitor.state, parents),
                         }),
                     );
                 }

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1937,34 +1937,43 @@ pub fn check_refinement(
 ///
 /// Returns [`RuntimeError`] if concrete evaluation or execution fails.
 pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> {
-    let initial = Monitor::new(model)?;
+    // The queue carries `State` only, not `Monitor` -- a full `Monitor`
+    // clone per explored state duplicates the whole `KernelModel` on every
+    // node (issue #730). `scratch` is re-pointed at each popped state
+    // instead; `BfsResult` never holds a trace, so there is no parent-link
+    // bookkeeping to do here (contrast `find_boundary_violation` and
+    // `first_self_violation`, which must reconstruct a trace on violation).
+    let mut scratch = Monitor::new(model)?;
+    let initial_state = scratch.state.clone();
     let mut result = BfsResult {
-        spec: initial.model.name.clone(),
+        spec: scratch.model.name.clone(),
         depth,
         states_explored: 0,
-        violation: initial.current_violation()?,
-        reachables: initial
+        violation: scratch.current_violation()?,
+        reachables: scratch
             .model
             .reachables
             .iter()
             .map(|property| (property.name.clone(), None))
             .collect(),
         deadlock_step: None,
-        action_coverage: initial
+        action_coverage: scratch
             .model
             .actions
             .iter()
             .map(|action| (action.name.clone(), false))
             .collect(),
     };
-    if let Some(violation) = record_reachables(&initial, 0, &mut result)? {
+    if let Some(violation) = record_reachables(&scratch, 0, &mut result)? {
         result.violation = Some(violation);
     }
-    let mut queue = VecDeque::from([(initial.clone(), 0_usize)]);
-    let mut visited = BTreeSet::from([initial.state.clone()]);
-    while let Some((monitor, step)) = queue.pop_front() {
+    let mut queue = VecDeque::from([(initial_state.clone(), 0_usize)]);
+    let mut visited = BTreeSet::from([initial_state]);
+    while let Some((state, step)) = queue.pop_front() {
         result.states_explored += 1;
-        let enabled = monitor.enabled()?;
+        scratch.state = state.clone();
+        scratch.step = step;
+        let enabled = scratch.enabled()?;
         if enabled.is_empty() {
             result.deadlock_step = Some(result.deadlock_step.map_or(step, |old| old.min(step)));
         }
@@ -1974,9 +1983,10 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
         if step >= depth {
             continue;
         }
-        for instance in enabled {
-            let mut child = monitor.clone();
-            let stepped = child.step(&instance)?;
+        for instance in &enabled {
+            scratch.state = state.clone();
+            scratch.step = step;
+            let stepped = scratch.step(instance)?;
             if let Some(violation) = stepped.violation {
                 if result
                     .violation
@@ -1987,7 +1997,7 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
                 }
                 continue;
             }
-            if let Some(violation) = record_reachables(&child, step + 1, &mut result)? {
+            if let Some(violation) = record_reachables(&scratch, step + 1, &mut result)? {
                 if result
                     .violation
                     .as_ref()
@@ -1997,8 +2007,8 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
                 }
                 continue;
             }
-            if visited.insert(child.state.clone()) {
-                queue.push_back((child, step + 1));
+            if visited.insert(scratch.state.clone()) {
+                queue.push_back((scratch.state.clone(), step + 1));
             }
         }
     }
@@ -2099,8 +2109,7 @@ pub fn find_boundary_violation(
             let stepped = scratch.step(&instance)?;
             if let Some(violation) = stepped.violation.clone() {
                 if matches!(violation.kind.as_str(), "partial_op" | "type_bound") {
-                    let mut found_trace =
-                        trace::reconstruct_trace(&initial_state, &state, &parents);
+                    let mut found_trace = trace::reconstruct_trace(&state, &parents);
                     found_trace.push(trace_step_from_result(
                         step + 1,
                         &state,
@@ -2172,47 +2181,64 @@ fn first_self_violation(
     initial_states: &[State],
     depth: usize,
 ) -> Result<Option<(Violation, Vec<TraceStep>)>, RuntimeError> {
+    // Queue nodes carry `State` only; a scratch `Monitor` is re-pointed at
+    // each popped state instead of cloning the whole model per node, and the
+    // trace is reconstructed from parent links only when a violation is
+    // actually found instead of cloning the whole `Vec<TraceStep>` so far at
+    // every node (issue #730 -- worse than `find_boundary_violation` was
+    // before #697, since this cloned both the model *and* the trace).
+    //
+    // Multiple roots (issue #493: a nondeterministic init has more than one
+    // concrete initial state) are handled by leaving every root out of
+    // `parents` and letting `trace::reconstruct_trace` discover whichever
+    // root a given state actually descends from -- see its doc comment.
+    let mut scratch = Monitor::from_state(model.clone(), State::new());
     let mut queue = VecDeque::new();
     let mut visited = BTreeSet::new();
+    let mut parents = BTreeMap::<State, trace::ParentLink>::new();
     for state in initial_states {
-        let initial = Monitor {
-            model: model.clone(),
-            state: state.clone(),
-            step: 0,
-        };
-        let initial_trace = vec![TraceStep {
-            step: 0,
-            state: initial.state.clone(),
-            action: None,
-            changes: BTreeMap::new(),
-        }];
-        if let Some(violation) = initial.current_violation()? {
-            return Ok(Some((violation, initial_trace)));
+        scratch.state = state.clone();
+        scratch.step = 0;
+        if let Some(violation) = scratch.current_violation()? {
+            return Ok(Some((violation, trace::reconstruct_trace(state, &parents))));
         }
-        if visited.insert(initial.state.clone()) {
-            queue.push_back((initial, initial_trace, 0_usize));
+        if visited.insert(state.clone()) {
+            queue.push_back((state.clone(), 0_usize));
         }
     }
-    while let Some((monitor, trace, step)) = queue.pop_front() {
+    while let Some((state, step)) = queue.pop_front() {
         if step >= depth {
             continue;
         }
-        for instance in monitor.enabled()? {
-            let mut child = monitor.clone();
-            let before = child.state.clone();
-            let stepped = child.step(&instance)?;
-            let mut child_trace = trace.clone();
-            child_trace.push(trace_step_from_result(
-                step + 1,
-                &before,
-                &instance,
-                &stepped,
-            ));
-            if let Some(violation) = stepped.violation {
-                return Ok(Some((violation, child_trace)));
+        scratch.state = state.clone();
+        scratch.step = step;
+        for instance in scratch.enabled()? {
+            scratch.state = state.clone();
+            scratch.step = step;
+            let stepped = scratch.step(&instance)?;
+            if let Some(violation) = stepped.violation.clone() {
+                let mut found_trace = trace::reconstruct_trace(&state, &parents);
+                found_trace.push(trace_step_from_result(
+                    step + 1,
+                    &state,
+                    &instance,
+                    &stepped,
+                ));
+                return Ok(Some((violation, found_trace)));
             }
-            if visited.insert(child.state.clone()) {
-                queue.push_back((child, child_trace, step + 1));
+            let child_state = scratch.state.clone();
+            if visited.insert(child_state.clone()) {
+                parents.insert(
+                    child_state.clone(),
+                    trace::ParentLink {
+                        parent: state.clone(),
+                        action: TraceAction {
+                            name: instance.action.clone(),
+                            params: instance.params.clone(),
+                        },
+                    },
+                );
+                queue.push_back((child_state, step + 1));
             }
         }
     }

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2007,8 +2007,9 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
                 }
                 continue;
             }
-            if visited.insert(scratch.state.clone()) {
-                queue.push_back((scratch.state.clone(), step + 1));
+            let child_state = scratch.state.clone();
+            if visited.insert(child_state.clone()) {
+                queue.push_back((child_state, step + 1));
             }
         }
     }

--- a/rust/fsl-runtime/src/trace.rs
+++ b/rust/fsl-runtime/src/trace.rs
@@ -26,11 +26,18 @@ pub(crate) struct ParentLink {
     pub(crate) action: TraceAction,
 }
 
-/// Walk `parents` back from `final_state` to `initial_state` and render the
-/// full forward [`TraceStep`] sequence, recomputing each step's field-level
-/// changes from the two states it connects.
+/// Walk `parents` back from `final_state` to its root -- the parentless
+/// state the chain terminates at -- and render the full forward
+/// [`TraceStep`] sequence, recomputing each step's field-level changes from
+/// the two states it connects.
+///
+/// The root is discovered by the walk itself rather than taken as a
+/// parameter, so this works unchanged for a multi-root search (issue #493):
+/// as long as every root is left out of `parents` (only non-root states get
+/// a `ParentLink` entry), the walk from any state -- reached from any root
+/// -- stops at the actual root it descends from, not a caller-assumed
+/// single initial state.
 pub(crate) fn reconstruct_trace(
-    initial_state: &State,
     final_state: &State,
     parents: &BTreeMap<State, ParentLink>,
 ) -> Vec<TraceStep> {
@@ -41,13 +48,14 @@ pub(crate) fn reconstruct_trace(
         cursor = link.parent.clone();
     }
     reversed.reverse();
+    let root_state = cursor;
     let mut trace = vec![TraceStep {
         step: 0,
-        state: initial_state.clone(),
+        state: root_state.clone(),
         action: None,
         changes: BTreeMap::new(),
     }];
-    let mut before = initial_state.clone();
+    let mut before = root_state;
     for (index, (state, action)) in reversed.into_iter().enumerate() {
         trace.push(TraceStep {
             step: index + 1,

--- a/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
@@ -13,9 +13,11 @@
 //! 16,290 states for the `LabelCoreRepro` reproducer below at depth 3,
 //! identical before and after the fix, with peak memory footprint dropping
 //! from ~946 MB (`maximum resident set size`, pre-fix) to ~236 MB
-//! (post-fix). That identity is not re-asserted here (it is a one-time
-//! measurement, not something this binary can assert about a version of
-//! itself it is not built from); this file is the mechanical trip-wire
+//! (post-fix). This file's own `states_explored` assertion below re-checks
+//! that count on whatever binary CI actually runs (a cheap sanity check,
+//! not a substitute for the direct before/after comparison above, which
+//! this process alone cannot reproduce since it is only ever built from one
+//! side of the fix); the file's main purpose is the mechanical trip-wire
 //! against a *silent reintroduction* of the per-node model clone, the same
 //! shape as `rust/fslc/tests/issue_697_all_properties_memory.rs`'s Control
 //! D. Like that control, macOS does not enforce `RLIMIT_AS` (observed
@@ -23,13 +25,26 @@
 //! ceiling without being killed), so this only runs on Linux, where CI
 //! actually executes it.
 //!
-//! The ceiling is calibrated to have discriminating power, not just a
-//! coarse "still bounded" check: 500 MB sits comfortably above the
-//! measured post-fix baseline's normal variance (~236 MB) but below what
+//! The ceiling is calibrated to have discriminating power against this
+//! specific regression class, not just a coarse "still bounded" check the
+//! way Control D's own >=10x margin is (deliberately -- Control D's margin
+//! is wide enough that it would not reliably catch a regression back to
+//! this fix's own pre-fix cost on this fixture, which is exactly the gap
+//! this file exists to close): 550 MB sits above the measured post-fix
+//! baseline's normal variance (~236 MB, ~2.3x headroom) but below what
 //! reintroducing the pre-fix per-node `Monitor` clone would cost on this
-//! same fixture (~946 MB), so a regression back to cloning the model per
-//! queued state fails this test instead of only showing up as a memory
-//! regression under load.
+//! same fixture (~946 MB, ~1.7x margin below it). That said, the
+//! measurement this ceiling is calibrated from is `maximum resident set
+//! size`/`peak memory footprint` on macOS (`/usr/bin/time -l`), a different
+//! metric on a different platform than what `ulimit -v` actually enforces
+//! here (`RLIMIT_AS`, i.e. reserved virtual address space, which is `>=`
+//! RSS and can differ from it by an allocator- and platform-dependent
+//! amount) -- CI has run this test and passed at this ceiling, but no one
+//! has measured what the *pre-fix* binary's `ulimit -v` cost actually is on
+//! Linux, so the margin's safety rests on an unverified monotonicity
+//! assumption (RSS improvement on macOS implies a comparable VSZ
+//! improvement on Linux), not a second direct measurement. If this test
+//! flakes, widen `CEILING_KB` rather than tightening this comment's claim.
 #![cfg(target_os = "linux")]
 
 use std::path::PathBuf;
@@ -143,7 +158,7 @@ spec LabelCoreRepro {
 #[test]
 fn bfs_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     // ~236 MB measured post-fix baseline, ~946 MB measured pre-fix, in KiB.
-    const CEILING_KB: u64 = 500 * 1024;
+    const CEILING_KB: u64 = 550 * 1024;
 
     let fixture = Fixture::new("bfs-ceiling", LABEL_CORE_REPRO_SOURCE);
     let command = format!(

--- a/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Regression coverage for issue #730: the `bfs` lane's queue used to carry
+//! `(Monitor, usize)`, cloning the whole `KernelModel` per queued state
+//! (`rust/fsl-runtime/src/lib.rs`'s `bfs`, before this fix). The fix carries
+//! `(State, usize)` instead and re-points one scratch `Monitor` at each
+//! popped state, the same pattern issue #697's `find_boundary_violation`
+//! established.
+//!
+//! State-count identity between the pre-fix and post-fix `bfs` was measured
+//! directly during development (`/usr/bin/time -l fsl-bfs`, release build):
+//! 16,290 states for the `LabelCoreRepro` reproducer below at depth 3,
+//! identical before and after the fix, with peak memory footprint dropping
+//! from ~946 MB (`maximum resident set size`, pre-fix) to ~236 MB
+//! (post-fix). That identity is not re-asserted here (it is a one-time
+//! measurement, not something this binary can assert about a version of
+//! itself it is not built from); this file is the mechanical trip-wire
+//! against a *silent reintroduction* of the per-node model clone, the same
+//! shape as `rust/fslc/tests/issue_697_all_properties_memory.rs`'s Control
+//! D. Like that control, macOS does not enforce `RLIMIT_AS` (observed
+//! directly there: child processes exceed a `setrlimit(RLIMIT_AS, ...)`
+//! ceiling without being killed), so this only runs on Linux, where CI
+//! actually executes it.
+//!
+//! The ceiling is calibrated to have discriminating power, not just a
+//! coarse "still bounded" check: 500 MB sits comfortably above the
+//! measured post-fix baseline's normal variance (~236 MB) but below what
+//! reintroducing the pre-fix per-node `Monitor` clone would cost on this
+//! same fixture (~946 MB), so a regression back to cloning the model per
+//! queued state fails this test instead of only showing up as a memory
+//! regression under load.
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-730-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// The same `LabelCoreRepro` reproducer
+/// `rust/fslc/tests/issue_697_all_properties_memory.rs` uses, copied rather
+/// than shared across crates (that file's own note explains why it is not a
+/// `specs`/`examples` corpus fixture): its `audit: Seq<LabelId, 10>` records
+/// push order, so the same *set* of pushed values in a different *order* is
+/// a different `Seq` value, `visited` dedup never collapses the branching,
+/// and the BFS frontier grows like branching^depth.
+const LABEL_CORE_REPRO_SOURCE: &str = r"
+spec LabelCoreRepro {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+  action review(l: LabelId, w: Qty) {
+    requires audit.size() < 10
+    requires not frozen
+    requires labels[l].phase == Draft
+    requires w > 0 and w <= quota
+    labels[l].phase = Review
+    labels[l].weight = w
+    reviewed = reviewed.add(l)
+    draft_count = draft_count - 1
+    audit = audit.push(l)
+  }
+  action approve(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Review
+    labels[l].phase = Approved
+    total = total + labels[l].weight
+    audit = audit.push(l)
+  }
+  action publish(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Approved
+    labels[l].phase = Published
+    published = published.add(l)
+    epoch = epoch + 1
+    audit = audit.push(l)
+  }
+  action retire(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Published
+    labels[l].phase = Retired
+    total = total - labels[l].weight
+    audit = audit.push(l)
+  }
+  action freeze() { requires not frozen  frozen = true }
+  invariant PublishedWasReviewed {
+    forall l: LabelId { published.contains(l) => reviewed.contains(l) }
+  }
+  invariant TotalConsistent {
+    total == sum(l: LabelId of labels[l].weight
+                 where labels[l].phase == Approved or labels[l].phase == Published)
+  }
+  invariant AuditCoversReview {
+    forall l: LabelId { labels[l].phase != Draft => audit.contains(l) }
+  }
+  trans EpochMonotone { epoch >= old(epoch) }
+  reachable AllPublished { published.size() >= 2 }
+  reachable SomeRetired { exists l: LabelId { labels[l].phase == Retired } }
+  reachable QuotaSaturated { total >= 6 }
+  reachable AuditFull { audit.size() >= 5 }
+}
+";
+
+#[test]
+fn bfs_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
+    // ~236 MB measured post-fix baseline, ~946 MB measured pre-fix, in KiB.
+    const CEILING_KB: u64 = 500 * 1024;
+
+    let fixture = Fixture::new("bfs-ceiling", LABEL_CORE_REPRO_SOURCE);
+    let command = format!(
+        "ulimit -v {CEILING_KB} && exec {:?} {:?} 3",
+        env!("CARGO_BIN_EXE_fsl-bfs"),
+        fixture.text(),
+    );
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("run capped fsl-bfs");
+    assert!(
+        output.status.success(),
+        "expected bfs to finish inside a {CEILING_KB} KiB address-space ceiling \
+         (calibrated between the measured post-fix and pre-fix peaks); status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON under the capped run: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(value["states_explored"], 16290, "{value:#}");
+}

--- a/rust/fsl-runtime/tests/issue_730_explicit_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_730_explicit_memory_ceiling.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Regression coverage for issue #730's `verify_explicit_selected` lane:
+//! its frontier used to be `BTreeMap<State, Monitor>`, cloning the whole
+//! `KernelModel` per live frontier state per level
+//! (`rust/fsl-runtime/src/explicit.rs`, before this fix). The fix carries a
+//! bare `BTreeSet<State>` instead and re-points one scratch `Monitor` at
+//! each frontier state.
+//!
+//! Unlike the `bfs` lane (see `issue_730_bfs_memory_ceiling.rs`), this
+//! lane's memory is not dominated by the model clone alone: level-
+//! synchronous exploration additionally holds one `Vec<EnabledAction>` per
+//! *simultaneously live* frontier state in `enabled_by_state`
+//! (`rust/fsl-runtime/src/explicit.rs`), each carrying its own
+//! `bindings`/`params` maps -- a cost this fix does not touch and #730
+//! never claimed to. Measured directly with `fsl-explicit` (a driver for
+//! `fsl_runtime::verify_explicit`, the same shape as `fsl-bfs`, added
+//! alongside this test specifically so the measurement is not diluted by
+//! `fslc verify`'s own Z3-backed vacuity checks, which run regardless of
+//! `--engine`): peak memory footprint on the `LabelCoreRepro` reproducer
+//! below (release build, depth 3, 16,290 states, max frontier width
+//! 15,424) dropped from ~1,783 MB (pre-fix) to ~954 MB (post-fix) --
+//! real and state-count-identical, but a much smaller *relative* drop than
+//! `bfs`'s ~4x, because `enabled_by_state`'s cost is unaffected and sets
+//! the floor both before and after.
+//!
+//! Same platform caveat as `issue_730_bfs_memory_ceiling.rs`: macOS does
+//! not enforce `RLIMIT_AS`, so this only runs on Linux (where CI actually
+//! executes it), and the calibration below crosses from a macOS RSS-style
+//! measurement to a Linux `ulimit -v` (`RLIMIT_AS`) ceiling -- a
+//! monotonicity assumption, not a second direct measurement on the
+//! enforcing platform. Because this lane's post/pre ratio (~0.54) leaves
+//! much less headroom than `bfs`'s (~0.25), the ceiling below sits closer
+//! to the post-fix baseline than `issue_730_bfs_memory_ceiling.rs`'s does;
+//! if it flakes, widen `CEILING_KB` rather than tightening this comment's
+//! claim.
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-730-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// The same `LabelCoreRepro` reproducer `issue_730_bfs_memory_ceiling.rs`
+/// and `rust/fslc/tests/issue_697_all_properties_memory.rs` use.
+const LABEL_CORE_REPRO_SOURCE: &str = r"
+spec LabelCoreRepro {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+  action review(l: LabelId, w: Qty) {
+    requires audit.size() < 10
+    requires not frozen
+    requires labels[l].phase == Draft
+    requires w > 0 and w <= quota
+    labels[l].phase = Review
+    labels[l].weight = w
+    reviewed = reviewed.add(l)
+    draft_count = draft_count - 1
+    audit = audit.push(l)
+  }
+  action approve(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Review
+    labels[l].phase = Approved
+    total = total + labels[l].weight
+    audit = audit.push(l)
+  }
+  action publish(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Approved
+    labels[l].phase = Published
+    published = published.add(l)
+    epoch = epoch + 1
+    audit = audit.push(l)
+  }
+  action retire(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Published
+    labels[l].phase = Retired
+    total = total - labels[l].weight
+    audit = audit.push(l)
+  }
+  action freeze() { requires not frozen  frozen = true }
+  invariant PublishedWasReviewed {
+    forall l: LabelId { published.contains(l) => reviewed.contains(l) }
+  }
+  invariant TotalConsistent {
+    total == sum(l: LabelId of labels[l].weight
+                 where labels[l].phase == Approved or labels[l].phase == Published)
+  }
+  invariant AuditCoversReview {
+    forall l: LabelId { labels[l].phase != Draft => audit.contains(l) }
+  }
+  trans EpochMonotone { epoch >= old(epoch) }
+  reachable AllPublished { published.size() >= 2 }
+  reachable SomeRetired { exists l: LabelId { labels[l].phase == Retired } }
+  reachable QuotaSaturated { total >= 6 }
+  reachable AuditFull { audit.size() >= 5 }
+}
+";
+
+#[test]
+fn explicit_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
+    // ~954 MB measured post-fix baseline, ~1,783 MB measured pre-fix, in KiB.
+    const CEILING_KB: u64 = 1_300 * 1024;
+
+    let fixture = Fixture::new("explicit-ceiling", LABEL_CORE_REPRO_SOURCE);
+    let command = format!(
+        "ulimit -v {CEILING_KB} && exec {:?} {:?} 3",
+        env!("CARGO_BIN_EXE_fsl-explicit"),
+        fixture.text(),
+    );
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("run capped fsl-explicit");
+    assert!(
+        output.status.success(),
+        "expected the explicit engine to finish inside a {CEILING_KB} KiB address-space \
+         ceiling (calibrated between the measured post-fix and pre-fix peaks); status={:?} \
+         stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON under the capped run: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(value["states_explored"], 16290, "{value:#}");
+    assert_eq!(value["max_frontier_width"], 15424, "{value:#}");
+}

--- a/rust/fsl-runtime/tests/refinement.rs
+++ b/rust/fsl-runtime/tests/refinement.rs
@@ -253,6 +253,68 @@ fn check_refinement_finds_a_self_violation_reachable_only_from_a_nondeterministi
     );
 }
 
+/// Coverage for issue #730's `trace::reconstruct_trace` generalization: the
+/// two tests above both violate at step 0 (inside the root-immediate-
+/// violation check, before any `ParentLink` is ever recorded), so neither
+/// exercises the walk-back-to-root path a violation found *after* BFS
+/// exploration starts takes. This impl has two nondeterministic-init roots
+/// (`choose = true`/`false`) that only diverge once exploration begins:
+/// `choose = true` can only call `inc_fast` (unconditionally enabled, `+2`
+/// per step) and walks `n` out of its declared `0..2` bound two steps in;
+/// `choose = false` can only call `inc_slow` (`+1`, guarded to at most one
+/// call), which reaches `n = 1` and then deadlocks without ever violating.
+/// `first_self_violation`'s shared `visited`/`queue`/`parents` therefore
+/// hold live entries from both roots at once when the violation is found,
+/// and reconstructing its trace must walk back through `inc_fast`'s own
+/// `ParentLink` to the `choose = true` root -- not the `choose = false`
+/// root, and not a caller-assumed single initial state.
+#[test]
+fn check_refinement_finds_a_self_violation_two_steps_into_one_of_two_nondeterministic_roots() {
+    let implementation = model(
+        "spec MRImplDeep { type IQty = 0..2 state { choose: Bool, n: IQty } \
+         init { if choose { n = 0 } else { n = 0 } } \
+         action inc_fast() { requires choose  n = n + 2 } \
+         action inc_slow() { requires not choose  requires n < 1  n = n + 1 } }",
+    );
+    let abstraction = model(
+        "spec MRAbsDeep { type AQty = 0..4 state { n: AQty } init { n = 0 } \
+         action inc_fast() { n = n + 2 } action inc_slow() { n = n + 1 } }",
+    );
+    let mapping = parse_refinement(
+        "refinement M { impl MRImplDeep abs MRAbsDeep maps auto }",
+        &implementation,
+        &abstraction,
+    )
+    .expect("parse mapping");
+
+    let checked = fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, 4)
+        .expect("check_refinement runs");
+
+    let (violation, trace) = checked
+        .impl_violation
+        .expect("the choose = true root's two-step-deep out-of-bounds walk must be reported");
+    assert_eq!(violation.kind, "type_bound");
+    assert_eq!(
+        trace.len(),
+        3,
+        "expected init + two inc_fast steps, not a step-0 shortcut: {trace:?}"
+    );
+    assert_eq!(
+        trace[0].state["choose"],
+        fsl_core::FslValue::Bool(true),
+        "the reconstructed trace's root must be the violating (choose = true) branch, not the \
+         other live root or a default initial state: {trace:?}"
+    );
+    assert_eq!(trace[0].state["n"], fsl_core::FslValue::Int(0));
+    assert_eq!(trace[1].state["n"], fsl_core::FslValue::Int(2));
+    assert_eq!(trace[2].state["n"], fsl_core::FslValue::Int(4));
+    assert!(
+        checked.failure.is_none(),
+        "impl_violation and failure must be mutually exclusive: {:?}",
+        checked.failure
+    );
+}
+
 const DIVMAP_ABS: &str = "spec DivMapAbs { state { q: 0..10 } init { q = 0 } \
      action go(v in 0..10) { q = v } }";
 


### PR DESCRIPTION
## Problem

`Monitor` holds its `KernelModel` by value (`rust/fsl-runtime/src/lib.rs`). `c455e50`/#697 fixed `find_boundary_violation`'s per-node model clone. **This PR fixes three more of the lanes that do the same thing** -- it does not claim to fix every remaining one; see "Scope and what's still open" below, which an independent review of this PR's first version (#776) required adding:

- `bfs` (`rust/fsl-runtime/src/lib.rs`, the solver-free agreement oracle, `fsl-bfs` binary): queue held `(Monitor, step)`, `monitor.clone()` per explored node.
- `first_self_violation` (`check_refinement`'s self-consistency precondition): queue held `(Monitor, Vec<TraceStep>, step)` -- **cloned both the model and the whole accumulated trace per node**, worse than `find_boundary_violation` was before #697.
- `verify_explicit_selected` (`rust/fsl-runtime/src/explicit.rs`): frontier was `BTreeMap<State, Monitor>`, `monitor.clone()` per child.

Measured directly (release build, `LabelCoreRepro` reproducer from `rust/fslc/tests/issue_697_all_properties_memory.rs`, depth 3, `/usr/bin/time -l`):

| | states_explored | peak memory footprint |
|---|---|---|
| `bfs`, before | 16,290 | ~946 MB |
| `bfs`, after | 16,290 | ~236 MB |
| `verify_explicit_selected`, before | 16,290 | ~1,783 MB |
| `verify_explicit_selected`, after | 16,290 | ~954 MB |

`verify_explicit_selected`'s relative drop is smaller than `bfs`'s (~1.9x vs. ~4x): its level-synchronous walk additionally holds one `Vec<EnabledAction>` per *simultaneously live* frontier state (`enabled_by_state`), a cost this fix does not touch and never claimed to.

Same identity/reduction shape on the corpus's largest `bfs` explorer (`examples/named_predicate.fsl`, depth 8): 23,409 states before and after, `bfs` peak footprint 343 MB -> 162 MB.

## Scope and what's still open (#783)

Independent review found three more `Monitor`-cloning lanes this PR does **not** touch, by `grep`:

- `check_refinement`'s own correspondence walk (`rust/fsl-runtime/src/lib.rs:1766,1777,1788`) -- **this is the one that matters most**: it still uses the pre-fix pattern, and it is *heavier* than `first_self_violation` was, so this PR's `first_self_violation` fix is largely absorbed by it whenever `check_refinement` reaches that walk. Reviewer's measurement:

  | depth | before | after (this PR) | improvement |
  |---|---|---|---|
  | 2 | 94,617,984 B | 73,597,336 B | 22% |
  | 3 | 2.06 GB | 1.72 GB | 17% |

  Compare `bfs`'s 75% reduction at the same depth 3. **The refine-path OOM issue #730 raised is not resolved by this PR** for any refinement whose impl doesn't self-violate before the correspondence walk starts.
- `action_cover_traces` (`rust/fsl-runtime/src/lib.rs:2578,2580`)
- `leadsto_response_traces` (`rust/fsl-runtime/src/lib.rs:2695,2700`)

(`expression_reachable` at `:2278` was already known out of scope, tracked as #729.)

These three, plus budgeting these lanes (already out of scope per the original issue), are tracked in **#783**: https://github.com/ymm-oss/fsl/issues/783

## Contract

**No public contract changes.** Same function signatures, same `BfsResult`/`ExplicitResult`/`RefinementCheck` fields, same JSON envelopes. This PR is a representation change only: queue/frontier elements shrink from `Monitor` (whole `KernelModel` by value) to bare `State`, with one scratch `Monitor` re-pointed at each popped state -- exactly `find_boundary_violation`'s established #697 pattern, extended to the three lanes above.

## State-count identity (the regression check that matters most)

Verified byte-for-byte identical `states_explored` before vs. after, both directions (checking out the pre-fix files under the same commit and re-measuring, release build):

- `fsl-bfs` on `LabelCoreRepro` depth 3: **16,290 == 16,290**.
- `fsl-bfs` on `examples/named_predicate.fsl` depth 8 (corpus's largest `bfs` explorer per `CONCRETE_PROBE_BUDGET`'s own calibration comment): **23,409 == 23,409**.
- `fsl-explicit`/`fslc verify --engine explicit` on both of the above: same `states_explored` (and `max_frontier_width` for the new driver), same verdict, before and after.

Independent review additionally reproduced this at corpus scale: BFS across 214 files (zero diff), explicit engine across 148 specs (1,402 lines of diff, zero semantic diff), and refine across 52 runs (12 with `impl_trace`), all byte-identical.

## `first_self_violation`'s trace-clone finding

The issue's own text estimated `first_self_violation` cost roughly the same as pre-#697 `find_boundary_violation`. Re-measuring on the current tree showed it is actually worse: its queue was `(Monitor, Vec<TraceStep>, usize)`, so every queued node cloned **both** the whole model **and** the whole trace accumulated so far. This PR removes both for this lane specifically (queue is now `(State, usize)`, trace reconstructed from parent links only once). It does **not** fix `check_refinement`'s main walk -- see "Scope" above.

## Multi-root generalization (#493)

`first_self_violation` checks every concrete initial state a nondeterministic `init` admits (issue #493), not just one. `trace::reconstruct_trace` no longer takes an `initial_state` parameter: it walks `parents` back from `final_state` until it hits a state with no entry (a root, since only non-root states ever get a `ParentLink`), and uses *that* state as step 0. This is correct for both single-root callers and the multi-root caller, and drops a parameter from every call site.

Independent review verified this externally across 2-root-deep, 3-root-deep, colliding-root, and single-root cases (step 0 correctly reports the actually-descended-from root, not the first/default one), byte-identical to before. This PR additionally adds `check_refinement_finds_a_self_violation_two_steps_into_one_of_two_nondeterministic_roots` to `rust/fsl-runtime/tests/refinement.rs`, since the two pre-existing multi-root tests both violate at step 0 (before any `ParentLink` exists) and so never exercised the walk-back-to-root path a deeper violation takes. Verified this new test has teeth: temporarily forcing the reconstructed root to the wrong live root (simulating the pre-generalization bug) makes it fail; reverted, all 10 `refinement.rs` tests pass.

## Memory-regression negative controls

- `rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs` (Linux-only, `bfs` lane): a `ulimit -v` ceiling on `fsl-bfs` running the `LabelCoreRepro` reproducer, calibrated between the measured pre/post-fix peaks (not Control D's coarse `>=10x` -- that margin would not reliably catch this regression class on this fixture) so a silent reintroduction of the per-node clone fails this test. The comment is explicit that this crosses from a macOS RSS measurement to a Linux `RLIMIT_AS` ceiling on an unverified monotonicity assumption, not a second direct measurement; CI has since run and confirmed this ceiling holds, but if it ever flakes, the fix is to widen `CEILING_KB`, not to over-claim precision.
- `rust/fsl-runtime/tests/issue_730_explicit_memory_ceiling.rs` (Linux-only, `verify_explicit_selected` lane): same shape, using a new `fsl-explicit` binary (a driver for `fsl_runtime::verify_explicit`, added alongside this test specifically so the measurement isn't diluted by `fslc verify`'s own Z3-backed vacuity checks, which run regardless of `--engine`).
- `first_self_violation` has **no** dedicated ceiling test in this PR -- not because isolating it from `check_refinement`'s still-unfixed main walk is structurally hard (it isn't: `check_refinement` returns early the moment `first_self_violation` finds a self-violation, `rust/fsl-runtime/src/lib.rs:1615-1627`, so an impl fixture that self-violates never reaches the main walk at all; separation is guaranteed by control flow, not by fixture cleverness), but because adding and calibrating a third fixture/ceiling was deferred to #783 under this review round's time budget. An independent-review measurement (same `LabelCoreRepro` reproducer plus one extra action, depth 4) confirms this lane's own numbers would in fact have been the best of the three: ~1,926 MB pre-fix -> ~492 MB post-fix (3.92x, on par with `bfs`'s 4.01x), ~2.03x headroom to a 1,000 MB ceiling. Recorded in #783 along with the fixture recipe: https://github.com/ymm-oss/fsl/issues/783#issuecomment-5225554597.

## Tests run (narrow, per the task's own instruction not to run the full workspace -- very slow)

All green:

- `cargo test -p fsl-runtime` (43 tests on macOS / 45 on Linux -- the two new ceiling files run 0 tests each on macOS by design (`#![cfg(target_os = "linux")]`) and 1 each on Linux -- across `action_correspondence`, `boundary_probe_budget`, `bounded_liveness`, `diagnostics`, `explicit_engine`, `monitor_regression`, `refinement` (now 10, +1 from this update), and the two new ceiling files).
- `cargo test -p fslc-rust --test typed_agreement` (27 tests: the three-engine -- `bfs`/`explicit`/BMC -- comparator harness `docs/DESIGN-conformance-harness.md` C6 describes).
- `cargo test -p fsl-verifier --test expression_agreement` (9 tests).
- `cargo test -p fslc-rust --test explicit_engine` (12 tests, including `explicit_and_bmc_agree_on_every_accepted_top_level_corpus_spec`).
- `cargo test -p fslc-rust --test issue_697_corpus_probe_budget` (`no_corpus_spec_exhausts_the_concrete_probe_budget`).
- `cargo test -p fslc-rust --test issue_697_all_properties_memory` (all 3, including the joint-verdict-agreement test).
- `cargo test -p fslc-rust --test triangulated_assurance` (15 tests, incl. `p2_witness_replay`).
- `cargo test -p fslc-rust --test issue_466_refine_impl_self_violation`, `issue_512_refine_map_partial_op`, `issue_519_monitor_deterministic_init`.

**Not run**: `cargo test --workspace` (explicitly excluded per the task brief as very slow for this scope).

`cargo fmt --all -- --check` and `cargo clippy -p fsl-runtime --all-targets -- -D warnings`: both clean.

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)
