### PR TITLE
fix(domain): apply declared evolves when a saga step emits its event (#779)

### DIFF
--- a/changelog.d/779-saga-emit-evolve.fixed.md
+++ b/changelog.d/779-saga-emit-evolve.fixed.md
@@ -1,0 +1,24 @@
+Fixed (#779): a saga step, timeout, or compensation action that emits an
+event no longer leaves that event's declared `evolve` unapplied. Both native
+`domain` lowering paths (`lower_saga_actions` in `domain_lowering.rs`,
+`render_saga_actions` in `domain.rs`) called `event_assignments` for these
+three action kinds without the paired `evolve_items`/`saga_emit_evolve` call,
+so an action could raise its emitted event's one-hot flag while the aggregate
+state that event was declared to evolve stayed frozen at its initial value
+forever — an accepted-but-unreachable-transition soundness defect in the same
+class PR #725 (#713) closed for the compensation guard. Both paths now apply
+the declared evolve in the same action, in emit order, matching the pairing
+already correct for command/decide, effect-completion, and saga-observe
+actions. A new corpus-wide sweep
+(`rust/fsl-core/tests/domain_saga_evolve_pairing.rs`) asserts, for every
+action any domain fixture lowers to on either path, that an action setting an
+event flag true also applies that event's declared evolve, so a future
+lowering rewrite (e.g. #679's saga-history rewrite) cannot silently drop the
+pairing again. Negative controls on `examples/domain/order_fulfillment_saga.fsl`
+confirm both the fix (`inventory_status != ReservationPending` and
+`payment_status != PaymentPending`, previously `proved` under
+`--engine induction`, now correctly `violated`) and its boundary
+(`inventory_status != ReleaseRequested` stays `proved`, and the saga's
+never-enabled compensation warning is unchanged, because the compensation
+action's dual event-flag guard is untouched by this fix and remains
+structurally disabled until #679).

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -68,7 +68,25 @@ Each aggregate becomes kernel state and actions:
 - aggregate invariant -> kernel `invariant`
 - event occurrence -> per-step `event_<Event>` Bool flags
 - saga step -> kernel action guarded by `starts_on`, `requires`, or awaited
-  event flags
+  event flags. **Evolve pairing invariant** (#779): an `evolve` is 1:1 with
+  the *occurrence* of its event, so any generated action that raises
+  `event_<Event> := true` — a command/decide action, an effect-completion
+  action, a saga observe action, or a saga step/timeout/compensation action —
+  must apply that event's declared `evolve` assignments in the same action, in
+  emit order, if the domain declares one for it. Before #779, saga
+  step/timeout/compensation actions called only the shared `event_assignments`
+  helper and never the paired `evolve_items`/`saga_emit_evolve` call, so a step
+  could raise its emitted event's flag while leaving the aggregate state that
+  event was declared to evolve frozen — an accepted-but-unreachable-transition
+  soundness defect in the same class PR #725 (#713) closed for the
+  compensation guard. Both lowering paths now call the paired helper for every
+  saga action kind; `rust/fsl-core/tests/domain_saga_evolve_pairing.rs` sweeps
+  every action in the domain corpus and fails if any future lowering change
+  (e.g. #679's saga-history rewrite) drops the pairing again. If the same
+  event appears in both a step's `emits` and its (or a later step's) `awaits`,
+  the evolve is applied twice — once per occurrence (emit, then observe) —
+  which is the correct event-sourcing reading, not a defect: applied count
+  equals `event_assignments` execution count equals occurrence count.
 - saga compensation -> kernel action guarded by trigger/after event flags
   (#713: both lowering paths, `lower_saga_actions` in `domain_lowering.rs` and
   `render_saga_actions` in `domain.rs`, emit a `requires` for the trigger

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -235,9 +235,13 @@ domain <Name> {
 エラー、純粋な `decide`/`evolve`、非同期エフェクトのライフサイクル、saga/プロセス
 マネージャの協調をモデル化します。各 command+decide+evolve のパスをカーネルの
 `action` へ、aggregate 状態をプレフィックス付きのカーネル状態へ、saga の step を
-イベントフラグでガードされた action へ、エフェクトライフサイクル状態を有限の
+イベントフラグでガードされ、かつ emit する各イベントの宣言済み `evolve` を同じ
+action 内で適用する action へ、エフェクトライフサイクル状態を有限の
 `Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` マップへと
-lowering します。domain の enum メンバーは lowering 時に名前空間化されるので、
+lowering します。イベントの発生フラグを立てる action は、それを生成した構文
+(command、effect の完了、saga の observe、saga の step/timeout/compensation の
+いずれであっても)によらず、そのイベントの宣言済み `evolve` を同じ action 内で
+適用します。domain の enum メンバーは lowering 時に名前空間化されるので、
 2 つの domain enum が両方とも `Pending` を含んでもかまいません。domain の式では
 `X in [A, B]` と `can(Command)` が使えます。これらは型付き domain ツリーから解決
 され、カーネル式へ構造的に lowering されます。裸の enum メンバーは期待される論理型

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -235,8 +235,7 @@ domain <Name> {
 エラー、純粋な `decide`/`evolve`、非同期エフェクトのライフサイクル、saga/プロセス
 マネージャの協調をモデル化します。各 command+decide+evolve のパスをカーネルの
 `action` へ、aggregate 状態をプレフィックス付きのカーネル状態へ、saga の step を
-イベントフラグでガードされ、かつ emit する各イベントの宣言済み `evolve` を同じ
-action 内で適用する action へ、エフェクトライフサイクル状態を有限の
+イベントフラグでガードされた action へ、エフェクトライフサイクル状態を有限の
 `Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` マップへと
 lowering します。イベントの発生フラグを立てる action は、それを生成した構文
 (command、effect の完了、saga の observe、saga の step/timeout/compensation の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -235,8 +235,13 @@ domain <Name> {
 events, domain errors, pure `decide`/`evolve`, async effect lifecycles, and
 saga/process-manager coordination. It lowers each command+decide+evolve path to
 a kernel `action`, aggregate state to prefixed kernel state, saga steps to
-event-flag guarded actions, and effect lifecycle state to finite
-`Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` maps. Domain
+event-flag guarded actions that also apply each emitted event's declared
+`evolve` in the same action, and effect lifecycle state to finite
+`Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` maps. Every
+action that raises an event's occurrence flag applies that event's declared
+`evolve` in the same action, whichever construct generated the action
+(command, effect completion, saga observe, or saga step/timeout/compensation).
+Domain
 enum members are namespaced during lowering, so two domain enums may both contain
 `Pending`. Domain expressions may use `X in [A, B]` and `can(Command)`; these are
 resolved from the typed domain tree and lowered structurally to kernel

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -235,15 +235,14 @@ domain <Name> {
 events, domain errors, pure `decide`/`evolve`, async effect lifecycles, and
 saga/process-manager coordination. It lowers each command+decide+evolve path to
 a kernel `action`, aggregate state to prefixed kernel state, saga steps to
-event-flag guarded actions that also apply each emitted event's declared
-`evolve` in the same action, and effect lifecycle state to finite
+event-flag guarded actions, and effect lifecycle state to finite
 `Map<CorrelationId, EffectStatus>` / `Map<CorrelationId, Attempt>` maps. Every
 action that raises an event's occurrence flag applies that event's declared
 `evolve` in the same action, whichever construct generated the action
 (command, effect completion, saga observe, or saga step/timeout/compensation).
-Domain
-enum members are namespaced during lowering, so two domain enums may both contain
-`Pending`. Domain expressions may use `X in [A, B]` and `can(Command)`; these are
+Domain enum members are namespaced during lowering, so two domain enums may
+both contain `Pending`. Domain expressions may use `X in [A, B]` and
+`can(Command)`; these are
 resolved from the typed domain tree and lowered structurally to kernel
 expressions. Bare enum members use the expected logical type; an untyped member
 shared by multiple enums is an error. Finite membership becomes an equality

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -273,9 +273,13 @@ events, domain errors, pure <code>decide</code>/<code>evolve</code>, async effec
 saga/process-manager coordination. It lowers each command+decide+evolve path to
 a kernel <code>action</code>, aggregate state to prefixed kernel state, saga steps to
 event-flag guarded actions, and effect lifecycle state to finite
-<code>Map&lt;CorrelationId, EffectStatus&gt;</code> / <code>Map&lt;CorrelationId, Attempt&gt;</code> maps. Domain
-enum members are namespaced during lowering, so two domain enums may both contain
-<code>Pending</code>. Domain expressions may use <code>X in [A, B]</code> and <code>can(Command)</code>; these are
+<code>Map&lt;CorrelationId, EffectStatus&gt;</code> / <code>Map&lt;CorrelationId, Attempt&gt;</code> maps. Every
+action that raises an event's occurrence flag applies that event's declared
+<code>evolve</code> in the same action, whichever construct generated the action
+(command, effect completion, saga observe, or saga step/timeout/compensation).
+Domain enum members are namespaced during lowering, so two domain enums may
+both contain <code>Pending</code>. Domain expressions may use <code>X in [A, B]</code> and
+<code>can(Command)</code>; these are
 resolved from the typed domain tree and lowered structurally to kernel
 expressions. Bare enum members use the expected logical type; an untyped member
 shared by multiple enums is an error. Finite membership becomes an equality

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -276,7 +276,10 @@ fsl-domain findings を報告します):</p>
 <code>action</code> へ、aggregate 状態をプレフィックス付きのカーネル状態へ、saga の step を
 イベントフラグでガードされた action へ、エフェクトライフサイクル状態を有限の
 <code>Map&lt;CorrelationId, EffectStatus&gt;</code> / <code>Map&lt;CorrelationId, Attempt&gt;</code> マップへと
-lowering します。domain の enum メンバーは lowering 時に名前空間化されるので、
+lowering します。イベントの発生フラグを立てる action は、それを生成した構文
+(command、effect の完了、saga の observe、saga の step/timeout/compensation の
+いずれであっても)によらず、そのイベントの宣言済み <code>evolve</code> を同じ action 内で
+適用します。domain の enum メンバーは lowering 時に名前空間化されるので、
 2 つの domain enum が両方とも <code>Pending</code> を含んでもかまいません。domain の式では
 <code>X in [A, B]</code> と <code>can(Command)</code> が使えます。これらは型付き domain ツリーから解決
 され、カーネル式へ構造的に lowering されます。裸の enum メンバーは期待される論理型

--- a/rust/fsl-core/src/domain.rs
+++ b/rust/fsl-core/src/domain.rs
@@ -720,6 +720,39 @@ fn evolve_assignments(
     output
 }
 
+/// Render the declared `evolve` for each event a saga step/timeout/compensation
+/// action emits, pairing with `event_assignments`: an action that raises
+/// `event_<E>` for an occurring event must apply E's declared evolve in the
+/// same action (docs/DESIGN-domain.md's saga step pairing invariant).
+fn saga_emit_evolve_lines(context: &Context<'_>, events: &[String]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for event_name in events {
+        let Some((aggregate, event)) = context.event(event_name) else {
+            continue;
+        };
+        let environment = aggregate
+            .state
+            .iter()
+            .chain(&event.fields)
+            .map(|field| (field.name.text.clone(), field.type_name.render_source()))
+            .collect();
+        lines.extend(
+            evolve_assignments(
+                context,
+                aggregate,
+                aggregate
+                    .evolves
+                    .iter()
+                    .find(|item| item.event == *event_name),
+                &environment,
+            )
+            .into_iter()
+            .map(|line| format!("  {line}")),
+        );
+    }
+    lines
+}
+
 fn render_effect_actions(context: &Context<'_>, effect: &DomainEffect) -> Vec<String> {
     let Some(correlation) = Context::correlation_field(effect) else {
         return Vec::new();
@@ -865,6 +898,7 @@ fn saga_guards(
     guards
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> {
     let mut lines = Vec::new();
     let mut observed = BTreeSet::new();
@@ -929,6 +963,7 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
                 .into_iter()
                 .map(|line| format!("  {line}")),
         );
+        lines.extend(saga_emit_evolve_lines(context, &step.emits));
         lines.push("}".to_owned());
         if let Some(timeout) = &step.timeout_event {
             lines.push(format!("action {action}_timeout() {{"));
@@ -938,6 +973,10 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
                     .into_iter()
                     .map(|line| format!("  {line}")),
             );
+            lines.extend(saga_emit_evolve_lines(
+                context,
+                std::slice::from_ref(timeout),
+            ));
             lines.push("}".to_owned());
         }
     }
@@ -961,6 +1000,7 @@ fn render_saga_actions(context: &Context<'_>, saga: &DomainSaga) -> Vec<String> 
                 .into_iter()
                 .map(|line| format!("  {line}")),
         );
+        lines.extend(saga_emit_evolve_lines(context, &compensation.emits));
         lines.push("}".to_owned());
     }
     lines

--- a/rust/fsl-core/src/domain_lowering.rs
+++ b/rust/fsl-core/src/domain_lowering.rs
@@ -207,11 +207,23 @@ fn lower_name(name: &str) -> String {
     safe(&output)
 }
 
-fn state_name(aggregate: &DomainAggregate, field: &str) -> String {
+/// The kernel state variable name a domain aggregate field lowers to
+/// (`{aggregate}_{field}`). Exported so an external corpus sweep can compute
+/// an `evolve` assignment's kernel target from the `DomainSpec` alone,
+/// instead of guessing from generated names (see `event_flag`).
+#[must_use]
+pub fn state_name(aggregate: &DomainAggregate, field: &str) -> String {
     format!("{}_{}", lower_name(&aggregate.name), safe(field))
 }
 
-fn event_flag(event: &str) -> String {
+/// The kernel one-hot event-occurrence flag name a domain event lowers to
+/// (`event_{event}`). Exported so an external corpus sweep (the #779 saga
+/// step/timeout/compensation "evolve pairing" gate) can compute which kernel
+/// variable an event's occurrence flag is from the `DomainSpec` alone,
+/// rather than pattern-matching generated action bodies for an `event_`
+/// prefix — the latter has no `DomainSpec`-side referent to check against.
+#[must_use]
+pub fn event_flag(event: &str) -> String {
     format!("event_{}", safe(event))
 }
 
@@ -2068,6 +2080,32 @@ impl<'a> Resolver<'a> {
         }
         Ok(items)
     }
+
+    /// Apply the declared `evolve` for each event a saga step/timeout/compensation
+    /// action emits, pairing with `event_assignments`: an action that raises
+    /// `event_<E>` for an occurring event must apply E's declared evolve in the
+    /// same action (docs/DESIGN-domain.md's saga step pairing invariant).
+    fn saga_emit_evolve(
+        &self,
+        loc: DomainLoc,
+        events: &[String],
+    ) -> Result<(Vec<ActionItem>, Annotations), CoreError> {
+        let mut items = Vec::new();
+        let mut annotations = Annotations::default();
+        for event_name in events {
+            let (aggregate, event) = self.event(event_name, loc)?;
+            let mut scope = self.scope_for_aggregate(aggregate)?;
+            self.extend_fields(&mut scope, &event.fields)?;
+            items.extend(self.evolve_items(aggregate, event_name, &scope)?);
+            annotations.extend(
+                evolve_annotations(aggregate, event_name)
+                    .source_order()
+                    .iter()
+                    .cloned(),
+            );
+        }
+        Ok((items, annotations))
+    }
 }
 
 fn metadata(id: impl Into<String>, text: impl Into<String>) -> MetaTag {
@@ -2785,13 +2823,18 @@ fn lower_saga_actions(
                     .into_iter()
                     .map(ActionItem::Statement),
             );
+            let (evolve_items, evolve_annotations) =
+                resolver.saga_emit_evolve(step.loc, &step.emits)?;
+            action_items.extend(evolve_items);
+            let mut annotations = step.annotations.clone();
+            annotations.extend(evolve_annotations.source_order().iter().cloned());
             let action_name = format!("saga_{}_{}", lower_name(&saga.name), lower_name(&step.name));
             items.push(action(
                 action_name.clone(),
                 Vec::new(),
                 action_items,
                 span,
-                step.annotations.clone(),
+                annotations,
             ));
             if let Some(timeout) = &step.timeout_event {
                 let mut timeout_items = guards
@@ -2804,12 +2847,18 @@ fn lower_saga_actions(
                         .into_iter()
                         .map(ActionItem::Statement),
                 );
+                let (timeout_evolve_items, timeout_evolve_annotations) =
+                    resolver.saga_emit_evolve(step.loc, std::slice::from_ref(timeout))?;
+                timeout_items.extend(timeout_evolve_items);
+                let mut timeout_annotations = step.annotations.clone();
+                timeout_annotations
+                    .extend(timeout_evolve_annotations.source_order().iter().cloned());
                 items.push(action(
                     format!("{action_name}_timeout"),
                     Vec::new(),
                     timeout_items,
                     span,
-                    step.annotations.clone(),
+                    timeout_annotations,
                 ));
             }
         }
@@ -2827,6 +2876,9 @@ fn lower_saga_actions(
                     .into_iter()
                     .map(ActionItem::Statement),
             );
+            let (evolve_items, evolve_annotations) =
+                resolver.saga_emit_evolve(compensation.loc, &compensation.emits)?;
+            action_items.extend(evolve_items);
             items.push(action(
                 format!(
                     "saga_{}_compensate_{}_after_{}",
@@ -2837,7 +2889,7 @@ fn lower_saga_actions(
                 Vec::new(),
                 action_items,
                 span,
-                Annotations::default(),
+                evolve_annotations,
             ));
         }
     }

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -55,7 +55,7 @@ pub use dialect::{
     lower_governance, lower_requirements, requirements_trace_contract,
 };
 pub use domain::{DomainDefault, domain_kernel_source, domain_type_default};
-pub use domain_lowering::domain_effect_owns_event;
+pub use domain_lowering::{domain_effect_owns_event, event_flag, state_name};
 pub use expr_text::{binder_text, expr_text, source_binder_text, source_expr_text};
 pub use model::{
     ActionDef, ActionGuard, KernelModel, LeadsToDef, ModelError, ParamDef, PropertyDef, TypeDef,

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -134,6 +134,7 @@ const VALID_DOMAIN_FIXTURES: &[&str] = &[
     "rust/fslc/tests/fixtures/issue_518_domain_replay.fsl",
     "rust/fslc/tests/fixtures/issue_641_domain_clean.fsl",
     "rust/fslc/tests/fixtures/issue_641_domain_unreachable_decide.fsl",
+    "rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl",
 ];
 
 /// Domain specs that parse into a [`DomainSpec`] but must be rejected by

--- a/rust/fsl-core/tests/domain_saga_evolve_pairing.rs
+++ b/rust/fsl-core/tests/domain_saga_evolve_pairing.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! #779 structural control: the "evolve pairing invariant"
+//! (`docs/DESIGN-domain.md`'s saga step section) says an `evolve` is 1:1
+//! with the *occurrence* of its event: any generated action whose
+//! `updates` sets `event_<E> := true` must, in the SAME action, apply E's
+//! declared `evolve` assignments if the domain declares one for E.
+//! `event_assignments` alone -- without the paired `evolve_items` call --
+//! is exactly the defect class #779 fixes: before the fix, the saga
+//! step/timeout/compensation actions in `domain_lowering.rs`
+//! (`lower_saga_actions`) and `domain.rs` (`render_saga_actions`) called
+//! only `event_assignments`, so a saga step could set its emitted event's
+//! flag true without ever writing the state the domain declared that event
+//! should evolve.
+//!
+//! This is a total sweep over every action in every corpus fixture, not a
+//! fixture spot-check, because #679's PR-A rewrites the saga
+//! step/timeout/resolve/compensate actions wholesale. A spot check on
+//! today's action shapes would silently stop covering the rewritten code;
+//! a sweep keyed only on "does this action set an event flag true" keeps
+//! covering whatever actions PR-A produces without a second copy of the
+//! judgment rule to keep in sync.
+//!
+//! Per #779's design-authority ruling, the check function is
+//! `fn check(domain: &DomainSpec, model: &KernelModel)` and stays that
+//! shape: "E's declared evolve" is a `DomainSpec`-surface concept with no
+//! kernel-model equivalent (the kernel has no notion of `evolve` at all),
+//! so a hand-written kernel spec with no backing `DomainSpec` cannot be
+//! passed to this check -- that is a scope boundary of the input types,
+//! not an oversight. The event-flag and state-variable names this check
+//! compares against are computed with the same `fsl_core::event_flag` /
+//! `fsl_core::state_name` naming functions `domain_lowering.rs` and
+//! `domain.rs` themselves use to generate those names, never guessed from
+//! an `event_` prefix on a generated kernel name -- prefix-matching a
+//! generated name has no `DomainSpec`-side referent to validate against
+//! and is explicitly out of scope for this gate.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use fsl_core::{
+    FsResolver, KernelModel, build_model, domain_kernel_source, event_flag, lower_domain,
+    parse_kernel_source, state_name,
+};
+use fsl_syntax::{
+    DomainSpec, Expr, LValue, Statement, SurfaceDocument, SyntaxLValue, parse_surface_document,
+};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust/ directory")
+        .parent()
+        .expect("repository root")
+        .to_path_buf()
+}
+
+/// `.fsl` files directly under `dir` (non-recursive), sorted for
+/// deterministic test output.
+fn fsl_files_in(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "fsl"))
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}
+
+/// The #779 sweep corpus: every `.fsl` file under `examples/domain/` and
+/// `rust/fslc/tests/fixtures/domain_characterization/`, plus
+/// `examples/annotations/annotated_domain.fsl`. This is a glob, not a
+/// manually maintained registration list like
+/// `domain_render_agreement.rs`'s `VALID_DOMAIN_FIXTURES` (that list exists
+/// for a different purpose: pinning each fixture's *expected* A/B agreement
+/// outcome one by one). Per #779, this sweep must keep covering new domain
+/// fixtures automatically as they are added, without a second list to
+/// remember to update -- files that fail to parse as a `domain` document,
+/// or that fail to lower on a given path (several
+/// `domain_characterization/` fixtures are deliberately-invalid negative
+/// controls for other gates), are skipped for that path rather than
+/// failing this test; this sweep only asserts the pairing invariant over
+/// successfully produced kernel models.
+fn sweep_corpus() -> Vec<PathBuf> {
+    let root = repo_root();
+    let mut files = fsl_files_in(&root.join("examples/domain"));
+    files.extend(fsl_files_in(
+        &root.join("rust/fslc/tests/fixtures/domain_characterization"),
+    ));
+    files.push(root.join("examples/annotations/annotated_domain.fsl"));
+    files
+}
+
+/// Root identifier of a domain-source lvalue (`item` for `item`,
+/// `counts[item]`, and `counter.value` alike). Purely syntactic: it never
+/// resolves or evaluates the lvalue, so it cannot drift from
+/// `resolve_lvalue`'s value semantics; it only needs the same root name
+/// that `state_name` combines with the aggregate name.
+fn syntax_lvalue_root(lvalue: &SyntaxLValue) -> &str {
+    match lvalue {
+        SyntaxLValue::Name(ident) => ident.text.as_str(),
+        SyntaxLValue::Index { base, .. } | SyntaxLValue::Field { base, .. } => {
+            syntax_lvalue_root(base)
+        }
+    }
+}
+
+/// Root variable name of a generated kernel lvalue (`order_status` for
+/// `order_status`, `counts[item]`, and `counter.value` alike).
+fn kernel_lvalue_root(lvalue: &LValue) -> &str {
+    match lvalue {
+        LValue::Var(name) | LValue::Index(name, _) => name.as_str(),
+        LValue::Field(base, _) => kernel_lvalue_root(base),
+    }
+}
+
+/// For every event with a non-empty declared `evolve`, the set of kernel
+/// state-variable ROOT names its assignments must write, keyed by the
+/// event's kernel flag name (`event_flag`). Only the root variable is
+/// checked, not the resolved value or the full lvalue path -- this mirrors
+/// the granularity the lowering-side pairing invariant actually operates
+/// at: whether the paired `evolve_items` call happened in the same action,
+/// not what expression value it computed (recomputing that would require
+/// re-deriving the resolver's expression semantics, the "second copy of
+/// the judgment rule" #779 explicitly says not to build). An event with a
+/// declared-but-empty evolve (no assignments, e.g. `evolve Opened {}`) has
+/// no required targets and is intentionally not registered here, so it is
+/// vacuously satisfied wherever its flag is set.
+fn required_targets(domain: &DomainSpec) -> BTreeMap<String, BTreeSet<String>> {
+    let mut required = BTreeMap::new();
+    for aggregate in &domain.aggregates {
+        for evolve in &aggregate.evolves {
+            if evolve.assignments.is_empty() {
+                continue;
+            }
+            let targets = evolve
+                .assignments
+                .iter()
+                .map(|assignment| state_name(aggregate, syntax_lvalue_root(&assignment.target)))
+                .collect::<BTreeSet<_>>();
+            required.insert(event_flag(&evolve.event), targets);
+        }
+    }
+    required
+}
+
+/// Collects, from `statements` and any nested `If`/`ForAll` branches: every
+/// event flag assigned literal `true` (`occurring`), and the root name of
+/// every kernel variable any assignment writes (`written`).
+fn collect_writes(
+    statements: &[Statement],
+    occurring: &mut BTreeSet<String>,
+    written: &mut BTreeSet<String>,
+) {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, value, .. } => {
+                written.insert(kernel_lvalue_root(target).to_owned());
+                if matches!(value, Expr::Bool(true))
+                    && let LValue::Var(name) = target
+                {
+                    occurring.insert(name.clone());
+                }
+            }
+            Statement::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                collect_writes(then_statements, occurring, written);
+                collect_writes(else_statements, occurring, written);
+            }
+            Statement::ForAll { statements, .. } => {
+                collect_writes(statements, occurring, written);
+            }
+        }
+    }
+}
+
+/// The #779 pairing-invariant check: `fn check(domain: &DomainSpec, model:
+/// &KernelModel)`, fixed at this signature per the design-authority ruling.
+/// Returns one human-readable finding per violation -- an action that sets
+/// some `event_<E> := true` without writing every kernel variable E's
+/// declared evolve requires in that same action; an empty result means the
+/// invariant held for every action in `model`.
+fn check_evolve_pairing(domain: &DomainSpec, model: &KernelModel) -> Vec<String> {
+    let required = required_targets(domain);
+    let mut findings = Vec::new();
+    for action in &model.actions {
+        let mut occurring = BTreeSet::new();
+        let mut written = BTreeSet::new();
+        collect_writes(&action.statements, &mut occurring, &mut written);
+        for flag in &occurring {
+            let Some(targets) = required.get(flag) else {
+                continue;
+            };
+            for target in targets {
+                if !written.contains(target) {
+                    findings.push(format!(
+                        "action '{}' sets '{flag} := true' but never writes '{target}' \
+                         (its declared evolve is not applied in this action)",
+                        action.name
+                    ));
+                }
+            }
+        }
+    }
+    findings
+}
+
+/// Runs [`check_evolve_pairing`] against both independent lowering paths
+/// (`lower_domain`, and `domain_kernel_source` reparsed through
+/// `parse_kernel_source`) for every fixture [`sweep_corpus`] discovers.
+#[test]
+fn evolve_pairing_holds_for_every_action_in_the_domain_corpus() {
+    let mut checked_any_model = false;
+    let mut findings = Vec::new();
+    for path in sweep_corpus() {
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(SurfaceDocument::Domain(domain)) = parse_surface_document(&source) else {
+            continue;
+        };
+
+        if let Ok(kernel) = lower_domain(&domain)
+            && let Ok(model) = build_model(kernel)
+        {
+            checked_any_model = true;
+            findings.extend(
+                check_evolve_pairing(&domain, &model)
+                    .into_iter()
+                    .map(|finding| format!("{} (path A, lower_domain): {finding}", path.display())),
+            );
+        }
+
+        if let Ok(text) = domain_kernel_source(&domain)
+            && let Ok(kernel) = parse_kernel_source(&text, &FsResolver::new("."))
+            && let Ok(model) = build_model(kernel)
+        {
+            checked_any_model = true;
+            findings.extend(
+                check_evolve_pairing(&domain, &model)
+                    .into_iter()
+                    .map(|finding| {
+                        format!(
+                            "{} (path B, domain_kernel_source): {finding}",
+                            path.display()
+                        )
+                    }),
+            );
+        }
+    }
+
+    assert!(
+        checked_any_model,
+        "the #779 sweep corpus glob (examples/domain/, \
+         rust/fslc/tests/fixtures/domain_characterization/, \
+         examples/annotations/annotated_domain.fsl) produced zero lowerable \
+         domain kernel models; the glob paths themselves are probably wrong"
+    );
+    assert!(
+        findings.is_empty(),
+        "evolve pairing invariant violated in the domain corpus:\n{}",
+        findings.join("\n")
+    );
+}

--- a/rust/fsl-core/tests/domain_saga_evolve_pairing.rs
+++ b/rust/fsl-core/tests/domain_saga_evolve_pairing.rs
@@ -56,42 +56,51 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// `.fsl` files directly under `dir` (non-recursive), sorted for
-/// deterministic test output.
-fn fsl_files_in(dir: &Path) -> Vec<PathBuf> {
+/// Every `.fsl` file anywhere under `dir` (recursive), collected into `out`.
+/// Deliberately the same breadth `domain_render_agreement.rs`'s
+/// `walk_fsl_files`/`discover_domain_fixtures` use for its own corpus
+/// discovery: a narrower walk here silently exempts part of the domain
+/// fixture corpus from this sweep. #779's independent review caught exactly
+/// that gap in an earlier version of this file (only `examples/domain/` and
+/// `rust/fslc/tests/fixtures/domain_characterization/` were walked, so
+/// `rust/fslc/tests/fixtures/` files sitting outside `domain_characterization/`
+/// -- including `domain_saga_compensation_dual_guard.fsl`, which has a saga
+/// compensation action and, at the time, an unfixed instance of this exact
+/// evolve-pairing defect -- were never swept).
+fn walk_fsl_files(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
-        return Vec::new();
+        return;
     };
-    let mut files = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|ext| ext == "fsl"))
-        .collect::<Vec<_>>();
-    files.sort();
-    files
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_fsl_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "fsl") {
+            out.push(path);
+        }
+    }
 }
 
