### PR TITLE
fix(verify): budget the vacuity reachability probe and report truncation (#729)

### DIFF
--- a/changelog.d/729-budget-vacuity-reachability-probe.fixed.md
+++ b/changelog.d/729-budget-vacuity-reachability-probe.fixed.md
@@ -1,0 +1,34 @@
+Fixed issue #729: `verification_warnings`'s `vacuous_implication`/
+`vacuous_leadsto` reachability probe (`fsl-runtime`) ran one **unbudgeted**
+concrete BFS per antecedent/trigger, cloning the whole `KernelModel` per
+explored node. On the `LabelCoreRepro` reproducer
+(`rust/fslc/tests/issue_697_all_properties_memory.rs`), isolating a single
+affected property (`--property PublishedWasReviewed`) consumed ~1,095 MB
+(measured control, before this fix; the issue reported ~1,096 MB), against
+~47 MB for an unaffected property, and `--vacuity ignore` did not help —
+`apply_vacuity_mode` only filtered the already-computed output. Every
+implication antecedent and leadsTo trigger now shares one budgeted BFS
+(`fsl_runtime::expression_reachability`, budgeted at the same
+`CONCRETE_PROBE_BUDGET` `find_boundary_violation` uses and reusing its
+established scratch-`Monitor` pattern from issue #730/#776), which drops the
+same isolated-property case to ~348 MB (no vacuity option change) or ~44 MB
+(`--vacuity ignore`, which now genuinely skips the probe instead of
+filtering its output) and removes the per-property multiplier the shared BFS
+was designed to eliminate. Reachability is now tri-state
+(`Reachability::{Reachable, Unreachable, Exhausted}`): a candidate that hits
+the budget before resolving reports the new `vacuity_probe_truncated` kind
+(added to `fsl_core::VACUITY_KINDS`, 6 → 7) instead of silently becoming
+`Unreachable` (fail-open) or being dropped (also fail-open under `--vacuity
+error`) — depth-bounded non-closure is unaffected and still reports
+`vacuous_implication`/`vacuous_leadsto` exactly as before. `skip_vacuity_probe`
+is threaded as an explicit argument from the one CLI derivation point
+(`--vacuity ignore` in `verify`/`sweep`); the `ledger`/`html`/`mutate`
+baseline and the wasm Worker surface (neither has a `--vacuity` option)
+always compute it. Negative controls: the `--vacuity ignore` envelope equals
+the `--vacuity warn` envelope with vacuity-kind warnings filtered out
+(`issue_729_vacuity_ignore_skip.rs`); `ledger`/`html` output for an ordinary
+vacuous finding is unchanged, and a `vacuity_probe_truncated` finding cannot
+move a requirement's assurance class since `assurance_token` never reads
+`warnings` (`issue_729_vacuity_probe_truncated_ledger.rs`); a
+corpus-conservation test confirms no maintained spec exhausts the shared
+budget (`issue_729_vacuity_probe_corpus_budget.rs`).

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -512,7 +512,8 @@ interpretation trigger even though commit/rollback policy remains centralized. R
 each observed step through a Monitor.
 
 Search ownership is broader than two BFS functions. `check_refinement`, `find_boundary_violation`,
-`expression_reachable`, `action_cover_traces`, and `leadsto_response_traces` each own a distinct
+`expression_reachability` (renamed and budgeted from `expression_reachable`, issue #729),
+`action_cover_traces`, and `leadsto_response_traces` each own a distinct
 solver-free queue/result contract and reuse Monitor transitions. The public legacy BFS does the
 same. The product explicit engine additionally owns deterministic-initialization and eligibility
 gates plus frontier, parent, closure, coverage, and state budget in `explicit.rs`; these APIs are

--- a/docs/DESIGN-rust-port.md
+++ b/docs/DESIGN-rust-port.md
@@ -261,8 +261,9 @@ solver-independent crates used by both delivery surfaces:
   out of the verifier as `BmcResult.vacuity`. The frontend renders that into
   warning JSON and passes it back into `verification_warnings`, which keeps
   the documented warning order in one place without giving `fsl-runtime` a
-  solver dependency. `--vacuity` selects over the closed 6-kind set in
-  `fsl-core::VACUITY_KINDS`, not a `"vacuous_"` name-prefix check.
+  solver dependency. `--vacuity` selects over the closed 7-kind set in
+  `fsl-core::VACUITY_KINDS` (issue #729 added `vacuity_probe_truncated`),
+  not a `"vacuous_"` name-prefix check.
 - The solver-dependent lanes run after every witness, reachable, and deadlock
   trace has been projected. They quantify over freshly named states and never
   read the unrolled ones, but a query still moves the backend's internal

--- a/docs/DESIGN-vacuity.md
+++ b/docs/DESIGN-vacuity.md
@@ -51,6 +51,86 @@ bugs. Conventionally `kind:"vacuous"` referred only to init unsatisfiability.
    reset age to zero and catches state-changing urgent handlers that disable
    their own guards. A `tick` transition that advances age is the rejecting
    control and suppresses the finding.
+7. **`vacuity_probe_truncated`** (issue #729): lanes 1–2's shared reachability
+   probe stopped at its state budget before deciding a candidate either way.
+   See the subsection immediately below.
+
+### Lanes 1–2: budgeted reachability probe and `vacuity_probe_truncated` (issue #729)
+
+`fsl-runtime::verification_warnings` used to run one **unbudgeted** concrete BFS
+(`expression_reachable`) per implication antecedent and per leadsTo trigger: a
+property count multiplier on top of a per-candidate search with no ceiling, so
+a spec whose state space defeats BFS dedup (e.g. an order-sensitive history
+`Seq`, the reproducer in `rust/fslc/tests/issue_697_all_properties_memory.rs`'s
+`LabelCoreRepro`) could consume gigabytes verifying a single property in
+isolation, and `--vacuity ignore` did not help: `apply_vacuity_mode`
+(`rust/fslc/src/verification.rs`) only filtered the rendered `warnings` array
+after the (already paid) computation.
+
+The fix follows the in-repo precedent `docs/DESIGN-explicit-engine.md`
+established for the same shape of problem (`--engine explicit`'s
+`unknown_budget` verdict): give the search a budget, and make "the search was
+cut off before it could decide" its own reportable outcome rather than
+silently reusing the closed-search verdict.
+
+- **One shared, budgeted BFS.** `fsl_runtime::expression_reachability` takes
+  every implication-antecedent and leadsTo-trigger candidate for a model at
+  once (built by `vacuous_implication_candidates`/`vacuous_leadsto_candidates`)
+  and walks the concrete state space once, checking every still-pending
+  candidate against each popped state and dropping it from `pending` the
+  instant it is found true. This removes the per-property multiplier: N
+  candidates no longer pay N full BFS traversals. It reuses `find_boundary_
+  violation`'s established scratch-`Monitor`/no-per-node-clone pattern
+  (issue #730/#776) rather than inventing a new search mechanism.
+- **Budget.** Reuses `CONCRETE_PROBE_BUDGET` (50,000 states) — the same
+  constant and calibration `find_boundary_violation` uses, protected by the
+  same style of corpus-conservation test
+  (`rust/fslc/tests/issue_729_vacuity_probe_corpus_budget.rs`, mirroring
+  `issue_697_corpus_probe_budget.rs`).
+- **Tri-state result, fail-closed.** `Reachability::{Reachable, Unreachable,
+  Exhausted}`. `Unreachable` means the same thing it always did — full
+  enumeration within `--depth` completed and the candidate never became
+  true — and keeps producing `vacuous_implication`/`vacuous_leadsto` exactly
+  as before; depth-bounded non-closure was already reported this way and is
+  unchanged. `Exhausted` is the new state: the budget was hit before the
+  candidate resolved either way. Folding `Exhausted` into `Unreachable` would
+  be fail-open (a false "confirmed vacuous" claim); silently dropping it
+  would let `--vacuity error` pass a spec whose vacuity was never actually
+  established. Both are unacceptable weakenings of `--vacuity error`'s
+  contract ("vacuity evidence is clean"), so `Exhausted` gets its own kind,
+  `vacuity_probe_truncated`, added to `fsl_core::VACUITY_KINDS` — selected by
+  `--vacuity` exactly like the other six kinds (`warn` shows it, `error`
+  fails closed on it, `ignore` discards it). An informational, non-selected
+  kind was considered and rejected for the same reason: it would make
+  `--vacuity error` strictly weaker than before #729, letting a
+  never-decided spec through silently.
+- **`--vacuity ignore` skips the computation, not just the output.** Consumer
+  audit (issue #729) found exactly one product call site that ever applies a
+  vacuity mode (`rust/fslc/src/verification.rs`'s `execute_cli_verification`,
+  reached by both the `verify` and `sweep` CLI commands — `sweep` funnels
+  through the same `run_verify_cli`); `ledger`/`html`/`mutate` share a
+  mode-less baseline (`rust/fslc/src/main.rs`'s `run_verify`, whose signature
+  has no vacuity parameter at all) and the wasm Worker request surface has no
+  `--vacuity` option either. So `skip_vacuity_probe`
+  (`BmcOutputOptions`/`BmcRequest`/`InductionRequest`/`ExplicitRequest` in
+  `rust/fslc/src/verification*.rs`) is an explicit argument threaded only
+  from that one derivation point (`options.vacuity == "ignore"`, plus its
+  `--lemma`-path twin in `run_induction_with_lemmas`); every other caller
+  passes `false`. Skipping is proved observationally equivalent to
+  computing-then-filtering by
+  `rust/fslc/tests/issue_729_vacuity_ignore_skip.rs`, which asserts the
+  `--vacuity ignore` envelope equals the `--vacuity warn` envelope with every
+  `is_vacuity_kind` warning removed (cost/timing fields excluded, since
+  skipping legitimately does less work).
+- **Ledger wording.** `rust/fsl-tools/src/ledger.rs`'s summary prefix
+  distinguishes the two: an ordinary vacuity finding reads "空虚性の疑い"
+  (suspected hollow — something was proven), while
+  `kind == "vacuity_probe_truncated"` reads "空虚性未確立（到達性 probe が
+  budget で打ち切り）" (vacuity not established — nothing was proven either
+  way). `html.rs` renders `kind`/`message` generically and needed no change.
+  `assurance_token` never reads `warnings`, so a truncated-probe finding
+  cannot move a requirement's assurance class
+  (`rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs`).
 
 ### Native lanes 3–6: "over all reachable states" is decided over the type space
 

--- a/docs/DESIGN-vacuity.md
+++ b/docs/DESIGN-vacuity.md
@@ -92,10 +92,12 @@ silently reusing the closed-search verdict.
   enumeration within `--depth` completed and the candidate never became
   true — and keeps producing `vacuous_implication`/`vacuous_leadsto` exactly
   as before; depth-bounded non-closure was already reported this way and is
-  unchanged. `Exhausted` is the new state: the budget was hit before the
-  candidate resolved either way. Folding `Exhausted` into `Unreachable` would
-  be fail-open (a false "confirmed vacuous" claim); silently dropping it
-  would let `--vacuity error` pass a spec whose vacuity was never actually
+  unchanged. `Exhausted` is the new state: no verdict was ever reached for
+  this candidate, either because the shared budget was hit while it was
+  still pending or because evaluating its expression in some visited state
+  returned an error. Folding `Exhausted` into `Unreachable` would be
+  fail-open (a false "confirmed vacuous" claim); silently dropping it would
+  let `--vacuity error` pass a spec whose vacuity was never actually
   established. Both are unacceptable weakenings of `--vacuity error`'s
   contract ("vacuity evidence is clean"), so `Exhausted` gets its own kind,
   `vacuity_probe_truncated`, added to `fsl_core::VACUITY_KINDS` — selected by
@@ -104,6 +106,36 @@ silently reusing the closed-search verdict.
   kind was considered and rejected for the same reason: it would make
   `--vacuity error` strictly weaker than before #729, letting a
   never-decided spec through silently.
+- **A per-candidate evaluation error also resolves `Exhausted`, not
+  `Reachable`.** The pre-#729 `expression_reachable` silently treated an
+  evaluation `Result::Err` for one property's antecedent as "no warning" for
+  that property alone (`matches!(expression_reachable(...), Ok(false))` is
+  `false` on `Err` too) — a pre-existing, out-of-scope-for-#729 fail-open on
+  an already-rare path. Batching forced a choice: fold that per-candidate
+  `Err` into `Reachable` (preserving the old silent-drop byte-for-byte) or
+  into `Exhausted` (fail-closed, consistent with the new budget-truncation
+  path). Chosen: `Exhausted`. Rationale — this issue's whole point is "never
+  silently pass a probe that could not decide," and a caller downstream
+  (`--vacuity error`) cannot tell *why* a candidate has no verdict, so the
+  two causes (budget cutoff, evaluation error) should not be allowed to
+  produce different fail-open/fail-closed outcomes; letting a candidate's
+  evaluation fail must not become a way to defeat `--vacuity error` that a
+  budget cutoff cannot. The `message`/`hint`/`recommended_action` text for
+  `vacuity_probe_truncated` is written cause-neutral ("the probe either
+  exhausted its internal state budget or failed to evaluate the candidate")
+  rather than claiming budget truncation specifically, since `Reachability`
+  does not (and need not) distinguish the two internally.
+- **Known gap: a whole-walk `RuntimeError` still loses every candidate's
+  finding for that run**, exactly as the pre-#729 per-property calls did for
+  their one property each (`verification_warnings`'s
+  `.unwrap_or_default()`). Unlike the per-candidate case above, this is not
+  attributable to one candidate — it means an action's `enabled`/`step`
+  itself could not be evaluated, the same condition that already fails the
+  surrounding BMC/explicit run before vacuity warnings are ever rendered, so
+  this path is not reachable on any spec that reaches `verification_warnings`
+  in the first place. Accepted as a narrow, practically-unreachable gap
+  rather than threading partial results out of an `Err` path (see the doc
+  comment on `expression_reachability`'s `unwrap_or_default` call site).
 - **`--vacuity ignore` skips the computation, not just the output.** Consumer
   audit (issue #729) found exactly one product call site that ever applies a
   vacuity mode (`rust/fslc/src/verification.rs`'s `execute_cli_verification`,
@@ -126,11 +158,24 @@ silently reusing the closed-search verdict.
   distinguishes the two: an ordinary vacuity finding reads "空虚性の疑い"
   (suspected hollow — something was proven), while
   `kind == "vacuity_probe_truncated"` reads "空虚性未確立（到達性 probe が
-  budget で打ち切り）" (vacuity not established — nothing was proven either
-  way). `html.rs` renders `kind`/`message` generically and needed no change.
+  判定に至らず）" (vacuity not established — the probe never reached a
+  verdict; deliberately cause-neutral, matching `Reachability::Exhausted`
+  not distinguishing budget cutoff from an evaluation error). `html.rs`
+  renders `kind`/`message` generically and needed no change.
   `assurance_token` never reads `warnings`, so a truncated-probe finding
   cannot move a requirement's assurance class
   (`rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs`).
+- **End-to-end truncation coverage.**
+  `rust/fslc/tests/issue_729_vacuity_probe_truncated_e2e.rs` drives the
+  `vacuity_probe_truncated` emission arm through the real CLI end to end
+  (not just at the `expression_reachability`/`render_ledger` unit level):
+  a `count = count * 10 + x` digit-growth model whose reachable state count
+  is unbounded and grows `10^level` per BFS level genuinely exhausts
+  `CONCRETE_PROBE_BUDGET` within a few seconds, so `--vacuity error` exits 2
+  with `kind:"vacuity_probe_truncated"` — proving the whole path from a real
+  budget exhaustion through `is_vacuity_kind` selection to the CLI exit code
+  actually fires, not just that its helper functions are individually
+  correct.
 
 ### Native lanes 3–6: "over all reachable states" is decided over the type space
 

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1015,6 +1015,9 @@ holds, violating_bindings?}`)は、invariant が複数の AND 連言肢から構
 (`insufficient_depth` | `over_constrained`)と `blocking`(前件/トリガーを不可能に
 している他の invariant。深さ内で単に未到達なだけのときは空)を得ます —
 `reachable_failed` の `unreached[].blocking_requires` と同じ形です。
+`vacuity_probe_truncated`(§15)は別の主張です — 到達性 probe が深さではなく
+state の budget で打ち切られた、というもので、上記のどちらでもなく独自の
+`classification: "probe_truncated"` を持ちます。
 blame は特定するだけで、修復(ガードの弱化、連言肢の削除)を提案することは決して
 ありません — それは anti-hollowing の原則に反するからです。これらはすべて JSON
 コントラクトへの厳密に追加的な変更です。
@@ -1022,7 +1025,9 @@ blame は特定するだけで、修復(ガードの弱化、連言肢の削除)
 忠実性/意図のギャップを特定する診断は、`faithfulness_class` と
 `recommended_action` も運ぶことがあります。現在のクラスは
 `partial_op_unguarded`、`frozen_only_invariant`、`intent_unexercised`、
-`liveness_not_refined` です。このタグは既存の `result` / `kind` /
+`liveness_not_refined`、`reachability_unknown`(`vacuity_probe_truncated`
+専用 — 到達性 probe が budget で打ち切られたのであって、単に意図が未行使
+なのではありません)です。このタグは既存の `result` / `kind` /
 `violation_kind` フィールドから導出される追加的なものです。消費者は詳細のために
 元の分類フィールドを読み続けるべきです。
 
@@ -2606,10 +2611,20 @@ DESIGN-*.md があります)。
   `tautology_over_frozen`(どの action も変えない状態の上の、動的に
   トートロジーである invariant)、`urgency_freeze`(urgency が時間を凍結するために
   死んでいると証明された、生成された deadline の `tick`)、
-  `vacuous_deadline`(生成 deadline の age が全遷移で 0 のままと証明される)を
-  警告します。
+  `vacuous_deadline`(生成 deadline の age が全遷移で 0 のままと証明される)、
+  `vacuity_probe_truncated`†を警告します。
   `error` は exit 2 です。→
   [`DESIGN-vacuity.md`](DESIGN-vacuity.md)
+
+  † `vacuity_probe_truncated`: `vacuous_implication`/`vacuous_leadsto` の
+  到達性 probe は、spec 内の全 antecedent/trigger にまたがって 1 回の
+  budget 付き concrete BFS を共有します。ある候補が、真になることも
+  到達可能な状態空間を使い切ることもないまま state 数の budget に
+  到達した場合、`vacuous_implication`/`vacuous_leadsto` の代わりにこの
+  kind を報告します — 空虚性はどちら向きにも確立されていないため、
+  「空虚性確定」として扱えば偽陽性になり、単に握りつぶせば
+  `--vacuity error` が空虚性を一度も判定していない spec を通過させて
+  しまいます。他の 6 kind と全く同様に `--vacuity` で選択されます。
 - **`--strict-tags`** — 成功の結果の上で、タグのない宣言(捏造の候補)と、参照
   されない要件(欠落の候補。空の requirement ブロックを含む)を警告します。存在
   レベルの突合です。→ [`DESIGN-strict-tags.md`](DESIGN-strict-tags.md)

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1049,16 +1049,21 @@ inherit both automatically. Vacuity findings (`vacuous_implication` /
 `over_constrained`) and `blocking` (the other invariants making the
 antecedent/trigger impossible, empty when it's merely unreached within
 depth) — same shape as `reachable_failed`'s `unreached[].blocking_requires`.
+`vacuity_probe_truncated` (§15) is a distinct claim — the reachability
+probe was cut off by its state budget, not by depth — and carries its own
+`classification: "probe_truncated"` rather than either of the above.
 Blame identifies; it never proposes a repair (weakening a guard, dropping a
 conjunct) — that would cut against the anti-hollowing principle. All of this
 is strictly additive to the JSON contract.
 
 Diagnostics that identify a faithfulness/intent gap may also carry
 `faithfulness_class` plus `recommended_action`. Current classes are:
-`partial_op_unguarded`, `frozen_only_invariant`, `intent_unexercised`, and
-`liveness_not_refined`. The tag is derived from existing `result` / `kind` /
-`violation_kind` fields and is additive; consumers should keep reading the
-original classification fields for detail.
+`partial_op_unguarded`, `frozen_only_invariant`, `intent_unexercised`,
+`liveness_not_refined`, and `reachability_unknown` (`vacuity_probe_truncated`
+only — the reachability probe was budget-cut, not merely intent-unexercised).
+The tag is derived from existing `result` / `kind` / `violation_kind` fields
+and is additive; consumers should keep reading the original classification
+fields for detail.
 
 Progress-preserving refinement failures are reported as `refinement_failed` with
 `kind:"progress_lost"`, `violation_kind:"leadsTo"`, `impl_trace`,
@@ -2664,9 +2669,20 @@ DESIGN-*.md).
   (a guard that is always true under the context of preceding clauses),
   `tautology_over_frozen` (a dynamically tautological invariant over state no
   action changes), `urgency_freeze` (a generated deadline `tick` proven dead
-  because urgency freezes time), and `vacuous_deadline` (a generated deadline
-  whose age is proven to remain zero across every transition). `error` exits 2. →
+  because urgency freezes time), `vacuous_deadline` (a generated deadline
+  whose age is proven to remain zero across every transition), and
+  `vacuity_probe_truncated`†. `error` exits 2. →
   [`DESIGN-vacuity.md`](DESIGN-vacuity.md)
+
+  † `vacuity_probe_truncated`: the `vacuous_implication`/`vacuous_leadsto`
+  reachability probe shares one budgeted concrete BFS across every
+  antecedent/trigger in the spec; a candidate that neither becomes true nor
+  finishes exhausting its reachable state space before the state-count
+  budget is hit reports this kind instead of `vacuous_implication`/
+  `vacuous_leadsto` — vacuity was never established either way, so treating
+  it as confirmed-vacuous would be a false positive and dropping it would
+  let `--vacuity error` pass a spec whose vacuity was never actually
+  decided. Selected by `--vacuity` exactly like the other six kinds.
 - **`--strict-tags`** — warns on success results about untagged declarations
   (fabrication candidates) and unreferenced requirements (omission candidates,
   including empty requirement blocks). Existence-level matching. → [`DESIGN-strict-tags.md`](DESIGN-strict-tags.md)

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1146,15 +1146,20 @@ inherit both automatically. Vacuity findings (<code>vacuous_implication</code> /
 <code>over_constrained</code>) and <code>blocking</code> (the other invariants making the
 antecedent/trigger impossible, empty when it's merely unreached within
 depth) — same shape as <code>reachable_failed</code>'s <code>unreached[].blocking_requires</code>.
+<code>vacuity_probe_truncated</code> (§15) is a distinct claim — the reachability
+probe was cut off by its state budget, not by depth — and carries its own
+<code>classification: "probe_truncated"</code> rather than either of the above.
 Blame identifies; it never proposes a repair (weakening a guard, dropping a
 conjunct) — that would cut against the anti-hollowing principle. All of this
 is strictly additive to the JSON contract.</p>
 <p>Diagnostics that identify a faithfulness/intent gap may also carry
 <code>faithfulness_class</code> plus <code>recommended_action</code>. Current classes are:
-<code>partial_op_unguarded</code>, <code>frozen_only_invariant</code>, <code>intent_unexercised</code>, and
-<code>liveness_not_refined</code>. The tag is derived from existing <code>result</code> / <code>kind</code> /
-<code>violation_kind</code> fields and is additive; consumers should keep reading the
-original classification fields for detail.</p>
+<code>partial_op_unguarded</code>, <code>frozen_only_invariant</code>, <code>intent_unexercised</code>,
+<code>liveness_not_refined</code>, and <code>reachability_unknown</code> (<code>vacuity_probe_truncated</code>
+only — the reachability probe was budget-cut, not merely intent-unexercised).
+The tag is derived from existing <code>result</code> / <code>kind</code> / <code>violation_kind</code> fields
+and is additive; consumers should keep reading the original classification
+fields for detail.</p>
 <p>Progress-preserving refinement failures are reported as <code>refinement_failed</code> with
 <code>kind:"progress_lost"</code>, <code>violation_kind:"leadsTo"</code>, <code>impl_trace</code>,
 <code>progress:{leadsTo, actions}</code>, and <code>faithfulness_class:"liveness_not_refined"</code>.</p>
@@ -2641,13 +2646,24 @@ DESIGN-*.md).</p>
   (a guard that is always true under the context of preceding clauses),
   <code>tautology_over_frozen</code> (a dynamically tautological invariant over state no
   action changes), <code>urgency_freeze</code> (a generated deadline <code>tick</code> proven dead
-  because urgency freezes time), and <code>vacuous_deadline</code> (a generated deadline
-  whose age is proven to remain zero across every transition). <code>error</code> exits 2. →
+  because urgency freezes time), <code>vacuous_deadline</code> (a generated deadline
+  whose age is proven to remain zero across every transition), and
+  <code>vacuity_probe_truncated</code>†. <code>error</code> exits 2. →
   <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-vacuity.md"><code>DESIGN-vacuity.md</code></a></li>
-<li><strong><code>--strict-tags</code></strong> — warns on success results about untagged declarations
+</ul>
+<p>† <code>vacuity_probe_truncated</code>: the <code>vacuous_implication</code>/<code>vacuous_leadsto</code>
+  reachability probe shares one budgeted concrete BFS across every
+  antecedent/trigger in the spec; a candidate that neither becomes true nor
+  finishes exhausting its reachable state space before the state-count
+  budget is hit reports this kind instead of <code>vacuous_implication</code>/
+  <code>vacuous_leadsto</code> — vacuity was never established either way, so treating
+  it as confirmed-vacuous would be a false positive and dropping it would
+  let <code>--vacuity error</code> pass a spec whose vacuity was never actually
+  decided. Selected by <code>--vacuity</code> exactly like the other six kinds.
+- <strong><code>--strict-tags</code></strong> — warns on success results about untagged declarations
   (fabrication candidates) and unreferenced requirements (omission candidates,
-  including empty requirement blocks). Existence-level matching. → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-strict-tags.md"><code>DESIGN-strict-tags.md</code></a></li>
-<li><strong><code>fslc mutate</code></strong> — mechanically mutates the spec and measures whether each
+  including empty requirement blocks). Existence-level matching. → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-strict-tags.md"><code>DESIGN-strict-tags.md</code></a>
+- <strong><code>fslc mutate</code></strong> — mechanically mutates the spec and measures whether each
   mutant is killed by the existing net of checks. The score is <strong>bounded
   mutant-set sensitivity</strong>: <code>kill_rate = killed / (killed + survived)</code> over a
   selected finite mutant set, at the selected <code>--depth</code>, under the
@@ -2674,15 +2690,15 @@ DESIGN-*.md).</p>
   kills use explicit requirement annotations on the failed trace declaration;
   AC/FB case IDs are not implicit requirements. Trace case IDs are unique
   within each declaration kind.
-  → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a></li>
-<li><strong><code>fslc explain --readable</code></strong> — a text view over skeleton enumeration (state,
+  → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a>
+- <strong><code>fslc explain --readable</code></strong> — a text view over skeleton enumeration (state,
   action who/when/what-changes, verification bounds, fairness, KPI projections,
   branch lowering, synthesized refinement mappings, automatic checks, tags) +
   counterfactuals ("without this rule, this procedure could break it") + witness
   narration. Moves human review from reading logical formulas to adjudicating
   concrete examples. JSON mode remains available without <code>--readable</code>. →
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-explain.md"><code>DESIGN-explain.md</code></a></li>
-<li><strong><code>fslc analyze</code></strong> — emits structural observation JSON. <code>--projection tsg</code>
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-explain.md"><code>DESIGN-explain.md</code></a>
+- <strong><code>fslc analyze</code></strong> — emits structural observation JSON. <code>--projection tsg</code>
   returns the Typed Semantic Graph of requirements, actions, state, properties,
   and scenarios. Graph projections return connected components, SCCs,
   representative cycles, degree, and structural metrics such as cycle rank and
@@ -2728,14 +2744,13 @@ DESIGN-*.md).</p>
   These findings carry <code>formal_status: "not_a_violation"</code>; a structural cycle or
   disconnected component is not a proof failure. Versioned schemas for the TSG,
   graph projections, and findings are published under <code>schemas/fslc/analysis/</code>. →
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md"><code>DESIGN-analysis.md</code></a></li>
-<li><strong><code>fslc html</code></strong> — a self-contained HTML report over the same explain/verify
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md"><code>DESIGN-analysis.md</code></a>
+- <strong><code>fslc html</code></strong> — a self-contained HTML report over the same explain/verify
   evidence: status summary, state/action/property tables, an action-to-state
   write graph, trace timelines, witness examples, counterfactuals, source, and
   raw JSON. It is meant for PRs, design reviews, and non-specialist project
   review without requiring the reader to run the CLI. →
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-html-report.md"><code>DESIGN-html-report.md</code></a></li>
-</ul>
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-html-report.md"><code>DESIGN-html-report.md</code></a></p>
 <p>The discipline before writing (the formalization memo, the NL→syntax reverse
 lookup, recommended practices) is in the AI-agent skills under <code>skills/</code>, with
 the shared language reference in <code>skills/fsl/SKILL.md</code>. A maintained worked example

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1113,13 +1113,18 @@ holds, violating_bindings?}</code>)は、invariant が複数の AND 連言肢か
 (<code>insufficient_depth</code> | <code>over_constrained</code>)と <code>blocking</code>(前件/トリガーを不可能に
 している他の invariant。深さ内で単に未到達なだけのときは空)を得ます —
 <code>reachable_failed</code> の <code>unreached[].blocking_requires</code> と同じ形です。
+<code>vacuity_probe_truncated</code>(§15)は別の主張です — 到達性 probe が深さではなく
+state の budget で打ち切られた、というもので、上記のどちらでもなく独自の
+<code>classification: "probe_truncated"</code> を持ちます。
 blame は特定するだけで、修復(ガードの弱化、連言肢の削除)を提案することは決して
 ありません — それは anti-hollowing の原則に反するからです。これらはすべて JSON
 コントラクトへの厳密に追加的な変更です。</p>
 <p>忠実性/意図のギャップを特定する診断は、<code>faithfulness_class</code> と
 <code>recommended_action</code> も運ぶことがあります。現在のクラスは
 <code>partial_op_unguarded</code>、<code>frozen_only_invariant</code>、<code>intent_unexercised</code>、
-<code>liveness_not_refined</code> です。このタグは既存の <code>result</code> / <code>kind</code> /
+<code>liveness_not_refined</code>、<code>reachability_unknown</code>(<code>vacuity_probe_truncated</code>
+専用 — 到達性 probe が budget で打ち切られたのであって、単に意図が未行使
+なのではありません)です。このタグは既存の <code>result</code> / <code>kind</code> /
 <code>violation_kind</code> フィールドから導出される追加的なものです。消費者は詳細のために
 元の分類フィールドを読み続けるべきです。</p>
 <p>進行を保存する refinement の失敗は、<code>refinement_failed</code> として、
@@ -2584,14 +2589,24 @@ DESIGN-*.md があります)。</p>
   <code>tautology_over_frozen</code>(どの action も変えない状態の上の、動的に
   トートロジーである invariant)、<code>urgency_freeze</code>(urgency が時間を凍結するために
   死んでいると証明された、生成された deadline の <code>tick</code>)、
-  <code>vacuous_deadline</code>(生成 deadline の age が全遷移で 0 のままと証明される)を
-  警告します。
+  <code>vacuous_deadline</code>(生成 deadline の age が全遷移で 0 のままと証明される)、
+  <code>vacuity_probe_truncated</code>†を警告します。
   <code>error</code> は exit 2 です。→
   <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-vacuity.md"><code>DESIGN-vacuity.md</code></a></li>
-<li><strong><code>--strict-tags</code></strong> — 成功の結果の上で、タグのない宣言(捏造の候補)と、参照
+</ul>
+<p>† <code>vacuity_probe_truncated</code>: <code>vacuous_implication</code>/<code>vacuous_leadsto</code> の
+  到達性 probe は、spec 内の全 antecedent/trigger にまたがって 1 回の
+  budget 付き concrete BFS を共有します。ある候補が、真になることも
+  到達可能な状態空間を使い切ることもないまま state 数の budget に
+  到達した場合、<code>vacuous_implication</code>/<code>vacuous_leadsto</code> の代わりにこの
+  kind を報告します — 空虚性はどちら向きにも確立されていないため、
+  「空虚性確定」として扱えば偽陽性になり、単に握りつぶせば
+  <code>--vacuity error</code> が空虚性を一度も判定していない spec を通過させて
+  しまいます。他の 6 kind と全く同様に <code>--vacuity</code> で選択されます。
+- <strong><code>--strict-tags</code></strong> — 成功の結果の上で、タグのない宣言(捏造の候補)と、参照
   されない要件(欠落の候補。空の requirement ブロックを含む)を警告します。存在
-  レベルの突合です。→ <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-strict-tags.md"><code>DESIGN-strict-tags.md</code></a></li>
-<li><strong><code>fslc mutate</code></strong> — spec を機械的に変異させ、各ミュータントが既存の検査の網に
+  レベルの突合です。→ <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-strict-tags.md"><code>DESIGN-strict-tags.md</code></a>
+- <strong><code>fslc mutate</code></strong> — spec を機械的に変異させ、各ミュータントが既存の検査の網に
   よって殺されるかを測定します。スコアは<strong>有界ミュータント集合への感度
   (bounded mutant-set sensitivity)</strong>です: 選択された有限のミュータント集合・
   選択された <code>--depth</code>・verify/acceptance/forbidden/refinement オラクルの下での
@@ -2617,15 +2632,15 @@ DESIGN-*.md があります)。</p>
   観測された下界です。acceptance と forbidden の kill は、失敗した trace 宣言の
   明示的な requirement annotation を使います。AC/FB case ID は暗黙の requirement
   ではなく、trace case ID は宣言種別ごとに一意です。→
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a></li>
-<li><strong><code>fslc explain --readable</code></strong> — 骨格の列挙(状態、action の誰が/いつ/何を変える
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a>
+- <strong><code>fslc explain --readable</code></strong> — 骨格の列挙(状態、action の誰が/いつ/何を変える
   か、検証の境界、公平性、KPI の射影、branch の lowering、合成された refinement
   マッピング、自動検査、タグ)+ counterfactual(「この規則がなければ、この手順で
   それを壊せる」)+ witness のナレーションの上のテキストビュー。人間のレビューを、
   論理式を読むことから、具体例を裁定することへ移します。<code>--readable</code> なしでは
   JSON モードが引き続き利用できます。→
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-explain.md"><code>DESIGN-explain.md</code></a></li>
-<li><strong><code>fslc analyze</code></strong> — 構造的な観測 JSON を出力します。<code>--projection tsg</code> は、
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-explain.md"><code>DESIGN-explain.md</code></a>
+- <strong><code>fslc analyze</code></strong> — 構造的な観測 JSON を出力します。<code>--projection tsg</code> は、
   要件、action、状態、プロパティ、シナリオの Typed Semantic Graph を返します。
   グラフの射影は、連結成分、SCC、代表的なサイクル、次数、そしてサイクルランクや
   ファンイン/ファンアウトのハブのような構造メトリクスを返します。
@@ -2674,14 +2689,13 @@ DESIGN-*.md があります)。</p>
   これらの findings は <code>formal_status: "not_a_violation"</code> を運びます。構造的な
   サイクルや非連結の成分は、証明の失敗ではありません。TSG、グラフの射影、findings
   のバージョン付きスキーマは <code>schemas/fslc/analysis/</code> の下で公開されています。→
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md"><code>DESIGN-analysis.md</code></a></li>
-<li><strong><code>fslc html</code></strong> — 同じ explain/verify のエビデンスの上の、自己完結の HTML
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-analysis.md"><code>DESIGN-analysis.md</code></a>
+- <strong><code>fslc html</code></strong> — 同じ explain/verify のエビデンスの上の、自己完結の HTML
   レポート: ステータスのサマリー、state/action/プロパティのテーブル、action から
   状態への書き込みグラフ、トレースのタイムライン、witness の例、counterfactual、
   ソース、生の JSON。読み手に CLI の実行を要求することなく、PR、設計レビュー、
   非専門家によるプロジェクトレビューに使うためのものです。→
-  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-html-report.md"><code>DESIGN-html-report.md</code></a></li>
-</ul>
+  <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-html-report.md"><code>DESIGN-html-report.md</code></a></p>
 <p>書く前の規律(形式化メモ、自然言語→構文の逆引き、推奨プラクティス)は
 <code>skills/</code> の下の AI エージェントスキルにあり、共有の言語リファレンスは
 <code>skills/fsl/SKILL.md</code> にあります。保守される実例は

--- a/rust/fsl-core/src/diagnostics.rs
+++ b/rust/fsl-core/src/diagnostics.rs
@@ -99,13 +99,24 @@ pub fn insert_requirement_metadata(
 /// not share that prefix, so a prefix check silently exempts them from both
 /// `--vacuity ignore` (they would stay in `warnings`) and `--vacuity error`
 /// (a hollow spec carrying only one of these kinds would never fail closed).
-pub const VACUITY_KINDS: [&str; 6] = [
+///
+/// `vacuity_probe_truncated` (issue #729) is not itself a vacuity finding --
+/// it means the concrete `vacuous_implication`/`vacuous_leadsto`
+/// reachability probe was cut off by its state budget before it could
+/// establish either verdict. It belongs in this set for the same reason
+/// the four kinds above do: `--vacuity error`'s contract is "vacuity
+/// evidence is clean," and a spec whose probe never completed has not
+/// earned that claim -- gating it as an informational, non-selected kind
+/// would let `--vacuity error` pass a spec without ever having established
+/// non-vacuity, which is a strictly weaker contract than today's.
+pub const VACUITY_KINDS: [&str; 7] = [
     "vacuous_implication",
     "vacuous_leadsto",
     "tautology_over_frozen",
     "urgency_freeze",
     "vacuous_deadline",
     "always_true_requires",
+    "vacuity_probe_truncated",
 ];
 
 /// Whether `kind` is one of the closed [`VACUITY_KINDS`] `--vacuity` selects over.

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2261,14 +2261,21 @@ pub enum Reachability {
     /// error`'s `vacuous_implication`/`vacuous_leadsto` findings stay keyed
     /// on this variant, unchanged by this issue's budget.
     Unreachable,
-    /// The BFS stopped because it reached `budget` distinct states before
-    /// either finding the expression true or exhausting the reachable
-    /// state space within `depth`. Fail-closed by construction: a caller
-    /// must not fold this into `Unreachable` — reachability was never
-    /// decided, so treating it as "confirmed vacuous" would be a false
-    /// positive and treating it as "confirmed not vacuous" (silently
+    /// The BFS stopped, or a per-candidate evaluation failed, before either
+    /// finding the expression true or exhausting the reachable state space
+    /// within `depth` -- reachability was never decided. Reached two ways:
+    /// the shared budget was hit while this candidate was still pending, or
+    /// evaluating this candidate's expression in some visited state
+    /// returned an error (rare on a checked model). Fail-closed by
+    /// construction: a caller must not fold this into `Unreachable` for
+    /// either reason — treating it as "confirmed vacuous" would be a false
+    /// positive, and treating it as "confirmed not vacuous" (silently
     /// dropping it) would let `--vacuity error` pass a spec whose vacuity
-    /// was never actually established.
+    /// was never actually established. The two causes are deliberately not
+    /// distinguished in this type: both mean the same thing to a caller
+    /// ("no verdict"), and a per-candidate evaluation error and a shared
+    /// state-budget cutoff are two ways of reaching the identical
+    /// obligation, not two different obligations.
     Exhausted,
 }
 
@@ -2284,19 +2291,29 @@ pub enum Reachability {
 /// visited exactly like [`find_boundary_violation`]'s budget (state count
 /// checked right after insertion, before the state is queued): once the
 /// pending set is non-empty and the budget is reached, every still-pending
-/// candidate resolves [`Reachability::Exhausted`] rather than silently
-/// falling back to `Unreachable`.
+/// candidate resolves [`Reachability::Exhausted`].
 ///
 /// A per-expression evaluation error (rare on a checked model) resolves
-/// *only that expression* as [`Reachability::Reachable`], i.e. it silently
-/// contributes no finding for it. This matches the original
-/// `expression_reachable`, where a `Result::Err` for one property's
-/// antecedent produced no warning for that property alone; batching must
-/// not let one malformed candidate suppress every other candidate's
-/// vacuity evidence in the same run. A failure of the state-space walk
-/// itself (an action's `enabled`/`step` cannot be evaluated) is not a
-/// per-candidate condition and still propagates as `Err` for the whole
-/// call, matching every other BFS in this module.
+/// *only that expression* as [`Reachability::Exhausted`] rather than
+/// aborting the whole call: batching must not let one malformed candidate
+/// suppress every other candidate's vacuity evidence in the same run. This
+/// is a deliberate behavior change from the original `expression_reachable`,
+/// where a `Result::Err` for one property's antecedent produced no warning
+/// at all for that property (silently treated as "not vacuous"); resolving
+/// it `Exhausted` instead keeps every no-verdict outcome on the same
+/// fail-closed path regardless of *why* a verdict could not be reached, so
+/// `--vacuity error` cannot be defeated by causing a candidate's evaluation
+/// to error rather than causing its BFS to run long. A failure of the
+/// state-space walk itself (an action's `enabled`/`step` cannot be
+/// evaluated) is not a per-candidate condition and still propagates as
+/// `Err` for the whole call, matching every other BFS in this module —
+/// unlike a per-candidate evaluation error, there is no narrower unit to
+/// attribute it to. When that happens, every candidate still pending at
+/// that point (including ones that would otherwise have resolved
+/// `Exhausted` from the budget moments later) loses its finding entirely
+/// rather than being reported `Exhausted`; `verification_warnings` accepts
+/// this as a known, narrow gap (see its own doc comment) rather than
+/// threading partial results out of an `Err` path.
 ///
 /// # Errors
 ///
@@ -2333,10 +2350,15 @@ pub fn expression_reachability(
             })
             .and_then(as_bool);
             match truth {
-                Ok(true) | Err(_) => {
-                    // An error is absorbed here, not propagated: see the
-                    // doc comment above.
+                Ok(true) => {
                     results[index] = Some(Reachability::Reachable);
+                    resolved.push(index);
+                }
+                Err(_) => {
+                    // Absorbed per-candidate, not propagated: see the doc
+                    // comment above. Fail-closed, unlike the pre-#729
+                    // behavior this replaces.
+                    results[index] = Some(Reachability::Exhausted);
                     resolved.push(index);
                 }
                 Ok(false) => {}
@@ -2464,7 +2486,7 @@ fn vacuity_reachability_warning(
         "blocking": [],
         "faithfulness_class": if kind == "vacuity_probe_truncated" { "reachability_unknown" } else { "intent_unexercised" },
         "recommended_action": if kind == "vacuity_probe_truncated" {
-            format!("the {subject}'s reachability could not be established within the internal probe budget; this is unusual and typically means the state shape (e.g. an order-sensitive history variable) defeats BFS dedup -- simplify it or reduce --depth")
+            format!("the {subject}'s reachability could not be established by the probe; this is unusual and typically means either the state shape (e.g. an order-sensitive history variable) defeats BFS dedup and exhausts the internal budget -- simplify it or reduce --depth -- or the {subject} itself fails to evaluate in some reached state -- check it for a construct the concrete evaluator cannot represent")
         } else {
             "add a single-shot reachable for the action / raise --depth".to_owned()
         },
@@ -2514,10 +2536,26 @@ pub fn verification_warnings(
             .collect();
         probe_expressions.extend(leadsto_candidates.iter().cloned());
         // A `RuntimeError` from the state-space walk itself (see
-        // `expression_reachability`'s doc comment) loses both lanes for
-        // this run, exactly as a single antecedent's `Err` silently lost
-        // just that one property's warning before batching -- there is no
-        // narrower fallback to degrade to.
+        // `expression_reachability`'s doc comment -- distinct from a
+        // per-candidate evaluation error, which resolves `Exhausted`
+        // instead of propagating) loses every candidate's finding for this
+        // run, with no narrower fallback to degrade to: `.unwrap_or_default`
+        // yields an empty `Vec`, so `probe_results.get(_)` is `None` for
+        // every index below and no warning is emitted for any candidate.
+        // This is NOT observationally equivalent to the pre-#729 baseline,
+        // where each property's own independent `expression_reachable` call
+        // only lost that one property's warning on error -- it is a known,
+        // narrow gap against this issue's own fail-closed contract: a
+        // candidate that would have resolved `Exhausted` (budget truncation)
+        // moments after the walk-level error occurred loses its
+        // `vacuity_probe_truncated` finding entirely instead of reporting
+        // it. Accepted rather than threading partial results out of an
+        // `Err` path, because a walk-level `RuntimeError` here means an
+        // action's `enabled`/`step` itself could not be evaluated -- the
+        // same condition that already fails the surrounding BMC/explicit
+        // run before vacuity warnings are ever rendered, so this path is
+        // not reachable on any spec that reaches `verification_warnings` in
+        // the first place. See `docs/DESIGN-vacuity.md`.
         let probe_results =
             expression_reachability(model, &probe_expressions, depth, CONCRETE_PROBE_BUDGET)
                 .unwrap_or_default();
@@ -2540,9 +2578,9 @@ pub fn verification_warnings(
                     "implication antecedent",
                     &name,
                     &format!(
-                        "invariant '{name}' has an implication antecedent whose reachability probe was truncated by the internal state budget before reaching depth {depth}"
+                        "invariant '{name}' has an implication antecedent whose reachability the probe could not establish within depth {depth}"
                     ),
-                    "vacuity was not established either way for this antecedent; the probe stopped at a state-count budget, not at depth",
+                    "vacuity was not established either way for this antecedent; the probe either exhausted its internal state budget or failed to evaluate the antecedent in some reached state before reaching a verdict",
                     &property.span.python_loc(),
                 ),
                 Some(Reachability::Reachable) | None => continue,
@@ -2571,9 +2609,9 @@ pub fn verification_warnings(
                     "leadsTo trigger",
                     &name,
                     &format!(
-                        "leadsTo '{name}' has a trigger whose reachability probe was truncated by the internal state budget before reaching depth {depth}"
+                        "leadsTo '{name}' has a trigger whose reachability the probe could not establish within depth {depth}"
                     ),
-                    "vacuity was not established either way for this trigger; the probe stopped at a state-count budget, not at depth",
+                    "vacuity was not established either way for this trigger; the probe either exhausted its internal state budget or failed to evaluate the trigger in some reached state before reaching a verdict",
                     &property.span.python_loc(),
                 ),
                 Some(Reachability::Reachable) | None => continue,

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2246,44 +2246,133 @@ fn first_self_violation(
     Ok(None)
 }
 
-/// Return whether a Boolean expression holds in any concrete state up to `depth`.
+/// The outcome of a budgeted vacuity-reachability probe for one
+/// antecedent/trigger expression (issue #729).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Reachability {
+    /// The expression became true in some concretely reached state within
+    /// `depth`.
+    Reachable,
+    /// The BFS enumerated every state reachable within `depth` (or
+    /// exhausted the frontier before `depth`) without the expression ever
+    /// becoming true — a completed, not merely truncated, empty search.
+    /// This is the verdict the former `expression_reachable` reported as a
+    /// plain `false`, and it keeps meaning the same thing: `--vacuity
+    /// error`'s `vacuous_implication`/`vacuous_leadsto` findings stay keyed
+    /// on this variant, unchanged by this issue's budget.
+    Unreachable,
+    /// The BFS stopped because it reached `budget` distinct states before
+    /// either finding the expression true or exhausting the reachable
+    /// state space within `depth`. Fail-closed by construction: a caller
+    /// must not fold this into `Unreachable` — reachability was never
+    /// decided, so treating it as "confirmed vacuous" would be a false
+    /// positive and treating it as "confirmed not vacuous" (silently
+    /// dropping it) would let `--vacuity error` pass a spec whose vacuity
+    /// was never actually established.
+    Exhausted,
+}
+
+/// Evaluate the reachability of every expression in `expressions` with one
+/// shared, budgeted BFS over `model`'s concrete state space (issue #729).
+///
+/// Sharing one BFS across every candidate removes the per-antecedent/
+/// per-trigger multiplier the former per-expression `expression_reachable`
+/// paid (a full BFS per property): each candidate still pending is
+/// evaluated against every popped state, drops out of the pending set the
+/// instant it is found true, and the walk stops early once every candidate
+/// has resolved. `budget` bounds the number of distinct concrete states
+/// visited exactly like [`find_boundary_violation`]'s budget (state count
+/// checked right after insertion, before the state is queued): once the
+/// pending set is non-empty and the budget is reached, every still-pending
+/// candidate resolves [`Reachability::Exhausted`] rather than silently
+/// falling back to `Unreachable`.
+///
+/// A per-expression evaluation error (rare on a checked model) resolves
+/// *only that expression* as [`Reachability::Reachable`], i.e. it silently
+/// contributes no finding for it. This matches the original
+/// `expression_reachable`, where a `Result::Err` for one property's
+/// antecedent produced no warning for that property alone; batching must
+/// not let one malformed candidate suppress every other candidate's
+/// vacuity evidence in the same run. A failure of the state-space walk
+/// itself (an action's `enabled`/`step` cannot be evaluated) is not a
+/// per-candidate condition and still propagates as `Err` for the whole
+/// call, matching every other BFS in this module.
 ///
 /// # Errors
 ///
-/// Returns [`RuntimeError`] when the expression or a reachable action cannot be
-/// evaluated concretely.
-pub fn expression_reachable(
-    model: KernelModel,
-    expression: &Expr,
+/// Returns [`RuntimeError`] when the state-space walk itself fails.
+pub fn expression_reachability(
+    model: &KernelModel,
+    expressions: &[Expr],
     depth: usize,
-) -> Result<bool, RuntimeError> {
-    let initial = Monitor::new(model)?;
-    let mut queue = VecDeque::from([(initial.clone(), 0_usize)]);
-    let mut visited = BTreeSet::from([initial.state.clone()]);
-    while let Some((monitor, step)) = queue.pop_front() {
-        if as_bool(with_total_division(|| {
-            eval(
-                expression,
-                &monitor.state,
-                &mut Bindings::new(),
-                &monitor.model,
-                None,
-            )
-        })?)? {
-            return Ok(true);
+    budget: usize,
+) -> Result<Vec<Reachability>, RuntimeError> {
+    if expressions.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut scratch = Monitor::new(model.clone())?;
+    let initial_state = scratch.state.clone();
+    let mut queue = VecDeque::from([(initial_state.clone(), 0_usize)]);
+    let mut visited = BTreeSet::from([initial_state]);
+    let mut results: Vec<Option<Reachability>> = vec![None; expressions.len()];
+    let mut pending: BTreeSet<usize> = (0..expressions.len()).collect();
+
+    'walk: while let Some((state, step)) = queue.pop_front() {
+        scratch.state = state.clone();
+        scratch.step = step;
+        let mut resolved = Vec::new();
+        for &index in &pending {
+            let truth = with_total_division(|| {
+                eval(
+                    &expressions[index],
+                    &scratch.state,
+                    &mut Bindings::new(),
+                    &scratch.model,
+                    None,
+                )
+            })
+            .and_then(as_bool);
+            match truth {
+                Ok(true) | Err(_) => {
+                    // An error is absorbed here, not propagated: see the
+                    // doc comment above.
+                    results[index] = Some(Reachability::Reachable);
+                    resolved.push(index);
+                }
+                Ok(false) => {}
+            }
+        }
+        for index in resolved {
+            pending.remove(&index);
+        }
+        if pending.is_empty() {
+            break 'walk;
         }
         if step >= depth {
             continue;
         }
-        for instance in monitor.enabled()? {
-            let mut child = monitor.clone();
-            let stepped = child.step(&instance)?;
-            if stepped.violation.is_none() && visited.insert(child.state.clone()) {
-                queue.push_back((child, step + 1));
+        for instance in scratch.enabled()? {
+            scratch.state = state.clone();
+            scratch.step = step;
+            let stepped = scratch.step(&instance)?;
+            if stepped.violation.is_some() {
+                continue;
+            }
+            if visited.insert(stepped.state.clone()) {
+                if visited.len() >= budget {
+                    for &index in &pending {
+                        results[index] = Some(Reachability::Exhausted);
+                    }
+                    break 'walk;
+                }
+                queue.push_back((stepped.state, step + 1));
             }
         }
     }
-    Ok(false)
+    Ok(results
+        .into_iter()
+        .map(|result| result.unwrap_or(Reachability::Unreachable))
+        .collect())
 }
 
 /// Wrap `expr` in a nested `exists` quantifier over `binders`, outermost
@@ -2301,34 +2390,22 @@ fn exists_wrap(binders: &[Binder], expr: Expr) -> Expr {
         })
 }
 
-/// Build the verification warnings shared by native and browser frontends.
-///
-/// The two reachability vacuity lanes are computed here and stay
-/// solver-independent. `solver_vacuity` carries the already-rendered
-/// `docs/DESIGN-vacuity.md` §2 lanes 3–6 that only `fsl-verifier` can decide;
-/// passing them in keeps the documented warning order (model → vacuity →
-/// deadlock → action coverage) owned by one function without giving
-/// `fsl-runtime` a solver dependency.
+/// The existentially-closed antecedent of each user invariant shaped
+/// `forall* P => Q` (`docs/DESIGN-vacuity.md` lane 1), paired with the
+/// index of the source invariant in `model.invariants`. An invariant
+/// without that shape (after peeling leading `forall`s) contributes no
+/// candidate, so the index travels with the expression rather than being
+/// assumed to line up with position.
 #[must_use]
-pub fn verification_warnings(
-    model: &KernelModel,
-    depth: usize,
-    warn_deadlock: bool,
-    deadlock_step: Option<usize>,
-    deadlock_state: Option<&State>,
-    action_coverage: &BTreeMap<String, bool>,
-    solver_vacuity: &[JsonValue],
-) -> Vec<JsonValue> {
-    let mut warnings = model_warnings(model);
-    for property in &model.invariants {
-        // `docs/DESIGN-vacuity.md`'s primary `vacuous_implication` shape is a
-        // single `=>` directly under `forall*`: peel every leading `forall`
-        // (nested foralls included, matching the frozen Python reference's
-        // `_implication_antecedent_candidate`), then existentially close the
-        // antecedent over the collected binders before checking
-        // reachability. With zero leading foralls this is a no-op
-        // (`exists_wrap` over an empty slice returns the antecedent
-        // unchanged), so the original top-level-`=>` shape still works.
+pub fn vacuous_implication_candidates(model: &KernelModel) -> Vec<(usize, Expr)> {
+    let mut candidates = Vec::new();
+    for (index, property) in model.invariants.iter().enumerate() {
+        // `forall* => ...` shape: peel every leading `forall` (nested
+        // foralls included, matching the frozen Python reference's
+        // `_implication_antecedent_candidate`), then existentially close
+        // the antecedent over the collected binders. With zero leading
+        // foralls this is a no-op, so the original top-level-`=>` shape
+        // still works.
         let mut binders = Vec::new();
         let mut inner = &property.expr;
         while let Expr::Quantified {
@@ -2349,45 +2426,158 @@ pub fn verification_warnings(
         if op != "=>" {
             continue;
         }
-        let antecedent = exists_wrap(&binders, (**left).clone());
-        if matches!(
-            expression_reachable(model.clone(), &antecedent, depth),
-            Ok(false)
-        ) {
-            let mut warning = json!({
-                "kind": "vacuous_implication",
-                "name": display_name(&property.name),
-                "message": format!("invariant '{}' has an implication antecedent that is unreachable within depth {depth}", display_name(&property.name)),
-                "hint": "the antecedent is not reachable within this depth; check whether an action that should establish it is missing, or whether the antecedent expression is wrong",
-                "loc": property.span.python_loc(),
-                "classification": "insufficient_depth",
-                "blocking": [],
-                "faithfulness_class": "intent_unexercised",
-                "recommended_action": "add a single-shot reachable for the action / raise --depth",
-            });
+        candidates.push((index, exists_wrap(&binders, (**left).clone())));
+    }
+    candidates
+}
+
+/// The existentially-closed trigger of each `leadsTo` property
+/// (`docs/DESIGN-vacuity.md` lane 2), one per `model.leadstos` entry in
+/// declaration order.
+#[must_use]
+pub fn vacuous_leadsto_candidates(model: &KernelModel) -> Vec<Expr> {
+    model
+        .leadstos
+        .iter()
+        .map(|property| exists_wrap(&property.binders, property.before.clone()))
+        .collect()
+}
+
+/// One `vacuous_implication`/`vacuous_leadsto` reachability finding shy of
+/// its `kind`, shared by the two lanes below so the truncated variant
+/// (`vacuity_probe_truncated`) does not need to duplicate the JSON shape.
+fn vacuity_reachability_warning(
+    kind: &str,
+    subject: &str,
+    name: &str,
+    message: &str,
+    hint: &str,
+    loc: &JsonValue,
+) -> JsonValue {
+    json!({
+        "kind": kind,
+        "name": name,
+        "message": message,
+        "hint": hint,
+        "loc": loc,
+        "classification": if kind == "vacuity_probe_truncated" { "probe_truncated" } else { "insufficient_depth" },
+        "blocking": [],
+        "faithfulness_class": if kind == "vacuity_probe_truncated" { "reachability_unknown" } else { "intent_unexercised" },
+        "recommended_action": if kind == "vacuity_probe_truncated" {
+            format!("the {subject}'s reachability could not be established within the internal probe budget; this is unusual and typically means the state shape (e.g. an order-sensitive history variable) defeats BFS dedup -- simplify it or reduce --depth")
+        } else {
+            "add a single-shot reachable for the action / raise --depth".to_owned()
+        },
+    })
+}
+
+/// Build the verification warnings shared by native and browser frontends.
+///
+/// The two reachability vacuity lanes are computed here, with one shared,
+/// budgeted BFS (issue #729) over every antecedent/trigger candidate
+/// (`CONCRETE_PROBE_BUDGET`, the same constant/calibration
+/// `find_boundary_violation` uses), and stay solver-independent.
+/// `solver_vacuity` carries the already-rendered `docs/DESIGN-vacuity.md`
+/// §2 lanes 3–6 that only `fsl-verifier` can decide; passing them in keeps
+/// the documented warning order (model → vacuity → deadlock → action
+/// coverage) owned by one function without giving `fsl-runtime` a solver
+/// dependency.
+///
+/// `skip_vacuity_probe` skips the whole reachability BFS (neither
+/// `vacuous_implication`/`vacuous_leadsto` nor `vacuity_probe_truncated` is
+/// computed or emitted) rather than computing it and filtering the result.
+/// INVARIANT (issue #729): only the `verify`/`sweep` CLI option parsing for
+/// `--vacuity ignore` may pass `true` here. Every other caller -- the
+/// `ledger`/`html`/`mutate` baseline, the wasm Worker surface (which has no
+/// `--vacuity` option at all), induction's internal BMC base pass, and
+/// tests -- must pass `false` so the probe always runs and `--vacuity
+/// error` never silently loses evidence it would otherwise catch.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn verification_warnings(
+    model: &KernelModel,
+    depth: usize,
+    warn_deadlock: bool,
+    deadlock_step: Option<usize>,
+    deadlock_state: Option<&State>,
+    action_coverage: &BTreeMap<String, bool>,
+    solver_vacuity: &[JsonValue],
+    skip_vacuity_probe: bool,
+) -> Vec<JsonValue> {
+    let mut warnings = model_warnings(model);
+    if !skip_vacuity_probe {
+        let implication_candidates = vacuous_implication_candidates(model);
+        let leadsto_candidates = vacuous_leadsto_candidates(model);
+        let mut probe_expressions: Vec<Expr> = implication_candidates
+            .iter()
+            .map(|(_, expression)| expression.clone())
+            .collect();
+        probe_expressions.extend(leadsto_candidates.iter().cloned());
+        // A `RuntimeError` from the state-space walk itself (see
+        // `expression_reachability`'s doc comment) loses both lanes for
+        // this run, exactly as a single antecedent's `Err` silently lost
+        // just that one property's warning before batching -- there is no
+        // narrower fallback to degrade to.
+        let probe_results =
+            expression_reachability(model, &probe_expressions, depth, CONCRETE_PROBE_BUDGET)
+                .unwrap_or_default();
+        for (candidate_index, (property_index, _)) in implication_candidates.iter().enumerate() {
+            let property = &model.invariants[*property_index];
+            let name = display_name(&property.name);
+            let mut warning = match probe_results.get(candidate_index) {
+                Some(Reachability::Unreachable) => vacuity_reachability_warning(
+                    "vacuous_implication",
+                    "implication antecedent",
+                    &name,
+                    &format!(
+                        "invariant '{name}' has an implication antecedent that is unreachable within depth {depth}"
+                    ),
+                    "the antecedent is not reachable within this depth; check whether an action that should establish it is missing, or whether the antecedent expression is wrong",
+                    &property.span.python_loc(),
+                ),
+                Some(Reachability::Exhausted) => vacuity_reachability_warning(
+                    "vacuity_probe_truncated",
+                    "implication antecedent",
+                    &name,
+                    &format!(
+                        "invariant '{name}' has an implication antecedent whose reachability probe was truncated by the internal state budget before reaching depth {depth}"
+                    ),
+                    "vacuity was not established either way for this antecedent; the probe stopped at a state-count budget, not at depth",
+                    &property.span.python_loc(),
+                ),
+                Some(Reachability::Reachable) | None => continue,
+            };
             if let JsonValue::Object(warning) = &mut warning {
                 insert_requirement_metadata(warning, &property.annotations, property.meta.as_ref());
             }
             warnings.push(warning);
         }
-    }
-    for property in &model.leadstos {
-        let trigger = exists_wrap(&property.binders, property.before.clone());
-        if matches!(
-            expression_reachable(model.clone(), &trigger, depth),
-            Ok(false)
-        ) {
-            let mut warning = json!({
-                "kind": "vacuous_leadsto",
-                "name": display_name(&property.name),
-                "message": format!("leadsTo '{}' has a trigger that is unreachable within depth {depth}", display_name(&property.name)),
-                "hint": "the trigger is not reachable within this depth; check whether an action that should establish it is missing, or whether the trigger expression is wrong",
-                "loc": property.span.python_loc(),
-                "classification": "insufficient_depth",
-                "blocking": [],
-                "faithfulness_class": "intent_unexercised",
-                "recommended_action": "add a single-shot reachable for the action / raise --depth",
-            });
+        let leadsto_offset = implication_candidates.len();
+        for (offset, property) in model.leadstos.iter().enumerate() {
+            let name = display_name(&property.name);
+            let mut warning = match probe_results.get(leadsto_offset + offset) {
+                Some(Reachability::Unreachable) => vacuity_reachability_warning(
+                    "vacuous_leadsto",
+                    "leadsTo trigger",
+                    &name,
+                    &format!(
+                        "leadsTo '{name}' has a trigger that is unreachable within depth {depth}"
+                    ),
+                    "the trigger is not reachable within this depth; check whether an action that should establish it is missing, or whether the trigger expression is wrong",
+                    &property.span.python_loc(),
+                ),
+                Some(Reachability::Exhausted) => vacuity_reachability_warning(
+                    "vacuity_probe_truncated",
+                    "leadsTo trigger",
+                    &name,
+                    &format!(
+                        "leadsTo '{name}' has a trigger whose reachability probe was truncated by the internal state budget before reaching depth {depth}"
+                    ),
+                    "vacuity was not established either way for this trigger; the probe stopped at a state-count budget, not at depth",
+                    &property.span.python_loc(),
+                ),
+                Some(Reachability::Reachable) | None => continue,
+            };
             if let JsonValue::Object(warning) = &mut warning {
                 insert_requirement_metadata(warning, &property.annotations, property.meta.as_ref());
             }

--- a/rust/fsl-runtime/tests/diagnostics.rs
+++ b/rust/fsl-runtime/tests/diagnostics.rs
@@ -33,6 +33,7 @@ fn vacuous_leadsto_is_reported_when_the_trigger_is_unreachable() {
         None,
         &BTreeMap::new(),
         &[],
+        false,
     );
     assert!(
         warnings
@@ -50,14 +51,105 @@ fn vacuous_leadsto_is_reported_when_the_trigger_is_unreachable() {
          action finish() { requires pending pending = false done = true } \
          leadsTo Served { pending ~> done } }",
     );
-    let warnings =
-        fsl_runtime::verification_warnings(&reachable, 3, false, None, None, &BTreeMap::new(), &[]);
+    let warnings = fsl_runtime::verification_warnings(
+        &reachable,
+        3,
+        false,
+        None,
+        None,
+        &BTreeMap::new(),
+        &[],
+        false,
+    );
     assert!(
         !warnings
             .iter()
             .any(|warning| warning.get("kind").and_then(|k| k.as_str()) == Some("vacuous_leadsto")),
         "reachable trigger must not be flagged: {warnings:#?}"
     );
+}
+
+/// Digit-growth model (same trick as
+/// `rust/fsl-runtime/tests/boundary_probe_budget.rs`): `count = count * 10 +
+/// x` is injective per level, so the distinct reachable state count grows
+/// exactly `10^level` and is fully predictable without the test doing
+/// meaningful work past a cutoff. `ReachesThree`'s antecedent becomes true
+/// at level 1 (`count == 3`, one of the ten `x in 0..9` successors of the
+/// root); `NeverNegative`'s antecedent (`count < 0`) can never become true,
+/// because `step` only ever appends a non-negative digit.
+fn digit_growth_vacuity_model() -> fsl_core::KernelModel {
+    build_model(
+        parse_kernel_source(
+            "spec DigitGrowthVacuity { state { count: Int } init { count = 0 } \
+             action step(x in 0..9) { count = count * 10 + x } \
+             invariant ReachesThree { count == 3 => count == 3 } \
+             invariant NeverNegative { count < 0 => count == 3 } }",
+            &fsl_core::FsResolver::new("."),
+        )
+        .expect("parse model"),
+    )
+    .expect("build model")
+}
+
+/// Positive and negative control for issue #729's tri-state contract, in one
+/// shared BFS call (`docs/DESIGN-vacuity.md`, `expression_reachability`):
+/// - Negative control: a genuinely unreachable antecedent
+///   (`NeverNegative`'s `count < 0`) must resolve `Exhausted`, not
+///   `Unreachable`, once the shared budget is hit -- folding it into
+///   `Unreachable` would be the exact fail-open #729 exists to prevent.
+/// - Positive control: a step-1-reachable antecedent (`ReachesThree`'s
+///   `count == 3`) must resolve `Reachable` under the very same budget --
+///   the budget must not suppress an early, cheap finding.
+#[test]
+fn a_genuinely_unreachable_candidate_exhausts_the_shared_budget_while_a_step_one_candidate_resolves_reachable()
+ {
+    let model = digit_growth_vacuity_model();
+    let candidates = fsl_runtime::vacuous_implication_candidates(&model);
+    assert_eq!(
+        candidates.len(),
+        2,
+        "both invariants are `forall*P => Q`-shaped: {candidates:?}"
+    );
+    let expressions: Vec<_> = candidates.iter().map(|(_, expr)| expr.clone()).collect();
+
+    // Level 1 alone already reaches 10 distinct states (`count` in `0..=9`);
+    // level 2 reaches 100 more -- far past a 50-state budget -- so at
+    // `depth: 8` the search for `NeverNegative`'s antecedent must exhaust
+    // long before it could ever exhaustively enumerate the (here: infinite,
+    // since `count` is an unbounded `Int`) space.
+    let results = fsl_runtime::expression_reachability(&model, &expressions, 8, 50)
+        .expect("shared probe must not error");
+    assert_eq!(
+        results,
+        vec![
+            fsl_runtime::Reachability::Reachable,
+            fsl_runtime::Reachability::Exhausted,
+        ],
+        "ReachesThree must resolve Reachable and NeverNegative must resolve Exhausted, \
+         not Unreachable: {results:?}"
+    );
+}
+
+/// Companion to the control above: the very same genuinely-unreachable
+/// antecedent resolves `Unreachable` (not `Exhausted`) when the BFS is
+/// allowed to actually complete -- `depth: 2` bounds the reachable set to
+/// exactly 100 distinct `count` values (`0..=99`), comfortably inside a
+/// 1,000-state budget that is never hit. This is the pre-#729 verdict,
+/// unchanged: budget exhaustion, not depth-bounded closure, is the only new
+/// way to reach `Exhausted`.
+#[test]
+fn the_same_candidate_resolves_unreachable_once_the_search_actually_completes() {
+    let model = digit_growth_vacuity_model();
+    let candidates = fsl_runtime::vacuous_implication_candidates(&model);
+    let never_negative = candidates
+        .iter()
+        .find(|(index, _)| model.invariants[*index].name.contains("NeverNegative"))
+        .map(|(_, expr)| expr.clone())
+        .expect("NeverNegative contributes a candidate");
+
+    let results = fsl_runtime::expression_reachability(&model, &[never_negative], 2, 1_000)
+        .expect("shared probe must not error");
+    assert_eq!(results, vec![fsl_runtime::Reachability::Unreachable]);
 }
 
 #[test]

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -359,16 +359,24 @@ fn collect_findings(model: &KernelModel, verification: &Value) -> Vec<Finding> {
             .and_then(Value::as_str)
             .unwrap_or("");
         let metadata = requirement(warning);
+        let kind = warning.get("kind").and_then(Value::as_str).unwrap_or("");
+        let message = warning.get("message").and_then(Value::as_str).unwrap_or("");
         findings.push(Finding {
             requirement_id: metadata.0,
             requirement_text: metadata.1,
             trace_type: "vacuity".to_owned(),
             name: name.to_owned(),
-            summary: format!(
-                "空虚性の疑い（{}）: {}",
-                warning.get("kind").and_then(Value::as_str).unwrap_or(""),
-                warning.get("message").and_then(Value::as_str).unwrap_or("")
-            ),
+            // `vacuity_probe_truncated` (issue #729) is not itself a
+            // vacuity finding: it means the reachability probe was cut off
+            // by its state budget before it could decide either way. That
+            // is a distinct claim from "疑い" (suspected hollow), so it
+            // gets its own prefix -- "未確立" (not established), not
+            // "疑い" (suspected).
+            summary: if kind == "vacuity_probe_truncated" {
+                format!("空虚性未確立（到達性 probe が budget で打ち切り）: {message}")
+            } else {
+                format!("空虚性の疑い（{kind}）: {message}")
+            },
             next_action: warning
                 .get("hint")
                 .and_then(Value::as_str)

--- a/rust/fsl-tools/src/ledger.rs
+++ b/rust/fsl-tools/src/ledger.rs
@@ -367,13 +367,15 @@ fn collect_findings(model: &KernelModel, verification: &Value) -> Vec<Finding> {
             trace_type: "vacuity".to_owned(),
             name: name.to_owned(),
             // `vacuity_probe_truncated` (issue #729) is not itself a
-            // vacuity finding: it means the reachability probe was cut off
-            // by its state budget before it could decide either way. That
-            // is a distinct claim from "疑い" (suspected hollow), so it
-            // gets its own prefix -- "未確立" (not established), not
-            // "疑い" (suspected).
+            // vacuity finding: it means the reachability probe (state
+            // budget exhaustion, or a per-candidate evaluation failure --
+            // `fsl_runtime::Reachability::Exhausted` does not distinguish
+            // the two) never reached a verdict either way. That is a
+            // distinct claim from "疑い" (suspected hollow), so it gets its
+            // own prefix -- "未確立" (not established), not "疑い"
+            // (suspected).
             summary: if kind == "vacuity_probe_truncated" {
-                format!("空虚性未確立（到達性 probe が budget で打ち切り）: {message}")
+                format!("空虚性未確立（到達性 probe が判定に至らず）: {message}")
             } else {
                 format!("空虚性の疑い（{kind}）: {message}")
             },

--- a/rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs
+++ b/rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Two obligations from issue #729's implementation brief, exercised
+//! directly at the `render_ledger` level (no real budget-exhausting run
+//! needed -- `collect_findings`/`assurance_token` operate on the JSON shape
+//! alone):
+//!
+//! 1. The ledger's summary prefix for `kind == "vacuity_probe_truncated"`
+//!    must read "空虚性未確立（到達性 probe が budget で打ち切り）"
+//!    (vacuity *not established*), never "空虚性の疑い" (*suspected*
+//!    hollow) -- the two are different claims: a suspected finding says
+//!    something was proven vacuous; a truncated probe says nothing was
+//!    proven either way.
+//! 2. Negative control (c): `assurance_token` (and therefore the rendered
+//!    保証クラス cell) must not move when a `vacuity_probe_truncated`
+//!    finding is present versus an ordinary `vacuous_implication` finding,
+//!    because it is derived from `completeness`/`result` alone and never
+//!    reads `warnings`.
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+use serde_json::json;
+
+const SPEC: &str = "spec LedgerTruncatedProbe { state { x: Bool } init { x = false } \
+     action flip() { x = not x } invariant Trivial { x => x } }";
+
+fn model() -> fsl_core::KernelModel {
+    build_model(parse_kernel_source(SPEC, &FsResolver::new(".")).expect("parse kernel"))
+        .expect("build model")
+}
+
+fn verification_with(warning_kind: &str) -> serde_json::Value {
+    json!({
+        "result": "verified",
+        "completeness": "bounded",
+        "checked_to_depth": 8,
+        "warnings": [{
+            "kind": warning_kind,
+            "name": "Trivial",
+            "message": format!("invariant 'Trivial' has an implication antecedent ({warning_kind} fixture)"),
+            "hint": "fixture hint",
+        }],
+    })
+}
+
+fn render(verification: &serde_json::Value) -> String {
+    fsl_tools::render_ledger(
+        "ledger_truncated_probe.fsl",
+        &model(),
+        verification,
+        &json!({}),
+        None,
+        &[],
+    )
+}
+
+#[test]
+fn vacuity_probe_truncated_uses_the_not_established_prefix_not_the_suspected_prefix() {
+    let rendered = render(&verification_with("vacuity_probe_truncated"));
+    assert!(
+        rendered.contains("空虚性未確立（到達性 probe が budget で打ち切り）"),
+        "expected the truncated-probe summary prefix: {rendered}"
+    );
+    assert!(
+        !rendered.contains("空虚性の疑い（vacuity_probe_truncated）"),
+        "a truncated (inconclusive) probe must not be worded as a suspected-hollow finding: \
+         {rendered}"
+    );
+}
+
+#[test]
+fn an_ordinary_vacuous_implication_still_uses_the_suspected_prefix() {
+    let rendered = render(&verification_with("vacuous_implication"));
+    assert!(
+        rendered.contains("空虚性の疑い（vacuous_implication）"),
+        "regression control: the ordinary vacuity prefix must be unchanged: {rendered}"
+    );
+    assert!(
+        !rendered.contains("空虚性未確立"),
+        "an ordinary (non-truncated) finding must not use the not-established wording: {rendered}"
+    );
+}
+
+/// Negative control (c) from the implementation brief: `assurance_token`
+/// reads only `completeness`/`kernel.completeness`/`result`/`evidence.kind`/
+/// `guarantee_kind`/`status` -- never `warnings` -- so the rendered
+/// assurance-class row for the spec-level finding must be byte-identical
+/// whether the finding is an ordinary `vacuous_implication` or a
+/// `vacuity_probe_truncated` truncation. `collect_findings` maps every
+/// `warnings` entry to `trace_type: "vacuity"` regardless of `kind`, so the
+/// whole spec-level row -- not just the assurance cell -- is expected to
+/// match exactly.
+#[test]
+fn assurance_class_is_unmoved_by_a_truncated_probe_finding() {
+    let with_vacuous = render(&verification_with("vacuous_implication"));
+    let with_truncated = render(&verification_with("vacuity_probe_truncated"));
+
+    let spec_level_row = |rendered: &str| -> String {
+        rendered
+            .lines()
+            .find(|line| line.contains("要件ID未付与の検出"))
+            .unwrap_or_else(|| panic!("expected a spec-level row: {rendered}"))
+            .to_owned()
+    };
+
+    assert_eq!(
+        spec_level_row(&with_vacuous),
+        spec_level_row(&with_truncated),
+        "the spec-level assurance row must not depend on which vacuity `kind` produced the \
+         finding: with_vacuous={with_vacuous}\n---\nwith_truncated={with_truncated}"
+    );
+}

--- a/rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs
+++ b/rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs
@@ -7,7 +7,7 @@
 //! alone):
 //!
 //! 1. The ledger's summary prefix for `kind == "vacuity_probe_truncated"`
-//!    must read "空虚性未確立（到達性 probe が budget で打ち切り）"
+//!    must read "空虚性未確立（到達性 probe が判定に至らず）"
 //!    (vacuity *not established*), never "空虚性の疑い" (*suspected*
 //!    hollow) -- the two are different claims: a suspected finding says
 //!    something was proven vacuous; a truncated probe says nothing was
@@ -58,7 +58,7 @@ fn render(verification: &serde_json::Value) -> String {
 fn vacuity_probe_truncated_uses_the_not_established_prefix_not_the_suspected_prefix() {
     let rendered = render(&verification_with("vacuity_probe_truncated"));
     assert!(
-        rendered.contains("空虚性未確立（到達性 probe が budget で打ち切り）"),
+        rendered.contains("空虚性未確立（到達性 probe が判定に至らず）"),
         "expected the truncated-probe summary prefix: {rendered}"
     );
     assert!(

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -363,6 +363,7 @@ fn add_frontend_metadata(
     output
 }
 
+#[allow(clippy::too_many_lines)]
 async fn verify(request: &Request, solver_version: &str) -> Value {
     let started = performance_now();
     if let Err(failure) = fsl_syntax::parse_surface_document(&request.source) {
@@ -417,6 +418,9 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
                             checked_bounds: None,
                             elapsed_s: (performance_now() - started) / 1000.0,
                             statistics: &statistics,
+                            // The Worker request surface has no `--vacuity`
+                            // option at all (issue #729): always compute.
+                            skip_vacuity_probe: false,
                         },
                     )
                     .0;
@@ -464,6 +468,9 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             checked_bounds: None,
             elapsed_s: (performance_now() - started) / 1000.0,
             statistics: &statistics,
+            // The Worker request surface has no `--vacuity` option at all
+            // (issue #729): always compute.
+            skip_vacuity_probe: false,
         },
     );
     prepend_compose_warnings(&mut output, compose_warnings);
@@ -597,6 +604,7 @@ mod tests {
                 checked_bounds: None,
                 elapsed_s,
                 statistics,
+                skip_vacuity_probe: false,
             },
         )
         .0

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -15128,12 +15128,18 @@ fn run_verify(
         property: None,
         excluded: &[],
     };
+    // This is the `ledger`/`html`/`mutate` baseline (`run_verify` has no
+    // `--vacuity` option at all): per the invariant recorded on
+    // `BmcOutputOptions::skip_vacuity_probe` (issue #729), it must always
+    // compute the reachability probe.
+    let skip_vacuity_probe = false;
     let (mut output, status) = match VerificationEngine::parse(engine) {
         Ok(VerificationEngine::Bmc) => run_bmc_filtered(BmcRequest {
             selection,
             depth,
             deadlock,
             initial_state: None,
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {
             selection,
@@ -15141,18 +15147,21 @@ fn run_verify(
             deadlock,
             k: k_ind,
             auxiliary: &[],
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
             selection,
             depth,
             deadlock,
             budget: explicit_budget,
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Auto) => run_auto_filtered(ExplicitRequest {
             selection,
             depth,
             deadlock,
             budget: explicit_budget,
+            skip_vacuity_probe,
         }),
         Err(error) => return (error_output("usage", &error), 2),
     };

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -53,6 +53,10 @@ pub(super) struct BmcRequest<'a> {
     pub(super) depth: usize,
     pub(super) deadlock: DeadlockMode,
     pub(super) initial_state: Option<&'a std::collections::BTreeMap<String, FslValue>>,
+    /// See `BmcOutputOptions::skip_vacuity_probe` (issue #729): only
+    /// `execute_cli_verification`'s `--vacuity ignore` handling may set
+    /// this `true`.
+    pub(super) skip_vacuity_probe: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -62,6 +66,8 @@ pub(super) struct InductionRequest<'a> {
     pub(super) deadlock: DeadlockMode,
     pub(super) k: usize,
     pub(super) auxiliary: &'a [(String, KernelExpr)],
+    /// See `BmcRequest::skip_vacuity_probe`.
+    pub(super) skip_vacuity_probe: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -70,6 +76,8 @@ pub(super) struct ExplicitRequest<'a> {
     pub(super) depth: usize,
     pub(super) deadlock: DeadlockMode,
     pub(super) budget: usize,
+    /// See `BmcRequest::skip_vacuity_probe`.
+    pub(super) skip_vacuity_probe: bool,
 }
 
 type CommandResult = (Value, i32);
@@ -182,6 +190,7 @@ fn selected_transition_induction_model(
     Ok(Some(model))
 }
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i32) {
     let InductionRequest {
         selection,
@@ -189,6 +198,7 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
         deadlock,
         k,
         auxiliary,
+        skip_vacuity_probe,
     } = request;
     let selected_transition_model = match selected_transition_induction_model(selection) {
         Ok(model) => model,
@@ -209,6 +219,7 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
         depth,
         deadlock,
         initial_state: None,
+        skip_vacuity_probe,
     };
     let (base_prepared, base_solved) = match execute_bmc(&base_request, started) {
         Ok(execution) => execution,
@@ -224,6 +235,7 @@ pub(super) fn run_induction_filtered(request: InductionRequest<'_>) -> (Value, i
             checked_bounds: base_prepared.checked_bounds.as_ref(),
             elapsed_s: started.elapsed().as_secs_f64(),
             statistics: &base_solved.statistics,
+            skip_vacuity_probe: base_request.skip_vacuity_probe,
         },
     );
     let Value::Object(base) = &base_value else {
@@ -876,6 +888,7 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
         started.elapsed().as_secs_f64(),
         &vacuity,
         &reachable_diagnostics,
+        request.skip_vacuity_probe,
     ))
 }
 
@@ -935,6 +948,7 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
             started.elapsed().as_secs_f64(),
             &vacuity,
             &reachable_diagnostics,
+            request.skip_vacuity_probe,
         ));
     if output.get("result").and_then(Value::as_str) == Some("unknown_budget") {
         return auto_fallback_to_bmc(request, &budget_fallback_reason(&output), "budget");
@@ -948,6 +962,7 @@ fn auto_fallback_to_bmc(request: ExplicitRequest<'_>, reason: &str, kind: &str) 
         depth: request.depth,
         deadlock: request.deadlock,
         initial_state: None,
+        skip_vacuity_probe: request.skip_vacuity_probe,
     });
     annotate_auto_fallback(&mut output, reason, kind);
     (output, status)
@@ -1008,6 +1023,7 @@ pub(super) fn run_bmc_filtered(request: BmcRequest<'_>) -> (Value, i32) {
             checked_bounds: prepared.checked_bounds.as_ref(),
             elapsed_s: started.elapsed().as_secs_f64(),
             statistics: &solved.statistics,
+            skip_vacuity_probe: request.skip_vacuity_probe,
         },
     )
 }
@@ -1058,6 +1074,10 @@ fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc
                             checked_bounds: None,
                             elapsed_s: started.elapsed().as_secs_f64(),
                             statistics: &statistics,
+                            // This branch renders `render_boundary_output`,
+                            // which never emits `warnings`, so this value is
+                            // inert here; threaded through for consistency.
+                            skip_vacuity_probe: request.skip_vacuity_probe,
                         },
                     ));
                 }
@@ -1345,6 +1365,11 @@ fn run_induction_with_lemmas(
         }
         entries.push(entry);
     }
+    // See `execute_cli_verification`'s matching comment: this is the
+    // `--lemma` path's own derivation of the same CLI `--vacuity` option,
+    // since `run_induction_with_lemmas` is called directly from
+    // `run_verify_cli` rather than through `execute_cli_verification`.
+    let skip_vacuity_probe = options.vacuity == "ignore";
     let (mut result, status) = loop {
         let (current, status) = run_induction_filtered(InductionRequest {
             selection,
@@ -1352,6 +1377,7 @@ fn run_induction_with_lemmas(
             deadlock,
             k: options.k_ind,
             auxiliary: &auxiliary,
+            skip_vacuity_probe,
         });
         if current.get("result").and_then(Value::as_str) != Some("unknown_cti")
             || current.get("violation_kind").and_then(Value::as_str) == Some("leadsTo_rank")
@@ -2171,12 +2197,25 @@ fn execute_cli_verification(
         property: options.property.as_deref(),
         excluded: &options.exclude_properties,
     };
+    // INVARIANT (issue #729): together with `run_induction_with_lemmas`'
+    // matching derivation (the `--lemma` path bypasses this function), this
+    // is the *only* place in the product that may set `skip_vacuity_probe`
+    // to `true`. It is derived directly from the CLI's own `--vacuity`
+    // option parsing, which both `verify` and `sweep` funnel through
+    // `run_verify_cli` -- `sweep` builds its own `CliVerifyOptions` per
+    // grid cell and calls `run_verify_cli` exactly like `verify` does.
+    // Every other constructor of `BmcRequest`/`InductionRequest`/
+    // `ExplicitRequest` in this codebase (the `ledger`/`html`/`mutate`
+    // baseline in `rust/fslc/src/main.rs`'s `run_verify`, and tests) must
+    // pass `false`.
+    let skip_vacuity_probe = options.vacuity == "ignore";
     let (mut output, status) = match VerificationEngine::parse(&options.engine) {
         Ok(VerificationEngine::Bmc) => run_bmc_filtered(BmcRequest {
             selection,
             depth: options.depth,
             deadlock,
             initial_state: prepared.initial_state.as_ref(),
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {
             selection,
@@ -2184,18 +2223,21 @@ fn execute_cli_verification(
             deadlock,
             k: options.k_ind,
             auxiliary: &[],
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
             selection,
             depth: options.depth,
             deadlock,
             budget: options.explicit_budget,
+            skip_vacuity_probe,
         }),
         Ok(VerificationEngine::Auto) => run_auto_filtered(ExplicitRequest {
             selection,
             depth: options.depth,
             deadlock,
             budget: options.explicit_budget,
+            skip_vacuity_probe,
         }),
         Err(error) => return (error_output("usage", &error), 2),
     };
@@ -2370,6 +2412,7 @@ mod tests {
             depth: 4,
             deadlock: DeadlockMode::Ignore,
             initial_state: None,
+            skip_vacuity_probe: false,
         });
         assert_eq!(status, 0);
         assert_eq!(output["result"], "verified");
@@ -2392,6 +2435,7 @@ mod tests {
             deadlock: DeadlockMode::Ignore,
             k: 1,
             auxiliary: &[],
+            skip_vacuity_probe: false,
         });
         assert_eq!(status, 1);
         assert_eq!(output["result"], "unknown_cti");
@@ -2454,6 +2498,7 @@ mod tests {
             0.0,
             &[],
             &std::collections::BTreeMap::new(),
+            false,
         );
         let (output, status) = finish_explicit_output(rendered);
         assert_eq!(status, 3);

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -81,6 +81,20 @@ pub struct BmcOutputOptions<'a> {
     pub checked_bounds: Option<&'a BTreeSet<String>>,
     pub elapsed_s: f64,
     pub statistics: &'a VerificationStatistics,
+    /// Whether to skip the budgeted vacuity reachability probe
+    /// (`fsl_runtime::verification_warnings`'s `vacuous_implication`/
+    /// `vacuous_leadsto`/`vacuity_probe_truncated` lanes) entirely, rather
+    /// than compute it and filter the result (issue #729).
+    ///
+    /// INVARIANT: only the `verify`/`sweep` CLI option parsing for
+    /// `--vacuity ignore` (`rust/fslc/src/verification.rs`'s
+    /// `execute_cli_verification`) may set this `true`. Every other
+    /// caller -- the `ledger`/`html`/`mutate` baseline (`run_verify`), the
+    /// wasm Worker surface (which has no `--vacuity` option at all),
+    /// induction's internal BMC base pass, and tests -- must pass `false`
+    /// so the probe always runs and `--vacuity error` never silently loses
+    /// evidence it would otherwise catch.
+    pub skip_vacuity_probe: bool,
 }
 
 /// The source location a typed-model diagnostic carries, if the model bound one
@@ -1025,6 +1039,7 @@ pub fn render_explicit_output(
     elapsed_s: f64,
     vacuity: &[VacuityFinding],
     reachable_diagnostics: &std::collections::BTreeMap<String, fsl_verifier::ReachableDiagnosis>,
+    skip_vacuity_probe: bool,
 ) -> Result<(Value, i32), String> {
     let compatible = explicit_as_bmc(result, vacuity, reachable_diagnostics);
     replay_bmc_witnesses(model, &compatible, None)?;
@@ -1037,6 +1052,7 @@ pub fn render_explicit_output(
             checked_bounds,
             elapsed_s,
             statistics: &statistics,
+            skip_vacuity_probe,
         };
         let (mut output, status) = if violation.kind == "partial_op" {
             let boundary = fsl_runtime::Violation {
@@ -1061,6 +1077,7 @@ pub fn render_explicit_output(
             checked_bounds,
             elapsed_s,
             statistics: &statistics,
+            skip_vacuity_probe,
         };
         let (mut output, status) =
             render_deadlock_failure(envelope, model, &compatible, step, &options);
@@ -1099,6 +1116,7 @@ pub fn render_explicit_output(
             checked_bounds,
             elapsed_s,
             statistics: &statistics,
+            skip_vacuity_probe,
         };
         let (mut output, status) =
             render_reachable_failure(envelope, model, &compatible, &unreached, &options);
@@ -1118,6 +1136,7 @@ pub fn render_explicit_output(
         deadlock,
         elapsed_s,
         &statistics,
+        skip_vacuity_probe,
     ))
 }
 
@@ -1189,6 +1208,9 @@ fn render_explicit_budget(
         checked_bounds,
         elapsed_s,
         statistics,
+        // This branch never renders `warnings` (see `add_common`), so the
+        // vacuity probe is never invoked from here regardless of this value.
+        skip_vacuity_probe: false,
     };
     add_common(&mut output, model, compatible, &options);
     output.insert("depth".to_owned(), json!(result.depth));
@@ -1223,6 +1245,7 @@ fn render_explicit_success(
     deadlock: DeadlockMode,
     elapsed_s: f64,
     statistics: &VerificationStatistics,
+    skip_vacuity_probe: bool,
 ) -> (Value, i32) {
     if !result.closure {
         let options = BmcOutputOptions {
@@ -1231,6 +1254,7 @@ fn render_explicit_success(
             checked_bounds,
             elapsed_s,
             statistics,
+            skip_vacuity_probe,
         };
         let (mut output, status) = render_success(output, model, compatible, &options);
         add_explicit_metadata(&mut output, result);
@@ -1245,6 +1269,7 @@ fn render_explicit_success(
         checked_bounds,
         elapsed_s,
         statistics,
+        skip_vacuity_probe,
     };
     add_common(&mut output, model, compatible, &options);
     output.insert("depth".to_owned(), json!(result.depth));
@@ -1822,6 +1847,7 @@ fn shared_warnings(
             .map(|entry| &entry.state),
         &result.action_coverage,
         &solver_vacuity_warnings(model, result),
+        options.skip_vacuity_probe,
     )
 }
 
@@ -2183,6 +2209,7 @@ mod tests {
             0.0,
             &[],
             &std::collections::BTreeMap::new(),
+            false,
         );
         assert!(rendered.is_err());
     }
@@ -2212,6 +2239,7 @@ mod tests {
                 checked_bounds: None,
                 elapsed_s: 0.0,
                 statistics: &statistics,
+                skip_vacuity_probe: false,
             },
         );
         let (mut explicit_output, explicit_status) = render_explicit_output(
@@ -2223,6 +2251,7 @@ mod tests {
             0.0,
             &[],
             &std::collections::BTreeMap::new(),
+            false,
         )
         .expect("explicit evidence replays");
         let explicit_envelope = explicit_output.as_object_mut().expect("explicit envelope");

--- a/rust/fslc/tests/issue_729_vacuity_ignore_skip.rs
+++ b/rust/fslc/tests/issue_729_vacuity_ignore_skip.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Negative control (a) for issue #729: `--vacuity ignore` is now allowed to
+//! *skip* the budgeted reachability probe entirely (`fsl_runtime::
+//! verification_warnings`'s `skip_vacuity_probe`) rather than compute it and
+//! filter the result, as it did before. Skipping the computation must never
+//! change what the CLI reports beyond the `warnings` array itself: this test
+//! proves the `--vacuity ignore` envelope is exactly the `--vacuity warn`
+//! envelope with every `is_vacuity_kind` entry removed from `warnings`
+//! (`--cost`/`elapsed_s`/`cost.solver.check_elapsed_s` excluded from the
+//! comparison, since skipping genuinely does less work and so legitimately
+//! takes less time).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_cli(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+const FIXTURE: &str = "rust/fslc/tests/fixtures/vacuous_leadsto.fsl";
+
+/// Timing/cost fields legitimately move when the probe is skipped -- they
+/// are not part of the "did skipping change anything else" claim.
+const TIMING_ONLY_KEYS: &[&str] = &["cost"];
+
+fn without_timing(mut envelope: Value) -> Value {
+    if let Value::Object(object) = &mut envelope {
+        for key in TIMING_ONLY_KEYS {
+            object.remove(*key);
+        }
+    }
+    envelope
+}
+
+fn without_vacuity_warnings(mut envelope: Value) -> Value {
+    if let Value::Object(object) = &mut envelope
+        && let Some(Value::Array(warnings)) = object.get_mut("warnings")
+    {
+        warnings.retain(|warning| {
+            !warning
+                .get("kind")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| fsl_core::VACUITY_KINDS.contains(&kind))
+        });
+    }
+    envelope
+}
+
+#[test]
+fn vacuity_ignore_skip_produces_the_same_envelope_as_warn_with_vacuity_kinds_filtered() {
+    let (warn_output, warn_status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "warn",
+        "--no-cache",
+    ]);
+    let (ignore_output, ignore_status) = run_cli(&[
+        "verify",
+        FIXTURE,
+        "--depth",
+        "3",
+        "--deadlock",
+        "ignore",
+        "--vacuity",
+        "ignore",
+        "--no-cache",
+    ]);
+    assert_eq!(warn_status, 0, "{warn_output:#}");
+    assert_eq!(ignore_status, 0, "{ignore_output:#}");
+
+    // Sanity: the fixture must actually exercise a vacuity finding, or this
+    // test would pass vacuously (no `warnings` difference to filter at all).
+    assert!(
+        warn_output["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_leadsto"),
+        "fixture must produce a vacuous_leadsto warning under --vacuity warn: {warn_output:#}"
+    );
+    assert!(
+        !ignore_output["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_leadsto"),
+        "--vacuity ignore must still suppress the vacuity finding in its own output: {ignore_output:#}"
+    );
+
+    let filtered_warn = without_timing(without_vacuity_warnings(warn_output));
+    let ignore_normalized = without_timing(ignore_output);
+    assert_eq!(
+        filtered_warn, ignore_normalized,
+        "skipping the probe (--vacuity ignore) must produce exactly the envelope warn-mode \
+         would produce with vacuity-kind warnings filtered out -- any other difference means \
+         skipping silently changed observable behavior beyond the warnings array"
+    );
+}

--- a/rust/fslc/tests/issue_729_vacuity_probe_corpus_budget.rs
+++ b/rust/fslc/tests/issue_729_vacuity_probe_corpus_budget.rs
@@ -15,6 +15,16 @@
 // that would otherwise get a clean vacuity verdict. This control fails
 // loudly if any spec in the maintained corpus would lose that clean verdict
 // to truncation, exactly like the `#697` control it mirrors.
+//
+// Every corpus `.fsl` is accounted for by exactly one bucket below --
+// `parse_kernel_source`/`build_model` failing (e.g. a domain/requirements/
+// business-dialect spec `fsl_core::parse_kernel_source` does not lower on
+// its own) is expected and not itself evidence of anything, but this
+// repository's discipline is not to build an implicit exclusion: the count
+// is printed, not swallowed silently (review of an earlier version of this
+// file found `probed`/`probed_with_candidates` incremented in the same
+// place, making them tautologically equal, and the corpus's actual total
+// `.fsl` count -- 214 at review time -- going unreported).
 
 use std::path::{Path, PathBuf};
 
@@ -50,18 +60,29 @@ fn kernel_specs() -> Vec<PathBuf> {
 fn no_corpus_spec_exhausts_the_shared_vacuity_reachability_budget() {
     let budget = fsl_runtime::CONCRETE_PROBE_BUDGET;
     let mut truncated: Vec<String> = Vec::new();
+    let total = kernel_specs().len();
+    let mut unreadable = 0usize;
+    let mut not_a_kernel_source = 0usize;
+    let mut model_build_failed = 0usize;
+    let mut no_candidates = 0usize;
+    let mut probe_errored = 0usize;
     let mut probed = 0usize;
-    let mut probed_with_candidates = 0usize;
 
     for path in kernel_specs() {
         let Ok(source) = std::fs::read_to_string(&path) else {
+            unreadable += 1;
             continue;
         };
         let Ok(document) = fsl_core::parse_kernel_source(&source, &fsl_core::FsResolver::new("."))
         else {
+            // Expected for a non-kernel-dialect spec (domain/requirements/
+            // business documents do not lower through this entrypoint on
+            // their own); counted, not silently excluded.
+            not_a_kernel_source += 1;
             continue;
         };
         let Ok(model) = fsl_core::build_model(document) else {
+            model_build_failed += 1;
             continue;
         };
         let implication_candidates = fsl_runtime::vacuous_implication_candidates(&model);
@@ -72,16 +93,17 @@ fn no_corpus_spec_exhausts_the_shared_vacuity_reachability_budget() {
             .collect();
         expressions.extend(leadsto_candidates.iter().cloned());
         if expressions.is_empty() {
+            no_candidates += 1;
             continue;
         }
         // Depth 8 matches this corpus control's `#697` counterpart and the
         // product default (`DEFAULT_DEPTH` in `rust/fslc/src/main.rs`).
         let Ok(results) = fsl_runtime::expression_reachability(&model, &expressions, 8, budget)
         else {
+            probe_errored += 1;
             continue;
         };
         probed += 1;
-        probed_with_candidates += 1;
         if results
             .iter()
             .any(|result| matches!(result, fsl_runtime::Reachability::Exhausted))
@@ -90,9 +112,26 @@ fn no_corpus_spec_exhausts_the_shared_vacuity_reachability_budget() {
         }
     }
 
+    let accounted = unreadable
+        + not_a_kernel_source
+        + model_build_failed
+        + no_candidates
+        + probe_errored
+        + probed;
     println!(
-        "probed {probed} corpus specs at depth 8, budget {budget}, \
-         {probed_with_candidates} carried at least one vacuity-reachability candidate"
+        "{total} corpus .fsl files total; unreadable={unreadable} \
+         not_a_kernel_source={not_a_kernel_source} model_build_failed={model_build_failed} \
+         no_candidates={no_candidates} probe_errored={probe_errored} probed={probed} \
+         (depth 8, budget {budget})"
+    );
+    assert_eq!(
+        accounted, total,
+        "every corpus .fsl must land in exactly one bucket -- a mismatch means this loop silently \
+         dropped a file instead of accounting for it"
+    );
+    assert!(
+        probed > 0,
+        "no corpus spec exercised the probe at all -- this control would pass vacuously"
     );
     assert!(
         truncated.is_empty(),

--- a/rust/fslc/tests/issue_729_vacuity_probe_corpus_budget.rs
+++ b/rust/fslc/tests/issue_729_vacuity_probe_corpus_budget.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+//
+// Corpus conservation control for issue #729's shared vacuity-reachability
+// probe, mirroring `rust/fslc/tests/issue_697_corpus_probe_budget.rs`'s
+// control for `CONCRETE_PROBE_BUDGET` on the concrete boundary pre-pass.
+//
+// `verification_warnings`'s `vacuous_implication`/`vacuous_leadsto` lanes
+// now share one budgeted BFS (`fsl_runtime::expression_reachability`) over
+// every implication antecedent and leadsTo trigger candidate, budgeted at
+// the same `CONCRETE_PROBE_BUDGET` `find_boundary_violation` uses. Reaching
+// the budget before every candidate resolves degrades a real
+// `vacuous_implication`/`vacuous_leadsto` finding to `vacuity_probe_truncated`
+// -- sound (fail-closed, not fail-open), but a UX regression for any spec
+// that would otherwise get a clean vacuity verdict. This control fails
+// loudly if any spec in the maintained corpus would lose that clean verdict
+// to truncation, exactly like the `#697` control it mirrors.
+
+use std::path::{Path, PathBuf};
+
+fn kernel_specs() -> Vec<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let mut out = Vec::new();
+    for dir in ["specs", "examples"] {
+        let mut stack = vec![root.join(dir)];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|s| s.to_str()) == Some("fsl") {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn no_corpus_spec_exhausts_the_shared_vacuity_reachability_budget() {
+    let budget = fsl_runtime::CONCRETE_PROBE_BUDGET;
+    let mut truncated: Vec<String> = Vec::new();
+    let mut probed = 0usize;
+    let mut probed_with_candidates = 0usize;
+
+    for path in kernel_specs() {
+        let Ok(source) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(document) = fsl_core::parse_kernel_source(&source, &fsl_core::FsResolver::new("."))
+        else {
+            continue;
+        };
+        let Ok(model) = fsl_core::build_model(document) else {
+            continue;
+        };
+        let implication_candidates = fsl_runtime::vacuous_implication_candidates(&model);
+        let leadsto_candidates = fsl_runtime::vacuous_leadsto_candidates(&model);
+        let mut expressions: Vec<_> = implication_candidates
+            .iter()
+            .map(|(_, expr)| expr.clone())
+            .collect();
+        expressions.extend(leadsto_candidates.iter().cloned());
+        if expressions.is_empty() {
+            continue;
+        }
+        // Depth 8 matches this corpus control's `#697` counterpart and the
+        // product default (`DEFAULT_DEPTH` in `rust/fslc/src/main.rs`).
+        let Ok(results) = fsl_runtime::expression_reachability(&model, &expressions, 8, budget)
+        else {
+            continue;
+        };
+        probed += 1;
+        probed_with_candidates += 1;
+        if results
+            .iter()
+            .any(|result| matches!(result, fsl_runtime::Reachability::Exhausted))
+        {
+            truncated.push(path.display().to_string());
+        }
+    }
+
+    println!(
+        "probed {probed} corpus specs at depth 8, budget {budget}, \
+         {probed_with_candidates} carried at least one vacuity-reachability candidate"
+    );
+    assert!(
+        truncated.is_empty(),
+        "these corpus specs would degrade a vacuous_implication/vacuous_leadsto finding to \
+         vacuity_probe_truncated under the shared budget: {truncated:#?}"
+    );
+}

--- a/rust/fslc/tests/issue_729_vacuity_probe_truncated_e2e.rs
+++ b/rust/fslc/tests/issue_729_vacuity_probe_truncated_e2e.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! End-to-end coverage for issue #729's `vacuity_probe_truncated` emission
+//! arm in `verification_warnings` (`rust/fsl-runtime/src/lib.rs`),
+//! independently confirmed missing by review. `rust/fsl-runtime/tests/
+//! diagnostics.rs`'s tri-state controls call `expression_reachability`
+//! directly and never go through `verification_warnings`.
+//! `rust/fsl-tools/tests/issue_729_vacuity_probe_truncated_ledger.rs`
+//! hand-constructs the JSON rather than producing it from a real run.
+//! `issue_729_vacuity_probe_corpus_budget.rs` asserts truncation does *not*
+//! happen. None of them drive a real budget exhaustion through the CLI, so
+//! a typo in the `vacuity_probe_truncated` string literal (which would
+//! make `is_vacuity_kind` false, letting `--vacuity error` pass a spec
+//! whose vacuity was never established: exactly the fail-open this issue
+//! exists to close) would leave every existing test green.
+//!
+//! The model below is the reviewer-provided reproducer. Its `step` action
+//! computes `count = (count * 10) + x`, which is injective per BFS level
+//! (same trick as `rust/fsl-runtime/tests/boundary_probe_budget.rs`), so
+//! the reachable state count grows `10` to the power of the level and is
+//! unbounded (`count: Int`, no type bound). It genuinely exhausts
+//! `CONCRETE_PROBE_BUDGET` within a `--depth` that would otherwise need
+//! `10` to the power of `depth` states to close. `NeverNegative`'s
+//! antecedent (`count < 0`) can never become true: `step` only ever
+//! appends a non-negative digit. Before this issue's budget existed, a
+//! full unbudgeted BFS eventually confirmed it vacuous; now the shared
+//! probe truncates instead. Measured on this tree, this fixture takes
+//! roughly 1.7 seconds and 290 MB after this fix, versus roughly 18
+//! seconds and 6 GB before it (a full, unbounded reachable-set
+//! enumeration): a cheap, fast test that also demonstrates this issue's
+//! own before/after memory story.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-729-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+const DIGIT_GROWTH_TRUNC_SOURCE: &str = r"
+spec DigitGrowthTrunc {
+  state { count: Int, done: Bool }
+  init { count = 0 done = false }
+  action step(x in 0..9) { count = count * 10 + x }
+  invariant NeverNegative { count < 0 => done }
+}
+";
+
+fn verify(fixture: &Fixture, extra: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            fixture.text(),
+            "--depth",
+            "6",
+            "--deadlock",
+            "ignore",
+            "--no-cache",
+        ])
+        .args(extra)
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+/// The core positive control: a genuine budget exhaustion reaches
+/// `--vacuity error`'s fail-closed exit, through the real emission arm this
+/// PR added, not a hand-built JSON envelope.
+#[test]
+fn a_genuine_budget_exhaustion_fails_closed_under_vacuity_error() {
+    let fixture = Fixture::new("trunc-error", DIGIT_GROWTH_TRUNC_SOURCE);
+    let (output, status) = verify(&fixture, &["--vacuity", "error"]);
+
+    assert_eq!(status, 2, "{output:#}");
+    assert_eq!(output["result"], "error", "{output:#}");
+    assert_eq!(output["kind"], "vacuity_probe_truncated", "{output:#}");
+    assert_eq!(output["trace_type"], "vacuity", "{output:#}");
+    let findings = output["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["kind"] == "vacuity_probe_truncated"
+                && finding["classification"] == "probe_truncated"
+                && finding["faithfulness_class"] == "reachability_unknown"),
+        "expected a vacuity_probe_truncated finding with its own classification/faithfulness_class: \
+         {output:#}"
+    );
+}
+
+/// Companion: the same genuine exhaustion is visible (not silently dropped)
+/// under the default `--vacuity warn`, with `result` staying `verified` --
+/// truncation is reported, not treated as a violation.
+#[test]
+fn the_same_exhaustion_is_a_warning_not_a_violation_under_vacuity_warn() {
+    let fixture = Fixture::new("trunc-warn", DIGIT_GROWTH_TRUNC_SOURCE);
+    let (output, status) = verify(&fixture, &["--vacuity", "warn"]);
+
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified", "{output:#}");
+    let warnings = output["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning["kind"] == "vacuity_probe_truncated"),
+        "expected a vacuity_probe_truncated warning: {output:#}"
+    );
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning["kind"] == "vacuous_implication"),
+        "a truncated probe must not also (or instead) report vacuous_implication -- that would be \
+         the exact fail-open this issue closes: {output:#}"
+    );
+}
+
+/// Companion: `--vacuity ignore` suppresses the finding entirely (skip, not
+/// just filter -- `issue_729_vacuity_ignore_skip.rs` covers the general
+/// equivalence; this confirms it holds for a genuinely truncated candidate
+/// specifically, not only an ordinary vacuous one).
+#[test]
+fn the_same_exhaustion_is_suppressed_under_vacuity_ignore() {
+    let fixture = Fixture::new("trunc-ignore", DIGIT_GROWTH_TRUNC_SOURCE);
+    let (output, status) = verify(&fixture, &["--vacuity", "ignore"]);
+
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified", "{output:#}");
+    assert!(
+        output["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .is_empty(),
+        "--vacuity ignore must suppress the truncated-probe finding: {output:#}"
+    );
+}

--- a/rust/fslc/tests/vacuity_contract.rs
+++ b/rust/fslc/tests/vacuity_contract.rs
@@ -2,8 +2,9 @@
 // Copyright 2026 Ryoichi Izumita
 
 //! Negative controls for #465: native `--vacuity` must select over the full
-//! documented 6-kind lane set (`docs/LANGUAGE.md` §15,
-//! `fsl_core::VACUITY_KINDS`), not just the two kinds spelled `vacuous_*`.
+//! documented 7-kind lane set (`docs/LANGUAGE.md` §15,
+//! `fsl_core::VACUITY_KINDS` -- `vacuity_probe_truncated` joined the other
+//! six in issue #729), not just the two kinds spelled `vacuous_*`.
 //! This file exercises the `vacuous_leadsto` lane end to end through the CLI
 //! (`warn`/`error`/`ignore`) — the lane that was entirely missing from
 //! native `verification_warnings` before the fix.

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -910,7 +910,18 @@ declared type space rather than over the states reached within `--depth`, so
 their verdict never moves with the bound: `requires visits < 100` on
 `visits: 0..100` is a real guard and stays unreported even at a depth that
 never reaches 100. `--vacuity error` gives
-`result:"error"`; `--vacuity ignore` disables it.
+`result:"error"`; `--vacuity ignore` disables it (and, unlike the other six
+kinds, skips computing the `vacuous_implication`/`vacuous_leadsto`
+reachability probe entirely rather than computing then filtering it).
+
+The `vacuous_implication`/`vacuous_leadsto` reachability probe shares one
+budgeted concrete BFS across every antecedent/trigger in the spec. A
+candidate that neither becomes true nor finishes exhausting its reachable
+state space before the internal state-count budget is hit reports
+`kind:"vacuity_probe_truncated"` instead — vacuity was never established
+either way, so it selects under `--vacuity` exactly like the other six
+kinds (`error` fails closed on it too). This is rare; a corpus-conservation
+test keeps the budget generous enough that no maintained spec hits it.
 
 ## 7. CLI and JSON essentials
 

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -910,18 +910,23 @@ declared type space rather than over the states reached within `--depth`, so
 their verdict never moves with the bound: `requires visits < 100` on
 `visits: 0..100` is a real guard and stays unreported even at a depth that
 never reaches 100. `--vacuity error` gives
-`result:"error"`; `--vacuity ignore` disables it (and, unlike the other six
-kinds, skips computing the `vacuous_implication`/`vacuous_leadsto`
-reachability probe entirely rather than computing then filtering it).
+`result:"error"`; `--vacuity ignore` disables it. For the two reachability
+kinds (`vacuous_implication`/`vacuous_leadsto`, next paragraph) and their
+`vacuity_probe_truncated` sibling, `ignore` additionally skips *computing*
+the shared reachability probe rather than computing it and filtering the
+result; the other four kinds (`always_true_requires`, `tautology_over_frozen`,
+`urgency_freeze`, `vacuous_deadline`) are solver-decided lanes that are
+still computed and then filtered.
 
 The `vacuous_implication`/`vacuous_leadsto` reachability probe shares one
 budgeted concrete BFS across every antecedent/trigger in the spec. A
 candidate that neither becomes true nor finishes exhausting its reachable
-state space before the internal state-count budget is hit reports
-`kind:"vacuity_probe_truncated"` instead — vacuity was never established
-either way, so it selects under `--vacuity` exactly like the other six
-kinds (`error` fails closed on it too). This is rare; a corpus-conservation
-test keeps the budget generous enough that no maintained spec hits it.
+state space before the internal state-count budget is hit (or whose
+expression fails to evaluate) reports `kind:"vacuity_probe_truncated"`
+instead — vacuity was never established either way, so it selects under
+`--vacuity` exactly like the other six kinds (`error` fails closed on it
+too). Budget exhaustion is rare; a corpus-conservation test keeps the
+budget generous enough that no maintained spec hits it.
 
 ## 7. CLI and JSON essentials
 


### PR DESCRIPTION
## Problem

`verification_warnings` (`rust/fsl-runtime/src/lib.rs`) ran one **unbudgeted** concrete BFS (`expression_reachable`) per implication antecedent and per leadsTo trigger, cloning the whole `KernelModel` per explored node. Re-measured on the current tree (post-#776, which fixed the *other* two lanes and explicitly deferred this one):

| run | before this fix | after |
|---|---|---|
| `--property PublishedWasReviewed` (isolated, affected) | **~1,095 MB** (control run; matches issue's ~1,096 MB) | **~348 MB** |
| same + `--vacuity ignore` | ~1,096 MB (**unchanged** — bug) | **~44 MB** |
| `--property TotalConsistent` (isolated, unaffected control) | ~47 MB | ~47 MB (unaffected) |
| default (all properties) | ~2,263 MB | ~1,485 MB |

Control-before-treatment: two back-to-back "before" runs of the isolated case measured 1,148,469,248 and 1,148,534,784 bytes (~0.006% variance) — the baseline is stable, not noise.

## Contract (lead-approved, recorded in `docs/DESIGN-vacuity.md`)

1. **Tri-state, fail-closed**: `Reachability::{Reachable, Unreachable, Exhausted}`. `Unreachable` keeps its exact old meaning (full enumeration within `--depth` completed, never true) and still produces `vacuous_implication`/`vacuous_leadsto`. `Exhausted` means no verdict was reached — either the shared budget was hit while the candidate was pending, or its expression failed to evaluate (see the M1 review response below).
2. **New kind `vacuity_probe_truncated`** added to `fsl_core::VACUITY_KINDS` (6 → 7), selected by `--vacuity` exactly like the other six (`warn` shows it, `error` fails closed on it, `ignore` discards it). An informational/non-selected kind was rejected: it would let `--vacuity error` pass a spec whose vacuity was never established, strictly weaker than today.
3. **Shared BFS**: every antecedent/trigger candidate is walked once (`fsl_runtime::expression_reachability`), each checked against every popped state and dropped from `pending` the instant it's found true. Reuses `find_boundary_violation`'s established scratch-`Monitor` pattern (#730/#776) — no new search mechanism.
4. **Budget**: reuses `CONCRETE_PROBE_BUDGET` (50,000), protected by a corpus-conservation test mirroring `issue_697_corpus_probe_budget.rs`.
5. **`--vacuity ignore` now skips computation**, not just output filtering, via an explicit `skip_vacuity_probe` argument threaded from the *one* CLI derivation point (`execute_cli_verification` / `run_induction_with_lemmas`, both reached by `verify` and `sweep`). `ledger`/`html`/`mutate`'s baseline (`run_verify`, no `--vacuity` option) and the wasm Worker (no `--vacuity` option) always pass `false` — invariant fixed in a doc comment on `BmcOutputOptions::skip_vacuity_probe`.
6. **Ledger wording**: `kind == "vacuity_probe_truncated"` gets its own summary prefix "空虚性未確立（到達性 probe が判定に至らず）" (vacuity not established — the probe never reached a verdict; deliberately cause-neutral) instead of "空虚性の疑い" (suspected) — a distinct claim. `html.rs` needed no change (renders `kind`/`message` generically).

## Negative controls

- **(a) `--vacuity ignore` envelope equivalence** — `issue_729_vacuity_ignore_skip.rs`: the `ignore` envelope equals the `warn` envelope with every `is_vacuity_kind` warning removed (cost/timing excluded). Passes.
- **(b) ledger/html byte-identical for an ordinary vacuous finding** — manually diffed `fslc ledger`/`fslc html` output for `vacuous_leadsto.fsl` between the pre-fix and post-fix binaries: `ledger` is byte-identical; `html` differs only in `elapsed_s`/timing fields (expected run-to-run noise). Everything else byte-identical. **Not automated in CI** — this is a manual, one-time comparison recorded here, not a regression test; there is no repository mechanism today that would catch a future change silently perturbing ledger/html output for an ordinary (non-truncated) vacuity finding beyond what `issue_729_vacuity_probe_truncated_ledger.rs` covers (the truncated-vs-ordinary assurance-class comparison).
- **(c) assurance label unmoved by a truncated finding** — `issue_729_vacuity_probe_truncated_ledger.rs`: `assurance_token` never reads `warnings`, and the spec-level assurance row is byte-identical whether the finding is `vacuous_implication` or `vacuity_probe_truncated`.

Plus the issue's own two controls at the `fsl-runtime` unit level (`rust/fsl-runtime/tests/diagnostics.rs`): a genuinely unreachable candidate resolves `Exhausted` (not `Unreachable`) under a tiny budget, and a step-1-reachable candidate resolves `Reachable` under the *same* shared-BFS call. Plus, added in review response, a true end-to-end test that drives a genuine budget exhaustion through the CLI (`issue_729_vacuity_probe_truncated_e2e.rs`, see below).

## `--vacuity error` is not weakened

- Depth-bounded non-closure is unaffected — unchanged `vacuous_implication`/`vacuous_leadsto` behavior.
- The new `Exhausted`/`vacuity_probe_truncated` path is strictly additive detection, not a suppression: a spec that used to (correctly) fail `--vacuity error` still fails it; a spec whose probe now truncates *also* fails it, where before it would have silently passed (fail-open, the bug this issue's contract explicitly rejects).
- `--vacuity ignore` skipping computation is proven observationally equivalent to computing-then-filtering (negative control (a)).
- Corpus-conservation test (`issue_729_vacuity_probe_corpus_budget.rs`) confirms no maintained spec's vacuity verdict degrades to truncation under the shared budget: of 214 corpus `.fsl` files, 39 are not a kernel-dialect source, 7 fail model build, 105 carry no vacuity-reachability candidate, and the remaining 63 are probed — none exhaust. Every file is accounted for in exactly one bucket (asserted, not just printed), following review feedback that an earlier version of this test silently dropped the ones that don't reach the probe.

## Judgment calls

- `expression_reachable` was renamed to `expression_reachability` (batched, tri-state) since its contract changed; only one internal caller (`verification_warnings`), so no compatibility shim needed.
- Found a second legitimate `skip_vacuity_probe` derivation point beyond `execute_cli_verification`: `run_induction_with_lemmas` (the `--lemma` path bypasses `execute_cli_verification` entirely). Both are documented as the closed set of allowed derivation sites.

## Verification

- `cargo test -p fsl-runtime`: all pass, including the tri-state controls.
- `cargo test -p fslc-rust --test vacuity_contract --test issue_486_vacuous_forall_implication --test issue_697_all_properties_memory --test issue_697_corpus_probe_budget --test vacuity_solver_lanes --test issue_729_vacuity_ignore_skip --test issue_729_vacuity_probe_corpus_budget --test issue_729_vacuity_probe_truncated_e2e --test ledger_evidence_findings_cli --test ledger_impl_log_cli --lib --bin fslc`: all pass.
- `cargo test -p fsl-tools --test issue_729_vacuity_probe_truncated_ledger --test typed_annotations`: all pass.
- `cargo test -p fsl-wasm`: all pass.
- `cargo fmt --check` / `cargo clippy -p fsl-runtime -p fsl-core -p fslc-rust -p fsl-tools -p fsl-wasm --all-targets -- -D warnings`: clean.
- `python3 tools/build_site_reference.py`: regenerated `docs/intro/language.{en,ja}.html` (section-alignment check passes).
- New test binaries are fast (all well under a minute total); no `tools/rust-test-shard-groups.txt` pin needed (the pre-existing `issue_697_*` binaries were already pinned).

## Review response (round 2)

Independent review returned **approve with changes (no blockers)**, confirming the contract design, a 214-spec before/after sweep with zero detection-power differences (`warn`-mode and `--vacuity error` both 0 diffs), memory reduction reproduced with a control run first (0.02% variance), and — despite my own self-reported stale-checkout concern during implementation — that the shipped code is line-for-line isomorphic to post-#776 `find_boundary_violation` (one scratch `Monitor`, per-instance `state`/`step` reset around `enabled()`, budget check right after `visited.insert()` and before `queue.push_back`). Two majors and four minors, addressed:

- **M2 (major) — no test drove the `vacuity_probe_truncated` emission arm through a real run.** All three existing controls either called `expression_reachability` directly (bypassing `verification_warnings`), hand-constructed the JSON (bypassing the whole probe), or asserted truncation does *not* happen — a typo in the `"vacuity_probe_truncated"` string literal would have made `is_vacuity_kind` false and let `--vacuity error` silently pass a never-decided spec, with every existing test green. Added `rust/fslc/tests/issue_729_vacuity_probe_truncated_e2e.rs` using the reviewer-provided digit-growth reproducer (`count = count * 10 + x`, unbounded `count: Int`, genuinely exhausts `CONCRETE_PROBE_BUDGET` in ~1.7s/~290 MB), covering `error`/`warn`/`ignore`.
- **M1 (major) — per-candidate eval-error handling: chose (a).** A per-candidate evaluation error now resolves `Reachability::Exhausted` (fail-closed), not `Reachable` (the old `expression_reachable`'s silent-drop behavior, which review confirmed was not itself a regression). Rationale: this issue's whole point is "never silently pass a probe that could not decide," and `--vacuity error` cannot distinguish *why* a candidate has no verdict, so an evaluation error must not become a way to defeat `--vacuity error` that a budget cutoff cannot. Generalized the `vacuity_probe_truncated` message/hint/recommended_action and the ledger's Japanese summary prefix to be cause-neutral (no longer claims "budget" specifically). Recorded the decision, its rationale, and the one remaining narrow gap it does *not* close (a whole-walk `RuntimeError` still loses every candidate's finding for that run, practically unreachable since it requires an `enabled`/`step` failure that would already fail the surrounding BMC/explicit run first) in `docs/DESIGN-vacuity.md`, per AGENTS.md's "accepted decisions live in docs/DESIGN-*.md".
- **m1 — negative control (b) is manual-only.** Documented explicitly above; no CI regression test protects it going forward.
- **m2 — stale "6-kind" references.** Fixed in `vacuity_contract.rs` and `docs/DESIGN-rust-port.md` (now 7). The #465 closed-set test itself already iterates `fsl_core::VACUITY_KINDS`, so it auto-tracked; only comments were stale.
- **m3 — corpus test counters were tautological and silently dropped unaccounted files.** Rewrote `issue_729_vacuity_probe_corpus_budget.rs` to bucket and print every one of the corpus's 214 `.fsl` files (see the updated number above; the original PR undercounted this using the collapsed counters).
- **m4 — inaccurate `skills/fsl/reference.md` claim.** Corrected: only the two reachability lanes (and their `vacuity_probe_truncated` sibling) skip computation under `--vacuity ignore`; the four solver-decided lanes are still computed then filtered.

Closes #729
