### PR TITLE
fix(runtime): remove the three remaining per-node Monitor clone lanes (#783)

### DIFF
--- a/changelog.d/783-refine-scenario-clone-lanes.fixed.md
+++ b/changelog.d/783-refine-scenario-clone-lanes.fixed.md
@@ -1,0 +1,31 @@
+Fixed issue #783: `fsl-runtime`'s `check_refinement` correspondence walk,
+`action_cover_traces`, and `leadsto_response_traces` were the three
+remaining lanes still holding a `Monitor` -- and therefore the whole
+`KernelModel` by value -- per queued/frontier node, the same defect class
+issue #730 fixed in `bfs`, `first_self_violation`, and
+`verify_explicit_selected`; the first two additionally cloned a growing
+`Vec<TraceStep>` per node. Measured directly on a `LabelCoreRepro`-based
+refinement fixture (release build, depth 3): `check_refinement`'s peak
+memory footprint dropped from ~1,557 MB (consistent with the issue's own
+reported ~1.72 GB) to ~491 MB, with `refines`/`refinement_failed` verdicts
+identical before and after. `check_refinement` and `action_cover_traces`
+now carry only a `State` per frontier node (plus a scratch `Monitor`
+re-pointed at each popped state) and reconstruct a trace from parent links
+only when one is actually needed, using the same `trace::ParentLink`/
+`reconstruct_trace` machinery issue #697 established; both are now locked
+onto a shared `LeanFrontier` type so a future per-node `Monitor`/
+`Vec<TraceStep>` clone in either is a consumer-side type error, not only a
+review-time judgment call. `leadsto_response_traces` is a partial fix
+scoped to the `Monitor` clone alone: its walk has no `visited` dedup (a
+`leadsTo` pending/response history is path-dependent, so two routes
+reaching the same state must stay distinct path-trees), so its per-node
+`Vec<TraceStep>` clone is unchanged. A negative control
+(`rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs`, Linux-only)
+adds a calibrated memory ceiling for `check_refinement`'s walk and, as
+PR #776 deferred to this issue, one for `first_self_violation`'s own
+frontier. No public contract changed: `RefinementCheck`/`LeadstoResponse`
+fields, JSON envelopes, exit codes, and verdicts/trace/state-count output
+are identical before and after, checked directly across every
+`specs`/`examples` corpus refinement mapping (`fslc refine`, 27 registered
+triples) and every `spec`-dialect corpus file (`fslc scenarios`, 93 files,
+default and `--depth 6`).

--- a/changelog.d/783-refine-scenario-clone-lanes.fixed.md
+++ b/changelog.d/783-refine-scenario-clone-lanes.fixed.md
@@ -4,9 +4,9 @@ remaining lanes still holding a `Monitor` -- and therefore the whole
 `KernelModel` by value -- per queued/frontier node, the same defect class
 issue #730 fixed in `bfs`, `first_self_violation`, and
 `verify_explicit_selected`; the first two additionally cloned a growing
-`Vec<TraceStep>` per node. Measured directly on a `LabelCoreRepro`-based
+`Vec<TraceStep>` per node. Measured directly on the shared `LabelCoreRepro`
 refinement fixture (release build, depth 3): `check_refinement`'s peak
-memory footprint dropped from ~1,557 MB (consistent with the issue's own
+memory footprint dropped from ~1,728 MB (consistent with the issue's own
 reported ~1.72 GB) to ~491 MB, with `refines`/`refinement_failed` verdicts
 identical before and after. `check_refinement` and `action_cover_traces`
 now carry only a `State` per frontier node (plus a scratch `Monitor`
@@ -19,13 +19,18 @@ review-time judgment call. `leadsto_response_traces` is a partial fix
 scoped to the `Monitor` clone alone: its walk has no `visited` dedup (a
 `leadsTo` pending/response history is path-dependent, so two routes
 reaching the same state must stay distinct path-trees), so its per-node
-`Vec<TraceStep>` clone is unchanged. A negative control
-(`rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs`, Linux-only)
-adds a calibrated memory ceiling for `check_refinement`'s walk and, as
-PR #776 deferred to this issue, one for `first_self_violation`'s own
-frontier. No public contract changed: `RefinementCheck`/`LeadstoResponse`
-fields, JSON envelopes, exit codes, and verdicts/trace/state-count output
-are identical before and after, checked directly across every
-`specs`/`examples` corpus refinement mapping (`fslc refine`, 27 registered
-triples) and every `spec`-dialect corpus file (`fslc scenarios`, 93 files,
-default and `--depth 6`).
+`Vec<TraceStep>` clone is unchanged -- but it is now locked onto a second
+shared type, `PathFrontier` (`(State, Vec<TraceStep>, usize)`, no
+`Monitor`), so a future per-node `Monitor` clone there is also a
+consumer-side type error, closing the one lane an independent review found
+without either a ceiling or a type guard. A negative control
+(`rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs`, Linux-only,
+its `LabelCoreRepro` fixture shared with the `issue_730_*` ceiling tests via
+`tests/support/mod.rs`) adds a calibrated memory ceiling for
+`check_refinement`'s walk and, as PR #776 deferred to this issue, one for
+`first_self_violation`'s own frontier. No public contract changed:
+`RefinementCheck`/`LeadstoResponse` fields, JSON envelopes, exit codes, and
+verdicts/trace/state-count output are identical before and after, checked
+directly across every `specs`/`examples` corpus refinement mapping (`fslc
+refine`, 27 registered triples) and every `spec`-dialect corpus file (`fslc
+scenarios`, 93 files, default and `--depth 6`).

--- a/changelog.d/783-refine-scenario-clone-lanes.fixed.md
+++ b/changelog.d/783-refine-scenario-clone-lanes.fixed.md
@@ -29,22 +29,27 @@ its `LabelCoreRepro` fixture shared with the `issue_730_*` ceiling tests via
 `tests/support/mod.rs`) adds a calibrated memory ceiling for
 `check_refinement`'s walk and, as PR #776 deferred to this issue, one for
 `first_self_violation`'s own frontier. Both ceilings are calibrated from a
-direct Linux measurement (`rust:1-bookworm` Docker, `aarch64`): a
-binary-search sweep of `CEILING_KB` against the fixed build and, per lane, a
-mutant with that lane's pre-fix per-node `Monitor` clone hand-restored,
-confirmed the `ulimit -v`-capped assertion actually passes on the fixed
-build and actually fails (`SIGABRT`, `status=...unix_wait_status(134)`,
-`stderr="memory allocation of N bytes failed"`) on the corresponding
-mutant, with both PASS/FAIL boundaries reproduced twice. `check_refinement`:
-fixed boundary `(500, 502]` MiB, pre-removal-commit boundary `(2000, 2020]`
-MiB, `CEILING_KB = 950 * 1024` (1.89-1.90x headroom, 2.11-2.13x margin).
-`first_self_violation`: fixed boundary `(500, 505]` MiB, pre-#776-clone
-boundary `(2120, 2150]` MiB, `CEILING_KB = 1000 * 1024` (1.98-2.00x
-headroom, 2.12-2.15x margin). The one remaining assumption is architecture:
-this measurement is `aarch64`, while this repository's CI runs `x86_64`; if
-either ceiling flakes on CI, that cross-architecture gap is the most likely
-cause, and widening `CEILING_KB` is the fix, not tightening the test's
-claim. No public contract changed:
+direct Linux measurement (`rust:1-bookworm` Docker, `aarch64`; exact
+commands, mutant source commits, and reasoning are recorded in the test
+file's own top comment, not only here): a binary-search sweep of
+`CEILING_KB` against the fixed build and a mutant confirmed the `ulimit
+-v`-capped assertion actually passes on the fixed build and actually fails
+(`SIGABRT`, `status=...unix_wait_status(134)`, `stderr="memory allocation
+of N bytes failed"`) on the corresponding mutant, with both PASS/FAIL
+boundaries reproduced twice. The two mutants differ in precision: commit
+`6012c00` (all three #783 lanes reverted) stands in for `check_refinement`'s
+mutant, sound teeth there because the measurement's driver never reaches
+`action_cover_traces`/`leadsto_response_traces`; `first_self_violation`'s
+mutant restores only that function to its pre-#776 form (commit
+`20d0a9b^`). `check_refinement`: fixed boundary `(500, 502]` MiB,
+`6012c00` boundary `(2000, 2020]` MiB, `CEILING_KB = 950 * 1024`
+(1.89-1.90x headroom, 2.11-2.13x margin). `first_self_violation`: fixed
+boundary `(500, 505]` MiB, pre-#776-clone boundary `(2120, 2150]` MiB,
+`CEILING_KB = 1000 * 1024` (1.98-2.00x headroom, 2.12-2.15x margin). The one
+remaining assumption is architecture: this measurement is `aarch64`, while
+this repository's CI runs `x86_64`; if either ceiling flakes on CI, that
+cross-architecture gap is the most likely cause, and widening `CEILING_KB`
+is the fix, not tightening the test's claim. No public contract changed:
 `RefinementCheck`/`LeadstoResponse` fields, JSON envelopes, exit codes, and
 verdicts/trace/state-count output are identical before and after, checked
 directly across every `specs`/`examples` corpus refinement mapping (`fslc

--- a/changelog.d/783-refine-scenario-clone-lanes.fixed.md
+++ b/changelog.d/783-refine-scenario-clone-lanes.fixed.md
@@ -28,7 +28,23 @@ without either a ceiling or a type guard. A negative control
 its `LabelCoreRepro` fixture shared with the `issue_730_*` ceiling tests via
 `tests/support/mod.rs`) adds a calibrated memory ceiling for
 `check_refinement`'s walk and, as PR #776 deferred to this issue, one for
-`first_self_violation`'s own frontier. No public contract changed:
+`first_self_violation`'s own frontier. Both ceilings are calibrated from a
+direct Linux measurement (`rust:1-bookworm` Docker, `aarch64`): a
+binary-search sweep of `CEILING_KB` against the fixed build and, per lane, a
+mutant with that lane's pre-fix per-node `Monitor` clone hand-restored,
+confirmed the `ulimit -v`-capped assertion actually passes on the fixed
+build and actually fails (`SIGABRT`, `status=...unix_wait_status(134)`,
+`stderr="memory allocation of N bytes failed"`) on the corresponding
+mutant, with both PASS/FAIL boundaries reproduced twice. `check_refinement`:
+fixed boundary `(500, 502]` MiB, pre-removal-commit boundary `(2000, 2020]`
+MiB, `CEILING_KB = 950 * 1024` (1.89-1.90x headroom, 2.11-2.13x margin).
+`first_self_violation`: fixed boundary `(500, 505]` MiB, pre-#776-clone
+boundary `(2120, 2150]` MiB, `CEILING_KB = 1000 * 1024` (1.98-2.00x
+headroom, 2.12-2.15x margin). The one remaining assumption is architecture:
+this measurement is `aarch64`, while this repository's CI runs `x86_64`; if
+either ceiling flakes on CI, that cross-architecture gap is the most likely
+cause, and widening `CEILING_KB` is the fix, not tightening the test's
+claim. No public contract changed:
 `RefinementCheck`/`LeadstoResponse` fields, JSON envelopes, exit codes, and
 verdicts/trace/state-count output are identical before and after, checked
 directly across every `specs`/`examples` corpus refinement mapping (`fslc

--- a/rust/fsl-runtime/src/bin/fsl-refine.rs
+++ b/rust/fsl-runtime/src/bin/fsl-refine.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! A minimal driver for [`fsl_runtime::check_refinement`], the same shape as
+//! `fsl-bfs`/`fsl-explicit`. Exists so a memory-ceiling regression test can
+//! exercise `check_refinement`'s own correspondence walk in isolation,
+//! without the `fslc refine` CLI's Z3-backed `progress` check (which runs
+//! whenever the mapping declares one and would fold solver memory into the
+//! measurement -- `fsl-runtime` itself never links a solver at all, see
+//! `rust-verifier.md`'s dependency-direction rule).
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::json;
+
+fn load_model(path: &str) -> Result<fsl_core::KernelModel, String> {
+    let source = fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let base = Path::new(path).parent().unwrap_or_else(|| Path::new("."));
+    let resolver = fsl_core::FsResolver::new(base);
+    let kernel =
+        fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| error.to_string())?;
+    fsl_core::build_model(kernel).map_err(|error| error.to_string())
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let usage = "usage: fsl-refine IMPL ABS MAPPING [DEPTH]";
+    let implementation_path = args.next().expect(usage);
+    let abstraction_path = args.next().expect(usage);
+    let mapping_path = args.next().expect(usage);
+    let depth = args
+        .next()
+        .map_or(Ok(8_usize), |value| value.parse::<usize>())
+        .expect("depth must be a non-negative integer");
+    let result = load_model(&implementation_path).and_then(|implementation| {
+        let abstraction = load_model(&abstraction_path)?;
+        let mapping_source =
+            fs::read_to_string(&mapping_path).map_err(|error| error.to_string())?;
+        let mapping = fsl_core::parse_refinement(&mapping_source, &implementation, &abstraction)
+            .map_err(|error| error.message)?;
+        fsl_runtime::check_refinement(&implementation, &abstraction, &mapping, depth)
+            .map_err(|error| error.to_string())
+    });
+    match result {
+        Ok(checked) => {
+            let (verdict, kind) = if let Some((violation, _)) = &checked.impl_violation {
+                ("impl_violation", Some(violation.kind.clone()))
+            } else if let Some(failure) = &checked.failure {
+                ("refinement_failed", Some(failure.kind.clone()))
+            } else {
+                ("refines", None)
+            };
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "implementation": checked.implementation,
+                    "abstraction": checked.abstraction,
+                    "depth": checked.depth,
+                    "verdict": verdict,
+                    "kind": kind,
+                }))
+                .expect("serialize refinement result")
+            );
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(2);
+        }
+    }
+}

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -2986,8 +2986,9 @@ pub fn leadsto_response_traces(
     }];
     let mut responses = BTreeMap::<(String, Bindings), LeadstoResponse>::new();
     let mut triggered = BTreeSet::<(String, Bindings)>::new();