-/// The #779 sweep corpus: every `.fsl` file under `examples/domain/` and
-/// `rust/fslc/tests/fixtures/domain_characterization/`, plus
-/// `examples/annotations/annotated_domain.fsl`. This is a glob, not a
-/// manually maintained registration list like
-/// `domain_render_agreement.rs`'s `VALID_DOMAIN_FIXTURES` (that list exists
-/// for a different purpose: pinning each fixture's *expected* A/B agreement
-/// outcome one by one). Per #779, this sweep must keep covering new domain
-/// fixtures automatically as they are added, without a second list to
-/// remember to update -- files that fail to parse as a `domain` document,
-/// or that fail to lower on a given path (several
-/// `domain_characterization/` fixtures are deliberately-invalid negative
-/// controls for other gates), are skipped for that path rather than
-/// failing this test; this sweep only asserts the pairing invariant over
-/// successfully produced kernel models.
+/// The #779 sweep corpus: every `.fsl` file anywhere under `examples/` and
+/// `rust/fslc/tests/fixtures/` -- the same two roots, walked with the same
+/// recursion, `domain_render_agreement.rs`'s `corpus_discovery_matches_registered_classification`
+/// uses to find every domain fixture in the repository. This is a glob, not
+/// a manually maintained registration list like that file's
+/// `VALID_DOMAIN_FIXTURES` (which exists for a different purpose: pinning
+/// each fixture's *expected* A/B agreement outcome one by one). Per #779,
+/// this sweep must keep covering new domain fixtures automatically as they
+/// are added, without a second list to remember to update -- files that do
+/// not parse as a `domain` document, or that fail to lower on a given path
+/// (several fixtures under `rust/fslc/tests/fixtures/` are
+/// deliberately-invalid negative controls for other gates), are skipped for
+/// that path rather than failing this test; this sweep only asserts the
+/// pairing invariant over successfully produced kernel models.
 fn sweep_corpus() -> Vec<PathBuf> {
     let root = repo_root();
-    let mut files = fsl_files_in(&root.join("examples/domain"));
-    files.extend(fsl_files_in(
-        &root.join("rust/fslc/tests/fixtures/domain_characterization"),
-    ));
-    files.push(root.join("examples/annotations/annotated_domain.fsl"));
+    let mut files = Vec::new();
+    walk_fsl_files(&root.join("examples"), &mut files);
+    walk_fsl_files(&root.join("rust/fslc/tests/fixtures"), &mut files);
+    files.sort();
     files
 }
 

--- a/rust/fslc/tests/domain_codegen_contract.rs
+++ b/rust/fslc/tests/domain_codegen_contract.rs
@@ -175,9 +175,18 @@ fn all_five_public_kernel_domain_targets_match_pre_migration_goldens() {
 
 #[test]
 fn domain_testgen_adapter_and_effects_match_the_typestate_contract_golden() {
+    // #779 intentionally regenerated this golden: with the fix, the saga
+    // capture-payment timeout action now applies `PaymentTimedOut`'s
+    // declared `evolve { status = Failed }` in the same action that sets
+    // its event flag, instead of leaving `Order.status` frozen at
+    // `Approved` after the timeout. `domain testgen`'s scenario exploration
+    // picks a different, now-correct trace through the widened reachable
+    // state space as a result (reviewed diff: pre-fix scenarios show
+    // `Order.status: "Status_Approved"` surviving `event.PaymentTimedOut:
+    // true`; post-fix scenarios correctly show `"Status_Failed"`).
     assert_eq!(
         domain_testgen_digest(),
-        "334724c8b917a5789eacfeb9076b6d7ab10c5d994880954ba404708e7908a76f"
+        "162a3acd293591147d84dff8a57c4b27038557ebcfdd02c9b938c91a58b6dbf3"
     );
 }
 

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -2417,6 +2417,18 @@
                 false
               ],
               "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Approved"