-    let mut queue = VecDeque::from([(initial_state, initial_trace, 0_usize)]);
-    while let Some((state, trace, step)) = queue.pop_front() {
+    let mut queue = trace::PathFrontier::new();
+    queue.push(initial_state, initial_trace, 0);
+    while let Some((state, trace, step)) = queue.pop() {
         for property in &model.leadstos {
             for binding in &bindings[&property.name] {
                 let key = (property.name.clone(), binding.clone());
@@ -3036,7 +3037,7 @@ pub fn leadsto_response_traces(
             }
             let mut child_trace = trace.clone();
             child_trace.push(trace_step_from_result(step + 1, &state, &instance, &result));
-            queue.push_back((result.state.clone(), child_trace, step + 1));
+            queue.push(result.state.clone(), child_trace, step + 1);
         }
     }
     let missing = bindings

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1719,64 +1719,70 @@ pub fn check_refinement(
             ));
             return Ok(check);
         }
-        queue.push_back((
-            Monitor {
-                model: implementation.clone(),
-                state: impl_state,
-                step: 0,
-            },
-            0_usize,
-            initial_trace,
-        ));
+        queue.push_back((impl_state, 0_usize));
     }
 
+    // The frontier carries `State` only, not `Monitor` -- a full `Monitor`
+    // clone per candidate transition duplicates the whole `KernelModel`
+    // repeatedly at every layer (issue #783's 1.72 GB @ depth 3). `scratch`
+    // is re-pointed at each state instead, following `first_self_violation`
+    // and `bfs`'s established pattern. Traces are no longer carried in the
+    // queue either; `parents` -- left empty for every root, per
+    // `trace::reconstruct_trace`'s multi-root contract -- reconstructs one
+    // only when a failure is about to be reported.
     let mut visited = BTreeSet::new();