+              ],
+              "<location>"
             ]
           ],
           "ensures": [],
@@ -2505,6 +2517,18 @@
               [
                 "bool",
                 true
+              ],
+              "<location>"
+            ],
+            [
+              "assign",
+              [
+                "var",
+                "order_status"
+              ],
+              [
+                "var",
+                "Status_Failed"
               ],
               "<location>"
             ]
@@ -7101,6 +7125,49 @@
                 },
                 "value": false
               }
+            },
+            {
+              "kind": "assign",
+              "type": {
+                "kind": "statement"
+              },
+              "span": {
+                "file": "effect_saga_valid.fsl",
+                "line": 32,
+                "column": 31,
+                "end_line": 32,
+                "end_column": 48
+              },
+              "target": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 32,
+                  "column": 31,
+                  "end_line": 32,
+                  "end_column": 48
+                },
+                "name": "order_status"
+              },
+              "value": {
+                "kind": "var",
+                "type": {
+                  "kind": "named",
+                  "name": "Status"
+                },
+                "span": {
+                  "file": "effect_saga_valid.fsl",
+                  "line": 32,
+                  "column": 31,
+                  "end_line": 32,
+                  "end_column": 48
+                },
+                "name": "Status_Approved"
+              }
             }
           ],
           "origin": {
@@ -7792,7 +7859,181 @@
             "saga_payment_flow_capture_timeout": true
           },
           "deadlock": {
-            "found": false
+            "found": true,
+            "at_step": 2,
+            "trace": [
+              {
+                "step": 0,
+                "state": {
+                  "capture_payment_attempts": {
+                    "0": 0,
+                    "1": 0
+                  },
+                  "capture_payment_status": {
+                    "0": "CapturePaymentEffectStatus_NotStarted",
+                    "1": "CapturePaymentEffectStatus_NotStarted"
+                  },
+                  "event_Approved": false,
+                  "event_PaymentCaptured": false,
+                  "event_PaymentFailed": false,
+                  "event_PaymentRequested": false,
+                  "event_PaymentTimedOut": false,
+                  "order_status": "Status_Draft"
+                }
+              },
+              {
+                "step": 1,
+                "state": {
+                  "capture_payment_attempts": {
+                    "0": 0,
+                    "1": 0
+                  },
+                  "capture_payment_status": {
+                    "0": "CapturePaymentEffectStatus_NotStarted",
+                    "1": "CapturePaymentEffectStatus_NotStarted"
+                  },
+                  "event_Approved": true,
+                  "event_PaymentCaptured": false,
+                  "event_PaymentFailed": false,
+                  "event_PaymentRequested": false,
+                  "event_PaymentTimedOut": false,
+                  "order_status": "Status_Approved"
+                },
+                "action": {
+                  "name": "Approve",
+                  "generated_name": "order_approve",
+                  "origin": {
+                    "identity": "domain:DomainEffectSagaCharacterization/aggregate/Order/decide/Approve:687:693:22:5",
+                    "dialect": "domain",
+                    "primary": {
+                      "source_file": "rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl",
+                      "span": {
+                        "start": {
+                          "offset": 687,
+                          "line": 22,
+                          "column": 5
+                        },
+                        "end": {
+                          "offset": 693,
+                          "line": 22,
+                          "column": 11
+                        }
+                      },
+                      "dialect": "domain",
+                      "declaration_path": [
+                        "DomainEffectSagaCharacterization",
+                        "aggregate",
+                        "Order",
+                        "decide",
+                        "Approve"
+                      ]
+                    },
+                    "secondary": [
+                      {
+                        "source_file": "rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl",
+                        "span": {
+                          "start": {
+                            "offset": 305,
+                            "line": 13,
+                            "column": 5
+                          },
+                          "end": {
+                            "offset": 312,
+                            "line": 13,
+                            "column": 12
+                          }
+                        },
+                        "dialect": "domain",
+                        "declaration_path": [
+                          "DomainEffectSagaCharacterization",
+                          "aggregate",
+                          "Order",
+                          "command",
+                          "Approve"
+                        ]
+                      }
+                    ],
+                    "lowering_steps": [
+                      {
+                        "kind": "lower_decision_to_action",
+                        "detail": null
+                      }
+                    ],
+                    "generated": true
+                  },
+                  "params": {},
+                  "loc": {
+                    "line": 22,
+                    "column": 5
+                  }
+                },
+                "changes": {
+                  "event_Approved": {
+                    "from": false,
+                    "to": true
+                  },
+                  "order_status": {
+                    "from": "Status_Draft",
+                    "to": "Status_Approved"
+                  }
+                }
+              },
+              {
+                "step": 2,
+                "state": {
+                  "capture_payment_attempts": {
+                    "0": 0,
+                    "1": 0
+                  },
+                  "capture_payment_status": {
+                    "0": "CapturePaymentEffectStatus_NotStarted",
+                    "1": "CapturePaymentEffectStatus_NotStarted"
+                  },
+                  "event_Approved": false,
+                  "event_PaymentCaptured": false,
+                  "event_PaymentFailed": false,
+                  "event_PaymentRequested": false,
+                  "event_PaymentTimedOut": true,
+                  "order_status": "Status_Failed"
+                },
+                "action": {
+                  "name": "saga_payment_flow_capture_timeout",
+                  "generated_name": "saga_payment_flow_capture_timeout",
+                  "origin": {
+                    "identity": "domain:generated:action:saga_payment_flow_capture_timeout",
+                    "dialect": "domain",
+                    "primary": null,
+                    "secondary": [],
+                    "lowering_steps": [
+                      {
+                        "kind": "generated",
+                        "detail": null
+                      }
+                    ],
+                    "generated": true
+                  },
+                  "params": {},
+                  "loc": {
+                    "line": 52,
+                    "column": 5
+                  }
+                },
+                "changes": {
+                  "event_Approved": {
+                    "from": true,
+                    "to": false
+                  },
+                  "event_PaymentTimedOut": {
+                    "from": false,
+                    "to": true
+                  },
+                  "order_status": {
+                    "from": "Status_Approved",
+                    "to": "Status_Failed"
+                  }
+                }
+              }
+            ]
           },
           "versions": {
             "verifier": {

--- a/rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl
+++ b/rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl
@@ -1,0 +1,136 @@
+domain Issue779SagaEmitEvolveNegativeControls {
+  // SPDX-License-Identifier: Apache-2.0
+  //
+  // #779 negative controls. This fixture is `examples/domain/order_fulfillment_saga.fsl`
+  // plus three invariants that exist ONLY to witness the fix and must NOT be added to the
+  // corpus example itself (#772: a "dead value is never reached" invariant would fossilize
+  // the pre-#779 defect as intended behavior instead of stating protocol intent).
+  //
+  // - `inventoryNeverReservationPending` / `paymentNeverPaymentPending`: before #779 these are
+  //   `proved` under `--engine induction` because the saga step/timeout/compensation actions
+  //   never apply their declared `evolve`, so `ReservationPending`/`PaymentPending` are
+  //   unreachable. After #779 they must flip to `violated` (reachable via
+  //   approve -> reserve_inventory / -> capture_payment).
+  // - `inventoryNeverReleaseRequested`: must stay `proved` both before and after #779. The
+  //   compensation action's one-hot dual guard (`requires event_PaymentFailed` and
+  //   `requires event_InventoryReserved`, mutually exclusive one-hot flags) keeps it
+  //   structurally unreachable until #679 changes the guard shape. #779 only adds the missing
+  //   `evolve` call and must not touch that guard.
+  implementation_profile functional_ddd
+
+  enum OrderStatus { Pending, Approved, Cancelled }
+  enum InventoryStatus { NotRequested, ReservationPending, Reserved, Failed, ReleaseRequested }
+  enum PaymentStatus { NotRequested, PaymentPending, Captured, Failed, TimedOut }
+
+  aggregate Order {
+    id OrderId
+
+    state {
+      status: OrderStatus = Pending;
+      inventory_status: InventoryStatus = NotRequested;
+      payment_status: PaymentStatus = NotRequested;
+    }
+
+    command ApproveOrder {}
+
+    event OrderApproved {}
+    event InventoryReservationRequested {}
+    event InventoryReserved {}
+    event InventoryReservationFailed {}
+    event PaymentCaptureRequested { payment_request_id: PaymentRequestId }
+    event PaymentCaptured { payment_request_id: PaymentRequestId }
+    event PaymentFailed { payment_request_id: PaymentRequestId }
+    event PaymentCaptureTimedOut { payment_request_id: PaymentRequestId }
+    event ShipmentRequested {}
+    event InventoryReleaseRequested {}
+
+    decide ApproveOrder {
+      requires status == Pending
+      emits OrderApproved
+    }
+
+    evolve OrderApproved {
+      status = Approved
+    }
+
+    evolve InventoryReservationRequested {
+      inventory_status = ReservationPending
+    }
+
+    evolve InventoryReserved {
+      inventory_status = Reserved
+    }
+
+    evolve InventoryReservationFailed {
+      inventory_status = Failed
+    }
+
+    evolve PaymentCaptureRequested {
+      payment_status = PaymentPending
+    }
+
+    evolve PaymentCaptured {
+      payment_status = Captured
+    }
+
+    evolve PaymentFailed {
+      payment_status = Failed
+    }
+
+    evolve PaymentCaptureTimedOut {
+      payment_status = TimedOut
+    }
+
+    evolve ShipmentRequested {
+      status = Approved
+    }
+
+    evolve InventoryReleaseRequested {
+      inventory_status = ReleaseRequested
+    }
+
+    invariant inventoryNeverReservationPending {
+      inventory_status != ReservationPending
+    }
+
+    invariant paymentNeverPaymentPending {
+      payment_status != PaymentPending
+    }
+
+    invariant inventoryNeverReleaseRequested {
+      inventory_status != ReleaseRequested
+    }
+  }
+
+  saga OrderFulfillment {
+    starts_on OrderApproved
+    outbox OrderOutbox
+    inbox FulfillmentInbox
+
+    step ReserveInventory {
+      async
+      emits InventoryReservationRequested
+      awaits one_of [InventoryReserved, InventoryReservationFailed]
+      timeout after 5m emits InventoryReservationFailed
+    }
+
+    step CapturePayment {
+      async
+      requires InventoryReserved
+      emits PaymentCaptureRequested
+      awaits one_of [PaymentCaptured, PaymentFailed, PaymentCaptureTimedOut]
+      timeout after 10m emits PaymentCaptureTimedOut
+    }
+
+    step ShipOrder {
+      requires PaymentCaptured
+      emits ShipmentRequested
+    }
+
+    compensation {
+      when PaymentFailed after InventoryReserved {
+        emits InventoryReleaseRequested
+      }
+    }
+  }
+}

--- a/rust/fslc/tests/issue_727_mutate_domain_rendered_kernel.rs
+++ b/rust/fslc/tests/issue_727_mutate_domain_rendered_kernel.rs
@@ -135,18 +135,31 @@ fn mutate_domain_positive_oracle_kills_capture_payment_success_sticky() {
 /// would then be reporting evidence without a working evidence channel.
 #[test]
 fn mutate_domain_negative_control_saga_compensation_dead_at_baseline() {
+    // #779 adds a new mutable evolve assignment to the compensation action
+    // itself (`order_inventory_status = InventoryStatus_ReleaseRequested`)
+    // in addition to the five other saga step/timeout actions the fix
+    // touches, growing the uncapped mutant count from 198 to 226. At the
+    // default 200-mutant cap this pushed the entire compensation-targeting
+    // mutant set (this test's own load-bearing evidence) past the cap and
+    // out of the report, so `--max-mutants` is raised here to a value
+    // comfortably above 226 to keep this test's actual subject --
+    // compensation mutants -- present to assert on; T1
+    // (`mutate_domain_positive_oracle_kills_capture_payment_success_sticky`,
+    // a different fixture) still exercises the untouched default cap path.
     let (output, status) = run(&[
         "mutate",
         "examples/domain/order_fulfillment_saga.fsl",
         "--depth",
         "4",
+        "--max-mutants",
+        "300",
     ]);
     assert_eq!(status, 0, "{output:#}");
     assert_eq!(output["result"], "mutated", "{output:#}");
-    assert_eq!(output["summary"]["total"], 198, "{}", output["summary"]);
+    assert_eq!(output["summary"]["total"], 226, "{}", output["summary"]);
     assert_eq!(output["summary"]["killed"], 3, "{}", output["summary"]);
     assert_eq!(
-        output["summary"]["kill_rate"], 0.0152,
+        output["summary"]["kill_rate"], 0.0133,
         "{}",
         output["summary"]
     );
@@ -162,8 +175,10 @@ fn mutate_domain_negative_control_saga_compensation_dead_at_baseline() {
         .collect::<Vec<_>>();
     assert_eq!(
         compensation_mutants.len(),
-        14,
-        "expected 14 compensation-targeting mutants, output={output:#}"
+        19,
+        "expected 19 compensation-targeting mutants (14 pre-#779, plus 5 new \
+         mutants from the compensation action's now-applied evolve \
+         assignment), output={output:#}"
     );
     for mutant in &compensation_mutants {
         assert_eq!(

--- a/rust/fslc/tests/issue_779_saga_emit_evolve.rs
+++ b/rust/fslc/tests/issue_779_saga_emit_evolve.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! #779: a saga step/timeout/compensation action that emits an event must
+//! apply that event's declared `evolve` in the same action. Before this
+//! fix, `lower_saga_actions` (`domain_lowering.rs`) and
+//! `render_saga_actions` (`domain.rs`) called `event_assignments` for a
+//! step/timeout/compensation action but never `evolve_items`
+//! (`saga_emit_evolve`/`saga_emit_evolve_lines` after the fix), so the
+//! event's one-hot flag flipped true while the aggregate state it was
+//! declared to evolve stayed frozen at its initial value forever.
+//!
+//! `rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl`
+//! is `examples/domain/order_fulfillment_saga.fsl` plus three invariants
+//! that exist only to witness the fix (see the fixture's own header comment
+//! for why they are not added to the corpus example itself: #772).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use fsl_core::domain_kernel_source;
+use fsl_syntax::{SurfaceDocument, parse_surface_document};
+use serde_json::Value;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("rust/ directory")
+        .parent()
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(args: &[&str]) -> (i32, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .current_dir(repo_root())
+        .args(args)
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse CLI JSON for {args:?}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (output.status.code().expect("fslc exit code"), value)
+}
+
+const FIXTURE: &str = "rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl";
+
+/// Flip control 1 (mandated by #779, evidenced pre-fix via `git stash` on
+/// `rust/fsl-core/src/domain_lowering.rs`/`domain.rs`/`lib.rs`:
+/// `--engine induction --property Order_inventoryNeverReservationPending`
+/// reports `"proved"` before this fix, because
+/// `saga_order_fulfillment_reserve_inventory` sets
+/// `event_InventoryReservationRequested := true` without ever writing
+/// `order_inventory_status`, so `ReservationPending` is unreachable by
+/// construction). After the fix it must flip to `"violated"`, reachable via
+/// `order_approve_order` -> `saga_order_fulfillment_reserve_inventory`.
+#[test]
+fn inventory_reservation_pending_flips_to_violated() {
+    let (status, output) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--engine",
+        "induction",
+        "--property",
+        "Order_inventoryNeverReservationPending",
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated", "{output:#}");
+}
+
+/// Flip control 2 (mandated by #779): same shape as control 1, for the
+/// independent `PaymentCaptureRequested` evolve
+/// (`saga_order_fulfillment_capture_payment`). Proved pre-fix, must flip to
+/// violated post-fix, reachable via `order_approve_order` ->
+/// `saga_order_fulfillment_reserve_inventory` ->
+/// `saga_order_fulfillment_observe_inventory_reserved` ->
+/// `saga_order_fulfillment_capture_payment`.
+#[test]
+fn payment_pending_flips_to_violated() {
+    let (status, output) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--engine",
+        "induction",
+        "--property",
+        "Order_paymentNeverPaymentPending",
+    ]);
+    assert_eq!(status, 1, "{output:#}");
+    assert_eq!(output["result"], "violated", "{output:#}");
+}
+
+/// Non-flip control (mandated by #779, "the control that must NOT flip"):
+/// `inventory_status != ReleaseRequested` must stay `"proved"` both before
+/// and after this fix. The compensation action's one-hot dual guard
+/// (`requires event_PaymentFailed` and `requires event_InventoryReserved`,
+/// mutually exclusive one-hot flags under `#713`/PR #725's dual guard) keeps
+/// `InventoryReleaseRequested` structurally unreachable until #679 changes
+/// the guard shape; #779 only adds the missing `evolve` call and must not
+/// touch that guard. Without this control, a fix that (wrongly) also
+/// loosened the compensation guard would not be caught by the two flip
+/// controls above.
+///
+/// `--k 2` (rather than the default `--k 1`): post-fix, the two newly
+/// reachable evolves (`ReservationPending`, `PaymentPending`) widen the
+/// aggregate's reachable state space (#679's design-authority ruling on
+/// this issue: 825 states after #779, static upper bound), so `k=1`
+/// induction can no longer discharge this property on its own
+/// (`unknown_cti`) even though it is still true; `k=2` proves it. This is
+/// expected induction-depth growth from the state space widening the fix
+/// itself causes, not a guard change -- verified directly: pre-fix, `k=1`
+/// alone already proves this property (smaller reachable set); post-fix,
+/// `k=1` returns `unknown_cti` and `k=2` returns `proved`.
+#[test]
+fn inventory_release_requested_stays_proved() {
+    let (status, output) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--engine",
+        "induction",
+        "--property",
+        "Order_inventoryNeverReleaseRequested",
+        "--k",
+        "2",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "proved", "{output:#}");
+}
+
+/// Positive structural evidence on the real corpus example (not the
+/// fixture): rendering `examples/domain/order_fulfillment_saga.fsl` through
+/// `domain_kernel_source` (path B -- the same renderer `domain expand` and
+/// `check_domain` use in production) must show every one of the six
+/// previously-broken saga step/timeout/compensation actions writing the
+/// aggregate state its emitted event's declared `evolve` names, in the same
+/// action block that sets the event flag.
+#[test]
+fn order_fulfillment_saga_expand_applies_every_saga_emit_evolve() {
+    let source_path = repo_root().join("examples/domain/order_fulfillment_saga.fsl");
+    let text = std::fs::read_to_string(&source_path).expect("read order_fulfillment_saga.fsl");
+    let SurfaceDocument::Domain(domain) =
+        parse_surface_document(&text).expect("parse order_fulfillment_saga.fsl")
+    else {
+        panic!("expected a domain document");
+    };
+    let source = domain_kernel_source(&domain).expect("render order_fulfillment_saga.fsl");
+
+    let expectations: &[(&str, &str)] = &[
+        (
+            "action saga_order_fulfillment_reserve_inventory(",
+            "order_inventory_status = InventoryStatus_ReservationPending",
+        ),
+        (
+            "action saga_order_fulfillment_reserve_inventory_timeout(",
+            "order_inventory_status = InventoryStatus_Failed",
+        ),
+        (
+            "action saga_order_fulfillment_capture_payment(",
+            "order_payment_status = PaymentStatus_PaymentPending",
+        ),
+        (
+            "action saga_order_fulfillment_capture_payment_timeout(",
+            "order_payment_status = PaymentStatus_TimedOut",
+        ),
+        (
+            "action saga_order_fulfillment_ship_order(",
+            "order_status = OrderStatus_Approved",
+        ),
+        (
+            "action saga_order_fulfillment_compensate_payment_failed_after_inventory_reserved(",
+            "order_inventory_status = InventoryStatus_ReleaseRequested",
+        ),
+    ];
+
+    for (action_header, expected_assignment) in expectations {
+        let block_start = source.find(action_header).unwrap_or_else(|| {
+            panic!("rendered kernel is missing action block '{action_header}': {source}")
+        });
+        let block_end = source[block_start..]
+            .find('}')
+            .map(|offset| block_start + offset)
+            .expect("action block must close");
+        let block = &source[block_start..block_end];
+        assert!(
+            block.contains(expected_assignment),
+            "action block '{action_header}' is missing '{expected_assignment}': {block}"
+        );
+    }
+}

--- a/rust/fslc/tests/issue_779_saga_emit_evolve.rs
+++ b/rust/fslc/tests/issue_779_saga_emit_evolve.rs
@@ -102,16 +102,35 @@ fn payment_pending_flips_to_violated() {
 /// loosened the compensation guard would not be caught by the two flip
 /// controls above.
 ///
-/// `--k 2` (rather than the default `--k 1`): post-fix, the two newly
-/// reachable evolves (`ReservationPending`, `PaymentPending`) widen the
-/// aggregate's reachable state space (#679's design-authority ruling on
-/// this issue: 825 states after #779, static upper bound), so `k=1`
-/// induction can no longer discharge this property on its own
-/// (`unknown_cti`) even though it is still true; `k=2` proves it. This is
-/// expected induction-depth growth from the state space widening the fix
-/// itself causes, not a guard change -- verified directly: pre-fix, `k=1`
-/// alone already proves this property (smaller reachable set); post-fix,
-/// `k=1` returns `unknown_cti` and `k=2` returns `proved`.
+/// `--k 2` (rather than the default `--k 1`): **not** induction-depth
+/// growth from a widened reachable state space (an earlier version of this
+/// comment claimed that; #779's independent review traced the actual `k=1`
+/// counterexample-to-induction and found it wrong). The real mechanism:
+///
+/// - **Pre-fix**, no action in the model could ever assign
+///   `order_inventory_status = ReleaseRequested` at all (the compensation
+///   action's `evolve` call was the exact thing missing), so the property
+///   was **vacuously** inductive at `k=1` -- there was no candidate
+///   transition for induction to even examine, let alone rule out. `k=1`
+///   `proved` pre-fix carried none of the "dual one-hot guard is
+///   unsatisfiable" evidence the control is meant to provide.
+/// - **Post-fix**, the compensation action's evolve now assigns that value
+///   for the first time, so induction must actually prove the one-hot
+///   `event_PaymentFailed`/`event_InventoryReserved` dual guard can never
+///   both hold -- and a single step of induction is not enough: the `k=1`
+///   counterexample-to-induction is the two-event one-hot state
+///   `{event_InventoryReserved: true, event_PaymentFailed: true,
+///   inventory_status: NotRequested}` stepping through the compensation
+///   action to `ReleaseRequested`, which is itself unreachable (one-hot
+///   flags are mutually exclusive) but `k=1` induction cannot rule out
+///   without a second step's history. `k=2` supplies that and proves it.
+///
+/// This makes the control **strictly stronger** than before, not weaker:
+/// pre-fix, `k=1` *and* `k=2` both trivially `proved` (vacuously,
+/// regardless of the guard), so the property carried near-zero evidentiary
+/// value. Post-fix `k=2` `proved` is the first point at which this property
+/// actually witnesses "the one-hot dual guard is structurally
+/// unsatisfiable" -- which is precisely the fact #679 must preserve.
 #[test]
 fn inventory_release_requested_stays_proved() {
     let (status, output) = run_cli(&[


### PR DESCRIPTION
## Problem

A saga step, timeout, or compensation action that emits an event left that event's declared
`evolve` unapplied. The event's one-hot `event_<Event>` flag flipped `true`, but the aggregate
state that event was declared to evolve stayed frozen at its initial value forever.

`fslc domain expand examples/domain/order_fulfillment_saga.fsl` showed the asymmetry directly:
`saga_order_fulfillment_reserve_inventory` set `event_InventoryReservationRequested = true` but
never wrote `order_inventory_status`, even though the aggregate declares
`evolve InventoryReservationRequested { inventory_status = ReservationPending }`. Six saga
step/timeout/compensation actions had this gap; the five saga-observe actions and the one command
action did not — this file's own observe path already called the paired evolve helper correctly.

Formally: `inventory_status != ReservationPending` was **`proved`** under
`fslc verify --engine induction`, meaning the declared transition was provably unreachable —
an accepted-but-unreachable construct, the soundness-defect class `AGENTS.md` and PR #725 (#713)
already established for the saga compensation guard.

## Pairing invariant (the fix)

> An `evolve` is 1:1 with the *occurrence* of its event. An action that raises `event_<E> := true`
> must apply E's declared `evolve` assignments in the same action, in emit order, if the domain
> declares one for E.

Command/decide, effect-completion, and saga-observe actions already followed this. Saga
step/timeout/compensation actions did not: they called the shared `event_assignments` helper but
never the paired `evolve_items` (path A) / `evolve_assignments` (path B) call.

**Origin**: a shared gap from the frozen Python reference (`src/fslc/domain_expand.py`), where
command/effect-request/saga-observe call `_evolve_assignments` but saga step/timeout/compensation
call only `_event_flag_assignments`. Native both paths inherited it faithfully. Fix is native-only;
the frozen Python reference is unchanged (precedent: PR #725).

### Both lowering paths fixed

- **Path A** (`rust/fsl-core/src/domain_lowering.rs`, `lower_saga_actions`): added a
  `Resolver::saga_emit_evolve(loc, events)` helper that, for each emitted event, resolves its
  aggregate, builds a scope (aggregate state + the event's own fields, matching the pattern
  `lower_saga_actions`'s own observe-action loop already used), and calls `evolve_items`. Called
  from the step, timeout, and compensation action builders, merging both the produced `ActionItem`s
  and the evolve's `Annotations` into each action.
- **Path B** (`rust/fsl-core/src/domain.rs`, `render_saga_actions`): added the equivalent
  `saga_emit_evolve_lines(context, events)` free function and called it from the same three sites.

`event_flag`/`state_name` (the two naming-convention functions `domain_lowering.rs` already used to
compute a kernel event-flag/state-variable name from a domain event/field) are now `pub` and
re-exported from `fsl-core`, so the structural sweep test (below) can compute "which kernel
variable does event E's flag/evolve target correspond to" from the `DomainSpec` alone, instead of
guessing from generated names.

### Edge case: an event in both `emits` and `awaits`

If the same event appears in a step's `emits` and (its own or a later step's) `awaits`, the evolve
now applies twice — once at emit, once at observe/completion. This is the correct event-sourcing
reading (evolve-application count = `event_assignments`-execution count = occurrence count), not a
bug; no special-casing was added.

## Negative controls (fixture only, not corpus — see #772)

`rust/fslc/tests/fixtures/issue_779_saga_emit_evolve_negative_controls.fsl` is
`examples/domain/order_fulfillment_saga.fsl` plus three invariants that exist only to witness the
fix. They are **not** added to the corpus example itself: a "dead value is never reached" invariant
would fossilize the pre-#779 defect as intended behavior and self-invalidate the moment the fix
lands (#772 is blocked on this issue for exactly that reason).

Measured against the true pre-fix baseline (`rust/fsl-core/src/{domain.rs,domain_lowering.rs,lib.rs}`
swapped to their content at the branch point, `1050a76`, then restored):

| Invariant | Pre-fix | Post-fix |
|---|---|---|
| `inventory_status != ReservationPending` (flip) | `proved` (k=1) | **`violated`** — reachable via `order_approve_order` → `reserve_inventory` |
| `payment_status != PaymentPending` (flip) | `proved` (k=1) | **`violated`** — reachable via … → `capture_payment` |
| `inventory_status != ReleaseRequested` (must NOT flip) | `proved` (k=1 **and** k=2) | **`proved`, but only at k=2** — k=1 now returns `unknown_cti` |

**The non-flip control's `k=2` requirement, corrected** (an earlier version of this PR wrongly
attributed it to "state-space growth induction-depth needs"; independent review traced the actual
`k=1` counterexample-to-induction and found that explanation wrong). The real mechanism:

- **Pre-fix**, no action in the model could ever assign `order_inventory_status = ReleaseRequested`
  at all — the compensation action's `evolve` call was the exact thing missing — so the property
  was **vacuously** inductive at both `k=1` and `k=2`: there was no candidate transition for
  induction to even examine, let alone rule out. Pre-fix `proved` carried none of the "the dual
  one-hot guard is unsatisfiable" evidence this control is meant to provide, at *either* k.
- **Post-fix**, the compensation action's evolve assigns that value for the first time, so
  induction must actually prove the one-hot `event_PaymentFailed`/`event_InventoryReserved` dual
  guard can never both hold. `k=1`'s counterexample-to-induction is the (unreachable, but not yet
  disproved at one step) two-event one-hot state
  `{event_InventoryReserved: true, event_PaymentFailed: true, inventory_status: NotRequested}`
  stepping through the compensation action to `ReleaseRequested`; `k=2` supplies the extra step of
  history needed to rule that state out and proves the property.

This makes the control **strictly stronger** than before, not weaker: pre-fix, `k=1` and `k=2` both
trivially `proved` regardless of the guard, so the property carried near-zero evidentiary value.
Post-fix `k=2` `proved` is the first point at which it actually witnesses "the one-hot dual guard is
structurally unsatisfiable" — the fact #679 must preserve. The compensation action's two `requires`
clauses (trigger + after-event one-hot flags) are byte-for-byte unchanged by this diff; this fix
only adds the missing evolve call.

The non-flip control matters because the compensation action's dual one-hot guard is structurally
disabled until #679 changes the guard shape (`docs/DESIGN-domain.md`'s accepted interim boundary,
"never-enabled warning stays until #679"); a fix that accidentally loosened that guard would not be
caught by the two flip controls alone. The existing `domain_compensation_guard.rs`
`order_fulfillment_saga_verify_surfaces_never_enabled_compensation_warning` test (unmodified) still
passes, confirming the warning survives.

`rust/fslc/tests/issue_779_saga_emit_evolve.rs` also asserts the positive structural evidence
directly on the real corpus file: rendering `order_fulfillment_saga.fsl` through
`domain_kernel_source` shows all six previously-broken actions now writing the state their emitted
event's evolve names, in the same action block.

## Structural control: corpus-wide evolve-pairing sweep

`rust/fsl-core/tests/domain_saga_evolve_pairing.rs` — `fn check_evolve_pairing(domain: &DomainSpec,
model: &KernelModel)`, walking **every action in every domain fixture's kernel model on both
lowering paths**: any action that sets `event_<E> := true` must also write every kernel state
variable `E`'s declared evolve names, in the same action. Fixed at this signature per design
authority: "E's declared evolve" only exists on the `DomainSpec` surface (kernel models have no
`evolve` concept), so a hand-written kernel spec cannot be passed in — that is a scope boundary of
the input types, not an oversight. Event-flag/state-variable names are computed via
`fsl_core::event_flag`/`fsl_core::state_name` (the same functions the lowering code itself uses),
never guessed from an `event_` name prefix.

**Corpus breadth, corrected during independent review.** An earlier version of this sweep only
walked `examples/domain/` and `rust/fslc/tests/fixtures/domain_characterization/`, narrower than
`domain_render_agreement.rs`'s own corpus discovery (`examples/` and `rust/fslc/tests/fixtures/`,
both recursive). That gap was real, not cosmetic: `rust/fslc/tests/fixtures/domain_saga_compensation_dual_guard.fsl`
(outside `domain_characterization/`) has a saga compensation action with a declared `evolve` and,
in the sweep's pre-fix state, an actual unfixed instance of this exact defect
(`domain expand` diff: `order_released = true` only appears post-fix). The narrower sweep could not
have caught a future regression there. `sweep_corpus()` now walks the identical two roots with the
identical recursion `domain_render_agreement.rs` uses (`walk_fsl_files`), so both gates see the same
corpus by construction.

**Why total sweep, not a fixture spot check**: #679's PR-A rewrites the saga
step/timeout/resolve/compensate actions wholesale; a spot check on today's action shapes would
silently stop covering the rewritten code. This sweep is keyed only on "does this action set an
event flag true," so it keeps covering whatever actions PR-A produces without a second copy of the
judgment rule to maintain.

**Non-vacuity, measured with the corrected corpus breadth**: temporarily neutered
`saga_emit_evolve`/`saga_emit_evolve_lines` to return nothing (simulating the pre-fix behavior) and
reran the sweep — it failed, reporting all 6 broken actions in `order_fulfillment_saga.fsl`, 2 more
real instances in `rust/fslc/tests/fixtures/domain_characterization/effect_saga_valid.fsl`
(`saga_payment_flow_capture` / `saga_payment_flow_capture_timeout`), **and, with the widened corpus,
a 9th instance**: `domain_saga_compensation_dual_guard.fsl`'s
`saga_compensate_both_compensate_trigger_happened_after_after_happened` action. Reverted before
commit. Runs in 0.07s (fsl-core, no solver dependency) — no shard pinning needed.

## State-space impact

`examples/domain/order_fulfillment_saga.fsl --depth 4 --engine explicit`: `states_explored` went
from **87 (pre-fix) to 67 (post-fix)** — fewer, not more, distinct states. `verified`, no deadlock,
`depth_reached: 4` (not truncated). Independent review additionally confirmed both counts are
fixpoints at depth 8 and depth 12 (not a depth-4 truncation artefact), and that the pre-fix
consistent-state subset is a strict subset of the post-fix reachable set — no consistent state is
lost, and post-fix has zero inconsistent (two-or-more-event-flags-simultaneously-true) states.

This is investigated, not just observed: dumped the full reachable-state set (BFS via
`fsl_runtime::Monitor`) before and after the fix and diffed them. **37 states disappeared, 17 states
were added** (net −20 → 67; a first pass of this diff miscounted these as 38/18 from a
missing-trailing-newline artifact in the dump — corrected here). Every one of the 37 that
disappeared shares the identical signature: an event flag `event_<E> := true` (an action just
fired) paired with a state field frozen at a value inconsistent with `E`'s declared evolve — for
example, pre-fix-only state `event_ShipmentRequested: true, order_status: OrderStatus_Pending`
(the terminal `ship_order` action fired, but because its own `evolve ShipmentRequested { status =
Approved }` was never applied, the aggregate's own status field still claimed the order had never
even been approved). Post-fix, that same trace produces `order_status: OrderStatus_Approved`, which
now coincides with — merges into — the state a "properly approved" trace already reaches, so the
previously-distinct wrong-value fingerprint disappears. The 17 added states are genuinely new
combinations a frozen field previously prevented from being distinctly reached (e.g.
`inventory_status: Reserved, payment_status: PaymentPending, status: Approved`).

**"Reachable transitions are unchanged" (an earlier version of this PR) was too strong, corrected**:
no `requires` clause text was touched, but a guard reads state, so which actions are *enabled*
(effectively reachable) at a given point genuinely does change when the state that guard reads is
computed correctly instead of staying frozen. The `effect_saga_valid.fsl` deadlock below is exactly
that consequence: `decide RequestPayment`'s `requires status == Approved` becomes unsatisfiable once
the timeout action's evolve correctly moves `status` to `Failed`. The accurate claim is: no `requires`
*expression* was edited by this diff; guard *evaluation results* do change downstream of now-correct
state.

`rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json` (regenerated,
`UPDATE_DOMAIN_CHARACTERIZATION=1`, diff reviewed): `effect_saga_valid.fsl`'s characterization now
shows a **new deadlock** after `Approve` → `saga_payment_flow_capture_timeout`
(`order_status: Status_Failed`, no further enabled actions). Mechanism: `PaymentTimedOut`'s
now-applied `evolve { status = Failed }` correctly makes `Status_Failed` terminal (this minimal
fixture declares no recovery action from `Failed`), reached via a trace where the timeout fires
without `RequestPayment` ever having executed — `saga_guards` gives the timeout action the *same*
`requires` list as the step's main action, with nothing gating on the step's own request having
happened. **This timeout-guard looseness is not new and this fix does not touch it** (`requires`
clauses byte-for-byte unchanged); it is the same class of gap #679's accepted design closes.
Citation corrected during independent review: `docs/DESIGN-saga-history.md:41-43` — "Generated saga
step/timeout/compensation actions will take the correlation key, guard the relevant saga phase, and
update that key's phase" — is the accepted-design source for this, not a specific issue comment.
`docs/LANGUAGE.md:736` documents deadlock as a default-`warn` finding (`violated` only under
`--deadlock error`), consistent with this test's role (recording observed CLI output, not asserting
non-deadlock). `examples/domain/order_fulfillment_saga.fsl` itself has no deadlock (verified above)
— this is fixture-specific.

No new pin test was added for this deadlock in this PR (independent review suggested one, modeled on
#728's precedent — a pin whose failure message names #679 as the reason it can be removed). Left as
a suggested #679 follow-up rather than added here: the mechanism is already recorded
(`docs/DESIGN-saga-history.md:41-43`, this PR body, `baseline.v1.json`'s own `deadlock.found: true`),
and #679's PR-A already carries an ordering interlock with #728's existing pin test.

## Other golden/snapshot updates (reviewed, not hand-edited)

Two more pre-existing tests legitimately changed because the fix adds real, executable statements
to previously-inert code, widening what those tests measure:

- `rust/fslc/tests/domain_codegen_contract.rs`: `domain_testgen_adapter_and_effects_match_the_typestate_contract_golden`'s
  digest changed. Diffed the underlying `.test.ts` before/after: the only difference is that
  `PaymentTimedOut`'s now-applied evolve makes generated scenario exploration correctly show
  `Order.status: "Status_Failed"` after a timeout, instead of `"Status_Approved"` surviving it.
  Golden updated.
- `rust/fslc/tests/issue_727_mutate_domain_rendered_kernel.rs`
  (`mutate_domain_negative_control_saga_compensation_dead_at_baseline`): the fix's new evolve
  statements grow `order_fulfillment_saga.fsl`'s uncapped mutant count from 198 to 226. At the
  default 200-mutant cap this pushed the *entire* compensation-targeting mutant set — this test's
  actual subject — past the cap and out of the report. Raised `--max-mutants` to 300 (comfortably
  above 226) so the test again exercises its real subject; updated `total`/`kill_rate` (226/0.0133,
  `killed` unchanged at 3) and the compensation-mutant count (14 → 19, the 5 new ones from the
  compensation action's own now-applied evolve statement). **Re-verified after the cap change: all
  19 compensation mutants still survive, all still carry the exact `"action dead at baseline —
  survival expected"` note** — the compensation action is not enabled by this fix, matching the
  non-flip control above. `mutate_domain_positive_oracle_kills_capture_payment_success_sticky`
  (`order_async_effect.fsl`, T1, 200/14/0.07) is untouched and unaffected — that fixture has zero
  `saga` blocks, so this fix's lowering paths never execute against it.

## Docs

- `docs/DESIGN-domain.md`: states the evolve pairing invariant at the saga-step lowering bullet,
  names the origin/fix and the self-await double-application reading, and points at the sweep test.
- `docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md`: corrected the saga-step lowering description (kept
  1:1 section-aligned; `## ` heading count unchanged, `18` in both files) — previously silent on
  whether emit-side evolve is applied, which mirrored the bug in prose. Also fixed an adjacent
  redundant sentence and a stray line-wrap artifact (independent review, nit n4) and regenerated
  `docs/intro/language.{en,ja}.html` (`python3 tools/build_site_reference.py`;
  `pytest tests/test_site_reference_snapshot.py` — 3/3 passed, confirming freshness).
- `changelog.d/779-saga-emit-evolve.fixed.md`.

## Independent review of this PR: addressed / deferred

PR #789's independent review (approve with required follow-ups) found two required issues, both
fixed in this revision (corpus-sweep breadth above; k=2 mechanism above), plus several
non-blocking findings:

- **Annotation asymmetry (m1)** — confirmed real: path A's `saga_emit_evolve` merges the evolve's
  `Annotations` into the action; path B's `saga_emit_evolve_lines` does not, because `domain.rs`'s
  textual renderer has *never* emitted `@`-annotation syntax for *any* action (grepped: zero
  annotation-emission sites in the whole file), so this predates #779 and is not specific to the
  saga-evolve fix. `public_kernel_contract` v1 does not project `Annotations`, so
  `domain_render_agreement.rs` cannot see the gap either. Filed as
  https://github.com/ymm-oss/fsl/issues/791 per the review's recommendation, rather than fixed here
  (likely subsumed by the #664 lowering-path unification).
- **Asymmetric failure mode between the two new helpers (m4)** — checked, not a new inconsistency:
  path A's `saga_emit_evolve` propagates an unknown-event lookup via `?` because *every* function in
  `domain_lowering.rs`'s `Resolver` returns `Result` and fails closed; path B's
  `saga_emit_evolve_lines` silently skips via `let Some(...) = ... else { continue }` because that is
  `domain.rs`'s own established, file-wide convention for the same lookup (identical pattern already
  at `render_effect_actions` and the saga-observe loop in `render_saga_actions`, both pre-existing).
  Each new helper matches its own file's existing idiom; deferring real validation to the shared
  `validate_lowerable_constructs` gate both paths call before rendering is `domain.rs`'s established
  design (`docs/DESIGN-domain.md`'s "Rejected constructs" section), not a gap introduced here.
- **n1** (the sweep checks a written root variable, not its value) — already stated in
  `required_targets`'s doc comment; unchanged.
- **n2** (citation) — fixed above (`docs/DESIGN-saga-history.md:41-43`, not an issue comment URL).
- **n4** (LANGUAGE.md redundant sentence / stray line wrap) — fixed above.

## Verification run

- Negative controls: `cargo test -p fslc-rust --test issue_779_saga_emit_evolve` — 4/4 `ok`.
- `cargo test -p fsl-core --test domain_render_agreement --test domain_saga_evolve_pairing` — 12/12 `ok`.
- Full `domain`-scoped sweep across `fslc-rust` (39 test binaries touching `domain`) — all `ok`, 0 failures.
- `pytest tests/test_site_reference_snapshot.py` — 3/3 passed (site reference freshness).
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — clean.
- `cargo clippy --manifest-path rust/Cargo.toml -p fsl-core -p fslc-rust --all-targets --locked -- -D warnings` — clean.
- `bash tools/aggregate_changelog.sh check` — PASS.
- No `/Users/` absolute paths in any committed file (grepped).

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)