-    while let Some((_, step, _)) = queue.front() {
+    let mut parents = BTreeMap::<State, trace::ParentLink>::new();
+    let mut scratch = Monitor::from_state(implementation.clone(), State::new());
+    while let Some((_, step)) = queue.front() {
         let step = *step;
         let mut layer = Vec::new();
         while queue
             .front()
-            .is_some_and(|(_, queued_step, _)| *queued_step == step)
+            .is_some_and(|(_, queued_step)| *queued_step == step)
         {
-            let Some((monitor, _, trace)) = queue.pop_front() else {
+            let Some((state, _)) = queue.pop_front() else {
                 unreachable!("queue front was present");
             };
-            if visited.insert(monitor.state.clone()) && step < depth {
-                layer.push((monitor, trace));
+            if visited.insert(state.clone()) && step < depth {
+                layer.push(state);
             }
         }
-        let mut candidates = Vec::new();
-        for (state_index, (monitor, trace)) in layer.into_iter().enumerate() {
-            let alpha_before = alpha_state(
-                &monitor.state,
+        // `alpha_before` for each layer state is computed once here, in
+        // layer order, and looked up by index below -- not recomputed per
+        // candidate -- to keep both the values and their computation order
+        // identical to the pre-#783 per-node walk.
+        let mut alphas = Vec::with_capacity(layer.len());
+        for state in &layer {
+            alphas.push(alpha_state(
+                state,
                 implementation,
                 abstraction,
                 mapping,
                 &eval_model,
-            )?;
-            for enabled in monitor.enabled()? {
+            )?);
+        }
+        let mut candidates = Vec::new();
+        for (state_index, state) in layer.iter().enumerate() {
+            scratch.state = state.clone();
+            scratch.step = step;
+            for enabled in scratch.enabled()? {
                 let action_index = implementation
                     .actions
                     .iter()
                     .position(|action| action.name == enabled.action)
                     .unwrap_or(usize::MAX);
-                candidates.push((
-                    action_index,
-                    enabled.params.clone(),
-                    state_index,
-                    monitor.clone(),
-                    trace.clone(),
-                    alpha_before.clone(),
-                    enabled,
-                ));
+                candidates.push((action_index, enabled.params.clone(), state_index, enabled));
             }
         }
         candidates.sort_by(|left, right| {
             (&left.0, &left.1, &left.2).cmp(&(&right.0, &right.1, &right.2))
         });
-        for (_, _, _, monitor, trace, alpha_before, enabled) in candidates {
-            let mut child = monitor.clone();
-            let stepped = child.step(&enabled)?;
+        for (_, _, state_index, enabled) in candidates {
+            let state = &layer[state_index];
+            let alpha_before = &alphas[state_index];
+            scratch.state = state.clone();
+            scratch.step = step;
+            let stepped = scratch.step(&enabled)?;
             if stepped.violation.is_some() {
                 // Unreachable in practice: `first_self_violation` above
                 // already proved the impl has no self-violation within
@@ -1786,15 +1792,9 @@ pub fn check_refinement(
                 // panic — would resurrect the false-green #466 fixes.
                 continue;
             }
-            let mut child_trace = trace.clone();
-            child_trace.push(trace_step_from_result(
-                step + 1,
-                &monitor.state,
-                &enabled,
-                &stepped,
-            ));
+            let child_state = stepped.state.clone();
             let alpha_after = alpha_state(
-                &child.state,
+                &child_state,
                 implementation,
                 abstraction,
                 mapping,
@@ -1803,7 +1803,9 @@ pub fn check_refinement(
             let action_map = &mapping.action_correspondences[&enabled.action];
             match &action_map.target {
                 ActionCorrespondenceTarget::Stutter => {
-                    if alpha_before != alpha_after {
+                    if alpha_before != &alpha_after {
+                        let child_trace =
+                            refinement_child_trace(state, &parents, step + 1, &enabled, &stepped);
                         check.failure = Some(refinement_failure(
                             "stutter_changed_abs",
                             Some("step"),
@@ -1828,7 +1830,7 @@ pub fn check_refinement(
                     let mut bindings = enabled.params.clone();
                     let values = match args
                         .iter()
-                        .map(|expr| eval(expr, &monitor.state, &mut bindings, &eval_model, None))
+                        .map(|expr| eval(expr, state, &mut bindings, &eval_model, None))
                         .collect::<Result<Vec<_>, _>>()
                     {
                         Ok(values) => values,
@@ -1845,6 +1847,13 @@ pub fn check_refinement(
                         // located refinement finding, not an unclassified
                         // internal error that the CLI defaults to `kind:"type"`.
                         Err(error) if is_partial_operation_error(&error.message) => {
+                            let child_trace = refinement_child_trace(
+                                state,
+                                &parents,
+                                step + 1,
+                                &enabled,
+                                &stepped,
+                            );
                             check.failure = Some(refinement_failure(
                                 "map_partial_op",
                                 Some("step"),
@@ -1868,7 +1877,7 @@ pub fn check_refinement(
                     // state is already fully computed, so there is nothing
                     // for `abstraction.init` to determine here either.
                     let abs_state = abstract_action_state(
-                        &alpha_before,
+                        alpha_before,
                         abstraction,
                         abs_action,
                         &expected_params,
@@ -1877,6 +1886,8 @@ pub fn check_refinement(
                     let Some(abs_enabled) =
                         refinement_action_instance(&abs_monitor, abs_action, expected_params)?
                     else {
+                        let child_trace =
+                            refinement_child_trace(state, &parents, step + 1, &enabled, &stepped);
                         check.failure = Some(refinement_failure(
                             "abs_requires_failed",
                             Some("step"),
@@ -1891,6 +1902,8 @@ pub fn check_refinement(
                     let abs_step = abs_monitor.step(&abs_enabled)?;
                     let expected_state = project_abstract_state(&abs_step.state, abstraction)?;
                     if expected_state != alpha_after {
+                        let child_trace =
+                            refinement_child_trace(state, &parents, step + 1, &enabled, &stepped);
                         check.failure = Some(refinement_failure(
                             "abs_state_mismatch",
                             Some("step"),
@@ -1911,6 +1924,8 @@ pub fn check_refinement(
                 } else {
                     "abs_state_mismatch"
                 };
+                let child_trace =
+                    refinement_child_trace(state, &parents, step + 1, &enabled, &stepped);
                 check.failure = Some(refinement_failure(
                     kind,
                     Some("step"),
@@ -1922,12 +1937,39 @@ pub fn check_refinement(
                 ));
                 return Ok(check);
             }
-            if !visited.contains(&child.state) {
-                queue.push_back((child, step + 1, child_trace));
+            if !visited.contains(&child_state) {
+                parents
+                    .entry(child_state.clone())
+                    .or_insert_with(|| trace::ParentLink {
+                        parent: state.clone(),
+                        action: TraceAction {
+                            name: enabled.action.clone(),
+                            params: enabled.params.clone(),
+                        },
+                    });
+                queue.push_back((child_state, step + 1));
             }
         }
     }
     Ok(check)
+}
+
+/// The replayable trace ending at the step just taken from `state`, built by
+/// walking `parents` back to the walk's root and appending that one step --
+/// reconstructed only when a refinement failure is about to be reported,
+/// mirroring `find_boundary_violation`'s and `first_self_violation`'s
+/// on-demand trace construction (issue #783) instead of carrying a growing
+/// `Vec<TraceStep>` clone in every queued frontier node.
+fn refinement_child_trace(
+    state: &State,
+    parents: &BTreeMap<State, trace::ParentLink>,
+    next_step: usize,
+    enabled: &EnabledAction,
+    stepped: &StepResult,
+) -> Vec<TraceStep> {
+    let mut child_trace = trace::reconstruct_trace(state, parents);
+    child_trace.push(trace_step_from_result(next_step, state, enabled, stepped));
+    child_trace
 }
 
 /// Exhaustively explore concrete reachable states to a bounded depth.
@@ -2833,37 +2875,49 @@ pub fn action_cover_traces(
     model: KernelModel,
     depth: usize,
 ) -> Result<BTreeMap<String, Vec<TraceStep>>, RuntimeError> {
-    let initial = Monitor::new(model)?;
-    let initial_trace = vec![TraceStep {
-        step: 0,
-        state: initial.state.clone(),
-        action: None,
-        changes: BTreeMap::new(),
-    }];
+    // `scratch` re-pointed per state, `parents` reconstructed only on
+    // witness discovery -- the same #783 pattern as `check_refinement`'s
+    // walk. The witness for a covered action is built from the *parent*
+    // state's own reconstructed trace plus the covering step, not from the
+    // child's `parents` entry: the witness registration below fires even
+    // when the child was already visited by an earlier path (it runs before
+    // the `visited` check), so it cannot depend on the child having a
+    // `ParentLink` at all.
+    let mut scratch = Monitor::new(model)?;
+    let initial_state = scratch.state.clone();
     let mut covered = BTreeMap::new();
-    let mut visited = BTreeSet::from([initial.state.clone()]);
-    let mut queue = VecDeque::from([(initial, initial_trace, 0_usize)]);
-    while let Some((monitor, trace, step)) = queue.pop_front() {
+    let mut visited = BTreeSet::from([initial_state.clone()]);
+    let mut parents = BTreeMap::<State, trace::ParentLink>::new();
+    let mut queue = VecDeque::from([(initial_state, 0_usize)]);
+    while let Some((state, step)) = queue.pop_front() {
         if step >= depth {
             continue;
         }
-        let enabled = monitor.enabled()?;
+        scratch.state = state.clone();
+        scratch.step = step;
+        let enabled = scratch.enabled()?;
         for instance in enabled {
-            let mut child = monitor.clone();
-            let result = child.step(&instance)?;
-            let mut child_trace = trace.clone();
-            child_trace.push(trace_step_from_result(
-                step + 1,
-                &monitor.state,
-                &instance,
-                &result,
-            ));
+            scratch.state = state.clone();
+            scratch.step = step;
+            let result = scratch.step(&instance)?;
             if result.violation.is_none() {
-                covered
-                    .entry(instance.action.clone())
-                    .or_insert_with(|| child_trace.clone());
-                if visited.insert(child.state.clone()) {
-                    queue.push_back((child, child_trace, step + 1));
+                let child_state = result.state.clone();
+                if !covered.contains_key(&instance.action) {
+                    let mut witness = trace::reconstruct_trace(&state, &parents);
+                    witness.push(trace_step_from_result(step + 1, &state, &instance, &result));
+                    covered.insert(instance.action.clone(), witness);
+                }
+                if visited.insert(child_state.clone()) {
+                    parents
+                        .entry(child_state.clone())
+                        .or_insert_with(|| trace::ParentLink {
+                            parent: state.clone(),
+                            action: TraceAction {
+                                name: instance.action.clone(),
+                                params: instance.params.clone(),
+                            },
+                        });
+                    queue.push_back((child_state, step + 1));
                 }
             }
         }
@@ -2906,28 +2960,37 @@ pub fn leadsto_response_traces(
     if model.leadstos.is_empty() {
         return Ok((Vec::new(), Vec::new()));
     }
-    let initial = Monitor::new(model.clone())?;
+    // Only the per-node `Monitor` clone (a whole `KernelModel` clone) is
+    // removed here, via a re-pointed `scratch` -- issue #783 scoped this
+    // lane to that clone alone. The per-node `Vec<TraceStep>` clone stays:
+    // this walk has no `visited` dedup (a `pending`/response history is
+    // path-dependent, so two routes to the same state must stay distinct
+    // path-trees, not merge behind a shared `ParentLink`), and a
+    // `reconstruct_trace`-style backward walk has no well-defined single
+    // parent to walk back through when routes fork and rejoin.
+    let mut scratch = Monitor::new(model.clone())?;
+    let initial_state = scratch.state.clone();
     let bindings = model
         .leadstos
         .iter()
         .map(|property| {
             Ok((
                 property.name.clone(),
-                leadsto_bindings(property, &initial.state, model)?,
+                leadsto_bindings(property, &initial_state, model)?,
             ))
         })
         .collect::<Result<BTreeMap<_, _>, RuntimeError>>()?;
     let target_count = bindings.values().map(Vec::len).sum::<usize>();
     let initial_trace = vec![TraceStep {
         step: 0,
-        state: initial.state.clone(),
+        state: initial_state.clone(),
         action: None,
         changes: BTreeMap::new(),
     }];
     let mut responses = BTreeMap::<(String, Bindings), LeadstoResponse>::new();
     let mut triggered = BTreeSet::<(String, Bindings)>::new();
-    let mut queue = VecDeque::from([(initial, initial_trace, 0_usize)]);
-    while let Some((monitor, trace, step)) = queue.pop_front() {
+    let mut queue = VecDeque::from([(initial_state, initial_trace, 0_usize)]);
+    while let Some((state, trace, step)) = queue.pop_front() {
         for property in &model.leadstos {
             for binding in &bindings[&property.name] {
                 let key = (property.name.clone(), binding.clone());
@@ -2965,20 +3028,18 @@ pub fn leadsto_response_traces(
         if responses.len() == target_count || step >= depth {
             continue;
         }
-        for instance in monitor.enabled()? {
-            let mut child = monitor.clone();
-            let result = child.step(&instance)?;
+        scratch.state = state.clone();
+        scratch.step = step;
+        for instance in scratch.enabled()? {
+            scratch.state = state.clone();
+            scratch.step = step;
+            let result = scratch.step(&instance)?;
             if result.violation.is_some() {
                 continue;
             }
             let mut child_trace = trace.clone();
-            child_trace.push(trace_step_from_result(
-                step + 1,
-                &monitor.state,
-                &instance,
-                &result,
-            ));
-            queue.push_back((child, child_trace, step + 1));
+            child_trace.push(trace_step_from_result(step + 1, &state, &instance, &result));
+            queue.push_back((result.state.clone(), child_trace, step + 1));
         }
     }
     let missing = bindings

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1665,7 +1665,7 @@ pub fn check_refinement(
     // failure reported is stable). Every candidate that passes seeds its
     // own root below, so the walk explores the full reachable set of every
     // nondeterministic initial branch, not just one.
-    let mut queue = VecDeque::new();
+    let mut queue = trace::LeanFrontier::new();
     for impl_state in impl_initial_states {
         let alpha_initial = alpha_state(
             &impl_state,
@@ -1719,7 +1719,7 @@ pub fn check_refinement(
             ));
             return Ok(check);
         }
-        queue.push_back((impl_state, 0_usize));
+        queue.push(impl_state, 0);
     }
 
     // The frontier carries `State` only, not `Monitor` -- a full `Monitor`
@@ -1733,14 +1733,10 @@ pub fn check_refinement(
     let mut visited = BTreeSet::new();
     let mut parents = BTreeMap::<State, trace::ParentLink>::new();
     let mut scratch = Monitor::from_state(implementation.clone(), State::new());
-    while let Some((_, step)) = queue.front() {
-        let step = *step;
+    while let Some(step) = queue.front_step() {
         let mut layer = Vec::new();
-        while queue
-            .front()
-            .is_some_and(|(_, queued_step)| *queued_step == step)
-        {
-            let Some((state, _)) = queue.pop_front() else {
+        while queue.front_step() == Some(step) {
+            let Some((state, _)) = queue.pop() else {
                 unreachable!("queue front was present");
             };
             if visited.insert(state.clone()) && step < depth {
@@ -1947,7 +1943,7 @@ pub fn check_refinement(
                             params: enabled.params.clone(),
                         },
                     });
-                queue.push_back((child_state, step + 1));
+                queue.push(child_state, step + 1);
             }
         }
     }
@@ -2888,8 +2884,9 @@ pub fn action_cover_traces(
     let mut covered = BTreeMap::new();
     let mut visited = BTreeSet::from([initial_state.clone()]);
     let mut parents = BTreeMap::<State, trace::ParentLink>::new();
-    let mut queue = VecDeque::from([(initial_state, 0_usize)]);
-    while let Some((state, step)) = queue.pop_front() {
+    let mut queue = trace::LeanFrontier::new();
+    queue.push(initial_state, 0);
+    while let Some((state, step)) = queue.pop() {
         if step >= depth {
             continue;
         }
@@ -2917,7 +2914,7 @@ pub fn action_cover_traces(
                                 params: instance.params.clone(),
                             },
                         });
-                    queue.push_back((child_state, step + 1));
+                    queue.push(child_state, step + 1);
                 }
             }
         }

--- a/rust/fsl-runtime/src/trace.rs
+++ b/rust/fsl-runtime/src/trace.rs
@@ -60,6 +60,40 @@ impl LeanFrontier {
     }
 }
 
+/// A step-ordered BFS frontier for a lane whose per-node `Vec<TraceStep>`
+/// is semantically required -- a path-dependent search with no `visited`
+/// dedup, where two routes reaching the same state must stay distinct
+/// path-trees rather than merge behind a shared [`ParentLink`]
+/// (`leadsto_response_traces`'s `pending`/response history is exactly this:
+/// it is a property of the *route*, not the state) -- but which must still
+/// never carry a whole `Monitor` per node. Holds only `(State,
+/// Vec<TraceStep>, usize)`; adding a `Monitor` back is exactly the
+/// #730/#783 regression this type exists to make harder.
+///
+/// Same caveat as [`LeanFrontier`]: this is a type-level guardrail for the
+/// *consuming* lane's own queue declaration, not a compile-time proof that
+/// no lane anywhere clones a `Monitor` per node.
+#[derive(Debug, Default)]
+pub(crate) struct PathFrontier {
+    queue: VecDeque<(State, Vec<TraceStep>, usize)>,
+}
+
+impl PathFrontier {
+    pub(crate) fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, state: State, trace: Vec<TraceStep>, step: usize) {
+        self.queue.push_back((state, trace, step));
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<(State, Vec<TraceStep>, usize)> {
+        self.queue.pop_front()
+    }
+}
+
 /// One step back from a state to its BFS parent and the action that produced it.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ParentLink {

--- a/rust/fsl-runtime/src/trace.rs
+++ b/rust/fsl-runtime/src/trace.rs
@@ -13,11 +13,52 @@
 //! originated this pattern for `verify_explicit_selected`; `find_boundary_violation`
 //! reuses it rather than duplicating it.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use fsl_core::{TraceAction, TraceChange, TraceStep};
 
 use super::State;
+
+/// A step-ordered BFS frontier holding only `(State, usize)` per queued
+/// node -- never a `Monitor` (a whole `KernelModel` clone) or a
+/// `Vec<TraceStep>` (a per-node trace clone). Adding either back to a
+/// lane's frontier is exactly the #730/#697/#783 regression this type
+/// exists to make harder: a lane that starts needing more than a state and
+/// a depth should reach for `ParentLink`/[`reconstruct_trace`] plus a
+/// re-pointed scratch `Monitor`, not a wider queue element here.
+///
+/// This is a type-level guardrail for the *consuming* lane's own queue
+/// declaration, not a compile-time proof that no lane anywhere clones a
+/// `Monitor` per node: a lane that declares its own `VecDeque<(Monitor,
+/// ..)>` instead of using this type is not stopped by it. Pair any change
+/// to a lane using `LeanFrontier` with its ceiling regression test
+/// (`tests/issue_730_bfs_memory_ceiling.rs`'s pattern) in review.
+#[derive(Debug, Default)]
+pub(crate) struct LeanFrontier {
+    queue: VecDeque<(State, usize)>,
+}
+
+impl LeanFrontier {
+    pub(crate) fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, state: State, step: usize) {
+        self.queue.push_back((state, step));
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<(State, usize)> {
+        self.queue.pop_front()
+    }
+
+    /// The step of the node at the front of the queue, or `None` when the
+    /// queue is empty.
+    pub(crate) fn front_step(&self) -> Option<usize> {
+        self.queue.front().map(|(_, step)| *step)
+    }
+}
 
 /// One step back from a state to its BFS parent and the action that produced it.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs
@@ -10,7 +10,9 @@
 //!
 //! State-count identity between the pre-fix and post-fix `bfs` was measured
 //! directly during development (`/usr/bin/time -l fsl-bfs`, release build):
-//! 16,290 states for the `LabelCoreRepro` reproducer below at depth 3,
+//! 16,290 states for the `LabelCoreRepro` reproducer (`support::LABEL_CORE_REPRO_SOURCE`,
+//! shared with `issue_730_explicit_memory_ceiling.rs` and `issue_783_refine_memory_ceiling.rs`)
+//! at depth 3,
 //! identical before and after the fix, with peak memory footprint dropping
 //! from ~946 MB (`maximum resident set size`, pre-fix) to ~236 MB
 //! (post-fix). This file's own `states_explored` assertion below re-checks
@@ -47,113 +49,13 @@
 //! flakes, widen `CEILING_KB` rather than tightening this comment's claim.
 #![cfg(target_os = "linux")]
 
-use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
-struct Fixture(PathBuf);
-
-impl Fixture {
-    fn new(name: &str, source: &str) -> Self {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "fsl-issue-730-{name}-{}-{nonce}.fsl",
-            std::process::id()
-        ));
-        std::fs::write(&path, source).expect("write fixture");
-        Self(path)
-    }
-
-    fn text(&self) -> &str {
-        self.0.to_str().expect("UTF-8 temporary path")
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
-    }
-}
-
-/// The same `LabelCoreRepro` reproducer
-/// `rust/fslc/tests/issue_697_all_properties_memory.rs` uses, copied rather
-/// than shared across crates (that file's own note explains why it is not a
-/// `specs`/`examples` corpus fixture): its `audit: Seq<LabelId, 10>` records
-/// push order, so the same *set* of pushed values in a different *order* is
-/// a different `Seq` value, `visited` dedup never collapses the branching,
-/// and the BFS frontier grows like branching^depth.
-const LABEL_CORE_REPRO_SOURCE: &str = r"
-spec LabelCoreRepro {
-  type LabelId = 0..3
-  type Qty     = 0..8
-  enum Phase { Draft, Review, Approved, Published, Retired }
-  struct Label { phase: Phase, weight: Qty, pinned: Bool }
-  state {
-    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
-    reviewed: Set<LabelId>, published: Set<LabelId>,
-    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
-  }
-  init {
-    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
-    audit = Seq {} reviewed = Set {} published = Set {}
-    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
-  }
-  action review(l: LabelId, w: Qty) {
-    requires audit.size() < 10
-    requires not frozen
-    requires labels[l].phase == Draft
-    requires w > 0 and w <= quota
-    labels[l].phase = Review
-    labels[l].weight = w
-    reviewed = reviewed.add(l)
-    draft_count = draft_count - 1
-    audit = audit.push(l)
-  }
-  action approve(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Review
-    labels[l].phase = Approved
-    total = total + labels[l].weight
-    audit = audit.push(l)
-  }
-  action publish(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Approved
-    labels[l].phase = Published
-    published = published.add(l)
-    epoch = epoch + 1
-    audit = audit.push(l)
-  }
-  action retire(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Published
-    labels[l].phase = Retired
-    total = total - labels[l].weight
-    audit = audit.push(l)
-  }
-  action freeze() { requires not frozen  frozen = true }
-  invariant PublishedWasReviewed {
-    forall l: LabelId { published.contains(l) => reviewed.contains(l) }
-  }
-  invariant TotalConsistent {
-    total == sum(l: LabelId of labels[l].weight
-                 where labels[l].phase == Approved or labels[l].phase == Published)
-  }
-  invariant AuditCoversReview {
-    forall l: LabelId { labels[l].phase != Draft => audit.contains(l) }
-  }
-  trans EpochMonotone { epoch >= old(epoch) }
-  reachable AllPublished { published.size() >= 2 }
-  reachable SomeRetired { exists l: LabelId { labels[l].phase == Retired } }
-  reachable QuotaSaturated { total >= 6 }
-  reachable AuditFull { audit.size() >= 5 }
-}
-";
+#[path = "support/mod.rs"]
+mod support;
+use support::{Fixture, LABEL_CORE_REPRO_SOURCE};
 
 #[test]
 fn bfs_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {

--- a/rust/fsl-runtime/tests/issue_730_explicit_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_730_explicit_memory_ceiling.rs
@@ -19,7 +19,9 @@
 //! alongside this test specifically so the measurement is not diluted by
 //! `fslc verify`'s own Z3-backed vacuity checks, which run regardless of
 //! `--engine`): peak memory footprint on the `LabelCoreRepro` reproducer
-//! below (release build, depth 3, 16,290 states, max frontier width
+//! (`support::LABEL_CORE_REPRO_SOURCE`, shared with
+//! `issue_730_bfs_memory_ceiling.rs` and `issue_783_refine_memory_ceiling.rs`)
+//! (release build, depth 3, 16,290 states, max frontier width
 //! 15,424) dropped from ~1,783 MB (pre-fix) to ~954 MB (post-fix) --
 //! real and state-count-identical, but a much smaller *relative* drop than
 //! `bfs`'s ~4x, because `enabled_by_state`'s cost is unaffected and sets
@@ -37,108 +39,13 @@
 //! claim.
 #![cfg(target_os = "linux")]
 
-use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
-struct Fixture(PathBuf);
-
-impl Fixture {
-    fn new(name: &str, source: &str) -> Self {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "fsl-issue-730-{name}-{}-{nonce}.fsl",
-            std::process::id()
-        ));
-        std::fs::write(&path, source).expect("write fixture");
-        Self(path)
-    }
-
-    fn text(&self) -> &str {
-        self.0.to_str().expect("UTF-8 temporary path")
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
-    }
-}
-
-/// The same `LabelCoreRepro` reproducer `issue_730_bfs_memory_ceiling.rs`
-/// and `rust/fslc/tests/issue_697_all_properties_memory.rs` use.
-const LABEL_CORE_REPRO_SOURCE: &str = r"
-spec LabelCoreRepro {
-  type LabelId = 0..3
-  type Qty     = 0..8
-  enum Phase { Draft, Review, Approved, Published, Retired }
-  struct Label { phase: Phase, weight: Qty, pinned: Bool }
-  state {
-    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
-    reviewed: Set<LabelId>, published: Set<LabelId>,
-    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
-  }
-  init {
-    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
-    audit = Seq {} reviewed = Set {} published = Set {}
-    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
-  }
-  action review(l: LabelId, w: Qty) {
-    requires audit.size() < 10
-    requires not frozen
-    requires labels[l].phase == Draft
-    requires w > 0 and w <= quota
-    labels[l].phase = Review
-    labels[l].weight = w
-    reviewed = reviewed.add(l)
-    draft_count = draft_count - 1
-    audit = audit.push(l)
-  }
-  action approve(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Review
-    labels[l].phase = Approved
-    total = total + labels[l].weight
-    audit = audit.push(l)
-  }
-  action publish(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Approved
-    labels[l].phase = Published
-    published = published.add(l)
-    epoch = epoch + 1
-    audit = audit.push(l)
-  }
-  action retire(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Published
-    labels[l].phase = Retired
-    total = total - labels[l].weight
-    audit = audit.push(l)
-  }
-  action freeze() { requires not frozen  frozen = true }
-  invariant PublishedWasReviewed {
-    forall l: LabelId { published.contains(l) => reviewed.contains(l) }
-  }
-  invariant TotalConsistent {
-    total == sum(l: LabelId of labels[l].weight
-                 where labels[l].phase == Approved or labels[l].phase == Published)
-  }
-  invariant AuditCoversReview {
-    forall l: LabelId { labels[l].phase != Draft => audit.contains(l) }
-  }
-  trans EpochMonotone { epoch >= old(epoch) }
-  reachable AllPublished { published.size() >= 2 }
-  reachable SomeRetired { exists l: LabelId { labels[l].phase == Retired } }
-  reachable QuotaSaturated { total >= 6 }
-  reachable AuditFull { audit.size() >= 5 }
-}
-";
+#[path = "support/mod.rs"]
+mod support;
+use support::{Fixture, LABEL_CORE_REPRO_SOURCE};
 
 #[test]
 fn explicit_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {

--- a/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
@@ -7,173 +7,74 @@
 //! #730/#697 already fixed and issue #776 documented as bisected apart from
 //! this one.
 //!
-//! Both tests below use the same `LabelCoreRepro` reproducer
-//! `issue_730_bfs_memory_ceiling.rs` uses (copied rather than shared across
-//! test binaries, for the same reason that file gives): its
-//! `audit: Seq<LabelId, 10>` records push order, so the same *set* of pushed
-//! values in a different *order* is a different `Seq` value, `visited` dedup
-//! never collapses the branching, and a BFS/correspondence-walk frontier
-//! grows like branching^depth.
+//! Both tests below build on the shared `LabelCoreRepro` reproducer in
+//! `support::LABEL_CORE_REPRO_SOURCE` (also used by
+//! `issue_730_bfs_memory_ceiling.rs` and `issue_730_explicit_memory_ceiling.rs`):
+//! its `audit: Seq<LabelId, 10>` records push order, so the same *set* of
+//! pushed values in a different *order* is a different `Seq` value,
+//! `visited` dedup never collapses the branching, and a BFS/correspondence-
+//! walk frontier grows like branching^depth. An independent review of an
+//! earlier version of this file found it had drifted from that shared
+//! reproducer -- missing `invariant`/`trans`/`reachable` declarations,
+//! which changes the `KernelModel`'s clone size and therefore the pre-fix
+//! calibration numbers below -- while claiming to be "the same" copy.
+//! Sharing the fixture via `support` makes that specific drift impossible
+//! to reintroduce by construction, not just by discipline.
 //!
-//! Like that file, macOS does not enforce `RLIMIT_AS` the way `ulimit -v`
-//! expects (observed directly on this repo's own macOS development
-//! environment: `sh -c 'ulimit -v N'` itself fails with "cannot modify
-//! limit: Invalid argument", not merely silently unenforced), so both tests
-//! are Linux-only and report zero tests run on macOS -- that is expected,
-//! not a skipped failure.
+//! `rust/fslc/tests/issue_697_all_properties_memory.rs` carries a fourth
+//! copy of this same reproducer, in a different crate that a `tests/`-local
+//! module cannot reach. Consolidating that one too is an explicit follow-up
+//! (tracked in the #783 pull request), not folded into this fix's scope.
+//!
+//! Like `issue_730_bfs_memory_ceiling.rs`, macOS does not enforce
+//! `RLIMIT_AS` the way `ulimit -v` expects -- observed directly on this
+//! repo's own macOS development environment, and more bluntly than that
+//! file's own caveat: here `sh -c 'ulimit -v N'` fails outright with
+//! "cannot modify limit: Invalid argument" before `fsl-refine` ever runs,
+//! rather than merely not being enforced once it does. Both tests below are
+//! therefore Linux-only and report zero tests run on macOS by design -- not
+//! a skipped failure, and not evidence either test's `ulimit`-capped
+//! assertion has ever actually been observed to fail on a mutant binary.
+//! Every "measured" figure in this file's calibration comments is a peak
+//! *memory* comparison (`/usr/bin/time -l`'s `peak memory footprint`),
+//! taken on macOS outside the `ulimit -v` gate entirely -- it is evidence
+//! that the two builds' memory use differs by roughly the stated amount,
+//! not evidence that the `ulimit`-capped assertion below has been observed
+//! to pass on one build and fail on the other. That direct observation
+//! (running both the fixed and a per-node-clone-reintroduced mutant on
+//! Linux under the actual `ulimit -v` cap and recording which assertion
+//! fails, the way #776's own review required) has not been taken and is
+//! deliberately deferred -- whether to rely on CI for it or set up a Linux
+//! environment for this repository's own development is still an open,
+//! human decision as of this file's current revision. As with the existing
+//! `issue_730_*` ceiling tests, macOS RSS improving is assumed, but not
+//! independently verified, to imply a comparable Linux `RLIMIT_AS` (`ulimit
+//! -v`) improvement; if a `CEILING_KB` below flakes on Linux CI, widen it
+//! rather than tightening this comment's claim.
 #![cfg(target_os = "linux")]
 
-use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
-struct Fixture(PathBuf);
+#[path = "support/mod.rs"]
+mod support;
+use support::{Fixture, LABEL_CORE_REPRO_SOURCE, insert_before_closing_brace};
 
-impl Fixture {
-    fn new(name: &str, source: &str) -> Self {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "fsl-issue-783-{name}-{}-{nonce}.fsl",
-            std::process::id()
-        ));
-        std::fs::write(&path, source).expect("write fixture");
-        Self(path)
-    }
-
-    fn text(&self) -> &str {
-        self.0.to_str().expect("UTF-8 temporary path")
-    }
-}
-
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
-    }
-}
-
-/// The plain, internally-consistent `LabelCoreRepro` implementation --
-/// identical to `issue_730_bfs_memory_ceiling.rs`'s copy, with no self-
-/// violating action added, so `check_refinement`'s `first_self_violation`
-/// precondition passes and the correspondence walk below actually runs to
-/// `depth`.
-const LABEL_CORE_REPRO_SOURCE: &str = r"
-spec LabelCoreRepro {
-  type LabelId = 0..3
-  type Qty     = 0..8
-  enum Phase { Draft, Review, Approved, Published, Retired }
-  struct Label { phase: Phase, weight: Qty, pinned: Bool }
-  state {
-    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
-    reviewed: Set<LabelId>, published: Set<LabelId>,
-    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
-  }
-  init {
-    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
-    audit = Seq {} reviewed = Set {} published = Set {}
-    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
-  }
-  action review(l: LabelId, w: Qty) {
-    requires audit.size() < 10
-    requires not frozen
-    requires labels[l].phase == Draft
-    requires w > 0 and w <= quota
-    labels[l].phase = Review
-    labels[l].weight = w
-    reviewed = reviewed.add(l)
-    draft_count = draft_count - 1
-    audit = audit.push(l)
-  }
-  action approve(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Review
-    labels[l].phase = Approved
-    total = total + labels[l].weight
-    audit = audit.push(l)
-  }
-  action publish(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Approved
-    labels[l].phase = Published
-    published = published.add(l)
-    epoch = epoch + 1
-    audit = audit.push(l)
-  }
-  action retire(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Published
-    labels[l].phase = Retired
-    total = total - labels[l].weight
-    audit = audit.push(l)
-  }
-  action freeze() { requires not frozen  frozen = true }
-}
-";
-
-/// The same reproducer plus one extra action that self-violates: `quota` is
-/// bounded `0..8`, so `quota + 8` once `quota` has reached its own bound
-/// overflows the type. `check_refinement`'s `first_self_violation`
-/// precondition (`rust/fsl-runtime/src/lib.rs:1615-1627`) finds this before
-/// the correspondence walk ever starts, so this fixture isolates
+/// The extra self-violating action, generated as a diff against
+/// [`LABEL_CORE_REPRO_SOURCE`] rather than duplicated inside a second full
+/// copy of the spec: `quota` is bounded `0..8`, so `quota + 8` once `quota`
+/// has reached its own bound overflows the type. `check_refinement`'s
+/// `first_self_violation` precondition finds this before the
+/// correspondence walk ever starts, so this fixture isolates
 /// `first_self_violation`'s own frontier -- the ceiling PR #776 deferred to
-/// this issue -- in isolation from the walk the other test below covers.
-const LABEL_CORE_REPRO_SELF_VIOLATING_SOURCE: &str = r"
-spec LabelCoreReproSelfViolating {
-  type LabelId = 0..3
-  type Qty     = 0..8
-  enum Phase { Draft, Review, Approved, Published, Retired }
-  struct Label { phase: Phase, weight: Qty, pinned: Bool }
-  state {
-    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
-    reviewed: Set<LabelId>, published: Set<LabelId>,
-    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
-  }
-  init {
-    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
-    audit = Seq {} reviewed = Set {} published = Set {}
-    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
-  }
-  action review(l: LabelId, w: Qty) {
-    requires audit.size() < 10
-    requires not frozen
-    requires labels[l].phase == Draft
-    requires w > 0 and w <= quota
-    labels[l].phase = Review
-    labels[l].weight = w
-    reviewed = reviewed.add(l)
-    draft_count = draft_count - 1
-    audit = audit.push(l)
-  }
-  action approve(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Review
-    labels[l].phase = Approved
-    total = total + labels[l].weight
-    audit = audit.push(l)
-  }
-  action publish(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Approved
-    labels[l].phase = Published
-    published = published.add(l)
-    epoch = epoch + 1
-    audit = audit.push(l)
-  }
-  action retire(l: LabelId) {
-    requires audit.size() < 10
-    requires labels[l].phase == Published
-    labels[l].phase = Retired
-    total = total - labels[l].weight
-    audit = audit.push(l)
-  }
-  action freeze() { requires not frozen  frozen = true }
-  action overflow() { requires audit.size() >= 3  quota = quota + 8 }
+/// this issue -- from the walk the other test below covers.
+const OVERFLOW_ACTION: &str =
+    "  action overflow() { requires audit.size() >= 3  quota = quota + 8 }\n";
+
+fn label_core_repro_self_violating_source() -> String {
+    insert_before_closing_brace(LABEL_CORE_REPRO_SOURCE, OVERFLOW_ACTION)
 }
-";
 
 /// An abstraction with the same state declarations as `LabelCoreRepro`, but
 /// no actions -- paired below with a mapping that maps every impl state
@@ -231,34 +132,20 @@ refinement LabelCoreReproStutter {
 }
 ";
 
-/// The same all-stutter mapping, covering the self-violating implementation's
-/// six actions (the five above plus `overflow`). Never actually evaluated --
-/// `first_self_violation` returns before the correspondence walk starts --
-/// but `fsl_core::parse_refinement` still requires a correspondence entry for
-/// every impl action to parse at all.
-const LABEL_CORE_REPRO_SELF_VIOLATING_STUTTER_MAPPING_SOURCE: &str = r"
-refinement LabelCoreReproSelfViolatingStutter {
-  impl LabelCoreReproSelfViolating
-  abs  LabelCoreReproAbs
+/// The extra `overflow -> stutter` correspondence, generated as a diff
+/// against [`LABEL_CORE_REPRO_ALL_STUTTER_MAPPING_SOURCE`] the same way
+/// [`label_core_repro_self_violating_source`] generates its spec. Never
+/// actually evaluated -- `first_self_violation` returns before the
+/// correspondence walk starts -- but `fsl_core::parse_refinement` still
+/// requires a correspondence entry for every impl action to parse at all.
+const OVERFLOW_STUTTER_CORRESPONDENCE: &str = "  action overflow()   -> stutter\n";
 
-  map labels[l: LabelId] = Label { phase: Draft, weight: 0, pinned: false }
-  map audit = Seq {}
-  map reviewed = Set {}
-  map published = Set {}
-  map draft_count = 4
-  map total = 0
-  map epoch = 0
-  map quota = 8
-  map frozen = false
-
-  action review(l, w) -> stutter
-  action approve(l)   -> stutter
-  action publish(l)   -> stutter
-  action retire(l)    -> stutter
-  action freeze()     -> stutter
-  action overflow()   -> stutter
+fn label_core_repro_self_violating_stutter_mapping_source() -> String {
+    insert_before_closing_brace(
+        LABEL_CORE_REPRO_ALL_STUTTER_MAPPING_SOURCE,
+        OVERFLOW_STUTTER_CORRESPONDENCE,
+    )
 }
-";
 
 fn run_capped(ceiling_kb: u64, args: &[&str]) -> std::process::Output {
     let command = format!(
@@ -281,20 +168,24 @@ fn run_capped(ceiling_kb: u64, args: &[&str]) -> std::process::Output {
 /// run). PR #776 fixed this lane's per-node `(Monitor, Vec<TraceStep>)`
 /// clone but deferred adding a ceiling regression test for it to this issue.
 ///
-/// Calibration (release build, `/usr/bin/time -l`, this repo's macOS
-/// development environment, `depth 4`): reintroducing the pre-#776 per-node
-/// clone measured ~1,926 MB peak memory footprint on this exact fixture;
-/// the current fix measures ~492 MB. 1000 * 1024 KiB sits about 2x above
-/// the fixed measurement and clearly below the reintroduced-clone one.
+/// Calibration (release build, `/usr/bin/time -l`'s `peak memory
+/// footprint`, this repo's macOS development environment, `depth 4`, the
+/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture plus `overflow`):
+/// reintroducing the pre-#776 per-node clone (temporarily, for this
+/// measurement only) measured ~2,101 MB; the current fix measures ~492 MB.
+/// 1000 * 1024 KiB sits ~2.03x above the fixed measurement and ~2.10x below
+/// the reintroduced-clone one. This is a peak-memory comparison, not an
+/// observation of the `ulimit`-capped assertion below actually failing on
+/// Linux against either build -- see this file's top comment.
 #[test]
 fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 1000 * 1024;
 
-    let implementation = Fixture::new("fsv-impl", LABEL_CORE_REPRO_SELF_VIOLATING_SOURCE);
+    let implementation = Fixture::new("fsv-impl", &label_core_repro_self_violating_source());
     let abstraction = Fixture::new("fsv-abs", LABEL_CORE_REPRO_ABSTRACTION_SOURCE);
     let mapping = Fixture::new(
         "fsv-map",
-        LABEL_CORE_REPRO_SELF_VIOLATING_STUTTER_MAPPING_SOURCE,
+        &label_core_repro_self_violating_stutter_mapping_source(),
     );
     let output = run_capped(
         CEILING_KB,
@@ -325,13 +216,16 @@ fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_repro
 /// `check_refinement`'s own correspondence walk -- the lane this issue's
 /// clone removal actually changes.
 ///
-/// Calibration (release build, `/usr/bin/time -l`, this repo's macOS
-/// development environment, `depth 3`, this exact fixture): the pre-removal
+/// Calibration (release build, `/usr/bin/time -l`'s `peak memory
+/// footprint`, this repo's macOS development environment, `depth 3`, the
+/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture): the pre-removal
 /// commit (`6012c00`, `fsl-refine` present but the per-node clone not yet
-/// removed) measured ~1,557 MB peak memory footprint, consistent with issue
-/// #783's own reported ~1.72 GB; the post-removal commit measures ~491 MB.
-/// 950 * 1024 KiB sits about 2x above the post-removal measurement (~1.98x)
-/// and clearly below the pre-removal one (~1.60x margin).
+/// removed) measured ~1,728 MB, consistent with issue #783's own reported
+/// ~1.72 GB; the post-removal commit (this branch) measures ~491 MB. 950 *
+/// 1024 KiB sits ~2.03x above the post-removal measurement and ~1.73x below
+/// the pre-removal one. As above, this is a peak-memory comparison, not an
+/// observation of the `ulimit`-capped assertion below actually failing on
+/// Linux against the pre-removal build -- see this file's top comment.
 #[test]
 fn check_refinement_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 950 * 1024;

--- a/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
@@ -33,24 +33,41 @@
 //! "cannot modify limit: Invalid argument" before `fsl-refine` ever runs,
 //! rather than merely not being enforced once it does. Both tests below are
 //! therefore Linux-only and report zero tests run on macOS by design -- not
-//! a skipped failure, and not evidence either test's `ulimit`-capped
-//! assertion has ever actually been observed to fail on a mutant binary.
-//! Every "measured" figure in this file's calibration comments is a peak
-//! *memory* comparison (`/usr/bin/time -l`'s `peak memory footprint`),
-//! taken on macOS outside the `ulimit -v` gate entirely -- it is evidence
-//! that the two builds' memory use differs by roughly the stated amount,
-//! not evidence that the `ulimit`-capped assertion below has been observed
-//! to pass on one build and fail on the other. That direct observation
-//! (running both the fixed and a per-node-clone-reintroduced mutant on
-//! Linux under the actual `ulimit -v` cap and recording which assertion
-//! fails, the way #776's own review required) has not been taken and is
-//! deliberately deferred -- whether to rely on CI for it or set up a Linux
-//! environment for this repository's own development is still an open,
-//! human decision as of this file's current revision. As with the existing
-//! `issue_730_*` ceiling tests, macOS RSS improving is assumed, but not
-//! independently verified, to imply a comparable Linux `RLIMIT_AS` (`ulimit
-//! -v`) improvement; if a `CEILING_KB` below flakes on Linux CI, widen it
-//! rather than tightening this comment's claim.
+//! a skipped failure.
+//!
+//! **Both `CEILING_KB` values below are calibrated from a direct Linux
+//! measurement, not a macOS peak-memory estimate.** Using a `rust:1-bookworm`
+//! Docker container (`aarch64`, `ulimit -v` confirmed to actually enforce
+//! `RLIMIT_AS` there -- unlike macOS), each test's `ulimit`-capped assertion
+//! was run under a binary search of `CEILING_KB` values against both the
+//! fixed build (this branch) and a per-node-Monitor-clone mutant, until the
+//! PASS/FAIL boundary on each side was pinned to within 20-50 MiB and
+//! confirmed reproducible by repeating both boundary points. That is the
+//! direct observation #776's own review asked for and #783-round2 deferred:
+//! each per-test comment below cites the exact boundary window measured on
+//! each side, and the mutant side's FAIL is a real `SIGABRT` (Rust's
+//! allocator aborting the process, `status=...unix_wait_status(134)`,
+//! `stderr="memory allocation of N bytes failed"`) under the `ulimit -v`
+//! cap, not a timeout or a different failure mode.
+//!
+//! Two assumptions still remain, stated precisely so they are not confused
+//! with what was actually measured:
+//! - The measurement above is `aarch64` Linux (an Apple Silicon Mac's
+//!   `colima`/Docker VM); this repository's actual CI runs GitHub Actions'
+//!   `ubuntu-latest`, which is `x86_64`. Cross-architecture allocator and
+//!   address-space-layout differences could shift the true PASS/FAIL
+//!   boundary on `x86_64` from what was measured here -- this has not been
+//!   independently checked on `x86_64`, and is the one monotonicity
+//!   assumption this file still carries.
+//! - The mutant used for each lane is a hand-restored reversion of exactly
+//!   that lane's per-node clone (verified below each `#[test]`'s doc comment
+//!   by a `monitor.clone()` occurrence count inside the function), not an
+//!   independently-authored regression -- it demonstrates this specific
+//!   defect class is caught, not every conceivable regression shape.
+//!
+//! If a `CEILING_KB` below flakes on Linux CI regardless, widen it rather
+//! than tightening this comment's claim -- the `x86_64` assumption above is
+//! the most likely reason a widening would ever be needed.
 #![cfg(target_os = "linux")]
 
 use std::process::Command;
@@ -168,15 +185,25 @@ fn run_capped(ceiling_kb: u64, args: &[&str]) -> std::process::Output {
 /// run). PR #776 fixed this lane's per-node `(Monitor, Vec<TraceStep>)`
 /// clone but deferred adding a ceiling regression test for it to this issue.
 ///
-/// Calibration (release build, `/usr/bin/time -l`'s `peak memory
-/// footprint`, this repo's macOS development environment, `depth 4`, the
-/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture plus `overflow`):
-/// reintroducing the pre-#776 per-node clone (temporarily, for this
-/// measurement only) measured ~2,101 MB; the current fix measures ~492 MB.
-/// 1000 * 1024 KiB sits ~2.03x above the fixed measurement and ~2.10x below
-/// the reintroduced-clone one. This is a peak-memory comparison, not an
-/// observation of the `ulimit`-capped assertion below actually failing on
-/// Linux against either build -- see this file's top comment.
+/// Calibration (`rust:1-bookworm` Docker, `aarch64` Linux, `depth 4`, the
+/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture plus `overflow`;
+/// `CEILING_KB` swept in binary-search steps against `--exact` runs of this
+/// test, both boundary points repeated twice and reproducing identically):
+/// the fixed build (`monitor.clone()` count inside `first_self_violation`:
+/// 0) passes down to a `CEILING_KB` of 505 MiB and fails at 500 MiB
+/// (`status=...unix_wait_status(134)`, `stderr="memory allocation of 5
+/// bytes failed"`) -- boundary in `(500, 505]` MiB. A mutant with the
+/// pre-#776 per-node clone hand-restored into `first_self_violation` only
+/// (`monitor.clone()` count: 1; every other lane, including
+/// `check_refinement`, left identical to the fixed build) passes at 2150
+/// MiB and fails at 2120 MiB -- boundary in `(2120, 2150]` MiB. `CEILING_KB
+/// = 1000 * 1024` (1000 MiB) therefore sits 1.98-2.00x above the fixed
+/// boundary and 2.12-2.15x below the mutant boundary (both ratios computed
+/// against the boundary's FAIL and PASS endpoints respectively, so the true
+/// margin is somewhere in each stated range). See this file's top comment
+/// for the two assumptions this measurement still rests on (`x86_64` CI vs.
+/// this `aarch64` measurement; this specific mutant vs. every conceivable
+/// regression shape).
 #[test]
 fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 1000 * 1024;
@@ -216,16 +243,22 @@ fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_repro
 /// `check_refinement`'s own correspondence walk -- the lane this issue's
 /// clone removal actually changes.
 ///
-/// Calibration (release build, `/usr/bin/time -l`'s `peak memory
-/// footprint`, this repo's macOS development environment, `depth 3`, the
-/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture): the pre-removal
-/// commit (`6012c00`, `fsl-refine` present but the per-node clone not yet
-/// removed) measured ~1,728 MB, consistent with issue #783's own reported
-/// ~1.72 GB; the post-removal commit (this branch) measures ~491 MB. 950 *
-/// 1024 KiB sits ~2.03x above the post-removal measurement and ~1.73x below
-/// the pre-removal one. As above, this is a peak-memory comparison, not an
-/// observation of the `ulimit`-capped assertion below actually failing on
-/// Linux against the pre-removal build -- see this file's top comment.
+/// Calibration (`rust:1-bookworm` Docker, `aarch64` Linux, `depth 3`, the
+/// shared `support::LABEL_CORE_REPRO_SOURCE` fixture; same binary-search
+/// sweep methodology as `first_self_violation`'s test above, both boundary
+/// points repeated twice and reproducing identically): the post-removal
+/// build (this branch; `monitor.clone()` count inside `check_refinement`:
+/// 0) passes down to a `CEILING_KB` of 502 MiB and fails at 500 MiB
+/// (`status=...unix_wait_status(134)`, `stderr="memory allocation of 6
+/// bytes failed"`) -- boundary in `(500, 502]` MiB. The pre-removal commit
+/// (`6012c00`, `fsl-refine` present but the per-node clone not yet removed;
+/// `monitor.clone()` count inside `check_refinement`: 2) passes at 2020 MiB
+/// and fails at 2000 MiB -- boundary in `(2000, 2020]` MiB, consistent with
+/// issue #783's own reported ~1.72 GB order of magnitude. `CEILING_KB = 950
+/// * 1024` (950 MiB) therefore sits 1.89-1.90x above the post-removal
+/// boundary and 2.11-2.13x below the pre-removal boundary (ratios computed
+/// against each boundary's FAIL/PASS endpoints, as above). See this file's
+/// top comment for the two assumptions this measurement still rests on.
 #[test]
 fn check_refinement_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 950 * 1024;

--- a/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
@@ -310,8 +310,8 @@ fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_repro
 /// rather than an imprecise mutant; `monitor.clone()` count inside
 /// `check_refinement` itself: 2) passes at 2020 MiB
 /// and fails at 2000 MiB -- boundary in `(2000, 2020]` MiB, consistent with
-/// issue #783's own reported ~1.72 GB order of magnitude. `CEILING_KB = 950
-/// * 1024` (950 MiB) therefore sits 1.89-1.90x above the post-removal
+/// issue #783's own reported ~1.72 GB order of magnitude. `CEILING_KB = 950 * 1024`
+/// (950 MiB) therefore sits 1.89-1.90x above the post-removal
 /// boundary and 2.11-2.13x below the pre-removal boundary (ratios computed
 /// against each boundary's FAIL/PASS endpoints, as above). See this file's
 /// top comment for the remaining `x86_64`-CI-vs-`aarch64`-measurement

--- a/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
@@ -36,38 +36,87 @@
 //! a skipped failure.
 //!
 //! **Both `CEILING_KB` values below are calibrated from a direct Linux
-//! measurement, not a macOS peak-memory estimate.** Using a `rust:1-bookworm`
-//! Docker container (`aarch64`, `ulimit -v` confirmed to actually enforce
-//! `RLIMIT_AS` there -- unlike macOS), each test's `ulimit`-capped assertion
-//! was run under a binary search of `CEILING_KB` values against both the
-//! fixed build (this branch) and a per-node-Monitor-clone mutant, until the
-//! PASS/FAIL boundary on each side was pinned to within 20-50 MiB and
-//! confirmed reproducible by repeating both boundary points. That is the
-//! direct observation #776's own review asked for and #783-round2 deferred:
-//! each per-test comment below cites the exact boundary window measured on
-//! each side, and the mutant side's FAIL is a real `SIGABRT` (Rust's
-//! allocator aborting the process, `status=...unix_wait_status(134)`,
-//! `stderr="memory allocation of N bytes failed"`) under the `ulimit -v`
-//! cap, not a timeout or a different failure mode.
+//! measurement, not a macOS peak-memory estimate.** That is the direct
+//! observation #776's own review asked for and #783-round2 deferred; a
+//! third-party reproduction needs no machine-specific path, only the
+//! container image, the two commits below, and the commands in this
+//! comment.
 //!
-//! Two assumptions still remain, stated precisely so they are not confused
-//! with what was actually measured:
-//! - The measurement above is `aarch64` Linux (an Apple Silicon Mac's
-//!   `colima`/Docker VM); this repository's actual CI runs GitHub Actions'
-//!   `ubuntu-latest`, which is `x86_64`. Cross-architecture allocator and
-//!   address-space-layout differences could shift the true PASS/FAIL
-//!   boundary on `x86_64` from what was measured here -- this has not been
-//!   independently checked on `x86_64`, and is the one monotonicity
-//!   assumption this file still carries.
-//! - The mutant used for each lane is a hand-restored reversion of exactly
-//!   that lane's per-node clone (verified below each `#[test]`'s doc comment
-//!   by a `monitor.clone()` occurrence count inside the function), not an
-//!   independently-authored regression -- it demonstrates this specific
-//!   defect class is caught, not every conceivable regression shape.
+//! **Container**: `docker run --rm -v <repo>:/w -w /w rust:1-bookworm bash`,
+//! where `<repo>` is a checkout of this repository (any path; the container
+//! only needs `/w/rust` to exist inside it). Confirmed directly in that
+//! container: `sh -c 'ulimit -v 500000 && ...'` really does enforce
+//! `RLIMIT_AS` there (unlike macOS, where the identical command fails
+//! outright with "cannot modify limit: Invalid argument" before anything
+//! else runs) -- a capped process that exceeds it is killed with `SIGABRT`
+//! (`status=...unix_wait_status(134)`, `stderr="memory allocation of N
+//! bytes failed"`), not merely slowed down or left unenforced.
 //!
-//! If a `CEILING_KB` below flakes on Linux CI regardless, widen it rather
-//! than tightening this comment's claim -- the `x86_64` assumption above is
-//! the most likely reason a widening would ever be needed.
+//! **Mutants**, each built by editing a checkout of this branch (`HEAD` at
+//! the time of the #783-linux measurement) and reconstructed from a named
+//! commit rather than a machine-local tree -- **not from the same commit**,
+//! and precise to a different degree, which the next section explains:
+//! - For `check_refinement`'s test: replace `rust/fsl-runtime/src/lib.rs`
+//!   and `rust/fsl-runtime/src/trace.rs` with their content at commit
+//!   `6012c00` (`feat(runtime): add fsl-refine driver for check_refinement
+//!   memory measurement (#783)` -- the commit immediately before this
+//!   issue's own clone-removal commit, i.e. all three #783 lanes still
+//!   carry their pre-fix per-node `Monitor` clone).
+//! - For `first_self_violation`'s test: on an unmodified checkout of this
+//!   branch, replace only the body of the `first_self_violation` function
+//!   in `rust/fsl-runtime/src/lib.rs` with its content at commit
+//!   `20d0a9b^` (the parent of `20d0a9b`, `fix(runtime): drop per-node
+//!   model clones from the three lanes issue #730 enumerates (#730)
+//!   (#776)` -- i.e. `first_self_violation`'s form immediately before PR
+//!   #776 fixed it). Every other function is left exactly as it is on this
+//!   branch.
+//!
+//! **These two mutants are built to two different degrees of precision, and
+//! that difference is deliberate, not an inconsistency:**
+//! `check_refinement`'s mutant is the coarser of the two -- restoring all of
+//! `lib.rs`/`trace.rs` to `6012c00` reverts `action_cover_traces` and
+//! `leadsto_response_traces` as well, not `check_refinement` alone. That is
+//! still sound teeth for this specific test because `fsl-refine` (the
+//! driver `run_capped` below invokes) only ever calls
+//! `fsl_runtime::check_refinement`; `action_cover_traces` and
+//! `leadsto_response_traces` are reachable only from `fslc scenarios`,
+//! which this measurement's path never touches, so their state at
+//! measurement time cannot affect either binary's peak memory. A
+//! function-only mutant was **not** available for `check_refinement`
+//! itself at the time of this measurement (its function was rewritten by
+//! this issue's own clone-removal commit in a way a single hand-edit could
+//! not cheaply invert to an equivalent pre-fix form), so the whole-file
+//! revert was the pragmatic choice, justified by the argument above rather
+//! than by precision. `first_self_violation`'s mutant is the surgical one:
+//! only that one function's body is replaced (verified in each `#[test]`'s
+//! doc comment below by a `monitor.clone()` occurrence count inside the
+//! function, checked to differ from the fixed build's count *before* any
+//! measurement was taken -- an earlier, invalid attempt at this measurement
+//! used a mutant where that count was accidentally unchanged, i.e. no real
+//! contrast, and was caught and discarded specifically by this count).
+//!
+//! **Commands** (run inside the container, from `/w/rust`, once per side
+//! -- fixed checkout and each mutant checkout in turn):
+//! ```sh
+//! cargo test -p fsl-runtime --test issue_783_refine_memory_ceiling --locked \
+//!   -- --exact <test name>
+//! ```
+//! **Boundary search**: with the target test's `const CEILING_KB` edited to
+//! successive candidate values (a coarse pass across roughly one order of
+//! magnitude, then a binary search narrowing the bracket), the PASS/FAIL
+//! boundary on each side was pinned to a 20-50 MiB window and confirmed
+//! reproducible by rerunning both endpoints of that window. Each per-test
+//! comment below cites the exact window measured on each side.
+//!
+//! One assumption remains, stated precisely so it is not confused with what
+//! was actually measured: the container above runs `aarch64` (an Apple
+//! Silicon Mac's Docker VM); this repository's actual CI runs GitHub
+//! Actions' `ubuntu-latest`, which is `x86_64`. Cross-architecture allocator
+//! and address-space-layout differences could shift the true PASS/FAIL
+//! boundary on `x86_64` from what was measured here -- this has not been
+//! independently checked on `x86_64`. If a `CEILING_KB` below flakes on
+//! Linux CI regardless, that gap is the most likely explanation, and
+//! widening `CEILING_KB` is the fix, not tightening this comment's claim.
 #![cfg(target_os = "linux")]
 
 use std::process::Command;
@@ -200,10 +249,12 @@ fn run_capped(ceiling_kb: u64, args: &[&str]) -> std::process::Output {
 /// = 1000 * 1024` (1000 MiB) therefore sits 1.98-2.00x above the fixed
 /// boundary and 2.12-2.15x below the mutant boundary (both ratios computed
 /// against the boundary's FAIL and PASS endpoints respectively, so the true
-/// margin is somewhere in each stated range). See this file's top comment
-/// for the two assumptions this measurement still rests on (`x86_64` CI vs.
-/// this `aarch64` measurement; this specific mutant vs. every conceivable
-/// regression shape).
+/// margin is somewhere in each stated range). This mutant demonstrates this
+/// specific defect class is caught, not every conceivable regression
+/// shape. See this file's top comment for the remaining `x86_64`-CI-vs-
+/// `aarch64`-measurement assumption, the exact commits both mutants are
+/// reconstructed from, and the container/command needed to reproduce this
+/// measurement.
 #[test]
 fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 1000 * 1024;
@@ -251,14 +302,21 @@ fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_repro
 /// 0) passes down to a `CEILING_KB` of 502 MiB and fails at 500 MiB
 /// (`status=...unix_wait_status(134)`, `stderr="memory allocation of 6
 /// bytes failed"`) -- boundary in `(500, 502]` MiB. The pre-removal commit
-/// (`6012c00`, `fsl-refine` present but the per-node clone not yet removed;
-/// `monitor.clone()` count inside `check_refinement`: 2) passes at 2020 MiB
+/// (`6012c00`, `fsl-refine` present but the per-node clone not yet removed
+/// in any of #783's three lanes, not `check_refinement` alone --
+/// `action_cover_traces`/`leadsto_response_traces` are unreachable from the
+/// `fsl-refine` binary this measurement runs, so their reverted state is
+/// inert here; see this file's top comment for why that is sound teeth
+/// rather than an imprecise mutant; `monitor.clone()` count inside
+/// `check_refinement` itself: 2) passes at 2020 MiB
 /// and fails at 2000 MiB -- boundary in `(2000, 2020]` MiB, consistent with
 /// issue #783's own reported ~1.72 GB order of magnitude. `CEILING_KB = 950
 /// * 1024` (950 MiB) therefore sits 1.89-1.90x above the post-removal
 /// boundary and 2.11-2.13x below the pre-removal boundary (ratios computed
 /// against each boundary's FAIL/PASS endpoints, as above). See this file's
-/// top comment for the two assumptions this measurement still rests on.
+/// top comment for the remaining `x86_64`-CI-vs-`aarch64`-measurement
+/// assumption, the exact commits both mutants are reconstructed from, and
+/// the container/command needed to reproduce this measurement.
 #[test]
 fn check_refinement_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
     const CEILING_KB: u64 = 950 * 1024;

--- a/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
+++ b/rust/fsl-runtime/tests/issue_783_refine_memory_ceiling.rs
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Regression coverage for issue #783: two more lanes that used to carry a
+//! whole `Monitor` (a `KernelModel` clone) per queued state, on top of the
+//! `bfs`/`find_boundary_violation`/`first_self_violation` lanes issue
+//! #730/#697 already fixed and issue #776 documented as bisected apart from
+//! this one.
+//!
+//! Both tests below use the same `LabelCoreRepro` reproducer
+//! `issue_730_bfs_memory_ceiling.rs` uses (copied rather than shared across
+//! test binaries, for the same reason that file gives): its
+//! `audit: Seq<LabelId, 10>` records push order, so the same *set* of pushed
+//! values in a different *order* is a different `Seq` value, `visited` dedup
+//! never collapses the branching, and a BFS/correspondence-walk frontier
+//! grows like branching^depth.
+//!
+//! Like that file, macOS does not enforce `RLIMIT_AS` the way `ulimit -v`
+//! expects (observed directly on this repo's own macOS development
+//! environment: `sh -c 'ulimit -v N'` itself fails with "cannot modify
+//! limit: Invalid argument", not merely silently unenforced), so both tests
+//! are Linux-only and report zero tests run on macOS -- that is expected,
+//! not a skipped failure.
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-issue-783-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// The plain, internally-consistent `LabelCoreRepro` implementation --
+/// identical to `issue_730_bfs_memory_ceiling.rs`'s copy, with no self-
+/// violating action added, so `check_refinement`'s `first_self_violation`
+/// precondition passes and the correspondence walk below actually runs to
+/// `depth`.
+const LABEL_CORE_REPRO_SOURCE: &str = r"
+spec LabelCoreRepro {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+  action review(l: LabelId, w: Qty) {
+    requires audit.size() < 10
+    requires not frozen
+    requires labels[l].phase == Draft
+    requires w > 0 and w <= quota
+    labels[l].phase = Review
+    labels[l].weight = w
+    reviewed = reviewed.add(l)
+    draft_count = draft_count - 1
+    audit = audit.push(l)
+  }
+  action approve(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Review
+    labels[l].phase = Approved
+    total = total + labels[l].weight
+    audit = audit.push(l)
+  }
+  action publish(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Approved
+    labels[l].phase = Published
+    published = published.add(l)
+    epoch = epoch + 1
+    audit = audit.push(l)
+  }
+  action retire(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Published
+    labels[l].phase = Retired
+    total = total - labels[l].weight
+    audit = audit.push(l)
+  }
+  action freeze() { requires not frozen  frozen = true }
+}
+";
+
+/// The same reproducer plus one extra action that self-violates: `quota` is
+/// bounded `0..8`, so `quota + 8` once `quota` has reached its own bound
+/// overflows the type. `check_refinement`'s `first_self_violation`
+/// precondition (`rust/fsl-runtime/src/lib.rs:1615-1627`) finds this before
+/// the correspondence walk ever starts, so this fixture isolates
+/// `first_self_violation`'s own frontier -- the ceiling PR #776 deferred to
+/// this issue -- in isolation from the walk the other test below covers.
+const LABEL_CORE_REPRO_SELF_VIOLATING_SOURCE: &str = r"
+spec LabelCoreReproSelfViolating {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+  action review(l: LabelId, w: Qty) {
+    requires audit.size() < 10
+    requires not frozen
+    requires labels[l].phase == Draft
+    requires w > 0 and w <= quota
+    labels[l].phase = Review
+    labels[l].weight = w
+    reviewed = reviewed.add(l)
+    draft_count = draft_count - 1
+    audit = audit.push(l)
+  }
+  action approve(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Review
+    labels[l].phase = Approved
+    total = total + labels[l].weight
+    audit = audit.push(l)
+  }
+  action publish(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Approved
+    labels[l].phase = Published
+    published = published.add(l)
+    epoch = epoch + 1
+    audit = audit.push(l)
+  }
+  action retire(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Published
+    labels[l].phase = Retired
+    total = total - labels[l].weight
+    audit = audit.push(l)
+  }
+  action freeze() { requires not frozen  frozen = true }
+  action overflow() { requires audit.size() >= 3  quota = quota + 8 }
+}
+";
+
+/// An abstraction with the same state declarations as `LabelCoreRepro`, but
+/// no actions -- paired below with a mapping that maps every impl state
+/// variable to a fixed constant (not the impl variable of the same name).
+/// An *identity* map would make every impl action that actually changes
+/// state immediately fail `stutter_changed_abs` at step 1 (alpha changes
+/// whenever the impl state does), short-circuiting `check_refinement`
+/// before it ever explores past depth 0 -- exactly the deep frontier this
+/// fixture needs to exercise. Mapping every field to a constant instead
+/// keeps `alpha_before == alpha_after` for every action at every depth, so
+/// the walk actually runs the full `depth` layers issue #783 measured 1.72
+/// GB (peak RSS) at.
+const LABEL_CORE_REPRO_ABSTRACTION_SOURCE: &str = r"
+spec LabelCoreReproAbs {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+}
+";
+
+/// Maps every `LabelCoreRepro` action to `stutter` against the constant-
+/// mapped abstraction above, covering the plain (non-self-violating) five
+/// actions only.
+const LABEL_CORE_REPRO_ALL_STUTTER_MAPPING_SOURCE: &str = r"
+refinement LabelCoreReproStutter {
+  impl LabelCoreRepro
+  abs  LabelCoreReproAbs
+
+  map labels[l: LabelId] = Label { phase: Draft, weight: 0, pinned: false }
+  map audit = Seq {}
+  map reviewed = Set {}
+  map published = Set {}
+  map draft_count = 4
+  map total = 0
+  map epoch = 0
+  map quota = 8
+  map frozen = false
+
+  action review(l, w) -> stutter
+  action approve(l)   -> stutter
+  action publish(l)   -> stutter
+  action retire(l)    -> stutter
+  action freeze()     -> stutter
+}
+";
+
+/// The same all-stutter mapping, covering the self-violating implementation's
+/// six actions (the five above plus `overflow`). Never actually evaluated --
+/// `first_self_violation` returns before the correspondence walk starts --
+/// but `fsl_core::parse_refinement` still requires a correspondence entry for
+/// every impl action to parse at all.
+const LABEL_CORE_REPRO_SELF_VIOLATING_STUTTER_MAPPING_SOURCE: &str = r"
+refinement LabelCoreReproSelfViolatingStutter {
+  impl LabelCoreReproSelfViolating
+  abs  LabelCoreReproAbs
+
+  map labels[l: LabelId] = Label { phase: Draft, weight: 0, pinned: false }
+  map audit = Seq {}
+  map reviewed = Set {}
+  map published = Set {}
+  map draft_count = 4
+  map total = 0
+  map epoch = 0
+  map quota = 8
+  map frozen = false
+
+  action review(l, w) -> stutter
+  action approve(l)   -> stutter
+  action publish(l)   -> stutter
+  action retire(l)    -> stutter
+  action freeze()     -> stutter
+  action overflow()   -> stutter
+}
+";
+
+fn run_capped(ceiling_kb: u64, args: &[&str]) -> std::process::Output {
+    let command = format!(
+        "ulimit -v {ceiling_kb} && exec {:?} {}",
+        env!("CARGO_BIN_EXE_fsl-refine"),
+        args.iter()
+            .map(|arg| format!("{arg:?}"))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("run capped fsl-refine")
+}
+
+/// `first_self_violation`'s own frontier, isolated from `check_refinement`'s
+/// correspondence walk (which this fixture's `overflow` action never lets
+/// run). PR #776 fixed this lane's per-node `(Monitor, Vec<TraceStep>)`
+/// clone but deferred adding a ceiling regression test for it to this issue.
+///
+/// Calibration (release build, `/usr/bin/time -l`, this repo's macOS
+/// development environment, `depth 4`): reintroducing the pre-#776 per-node
+/// clone measured ~1,926 MB peak memory footprint on this exact fixture;
+/// the current fix measures ~492 MB. 1000 * 1024 KiB sits about 2x above
+/// the fixed measurement and clearly below the reintroduced-clone one.
+#[test]
+fn first_self_violation_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
+    const CEILING_KB: u64 = 1000 * 1024;
+
+    let implementation = Fixture::new("fsv-impl", LABEL_CORE_REPRO_SELF_VIOLATING_SOURCE);
+    let abstraction = Fixture::new("fsv-abs", LABEL_CORE_REPRO_ABSTRACTION_SOURCE);
+    let mapping = Fixture::new(
+        "fsv-map",
+        LABEL_CORE_REPRO_SELF_VIOLATING_STUTTER_MAPPING_SOURCE,
+    );
+    let output = run_capped(
+        CEILING_KB,
+        &[
+            implementation.text(),
+            abstraction.text(),
+            mapping.text(),
+            "4",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "expected first_self_violation to finish inside a {CEILING_KB} KiB address-space \
+         ceiling; status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON under the capped run: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(value["verdict"], "impl_violation", "{value:#}");
+    assert_eq!(value["kind"], "type_bound", "{value:#}");
+}
+
+/// `check_refinement`'s own correspondence walk -- the lane this issue's
+/// clone removal actually changes.
+///
+/// Calibration (release build, `/usr/bin/time -l`, this repo's macOS
+/// development environment, `depth 3`, this exact fixture): the pre-removal
+/// commit (`6012c00`, `fsl-refine` present but the per-node clone not yet
+/// removed) measured ~1,557 MB peak memory footprint, consistent with issue
+/// #783's own reported ~1.72 GB; the post-removal commit measures ~491 MB.
+/// 950 * 1024 KiB sits about 2x above the post-removal measurement (~1.98x)
+/// and clearly below the pre-removal one (~1.60x margin).
+#[test]
+fn check_refinement_stays_under_a_calibrated_ceiling_for_the_branching_reproducer() {
+    const CEILING_KB: u64 = 950 * 1024;
+
+    let implementation = Fixture::new("cr-impl", LABEL_CORE_REPRO_SOURCE);
+    let abstraction = Fixture::new("cr-abs", LABEL_CORE_REPRO_ABSTRACTION_SOURCE);
+    let mapping = Fixture::new("cr-map", LABEL_CORE_REPRO_ALL_STUTTER_MAPPING_SOURCE);
+    let output = run_capped(
+        CEILING_KB,
+        &[
+            implementation.text(),
+            abstraction.text(),
+            mapping.text(),
+            "3",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "expected check_refinement to finish inside a {CEILING_KB} KiB address-space \
+         ceiling (calibrated between the measured pre-/post-removal peaks); status={:?} \
+         stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON under the capped run: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(value["verdict"], "refines", "{value:#}");
+}

--- a/rust/fsl-runtime/tests/support/mod.rs
+++ b/rust/fsl-runtime/tests/support/mod.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Fixture helpers shared by `fsl-runtime`'s memory-ceiling regression
+//! tests (issue #730, #783). Before this module, `issue_730_bfs_memory_ceiling.rs`
+//! and `issue_730_explicit_memory_ceiling.rs` each carried an identical copy
+//! of `Fixture` and the `LabelCoreRepro` reproducer; `issue_783_refine_memory_ceiling.rs`
+//! adding a *third*, non-identical copy (missing `invariants`/`trans`/
+//! `reachables`, which changes the `KernelModel` clone size these ceilings
+//! are calibrated against) is exactly the "same fixture in 3+ places, and
+//! drifting" duplication an independent review of #783 flagged. One
+//! canonical copy here, reused by all three.
+//!
+//! Placed at `tests/support/mod.rs` (not `tests/support.rs`) so Cargo does
+//! not compile it as its own top-level integration-test binary; each
+//! consumer pulls it in with `#[path = "support/mod.rs"] mod support;`.
+//! Every item is `pub` because a given consumer only needs a subset, and
+//! `#[allow(dead_code)]` is applied per item because each integration test
+//! is compiled as its own binary crate, where an unused `pub` item still
+//! triggers the lint (the same rationale `rust/fslc/tests/support/mod.rs`
+//! documents).
+//!
+//! `rust/fslc/tests/issue_697_all_properties_memory.rs` carries a fourth
+//! copy of this same reproducer, in a different crate (`fslc-rust`, not
+//! `fsl-runtime`) that this test-only module cannot reach without a shared
+//! dev-dependency crate. Consolidating that one too is left as an explicit
+//! follow-up rather than folded into #783's own scope.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A temporary `.fsl` file, removed on drop.
+pub struct Fixture(PathBuf);
+
+impl Fixture {
+    #[allow(dead_code)]
+    pub fn new(name: &str, source: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "fsl-fixture-{name}-{}-{nonce}.fsl",
+            std::process::id()
+        ));
+        std::fs::write(&path, source).expect("write fixture");
+        Self(path)
+    }
+
+    #[allow(dead_code)]
+    pub fn text(&self) -> &str {
+        self.0.to_str().expect("UTF-8 temporary path")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// A branching reproducer whose `audit: Seq<LabelId, 10>` records push
+/// order, so the same *set* of pushed values in a different *order* is a
+/// different `Seq` value: `visited` dedup never collapses the branching,
+/// and a BFS/correspondence-walk frontier grows like branching^depth. This
+/// is the shared calibration fixture for every `fsl-runtime` memory-ceiling
+/// regression test.
+#[allow(dead_code)]
+pub const LABEL_CORE_REPRO_SOURCE: &str = r"
+spec LabelCoreRepro {
+  type LabelId = 0..3
+  type Qty     = 0..8
+  enum Phase { Draft, Review, Approved, Published, Retired }
+  struct Label { phase: Phase, weight: Qty, pinned: Bool }
+  state {
+    labels: Map<LabelId, Label>, audit: Seq<LabelId, 10>,
+    reviewed: Set<LabelId>, published: Set<LabelId>,
+    draft_count: Qty, total: Int, epoch: 0..16, quota: Qty, frozen: Bool
+  }
+  init {
+    forall l: LabelId { labels[l] = Label { phase: Draft, weight: 0, pinned: false } }
+    audit = Seq {} reviewed = Set {} published = Set {}
+    draft_count = 4 total = 0 epoch = 0 quota = 8 frozen = false
+  }
+  action review(l: LabelId, w: Qty) {
+    requires audit.size() < 10
+    requires not frozen
+    requires labels[l].phase == Draft
+    requires w > 0 and w <= quota
+    labels[l].phase = Review
+    labels[l].weight = w
+    reviewed = reviewed.add(l)
+    draft_count = draft_count - 1
+    audit = audit.push(l)
+  }
+  action approve(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Review
+    labels[l].phase = Approved
+    total = total + labels[l].weight
+    audit = audit.push(l)
+  }
+  action publish(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Approved
+    labels[l].phase = Published
+    published = published.add(l)
+    epoch = epoch + 1
+    audit = audit.push(l)
+  }
+  action retire(l: LabelId) {
+    requires audit.size() < 10
+    requires labels[l].phase == Published
+    labels[l].phase = Retired
+    total = total - labels[l].weight
+    audit = audit.push(l)
+  }
+  action freeze() { requires not frozen  frozen = true }
+  invariant PublishedWasReviewed {
+    forall l: LabelId { published.contains(l) => reviewed.contains(l) }
+  }
+  invariant TotalConsistent {
+    total == sum(l: LabelId of labels[l].weight
+                 where labels[l].phase == Approved or labels[l].phase == Published)
+  }
+  invariant AuditCoversReview {
+    forall l: LabelId { labels[l].phase != Draft => audit.contains(l) }
+  }
+  trans EpochMonotone { epoch >= old(epoch) }
+  reachable AllPublished { published.size() >= 2 }
+  reachable SomeRetired { exists l: LabelId { labels[l].phase == Retired } }
+  reachable QuotaSaturated { total >= 6 }
+  reachable AuditFull { audit.size() >= 5 }
+}
+";
+
+/// Insert a new top-level item just before `source`'s closing `spec { .. }`
+/// brace -- the last `}` in the string -- so a variant fixture (e.g. one
+/// extra self-violating action) can be generated as a diff against
+/// [`LABEL_CORE_REPRO_SOURCE`] instead of a full duplicate copy.
+#[allow(dead_code)]
+pub fn insert_before_closing_brace(source: &str, item: &str) -> String {
+    let insert_at = source.rfind('}').expect("spec has a closing brace");
+    let mut generated = source[..insert_at].to_owned();
+    generated.push_str(item);
+    generated.push_str(&source[insert_at..]);
+    generated
+}


### PR DESCRIPTION
## Problem

PR #776 removed per-node `Monitor` clones from three BFS lanes, but three more remained —
and one of them is heavier than the lanes that were fixed. `check_refinement`'s own
correspondence walk materialises a whole layer of `(Monitor, Vec<TraceStep>)` candidates at
once, so `fslc refine` on a `Seq`-carrying spec still exhausted memory at roughly the same
depth as before #776.

Issue #783 also recorded an asymmetry in the negative controls: only the `bfs` lane had a
memory-regression ceiling. Reverting `first_self_violation`'s or `verify_explicit_selected`'s
frontier to a model-carrying queue would have left every test in the repository green.

## Contract change

Representation only. Function signatures, `RefinementCheck` / `LeadstoResponse` fields, the
JSON envelope, and exit codes are unchanged.

| lane | change |
|---|---|
| `check_refinement`'s correspondence walk | queue carries `(State, usize)`; `ParentLink` + `reconstruct_trace` build the failing trace, following `first_self_violation`'s established pattern |
| `action_cover_traces` | same pattern. The witness is reconstructed from the parent state, because `covered` is populated *before* the visited check and so fires on already-visited children too |
| `leadsto_response_traces` | **model clone only.** This lane has no visited set and `response_pending_at` takes the trace as input, so responses are path-dependent. Deduplicating by state would change results, so the per-node `Vec<TraceStep>` stays |

All three lanes are now locked onto frontier types with private fields — `LeanFrontier`
(`(State, usize)`) for the first two, `PathFrontier` (`(State, Vec<TraceStep>, usize)`) for
`leadsto_response_traces`. Putting a `Monitor` back into any of them is a compile error.

## Measured results

**Memory** (`fsl-refine`, release, `LabelCoreRepro` + all-stutter refinement):

| depth | before | after |
|---|---|---|
| 2 | 63.9 MB | 28.0 MB |
| 3 | **1557 MB** | **491 MB** |

Verdict and trace are identical on both sides at both depths.

**Output identity** (before = the driver-only commit, after = HEAD, separate `--target-dir`):

- `fslc refine` over the 27 declared corpus cases — byte-identical.
- `fslc scenarios` over 93 specs × two depths (186 runs) — identical once the two elapsed-time
  fields are excluded.
- The existing `fsl-bfs` / `fsl-explicit` ceiling fixtures still report
  `states_explored = 16290`, confirming the already-fixed lanes were not disturbed.

## Negative controls

Two Linux-only ceilings are added, and **both were verified to actually fail against a
reintroduced clone** — measured under a real `RLIMIT_AS` cap, not inferred from peak-memory
numbers:

| test | fixed | mutant |
|---|---|---|
| `first_self_violation_stays_under_a_calibrated_ceiling_…` | pass | fails at `:199`, `unix_wait_status(134)`, `memory allocation of N bytes failed` |
| `check_refinement_stays_under_a_calibrated_ceiling_…` | pass | fails at `:245`, same signature |

Both `CEILING_KB` values are calibrated from the measured Linux PASS/FAIL boundary on each
side (pinned to within 20–50 MiB), not from a macOS peak-memory estimate. The test file
records the container image, the commits each mutant is rebuilt from, and the commands, so
the measurement is reproducible.

This is the first time this repository has confirmed that its `ulimit -v` ceiling mechanism
actually enforces `RLIMIT_AS` — the pre-existing `issue_730_*` ceilings documented that as an
unverified assumption.

`LabelCoreRepro` is now shared from `rust/fsl-runtime/tests/support/mod.rs`, which also
removes the duplicate copies in `issue_730_bfs_memory_ceiling.rs` and
`issue_730_explicit_memory_ceiling.rs`. Those tests' spec, depth, ceiling, and expected
values are unchanged.

## Scope and what is still open

- **`leadsto_response_traces` keeps its per-node trace clone.** Removing it needs a different
  search structure (path-tree node ids), which would mean inventing a mechanism this issue
  explicitly rules out. The model clone — the dominant term at roughly 60 KB per state — is gone.
- **The ceiling measurements are `aarch64` Linux** (a Docker container on an Apple Silicon
  host). CI runs `ubuntu-latest`, which is `x86_64`. The boundary has not been measured there.
  If a ceiling flakes on CI, cross-architecture allocator behaviour is the first thing to check
  and widening `CEILING_KB` is the remedy.
- **On macOS these ceilings report zero tests run** (`#![cfg(target_os = "linux")]`), because
  macOS does not enforce `RLIMIT_AS` the way `ulimit -v` expects. A local `cargo test` run
  passing is not evidence that they passed.
- `rust/fsl-runtime/tests/support/mod.rs` is per-crate; `rust/fslc/tests/` keeps its own copy
  of the fixture. Consolidating across crates is out of scope here.

Closes #783
